### PR TITLE
refactor: align @koi/core L0 contracts with architecture doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ The 6 contracts that define Koi's extension points:
 
 | # | Contract | Purpose | Minimal surface |
 |---|----------|---------|-----------------|
-| 1 | **Middleware** | Sole interposition layer for model/tool calls | 6 optional hooks |
+| 1 | **Middleware** | Sole interposition layer for model/tool calls | 8 optional hooks |
 | 2 | **Message** | Inbound/outbound data format | `ContentBlock[]` |
 | 3 | **Channel** | I/O interface to users | `send()` + `onMessage()` |
 | 4 | **Resolver** | Discovery of tools/skills/agents | `discover()` + `load()` |

--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -28,8 +28,11 @@ import type {
   EventComponent,
   FileBlock,
   GovernanceComponent,
+  GovernanceUsage,
   ImageBlock,
   InboundMessage,
+  // common
+  JsonObject,
   KoiError,
   // errors
   KoiErrorCode,
@@ -52,6 +55,7 @@ import type {
   // middleware
   SessionContext,
   SkillMetadata,
+  SpawnCheck,
   // ecs
   SubsystemToken,
   // message
@@ -62,6 +66,7 @@ import type {
   ToolHandler,
   ToolRequest,
   ToolResponse,
+  TrustTier,
   TurnContext,
 } from "../index.js";
 
@@ -79,6 +84,7 @@ import {
 // Prevent type imports from being optimized away
 type AssertDefined<T> = T extends undefined ? never : T;
 type _TypeGuard =
+  | AssertDefined<JsonObject>
   | AssertDefined<KoiErrorCode>
   | AssertDefined<KoiError>
   | AssertDefined<Result<unknown>>
@@ -122,10 +128,13 @@ type _TypeGuard =
   | AssertDefined<Agent>
   | AssertDefined<ToolDescriptor>
   | AssertDefined<Tool>
+  | AssertDefined<TrustTier>
   | AssertDefined<SkillMetadata>
   | AssertDefined<ComponentProvider>
   | AssertDefined<MemoryComponent>
   | AssertDefined<GovernanceComponent>
+  | AssertDefined<GovernanceUsage>
+  | AssertDefined<SpawnCheck>
   | AssertDefined<CredentialComponent>
   | AssertDefined<EventComponent>;
 

--- a/packages/core/src/__tests__/tokens.test.ts
+++ b/packages/core/src/__tests__/tokens.test.ts
@@ -28,6 +28,10 @@ describe("token()", () => {
   test("different names produce different tokens", () => {
     expect(str(token("a"))).not.toBe(str(token("b")));
   });
+
+  test("empty string returns empty string", () => {
+    expect(str(token(""))).toBe("");
+  });
 });
 
 describe("toolToken()", () => {
@@ -37,6 +41,14 @@ describe("toolToken()", () => {
 
   test("contains namespace separator", () => {
     expect(str(toolToken("search"))).toContain(":");
+  });
+
+  test("empty name produces tool: prefix only", () => {
+    expect(str(toolToken(""))).toBe("tool:");
+  });
+
+  test("name with colon produces double colon", () => {
+    expect(str(toolToken("search:v2"))).toBe("tool:search:v2");
   });
 });
 
@@ -48,6 +60,10 @@ describe("channelToken()", () => {
   test("contains namespace separator", () => {
     expect(str(channelToken("slack"))).toContain(":");
   });
+
+  test("empty name produces channel: prefix only", () => {
+    expect(str(channelToken(""))).toBe("channel:");
+  });
 });
 
 describe("skillToken()", () => {
@@ -57,6 +73,10 @@ describe("skillToken()", () => {
 
   test("contains namespace separator", () => {
     expect(str(skillToken("summarize"))).toContain(":");
+  });
+
+  test("empty name produces skill: prefix only", () => {
+    expect(str(skillToken(""))).toBe("skill:");
   });
 });
 

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import type {
   Agent,
+  AgentManifest,
   ContentBlock,
   EngineEvent,
   EngineInput,
   EngineStopReason,
+  GovernanceUsage,
   KoiError,
+  KoiMiddleware,
+  ProcessId,
   Result,
+  SpawnCheck,
   SubsystemToken,
+  ToolDescriptor,
+  TrustTier,
 } from "../index.js";
-import { token } from "../index.js";
+import { CREDENTIALS, EVENTS, GOVERNANCE, MEMORY, token } from "../index.js";
 
 /**
  * Type-level tests using @ts-expect-error.
@@ -102,10 +109,19 @@ describe("EngineEvent discriminant", () => {
     }
   });
 
-  test("narrows to tool_call_start", () => {
-    const event: EngineEvent = { kind: "tool_call_start", toolId: "calc", input: {} };
+  test("narrows to tool_call_start with toolName and callId", () => {
+    const event: EngineEvent = { kind: "tool_call_start", toolName: "calc", callId: "c1" };
     if (event.kind === "tool_call_start") {
-      expect(event.toolId).toBe("calc");
+      expect(event.toolName).toBe("calc");
+      expect(event.callId).toBe("c1");
+    }
+  });
+
+  test("narrows to tool_call_end with callId and result", () => {
+    const event: EngineEvent = { kind: "tool_call_end", callId: "c1", result: 42 };
+    if (event.kind === "tool_call_end") {
+      expect(event.callId).toBe("c1");
+      expect(event.result).toBe(42);
     }
   });
 
@@ -175,16 +191,124 @@ describe("readonly enforcement", () => {
     // @ts-expect-error — cannot assign to readonly property
     block.kind = "file";
   });
+
+  test("ProcessId properties are readonly", () => {
+    const pid: ProcessId = { id: "1", name: "test", type: "copilot", depth: 0 };
+    // @ts-expect-error — cannot assign to readonly property
+    pid.id = "2";
+  });
+
+  test("ToolDescriptor properties are readonly", () => {
+    const td: ToolDescriptor = { name: "calc", description: "Calculator", inputSchema: {} };
+    // @ts-expect-error — cannot assign to readonly property
+    td.name = "other";
+  });
+
+  test("AgentManifest properties are readonly", () => {
+    const m: AgentManifest = { name: "test", version: "0.0.0", model: { name: "gpt-4" } };
+    // @ts-expect-error — cannot assign to readonly property
+    m.name = "other";
+  });
 });
 
 describe("Agent component typing", () => {
   test("component returns T | undefined for typed token", () => {
-    // Verify the type signature compiles correctly
     const agentLike: Pick<Agent, "component"> = {
       component: <T>(_token: SubsystemToken<T>): T | undefined => undefined,
     };
     const result = agentLike.component(token<{ readonly val: number }>("test"));
-    // result is { readonly val: number } | undefined
     expect(result).toBeUndefined();
+  });
+});
+
+describe("well-known token type narrowing", () => {
+  test("MEMORY token narrows component to MemoryComponent", () => {
+    const agentLike: Pick<Agent, "component"> = {
+      component: <T>(_token: SubsystemToken<T>): T | undefined => undefined,
+    };
+    const mem = agentLike.component(MEMORY);
+    // If this compiles, MEMORY correctly narrows to MemoryComponent | undefined
+    if (mem) {
+      const _: Promise<readonly unknown[]> = mem.recall("test");
+      void _;
+    }
+    expect(mem).toBeUndefined();
+  });
+
+  test("GOVERNANCE token narrows component to GovernanceComponent", () => {
+    const agentLike: Pick<Agent, "component"> = {
+      component: <T>(_token: SubsystemToken<T>): T | undefined => undefined,
+    };
+    const gov = agentLike.component(GOVERNANCE);
+    if (gov) {
+      const _usage: GovernanceUsage = gov.usage();
+      const _check: SpawnCheck = gov.checkSpawn(0);
+      void _usage;
+      void _check;
+    }
+    expect(gov).toBeUndefined();
+  });
+
+  test("CREDENTIALS token narrows component to CredentialComponent", () => {
+    const agentLike: Pick<Agent, "component"> = {
+      component: <T>(_token: SubsystemToken<T>): T | undefined => undefined,
+    };
+    const cred = agentLike.component(CREDENTIALS);
+    if (cred) {
+      const _: Promise<string | undefined> = cred.get("api_key");
+      void _;
+    }
+    expect(cred).toBeUndefined();
+  });
+
+  test("EVENTS token narrows component to EventComponent", () => {
+    const agentLike: Pick<Agent, "component"> = {
+      component: <T>(_token: SubsystemToken<T>): T | undefined => undefined,
+    };
+    const events = agentLike.component(EVENTS);
+    if (events) {
+      const _: Promise<void> = events.emit("test", {});
+      void _;
+    }
+    expect(events).toBeUndefined();
+  });
+});
+
+describe("KoiMiddleware optionality", () => {
+  test("middleware with only name is valid", () => {
+    const mw: KoiMiddleware = { name: "noop" };
+    expect(mw.name).toBe("noop");
+  });
+
+  test("middleware with session hooks is valid", () => {
+    const mw: KoiMiddleware = {
+      name: "session-only",
+      onSessionStart: async () => {},
+      onSessionEnd: async () => {},
+    };
+    expect(mw.name).toBe("session-only");
+  });
+});
+
+describe("TrustTier", () => {
+  test("accepts valid trust tier literals", () => {
+    const tiers: readonly TrustTier[] = ["sandbox", "verified", "promoted"];
+    expect(tiers).toHaveLength(3);
+  });
+});
+
+describe("SpawnCheck discriminant", () => {
+  test("narrows to allowed branch", () => {
+    const check: SpawnCheck = { allowed: true };
+    if (check.allowed) {
+      expect(check.allowed).toBe(true);
+    }
+  });
+
+  test("narrows to denied branch with reason", () => {
+    const check: SpawnCheck = { allowed: false, reason: "max depth exceeded" };
+    if (!check.allowed) {
+      expect(check.reason).toBe("max depth exceeded");
+    }
   });
 });

--- a/packages/core/src/assembly.ts
+++ b/packages/core/src/assembly.ts
@@ -2,24 +2,26 @@
  * Agent manifest and configuration types.
  */
 
+import type { JsonObject } from "./common.js";
+
 export interface ModelConfig {
   readonly name: string;
-  readonly options?: Readonly<Record<string, unknown>>;
+  readonly options?: JsonObject;
 }
 
 export interface ToolConfig {
   readonly name: string;
-  readonly options?: Readonly<Record<string, unknown>>;
+  readonly options?: JsonObject;
 }
 
 export interface ChannelConfig {
   readonly name: string;
-  readonly options?: Readonly<Record<string, unknown>>;
+  readonly options?: JsonObject;
 }
 
 export interface MiddlewareConfig {
   readonly name: string;
-  readonly options?: Readonly<Record<string, unknown>>;
+  readonly options?: JsonObject;
 }
 
 export interface PermissionConfig {
@@ -30,11 +32,12 @@ export interface PermissionConfig {
 
 export interface AgentManifest {
   readonly name: string;
+  readonly version: string;
   readonly description?: string;
   readonly model: ModelConfig;
   readonly tools?: readonly ToolConfig[];
   readonly channels?: readonly ChannelConfig[];
   readonly middleware?: readonly MiddlewareConfig[];
   readonly permissions?: PermissionConfig;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }

--- a/packages/core/src/common.ts
+++ b/packages/core/src/common.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared type aliases used across all contracts.
+ */
+
+export type JsonObject = Readonly<Record<string, unknown>>;

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -9,6 +9,7 @@
 
 import type { AgentManifest } from "./assembly.js";
 import type { ChannelAdapter } from "./channel.js";
+import type { JsonObject } from "./common.js";
 
 // ---------------------------------------------------------------------------
 // Branded token
@@ -28,8 +29,8 @@ export function token<T>(name: string): SubsystemToken<T> {
   return name as SubsystemToken<T>;
 }
 
-export function toolToken(name: string): SubsystemToken<ToolDescriptor> {
-  return `tool:${name}` as SubsystemToken<ToolDescriptor>;
+export function toolToken(name: string): SubsystemToken<Tool> {
+  return `tool:${name}` as SubsystemToken<Tool>;
 }
 
 export function channelToken(name: string): SubsystemToken<ChannelAdapter> {
@@ -64,9 +65,15 @@ export interface Agent {
   readonly state: ProcessState;
   readonly component: <T>(token: SubsystemToken<T>) => T | undefined;
   readonly has: (token: SubsystemToken<unknown>) => boolean;
-  readonly query: (...tokens: readonly SubsystemToken<unknown>[]) => boolean;
+  readonly query: <T>(prefix: string) => ReadonlyMap<SubsystemToken<T>, T>;
   readonly components: () => ReadonlyMap<string, unknown>;
 }
+
+// ---------------------------------------------------------------------------
+// Trust tiers
+// ---------------------------------------------------------------------------
+
+export type TrustTier = "sandbox" | "verified" | "promoted";
 
 // ---------------------------------------------------------------------------
 // Tool & Skill
@@ -75,12 +82,13 @@ export interface Agent {
 export interface ToolDescriptor {
   readonly name: string;
   readonly description: string;
-  readonly inputSchema: Readonly<Record<string, unknown>>;
+  readonly inputSchema: JsonObject;
 }
 
 export interface Tool {
   readonly descriptor: ToolDescriptor;
-  readonly execute: (input: unknown) => Promise<unknown>;
+  readonly trustTier: TrustTier;
+  readonly execute: (args: JsonObject) => Promise<unknown>;
 }
 
 export interface SkillMetadata {
@@ -107,8 +115,18 @@ export interface MemoryComponent {
   readonly store: (content: unknown) => Promise<void>;
 }
 
+export interface GovernanceUsage {
+  readonly turns: number;
+  readonly spawns: number;
+}
+
+export type SpawnCheck =
+  | { readonly allowed: true }
+  | { readonly allowed: false; readonly reason: string };
+
 export interface GovernanceComponent {
-  readonly check: (action: string) => Promise<boolean>;
+  readonly usage: () => GovernanceUsage;
+  readonly checkSpawn: (depth: number) => SpawnCheck;
 }
 
 export interface CredentialComponent {
@@ -116,7 +134,7 @@ export interface CredentialComponent {
 }
 
 export interface EventComponent {
-  readonly emit: (type: string, data: unknown) => void;
+  readonly emit: (type: string, data: unknown) => Promise<void>;
   readonly on: (type: string, handler: (data: unknown) => void) => () => void;
 }
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2,6 +2,7 @@
  * Engine adapter contract — swappable agent loop.
  */
 
+import type { JsonObject } from "./common.js";
 import type { ContentBlock, InboundMessage } from "./message.js";
 
 export type EngineStopReason = "completed" | "max_turns" | "interrupted" | "error";
@@ -18,7 +19,7 @@ export interface EngineOutput {
   readonly content: readonly ContentBlock[];
   readonly stopReason: EngineStopReason;
   readonly metrics: EngineMetrics;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export interface EngineState {
@@ -33,8 +34,12 @@ export type EngineInput =
 
 export type EngineEvent =
   | { readonly kind: "text_delta"; readonly delta: string }
-  | { readonly kind: "tool_call_start"; readonly toolId: string; readonly input: unknown }
-  | { readonly kind: "tool_call_end"; readonly toolId: string; readonly output: unknown }
+  | { readonly kind: "tool_call_start"; readonly toolName: string; readonly callId: string }
+  | {
+      readonly kind: "tool_call_end";
+      readonly callId: string;
+      readonly result: unknown;
+    }
   | { readonly kind: "turn_end"; readonly turnIndex: number }
   | { readonly kind: "done"; readonly output: EngineOutput }
   | { readonly kind: "custom"; readonly type: string; readonly data: unknown };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export type {
 } from "./assembly.js";
 // channel
 export type { ChannelAdapter, ChannelCapabilities, MessageHandler } from "./channel.js";
+// common
+export type { JsonObject } from "./common.js";
 // ecs — types
 export type {
   Agent,
@@ -23,13 +25,16 @@ export type {
   CredentialComponent,
   EventComponent,
   GovernanceComponent,
+  GovernanceUsage,
   MemoryComponent,
   ProcessId,
   ProcessState,
   SkillMetadata,
+  SpawnCheck,
   SubsystemToken,
   Tool,
   ToolDescriptor,
+  TrustTier,
 } from "./ecs.js";
 // ecs — runtime values (token factories + well-known constants)
 export {

--- a/packages/core/src/message.ts
+++ b/packages/core/src/message.ts
@@ -2,6 +2,8 @@
  * Content block union and message types.
  */
 
+import type { JsonObject } from "./common.js";
+
 export interface TextBlock {
   readonly kind: "text";
   readonly text: string;
@@ -38,7 +40,7 @@ export type ContentBlock = TextBlock | FileBlock | ImageBlock | ButtonBlock | Cu
 export interface OutboundMessage {
   readonly content: readonly ContentBlock[];
   readonly threadId?: string;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export interface InboundMessage {
@@ -46,5 +48,5 @@ export interface InboundMessage {
   readonly senderId: string;
   readonly threadId?: string;
   readonly timestamp: number;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -2,19 +2,20 @@
  * Middleware contract — sole interposition layer for model/tool calls.
  */
 
+import type { JsonObject } from "./common.js";
 import type { InboundMessage } from "./message.js";
 
 export interface SessionContext {
   readonly agentId: string;
   readonly sessionId: string;
-  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly metadata: JsonObject;
 }
 
 export interface TurnContext {
   readonly session: SessionContext;
   readonly turnIndex: number;
   readonly messages: readonly InboundMessage[];
-  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly metadata: JsonObject;
 }
 
 export interface ModelRequest {
@@ -22,7 +23,7 @@ export interface ModelRequest {
   readonly model?: string;
   readonly temperature?: number;
   readonly maxTokens?: number;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export interface ModelResponse {
@@ -32,7 +33,7 @@ export interface ModelResponse {
     readonly inputTokens: number;
     readonly outputTokens: number;
   };
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export type ModelHandler = (request: ModelRequest) => Promise<ModelResponse>;
@@ -40,18 +41,20 @@ export type ModelHandler = (request: ModelRequest) => Promise<ModelResponse>;
 export interface ToolRequest {
   readonly toolId: string;
   readonly input: unknown;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export interface ToolResponse {
   readonly output: unknown;
-  readonly metadata?: Readonly<Record<string, unknown>>;
+  readonly metadata?: JsonObject;
 }
 
 export type ToolHandler = (request: ToolRequest) => Promise<ToolResponse>;
 
 export interface KoiMiddleware {
   readonly name: string;
+  readonly onSessionStart?: (ctx: SessionContext) => Promise<void>;
+  readonly onSessionEnd?: (ctx: SessionContext) => Promise<void>;
   readonly beforeModel?: (
     ctx: TurnContext,
     request: ModelRequest,


### PR DESCRIPTION
## Summary

- **Agent.query()** changed from boolean multi-has to prefix-based lookup (`ReadonlyMap<SubsystemToken<T>, T>`) — enables engine adapter tool discovery
- **Tool** interface: added `trustTier` field and tightened `execute` args to `JsonObject`; `toolToken()` now returns `SubsystemToken<Tool>` per arch doc
- **KoiMiddleware**: added `onSessionStart`/`onSessionEnd` session lifecycle hooks (6 → 8 optional hooks)
- **AgentManifest**: added required `version` field for forge brick versioning
- **EngineEvent**: `tool_call_start`/`tool_call_end` now use `toolName` + `callId` for concurrent call correlation
- **GovernanceComponent**: replaced generic `check()` with `usage()` + `checkSpawn(depth)` using `GovernanceUsage` and `SpawnCheck` types
- **EventComponent.emit**: made async (`Promise<void>`) for consistency
- **DRY**: extracted `JsonObject` type alias to `common.ts`, replacing 15 occurrences of `Readonly<Record<string, unknown>>`
- **Tests**: 38 → 56 tests (edge cases, type narrowing, readonly enforcement, middleware optionality)

All changes cross-referenced against [architecture doc](docs/architecture/Koi.md) and modern ECS best practices.

## Verification

| Check | Result |
|-------|--------|
| Build | 459B bundle, 10.94KB types |
| Tests | 56 pass, 0 fail, 100% coverage |
| Typecheck | Clean |
| Lint | Clean |
| Code Review | PASS — no CRITICAL/HIGH issues |

## Test plan

- [x] `bun run build` — 459B bundle, clean DTS generation
- [x] `bun test` — 56 tests pass, 100% coverage
- [x] `bun run typecheck` — no type errors
- [x] `bun run lint` — no lint errors
- [x] Anti-leak checklist verified (zero @koi/* imports, no vendor types, all readonly)