### PR TITLE
feat: @koi/forge — self-extension system (Phase 1 MVP)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,13 @@
       "name": "@koi/core",
       "version": "0.0.0",
     },
+    "packages/forge": {
+      "name": "@koi/forge",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/gateway": {
       "name": "@koi/gateway",
       "version": "0.0.0",
@@ -129,6 +136,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@koi/core": ["@koi/core@workspace:packages/core"],
+
+    "@koi/forge": ["@koi/forge@workspace:packages/forge"],
 
     "@koi/gateway": ["@koi/gateway@workspace:packages/gateway"],
 

--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -8,6 +8,9 @@ import { describe, expect, test } from "bun:test";
 import type {
   Agent,
   AgentManifest,
+  // forge types
+  BrickKind,
+  BrickLifecycle,
   ButtonBlock,
   ChannelAdapter,
   // channel
@@ -29,6 +32,7 @@ import type {
   FileBlock,
   // sandbox
   FilesystemPolicy,
+  ForgeScope,
   GovernanceComponent,
   GovernanceUsage,
   ImageBlock,
@@ -96,6 +100,10 @@ import {
 type AssertDefined<T> = T extends undefined ? never : T;
 type _TypeGuard =
   | AssertDefined<JsonObject>
+  | AssertDefined<BrickKind>
+  | AssertDefined<BrickLifecycle>
+  | AssertDefined<ForgeScope>
+  | AssertDefined<TrustTier>
   | AssertDefined<KoiErrorCode>
   | AssertDefined<KoiError>
   | AssertDefined<Result<unknown>>

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type {
   Agent,
   AgentManifest,
+  BrickKind,
+  BrickLifecycle,
   ChannelAdapter,
   ChannelCapabilities,
   ContentBlock,
@@ -10,6 +12,7 @@ import type {
   EngineInput,
   EngineStopReason,
   FilesystemPolicy,
+  ForgeScope,
   GovernanceUsage,
   KoiError,
   KoiErrorCode,
@@ -249,7 +252,7 @@ describe("Agent component typing", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Well-known token type narrowing (from main)
+// Well-known token type narrowing
 // ---------------------------------------------------------------------------
 
 describe("well-known token type narrowing", () => {
@@ -457,7 +460,7 @@ describe("PermissionConfig negative types", () => {
 });
 
 // ---------------------------------------------------------------------------
-// TrustTier and SpawnCheck (from main)
+// TrustTier and SpawnCheck
 // ---------------------------------------------------------------------------
 
 describe("TrustTier", () => {
@@ -484,7 +487,7 @@ describe("SpawnCheck discriminant", () => {
 });
 
 // ---------------------------------------------------------------------------
-// KoiErrorCode and KoiError extended fields (from main)
+// KoiErrorCode and KoiError extended fields
 // ---------------------------------------------------------------------------
 
 describe("KoiErrorCode", () => {
@@ -583,6 +586,10 @@ describe("Result with custom error type", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sandbox types
+// ---------------------------------------------------------------------------
 
 describe("SandboxTier", () => {
   test("accepts valid tier literals", () => {
@@ -808,5 +815,39 @@ describe("Tool input typing", () => {
       },
     };
     expect(tool.descriptor.name).toBe("calc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forge type aliases
+// ---------------------------------------------------------------------------
+
+describe("Forge type aliases", () => {
+  test("ForgeScope accepts valid literals", () => {
+    const scopes: readonly ForgeScope[] = ["agent", "zone", "global"];
+    expect(scopes).toHaveLength(3);
+  });
+
+  test("BrickLifecycle accepts valid literals", () => {
+    const states: readonly BrickLifecycle[] = [
+      "draft",
+      "verifying",
+      "active",
+      "failed",
+      "deprecated",
+    ];
+    expect(states).toHaveLength(5);
+  });
+
+  test("BrickKind accepts valid literals", () => {
+    const kinds: readonly BrickKind[] = [
+      "tool",
+      "skill",
+      "agent",
+      "composite",
+      "middleware",
+      "channel",
+    ];
+    expect(kinds).toHaveLength(6);
   });
 });

--- a/packages/core/src/forge-types.ts
+++ b/packages/core/src/forge-types.ts
@@ -1,0 +1,15 @@
+/**
+ * Forge type aliases — extension points for the self-extension system.
+ *
+ * TrustTier lives in ecs.ts (used by Tool interface).
+ * These are additional L0 types used by @koi/forge (L2).
+ */
+
+/** Visibility scope of a forged brick. */
+export type ForgeScope = "agent" | "zone" | "global";
+
+/** Lifecycle state of a forged brick artifact. */
+export type BrickLifecycle = "draft" | "verifying" | "active" | "failed" | "deprecated";
+
+/** Kind of forged brick (tool, skill, agent, composite, middleware, channel). */
+export type BrickKind = "tool" | "skill" | "agent" | "composite" | "middleware" | "channel";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,8 @@ export type {
 export type { KoiError, KoiErrorCode, Result } from "./errors.js";
 // errors — runtime values
 export { RETRYABLE_DEFAULTS } from "./errors.js";
+// forge types
+export type { BrickKind, BrickLifecycle, ForgeScope } from "./forge-types.js";
 // message
 export type {
   ButtonBlock,

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@koi/forge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  }
+}

--- a/packages/forge/src/__tests__/edge-cases.test.ts
+++ b/packages/forge/src/__tests__/edge-cases.test.ts
@@ -1,0 +1,370 @@
+/**
+ * 12 mandatory edge case tests — security + correctness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import type { ForgeError } from "../errors.js";
+import { checkGovernance } from "../governance.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import { createForgeToolTool } from "../tools/forge-tool.js";
+import type { ForgeDeps } from "../tools/shared.js";
+import type { BrickArtifact, ForgeContext, ForgeInput, SandboxExecutor } from "../types.js";
+import { verify } from "../verify.js";
+import { verifyStatic } from "../verify-static.js";
+
+const DEFAULT_VERIFICATION = createDefaultForgeConfig().verification;
+
+const DEFAULT_CONTEXT: ForgeContext = {
+  agentId: "agent-1",
+  depth: 0,
+  sessionId: "session-1",
+  forgesThisSession: 0,
+};
+
+function mockExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, input, _timeout) => ({
+      ok: true,
+      value: { output: input, durationMs: 1 },
+    }),
+  };
+}
+
+function createDeps(overrides?: Partial<ForgeDeps>): ForgeDeps {
+  return {
+    store: createInMemoryForgeStore(),
+    executor: mockExecutor(),
+    verifiers: [],
+    config: createDefaultForgeConfig(),
+    context: DEFAULT_CONTEXT,
+    ...overrides,
+  };
+}
+
+describe("Edge case 1: __proto__ / constructor in schema keys", () => {
+  test("rejects schema with 'constructor' key", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object", properties: { constructor: { type: "string" } } },
+      implementation: "return 1;",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("INVALID_SCHEMA");
+    }
+  });
+
+  test("rejects schema with 'prototype' key", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object", properties: { prototype: { type: "string" } } },
+      implementation: "return 1;",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("Edge case 2: Name with path traversal", () => {
+  test("rejects name like ../../../etc/passwd", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "../../../etc/passwd",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("INVALID_NAME");
+    }
+  });
+
+  test("rejects name with backslash traversal", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "..\\..\\etc\\passwd",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("Edge case 3: Implementation importing node:child_process", () => {
+  test("sandbox rejects via permission error", async () => {
+    const executor: SandboxExecutor = {
+      execute: async () => ({
+        ok: false,
+        error: {
+          code: "PERMISSION",
+          message: "permission denied: cannot import node:child_process",
+          durationMs: 1,
+        },
+      }),
+    };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "malicious",
+      description: "Evil tool",
+      inputSchema: { type: "object" },
+      implementation: 'import { exec } from "node:child_process";',
+    };
+    const config = createDefaultForgeConfig();
+    const result = await verify(input, DEFAULT_CONTEXT, executor, [], config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("sandbox");
+      if (result.error.stage === "sandbox") {
+        expect(result.error.code).toBe("PERMISSION");
+      }
+    }
+  });
+});
+
+describe("Edge case 4: Forge at depth > maxForgeDepth", () => {
+  test("governance rejects deep forging", () => {
+    const config = createDefaultForgeConfig({ maxForgeDepth: 1 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, depth: 2 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("MAX_DEPTH");
+    }
+  });
+});
+
+describe("Edge case 5: N+1th forge when maxForgesPerSession = N", () => {
+  test("governance rejects at limit", () => {
+    const config = createDefaultForgeConfig({ maxForgesPerSession: 3 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, forgesThisSession: 3 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("MAX_SESSION_FORGES");
+    }
+  });
+});
+
+describe("Edge case 6: Scope promotion without HITL when required", () => {
+  test("returns requiresHumanApproval", async () => {
+    const { checkScopePromotion } = await import("../governance.js");
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: true,
+        minTrustForZone: "sandbox",
+        minTrustForGlobal: "sandbox",
+      },
+    });
+    const result = checkScopePromotion("agent", "zone", "sandbox", config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.requiresHumanApproval).toBe(true);
+    }
+  });
+});
+
+describe("Edge case 7: Concurrent forge attempts — no shared state corruption", () => {
+  test("concurrent saves to same store do not corrupt data", async () => {
+    const store = createInMemoryForgeStore();
+    const bricks: BrickArtifact[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `brick_${i}`,
+      kind: "tool" as const,
+      name: `tool-${i}`,
+      description: `Tool ${i}`,
+      scope: "agent" as const,
+      trustTier: "sandbox" as const,
+      lifecycle: "active" as const,
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      implementation: `return ${i};`,
+    }));
+
+    // Save all concurrently
+    await Promise.all(bricks.map((b) => store.save(b)));
+
+    // All should be retrievable
+    const results = await store.search({});
+    expect(results.ok).toBe(true);
+    if (results.ok) {
+      expect(results.value.length).toBe(10);
+    }
+  });
+});
+
+describe("Edge case 8: Duplicate brick name in same scope", () => {
+  test("second save overwrites first (store allows by id)", async () => {
+    const store = createInMemoryForgeStore();
+    const brick1: BrickArtifact = {
+      id: "same-id",
+      kind: "tool",
+      name: "duplicate",
+      description: "First",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+    };
+    const brick2: BrickArtifact = {
+      ...brick1,
+      description: "Second",
+    };
+
+    await store.save(brick1);
+    await store.save(brick2);
+
+    const result = await store.load("same-id");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.description).toBe("Second");
+    }
+  });
+});
+
+describe("Edge case 9: Empty testCases array — Stage 3 passes", () => {
+  test("passes self-test with no tests to fail", async () => {
+    const config = createDefaultForgeConfig();
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+      testCases: [],
+    };
+    const result = await verify(input, DEFAULT_CONTEXT, mockExecutor(), [], config);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("Edge case 10: SandboxExecutor returns CRASH error", () => {
+  test("verify propagates structured sandbox error", async () => {
+    const executor: SandboxExecutor = {
+      execute: async () => ({
+        ok: false,
+        error: { code: "CRASH", message: "unexpected null reference", durationMs: 1 },
+      }),
+    };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "broken code",
+    };
+    const config = createDefaultForgeConfig();
+    const result = await verify(input, DEFAULT_CONTEXT, executor, [], config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("sandbox");
+      if (result.error.stage === "sandbox") {
+        expect(result.error.code).toBe("CRASH");
+      }
+    }
+  });
+});
+
+describe("Edge case 11: ForgeStore.save() failure after verification", () => {
+  test("returns error when store save fails", async () => {
+    const failingStore = {
+      save: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "disk full", retryable: false },
+      }),
+      load: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "disk full", retryable: false },
+      }),
+      search: async () => ({ ok: true as const, value: [] as readonly BrickArtifact[] }),
+      remove: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "disk full", retryable: false },
+      }),
+      update: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "disk full", retryable: false },
+      }),
+    };
+
+    const tool = createForgeToolTool(createDeps({ store: failingStore }));
+    const result = (await tool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: false; readonly error: ForgeError };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toContain("disk full");
+  });
+});
+
+describe("Edge case 12: Only valid BrickLifecycle transitions", () => {
+  test("store update changes lifecycle from active to deprecated", async () => {
+    const store = createInMemoryForgeStore();
+    const brick: BrickArtifact = {
+      id: "b1",
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+    };
+    await store.save(brick);
+
+    await store.update("b1", { lifecycle: "deprecated" });
+    const result = await store.load("b1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.lifecycle).toBe("deprecated");
+    }
+  });
+
+  test("store update changes lifecycle from draft to verifying", async () => {
+    const store = createInMemoryForgeStore();
+    const brick: BrickArtifact = {
+      id: "b1",
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "draft",
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+    };
+    await store.save(brick);
+
+    await store.update("b1", { lifecycle: "verifying" });
+    const result = await store.load("b1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.lifecycle).toBe("verifying");
+    }
+  });
+});

--- a/packages/forge/src/__tests__/lifecycle.test.ts
+++ b/packages/forge/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,281 @@
+/**
+ * End-to-end lifecycle test — exercises the full forge workflow
+ * through the public primordial tool API against a shared store.
+ *
+ * Flow: forge_tool → search_forge → forge_skill → search by kind
+ *     → search by tags → hit governance rate limit
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import { createForgeSkillTool } from "../tools/forge-skill.js";
+import { createForgeToolTool } from "../tools/forge-tool.js";
+import { createSearchForgeTool } from "../tools/search-forge.js";
+import type { ForgeDeps } from "../tools/shared.js";
+import type { BrickArtifact, ForgeContext, ForgeResult, SandboxExecutor } from "../types.js";
+
+function mockExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, input, _timeout) => ({
+      ok: true,
+      value: { output: input, durationMs: 1 },
+    }),
+  };
+}
+
+describe("Forge lifecycle — end-to-end", () => {
+  test("forge tool → discover → forge skill → search → governance limit", async () => {
+    const store = createInMemoryForgeStore();
+    const config = createDefaultForgeConfig({ maxForgesPerSession: 3 });
+    const context: ForgeContext = {
+      agentId: "agent-lifecycle",
+      depth: 0,
+      sessionId: "session-e2e",
+      forgesThisSession: 0,
+    };
+
+    const deps: ForgeDeps = {
+      store,
+      executor: mockExecutor(),
+      verifiers: [],
+      config,
+      context,
+    };
+
+    const forgeTool = createForgeToolTool(deps);
+    const forgeSkill = createForgeSkillTool(deps);
+    const searchForge = createSearchForgeTool(deps);
+
+    // --- Step 1: Forge a tool ---
+    const toolResult = (await forgeTool.execute({
+      name: "adder",
+      description: "Adds two numbers",
+      inputSchema: { type: "object", properties: { a: { type: "number" }, b: { type: "number" } } },
+      implementation: "return input.a + input.b;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(toolResult.ok).toBe(true);
+    expect(toolResult.value.kind).toBe("tool");
+    expect(toolResult.value.name).toBe("adder");
+    expect(toolResult.value.trustTier).toBe("sandbox");
+    expect(toolResult.value.lifecycle).toBe("active");
+    expect(toolResult.value.verificationReport.passed).toBe(true);
+    expect(toolResult.value.verificationReport.stages).toHaveLength(4);
+    expect(toolResult.value.metadata.forgedBy).toBe("agent-lifecycle");
+    expect(toolResult.value.metadata.sessionId).toBe("session-e2e");
+    expect(toolResult.value.forgesConsumed).toBe(1);
+
+    const toolId = toolResult.value.id;
+    expect(toolId).toMatch(/^brick_[0-9a-f-]{36}$/);
+
+    // --- Step 2: Search — find the forged tool ---
+    const searchAll = (await searchForge.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(searchAll.ok).toBe(true);
+    expect(searchAll.value.length).toBe(1);
+    const firstBrick = searchAll.value[0];
+    expect(firstBrick?.id).toBe(toolId);
+    expect(firstBrick?.kind).toBe("tool");
+
+    // --- Step 3: Forge a skill with tags ---
+    const skillResult = (await forgeSkill.execute({
+      name: "mathHelper",
+      description: "Tips for math operations",
+      content: "# Math Helper\n\nUse the adder tool for addition.",
+      tags: ["math", "helper"],
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(skillResult.ok).toBe(true);
+    expect(skillResult.value.kind).toBe("skill");
+    expect(skillResult.value.name).toBe("mathHelper");
+    expect(skillResult.value.lifecycle).toBe("active");
+
+    const skillId = skillResult.value.id;
+
+    // --- Step 4: Search by kind — tools only ---
+    const toolsOnly = (await searchForge.execute({ kind: "tool" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(toolsOnly.ok).toBe(true);
+    expect(toolsOnly.value.length).toBe(1);
+    expect(toolsOnly.value[0]?.id).toBe(toolId);
+
+    // --- Step 5: Search by kind — skills only ---
+    const skillsOnly = (await searchForge.execute({ kind: "skill" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(skillsOnly.ok).toBe(true);
+    expect(skillsOnly.value.length).toBe(1);
+    expect(skillsOnly.value[0]?.id).toBe(skillId);
+
+    // --- Step 6: Search all — both bricks present ---
+    const allBricks = (await searchForge.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(allBricks.ok).toBe(true);
+    expect(allBricks.value.length).toBe(2);
+
+    // --- Step 7: Search by tags ---
+    const byTag = (await searchForge.execute({ tags: ["math"] })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(byTag.ok).toBe(true);
+    expect(byTag.value.length).toBe(1);
+    expect(byTag.value[0]?.name).toBe("mathHelper");
+
+    // --- Step 8: Forge a third tool (still within limit of 3) ---
+    // Note: forgesThisSession is a snapshot — governance checks against it.
+    // The context was created with forgesThisSession: 0 and limit: 3,
+    // so the 3rd forge should still pass.
+    const tool2Result = (await forgeTool.execute({
+      name: "multiplier",
+      description: "Multiplies two numbers",
+      inputSchema: { type: "object" },
+      implementation: "return input.a * input.b;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(tool2Result.ok).toBe(true);
+    expect(tool2Result.value.name).toBe("multiplier");
+
+    // --- Step 9: Hit governance limit ---
+    // Create new deps with forgesThisSession at the limit
+    const limitedDeps: ForgeDeps = {
+      ...deps,
+      context: { ...context, forgesThisSession: 3 },
+    };
+    const limitedForgeTool = createForgeToolTool(limitedDeps);
+
+    const blocked = (await limitedForgeTool.execute({
+      name: "divider",
+      description: "Divides two numbers",
+      inputSchema: { type: "object" },
+      implementation: "return input.a / input.b;",
+    })) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly code: string };
+    };
+
+    expect(blocked.ok).toBe(false);
+    expect(blocked.error.stage).toBe("governance");
+    expect(blocked.error.code).toBe("MAX_SESSION_FORGES");
+
+    // --- Step 10: Verify store still has exactly 3 bricks ---
+    const finalSearch = (await searchForge.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+
+    expect(finalSearch.ok).toBe(true);
+    expect(finalSearch.value.length).toBe(3);
+
+    // Verify all 3 are active with correct kinds
+    const kinds = finalSearch.value.map((b) => b.kind).sort();
+    expect(kinds).toEqual(["skill", "tool", "tool"]);
+  });
+
+  test("forge at depth > max is rejected", async () => {
+    const store = createInMemoryForgeStore();
+    const config = createDefaultForgeConfig({ maxForgeDepth: 1 });
+    const context: ForgeContext = {
+      agentId: "deep-agent",
+      depth: 2,
+      sessionId: "session-deep",
+      forgesThisSession: 0,
+    };
+
+    const deps: ForgeDeps = {
+      store,
+      executor: mockExecutor(),
+      verifiers: [],
+      config,
+      context,
+    };
+
+    const forgeTool = createForgeToolTool(deps);
+
+    const result = (await forgeTool.execute({
+      name: "deepTool",
+      description: "Should be rejected",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly code: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("governance");
+    expect(result.error.code).toBe("MAX_DEPTH");
+
+    // Store should be empty — nothing saved
+    const search = (await store.search({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(search.ok).toBe(true);
+    expect(search.value.length).toBe(0);
+  });
+
+  test("forge disabled rejects all operations", async () => {
+    const store = createInMemoryForgeStore();
+    const config = createDefaultForgeConfig({ enabled: false });
+    const context: ForgeContext = {
+      agentId: "agent-1",
+      depth: 0,
+      sessionId: "session-1",
+      forgesThisSession: 0,
+    };
+
+    const deps: ForgeDeps = {
+      store,
+      executor: mockExecutor(),
+      verifiers: [],
+      config,
+      context,
+    };
+
+    const forgeTool = createForgeToolTool(deps);
+    const forgeSkill = createForgeSkillTool(deps);
+    const searchForge = createSearchForgeTool(deps);
+
+    // All three tools should reject
+    const toolResult = (await forgeTool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: false; readonly error: { readonly stage: string } };
+
+    const skillResult = (await forgeSkill.execute({
+      name: "mySkill",
+      description: "A skill",
+      content: "# Skill content",
+    })) as { readonly ok: false; readonly error: { readonly stage: string } };
+
+    const searchResult = (await searchForge.execute({})) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string };
+    };
+
+    expect(toolResult.ok).toBe(false);
+    expect(toolResult.error.stage).toBe("governance");
+
+    expect(skillResult.ok).toBe(false);
+    expect(skillResult.error.stage).toBe("governance");
+
+    expect(searchResult.ok).toBe(false);
+    expect(searchResult.error.stage).toBe("governance");
+  });
+});

--- a/packages/forge/src/__tests__/store-contract.ts
+++ b/packages/forge/src/__tests__/store-contract.ts
@@ -1,0 +1,176 @@
+/**
+ * Reusable contract test suite for ForgeStore implementations.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ForgeStore } from "../store.js";
+import type { BrickArtifact } from "../types.js";
+
+function createBrick(overrides?: Partial<BrickArtifact>): BrickArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: "return 1;",
+    ...overrides,
+  };
+}
+
+export function runForgeStoreContractTests(createStore: () => ForgeStore): void {
+  describe("ForgeStore contract", () => {
+    test("save and load round-trip", async () => {
+      const store = createStore();
+      const brick = createBrick({ id: "brick_rt" });
+      const saveResult = await store.save(brick);
+      expect(saveResult.ok).toBe(true);
+
+      const loadResult = await store.load("brick_rt");
+      expect(loadResult.ok).toBe(true);
+      if (loadResult.ok) {
+        expect(loadResult.value.id).toBe("brick_rt");
+        expect(loadResult.value.name).toBe("test-brick");
+      }
+    });
+
+    test("load returns NOT_FOUND for missing id", async () => {
+      const store = createStore();
+      const result = await store.load("nonexistent");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    });
+
+    test("search with empty query returns all", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1" }));
+      await store.save(createBrick({ id: "b2" }));
+
+      const result = await store.search({});
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(2);
+      }
+    });
+
+    test("search filters by kind", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1", kind: "tool" }));
+      await store.save(createBrick({ id: "b2", kind: "skill" }));
+
+      const result = await store.search({ kind: "tool" });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(1);
+        expect(result.value[0]?.kind).toBe("tool");
+      }
+    });
+
+    test("search filters by scope", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1", scope: "agent" }));
+      await store.save(createBrick({ id: "b2", scope: "global" }));
+
+      const result = await store.search({ scope: "global" });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(1);
+        expect(result.value[0]?.scope).toBe("global");
+      }
+    });
+
+    test("search filters by tags (AND match)", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1", tags: ["math", "calc"] }));
+      await store.save(createBrick({ id: "b2", tags: ["math"] }));
+      await store.save(createBrick({ id: "b3", tags: ["text"] }));
+
+      const result = await store.search({ tags: ["math", "calc"] });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(1);
+        expect(result.value[0]?.id).toBe("b1");
+      }
+    });
+
+    test("search respects limit", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1" }));
+      await store.save(createBrick({ id: "b2" }));
+      await store.save(createBrick({ id: "b3" }));
+
+      const result = await store.search({ limit: 2 });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(2);
+      }
+    });
+
+    test("remove deletes from results", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1" }));
+      await store.remove("b1");
+
+      const result = await store.search({});
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.length).toBe(0);
+      }
+    });
+
+    test("remove returns NOT_FOUND for missing", async () => {
+      const store = createStore();
+      const result = await store.remove("nonexistent");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    });
+
+    test("update modifies specific fields", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1", lifecycle: "active", usageCount: 0 }));
+
+      const updateResult = await store.update("b1", { lifecycle: "deprecated", usageCount: 5 });
+      expect(updateResult.ok).toBe(true);
+
+      const loadResult = await store.load("b1");
+      expect(loadResult.ok).toBe(true);
+      if (loadResult.ok) {
+        expect(loadResult.value.lifecycle).toBe("deprecated");
+        expect(loadResult.value.usageCount).toBe(5);
+        expect(loadResult.value.name).toBe("test-brick"); // unchanged
+      }
+    });
+
+    test("update returns NOT_FOUND for missing id", async () => {
+      const store = createStore();
+      const result = await store.update("nonexistent", { usageCount: 1 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    });
+
+    test("save with existing id overwrites", async () => {
+      const store = createStore();
+      await store.save(createBrick({ id: "b1", name: "original" }));
+      await store.save(createBrick({ id: "b1", name: "updated" }));
+
+      const result = await store.load("b1");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.name).toBe("updated");
+      }
+    });
+  });
+}

--- a/packages/forge/src/adversarial-verifiers.test.ts
+++ b/packages/forge/src/adversarial-verifiers.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAdversarialVerifiers,
+  createExfiltrationVerifier,
+  createInjectionVerifier,
+  createResourceExhaustionVerifier,
+} from "./adversarial-verifiers.js";
+import type { ForgeContext, ForgeInput, SandboxExecutor } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CTX: ForgeContext = {
+  agentId: "agent-1",
+  depth: 0,
+  sessionId: "session-1",
+  forgesThisSession: 0,
+};
+
+function safeToolInput(impl?: string): ForgeInput {
+  return {
+    kind: "tool",
+    name: "safeTool",
+    description: "A safe tool",
+    inputSchema: { type: "object" },
+    implementation: impl ?? "return { result: 'ok' };",
+  };
+}
+
+function skillInput(): ForgeInput {
+  return {
+    kind: "skill",
+    name: "mySkill",
+    description: "A skill",
+    content: "# Hello",
+  };
+}
+
+/** Executor that returns input as output (echo). */
+function echoExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, input, _timeout) => ({
+      ok: true as const,
+      value: { output: input, durationMs: 1 },
+    }),
+  };
+}
+
+/** Executor that returns a fixed output. */
+function fixedExecutor(output: unknown): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: true as const,
+      value: { output, durationMs: 1 },
+    }),
+  };
+}
+
+/** Executor that always times out. */
+function timeoutExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: false as const,
+      error: { code: "TIMEOUT" as const, message: "timed out", durationMs: 5000 },
+    }),
+  };
+}
+
+/** Executor that always OOMs. */
+function oomExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: false as const,
+      error: { code: "OOM" as const, message: "out of memory", durationMs: 100 },
+    }),
+  };
+}
+
+/** Executor that crashes. */
+function crashExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: false as const,
+      error: { code: "CRASH" as const, message: "crash", durationMs: 1 },
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Injection verifier
+// ---------------------------------------------------------------------------
+
+describe("createInjectionVerifier", () => {
+  test("passes when tool returns clean output", async () => {
+    const verifier = createInjectionVerifier(fixedExecutor({ result: "clean" }));
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails when tool returns proto-polluted output", async () => {
+    const verifier = createInjectionVerifier(fixedExecutor({ polluted: true }));
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("prototype pollution");
+  });
+
+  test("passes when tool crashes on injection (sandbox caught it)", async () => {
+    const verifier = createInjectionVerifier(crashExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+
+  test("skips for non-tool inputs", async () => {
+    const verifier = createInjectionVerifier(echoExecutor());
+    const result = await verifier.verify(skillInput(), CTX);
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Skipped");
+  });
+
+  test("detects nested proto pollution", async () => {
+    const verifier = createInjectionVerifier(
+      fixedExecutor({ data: { nested: { polluted: true } } }),
+    );
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource exhaustion verifier
+// ---------------------------------------------------------------------------
+
+describe("createResourceExhaustionVerifier", () => {
+  test("passes when tool handles large inputs gracefully", async () => {
+    const verifier = createResourceExhaustionVerifier(fixedExecutor({ result: "ok" }));
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails when tool OOMs on large input", async () => {
+    const verifier = createResourceExhaustionVerifier(oomExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("OOM");
+  });
+
+  test("fails when tool times out on large input", async () => {
+    const verifier = createResourceExhaustionVerifier(timeoutExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("TIMEOUT");
+  });
+
+  test("passes when tool crashes (sandbox caught it)", async () => {
+    const verifier = createResourceExhaustionVerifier(crashExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+
+  test("skips for non-tool inputs", async () => {
+    const verifier = createResourceExhaustionVerifier(echoExecutor());
+    const result = await verifier.verify(skillInput(), CTX);
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Skipped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exfiltration verifier
+// ---------------------------------------------------------------------------
+
+describe("createExfiltrationVerifier", () => {
+  test("passes when tool does not leak sensitive input", async () => {
+    const verifier = createExfiltrationVerifier(fixedExecutor({ result: "clean" }));
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+
+  test("fails when tool echoes secret values", async () => {
+    // Echo executor returns input as output — leaks secrets
+    const verifier = createExfiltrationVerifier(echoExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("Exfiltration detected");
+  });
+
+  test("fails when output contains sensitive patterns", async () => {
+    const verifier = createExfiltrationVerifier(
+      fixedExecutor({ data: "Bearer eyJhbGciOiJIUzI1NiJ9.test" }),
+    );
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("sensitive pattern");
+  });
+
+  test("fails when output contains password pattern", async () => {
+    const verifier = createExfiltrationVerifier(
+      fixedExecutor({ config: "password: my_secret_123" }),
+    );
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("sensitive pattern");
+  });
+
+  test("skips for non-tool inputs", async () => {
+    const verifier = createExfiltrationVerifier(echoExecutor());
+    const result = await verifier.verify(skillInput(), CTX);
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Skipped");
+  });
+
+  test("passes when tool crashes (no output to check)", async () => {
+    const verifier = createExfiltrationVerifier(crashExecutor());
+    const result = await verifier.verify(safeToolInput(), CTX);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAdversarialVerifiers (factory)
+// ---------------------------------------------------------------------------
+
+describe("createAdversarialVerifiers", () => {
+  test("returns 3 verifiers", () => {
+    const verifiers = createAdversarialVerifiers(echoExecutor());
+    expect(verifiers).toHaveLength(3);
+  });
+
+  test("all verifiers have unique names", () => {
+    const verifiers = createAdversarialVerifiers(echoExecutor());
+    const names = verifiers.map((v) => v.name);
+    expect(new Set(names).size).toBe(3);
+  });
+
+  test("verifier names follow adversarial: prefix", () => {
+    const verifiers = createAdversarialVerifiers(echoExecutor());
+    for (const v of verifiers) {
+      expect(v.name).toMatch(/^adversarial:/);
+    }
+  });
+});

--- a/packages/forge/src/adversarial-verifiers.ts
+++ b/packages/forge/src/adversarial-verifiers.ts
@@ -1,0 +1,229 @@
+/**
+ * Built-in adversarial ForgeVerifier implementations.
+ *
+ * Three categories of adversarial probes:
+ * 1. Injection — malicious input strings (__proto__, SQL injection, path traversal)
+ * 2. Resource exhaustion — deeply nested or very large inputs
+ * 3. Exfiltration — checks that outputs don't leak sensitive data
+ */
+
+import type {
+  ForgeContext,
+  ForgeInput,
+  ForgeVerifier,
+  SandboxExecutor,
+  VerifierResult,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INJECTION_PROBE_TIMEOUT_MS = 3_000;
+const RESOURCE_EXHAUSTION_TIMEOUT_MS = 5_000;
+const EXFILTRATION_PROBE_TIMEOUT_MS = 3_000;
+
+// ---------------------------------------------------------------------------
+// Injection probe verifier
+// ---------------------------------------------------------------------------
+
+const INJECTION_PAYLOADS: readonly Record<string, unknown>[] = [
+  { __proto__: { polluted: true } },
+  { constructor: { prototype: { polluted: true } } },
+  { key: "'; DROP TABLE users; --" },
+  { key: "<script>alert(1)</script>" },
+  { key: "{{7*7}}" },
+  { path: "../../../etc/passwd" },
+  { path: "..\\..\\..\\windows\\system32" },
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional injection test payload
+  { key: "${process.env.SECRET}" },
+  { key: "() => { while(true) {} }" },
+];
+
+function createInjectionVerifier(executor: SandboxExecutor): ForgeVerifier {
+  return {
+    name: "adversarial:injection",
+    verify: async (input: ForgeInput, _context: ForgeContext): Promise<VerifierResult> => {
+      if (input.kind !== "tool") {
+        return { passed: true, message: "Skipped: not a tool" };
+      }
+
+      for (const payload of INJECTION_PAYLOADS) {
+        const result = await executor.execute(
+          input.implementation,
+          payload,
+          INJECTION_PROBE_TIMEOUT_MS,
+        );
+
+        // A crash from injection is acceptable (defense in depth).
+        // What we're checking is that the tool doesn't return polluted data.
+        if (result.ok) {
+          const output = result.value.output;
+          if (hasProtoPollution(output)) {
+            return {
+              passed: false,
+              message: `Injection probe detected prototype pollution with payload: ${JSON.stringify(payload)}`,
+            };
+          }
+        }
+      }
+
+      return { passed: true, message: "All injection probes passed" };
+    },
+  };
+}
+
+function hasProtoPollution(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+
+  // Handle arrays — check each element
+  if (Array.isArray(value)) {
+    return value.some((item) => hasProtoPollution(item));
+  }
+
+  const obj = value as Record<string, unknown>;
+  if ("polluted" in obj && obj.polluted === true) return true;
+
+  for (const key of Object.keys(obj)) {
+    if (hasProtoPollution(obj[key])) return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Resource exhaustion verifier
+// ---------------------------------------------------------------------------
+
+function buildDeeplyNested(depth: number): Record<string, unknown> {
+  // Iterative to avoid stack overflow at depth 100+
+  let current: Record<string, unknown> = { value: "leaf" };
+  for (let i = 0; i < depth; i++) {
+    current = { nested: current };
+  }
+  return current;
+}
+
+function buildWideObject(width: number): Record<string, unknown> {
+  return Object.fromEntries(Array.from({ length: width }, (_, i) => [`key_${i}`, `value_${i}`]));
+}
+
+const EXHAUSTION_PAYLOADS: readonly {
+  readonly name: string;
+  readonly input: unknown;
+}[] = [
+  { name: "deeply-nested-100", input: buildDeeplyNested(100) },
+  { name: "wide-object-1000", input: buildWideObject(1_000) },
+  { name: "large-string", input: { data: "x".repeat(100_000) } },
+  { name: "large-array", input: { items: Array.from({ length: 10_000 }, (_, i) => i) } },
+];
+
+function createResourceExhaustionVerifier(executor: SandboxExecutor): ForgeVerifier {
+  return {
+    name: "adversarial:resource_exhaustion",
+    verify: async (input: ForgeInput, _context: ForgeContext): Promise<VerifierResult> => {
+      if (input.kind !== "tool") {
+        return { passed: true, message: "Skipped: not a tool" };
+      }
+
+      for (const payload of EXHAUSTION_PAYLOADS) {
+        const result = await executor.execute(
+          input.implementation,
+          payload.input,
+          RESOURCE_EXHAUSTION_TIMEOUT_MS,
+        );
+
+        // OOM or TIMEOUT from resource exhaustion probes → verifier rejects
+        if (!result.ok) {
+          if (result.error.code === "OOM" || result.error.code === "TIMEOUT") {
+            return {
+              passed: false,
+              message: `Resource exhaustion: tool ${result.error.code} on "${payload.name}" probe`,
+            };
+          }
+          // CRASH or PERMISSION errors are acceptable — the sandbox caught the issue
+        }
+      }
+
+      return { passed: true, message: "All resource exhaustion probes passed" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exfiltration verifier
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_PATTERNS: readonly RegExp[] = [
+  /process\.env/i,
+  /PRIVATE.KEY/i,
+  /BEGIN RSA/i,
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/,
+  /password\s*[:=]\s*\S+/i,
+  /secret\s*[:=]\s*\S+/i,
+  /api[_-]?key\s*[:=]\s*\S+/i,
+];
+
+const EXFILTRATION_INPUTS: readonly Record<string, unknown>[] = [
+  { secret: "SUPER_SECRET_VALUE_12345", data: "normal" },
+  { apiKey: "sk-test-1234567890", query: "hello" },
+  { password: "hunter2", username: "admin" },
+];
+
+function createExfiltrationVerifier(executor: SandboxExecutor): ForgeVerifier {
+  return {
+    name: "adversarial:exfiltration",
+    verify: async (input: ForgeInput, _context: ForgeContext): Promise<VerifierResult> => {
+      if (input.kind !== "tool") {
+        return { passed: true, message: "Skipped: not a tool" };
+      }
+
+      for (const testInput of EXFILTRATION_INPUTS) {
+        const result = await executor.execute(
+          input.implementation,
+          testInput,
+          EXFILTRATION_PROBE_TIMEOUT_MS,
+        );
+
+        if (result.ok) {
+          const outputStr = JSON.stringify(result.value.output);
+
+          // Check if the output contains known sensitive values from input
+          const secretValue = testInput.secret ?? testInput.apiKey ?? testInput.password;
+          if (typeof secretValue === "string" && outputStr.includes(secretValue)) {
+            return {
+              passed: false,
+              message: `Exfiltration detected: output contains sensitive input value "${secretValue.slice(0, 10)}..."`,
+            };
+          }
+
+          // Check for common sensitive patterns in output
+          for (const pattern of SENSITIVE_PATTERNS) {
+            if (pattern.test(outputStr)) {
+              return {
+                passed: false,
+                message: `Exfiltration risk: output matches sensitive pattern ${pattern.source}`,
+              };
+            }
+          }
+        }
+      }
+
+      return { passed: true, message: "All exfiltration probes passed" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createAdversarialVerifiers(executor: SandboxExecutor): readonly ForgeVerifier[] {
+  return [
+    createInjectionVerifier(executor),
+    createResourceExhaustionVerifier(executor),
+    createExfiltrationVerifier(executor),
+  ];
+}
+
+export { createInjectionVerifier, createResourceExhaustionVerifier, createExfiltrationVerifier };

--- a/packages/forge/src/config.test.ts
+++ b/packages/forge/src/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "./config.js";
+
+describe("createDefaultForgeConfig", () => {
+  test("returns defaults when no overrides", () => {
+    const config = createDefaultForgeConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.maxForgeDepth).toBe(1);
+    expect(config.maxForgesPerSession).toBe(5);
+    expect(config.defaultScope).toBe("agent");
+    expect(config.defaultTrustTier).toBe("sandbox");
+  });
+
+  test("returns defaults for nested scopePromotion", () => {
+    const config = createDefaultForgeConfig();
+    expect(config.scopePromotion.requireHumanApproval).toBe(true);
+    expect(config.scopePromotion.minTrustForZone).toBe("verified");
+    expect(config.scopePromotion.minTrustForGlobal).toBe("promoted");
+  });
+
+  test("returns defaults for nested verification", () => {
+    const config = createDefaultForgeConfig();
+    expect(config.verification.staticTimeoutMs).toBe(1_000);
+    expect(config.verification.sandboxTimeoutMs).toBe(5_000);
+    expect(config.verification.selfTestTimeoutMs).toBe(10_000);
+    expect(config.verification.totalTimeoutMs).toBe(30_000);
+    expect(config.verification.maxBrickSizeBytes).toBe(50_000);
+  });
+
+  test("overrides top-level fields", () => {
+    const config = createDefaultForgeConfig({ enabled: false, maxForgeDepth: 3 });
+    expect(config.enabled).toBe(false);
+    expect(config.maxForgeDepth).toBe(3);
+    expect(config.maxForgesPerSession).toBe(5); // unchanged
+  });
+
+  test("overrides nested scopePromotion", () => {
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: false,
+        minTrustForZone: "sandbox",
+        minTrustForGlobal: "verified",
+      },
+    });
+    expect(config.scopePromotion.requireHumanApproval).toBe(false);
+    expect(config.scopePromotion.minTrustForZone).toBe("sandbox");
+    expect(config.scopePromotion.minTrustForGlobal).toBe("verified");
+  });
+
+  test("overrides nested verification", () => {
+    const config = createDefaultForgeConfig({
+      verification: {
+        staticTimeoutMs: 500,
+        sandboxTimeoutMs: 2_000,
+        selfTestTimeoutMs: 5_000,
+        totalTimeoutMs: 15_000,
+        maxBrickSizeBytes: 25_000,
+      },
+    });
+    expect(config.verification.sandboxTimeoutMs).toBe(2_000);
+    expect(config.verification.maxBrickSizeBytes).toBe(25_000);
+  });
+
+  test("returns new object each time", () => {
+    const a = createDefaultForgeConfig();
+    const b = createDefaultForgeConfig();
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/forge/src/config.ts
+++ b/packages/forge/src/config.ts
@@ -1,0 +1,79 @@
+/**
+ * Forge configuration — required fields with factory defaults.
+ */
+
+import type { ForgeScope, TrustTier } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Configuration interfaces
+// ---------------------------------------------------------------------------
+
+export interface ScopePromotionConfig {
+  readonly requireHumanApproval: boolean;
+  readonly minTrustForZone: TrustTier;
+  readonly minTrustForGlobal: TrustTier;
+}
+
+export interface VerificationConfig {
+  readonly staticTimeoutMs: number;
+  readonly sandboxTimeoutMs: number;
+  readonly selfTestTimeoutMs: number;
+  readonly totalTimeoutMs: number;
+  readonly maxBrickSizeBytes: number;
+}
+
+export interface ForgeConfig {
+  readonly enabled: boolean;
+  readonly maxForgeDepth: number;
+  readonly maxForgesPerSession: number;
+  readonly defaultScope: ForgeScope;
+  readonly defaultTrustTier: TrustTier;
+  readonly scopePromotion: ScopePromotionConfig;
+  readonly verification: VerificationConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SCOPE_PROMOTION: ScopePromotionConfig = {
+  requireHumanApproval: true,
+  minTrustForZone: "verified",
+  minTrustForGlobal: "promoted",
+} as const;
+
+const DEFAULT_VERIFICATION: VerificationConfig = {
+  staticTimeoutMs: 1_000,
+  sandboxTimeoutMs: 5_000,
+  selfTestTimeoutMs: 10_000,
+  totalTimeoutMs: 30_000,
+  maxBrickSizeBytes: 50_000,
+} as const;
+
+const DEFAULT_CONFIG: ForgeConfig = {
+  enabled: true,
+  maxForgeDepth: 1,
+  maxForgesPerSession: 5,
+  defaultScope: "agent",
+  defaultTrustTier: "sandbox",
+  scopePromotion: DEFAULT_SCOPE_PROMOTION,
+  verification: DEFAULT_VERIFICATION,
+} as const;
+
+export function createDefaultForgeConfig(overrides?: Partial<ForgeConfig>): ForgeConfig {
+  if (overrides === undefined) {
+    return DEFAULT_CONFIG;
+  }
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides,
+    scopePromotion:
+      overrides.scopePromotion !== undefined
+        ? { ...DEFAULT_SCOPE_PROMOTION, ...overrides.scopePromotion }
+        : DEFAULT_SCOPE_PROMOTION,
+    verification:
+      overrides.verification !== undefined
+        ? { ...DEFAULT_VERIFICATION, ...overrides.verification }
+        : DEFAULT_VERIFICATION,
+  };
+}

--- a/packages/forge/src/errors.test.ts
+++ b/packages/forge/src/errors.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import type { ForgeError } from "./errors.js";
+import {
+  governanceError,
+  sandboxError,
+  selfTestError,
+  staticError,
+  storeError,
+  trustError,
+} from "./errors.js";
+
+describe("staticError", () => {
+  test("creates error with stage 'static'", () => {
+    const err = staticError("INVALID_NAME", "bad name");
+    expect(err.stage).toBe("static");
+    expect(err.code).toBe("INVALID_NAME");
+    expect(err.message).toBe("bad name");
+  });
+});
+
+describe("sandboxError", () => {
+  test("creates error with stage 'sandbox'", () => {
+    const err = sandboxError("TIMEOUT", "timed out", 5000);
+    expect(err.stage).toBe("sandbox");
+    expect(err.code).toBe("TIMEOUT");
+    if (err.stage === "sandbox") {
+      expect(err.durationMs).toBe(5000);
+    }
+  });
+
+  test("omits durationMs when undefined", () => {
+    const err = sandboxError("CRASH", "crashed");
+    expect(err.stage).toBe("sandbox");
+    if (err.stage === "sandbox") {
+      expect(err.durationMs).toBeUndefined();
+    }
+  });
+});
+
+describe("selfTestError", () => {
+  test("creates error with failures", () => {
+    const failures = [{ testName: "t1", expected: 1, actual: 2 }];
+    const err = selfTestError("TEST_FAILED", "1 failed", failures);
+    expect(err.stage).toBe("self_test");
+    if (err.stage === "self_test") {
+      expect(err.failures).toHaveLength(1);
+    }
+  });
+
+  test("omits failures when undefined", () => {
+    const err = selfTestError("VERIFIER_REJECTED", "rejected");
+    if (err.stage === "self_test") {
+      expect(err.failures).toBeUndefined();
+    }
+  });
+});
+
+describe("trustError", () => {
+  test("creates error with stage 'trust'", () => {
+    const err = trustError("GOVERNANCE_REJECTED", "rejected");
+    expect(err.stage).toBe("trust");
+    expect(err.code).toBe("GOVERNANCE_REJECTED");
+  });
+});
+
+describe("governanceError", () => {
+  test("creates error with stage 'governance'", () => {
+    const err = governanceError("FORGE_DISABLED", "disabled");
+    expect(err.stage).toBe("governance");
+    expect(err.code).toBe("FORGE_DISABLED");
+  });
+});
+
+describe("storeError", () => {
+  test("creates error with stage 'store'", () => {
+    const err = storeError("SAVE_FAILED", "disk full");
+    expect(err.stage).toBe("store");
+    expect(err.code).toBe("SAVE_FAILED");
+    expect(err.message).toBe("disk full");
+  });
+
+  test("supports all store error codes", () => {
+    expect(storeError("LOAD_FAILED", "not found").code).toBe("LOAD_FAILED");
+    expect(storeError("SEARCH_FAILED", "error").code).toBe("SEARCH_FAILED");
+  });
+});
+
+describe("ForgeError discriminant narrowing", () => {
+  test("narrows to static variant", () => {
+    const err: ForgeError = staticError("INVALID_SCHEMA", "bad schema");
+    if (err.stage === "static") {
+      expect(err.code).toBe("INVALID_SCHEMA");
+    }
+  });
+
+  test("narrows to sandbox variant with durationMs", () => {
+    const err: ForgeError = sandboxError("OOM", "oom", 3000);
+    if (err.stage === "sandbox") {
+      expect(err.durationMs).toBe(3000);
+    }
+  });
+
+  test("narrows to self_test variant with failures", () => {
+    const err: ForgeError = selfTestError("TEST_FAILED", "fail", [
+      { testName: "t", expected: 1, actual: 2 },
+    ]);
+    if (err.stage === "self_test") {
+      expect(err.failures).toBeDefined();
+    }
+  });
+});

--- a/packages/forge/src/errors.ts
+++ b/packages/forge/src/errors.ts
@@ -1,0 +1,104 @@
+/**
+ * Forge error types — discriminated union with per-stage variants.
+ */
+
+// ---------------------------------------------------------------------------
+// Test failure detail
+// ---------------------------------------------------------------------------
+
+export interface TestFailure {
+  readonly testName: string;
+  readonly expected: unknown;
+  readonly actual: unknown;
+  readonly error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ForgeError discriminated union
+// ---------------------------------------------------------------------------
+
+export type ForgeError =
+  | {
+      readonly stage: "static";
+      readonly code: "INVALID_SCHEMA" | "INVALID_NAME" | "SIZE_EXCEEDED" | "MISSING_FIELD";
+      readonly message: string;
+    }
+  | {
+      readonly stage: "sandbox";
+      readonly code: "TIMEOUT" | "OOM" | "CRASH" | "PERMISSION";
+      readonly message: string;
+      readonly durationMs?: number;
+    }
+  | {
+      readonly stage: "self_test";
+      readonly code: "TEST_FAILED" | "VERIFIER_REJECTED";
+      readonly message: string;
+      readonly failures?: readonly TestFailure[];
+    }
+  | {
+      readonly stage: "trust";
+      readonly code: "GOVERNANCE_REJECTED" | "RATE_LIMITED" | "DEPTH_EXCEEDED";
+      readonly message: string;
+    }
+  | {
+      readonly stage: "governance";
+      readonly code: "FORGE_DISABLED" | "MAX_DEPTH" | "MAX_SESSION_FORGES" | "SCOPE_VIOLATION";
+      readonly message: string;
+    }
+  | {
+      readonly stage: "store";
+      readonly code: "SAVE_FAILED" | "LOAD_FAILED" | "SEARCH_FAILED";
+      readonly message: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+export function staticError(
+  code: Extract<ForgeError, { readonly stage: "static" }>["code"],
+  message: string,
+): ForgeError {
+  return { stage: "static", code, message };
+}
+
+export function sandboxError(
+  code: Extract<ForgeError, { readonly stage: "sandbox" }>["code"],
+  message: string,
+  durationMs?: number,
+): ForgeError {
+  return durationMs !== undefined
+    ? { stage: "sandbox", code, message, durationMs }
+    : { stage: "sandbox", code, message };
+}
+
+export function selfTestError(
+  code: Extract<ForgeError, { readonly stage: "self_test" }>["code"],
+  message: string,
+  failures?: readonly TestFailure[],
+): ForgeError {
+  return failures !== undefined
+    ? { stage: "self_test", code, message, failures }
+    : { stage: "self_test", code, message };
+}
+
+export function trustError(
+  code: Extract<ForgeError, { readonly stage: "trust" }>["code"],
+  message: string,
+): ForgeError {
+  return { stage: "trust", code, message };
+}
+
+export function governanceError(
+  code: Extract<ForgeError, { readonly stage: "governance" }>["code"],
+  message: string,
+): ForgeError {
+  return { stage: "governance", code, message };
+}
+
+export function storeError(
+  code: Extract<ForgeError, { readonly stage: "store" }>["code"],
+  message: string,
+): ForgeError {
+  return { stage: "store", code, message };
+}

--- a/packages/forge/src/forge-component-provider.test.ts
+++ b/packages/forge/src/forge-component-provider.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, test } from "bun:test";
+import type { Agent, SubsystemToken } from "@koi/core";
+import { toolToken } from "@koi/core";
+import { brickToTool, createForgeComponentProviderAsync } from "./forge-component-provider.js";
+import { createInMemoryForgeStore } from "./memory-store.js";
+import type { BrickArtifact, SandboxExecutor } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockAgent(): Agent {
+  const components = new Map<string, unknown>();
+  return {
+    pid: { id: "agent-1", name: "test", type: "worker", depth: 0 },
+    manifest: {
+      name: "test-agent",
+      version: "0.0.0",
+      model: { name: "test-model" },
+    },
+    state: "running",
+    component: <T>(token: { toString: () => string }): T | undefined =>
+      components.get(token.toString()) as T | undefined,
+    has: (token: { toString: () => string }): boolean => components.has(token.toString()),
+    hasAll: (...tokens: readonly { toString: () => string }[]): boolean =>
+      tokens.every((t) => components.has(t.toString())),
+    query: <T>(_prefix: string): ReadonlyMap<SubsystemToken<T>, T> => new Map(),
+    components: (): ReadonlyMap<string, unknown> => components,
+  };
+}
+
+function createToolBrick(overrides?: Partial<BrickArtifact>): BrickArtifact {
+  return {
+    id: `brick_${crypto.randomUUID()}`,
+    kind: "tool",
+    name: "calc",
+    description: "A calculator",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: "return input.a + input.b;",
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+/** Create a brick with no implementation (for testing missing impl). */
+function createBrickWithoutImpl(
+  overrides?: Partial<Omit<BrickArtifact, "implementation">>,
+): BrickArtifact {
+  return {
+    id: `brick_${crypto.randomUUID()}`,
+    kind: "tool",
+    name: "calc",
+    description: "A calculator",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+function echoExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, input, _timeout) => ({
+      ok: true as const,
+      value: { output: input, durationMs: 1 },
+    }),
+  };
+}
+
+function failExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: false as const,
+      error: { code: "CRASH" as const, message: "boom", durationMs: 1 },
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// brickToTool
+// ---------------------------------------------------------------------------
+
+describe("brickToTool", () => {
+  test("converts brick to executable tool", async () => {
+    const brick = createToolBrick();
+    const tool = brickToTool(brick, echoExecutor(), 5000);
+
+    expect(tool.descriptor.name).toBe("calc");
+    expect(tool.descriptor.description).toBe("A calculator");
+    expect(tool.trustTier).toBe("sandbox");
+
+    const result = await tool.execute({ a: 1, b: 2 });
+    expect(result).toEqual({ a: 1, b: 2 }); // echo executor returns input
+  });
+
+  test("returns error when brick has no implementation", async () => {
+    const brick = createBrickWithoutImpl();
+    const tool = brickToTool(brick, echoExecutor(), 5000);
+
+    const result = (await tool.execute({})) as {
+      readonly ok: false;
+      readonly error: { readonly code: string };
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("NO_IMPLEMENTATION");
+  });
+
+  test("returns error when sandbox fails", async () => {
+    const brick = createToolBrick();
+    const tool = brickToTool(brick, failExecutor(), 5000);
+
+    const result = (await tool.execute({})) as {
+      readonly ok: false;
+      readonly error: { readonly code: string; readonly message: string };
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("CRASH");
+    expect(result.error.message).toContain("calc");
+  });
+
+  test("preserves trust tier from brick", async () => {
+    const brick = createToolBrick({ trustTier: "verified" });
+    const tool = brickToTool(brick, echoExecutor(), 5000);
+    expect(tool.trustTier).toBe("verified");
+  });
+
+  test("uses default schema when brick has none", async () => {
+    const brick = createBrickWithoutImpl();
+    const tool = brickToTool(brick, echoExecutor(), 5000);
+    expect(tool.descriptor.inputSchema).toEqual({ type: "object" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createForgeComponentProviderAsync
+// ---------------------------------------------------------------------------
+
+describe("createForgeComponentProviderAsync", () => {
+  test("attaches tool bricks as components", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "add" }));
+    await store.save(createToolBrick({ name: "subtract" }));
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    expect(provider.name).toBe("forge");
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(2);
+
+    const addToken = toolToken("add") as string;
+    const subToken = toolToken("subtract") as string;
+    expect(components.has(addToken)).toBe(true);
+    expect(components.has(subToken)).toBe(true);
+  });
+
+  test("returns empty map when store is empty", async () => {
+    const store = createInMemoryForgeStore();
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(0);
+  });
+
+  test("skips non-tool bricks", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "myTool" }));
+    // Save a skill brick (no implementation, has content)
+    const skillBrick: BrickArtifact = {
+      id: `brick_${crypto.randomUUID()}`,
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      content: "# Skill",
+    };
+    await store.save(skillBrick);
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(1);
+  });
+
+  test("skips tool bricks without implementation", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "withImpl" }));
+    await store.save(createBrickWithoutImpl({ name: "noImpl" }));
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(1);
+  });
+
+  test("only loads active bricks", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "b1", name: "active" }));
+    await store.save(createToolBrick({ id: "b2", name: "deprecated", lifecycle: "deprecated" }));
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(1);
+  });
+
+  test("uses custom timeout", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "myTool" }));
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+      sandboxTimeoutMs: 10_000,
+    });
+
+    const components = provider.attach(createMockAgent());
+    expect(components.size).toBe(1);
+  });
+
+  test("throws when store search fails", async () => {
+    const failingStore = {
+      save: async () => ({ ok: true as const, value: undefined }),
+      load: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+      search: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "store unavailable", retryable: false },
+      }),
+      remove: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+      update: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+    };
+
+    await expect(
+      createForgeComponentProviderAsync({ store: failingStore, executor: echoExecutor() }),
+    ).rejects.toThrow("store unavailable");
+  });
+
+  test("attached tool is executable", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "echo" }));
+
+    const provider = await createForgeComponentProviderAsync({
+      store,
+      executor: echoExecutor(),
+    });
+
+    const components = provider.attach(createMockAgent());
+    const token = toolToken("echo") as string;
+    const tool = components.get(token) as { execute: (input: unknown) => Promise<unknown> };
+
+    const result = await tool.execute({ hello: "world" });
+    expect(result).toEqual({ hello: "world" });
+  });
+});

--- a/packages/forge/src/forge-component-provider.ts
+++ b/packages/forge/src/forge-component-provider.ts
@@ -1,0 +1,115 @@
+/**
+ * ForgeComponentProvider — attaches forged tools as components to agents.
+ *
+ * Implements the L0 ComponentProvider interface. On attach, it discovers all
+ * active tool bricks from the ForgeStore and wraps each as an executable Tool
+ * that runs in the sandbox.
+ */
+
+import type { Agent, ComponentProvider, JsonObject, Tool, ToolDescriptor } from "@koi/core";
+import { toolToken } from "@koi/core";
+import type { ForgeStore } from "./store.js";
+import type { BrickArtifact, SandboxExecutor } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SANDBOX_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Brick → Tool conversion
+// ---------------------------------------------------------------------------
+
+function brickToTool(brick: BrickArtifact, executor: SandboxExecutor, timeoutMs: number): Tool {
+  const descriptor: ToolDescriptor = {
+    name: brick.name,
+    description: brick.description,
+    inputSchema: brick.inputSchema ?? { type: "object" },
+  };
+
+  const execute = async (input: JsonObject): Promise<unknown> => {
+    if (brick.implementation === undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "NO_IMPLEMENTATION",
+          message: `Brick "${brick.name}" has no implementation`,
+        },
+      };
+    }
+
+    const result = await executor.execute(brick.implementation, input, timeoutMs);
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: {
+          code: result.error.code,
+          message: `Forged tool "${brick.name}" failed: ${result.error.message}`,
+        },
+      };
+    }
+    return result.value.output;
+  };
+
+  return {
+    descriptor,
+    trustTier: brick.trustTier,
+    execute,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ForgeComponentProviderConfig {
+  readonly store: ForgeStore;
+  readonly executor: SandboxExecutor;
+  readonly sandboxTimeoutMs?: number;
+}
+
+/**
+ * Async factory that pre-loads tools from the store, then returns
+ * a ComponentProvider whose attach() is already populated.
+ *
+ * Note: The L0 ComponentProvider.attach() is synchronous, but ForgeStore
+ * is async. This factory resolves the async gap by pre-loading tools
+ * before returning the provider.
+ *
+ * The same tool instances are shared across all attach() calls for efficiency.
+ * Forged tools are stateless — state lives in the sandbox execution context.
+ */
+export async function createForgeComponentProviderAsync(
+  config: ForgeComponentProviderConfig,
+): Promise<ComponentProvider> {
+  const timeoutMs = config.sandboxTimeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS;
+
+  // Load all active tool bricks
+  const searchResult = await config.store.search({
+    kind: "tool",
+    lifecycle: "active",
+  });
+
+  if (!searchResult.ok) {
+    throw new Error(`ForgeComponentProvider: failed to load tools: ${searchResult.error.message}`);
+  }
+
+  const tools: Map<string, unknown> = new Map();
+  for (const brick of searchResult.value) {
+    if (brick.kind === "tool" && brick.implementation !== undefined) {
+      const token = toolToken(brick.name);
+      const tool = brickToTool(brick, config.executor, timeoutMs);
+      tools.set(token as string, tool);
+    }
+  }
+
+  return {
+    name: "forge",
+    attach: (_agent: Agent): ReadonlyMap<string, unknown> => {
+      return tools;
+    },
+  };
+}
+
+export { brickToTool };

--- a/packages/forge/src/forge-resolver.test.ts
+++ b/packages/forge/src/forge-resolver.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { createForgeResolver } from "./forge-resolver.js";
+import { createInMemoryForgeStore } from "./memory-store.js";
+import type { BrickArtifact } from "./types.js";
+
+function createBrick(overrides?: Partial<BrickArtifact>): BrickArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: "return 1;",
+    ...overrides,
+  };
+}
+
+describe("createForgeResolver", () => {
+  test("discover returns all bricks", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1" }));
+    await store.save(createBrick({ id: "b2" }));
+
+    const resolver = createForgeResolver(store);
+    const results = await resolver.discover();
+    expect(results).toHaveLength(2);
+  });
+
+  test("discover returns empty when store is empty", async () => {
+    const store = createInMemoryForgeStore();
+    const resolver = createForgeResolver(store);
+    const results = await resolver.discover();
+    expect(results).toHaveLength(0);
+  });
+
+  test("load returns brick by id", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", name: "my-tool" }));
+
+    const resolver = createForgeResolver(store);
+    const result = await resolver.load("b1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.name).toBe("my-tool");
+    }
+  });
+
+  test("load returns NOT_FOUND for missing id", async () => {
+    const store = createInMemoryForgeStore();
+    const resolver = createForgeResolver(store);
+    const result = await resolver.load("nonexistent");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+});

--- a/packages/forge/src/forge-resolver.ts
+++ b/packages/forge/src/forge-resolver.ts
@@ -1,0 +1,28 @@
+/**
+ * ForgeResolver — Resolver adapter backed by a ForgeStore.
+ * Implements the L0 Resolver<BrickArtifact, BrickArtifact> interface.
+ */
+
+import type { KoiError, Resolver, Result } from "@koi/core";
+import type { ForgeStore } from "./store.js";
+import type { BrickArtifact } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createForgeResolver(store: ForgeStore): Resolver<BrickArtifact, BrickArtifact> {
+  const discover = async (): Promise<readonly BrickArtifact[]> => {
+    const result = await store.search({});
+    if (result.ok) {
+      return result.value;
+    }
+    return [];
+  };
+
+  const load = async (id: string): Promise<Result<BrickArtifact, KoiError>> => {
+    return store.load(id);
+  };
+
+  return { discover, load };
+}

--- a/packages/forge/src/governance.test.ts
+++ b/packages/forge/src/governance.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "./config.js";
+import { checkGovernance, checkScopePromotion } from "./governance.js";
+import type { ForgeContext } from "./types.js";
+
+const DEFAULT_CONTEXT: ForgeContext = {
+  agentId: "agent-1",
+  depth: 0,
+  sessionId: "session-1",
+  forgesThisSession: 0,
+};
+
+describe("checkGovernance", () => {
+  test("passes with default config and fresh context", () => {
+    const config = createDefaultForgeConfig();
+    const result = checkGovernance(DEFAULT_CONTEXT, config);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects when forge is disabled", () => {
+    const config = createDefaultForgeConfig({ enabled: false });
+    const result = checkGovernance(DEFAULT_CONTEXT, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("FORGE_DISABLED");
+    }
+  });
+
+  test("rejects when depth exceeds max", () => {
+    const config = createDefaultForgeConfig({ maxForgeDepth: 1 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, depth: 2 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("MAX_DEPTH");
+    }
+  });
+
+  test("allows depth equal to max", () => {
+    const config = createDefaultForgeConfig({ maxForgeDepth: 2 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, depth: 2 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects when session forges exceed max", () => {
+    const config = createDefaultForgeConfig({ maxForgesPerSession: 3 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, forgesThisSession: 3 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("MAX_SESSION_FORGES");
+    }
+  });
+
+  test("allows forges below max", () => {
+    const config = createDefaultForgeConfig({ maxForgesPerSession: 3 });
+    const context: ForgeContext = { ...DEFAULT_CONTEXT, forgesThisSession: 2 };
+    const result = checkGovernance(context, config);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("checkScopePromotion", () => {
+  test("allows same-scope (no promotion needed)", () => {
+    const config = createDefaultForgeConfig();
+    const result = checkScopePromotion("agent", "agent", "sandbox", config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.requiresHumanApproval).toBe(false);
+    }
+  });
+
+  test("allows downgrade (global to agent)", () => {
+    const config = createDefaultForgeConfig();
+    const result = checkScopePromotion("global", "agent", "sandbox", config);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects zone promotion with insufficient trust", () => {
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: false,
+        minTrustForZone: "verified",
+        minTrustForGlobal: "promoted",
+      },
+    });
+    const result = checkScopePromotion("agent", "zone", "sandbox", config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "governance") {
+      expect(result.error.code).toBe("SCOPE_VIOLATION");
+    }
+  });
+
+  test("allows zone promotion with sufficient trust", () => {
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: false,
+        minTrustForZone: "verified",
+        minTrustForGlobal: "promoted",
+      },
+    });
+    const result = checkScopePromotion("agent", "zone", "verified", config);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects global promotion with insufficient trust", () => {
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: false,
+        minTrustForZone: "sandbox",
+        minTrustForGlobal: "promoted",
+      },
+    });
+    const result = checkScopePromotion("agent", "global", "verified", config);
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns requiresHumanApproval when enabled", () => {
+    const config = createDefaultForgeConfig({
+      scopePromotion: {
+        requireHumanApproval: true,
+        minTrustForZone: "sandbox",
+        minTrustForGlobal: "sandbox",
+      },
+    });
+    const result = checkScopePromotion("agent", "zone", "sandbox", config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.requiresHumanApproval).toBe(true);
+      expect(result.value.message).toContain("human approval");
+    }
+  });
+});

--- a/packages/forge/src/governance.ts
+++ b/packages/forge/src/governance.ts
@@ -1,0 +1,125 @@
+/**
+ * Governance — depth-aware forge policies and scope promotion checks.
+ */
+
+import type { ForgeScope, Result, TrustTier } from "@koi/core";
+import type { ForgeConfig } from "./config.js";
+import type { ForgeError } from "./errors.js";
+import { governanceError } from "./errors.js";
+import type { ForgeContext } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Trust tier ordering (for comparison)
+// ---------------------------------------------------------------------------
+
+const TRUST_ORDER: Readonly<Record<TrustTier, number>> = {
+  sandbox: 0,
+  verified: 1,
+  promoted: 2,
+} as const;
+
+const SCOPE_ORDER: Readonly<Record<ForgeScope, number>> = {
+  agent: 0,
+  zone: 1,
+  global: 2,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Governance check result for HITL
+// ---------------------------------------------------------------------------
+
+export interface GovernanceResult {
+  readonly requiresHumanApproval: boolean;
+  readonly message?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function checkGovernance(
+  context: ForgeContext,
+  config: ForgeConfig,
+): Result<void, ForgeError> {
+  if (!config.enabled) {
+    return {
+      ok: false,
+      error: governanceError("FORGE_DISABLED", "Forge is disabled in configuration"),
+    };
+  }
+
+  if (context.depth > config.maxForgeDepth) {
+    return {
+      ok: false,
+      error: governanceError(
+        "MAX_DEPTH",
+        `Forge depth ${context.depth} exceeds max ${config.maxForgeDepth}`,
+      ),
+    };
+  }
+
+  if (context.forgesThisSession >= config.maxForgesPerSession) {
+    return {
+      ok: false,
+      error: governanceError(
+        "MAX_SESSION_FORGES",
+        `Session has reached max forges (${config.maxForgesPerSession})`,
+      ),
+    };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export function checkScopePromotion(
+  currentScope: ForgeScope,
+  targetScope: ForgeScope,
+  trustTier: TrustTier,
+  config: ForgeConfig,
+): Result<GovernanceResult, ForgeError> {
+  // No promotion needed if target is same or lower scope
+  if (SCOPE_ORDER[targetScope] <= SCOPE_ORDER[currentScope]) {
+    return { ok: true, value: { requiresHumanApproval: false } };
+  }
+
+  // Zone promotion
+  if (targetScope === "zone") {
+    const minTrust = config.scopePromotion.minTrustForZone;
+    if (TRUST_ORDER[trustTier] < TRUST_ORDER[minTrust]) {
+      return {
+        ok: false,
+        error: governanceError(
+          "SCOPE_VIOLATION",
+          `Zone promotion requires trust tier "${minTrust}" or higher, got "${trustTier}"`,
+        ),
+      };
+    }
+  }
+
+  // Global promotion
+  if (targetScope === "global") {
+    const minTrust = config.scopePromotion.minTrustForGlobal;
+    if (TRUST_ORDER[trustTier] < TRUST_ORDER[minTrust]) {
+      return {
+        ok: false,
+        error: governanceError(
+          "SCOPE_VIOLATION",
+          `Global promotion requires trust tier "${minTrust}" or higher, got "${trustTier}"`,
+        ),
+      };
+    }
+  }
+
+  // Check if HITL is required
+  if (config.scopePromotion.requireHumanApproval) {
+    return {
+      ok: true,
+      value: {
+        requiresHumanApproval: true,
+        message: `Scope promotion from "${currentScope}" to "${targetScope}" requires human approval`,
+      },
+    };
+  }
+
+  return { ok: true, value: { requiresHumanApproval: false } };
+}

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * @koi/forge — Self-extension system (Layer 2)
+ *
+ * Enables agents to create, discover, and compose tools, skills, and
+ * sub-agents at runtime through a 4-stage verification pipeline.
+ *
+ * Depends on @koi/core only — never on L1 or peer L2 packages.
+ */
+
+// runtime values — adversarial verifiers
+export {
+  createAdversarialVerifiers,
+  createExfiltrationVerifier,
+  createInjectionVerifier,
+  createResourceExhaustionVerifier,
+} from "./adversarial-verifiers.js";
+export type { ForgeConfig, ScopePromotionConfig, VerificationConfig } from "./config.js";
+// runtime values — config
+export { createDefaultForgeConfig } from "./config.js";
+export type { ForgeError, TestFailure } from "./errors.js";
+// runtime values — errors
+export {
+  governanceError,
+  sandboxError,
+  selfTestError,
+  staticError,
+  storeError,
+  trustError,
+} from "./errors.js";
+// runtime values — component provider
+export type { ForgeComponentProviderConfig } from "./forge-component-provider.js";
+export { brickToTool, createForgeComponentProviderAsync } from "./forge-component-provider.js";
+export { createForgeResolver } from "./forge-resolver.js";
+export type { GovernanceResult } from "./governance.js";
+// runtime values — governance
+export { checkGovernance, checkScopePromotion } from "./governance.js";
+// runtime values — storage
+export { createInMemoryForgeStore } from "./memory-store.js";
+export type { BrickUpdate, ForgeStore } from "./store.js";
+export { createComposeForgeTool } from "./tools/compose-forge.js";
+export { createForgeAgentTool } from "./tools/forge-agent.js";
+export { createForgeSkillTool } from "./tools/forge-skill.js";
+export { createForgeToolTool } from "./tools/forge-tool.js";
+export { createPromoteForgeTool } from "./tools/promote-forge.js";
+export { createSearchForgeTool } from "./tools/search-forge.js";
+export type { ForgeDeps, ForgeToolConfig } from "./tools/shared.js";
+
+// runtime values — primordial tools
+export { createForgeTool } from "./tools/shared.js";
+// types
+export type {
+  BrickArtifact,
+  ForgeAgentInput,
+  ForgeCompositeInput,
+  ForgeContext,
+  ForgeInput,
+  ForgeQuery,
+  ForgeResult,
+  ForgeResultMetadata,
+  ForgeSkillInput,
+  ForgeToolInput,
+  ForgeVerifier,
+  SandboxError,
+  SandboxErrorCode,
+  SandboxExecutor,
+  SandboxResult,
+  StageReport,
+  TestCase,
+  TrustStageReport,
+  VerificationReport,
+  VerificationStage,
+  VerifierResult,
+} from "./types.js";
+// runtime values — verification
+export { verify } from "./verify.js";
+export { verifySandbox } from "./verify-sandbox.js";
+export { verifySelfTest } from "./verify-self-test.js";
+export { verifyStatic } from "./verify-static.js";
+export { assignTrust } from "./verify-trust.js";

--- a/packages/forge/src/memory-store.test.ts
+++ b/packages/forge/src/memory-store.test.ts
@@ -1,0 +1,5 @@
+import { runForgeStoreContractTests } from "./__tests__/store-contract.js";
+import { createInMemoryForgeStore } from "./memory-store.js";
+
+// Run the full contract test suite against InMemoryForgeStore
+runForgeStoreContractTests(createInMemoryForgeStore);

--- a/packages/forge/src/memory-store.ts
+++ b/packages/forge/src/memory-store.ts
@@ -1,0 +1,103 @@
+/**
+ * InMemoryForgeStore — simple Map-based store for tests and development.
+ * No eviction, no persistence across restarts.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import type { BrickUpdate, ForgeStore } from "./store.js";
+import type { BrickArtifact, ForgeQuery } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function notFoundError(id: string): KoiError {
+  return { code: "NOT_FOUND", message: `Brick not found: ${id}`, retryable: false };
+}
+
+function matchesQuery(brick: BrickArtifact, query: ForgeQuery): boolean {
+  if (query.kind !== undefined && brick.kind !== query.kind) {
+    return false;
+  }
+  if (query.scope !== undefined && brick.scope !== query.scope) {
+    return false;
+  }
+  if (query.trustTier !== undefined && brick.trustTier !== query.trustTier) {
+    return false;
+  }
+  if (query.lifecycle !== undefined && brick.lifecycle !== query.lifecycle) {
+    return false;
+  }
+  if (query.createdBy !== undefined && brick.createdBy !== query.createdBy) {
+    return false;
+  }
+  // Tags use AND-subset matching: brick must contain all query tags
+  if (query.tags !== undefined && query.tags.length > 0) {
+    for (const tag of query.tags) {
+      if (!brick.tags.includes(tag)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createInMemoryForgeStore(): ForgeStore {
+  const bricks = new Map<string, BrickArtifact>();
+
+  const save = async (brick: BrickArtifact): Promise<Result<void, KoiError>> => {
+    bricks.set(brick.id, brick);
+    return { ok: true, value: undefined };
+  };
+
+  const load = async (id: string): Promise<Result<BrickArtifact, KoiError>> => {
+    const brick = bricks.get(id);
+    if (brick === undefined) {
+      return { ok: false, error: notFoundError(id) };
+    }
+    return { ok: true, value: brick };
+  };
+
+  const search = async (query: ForgeQuery): Promise<Result<readonly BrickArtifact[], KoiError>> => {
+    const results: BrickArtifact[] = [];
+    for (const brick of bricks.values()) {
+      if (matchesQuery(brick, query)) {
+        results.push(brick);
+        if (query.limit !== undefined && results.length >= query.limit) {
+          break;
+        }
+      }
+    }
+    return { ok: true, value: results };
+  };
+
+  const remove = async (id: string): Promise<Result<void, KoiError>> => {
+    if (!bricks.has(id)) {
+      return { ok: false, error: notFoundError(id) };
+    }
+    bricks.delete(id);
+    return { ok: true, value: undefined };
+  };
+
+  const update = async (id: string, updates: BrickUpdate): Promise<Result<void, KoiError>> => {
+    const existing = bricks.get(id);
+    if (existing === undefined) {
+      return { ok: false, error: notFoundError(id) };
+    }
+    const updated: BrickArtifact = {
+      ...existing,
+      ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
+      ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
+      ...(updates.scope !== undefined ? { scope: updates.scope } : {}),
+      ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
+    };
+    bricks.set(id, updated);
+    return { ok: true, value: undefined };
+  };
+
+  return { save, load, search, remove, update };
+}

--- a/packages/forge/src/store.ts
+++ b/packages/forge/src/store.ts
@@ -1,0 +1,23 @@
+/**
+ * ForgeStore interface — Repository pattern for brick persistence.
+ */
+
+import type { BrickLifecycle, ForgeScope, KoiError, Result, TrustTier } from "@koi/core";
+import type { BrickArtifact, ForgeQuery } from "./types.js";
+
+export type { BrickArtifact, ForgeQuery };
+
+export interface BrickUpdate {
+  readonly lifecycle?: BrickLifecycle;
+  readonly trustTier?: TrustTier;
+  readonly scope?: ForgeScope;
+  readonly usageCount?: number;
+}
+
+export interface ForgeStore {
+  readonly save: (brick: BrickArtifact) => Promise<Result<void, KoiError>>;
+  readonly load: (id: string) => Promise<Result<BrickArtifact, KoiError>>;
+  readonly search: (query: ForgeQuery) => Promise<Result<readonly BrickArtifact[], KoiError>>;
+  readonly remove: (id: string) => Promise<Result<void, KoiError>>;
+  readonly update: (id: string, updates: BrickUpdate) => Promise<Result<void, KoiError>>;
+}

--- a/packages/forge/src/tools/compose-forge.ts
+++ b/packages/forge/src/tools/compose-forge.ts
@@ -1,0 +1,43 @@
+/**
+ * compose_forge — Stub for brick composition.
+ * Full implementation deferred to follow-up PR.
+ */
+
+import type { Tool } from "@koi/core";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool } from "./shared.js";
+
+const COMPOSE_FORGE_CONFIG: ForgeToolConfig = {
+  name: "compose_forge",
+  description: "Composes multiple bricks into a composite (not yet implemented)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      description: { type: "string" },
+      brickIds: { type: "array", items: { type: "string" } },
+    },
+    required: ["name", "description", "brickIds"],
+  },
+  handler: async (): Promise<{
+    readonly ok: false;
+    readonly error: {
+      readonly stage: "governance";
+      readonly code: "FORGE_DISABLED";
+      readonly message: string;
+    };
+  }> => {
+    return {
+      ok: false,
+      error: {
+        stage: "governance",
+        code: "FORGE_DISABLED",
+        message: "compose_forge is not yet implemented — requires brick composition logic",
+      },
+    };
+  },
+};
+
+export function createComposeForgeTool(deps: ForgeDeps): Tool {
+  return createForgeTool(COMPOSE_FORGE_CONFIG, deps);
+}

--- a/packages/forge/src/tools/forge-agent.ts
+++ b/packages/forge/src/tools/forge-agent.ts
@@ -1,0 +1,43 @@
+/**
+ * forge_agent — Stub for agent forging (requires L1 assembly system).
+ * Full implementation deferred to follow-up PR.
+ */
+
+import type { Tool } from "@koi/core";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool } from "./shared.js";
+
+const FORGE_AGENT_CONFIG: ForgeToolConfig = {
+  name: "forge_agent",
+  description: "Creates a new sub-agent (not yet implemented — requires assembly system)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      description: { type: "string" },
+      manifestYaml: { type: "string" },
+    },
+    required: ["name", "description", "manifestYaml"],
+  },
+  handler: async (): Promise<{
+    readonly ok: false;
+    readonly error: {
+      readonly stage: "governance";
+      readonly code: "FORGE_DISABLED";
+      readonly message: string;
+    };
+  }> => {
+    return {
+      ok: false,
+      error: {
+        stage: "governance",
+        code: "FORGE_DISABLED",
+        message: "forge_agent is not yet implemented — requires L1 assembly system",
+      },
+    };
+  },
+};
+
+export function createForgeAgentTool(deps: ForgeDeps): Tool {
+  return createForgeTool(FORGE_AGENT_CONFIG, deps);
+}

--- a/packages/forge/src/tools/forge-skill.test.ts
+++ b/packages/forge/src/tools/forge-skill.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import type { ForgeResult } from "../types.js";
+import { createForgeSkillTool } from "./forge-skill.js";
+import type { ForgeDeps } from "./shared.js";
+
+function createDeps(overrides?: Partial<ForgeDeps>): ForgeDeps {
+  return {
+    store: createInMemoryForgeStore(),
+    executor: { execute: async () => ({ ok: true, value: { output: "ok", durationMs: 1 } }) },
+    verifiers: [],
+    config: createDefaultForgeConfig(),
+    context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+    ...overrides,
+  };
+}
+
+describe("createForgeSkillTool", () => {
+  test("has correct descriptor", () => {
+    const tool = createForgeSkillTool(createDeps());
+    expect(tool.descriptor.name).toBe("forge_skill");
+  });
+
+  test("forges a skill and saves to store", async () => {
+    const store = createInMemoryForgeStore();
+    const tool = createForgeSkillTool(createDeps({ store }));
+
+    const result = (await tool.execute({
+      name: "mySkill",
+      description: "A skill",
+      content: "# My Skill\nContent here.",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.kind).toBe("skill");
+    expect(result.value.name).toBe("mySkill");
+    expect(result.value.lifecycle).toBe("active");
+
+    // Verify saved in store
+    const loadResult = await store.load(result.value.id);
+    expect(loadResult.ok).toBe(true);
+  });
+
+  test("does not run sandbox for skills", async () => {
+    const tool = createForgeSkillTool(createDeps());
+    const result = (await tool.execute({
+      name: "mySkill",
+      description: "A skill",
+      content: "Some content here.",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    // Sandbox stage should show as skipped
+    const sandboxStage = result.value.verificationReport.stages.find((s) => s.stage === "sandbox");
+    expect(sandboxStage?.message).toContain("Skipped");
+  });
+
+  test("propagates tags", async () => {
+    const store = createInMemoryForgeStore();
+    const tool = createForgeSkillTool(createDeps({ store }));
+
+    const result = (await tool.execute({
+      name: "taggedSkill",
+      description: "A tagged skill",
+      content: "Content",
+      tags: ["math", "calc"],
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    const loadResult = await store.load(result.value.id);
+    if (loadResult.ok) {
+      expect(loadResult.value.tags).toEqual(["math", "calc"]);
+    }
+  });
+
+  test("returns error for invalid name", async () => {
+    const tool = createForgeSkillTool(createDeps());
+    const result = (await tool.execute({
+      name: "x",
+      description: "A skill",
+      content: "Content",
+    })) as { readonly ok: false; readonly error: { readonly stage: string } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("static");
+  });
+});

--- a/packages/forge/src/tools/forge-skill.ts
+++ b/packages/forge/src/tools/forge-skill.ts
@@ -1,0 +1,136 @@
+/**
+ * forge_skill — Creates a new SKILL.md (markdown-based knowledge unit).
+ * Lighter verification — no sandbox stage for markdown content.
+ */
+
+import type { Result, Tool } from "@koi/core";
+import type { ForgeError } from "../errors.js";
+import type { BrickArtifact, ForgeResult, ForgeSkillInput } from "../types.js";
+import { verify } from "../verify.js";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool, validateInputFields } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Tool config
+// ---------------------------------------------------------------------------
+
+const FORGE_SKILL_CONFIG: ForgeToolConfig = {
+  name: "forge_skill",
+  description: "Creates a new skill (SKILL.md) — a reusable markdown-based knowledge unit",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      description: { type: "string" },
+      content: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    required: ["name", "description", "content"],
+  },
+  handler: forgeSkillHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const FORGE_SKILL_FIELDS = [
+  { name: "name", type: "string", required: true },
+  { name: "description", type: "string", required: true },
+  { name: "content", type: "string", required: true },
+  { name: "tags", type: "array", required: false },
+] as const;
+
+async function forgeSkillHandler(
+  input: unknown,
+  deps: ForgeDeps,
+): Promise<Result<ForgeResult, ForgeError>> {
+  const validationErr = validateInputFields(input, FORGE_SKILL_FIELDS);
+  if (validationErr !== undefined) {
+    return { ok: false, error: validationErr };
+  }
+  const skillInput = input as ForgeSkillInput;
+  const forgeInput: ForgeSkillInput = {
+    kind: "skill",
+    name: skillInput.name,
+    description: skillInput.description,
+    content: skillInput.content,
+    ...(skillInput.tags !== undefined ? { tags: skillInput.tags } : {}),
+  };
+
+  // Run verification pipeline (sandbox and self-test will skip for skills)
+  const verifyResult = await verify(
+    forgeInput,
+    deps.context,
+    deps.executor,
+    deps.verifiers,
+    deps.config,
+  );
+
+  if (!verifyResult.ok) {
+    return { ok: false, error: verifyResult.error };
+  }
+
+  const report = verifyResult.value;
+  const id = `brick_${crypto.randomUUID()}`;
+
+  const artifact: BrickArtifact = {
+    id,
+    kind: "skill",
+    name: forgeInput.name,
+    description: forgeInput.description,
+    scope: deps.config.defaultScope,
+    trustTier: report.finalTrustTier,
+    lifecycle: "active",
+    createdBy: deps.context.agentId,
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: forgeInput.tags ?? [],
+    usageCount: 0,
+    content: forgeInput.content,
+  };
+
+  const saveResult = await deps.store.save(artifact);
+  if (!saveResult.ok) {
+    return {
+      ok: false,
+      error: {
+        stage: "store",
+        code: "SAVE_FAILED",
+        message: `Failed to save artifact: ${saveResult.error.message}`,
+      },
+    };
+  }
+
+  const forgeResult: ForgeResult = {
+    id,
+    kind: "skill",
+    name: forgeInput.name,
+    descriptor: {
+      name: forgeInput.name,
+      description: forgeInput.description,
+      inputSchema: {},
+    },
+    trustTier: report.finalTrustTier,
+    scope: deps.config.defaultScope,
+    lifecycle: "active",
+    verificationReport: report,
+    metadata: {
+      forgedAt: artifact.createdAt,
+      forgedBy: deps.context.agentId,
+      sessionId: deps.context.sessionId,
+      depth: deps.context.depth,
+    },
+    forgesConsumed: 1,
+  };
+
+  return { ok: true, value: forgeResult };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createForgeSkillTool(deps: ForgeDeps): Tool {
+  return createForgeTool(FORGE_SKILL_CONFIG, deps);
+}

--- a/packages/forge/src/tools/forge-tool.test.ts
+++ b/packages/forge/src/tools/forge-tool.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import type { ForgeResult } from "../types.js";
+import { createForgeToolTool } from "./forge-tool.js";
+import type { ForgeDeps } from "./shared.js";
+
+function createDeps(overrides?: Partial<ForgeDeps>): ForgeDeps {
+  return {
+    store: createInMemoryForgeStore(),
+    executor: {
+      execute: async (_code, input, _timeout) => ({
+        ok: true,
+        value: { output: input, durationMs: 1 },
+      }),
+    },
+    verifiers: [],
+    config: createDefaultForgeConfig(),
+    context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+    ...overrides,
+  };
+}
+
+describe("createForgeToolTool", () => {
+  test("has correct descriptor", () => {
+    const tool = createForgeToolTool(createDeps());
+    expect(tool.descriptor.name).toBe("forge_tool");
+    expect(tool.trustTier).toBe("promoted");
+  });
+
+  test("forges a tool and saves to store", async () => {
+    const store = createInMemoryForgeStore();
+    const deps = createDeps({ store });
+    const tool = createForgeToolTool(deps);
+
+    const result = (await tool.execute({
+      name: "calc",
+      description: "A calculator",
+      inputSchema: { type: "object" },
+      implementation: "return input.a + input.b;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.kind).toBe("tool");
+    expect(result.value.name).toBe("calc");
+    expect(result.value.trustTier).toBe("sandbox");
+    expect(result.value.lifecycle).toBe("active");
+
+    // Verify saved in store
+    const loadResult = await store.load(result.value.id);
+    expect(loadResult.ok).toBe(true);
+  });
+
+  test("returns error for invalid name", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({
+      name: "x",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: false; readonly error: { readonly stage: string } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("static");
+  });
+
+  test("returns verification report in result", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.verificationReport.stages).toHaveLength(4);
+    expect(result.value.verificationReport.passed).toBe(true);
+  });
+
+  test("includes metadata in result", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.metadata.forgedBy).toBe("agent-1");
+    expect(result.value.metadata.sessionId).toBe("session-1");
+  });
+
+  test("returns forgesConsumed = 1 on success", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.forgesConsumed).toBe(1);
+  });
+
+  test("returns store error on save failure", async () => {
+    const failingStore = {
+      save: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "disk full", retryable: false },
+      }),
+      load: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+      search: async () => ({
+        ok: true as const,
+        value: [] as readonly import("../types.js").BrickArtifact[],
+      }),
+      remove: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+      update: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "n/a", retryable: false },
+      }),
+    };
+
+    const tool = createForgeToolTool(createDeps({ store: failingStore }));
+    const result = (await tool.execute({
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly code: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("store");
+    expect(result.error.code).toBe("SAVE_FAILED");
+  });
+
+  test("rejects null input with validation error", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute(null as unknown as Record<string, unknown>)) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly code: string; readonly message: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("static");
+    expect(result.error.code).toBe("MISSING_FIELD");
+  });
+
+  test("rejects input missing required fields", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({ name: "myTool" })) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly message: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("static");
+    expect(result.error.message).toContain("description");
+  });
+
+  test("rejects input with wrong field type", async () => {
+    const tool = createForgeToolTool(createDeps());
+    const result = (await tool.execute({
+      name: 123,
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    })) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string; readonly message: string };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("static");
+    expect(result.error.message).toContain("name");
+    expect(result.error.message).toContain("string");
+  });
+});

--- a/packages/forge/src/tools/forge-tool.ts
+++ b/packages/forge/src/tools/forge-tool.ts
@@ -1,0 +1,153 @@
+/**
+ * forge_tool — Creates a new tool through the verification pipeline.
+ */
+
+import type { Result, Tool } from "@koi/core";
+import type { ForgeError } from "../errors.js";
+import type { BrickArtifact, ForgeResult, ForgeToolInput } from "../types.js";
+import { verify } from "../verify.js";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool, validateInputFields } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Tool config
+// ---------------------------------------------------------------------------
+
+const FORGE_TOOL_CONFIG: ForgeToolConfig = {
+  name: "forge_tool",
+  description: "Creates a new tool by running it through the 4-stage verification pipeline",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      description: { type: "string" },
+      inputSchema: { type: "object" },
+      implementation: { type: "string" },
+      testCases: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            input: {},
+            expectedOutput: {},
+            shouldThrow: { type: "boolean" },
+          },
+          required: ["name", "input"],
+        },
+      },
+    },
+    required: ["name", "description", "inputSchema", "implementation"],
+  },
+  handler: forgeToolHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+const FORGE_TOOL_FIELDS = [
+  { name: "name", type: "string", required: true },
+  { name: "description", type: "string", required: true },
+  { name: "inputSchema", type: "object", required: true },
+  { name: "implementation", type: "string", required: true },
+  { name: "testCases", type: "array", required: false },
+] as const;
+
+async function forgeToolHandler(
+  input: unknown,
+  deps: ForgeDeps,
+): Promise<Result<ForgeResult, ForgeError>> {
+  const validationErr = validateInputFields(input, FORGE_TOOL_FIELDS);
+  if (validationErr !== undefined) {
+    return { ok: false, error: validationErr };
+  }
+  const toolInput = input as ForgeToolInput;
+  const forgeInput: ForgeToolInput = {
+    kind: "tool",
+    name: toolInput.name,
+    description: toolInput.description,
+    inputSchema: toolInput.inputSchema,
+    implementation: toolInput.implementation,
+    ...(toolInput.testCases !== undefined ? { testCases: toolInput.testCases } : {}),
+  };
+
+  // Run verification pipeline
+  const verifyResult = await verify(
+    forgeInput,
+    deps.context,
+    deps.executor,
+    deps.verifiers,
+    deps.config,
+  );
+
+  if (!verifyResult.ok) {
+    return { ok: false, error: verifyResult.error };
+  }
+
+  const report = verifyResult.value;
+  const id = `brick_${crypto.randomUUID()}`;
+
+  // Save to store
+  const artifact: BrickArtifact = {
+    id,
+    kind: "tool",
+    name: forgeInput.name,
+    description: forgeInput.description,
+    scope: deps.config.defaultScope,
+    trustTier: report.finalTrustTier,
+    lifecycle: "active",
+    createdBy: deps.context.agentId,
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: forgeInput.implementation,
+    inputSchema: forgeInput.inputSchema,
+    ...(forgeInput.testCases !== undefined ? { testCases: forgeInput.testCases } : {}),
+  };
+
+  const saveResult = await deps.store.save(artifact);
+  if (!saveResult.ok) {
+    return {
+      ok: false,
+      error: {
+        stage: "store",
+        code: "SAVE_FAILED",
+        message: `Failed to save artifact: ${saveResult.error.message}`,
+      },
+    };
+  }
+
+  const forgeResult: ForgeResult = {
+    id,
+    kind: "tool",
+    name: forgeInput.name,
+    descriptor: {
+      name: forgeInput.name,
+      description: forgeInput.description,
+      inputSchema: forgeInput.inputSchema,
+    },
+    trustTier: report.finalTrustTier,
+    scope: deps.config.defaultScope,
+    lifecycle: "active",
+    verificationReport: report,
+    metadata: {
+      forgedAt: artifact.createdAt,
+      forgedBy: deps.context.agentId,
+      sessionId: deps.context.sessionId,
+      depth: deps.context.depth,
+    },
+    forgesConsumed: 1,
+  };
+
+  return { ok: true, value: forgeResult };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createForgeToolTool(deps: ForgeDeps): Tool {
+  return createForgeTool(FORGE_TOOL_CONFIG, deps);
+}

--- a/packages/forge/src/tools/promote-forge.ts
+++ b/packages/forge/src/tools/promote-forge.ts
@@ -1,0 +1,43 @@
+/**
+ * promote_forge — Stub for scope/trust promotion.
+ * Full implementation deferred to follow-up PR (requires HITL integration).
+ */
+
+import type { Tool } from "@koi/core";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool } from "./shared.js";
+
+const PROMOTE_FORGE_CONFIG: ForgeToolConfig = {
+  name: "promote_forge",
+  description: "Promotes a brick's scope or trust tier (not yet implemented — requires HITL)",
+  inputSchema: {
+    type: "object",
+    properties: {
+      brickId: { type: "string" },
+      targetScope: { type: "string" },
+      targetTrustTier: { type: "string" },
+    },
+    required: ["brickId"],
+  },
+  handler: async (): Promise<{
+    readonly ok: false;
+    readonly error: {
+      readonly stage: "governance";
+      readonly code: "FORGE_DISABLED";
+      readonly message: string;
+    };
+  }> => {
+    return {
+      ok: false,
+      error: {
+        stage: "governance",
+        code: "FORGE_DISABLED",
+        message: "promote_forge is not yet implemented — requires HITL integration",
+      },
+    };
+  },
+};
+
+export function createPromoteForgeTool(deps: ForgeDeps): Tool {
+  return createForgeTool(PROMOTE_FORGE_CONFIG, deps);
+}

--- a/packages/forge/src/tools/search-forge.test.ts
+++ b/packages/forge/src/tools/search-forge.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import type { BrickArtifact } from "../types.js";
+import { createSearchForgeTool } from "./search-forge.js";
+import type { ForgeDeps } from "./shared.js";
+
+function createBrick(overrides?: Partial<BrickArtifact>): BrickArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: "return 1;",
+    ...overrides,
+  };
+}
+
+function createDeps(overrides?: Partial<ForgeDeps>): ForgeDeps {
+  return {
+    store: createInMemoryForgeStore(),
+    executor: { execute: async () => ({ ok: true, value: { output: "ok", durationMs: 1 } }) },
+    verifiers: [],
+    config: createDefaultForgeConfig(),
+    context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+    ...overrides,
+  };
+}
+
+describe("createSearchForgeTool", () => {
+  test("has correct descriptor", () => {
+    const tool = createSearchForgeTool(createDeps());
+    expect(tool.descriptor.name).toBe("search_forge");
+  });
+
+  test("returns all bricks with empty query", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1" }));
+    await store.save(createBrick({ id: "b2" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(2);
+  });
+
+  test("filters by kind", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", kind: "tool" }));
+    await store.save(createBrick({ id: "b2", kind: "skill" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ kind: "skill" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.kind).toBe("skill");
+  });
+
+  test("filters by scope", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent" }));
+    await store.save(createBrick({ id: "b2", scope: "global" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ scope: "global" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+  });
+
+  test("returns empty array when no matches", async () => {
+    const store = createInMemoryForgeStore();
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ kind: "agent" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(0);
+  });
+});

--- a/packages/forge/src/tools/search-forge.ts
+++ b/packages/forge/src/tools/search-forge.ts
@@ -1,0 +1,71 @@
+/**
+ * search_forge — Discovers existing bricks via ForgeStore queries.
+ */
+
+import type { Result, Tool } from "@koi/core";
+import type { ForgeError } from "../errors.js";
+import type { BrickArtifact, ForgeQuery } from "../types.js";
+import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
+import { createForgeTool, validateInputFields } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Tool config
+// ---------------------------------------------------------------------------
+
+const SEARCH_FORGE_CONFIG: ForgeToolConfig = {
+  name: "search_forge",
+  description: "Discovers existing forged bricks by kind, scope, tags, and other criteria",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: { type: "string" },
+      scope: { type: "string" },
+      trustTier: { type: "string" },
+      lifecycle: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+      createdBy: { type: "string" },
+      limit: { type: "number" },
+    },
+  },
+  handler: searchForgeHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function searchForgeHandler(
+  input: unknown,
+  deps: ForgeDeps,
+): Promise<Result<readonly BrickArtifact[], ForgeError>> {
+  // Allow null/undefined (defaults to empty query), but reject non-objects
+  if (input !== null && input !== undefined) {
+    const validationErr = validateInputFields(input, []);
+    if (validationErr !== undefined) {
+      return { ok: false, error: validationErr };
+    }
+  }
+  const query = (input ?? {}) as ForgeQuery;
+  const result = await deps.store.search(query);
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: {
+        stage: "store",
+        code: "SEARCH_FAILED",
+        message: `Search failed: ${result.error.message}`,
+      },
+    };
+  }
+
+  return { ok: true, value: result.value };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createSearchForgeTool(deps: ForgeDeps): Tool {
+  return createForgeTool(SEARCH_FORGE_CONFIG, deps);
+}

--- a/packages/forge/src/tools/shared.test.ts
+++ b/packages/forge/src/tools/shared.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "../config.js";
+import { createInMemoryForgeStore } from "../memory-store.js";
+import type { ForgeContext } from "../types.js";
+import type { ForgeDeps } from "./shared.js";
+import { createForgeTool } from "./shared.js";
+
+function createDeps(overrides?: Partial<ForgeDeps>): ForgeDeps {
+  return {
+    store: createInMemoryForgeStore(),
+    executor: { execute: async () => ({ ok: true, value: { output: "ok", durationMs: 1 } }) },
+    verifiers: [],
+    config: createDefaultForgeConfig(),
+    context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+    ...overrides,
+  };
+}
+
+describe("createForgeTool — factory", () => {
+  test("creates tool with correct descriptor", () => {
+    const deps = createDeps();
+    const tool = createForgeTool(
+      {
+        name: "test_tool",
+        description: "Test",
+        inputSchema: { type: "object" },
+        handler: async () => ({ ok: true, value: "done" }),
+      },
+      deps,
+    );
+    expect(tool.descriptor.name).toBe("test_tool");
+    expect(tool.descriptor.description).toBe("Test");
+    expect(tool.trustTier).toBe("promoted");
+  });
+
+  test("rejects execution when forge is disabled", async () => {
+    const deps = createDeps({ config: createDefaultForgeConfig({ enabled: false }) });
+    const tool = createForgeTool(
+      {
+        name: "test_tool",
+        description: "Test",
+        inputSchema: { type: "object" },
+        handler: async () => ({ ok: true, value: "done" }),
+      },
+      deps,
+    );
+    const result = (await tool.execute({})) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string };
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error.stage).toBe("governance");
+  });
+
+  test("rejects execution when depth exceeds max", async () => {
+    const context: ForgeContext = { agentId: "a", depth: 5, sessionId: "s", forgesThisSession: 0 };
+    const deps = createDeps({ context, config: createDefaultForgeConfig({ maxForgeDepth: 1 }) });
+    const tool = createForgeTool(
+      {
+        name: "test_tool",
+        description: "Test",
+        inputSchema: { type: "object" },
+        handler: async () => ({ ok: true, value: "done" }),
+      },
+      deps,
+    );
+    const result = (await tool.execute({})) as {
+      readonly ok: false;
+      readonly error: { readonly stage: string };
+    };
+    expect(result.ok).toBe(false);
+  });
+
+  test("delegates to handler when governance passes", async () => {
+    const deps = createDeps();
+    let handlerCalled = false;
+    const tool = createForgeTool(
+      {
+        name: "test_tool",
+        description: "Test",
+        inputSchema: { type: "object" },
+        handler: async () => {
+          handlerCalled = true;
+          return { ok: true, value: "done" };
+        },
+      },
+      deps,
+    );
+    await tool.execute({});
+    expect(handlerCalled).toBe(true);
+  });
+});

--- a/packages/forge/src/tools/shared.ts
+++ b/packages/forge/src/tools/shared.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared factory for primordial forge tools — DRY across all 6 tools.
+ */
+
+import type { JsonObject, Result, Tool, ToolDescriptor } from "@koi/core";
+import type { ForgeConfig } from "../config.js";
+import type { ForgeError } from "../errors.js";
+import { staticError } from "../errors.js";
+import { checkGovernance } from "../governance.js";
+import type { ForgeStore } from "../store.js";
+import type { ForgeContext, ForgeVerifier, SandboxExecutor } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Shared dependencies
+// ---------------------------------------------------------------------------
+
+export interface ForgeDeps {
+  readonly store: ForgeStore;
+  readonly executor: SandboxExecutor;
+  readonly verifiers: readonly ForgeVerifier[];
+  readonly config: ForgeConfig;
+  readonly context: ForgeContext;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface ForgeToolConfig {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+  readonly handler: (input: unknown, deps: ForgeDeps) => Promise<Result<unknown, ForgeError>>;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime input validation
+// ---------------------------------------------------------------------------
+
+interface FieldSpec {
+  readonly name: string;
+  readonly type: "string" | "object" | "array";
+  readonly required: boolean;
+}
+
+export function validateInputFields(
+  input: unknown,
+  fields: readonly FieldSpec[],
+): ForgeError | undefined {
+  if (input === null || typeof input !== "object") {
+    return staticError("MISSING_FIELD", "Input must be a non-null object");
+  }
+  const obj = input as Record<string, unknown>;
+
+  for (const field of fields) {
+    const value = obj[field.name];
+    if (field.required && value === undefined) {
+      return staticError("MISSING_FIELD", `Missing required field: "${field.name}"`);
+    }
+    if (value !== undefined) {
+      if (field.type === "string" && typeof value !== "string") {
+        return staticError(
+          "MISSING_FIELD",
+          `Field "${field.name}" must be a string, got ${typeof value}`,
+        );
+      }
+      if (field.type === "object" && (typeof value !== "object" || value === null)) {
+        return staticError(
+          "MISSING_FIELD",
+          `Field "${field.name}" must be an object, got ${typeof value}`,
+        );
+      }
+      if (field.type === "array" && !Array.isArray(value)) {
+        return staticError(
+          "MISSING_FIELD",
+          `Field "${field.name}" must be an array, got ${typeof value}`,
+        );
+      }
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+export function createForgeTool(toolConfig: ForgeToolConfig, deps: ForgeDeps): Tool {
+  const descriptor: ToolDescriptor = {
+    name: toolConfig.name,
+    description: toolConfig.description,
+    inputSchema: toolConfig.inputSchema,
+  };
+
+  const execute = async (input: JsonObject): Promise<unknown> => {
+    // Governance pre-check
+    const govResult = checkGovernance(deps.context, deps.config);
+    if (!govResult.ok) {
+      return { ok: false, error: govResult.error };
+    }
+
+    // Delegate to handler
+    return toolConfig.handler(input, deps);
+  };
+
+  return {
+    descriptor,
+    trustTier: "promoted", // Primordial tools are first-party
+    execute,
+  };
+}

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Core types for the @koi/forge self-extension system.
+ */
+
+import type { BrickKind, BrickLifecycle, ForgeScope, ToolDescriptor, TrustTier } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Forge result (pure data — L1 handles mutation)
+// ---------------------------------------------------------------------------
+
+export interface ForgeResultMetadata {
+  readonly forgedAt: number;
+  readonly forgedBy: string;
+  readonly sessionId: string;
+  readonly depth: number;
+}
+
+export interface ForgeResult {
+  readonly id: string;
+  readonly kind: BrickKind;
+  readonly name: string;
+  readonly descriptor: ToolDescriptor;
+  readonly trustTier: TrustTier;
+  readonly scope: ForgeScope;
+  readonly lifecycle: BrickLifecycle;
+  readonly verificationReport: VerificationReport;
+  readonly metadata: ForgeResultMetadata;
+  /** Number of forge operations consumed (caller must increment forgesThisSession by this amount). */
+  readonly forgesConsumed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Verification report
+// ---------------------------------------------------------------------------
+
+export type VerificationStage = "static" | "sandbox" | "self_test" | "trust";
+
+export interface StageReport {
+  readonly stage: VerificationStage;
+  readonly passed: boolean;
+  readonly durationMs: number;
+  readonly message?: string;
+}
+
+export interface TrustStageReport extends StageReport {
+  readonly stage: "trust";
+  readonly trustTier: TrustTier;
+}
+
+export interface VerificationReport {
+  readonly stages: readonly StageReport[];
+  readonly finalTrustTier: TrustTier;
+  readonly totalDurationMs: number;
+  readonly passed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Forge inputs (discriminated union)
+// ---------------------------------------------------------------------------
+
+export interface TestCase {
+  readonly name: string;
+  readonly input: unknown;
+  readonly expectedOutput?: unknown;
+  readonly shouldThrow?: boolean;
+}
+
+export interface ForgeToolInput {
+  readonly kind: "tool";
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+  readonly implementation: string;
+  readonly testCases?: readonly TestCase[];
+}
+
+export interface ForgeSkillInput {
+  readonly kind: "skill";
+  readonly name: string;
+  readonly description: string;
+  readonly content: string;
+  readonly tags?: readonly string[];
+}
+
+export interface ForgeAgentInput {
+  readonly kind: "agent";
+  readonly name: string;
+  readonly description: string;
+  readonly manifestYaml: string;
+}
+
+export interface ForgeCompositeInput {
+  readonly kind: "composite";
+  readonly name: string;
+  readonly description: string;
+  readonly brickIds: readonly string[];
+}
+
+export type ForgeInput = ForgeToolInput | ForgeSkillInput | ForgeAgentInput | ForgeCompositeInput;
+
+// ---------------------------------------------------------------------------
+// Pluggable verifier (Stage 3)
+// ---------------------------------------------------------------------------
+
+export interface VerifierResult {
+  readonly passed: boolean;
+  readonly message?: string;
+}
+
+export interface ForgeVerifier {
+  readonly name: string;
+  readonly verify: (input: ForgeInput, context: ForgeContext) => Promise<VerifierResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox executor (injected dependency)
+// ---------------------------------------------------------------------------
+
+export type SandboxErrorCode = "TIMEOUT" | "OOM" | "PERMISSION" | "CRASH";
+
+export interface SandboxError {
+  readonly code: SandboxErrorCode;
+  readonly message: string;
+  readonly durationMs: number;
+}
+
+export interface SandboxResult {
+  readonly output: unknown;
+  readonly durationMs: number;
+  readonly memoryUsedBytes?: number;
+}
+
+export interface SandboxExecutor {
+  readonly execute: (
+    code: string,
+    input: unknown,
+    timeoutMs: number,
+  ) => Promise<
+    | { readonly ok: true; readonly value: SandboxResult }
+    | { readonly ok: false; readonly error: SandboxError }
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Forge context
+// ---------------------------------------------------------------------------
+
+export interface ForgeContext {
+  readonly agentId: string;
+  readonly depth: number;
+  readonly sessionId: string;
+  readonly forgesThisSession: number;
+}
+
+// ---------------------------------------------------------------------------
+// Brick artifact (stored representation)
+// ---------------------------------------------------------------------------
+
+export interface BrickArtifact {
+  readonly id: string;
+  readonly kind: BrickKind;
+  readonly name: string;
+  readonly description: string;
+  readonly scope: ForgeScope;
+  readonly trustTier: TrustTier;
+  readonly lifecycle: BrickLifecycle;
+  readonly createdBy: string;
+  readonly createdAt: number;
+  readonly version: string;
+  readonly tags: readonly string[];
+  readonly usageCount: number;
+  readonly implementation?: string;
+  readonly content?: string;
+  readonly inputSchema?: Readonly<Record<string, unknown>>;
+  readonly testCases?: readonly TestCase[];
+}
+
+// ---------------------------------------------------------------------------
+// Forge query (structured search)
+// ---------------------------------------------------------------------------
+
+export interface ForgeQuery {
+  readonly kind?: BrickKind;
+  readonly scope?: ForgeScope;
+  readonly trustTier?: TrustTier;
+  readonly lifecycle?: BrickLifecycle;
+  readonly tags?: readonly string[];
+  readonly createdBy?: string;
+  readonly limit?: number;
+}

--- a/packages/forge/src/verify-sandbox.test.ts
+++ b/packages/forge/src/verify-sandbox.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeInput, SandboxExecutor } from "./types.js";
+import { verifySandbox } from "./verify-sandbox.js";
+
+const DEFAULT_VERIFICATION: VerificationConfig = {
+  staticTimeoutMs: 1_000,
+  sandboxTimeoutMs: 5_000,
+  selfTestTimeoutMs: 10_000,
+  totalTimeoutMs: 30_000,
+  maxBrickSizeBytes: 50_000,
+};
+
+function mockExecutor(overrides?: Partial<SandboxExecutor>): SandboxExecutor {
+  return {
+    execute: async (_code, _input, _timeout) => ({
+      ok: true,
+      value: { output: "ok", durationMs: 10 },
+    }),
+    ...overrides,
+  };
+}
+
+describe("verifySandbox", () => {
+  test("skips for skill kind", async () => {
+    const input: ForgeInput = {
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      content: "content",
+    };
+    const result = await verifySandbox(input, mockExecutor(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.passed).toBe(true);
+      expect(result.value.message).toContain("Skipped");
+    }
+  });
+
+  test("skips for agent kind", async () => {
+    const input: ForgeInput = {
+      kind: "agent",
+      name: "myAgent",
+      description: "An agent",
+      manifestYaml: "name: test",
+    };
+    const result = await verifySandbox(input, mockExecutor(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("skips for composite kind", async () => {
+    const input: ForgeInput = {
+      kind: "composite",
+      name: "myComposite",
+      description: "A composite",
+      brickIds: ["a"],
+    };
+    const result = await verifySandbox(input, mockExecutor(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("succeeds for tool with passing executor", async () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = await verifySandbox(input, mockExecutor(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.stage).toBe("sandbox");
+      expect(result.value.passed).toBe(true);
+    }
+  });
+
+  test("returns TIMEOUT error on timeout", async () => {
+    const executor = mockExecutor({
+      execute: async () => ({
+        ok: false,
+        error: { code: "TIMEOUT", message: "timeout exceeded", durationMs: 5000 },
+      }),
+    });
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "while(true){}",
+    };
+    const result = await verifySandbox(input, executor, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "sandbox") {
+      expect(result.error.code).toBe("TIMEOUT");
+    }
+  });
+
+  test("returns OOM error on memory issue", async () => {
+    const executor = mockExecutor({
+      execute: async () => ({
+        ok: false,
+        error: { code: "OOM", message: "out of memory", durationMs: 100 },
+      }),
+    });
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "new Array(1e9)",
+    };
+    const result = await verifySandbox(input, executor, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "sandbox") {
+      expect(result.error.code).toBe("OOM");
+    }
+  });
+
+  test("returns PERMISSION error on permission violation", async () => {
+    const executor = mockExecutor({
+      execute: async () => ({
+        ok: false,
+        error: { code: "PERMISSION", message: "permission denied", durationMs: 1 },
+      }),
+    });
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "require('child_process')",
+    };
+    const result = await verifySandbox(input, executor, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "sandbox") {
+      expect(result.error.code).toBe("PERMISSION");
+    }
+  });
+
+  test("returns CRASH error on generic failure", async () => {
+    const executor = mockExecutor({
+      execute: async () => ({
+        ok: false,
+        error: { code: "CRASH", message: "something broke", durationMs: 1 },
+      }),
+    });
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "throw 'oops'",
+    };
+    const result = await verifySandbox(input, executor, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "sandbox") {
+      expect(result.error.code).toBe("CRASH");
+    }
+  });
+
+  test("includes durationMs in error", async () => {
+    const executor = mockExecutor({
+      execute: async () => ({
+        ok: false,
+        error: { code: "TIMEOUT", message: "timeout exceeded", durationMs: 42 },
+      }),
+    });
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "x",
+    };
+    const result = await verifySandbox(input, executor, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "sandbox") {
+      expect(result.error.durationMs).toBe(42);
+    }
+  });
+});

--- a/packages/forge/src/verify-sandbox.ts
+++ b/packages/forge/src/verify-sandbox.ts
@@ -1,0 +1,56 @@
+/**
+ * Stage 2: Sandbox execution — runs tool implementation in a sandboxed environment.
+ * Only applies to "tool" and "composite" kinds; skills/agents skip with a pass.
+ */
+
+import type { Result } from "@koi/core";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeError } from "./errors.js";
+import { sandboxError } from "./errors.js";
+import type { ForgeInput, SandboxExecutor, StageReport } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function verifySandbox(
+  input: ForgeInput,
+  executor: SandboxExecutor,
+  config: VerificationConfig,
+): Promise<Result<StageReport, ForgeError>> {
+  // Skills and agents skip sandbox execution
+  if (input.kind === "skill" || input.kind === "agent") {
+    return {
+      ok: true,
+      value: {
+        stage: "sandbox",
+        passed: true,
+        durationMs: 0,
+        message: `Skipped for ${input.kind}`,
+      },
+    };
+  }
+
+  // For composite, we just verify it's constructable (no code to run)
+  if (input.kind === "composite") {
+    return {
+      ok: true,
+      value: { stage: "sandbox", passed: true, durationMs: 0, message: "Skipped for composite" },
+    };
+  }
+
+  // Tool kind — run implementation in sandbox
+  const result = await executor.execute(input.implementation, {}, config.sandboxTimeoutMs);
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: sandboxError(result.error.code, result.error.message, result.error.durationMs),
+    };
+  }
+
+  return {
+    ok: true,
+    value: { stage: "sandbox", passed: true, durationMs: result.value.durationMs },
+  };
+}

--- a/packages/forge/src/verify-self-test.test.ts
+++ b/packages/forge/src/verify-self-test.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "bun:test";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeContext, ForgeInput, ForgeVerifier, SandboxExecutor } from "./types.js";
+import { verifySelfTest } from "./verify-self-test.js";
+
+const DEFAULT_VERIFICATION: VerificationConfig = {
+  staticTimeoutMs: 1_000,
+  sandboxTimeoutMs: 5_000,
+  selfTestTimeoutMs: 10_000,
+  totalTimeoutMs: 30_000,
+  maxBrickSizeBytes: 50_000,
+};
+
+const DEFAULT_CONTEXT: ForgeContext = {
+  agentId: "agent-1",
+  depth: 0,
+  sessionId: "session-1",
+  forgesThisSession: 0,
+};
+
+function mockExecutor(fn?: SandboxExecutor["execute"]): SandboxExecutor {
+  return {
+    execute:
+      fn ??
+      (async (_code, input, _timeout) => ({
+        ok: true,
+        value: { output: input, durationMs: 1 },
+      })),
+  };
+}
+
+describe("verifySelfTest — test cases", () => {
+  test("passes with empty testCases array", async () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return input;",
+      testCases: [],
+    };
+    const result = await verifySelfTest(
+      input,
+      mockExecutor(),
+      [],
+      DEFAULT_CONTEXT,
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  test("passes when test output matches expectedOutput", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: true,
+      value: { output: 42, durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 42;",
+      testCases: [{ name: "returns 42", input: {}, expectedOutput: 42 }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("fails when test output does not match expectedOutput", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: true,
+      value: { output: 99, durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 99;",
+      testCases: [{ name: "expects 42", input: {}, expectedOutput: 42 }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "self_test") {
+      expect(result.error.code).toBe("TEST_FAILED");
+      expect(result.error.failures).toHaveLength(1);
+    }
+  });
+
+  test("passes when shouldThrow is true and execution fails", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: false,
+      error: { code: "CRASH", message: "expected failure", durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "throw new Error('expected');",
+      testCases: [{ name: "should throw", input: {}, shouldThrow: true }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("fails when shouldThrow is true but execution succeeds", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: true,
+      value: { output: "ok", durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 'ok';",
+      testCases: [{ name: "should throw", input: {}, shouldThrow: true }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "self_test") {
+      expect(result.error.code).toBe("TEST_FAILED");
+    }
+  });
+
+  test("fails when execution fails but shouldThrow is not set", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: false,
+      error: { code: "CRASH", message: "unexpected", durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "throw 'err';",
+      testCases: [{ name: "no throw expected", input: {} }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("distinguishes arrays from objects in expectedOutput", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: true,
+      value: { output: [1, 2], durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return [1, 2];",
+      testCases: [{ name: "array vs object", input: {}, expectedOutput: { 0: 1, 1: 2 } }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "self_test") {
+      expect(result.error.code).toBe("TEST_FAILED");
+    }
+  });
+
+  test("passes when arrays match deeply", async () => {
+    const executor = mockExecutor(async () => ({
+      ok: true,
+      value: { output: [1, [2, 3]], durationMs: 1 },
+    }));
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return [1, [2, 3]];",
+      testCases: [{ name: "nested arrays", input: {}, expectedOutput: [1, [2, 3]] }],
+    };
+    const result = await verifySelfTest(input, executor, [], DEFAULT_CONTEXT, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("passes without testCases (undefined)", async () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = await verifySelfTest(
+      input,
+      mockExecutor(),
+      [],
+      DEFAULT_CONTEXT,
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("verifySelfTest — pluggable verifiers", () => {
+  test("passes when verifier approves", async () => {
+    const verifier: ForgeVerifier = {
+      name: "always-pass",
+      verify: async () => ({ passed: true }),
+    };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = await verifySelfTest(
+      input,
+      mockExecutor(),
+      [verifier],
+      DEFAULT_CONTEXT,
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  test("fails when verifier rejects", async () => {
+    const verifier: ForgeVerifier = {
+      name: "always-reject",
+      verify: async () => ({ passed: false, message: "not allowed" }),
+    };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = await verifySelfTest(
+      input,
+      mockExecutor(),
+      [verifier],
+      DEFAULT_CONTEXT,
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "self_test") {
+      expect(result.error.code).toBe("VERIFIER_REJECTED");
+      expect(result.error.message).toContain("always-reject");
+    }
+  });
+
+  test("runs verifiers in order and stops at first rejection", async () => {
+    const calls: string[] = [];
+    const v1: ForgeVerifier = {
+      name: "v1",
+      verify: async () => {
+        calls.push("v1");
+        return { passed: true };
+      },
+    };
+    const v2: ForgeVerifier = {
+      name: "v2",
+      verify: async () => {
+        calls.push("v2");
+        return { passed: false, message: "nope" };
+      },
+    };
+    const v3: ForgeVerifier = {
+      name: "v3",
+      verify: async () => {
+        calls.push("v3");
+        return { passed: true };
+      },
+    };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    await verifySelfTest(
+      input,
+      mockExecutor(),
+      [v1, v2, v3],
+      DEFAULT_CONTEXT,
+      DEFAULT_VERIFICATION,
+    );
+    expect(calls).toEqual(["v1", "v2"]);
+  });
+});

--- a/packages/forge/src/verify-self-test.ts
+++ b/packages/forge/src/verify-self-test.ts
@@ -1,0 +1,153 @@
+/**
+ * Stage 3: Self-test — run test cases and pluggable verifiers.
+ */
+
+import type { Result } from "@koi/core";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeError, TestFailure } from "./errors.js";
+import { selfTestError } from "./errors.js";
+import type {
+  ForgeContext,
+  ForgeInput,
+  ForgeVerifier,
+  SandboxExecutor,
+  StageReport,
+  TestCase,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+
+  // Arrays and objects are not interchangeable
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    if (!deepEqual(aObj[key], bObj[key])) return false;
+  }
+  return true;
+}
+
+async function runTestCase(
+  testCase: TestCase,
+  implementation: string,
+  executor: SandboxExecutor,
+  timeoutMs: number,
+): Promise<TestFailure | undefined> {
+  const result = await executor.execute(implementation, testCase.input, timeoutMs);
+
+  if (!result.ok) {
+    // Sandbox returned a structured error
+    if (testCase.shouldThrow === true) {
+      return undefined; // Expected to fail
+    }
+    return {
+      testName: testCase.name,
+      expected: testCase.expectedOutput,
+      actual: undefined,
+      error: result.error.message,
+    };
+  }
+
+  if (testCase.shouldThrow === true) {
+    return {
+      testName: testCase.name,
+      expected: "should throw",
+      actual: result.value.output,
+      error: "Expected execution to throw, but it succeeded",
+    };
+  }
+
+  if (
+    testCase.expectedOutput !== undefined &&
+    !deepEqual(result.value.output, testCase.expectedOutput)
+  ) {
+    return {
+      testName: testCase.name,
+      expected: testCase.expectedOutput,
+      actual: result.value.output,
+    };
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function verifySelfTest(
+  input: ForgeInput,
+  executor: SandboxExecutor,
+  verifiers: readonly ForgeVerifier[],
+  context: ForgeContext,
+  config: VerificationConfig,
+): Promise<Result<StageReport, ForgeError>> {
+  const start = performance.now();
+  const failures: TestFailure[] = [];
+
+  // Run test cases for tools
+  if (input.kind === "tool" && input.testCases !== undefined && input.testCases.length > 0) {
+    for (const testCase of input.testCases) {
+      const failure = await runTestCase(
+        testCase,
+        input.implementation,
+        executor,
+        config.selfTestTimeoutMs,
+      );
+      if (failure !== undefined) {
+        failures.push(failure);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    return {
+      ok: false,
+      error: selfTestError("TEST_FAILED", `${failures.length} test case(s) failed`, failures),
+    };
+  }
+
+  // Run pluggable verifiers
+  for (const verifier of verifiers) {
+    const result = await verifier.verify(input, context);
+    if (!result.passed) {
+      return {
+        ok: false,
+        error: selfTestError(
+          "VERIFIER_REJECTED",
+          `Verifier "${verifier.name}" rejected: ${result.message ?? "no reason given"}`,
+        ),
+      };
+    }
+  }
+
+  const durationMs = performance.now() - start;
+  return {
+    ok: true,
+    value: { stage: "self_test", passed: true, durationMs },
+  };
+}

--- a/packages/forge/src/verify-static.test.ts
+++ b/packages/forge/src/verify-static.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeInput } from "./types.js";
+import { verifyStatic } from "./verify-static.js";
+
+const DEFAULT_VERIFICATION: VerificationConfig = {
+  staticTimeoutMs: 1_000,
+  sandboxTimeoutMs: 5_000,
+  selfTestTimeoutMs: 10_000,
+  totalTimeoutMs: 30_000,
+  maxBrickSizeBytes: 50_000,
+};
+
+function validToolInput(overrides?: Partial<ForgeInput>): ForgeInput {
+  return {
+    kind: "tool",
+    name: "myTool",
+    description: "A test tool",
+    inputSchema: { type: "object" },
+    implementation: "function run(input) { return input; }",
+    ...overrides,
+  } as ForgeInput;
+}
+
+describe("verifyStatic — name validation", () => {
+  test("accepts valid name", () => {
+    const result = verifyStatic(validToolInput(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects name with path traversal", () => {
+    const result = verifyStatic(
+      validToolInput({ name: "../../../etc/passwd" } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("static");
+      if (result.error.stage === "static") {
+        expect(result.error.code).toBe("INVALID_NAME");
+      }
+    }
+  });
+
+  test("rejects name shorter than 3 chars", () => {
+    const result = verifyStatic(validToolInput({ name: "ab" } as ForgeInput), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects name starting with number", () => {
+    const result = verifyStatic(
+      validToolInput({ name: "1tool" } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects name over 50 chars", () => {
+    const result = verifyStatic(
+      validToolInput({ name: "a".repeat(51) } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts name with hyphens and underscores", () => {
+    const result = verifyStatic(
+      validToolInput({ name: "my-tool_v2" } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("verifyStatic — description validation", () => {
+  test("rejects empty description", () => {
+    const result = verifyStatic(
+      validToolInput({ description: "" } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("MISSING_FIELD");
+    }
+  });
+
+  test("rejects description over 500 chars", () => {
+    const result = verifyStatic(
+      validToolInput({ description: "x".repeat(501) } as ForgeInput),
+      DEFAULT_VERIFICATION,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("SIZE_EXCEEDED");
+    }
+  });
+});
+
+describe("verifyStatic — schema validation", () => {
+  test("rejects schema without type field", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { properties: {} },
+      implementation: "return 1;",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("INVALID_SCHEMA");
+    }
+  });
+
+  test("rejects schema with __proto__ key", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object", __proto__: {} } as unknown as Readonly<
+        Record<string, unknown>
+      >,
+      implementation: "return 1;",
+    };
+    const _result = verifyStatic(input, DEFAULT_VERIFICATION);
+    // __proto__ is special in JS — it may not show up as own key
+    // Test with nested dangerous key instead
+    const input2: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object", properties: { constructor: { type: "string" } } },
+      implementation: "return 1;",
+    };
+    const result2 = verifyStatic(input2, DEFAULT_VERIFICATION);
+    expect(result2.ok).toBe(false);
+    if (!result2.ok && result2.error.stage === "static") {
+      expect(result2.error.code).toBe("INVALID_SCHEMA");
+    }
+  });
+});
+
+describe("verifyStatic — size validation", () => {
+  test("rejects implementation exceeding maxBrickSizeBytes", () => {
+    const config: VerificationConfig = { ...DEFAULT_VERIFICATION, maxBrickSizeBytes: 100 };
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "x".repeat(200),
+    };
+    const result = verifyStatic(input, config);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.stage === "static") {
+      expect(result.error.code).toBe("SIZE_EXCEEDED");
+    }
+  });
+});
+
+describe("verifyStatic — kind-specific validation", () => {
+  test("rejects tool with empty implementation", () => {
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "myTool",
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects skill with empty content", () => {
+    const input: ForgeInput = {
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      content: "",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts valid skill", () => {
+    const input: ForgeInput = {
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      content: "# My Skill\nSome content here.",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects agent with empty manifest", () => {
+    const input: ForgeInput = {
+      kind: "agent",
+      name: "myAgent",
+      description: "An agent",
+      manifestYaml: "",
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects composite with empty brickIds", () => {
+    const input: ForgeInput = {
+      kind: "composite",
+      name: "myComposite",
+      description: "A composite",
+      brickIds: [],
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts valid composite", () => {
+    const input: ForgeInput = {
+      kind: "composite",
+      name: "myComposite",
+      description: "A composite",
+      brickIds: ["brick_1"],
+    };
+    const result = verifyStatic(input, DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns StageReport with timing on success", () => {
+    const result = verifyStatic(validToolInput(), DEFAULT_VERIFICATION);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.stage).toBe("static");
+      expect(result.value.passed).toBe(true);
+      expect(result.value.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/packages/forge/src/verify-static.ts
+++ b/packages/forge/src/verify-static.ts
@@ -1,0 +1,172 @@
+/**
+ * Stage 1: Static validation — name, schema, size, security checks.
+ * No external deps. Pure synchronous validation.
+ */
+
+import type { Result } from "@koi/core";
+import type { VerificationConfig } from "./config.js";
+import type { ForgeError } from "./errors.js";
+import { staticError } from "./errors.js";
+import type { ForgeInput, StageReport } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]{2,49}$/;
+const MAX_DESCRIPTION_LENGTH = 500;
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const TEXT_ENCODER = new TextEncoder();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validateName(name: string): ForgeError | undefined {
+  if (name.includes("/") || name.includes("\\") || name.includes("..")) {
+    return staticError("INVALID_NAME", `Name contains path traversal characters: "${name}"`);
+  }
+  if (!NAME_PATTERN.test(name)) {
+    return staticError("INVALID_NAME", `Name must match ${NAME_PATTERN.source}, got: "${name}"`);
+  }
+  return undefined;
+}
+
+function validateDescription(description: string): ForgeError | undefined {
+  if (description.length === 0) {
+    return staticError("MISSING_FIELD", "Description must not be empty");
+  }
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    return staticError(
+      "SIZE_EXCEEDED",
+      `Description exceeds ${MAX_DESCRIPTION_LENGTH} chars (got ${description.length})`,
+    );
+  }
+  return undefined;
+}
+
+function hasDangerousKeys(obj: unknown, depth = 0): boolean {
+  if (depth > 10 || obj === null || typeof obj !== "object") {
+    return false;
+  }
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.has(key)) {
+      return true;
+    }
+    if (hasDangerousKeys((obj as Record<string, unknown>)[key], depth + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validateSchema(schema: Readonly<Record<string, unknown>>): ForgeError | undefined {
+  if (schema.type === undefined) {
+    return staticError("INVALID_SCHEMA", 'Input schema must have a "type" field');
+  }
+  if (hasDangerousKeys(schema)) {
+    return staticError(
+      "INVALID_SCHEMA",
+      "Input schema contains dangerous keys (__proto__, constructor, prototype)",
+    );
+  }
+  return undefined;
+}
+
+function validateSize(content: string, maxBytes: number, label: string): ForgeError | undefined {
+  const size = TEXT_ENCODER.encode(content).byteLength;
+  if (size > maxBytes) {
+    return staticError("SIZE_EXCEEDED", `${label} exceeds ${maxBytes} bytes (got ${size})`);
+  }
+  return undefined;
+}
+
+function validateToolInput(
+  input: Extract<ForgeInput, { readonly kind: "tool" }>,
+  config: VerificationConfig,
+): ForgeError | undefined {
+  if (input.implementation.length === 0) {
+    return staticError("MISSING_FIELD", "Tool implementation must not be empty");
+  }
+  const schemaErr = validateSchema(input.inputSchema);
+  if (schemaErr !== undefined) {
+    return schemaErr;
+  }
+  return validateSize(input.implementation, config.maxBrickSizeBytes, "Implementation");
+}
+
+function validateSkillInput(
+  input: Extract<ForgeInput, { readonly kind: "skill" }>,
+  config: VerificationConfig,
+): ForgeError | undefined {
+  if (input.content.length === 0) {
+    return staticError("MISSING_FIELD", "Skill content must not be empty");
+  }
+  return validateSize(input.content, config.maxBrickSizeBytes, "Content");
+}
+
+function validateAgentInput(
+  input: Extract<ForgeInput, { readonly kind: "agent" }>,
+  config: VerificationConfig,
+): ForgeError | undefined {
+  if (input.manifestYaml.length === 0) {
+    return staticError("MISSING_FIELD", "Agent manifest YAML must not be empty");
+  }
+  return validateSize(input.manifestYaml, config.maxBrickSizeBytes, "Manifest YAML");
+}
+
+function validateCompositeInput(
+  input: Extract<ForgeInput, { readonly kind: "composite" }>,
+): ForgeError | undefined {
+  if (input.brickIds.length === 0) {
+    return staticError("MISSING_FIELD", "Composite must reference at least one brick");
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function verifyStatic(
+  input: ForgeInput,
+  config: VerificationConfig,
+): Result<StageReport, ForgeError> {
+  const start = performance.now();
+
+  const nameErr = validateName(input.name);
+  if (nameErr !== undefined) {
+    return { ok: false, error: nameErr };
+  }
+
+  const descErr = validateDescription(input.description);
+  if (descErr !== undefined) {
+    return { ok: false, error: descErr };
+  }
+
+  let kindErr: ForgeError | undefined;
+  switch (input.kind) {
+    case "tool":
+      kindErr = validateToolInput(input, config);
+      break;
+    case "skill":
+      kindErr = validateSkillInput(input, config);
+      break;
+    case "agent":
+      kindErr = validateAgentInput(input, config);
+      break;
+    case "composite":
+      kindErr = validateCompositeInput(input);
+      break;
+  }
+
+  if (kindErr !== undefined) {
+    return { ok: false, error: kindErr };
+  }
+
+  const durationMs = performance.now() - start;
+  return {
+    ok: true,
+    value: { stage: "static", passed: true, durationMs },
+  };
+}

--- a/packages/forge/src/verify-trust.test.ts
+++ b/packages/forge/src/verify-trust.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "./config.js";
+import type { ForgeInput, StageReport } from "./types.js";
+import { assignTrust } from "./verify-trust.js";
+
+const validInput: ForgeInput = {
+  kind: "tool",
+  name: "myTool",
+  description: "A tool",
+  inputSchema: { type: "object" },
+  implementation: "return 1;",
+};
+
+const passingStages: readonly StageReport[] = [
+  { stage: "static", passed: true, durationMs: 1 },
+  { stage: "sandbox", passed: true, durationMs: 2 },
+  { stage: "self_test", passed: true, durationMs: 3 },
+];
+
+describe("assignTrust", () => {
+  test("assigns default trust tier from config", () => {
+    const config = createDefaultForgeConfig();
+    const result = assignTrust(validInput, config, passingStages);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.trustTier).toBe("sandbox");
+      expect(result.value.passed).toBe(true);
+      expect(result.value.stage).toBe("trust");
+    }
+  });
+
+  test("caps trust at verified when config says promoted", () => {
+    const config = createDefaultForgeConfig({ defaultTrustTier: "promoted" });
+    const result = assignTrust(validInput, config, passingStages);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.trustTier).toBe("verified");
+    }
+  });
+
+  test("assigns verified when config says verified", () => {
+    const config = createDefaultForgeConfig({ defaultTrustTier: "verified" });
+    const result = assignTrust(validInput, config, passingStages);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.trustTier).toBe("verified");
+    }
+  });
+
+  test("rejects when a prior stage failed", () => {
+    const config = createDefaultForgeConfig();
+    const failedStages: readonly StageReport[] = [
+      { stage: "static", passed: true, durationMs: 1 },
+      { stage: "sandbox", passed: false, durationMs: 2, message: "crashed" },
+    ];
+    const result = assignTrust(validInput, config, failedStages);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("trust");
+    }
+  });
+
+  test("includes durationMs in report", () => {
+    const config = createDefaultForgeConfig();
+    const result = assignTrust(validInput, config, passingStages);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/packages/forge/src/verify-trust.ts
+++ b/packages/forge/src/verify-trust.ts
@@ -1,0 +1,50 @@
+/**
+ * Stage 4: Trust tier assignment — determines the trust level for a forged brick.
+ */
+
+import type { Result, TrustTier } from "@koi/core";
+import type { ForgeConfig } from "./config.js";
+import type { ForgeError } from "./errors.js";
+import { trustError } from "./errors.js";
+import type { ForgeInput, StageReport, TrustStageReport } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function assignTrust(
+  _input: ForgeInput,
+  config: ForgeConfig,
+  stageResults: readonly StageReport[],
+): Result<TrustStageReport, ForgeError> {
+  const start = performance.now();
+
+  // All prior stages must have passed
+  for (const stage of stageResults) {
+    if (!stage.passed) {
+      return {
+        ok: false,
+        error: trustError(
+          "GOVERNANCE_REJECTED",
+          `Cannot assign trust: stage "${stage.stage}" did not pass`,
+        ),
+      };
+    }
+  }
+
+  // Trust never exceeds "verified" via automated pipeline
+  // "promoted" requires human-in-the-loop
+  const tier: TrustTier =
+    config.defaultTrustTier === "promoted" ? "verified" : config.defaultTrustTier;
+
+  const durationMs = performance.now() - start;
+  return {
+    ok: true,
+    value: {
+      stage: "trust",
+      passed: true,
+      durationMs,
+      trustTier: tier,
+    },
+  };
+}

--- a/packages/forge/src/verify.test.ts
+++ b/packages/forge/src/verify.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultForgeConfig } from "./config.js";
+import type { ForgeContext, ForgeInput, ForgeVerifier, SandboxExecutor } from "./types.js";
+import { verify } from "./verify.js";
+
+const DEFAULT_CONTEXT: ForgeContext = {
+  agentId: "agent-1",
+  depth: 0,
+  sessionId: "session-1",
+  forgesThisSession: 0,
+};
+
+function mockExecutor(): SandboxExecutor {
+  return {
+    execute: async (_code, input, _timeout) => ({
+      ok: true,
+      value: { output: input, durationMs: 1 },
+    }),
+  };
+}
+
+const validToolInput: ForgeInput = {
+  kind: "tool",
+  name: "myTool",
+  description: "A test tool",
+  inputSchema: { type: "object" },
+  implementation: "function run(input) { return input; }",
+};
+
+describe("verify — full pipeline", () => {
+  test("succeeds for valid tool input", async () => {
+    const config = createDefaultForgeConfig();
+    const result = await verify(validToolInput, DEFAULT_CONTEXT, mockExecutor(), [], config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.passed).toBe(true);
+      expect(result.value.stages).toHaveLength(4);
+      expect(result.value.finalTrustTier).toBe("sandbox");
+      expect(result.value.totalDurationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("succeeds for valid skill input", async () => {
+    const config = createDefaultForgeConfig();
+    const input: ForgeInput = {
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      content: "# Skill content",
+    };
+    const result = await verify(input, DEFAULT_CONTEXT, mockExecutor(), [], config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.passed).toBe(true);
+      expect(result.value.stages).toHaveLength(4);
+    }
+  });
+
+  test("early-terminates on static validation failure", async () => {
+    const config = createDefaultForgeConfig();
+    const input: ForgeInput = {
+      kind: "tool",
+      name: "x", // too short
+      description: "A tool",
+      inputSchema: { type: "object" },
+      implementation: "return 1;",
+    };
+    const result = await verify(input, DEFAULT_CONTEXT, mockExecutor(), [], config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("static");
+    }
+  });
+
+  test("early-terminates on sandbox failure", async () => {
+    const config = createDefaultForgeConfig();
+    const executor: SandboxExecutor = {
+      execute: async () => ({
+        ok: false,
+        error: { code: "TIMEOUT", message: "timeout", durationMs: 5000 },
+      }),
+    };
+    const result = await verify(validToolInput, DEFAULT_CONTEXT, executor, [], config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("sandbox");
+    }
+  });
+
+  test("early-terminates on self-test failure", async () => {
+    const config = createDefaultForgeConfig();
+    const verifier: ForgeVerifier = {
+      name: "reject",
+      verify: async () => ({ passed: false, message: "nope" }),
+    };
+    const result = await verify(
+      validToolInput,
+      DEFAULT_CONTEXT,
+      mockExecutor(),
+      [verifier],
+      config,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("self_test");
+    }
+  });
+});
+
+describe("verify — pipeline timeout", () => {
+  test("aborts when totalTimeoutMs is exceeded between stages", async () => {
+    // Use a slow executor that takes longer than the total timeout
+    const slowExecutor: SandboxExecutor = {
+      execute: async (_code, input, _timeout) => {
+        // Simulate slow sandbox — block for longer than the total timeout
+        const start = performance.now();
+        while (performance.now() - start < 50) {
+          // busy wait
+        }
+        return { ok: true, value: { output: input, durationMs: 50 } };
+      },
+    };
+
+    // Set a very short total timeout so the pipeline timeout fires after sandbox
+    const config = createDefaultForgeConfig({
+      verification: {
+        staticTimeoutMs: 1_000,
+        sandboxTimeoutMs: 5_000,
+        selfTestTimeoutMs: 10_000,
+        totalTimeoutMs: 10, // 10ms total — sandbox alone takes 50ms
+        maxBrickSizeBytes: 50_000,
+      },
+    });
+
+    const result = await verify(validToolInput, DEFAULT_CONTEXT, slowExecutor, [], config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.stage).toBe("sandbox");
+      if (result.error.stage === "sandbox") {
+        expect(result.error.code).toBe("TIMEOUT");
+      }
+    }
+  });
+});
+
+describe("verify — timing", () => {
+  test("reports total duration covering all stages", async () => {
+    const config = createDefaultForgeConfig();
+    const result = await verify(validToolInput, DEFAULT_CONTEXT, mockExecutor(), [], config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.totalDurationMs).toBeGreaterThanOrEqual(0);
+      expect(result.value.stages).toHaveLength(4);
+    }
+  });
+});

--- a/packages/forge/src/verify.ts
+++ b/packages/forge/src/verify.ts
@@ -1,0 +1,117 @@
+/**
+ * Pipeline orchestrator — runs verification stages sequentially with early termination.
+ *
+ * Governance checks are handled by the createForgeTool factory (shared.ts),
+ * NOT here. This function is purely the 4-stage verification pipeline.
+ */
+
+import type { Result } from "@koi/core";
+import type { ForgeConfig } from "./config.js";
+import type { ForgeError } from "./errors.js";
+import { sandboxError } from "./errors.js";
+import type {
+  ForgeContext,
+  ForgeInput,
+  ForgeVerifier,
+  SandboxExecutor,
+  StageReport,
+  VerificationReport,
+} from "./types.js";
+import { verifySandbox } from "./verify-sandbox.js";
+import { verifySelfTest } from "./verify-self-test.js";
+import { verifyStatic } from "./verify-static.js";
+import { assignTrust } from "./verify-trust.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function checkTimeout(pipelineStart: number, totalTimeoutMs: number): ForgeError | undefined {
+  const elapsed = performance.now() - pipelineStart;
+  if (elapsed > totalTimeoutMs) {
+    return sandboxError(
+      "TIMEOUT",
+      `Verification pipeline exceeded total timeout (${totalTimeoutMs}ms, elapsed ${Math.round(elapsed)}ms)`,
+      elapsed,
+    );
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function verify(
+  input: ForgeInput,
+  context: ForgeContext,
+  executor: SandboxExecutor,
+  verifiers: readonly ForgeVerifier[],
+  config: ForgeConfig,
+): Promise<Result<VerificationReport, ForgeError>> {
+  const pipelineStart = performance.now();
+  const totalTimeoutMs = config.verification.totalTimeoutMs;
+
+  const stages: StageReport[] = [];
+
+  // Stage 1: Static validation
+  const staticResult = verifyStatic(input, config.verification);
+  if (!staticResult.ok) {
+    return { ok: false, error: staticResult.error };
+  }
+  stages.push(staticResult.value);
+
+  const timeoutAfterStatic = checkTimeout(pipelineStart, totalTimeoutMs);
+  if (timeoutAfterStatic !== undefined) {
+    return { ok: false, error: timeoutAfterStatic };
+  }
+
+  // Stage 2: Sandbox execution
+  const sandboxResult = await verifySandbox(input, executor, config.verification);
+  if (!sandboxResult.ok) {
+    return { ok: false, error: sandboxResult.error };
+  }
+  stages.push(sandboxResult.value);
+
+  const timeoutAfterSandbox = checkTimeout(pipelineStart, totalTimeoutMs);
+  if (timeoutAfterSandbox !== undefined) {
+    return { ok: false, error: timeoutAfterSandbox };
+  }
+
+  // Stage 3: Self-test + verifiers
+  const selfTestResult = await verifySelfTest(
+    input,
+    executor,
+    verifiers,
+    context,
+    config.verification,
+  );
+  if (!selfTestResult.ok) {
+    return { ok: false, error: selfTestResult.error };
+  }
+  stages.push(selfTestResult.value);
+
+  const timeoutAfterSelfTest = checkTimeout(pipelineStart, totalTimeoutMs);
+  if (timeoutAfterSelfTest !== undefined) {
+    return { ok: false, error: timeoutAfterSelfTest };
+  }
+
+  // Stage 4: Trust assignment
+  const trustResult = assignTrust(input, config, stages);
+  if (!trustResult.ok) {
+    return { ok: false, error: trustResult.error };
+  }
+  stages.push(trustResult.value);
+
+  const totalDurationMs = performance.now() - pipelineStart;
+
+  return {
+    ok: true,
+    value: {
+      stages,
+      finalTrustTier: trustResult.value.trustTier,
+      totalDurationMs,
+      passed: true,
+    },
+  };
+}

--- a/packages/forge/tsconfig.json
+++ b/packages/forge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/forge/tsup.config.ts
+++ b/packages/forge/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   "references": [
     { "path": "packages/core" },
     { "path": "packages/sandbox" },
-    { "path": "packages/search" }
+    { "path": "packages/search" },
+    { "path": "packages/forge" }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the `@koi/forge` package — the self-extension system that enables agents to create, discover, and compose tools at runtime through a 4-stage verification pipeline.

- **L0 type additions**: `TrustTier`, `ForgeScope`, `BrickLifecycle`, `BrickKind` + `trustTier` on `Tool`
- **4-stage verification pipeline**: static → sandbox → self_test → trust (sequential, early termination)
- **3 adversarial verifiers**: injection probes, resource exhaustion, exfiltration detection
- **6 primordial tools**: `forge_tool`, `search_forge`, `forge_skill` + 3 stubs (`forge_agent`, `compose_forge`, `promote_forge`)
- **ForgeStore** interface + `InMemoryForgeStore` implementation
- **ForgeComponentProvider**: converts `BrickArtifact` → executable `Tool`, attaches to agents via L0 `ComponentProvider`
- **ForgeResolver**: `Resolver` adapter backed by `ForgeStore`
- **Governance**: depth limits, session rate limiting, scope promotion policies
- **172 tests**, 0 failures, 94.9% line coverage

### Remaining gaps (tracked in separate issues)
- BM25/semantic search → #110
- AST analysis / namespace collision → #44
- ArtifactClient persistence → #57
- Real sandbox (already merged) → #16

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] `bun run lint` passes (Biome)
- [x] 172 tests pass across 18 test files
- [x] 12 mandatory edge case tests (proto injection, path traversal, depth limits, etc.)
- [x] Full lifecycle E2E test (forge → discover → search → governance limit)
- [x] L0 layer boundary preserved (`@koi/forge` only imports from `@koi/core`)

Closes #63