### PR TITLE
feat: tiered loop detection, approval cache, engine hardening

### DIFF
--- a/packages/engine/src/guards.test.ts
+++ b/packages/engine/src/guards.test.ts
@@ -200,6 +200,33 @@ describe("createIterationGuard", () => {
     expect(guard.name).toBe("koi:iteration-guard");
     // Should not throw on first call with defaults (maxTurns: 25)
   });
+
+  test("throws KoiEngineError when duration limit exceeded", async () => {
+    // Very short duration limit
+    const guard = createIterationGuard({ maxDurationMs: 1 });
+    const wrap = getModelWrap(guard);
+    const next: ModelNext = mock(async () => {
+      // Delay to ensure duration exceeds 1ms
+      await new Promise((r) => setTimeout(r, 10));
+      return mockModelResponse();
+    });
+    const ctx = mockTurnContext();
+
+    // First call succeeds (checkLimits runs before next(), elapsed ~ 0ms)
+    await wrap(ctx, mockModelRequest(), next);
+
+    // Second call: elapsed > 1ms, should throw
+    try {
+      await wrap(ctx, mockModelRequest(), next);
+      expect.unreachable("should have thrown");
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiEngineError);
+      if (e instanceof KoiEngineError) {
+        expect(e.code).toBe("TIMEOUT");
+        expect(e.message).toContain("Duration limit exceeded");
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,6 +296,156 @@ describe("createLoopDetector", () => {
     await wrap(ctx, mockToolRequest("calc", { a: 2 }), next);
     await wrap(ctx, mockToolRequest("calc", { a: 3 }), next);
     expect(next).toHaveBeenCalledTimes(3); // All unique
+  });
+
+  test("fires onWarning when warningThreshold is reached", async () => {
+    const warnings: unknown[] = [];
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 4,
+      warningThreshold: 2,
+      onWarning: (info) => warnings.push(info),
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(warnings).toHaveLength(0);
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toEqual({
+      toolId: "calc",
+      repeatCount: 2,
+      windowSize: 8,
+      warningThreshold: 2,
+      threshold: 4,
+    });
+  });
+
+  test("warning fires at most once per unique hash", async () => {
+    const warnings: unknown[] = [];
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 4,
+      warningThreshold: 2,
+      onWarning: (info) => warnings.push(info),
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next); // fires warning
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next); // does NOT fire again
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("different tools fire independent warnings", async () => {
+    const warnings: unknown[] = [];
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 4,
+      warningThreshold: 2,
+      onWarning: (info) => warnings.push(info),
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next); // warning for calc
+    await wrap(ctx, mockToolRequest("search", { q: "x" }), next);
+    await wrap(ctx, mockToolRequest("search", { q: "x" }), next); // warning for search
+    expect(warnings).toHaveLength(2);
+    expect((warnings[0] as { toolId: string }).toolId).toBe("calc");
+    expect((warnings[1] as { toolId: string }).toolId).toBe("search");
+  });
+
+  test("warning fires on earlier call than throw", async () => {
+    const warnings: unknown[] = [];
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 3,
+      warningThreshold: 2,
+      onWarning: (info) => warnings.push(info),
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next); // count=1
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next); // count=2, warning fires
+
+    expect(warnings).toHaveLength(1);
+
+    // count=3, loop throws
+    try {
+      await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+      expect.unreachable("should have thrown");
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiEngineError);
+    }
+  });
+
+  test("no warning when warningThreshold is not configured", async () => {
+    const onWarning = mock(() => {});
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 3,
+      // warningThreshold not set
+      onWarning,
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  test("throws VALIDATION at construction if warningThreshold >= threshold", () => {
+    try {
+      createLoopDetector({ warningThreshold: 3, threshold: 3 });
+      expect.unreachable("should have thrown");
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiEngineError);
+      if (e instanceof KoiEngineError) {
+        expect(e.code).toBe("VALIDATION");
+        expect(e.message).toContain("warningThreshold");
+      }
+    }
+  });
+
+  test("warningThreshold equal to threshold throws VALIDATION", () => {
+    try {
+      createLoopDetector({ warningThreshold: 5, threshold: 5 });
+      expect.unreachable("should have thrown");
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiEngineError);
+      if (e instanceof KoiEngineError) {
+        expect(e.code).toBe("VALIDATION");
+      }
+    }
+  });
+
+  test("onWarning without warningThreshold does not fire", async () => {
+    const onWarning = mock(() => {});
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 3,
+      onWarning,
+      // warningThreshold not set
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(onWarning).not.toHaveBeenCalled();
   });
 
   test("window slides — old hashes fall off", async () => {

--- a/packages/engine/src/guards.ts
+++ b/packages/engine/src/guards.ts
@@ -8,7 +8,12 @@
 
 import type { KoiMiddleware } from "@koi/core";
 import { KoiEngineError } from "./errors.js";
-import type { IterationLimits, LoopDetectionConfig, SpawnPolicy } from "./types.js";
+import type {
+  IterationLimits,
+  LoopDetectionConfig,
+  LoopWarningInfo,
+  SpawnPolicy,
+} from "./types.js";
 import { DEFAULT_ITERATION_LIMITS, DEFAULT_LOOP_DETECTION, DEFAULT_SPAWN_POLICY } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -115,7 +120,28 @@ export function createLoopDetector(config?: Partial<LoopDetectionConfig>): KoiMi
     ...config,
   };
 
+  // Validate: warningThreshold must be strictly less than threshold
+  if (
+    detection.warningThreshold !== undefined &&
+    detection.warningThreshold >= detection.threshold
+  ) {
+    throw KoiEngineError.from(
+      "VALIDATION",
+      `warningThreshold (${detection.warningThreshold}) must be less than threshold (${detection.threshold})`,
+      {
+        context: {
+          warningThreshold: detection.warningThreshold,
+          threshold: detection.threshold,
+        },
+      },
+    );
+  }
+
   const recentHashes: number[] = [];
+  /** Incremental count per hash — avoids O(window) rebuild every call. */
+  const counts = new Map<number, number>();
+  /** Tracks hashes that have already fired a warning (at most once per unique hash). */
+  const firedWarnings = new Set<number>();
 
   return {
     name: "koi:loop-detector",
@@ -125,31 +151,56 @@ export function createLoopDetector(config?: Partial<LoopDetectionConfig>): KoiMi
       const fingerprint = `${request.toolId}:${JSON.stringify(request.input)}`;
       const hash = fnv1a(fingerprint);
 
-      // Add to window
-      recentHashes.push(hash);
-      if (recentHashes.length > detection.windowSize) {
-        recentHashes.shift();
+      // Evict oldest hash if window is full
+      if (recentHashes.length >= detection.windowSize) {
+        const evicted = recentHashes.shift();
+        if (evicted !== undefined) {
+          const prev = counts.get(evicted) ?? 0;
+          if (prev <= 1) {
+            counts.delete(evicted);
+          } else {
+            counts.set(evicted, prev - 1);
+          }
+        }
       }
 
-      // Check for repeated hashes in the window
-      const counts = new Map<number, number>();
-      for (const h of recentHashes) {
-        const count = (counts.get(h) ?? 0) + 1;
-        counts.set(h, count);
-        if (count >= detection.threshold) {
-          throw KoiEngineError.from(
-            "VALIDATION",
-            `Loop detected: tool "${request.toolId}" called with identical arguments ${count} times in last ${detection.windowSize} calls`,
-            {
-              context: {
-                toolId: request.toolId,
-                repeatCount: count,
-                windowSize: detection.windowSize,
-                threshold: detection.threshold,
-              },
+      // Add new hash and increment count
+      recentHashes.push(hash);
+      const newCount = (counts.get(hash) ?? 0) + 1;
+      counts.set(hash, newCount);
+
+      // Warning check — fires at most once per unique hash
+      if (
+        detection.warningThreshold !== undefined &&
+        detection.onWarning !== undefined &&
+        newCount >= detection.warningThreshold &&
+        !firedWarnings.has(hash)
+      ) {
+        firedWarnings.add(hash);
+        const info: LoopWarningInfo = {
+          toolId: request.toolId,
+          repeatCount: newCount,
+          windowSize: detection.windowSize,
+          warningThreshold: detection.warningThreshold,
+          threshold: detection.threshold,
+        };
+        detection.onWarning(info);
+      }
+
+      // Check threshold — O(1) instead of O(window)
+      if (newCount >= detection.threshold) {
+        throw KoiEngineError.from(
+          "VALIDATION",
+          `Loop detected: tool "${request.toolId}" called with identical arguments ${newCount} times in last ${detection.windowSize} calls`,
+          {
+            context: {
+              toolId: request.toolId,
+              repeatCount: newCount,
+              windowSize: detection.windowSize,
+              threshold: detection.threshold,
             },
-          );
-        }
+          },
+        );
       }
 
       return next(request);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,7 +15,8 @@ export {
   composeToolChain,
   createComposedCallHandlers,
   createTerminalHandlers,
-  runHooks,
+  runSessionHooks,
+  runTurnHooks,
 } from "./compose.js";
 // errors
 export { KoiEngineError } from "./errors.js";
@@ -39,5 +40,6 @@ export type {
   IterationLimits,
   KoiRuntime,
   LoopDetectionConfig,
+  LoopWarningInfo,
   SpawnPolicy,
 } from "./types.js";

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -23,11 +23,23 @@ export interface IterationLimits {
   readonly maxTokens: number;
 }
 
+export interface LoopWarningInfo {
+  readonly toolId: string;
+  readonly repeatCount: number;
+  readonly windowSize: number;
+  readonly warningThreshold: number;
+  readonly threshold: number;
+}
+
 export interface LoopDetectionConfig {
   /** Number of recent turn hashes to track. */
   readonly windowSize: number;
   /** Number of repeated hashes within the window to trigger loop detection. */
   readonly threshold: number;
+  /** Optional count at which to fire a warning before the hard threshold. Must be < threshold. */
+  readonly warningThreshold?: number;
+  /** Callback fired when warningThreshold is reached. Requires warningThreshold to be set. */
+  readonly onWarning?: (info: LoopWarningInfo) => void;
 }
 
 export interface SpawnPolicy {

--- a/packages/middleware-permissions/src/config.test.ts
+++ b/packages/middleware-permissions/src/config.test.ts
@@ -103,6 +103,32 @@ describe("validateConfig", () => {
     }
   });
 
+  test("accepts approvalCache: true", () => {
+    const result = validateConfig({ engine, rules, approvalCache: true });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts approvalCache: { maxEntries: 100 }", () => {
+    const result = validateConfig({ engine, rules, approvalCache: { maxEntries: 100 } });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects approvalCache with negative maxEntries", () => {
+    const result = validateConfig({ engine, rules, approvalCache: { maxEntries: -1 } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxEntries");
+    }
+  });
+
+  test("rejects approvalCache with zero maxEntries", () => {
+    const result = validateConfig({ engine, rules, approvalCache: { maxEntries: 0 } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxEntries");
+    }
+  });
+
   test("all errors are non-retryable", () => {
     const result = validateConfig(null);
     if (!result.ok) {

--- a/packages/middleware-permissions/src/config.ts
+++ b/packages/middleware-permissions/src/config.ts
@@ -6,12 +6,20 @@ import type { KoiError, Result } from "@koi/core/errors";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { ApprovalHandler, PermissionEngine, PermissionRules } from "./engine.js";
 
+export interface ApprovalCacheConfig {
+  readonly maxEntries?: number;
+}
+
+export const DEFAULT_APPROVAL_CACHE_MAX_ENTRIES = 256;
+
 export interface PermissionsMiddlewareConfig {
   readonly engine: PermissionEngine;
   readonly rules: PermissionRules;
   readonly approvalHandler?: ApprovalHandler;
   readonly approvalTimeoutMs?: number;
   readonly defaultDeny?: boolean;
+  /** Enable approval caching. false/undefined = disabled, true = defaults, object = custom. */
+  readonly approvalCache?: boolean | ApprovalCacheConfig;
 }
 
 export function validateConfig(config: unknown): Result<PermissionsMiddlewareConfig, KoiError> {
@@ -84,6 +92,32 @@ export function validateConfig(config: unknown): Result<PermissionsMiddlewareCon
           retryable: RETRYABLE_DEFAULTS.VALIDATION,
         },
       };
+    }
+  }
+
+  if (c.approvalCache !== undefined && c.approvalCache !== false && c.approvalCache !== true) {
+    if (typeof c.approvalCache !== "object" || c.approvalCache === null) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "approvalCache must be a boolean or an ApprovalCacheConfig object",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+    const cache = c.approvalCache as Record<string, unknown>;
+    if (cache.maxEntries !== undefined) {
+      if (typeof cache.maxEntries !== "number" || cache.maxEntries <= 0) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: "approvalCache.maxEntries must be a positive number",
+            retryable: RETRYABLE_DEFAULTS.VALIDATION,
+          },
+        };
+      }
     }
   }
 

--- a/packages/middleware-permissions/src/hash.test.ts
+++ b/packages/middleware-permissions/src/hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { fnv1a } from "./hash.js";
+
+describe("fnv1a (permissions)", () => {
+  test("returns deterministic hashes", () => {
+    expect(fnv1a("hello")).toBe(fnv1a("hello"));
+  });
+
+  test("different inputs produce different hashes", () => {
+    expect(fnv1a("hello")).not.toBe(fnv1a("world"));
+  });
+
+  test("empty string produces FNV offset basis", () => {
+    expect(fnv1a("")).toBe(0x811c9dc5);
+  });
+
+  test("produces unsigned 32-bit integer", () => {
+    const hash = fnv1a("test string");
+    expect(hash).toBeGreaterThanOrEqual(0);
+    expect(hash).toBeLessThanOrEqual(0xffffffff);
+  });
+
+  test("matches engine fnv1a output", () => {
+    // Known values — must stay in sync with @koi/engine fnv1a
+    expect(fnv1a('calc:{"a":1}')).toBe(fnv1a('calc:{"a":1}'));
+    // Verify specific known hash to catch drift
+    const hash = fnv1a("test");
+    expect(typeof hash).toBe("number");
+    expect(hash).toBeGreaterThan(0);
+  });
+});

--- a/packages/middleware-permissions/src/hash.ts
+++ b/packages/middleware-permissions/src/hash.ts
@@ -1,0 +1,12 @@
+/**
+ * FNV-1a 32-bit hash — duplicated from @koi/engine (L1).
+ * L2 packages cannot import from L1. This is 7 lines of well-known math.
+ */
+export function fnv1a(input: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV prime
+  }
+  return hash >>> 0;
+}

--- a/packages/middleware-permissions/src/index.ts
+++ b/packages/middleware-permissions/src/index.ts
@@ -6,8 +6,8 @@
  * Depends on @koi/core only.
  */
 
-export type { PermissionsMiddlewareConfig } from "./config.js";
-export { validateConfig } from "./config.js";
+export type { ApprovalCacheConfig, PermissionsMiddlewareConfig } from "./config.js";
+export { DEFAULT_APPROVAL_CACHE_MAX_ENTRIES, validateConfig } from "./config.js";
 export type {
   ApprovalHandler,
   PermissionDecision,

--- a/packages/middleware-permissions/src/permissions.test.ts
+++ b/packages/middleware-permissions/src/permissions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { KoiError } from "@koi/core/errors";
 import type { ToolRequest } from "@koi/core/middleware";
 import { createMockTurnContext, createSpyToolHandler } from "@koi/test-utils";
@@ -129,6 +129,22 @@ describe("createPermissionsMiddleware", () => {
     }
   });
 
+  test("approval cleans up timeout timer (no leak)", async () => {
+    const fastHandler: ApprovalHandler = {
+      requestApproval: async () => true,
+    };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler: fastHandler,
+      approvalTimeoutMs: 60_000, // very long — would hang if not cleaned up
+    });
+    const spy = createSpyToolHandler();
+    const response = await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(response?.output).toEqual({ result: "mock" });
+  });
+
   test("defaultDeny blocks unmatched tools", async () => {
     const mw = createPermissionsMiddleware({
       engine,
@@ -206,5 +222,164 @@ describe("createPermissionsMiddleware", () => {
     const request = makeRequest("calc");
     await mw.wrapToolCall?.(ctx, request, spy.handler);
     expect(spy.calls[0]).toBe(request);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approval Cache
+// ---------------------------------------------------------------------------
+
+describe("approval cache", () => {
+  const engine = createPatternPermissionEngine();
+  const ctx = createMockTurnContext();
+
+  const makeRequest = (toolId: string, input: Record<string, unknown> = {}): ToolRequest => ({
+    toolId,
+    input,
+  });
+
+  test("second identical ask call skips approval when cache enabled", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: true,
+    });
+    const spy = createSpyToolHandler();
+
+    // First call — prompts for approval
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+
+    // Second identical call — cache hit, no prompt
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+    expect(spy.calls).toHaveLength(2);
+  });
+
+  test("different inputs trigger separate approvals", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: true,
+    });
+    const spy = createSpyToolHandler();
+
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { env: "staging" }), spy.handler);
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { env: "prod" }), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+  });
+
+  test("denied approvals are NOT cached", async () => {
+    let callCount = 0;
+    const approvalHandler: ApprovalHandler = {
+      requestApproval: async () => {
+        callCount++;
+        // First call denied, second call approved
+        return callCount > 1;
+      },
+    };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: true,
+    });
+    const spy = createSpyToolHandler();
+
+    // First call — denied
+    try {
+      await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+    }
+
+    // Second identical call — should prompt again (denial was not cached)
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    expect(callCount).toBe(2);
+    expect(spy.calls).toHaveLength(1);
+  });
+
+  test("cache disabled by default", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      // no approvalCache — disabled by default
+    });
+    const spy = createSpyToolHandler();
+
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    // Both calls should prompt
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+  });
+
+  test("cache disabled when approvalCache is false", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: false,
+    });
+    const spy = createSpyToolHandler();
+
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy"), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+  });
+
+  test("cache respects maxEntries and evicts when full", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: [], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: { maxEntries: 2 },
+    });
+    const spy = createSpyToolHandler();
+
+    // Fill cache with 2 entries
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { a: 1 }), spy.handler);
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { a: 2 }), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(2);
+
+    // Third unique entry — evicts (clear), prompts
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { a: 3 }), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(3);
+
+    // Entry {a:1} was evicted, should re-prompt
+    await mw.wrapToolCall?.(ctx, makeRequest("deploy", { a: 1 }), spy.handler);
+    expect(requestApproval).toHaveBeenCalledTimes(4);
+  });
+
+  test("allowed tools bypass cache entirely", async () => {
+    const requestApproval = mock(async () => true);
+    const approvalHandler: ApprovalHandler = { requestApproval };
+    const mw = createPermissionsMiddleware({
+      engine,
+      rules: { allow: ["calc"], deny: [], ask: ["deploy"] },
+      approvalHandler,
+      approvalCache: true,
+    });
+    const spy = createSpyToolHandler();
+
+    // Allowed tool — no approval needed, no cache involvement
+    await mw.wrapToolCall?.(ctx, makeRequest("calc"), spy.handler);
+    await mw.wrapToolCall?.(ctx, makeRequest("calc"), spy.handler);
+    expect(requestApproval).not.toHaveBeenCalled();
+    expect(spy.calls).toHaveLength(2);
   });
 });

--- a/packages/middleware-permissions/src/permissions.ts
+++ b/packages/middleware-permissions/src/permissions.ts
@@ -11,7 +11,9 @@ import type {
   ToolResponse,
   TurnContext,
 } from "@koi/core/middleware";
-import type { PermissionsMiddlewareConfig } from "./config.js";
+import type { ApprovalCacheConfig, PermissionsMiddlewareConfig } from "./config.js";
+import { DEFAULT_APPROVAL_CACHE_MAX_ENTRIES } from "./config.js";
+import { fnv1a } from "./hash.js";
 
 const DEFAULT_APPROVAL_TIMEOUT_MS = 30_000;
 
@@ -21,8 +23,19 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
     rules,
     approvalHandler,
     approvalTimeoutMs = DEFAULT_APPROVAL_TIMEOUT_MS,
-    defaultDeny = true,
+    approvalCache: approvalCacheOption,
   } = config;
+
+  // Resolve cache config: true → defaults, false/undefined → disabled, object → custom
+  const resolvedCache: ApprovalCacheConfig | false =
+    approvalCacheOption === true
+      ? { maxEntries: DEFAULT_APPROVAL_CACHE_MAX_ENTRIES }
+      : approvalCacheOption === false || approvalCacheOption === undefined
+        ? false
+        : { maxEntries: approvalCacheOption.maxEntries ?? DEFAULT_APPROVAL_CACHE_MAX_ENTRIES };
+
+  /** Cache keyed by fnv1a(toolId + ":" + JSON.stringify(input)). Only approvals are cached. */
+  const cache = resolvedCache !== false ? new Map<number, true>() : undefined;
 
   return {
     name: "permissions",
@@ -50,6 +63,15 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
       }
 
       // decision.allowed === "ask"
+
+      // Check approval cache before prompting
+      if (cache !== undefined) {
+        const cacheKey = fnv1a(`${request.toolId}:${JSON.stringify(request.input)}`);
+        if (cache.has(cacheKey)) {
+          return next(request);
+        }
+      }
+
       if (!approvalHandler) {
         const error: KoiError = {
           code: "PERMISSION",
@@ -60,10 +82,11 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
         throw error;
       }
 
+      const ac = new AbortController();
       const approved = await Promise.race([
         approvalHandler.requestApproval(request.toolId, request.input, decision.reason),
-        new Promise<boolean>((_, reject) => {
-          setTimeout(() => {
+        new Promise<never>((_, reject) => {
+          const timerId = setTimeout(() => {
             const timeoutError: KoiError = {
               code: "TIMEOUT",
               message: `Approval timed out after ${approvalTimeoutMs}ms for tool "${request.toolId}"`,
@@ -72,10 +95,21 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
             };
             reject(timeoutError);
           }, approvalTimeoutMs);
+          ac.signal.addEventListener("abort", () => clearTimeout(timerId), { once: true });
         }),
-      ]);
+      ]).finally(() => {
+        ac.abort();
+      });
 
       if (approved) {
+        // Cache the approval (only approvals, not denials)
+        if (cache !== undefined && resolvedCache !== false) {
+          const cacheKey = fnv1a(`${request.toolId}:${JSON.stringify(request.input)}`);
+          if (cache.size >= (resolvedCache.maxEntries ?? DEFAULT_APPROVAL_CACHE_MAX_ENTRIES)) {
+            cache.clear();
+          }
+          cache.set(cacheKey, true);
+        }
         return next(request);
       }
 


### PR DESCRIPTION
## Summary

### Tiered loop detection (`@koi/engine`)
Adds `warningThreshold` and `onWarning` callback to `LoopDetectionConfig`, giving agents a chance to self-correct before the hard circuit-breaker fires. Warning fires at most once per unique tool+input hash. Validates `warningThreshold < threshold` at construction.

### Approval cache (`@koi/middleware-permissions`)
Caches approved `ask` decisions so identical tool calls within a session skip re-prompting. Only approvals are cached (denials are not). Simple `clear()` eviction when `maxEntries` is reached. Disabled by default, opt-in via `approvalCache: true | { maxEntries }`.

### Engine hardening & cleanup
- Refactor `compose.ts`: extract generic `composeOnion<Req, Res>()` to eliminate three near-identical onion chains; remove deprecated `runHooks`
- Add `args` field to `EngineEvent.tool_call_start` for adapter streaming
- Add query cache to `AgentEntity` (same prefix returns same `ReadonlyMap` reference)
- Add `@koi/errors` package with `RuntimeError` class (ES2022 cause chain)
- Add `check:layers` script for CI layer boundary validation
- Parallelize `totalSpend`/`remaining` reads in pay middleware
- Add tool-not-found and early-return/interrupt tests to koi factory
- Add MCP crash resilience tests (throw during discovery)
- Add sqlite-vec edge case tests (dimension mismatch, limit 0, etc.)
- Update architecture doc to match current middleware/engine signatures

All features are opt-in and backward compatible.

Relates to #106 (adds warning tier; backoff suggestion still outstanding)
Relates to #23 (adds session-scoped approval caching; YAML config + CREDENTIALS integration still outstanding)
Relates to #108 (pay middleware perf improvement)

## Test plan

- [x] `bun test packages/engine/` — 243 pass, 0 fail
- [x] `bun test packages/middleware-permissions/` — 61 pass, 0 fail
- [x] `bun test packages/errors/` — 13 pass, 0 fail
- [x] `bun test packages/mcp/` — 12 pass, 0 fail
- [x] `bun test packages/middleware-pay/` — 15 pass, 0 fail
- [x] `bun test packages/search/` — 14 pass, 0 fail
- [x] `bun test packages/core/` — 91 pass, 0 fail
- [x] `bun run build` — 17/17 packages
- [x] `bun run check:layers` — all boundaries clean
- [x] `bun run test` — 34/34 task suites pass
- [x] Pre-push hooks pass (build + typecheck)