### PR TITLE
refactor: trim L0 @koi/core types and interfaces

### DIFF
--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -60,6 +60,7 @@ import type {
   KoiErrorCode,
   KoiMiddleware,
   MemoryComponent,
+  MemoryResult,
   MessageHandler,
   MiddlewareConfig,
   // assembly
@@ -84,7 +85,6 @@ import type {
   SandboxInstance,
   SandboxProfile,
   SandboxResult,
-  SandboxTier,
   // delegation
   ScopeChecker,
   // middleware
@@ -176,12 +176,12 @@ type _TypeGuard =
   | AssertDefined<SkillMetadata>
   | AssertDefined<ComponentProvider>
   | AssertDefined<MemoryComponent>
+  | AssertDefined<MemoryResult>
   | AssertDefined<GovernanceComponent>
   | AssertDefined<GovernanceUsage>
   | AssertDefined<SpawnCheck>
   | AssertDefined<CredentialComponent>
   | AssertDefined<EventComponent>
-  | AssertDefined<SandboxTier>
   | AssertDefined<FilesystemPolicy>
   | AssertDefined<NetworkPolicy>
   | AssertDefined<ResourceLimits>

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -24,6 +24,7 @@ import type {
   KoiError,
   KoiErrorCode,
   KoiMiddleware,
+  MemoryResult,
   ModelCapabilities,
   ModelConfig,
   ModelProvider,
@@ -37,7 +38,6 @@ import type {
   SandboxInstance,
   SandboxProfile,
   SandboxResult,
-  SandboxTier,
   ScopeChecker,
   SpawnCheck,
   SubsystemToken,
@@ -287,7 +287,7 @@ describe("well-known token type narrowing", () => {
     };
     const mem = agentLike.component(MEMORY);
     if (mem) {
-      const _: Promise<readonly unknown[]> = mem.recall("test");
+      const _: Promise<readonly MemoryResult[]> = mem.recall("test");
       void _;
     }
     expect(mem).toBeUndefined();
@@ -632,15 +632,15 @@ describe("Result with custom error type", () => {
 // Sandbox types
 // ---------------------------------------------------------------------------
 
-describe("SandboxTier", () => {
+describe("TrustTier (replaces SandboxTier)", () => {
   test("accepts valid tier literals", () => {
-    const tiers: readonly SandboxTier[] = ["sandbox", "verified", "promoted"];
+    const tiers: readonly TrustTier[] = ["sandbox", "verified", "promoted"];
     expect(tiers).toHaveLength(3);
   });
 
   test("rejects invalid tier literal", () => {
-    // @ts-expect-error — "untrusted" is not a valid SandboxTier
-    const _t: SandboxTier = "untrusted";
+    // @ts-expect-error — "untrusted" is not a valid TrustTier
+    const _t: TrustTier = "untrusted";
     void _t;
   });
 });
@@ -932,18 +932,15 @@ describe("DelegationGrant readonly enforcement", () => {
 });
 
 describe("DelegationScope", () => {
-  test("permissions is required, resources and maxBudget are optional", () => {
+  test("permissions is required, resources is optional", () => {
     const minimal: DelegationScope = { permissions: { allow: ["*"] } };
     expect(minimal.resources).toBeUndefined();
-    expect(minimal.maxBudget).toBeUndefined();
 
     const full: DelegationScope = {
       permissions: { allow: ["read_file"], deny: ["write_file"] },
       resources: ["read_file:/workspace/**"],
-      maxBudget: 100,
     };
     expect(full.resources).toHaveLength(1);
-    expect(full.maxBudget).toBe(100);
   });
 
   test("resources array is readonly", () => {
@@ -1049,16 +1046,26 @@ describe("ScopeChecker interface", () => {
 });
 
 describe("RevocationRegistry interface", () => {
-  test("satisfies with minimal implementation", () => {
+  test("satisfies with minimal sync implementation", () => {
     const revoked = new Set<DelegationId>();
     const registry: RevocationRegistry = {
       isRevoked: (id) => revoked.has(id),
-      revoke: (id) => {
+      revoke: (id, _cascade) => {
         revoked.add(id);
       },
-      revokedIds: () => revoked,
     };
     expect(registry.isRevoked("test" as DelegationId)).toBe(false);
+  });
+
+  test("satisfies with async implementation", () => {
+    const revoked = new Set<DelegationId>();
+    const registry: RevocationRegistry = {
+      isRevoked: async (id) => revoked.has(id),
+      revoke: async (id, _cascade) => {
+        revoked.add(id);
+      },
+    };
+    expect(registry.isRevoked("test" as DelegationId)).toBeInstanceOf(Promise);
   });
 });
 
@@ -1068,8 +1075,6 @@ describe("DelegationConfig", () => {
     const _partial: DelegationConfig = {
       maxChainDepth: 3,
       defaultTtlMs: 3600000,
-      maxEntries: 10000,
-      cleanupIntervalMs: 60000,
     };
     void _partial;
   });
@@ -1079,8 +1084,6 @@ describe("DelegationConfig", () => {
       enabled: true,
       maxChainDepth: 3,
       defaultTtlMs: 3600000,
-      maxEntries: 10000,
-      cleanupIntervalMs: 60000,
     };
     // @ts-expect-error — cannot assign to readonly property
     config.enabled = false;
@@ -1120,8 +1123,6 @@ describe("AgentManifest delegation config", () => {
         enabled: true,
         maxChainDepth: 3,
         defaultTtlMs: 3600000,
-        maxEntries: 10000,
-        cleanupIntervalMs: 60000,
       },
     };
     expect(withDelegation.delegation?.enabled).toBe(true);

--- a/packages/core/src/delegation.ts
+++ b/packages/core/src/delegation.ts
@@ -26,14 +26,12 @@ export type DelegationId = string & { readonly [__delegationBrand]: "DelegationI
 
 /**
  * What is being delegated. Wraps the existing PermissionConfig to stay DRY
- * and adds optional resource patterns and budget cap.
+ * and adds optional resource patterns.
  */
 export interface DelegationScope {
   readonly permissions: PermissionConfig;
   /** Optional glob-style resource patterns (e.g., "read_file:/workspace/src/**"). */
   readonly resources?: readonly string[];
-  /** Optional budget cap for metered operations. */
-  readonly maxBudget?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -105,9 +103,8 @@ export interface ScopeChecker {
 
 /** Pluggable revocation store. Default implementation is in-memory (L2). */
 export interface RevocationRegistry {
-  readonly isRevoked: (id: DelegationId) => boolean;
-  readonly revoke: (id: DelegationId, cascade: boolean) => void;
-  readonly revokedIds: () => ReadonlySet<DelegationId>;
+  readonly isRevoked: (id: DelegationId) => boolean | Promise<boolean>;
+  readonly revoke: (id: DelegationId, cascade: boolean) => void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,10 +118,6 @@ export interface DelegationConfig {
   readonly maxChainDepth: number;
   /** Default grant TTL in milliseconds (default: 3600000 = 1 hour). */
   readonly defaultTtlMs: number;
-  /** Maximum entries in the revocation registry (default: 10000). */
-  readonly maxEntries: number;
-  /** Cleanup interval in milliseconds (default: 60000 = 1 minute). */
-  readonly cleanupIntervalMs: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -132,14 +132,23 @@ export interface ComponentProvider {
 // Singleton component types (sub-types deferred to L2)
 // ---------------------------------------------------------------------------
 
+/** A single memory recall result with content and optional metadata. */
+export interface MemoryResult {
+  readonly content: string;
+  readonly score?: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
 export interface MemoryComponent {
-  readonly recall: (query: string) => Promise<readonly unknown[]>;
-  readonly store: (content: unknown) => Promise<void>;
+  readonly recall: (query: string) => Promise<readonly MemoryResult[]>;
+  readonly store: (content: string) => Promise<void>;
 }
 
 export interface GovernanceUsage {
   readonly turns: number;
   readonly spawns: number;
+  /** Extensible counters for L2-defined metrics (e.g., tokens, tool calls). */
+  readonly counters?: Readonly<Record<string, number>>;
 }
 
 export type SpawnCheck =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type {
   GovernanceComponent,
   GovernanceUsage,
   MemoryComponent,
+  MemoryResult,
   ProcessId,
   ProcessState,
   SkillMetadata,
@@ -154,19 +155,11 @@ export type {
   SandboxInstance,
   SandboxProfile,
   SandboxResult,
-  SandboxTier,
 } from "./sandbox.js";
 // search value types
 export type {
-  FusionFunction,
-  FusionStrategy,
   IndexDocument,
-  ScoreNormalizer,
-  SearchErr,
-  SearchError,
   SearchFilter,
-  SearchOk,
-  SearchOutcome,
   SearchPage,
   SearchQuery,
   SearchResult,

--- a/packages/core/src/retriever.ts
+++ b/packages/core/src/retriever.ts
@@ -4,11 +4,12 @@
  * Interfaces only — no runtime code.
  */
 
-import type { IndexDocument, SearchOutcome, SearchPage, SearchQuery } from "./search.js";
+import type { KoiError, Result } from "./errors.js";
+import type { IndexDocument, SearchPage, SearchQuery } from "./search.js";
 
 /** Contract 1: Retriever (read path) */
 export interface Retriever<T = unknown> {
-  readonly retrieve: (query: SearchQuery) => Promise<SearchOutcome<SearchPage<T>>>;
+  readonly retrieve: (query: SearchQuery) => Promise<Result<SearchPage<T>, KoiError>>;
 }
 
 /** Contract 2: Embedder (embedding generation) */
@@ -20,6 +21,6 @@ export interface Embedder {
 
 /** Contract 3: Indexer (write path) */
 export interface Indexer<T = unknown> {
-  readonly index: (documents: readonly IndexDocument<T>[]) => Promise<SearchOutcome<void>>;
-  readonly remove: (ids: readonly string[]) => Promise<SearchOutcome<void>>;
+  readonly index: (documents: readonly IndexDocument<T>[]) => Promise<Result<void, KoiError>>;
+  readonly remove: (ids: readonly string[]) => Promise<Result<void, KoiError>>;
 }

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -3,8 +3,7 @@
  * Types only, zero runtime code.
  */
 
-/** Trust tier determines sandbox enforcement level. */
-export type SandboxTier = "sandbox" | "verified" | "promoted";
+import type { TrustTier } from "./ecs.js";
 
 /** Filesystem isolation policy. */
 export interface FilesystemPolicy {
@@ -30,7 +29,7 @@ export interface ResourceLimits {
 
 /** Declarative sandbox profile — platform-agnostic policy. */
 export interface SandboxProfile {
-  readonly tier: SandboxTier;
+  readonly tier: TrustTier;
   readonly filesystem: FilesystemPolicy;
   readonly network: NetworkPolicy;
   readonly resources: ResourceLimits;

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -50,30 +50,6 @@ export type SearchFilter =
   | { readonly kind: "or"; readonly filters: readonly SearchFilter[] }
   | { readonly kind: "not"; readonly filter: SearchFilter };
 
-/** Score normalization method */
-export type ScoreNormalizer = "min_max" | "z_score" | "l2";
-
-/** Fusion function signature for custom strategies */
-export type FusionFunction = (
-  rankedLists: readonly (readonly SearchResult[])[],
-  limit: number,
-) => readonly SearchResult[];
-
-/** Fusion strategy (discriminated union — logic lives in L2) */
-export type FusionStrategy =
-  | { readonly kind: "rrf"; readonly k?: number }
-  | {
-      readonly kind: "weighted_rrf";
-      readonly k?: number;
-      readonly weights: readonly number[];
-    }
-  | {
-      readonly kind: "linear";
-      readonly weights: readonly number[];
-      readonly normalizer?: ScoreNormalizer;
-    }
-  | { readonly kind: "custom"; readonly fuse: FusionFunction };
-
 /** Document for indexing */
 export interface IndexDocument<T = unknown> {
   readonly id: string;
@@ -82,19 +58,3 @@ export interface IndexDocument<T = unknown> {
   readonly embedding?: readonly number[];
   readonly data?: T;
 }
-
-/** Search errors (expected failures — typed values, not thrown) */
-export type SearchError =
-  | { readonly kind: "not_found"; readonly query: string }
-  | { readonly kind: "timeout"; readonly ms: number }
-  | {
-      readonly kind: "backend_unavailable";
-      readonly backend: string;
-      readonly cause?: unknown;
-    }
-  | { readonly kind: "invalid_query"; readonly reason: string };
-
-/** Result type for search operations */
-export type SearchOk<T> = { readonly ok: true; readonly value: T };
-export type SearchErr = { readonly ok: false; readonly error: SearchError };
-export type SearchOutcome<T> = SearchOk<T> | SearchErr;

--- a/packages/delegation/src/__tests__/e2e.test.ts
+++ b/packages/delegation/src/__tests__/e2e.test.ts
@@ -335,59 +335,6 @@ describe("e2e: pluggable ScopeChecker", () => {
 });
 
 // ---------------------------------------------------------------------------
-// E2E: Budget attenuation across chain
-// ---------------------------------------------------------------------------
-
-describe("e2e: budget attenuation", () => {
-  test("budget can only shrink through delegation chain", () => {
-    const rootGrant = createGrant({
-      issuerId: "orchestrator",
-      delegateeId: "worker",
-      scope: {
-        permissions: { allow: ["*"] },
-        maxBudget: 100,
-      },
-      maxChainDepth: 3,
-      ttlMs: 3600000,
-      secret: SECRET,
-    });
-
-    // Lower budget is ok
-    const lowerResult = attenuateGrant(
-      rootGrant,
-      {
-        delegateeId: "sub-worker",
-        scope: { permissions: { allow: ["read_file"] }, maxBudget: 50 },
-      },
-      SECRET,
-    );
-    expect(lowerResult.ok).toBe(true);
-
-    // Higher budget is rejected
-    const higherResult = attenuateGrant(
-      rootGrant,
-      {
-        delegateeId: "sub-worker",
-        scope: { permissions: { allow: ["read_file"] }, maxBudget: 200 },
-      },
-      SECRET,
-    );
-    expect(higherResult.ok).toBe(false);
-
-    // No budget specified when parent has one is rejected
-    const noBudgetResult = attenuateGrant(
-      rootGrant,
-      {
-        delegateeId: "sub-worker",
-        scope: { permissions: { allow: ["read_file"] } },
-      },
-      SECRET,
-    );
-    expect(noBudgetResult.ok).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // E2E: Deny rules grow monotonically
 // ---------------------------------------------------------------------------
 

--- a/packages/delegation/src/__tests__/property.test.ts
+++ b/packages/delegation/src/__tests__/property.test.ts
@@ -43,10 +43,8 @@ function randomSubset(items: readonly string[], seed: number): readonly string[]
 
 function makeRandomScope(seed: number): DelegationScope {
   const allow = randomSubset(ALL_TOOLS, seed);
-  const budget = ((seed * 31) % 200) + 1;
   return {
     permissions: { allow },
-    maxBudget: budget,
   };
 }
 
@@ -57,13 +55,6 @@ function makeNarrowerScope(parent: DelegationScope, seed: number): DelegationSco
     parent.permissions.deny !== undefined
       ? { allow: childAllow, deny: parent.permissions.deny }
       : { allow: childAllow };
-  if (parent.maxBudget !== undefined) {
-    const childBudget = Math.max(
-      1,
-      Math.floor((parent.maxBudget * (((seed * 17) % 80) + 10)) / 100),
-    );
-    return { permissions, maxBudget: childBudget };
-  }
   return { permissions };
 }
 
@@ -99,11 +90,6 @@ describe("property: monotonic attenuation", () => {
         // Every child allow must be in parent allow
         for (const perm of childAllow) {
           expect(parentAllow.has(perm)).toBe(true);
-        }
-
-        // Child budget <= parent budget
-        if (parentScope.maxBudget !== undefined && childGrant.scope.maxBudget !== undefined) {
-          expect(childGrant.scope.maxBudget).toBeLessThanOrEqual(parentScope.maxBudget);
         }
       }
       // If attenuation failed, the invariant holds trivially (denied escalation)

--- a/packages/delegation/src/grant.test.ts
+++ b/packages/delegation/src/grant.test.ts
@@ -89,7 +89,6 @@ describe("attenuateGrant", () => {
       scope: {
         permissions: { allow: ["read_file", "write_file"], deny: ["delete_file"] },
         resources: ["read_file:/workspace/**", "write_file:/workspace/src/**"],
-        maxBudget: 100,
       },
       maxChainDepth: 3,
       ttlMs: 3600000,
@@ -106,7 +105,6 @@ describe("attenuateGrant", () => {
         scope: {
           permissions: { allow: ["read_file"], deny: ["delete_file"] },
           resources: ["read_file:/workspace/**"],
-          maxBudget: 50,
         },
       },
       SECRET,
@@ -152,7 +150,6 @@ describe("attenuateGrant", () => {
         delegateeId: "agent-3",
         scope: {
           permissions: { allow: ["read_file"], deny: ["delete_file"] },
-          maxBudget: 50,
         },
         ttlMs: 1800000, // 30 minutes — less than parent's 1 hour
       },
@@ -173,7 +170,6 @@ describe("attenuateGrant", () => {
         delegateeId: "agent-3",
         scope: {
           permissions: { allow: ["read_file"], deny: ["delete_file"] },
-          maxBudget: 50,
         },
         ttlMs: 7200000, // 2 hours — exceeds parent's 1 hour
       },
@@ -224,47 +220,6 @@ describe("attenuateGrant", () => {
         expect(grandchild.error.code).toBe("PERMISSION");
         expect(grandchild.error.message).toContain("chain depth");
       }
-    }
-  });
-
-  test("attenuate with lower budget succeeds", () => {
-    const parent = makeParent();
-    const result = attenuateGrant(
-      parent,
-      {
-        delegateeId: "agent-3",
-        scope: {
-          permissions: { allow: ["read_file"], deny: ["delete_file"] },
-          maxBudget: 50,
-        },
-      },
-      SECRET,
-    );
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.scope.maxBudget).toBe(50);
-    }
-  });
-
-  test("attenuate with higher budget is rejected", () => {
-    const parent = makeParent();
-    const result = attenuateGrant(
-      parent,
-      {
-        delegateeId: "agent-3",
-        scope: {
-          permissions: { allow: ["read_file"], deny: ["delete_file"] },
-          maxBudget: 200,
-        },
-      },
-      SECRET,
-    );
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe("PERMISSION");
-      expect(result.error.message).toContain("budget");
     }
   });
 

--- a/packages/delegation/src/grant.ts
+++ b/packages/delegation/src/grant.ts
@@ -76,7 +76,6 @@ export function createGrant(params: CreateGrantParams): DelegationGrant {
  * - Child must include all parent deny rules
  * - Child expiresAt <= parent expiresAt
  * - Child chainDepth = parent.chainDepth + 1 <= parent.maxChainDepth
- * - Child budget <= parent budget (if parent has one)
  *
  * The parent's delegateeId becomes the child's issuerId (re-delegation).
  */
@@ -152,17 +151,6 @@ function validateScopeAttenuation(
         "Child scope permissions exceed parent scope — allow must be a subset and all parent deny rules must be preserved",
       retryable: false,
     };
-  }
-
-  // Check budget
-  if (parent.maxBudget !== undefined) {
-    if (child.maxBudget === undefined || child.maxBudget > parent.maxBudget) {
-      return {
-        code: "PERMISSION",
-        message: `Child budget ${String(child.maxBudget ?? "unlimited")} exceeds parent budget ${String(parent.maxBudget)}`,
-        retryable: false,
-      };
-    }
   }
 
   return undefined;

--- a/packages/delegation/src/index.ts
+++ b/packages/delegation/src/index.ts
@@ -16,7 +16,7 @@ export type { AttenuateParams, CreateGrantParams } from "./grant.js";
 export { attenuateGrant, createGrant } from "./grant.js";
 // middleware
 export { createDelegationMiddleware } from "./middleware.js";
-export type { GrantIndex } from "./registry.js";
+export type { GrantIndex, InMemoryRegistry } from "./registry.js";
 // registry
 export { createGrantIndex, createInMemoryRegistry } from "./registry.js";
 // revocation

--- a/packages/delegation/src/middleware.test.ts
+++ b/packages/delegation/src/middleware.test.ts
@@ -22,7 +22,6 @@ function makeRegistry(revokedSet?: Set<DelegationId>): RevocationRegistry {
     revoke: (id) => {
       revoked.add(id);
     },
-    revokedIds: () => revoked,
   };
 }
 

--- a/packages/delegation/src/registry.ts
+++ b/packages/delegation/src/registry.ts
@@ -15,15 +15,23 @@ interface RegistryEntry {
   readonly revokedAt: number;
 }
 
+/** Concrete return type for the in-memory registry with convenience methods. */
+export interface InMemoryRegistry extends RevocationRegistry {
+  /** Returns all currently revoked IDs (convenience — not part of the L0 interface). */
+  readonly revokedIds: () => ReadonlySet<DelegationId>;
+  /** Stops the periodic cleanup interval. */
+  readonly dispose: () => void;
+}
+
 /**
  * Creates an in-memory revocation registry with configurable max entries
- * and periodic cleanup. Returns a RevocationRegistry with a dispose function
- * to stop the cleanup interval.
+ * and periodic cleanup. `maxEntries` and `cleanupIntervalMs` are local
+ * configuration for this implementation, not part of L0 DelegationConfig.
  */
 export function createInMemoryRegistry(config?: {
   readonly maxEntries?: number;
   readonly cleanupIntervalMs?: number;
-}): RevocationRegistry & { readonly dispose: () => void } {
+}): InMemoryRegistry {
   const maxEntries = config?.maxEntries ?? 10_000;
   const cleanupIntervalMs = config?.cleanupIntervalMs ?? 60_000;
 

--- a/packages/delegation/src/revoke.test.ts
+++ b/packages/delegation/src/revoke.test.ts
@@ -14,7 +14,6 @@ function makeRegistry(): RevocationRegistry & { readonly _revoked: Set<Delegatio
     revoke: (id) => {
       revoked.add(id);
     },
-    revokedIds: () => revoked,
   };
 }
 

--- a/packages/delegation/src/verify.test.ts
+++ b/packages/delegation/src/verify.test.ts
@@ -19,7 +19,6 @@ function makeRegistry(revokedSet?: Set<DelegationId>): RevocationRegistry {
     revoke: (id) => {
       revoked.add(id);
     },
-    revokedIds: () => revoked,
   };
 }
 

--- a/packages/sandbox/src/profiles.ts
+++ b/packages/sandbox/src/profiles.ts
@@ -2,7 +2,7 @@
  * Preset sandbox profile constructors.
  */
 
-import type { SandboxProfile, SandboxTier } from "@koi/core";
+import type { SandboxProfile, TrustTier } from "@koi/core";
 
 const SENSITIVE_PATHS: readonly string[] = [
   "~/.ssh",
@@ -61,7 +61,7 @@ export function permissiveProfile(overrides?: Partial<SandboxProfile>): SandboxP
   return mergeProfile(PERMISSIVE_DEFAULTS, overrides);
 }
 
-export function profileForTier(tier: SandboxTier): SandboxProfile {
+export function profileForTier(tier: TrustTier): SandboxProfile {
   switch (tier) {
     case "sandbox":
       return restrictiveProfile();

--- a/packages/search/src/bm25/bm25-retriever.ts
+++ b/packages/search/src/bm25/bm25-retriever.ts
@@ -1,7 +1,8 @@
 import type {
+  KoiError,
+  Result,
   Retriever,
   SearchFilter,
-  SearchOutcome,
   SearchPage,
   SearchQuery,
   SearchResult,
@@ -29,7 +30,7 @@ export function createBm25Retriever(config: BM25RetrieverConfig): Retriever {
   const tokenize = config.tokenize ?? defaultTokenize;
 
   return {
-    retrieve: async (query: SearchQuery): Promise<SearchOutcome<SearchPage>> => {
+    retrieve: async (query: SearchQuery): Promise<Result<SearchPage, KoiError>> => {
       const terms = config.queryExpansion
         ? expandQuery(query.text, config.queryExpansion)
         : tokenize(query.text);

--- a/packages/search/src/fusion-types.ts
+++ b/packages/search/src/fusion-types.ts
@@ -1,0 +1,29 @@
+/**
+ * Fusion algorithm types — L2 search-specific.
+ *
+ * These types define how multiple ranked lists are combined into a single
+ * result set. They are NOT part of L0 (@koi/core) because fusion strategies
+ * are implementation details of the search package.
+ */
+
+import type { SearchResult } from "@koi/core";
+
+/** Score normalizer names for linear combination fusion */
+export type ScoreNormalizer = "min_max" | "z_score" | "l2";
+
+/** Custom fusion function signature */
+export type FusionFunction = (
+  rankedLists: readonly (readonly SearchResult[])[],
+  limit: number,
+) => readonly SearchResult[];
+
+/** Discriminated union of supported fusion strategies */
+export type FusionStrategy =
+  | { readonly kind: "rrf"; readonly k?: number }
+  | { readonly kind: "weighted_rrf"; readonly k?: number; readonly weights: readonly number[] }
+  | {
+      readonly kind: "linear";
+      readonly weights: readonly number[];
+      readonly normalizer?: ScoreNormalizer;
+    }
+  | { readonly kind: "custom"; readonly fuse: FusionFunction };

--- a/packages/search/src/hybrid/fusion.ts
+++ b/packages/search/src/hybrid/fusion.ts
@@ -1,4 +1,5 @@
-import type { FusionStrategy, ScoreNormalizer, SearchResult } from "@koi/core";
+import type { SearchResult } from "@koi/core";
+import type { FusionStrategy, ScoreNormalizer } from "../fusion-types.js";
 import { normalize } from "../normalize.js";
 
 const DEFAULT_RRF_K = 60;

--- a/packages/search/src/hybrid/hybrid-retriever.test.ts
+++ b/packages/search/src/hybrid/hybrid-retriever.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Retriever, SearchOutcome, SearchPage, SearchQuery, SearchResult } from "@koi/core";
+import type { KoiError, Result, Retriever, SearchPage, SearchQuery, SearchResult } from "@koi/core";
 import { createHybridRetriever } from "./hybrid-retriever.js";
 
 function makeResult(id: string, score: number, source: string): SearchResult {
@@ -8,7 +8,7 @@ function makeResult(id: string, score: number, source: string): SearchResult {
 
 function mockRetriever(results: readonly SearchResult[]): Retriever {
   return {
-    retrieve: async (query: SearchQuery): Promise<SearchOutcome<SearchPage>> => ({
+    retrieve: async (query: SearchQuery): Promise<Result<SearchPage, KoiError>> => ({
       ok: true,
       value: {
         results: results.slice(0, query.limit),
@@ -21,9 +21,14 @@ function mockRetriever(results: readonly SearchResult[]): Retriever {
 
 function failingRetriever(): Retriever {
   return {
-    retrieve: async (): Promise<SearchOutcome<SearchPage>> => ({
+    retrieve: async (): Promise<Result<SearchPage, KoiError>> => ({
       ok: false,
-      error: { kind: "backend_unavailable", backend: "test" },
+      error: {
+        code: "EXTERNAL",
+        message: "Backend unavailable",
+        retryable: true,
+        context: { backend: "test" },
+      },
     }),
   };
 }
@@ -88,7 +93,7 @@ describe("HybridRetriever", () => {
     const result = await hybrid.retrieve({ text: "test", limit: 10 });
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.kind).toBe("backend_unavailable");
+    expect(result.error.code).toBe("EXTERNAL");
   });
 
   test("timeout — slow retriever is dropped", async () => {

--- a/packages/search/src/hybrid/hybrid-retriever.ts
+++ b/packages/search/src/hybrid/hybrid-retriever.ts
@@ -1,11 +1,5 @@
-import type {
-  FusionStrategy,
-  Retriever,
-  SearchOutcome,
-  SearchPage,
-  SearchQuery,
-  SearchResult,
-} from "@koi/core";
+import type { KoiError, Result, Retriever, SearchPage, SearchQuery, SearchResult } from "@koi/core";
+import type { FusionStrategy } from "../fusion-types.js";
 import { applyFusion } from "./fusion.js";
 import type { MmrConfig } from "./mmr.js";
 import { applyMmr } from "./mmr.js";
@@ -29,7 +23,7 @@ export function createHybridRetriever(config: HybridRetrieverConfig): Retriever 
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   return {
-    retrieve: async (query: SearchQuery): Promise<SearchOutcome<SearchPage>> => {
+    retrieve: async (query: SearchQuery): Promise<Result<SearchPage, KoiError>> => {
       // Over-fetch from each retriever for better fusion
       // Omit offset/minScore — each retriever starts from 0; we paginate after fusion
       const expandedQuery: SearchQuery = {
@@ -58,9 +52,10 @@ export function createHybridRetriever(config: HybridRetrieverConfig): Retriever 
         return {
           ok: false,
           error: {
-            kind: "backend_unavailable",
-            backend: "all",
-            cause: "All retrievers failed or timed out",
+            code: "EXTERNAL",
+            message: "All retrievers failed or timed out",
+            retryable: true,
+            context: { backend: "all" },
           },
         };
       }

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -5,12 +5,13 @@
  * Wraps local SQLite by default; swap to Nexus via manifest config.
  */
 
-import type { Embedder, FusionStrategy, Indexer, Retriever } from "@koi/core";
+import type { Embedder, Indexer, Retriever } from "@koi/core";
 import type { BM25Config } from "./bm25/bm25-index.js";
 import { createBm25Index, defaultTokenize } from "./bm25/bm25-index.js";
 import { createBm25Retriever } from "./bm25/bm25-retriever.js";
 import type { EmbedderCacheConfig } from "./embedder-cache.js";
 import { createCachedEmbedder } from "./embedder-cache.js";
+import type { FusionStrategy } from "./fusion-types.js";
 import { createHybridRetriever } from "./hybrid/hybrid-retriever.js";
 import type { MmrConfig } from "./hybrid/mmr.js";
 import type { TemporalDecayConfig } from "./hybrid/temporal-decay.js";
@@ -156,13 +157,14 @@ export function createSearch(config: KoiSearchConfig): KoiSearch {
   };
 }
 
-// Re-export individual pieces for advanced usage
 export type { BM25Config, BM25Hit, BM25Index } from "./bm25/bm25-index.js";
 export { createBm25Index, defaultTokenize } from "./bm25/bm25-index.js";
 export type { BM25RetrieverConfig } from "./bm25/bm25-retriever.js";
 export { createBm25Retriever } from "./bm25/bm25-retriever.js";
 export type { CachedEmbedder, CacheStats, EmbedderCacheConfig } from "./embedder-cache.js";
 export { createCachedEmbedder } from "./embedder-cache.js";
+// Re-export individual pieces for advanced usage
+export type { FusionFunction, FusionStrategy, ScoreNormalizer } from "./fusion-types.js";
 export { applyFusion, applyLinear, applyRrf, applyWeightedRrf } from "./hybrid/fusion.js";
 export type { HybridRetrieverConfig } from "./hybrid/hybrid-retriever.js";
 export { createHybridRetriever } from "./hybrid/hybrid-retriever.js";

--- a/packages/search/src/indexer/sqlite-indexer.ts
+++ b/packages/search/src/indexer/sqlite-indexer.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import type { Embedder, IndexDocument, Indexer, SearchOutcome } from "@koi/core";
+import type { Embedder, IndexDocument, Indexer, KoiError, Result } from "@koi/core";
 import type { ChunkerConfig } from "./chunker.js";
 import { chunk } from "./chunker.js";
 
@@ -70,7 +70,9 @@ export function createSqliteIndexer(
     return new Uint8Array(floats.buffer);
   }
 
-  async function indexDocuments(documents: readonly IndexDocument[]): Promise<SearchOutcome<void>> {
+  async function indexDocuments(
+    documents: readonly IndexDocument[],
+  ): Promise<Result<void, KoiError>> {
     try {
       for (const doc of documents) {
         // Chunk the document
@@ -112,15 +114,17 @@ export function createSqliteIndexer(
       return {
         ok: false,
         error: {
-          kind: "backend_unavailable",
-          backend: "sqlite-indexer",
+          code: "EXTERNAL",
+          message: "SQLite indexer failed to index documents",
+          retryable: true,
           cause: err,
+          context: { backend: "sqlite-indexer" },
         },
       };
     }
   }
 
-  async function removeDocuments(ids: readonly string[]): Promise<SearchOutcome<void>> {
+  async function removeDocuments(ids: readonly string[]): Promise<Result<void, KoiError>> {
     try {
       db.transaction(() => {
         for (const id of ids) {
@@ -134,9 +138,11 @@ export function createSqliteIndexer(
       return {
         ok: false,
         error: {
-          kind: "backend_unavailable",
-          backend: "sqlite-indexer",
+          code: "EXTERNAL",
+          message: "SQLite indexer failed to remove documents",
+          retryable: true,
           cause: err,
+          context: { backend: "sqlite-indexer" },
         },
       };
     }

--- a/packages/search/src/normalize.ts
+++ b/packages/search/src/normalize.ts
@@ -1,4 +1,4 @@
-import type { ScoreNormalizer } from "@koi/core";
+import type { ScoreNormalizer } from "./fusion-types.js";
 
 /** Min-max normalization: scales scores to [0, 1] */
 export function normalizeMinMax(scores: readonly number[]): readonly number[] {

--- a/packages/search/src/vector/vector-retriever.ts
+++ b/packages/search/src/vector/vector-retriever.ts
@@ -1,8 +1,9 @@
 import type {
   Embedder,
+  KoiError,
+  Result,
   Retriever,
   SearchFilter,
-  SearchOutcome,
   SearchPage,
   SearchQuery,
   SearchResult,
@@ -17,7 +18,7 @@ export interface VectorRetrieverConfig {
 
 export function createVectorRetriever(config: VectorRetrieverConfig): Retriever {
   return {
-    retrieve: async (query: SearchQuery): Promise<SearchOutcome<SearchPage>> => {
+    retrieve: async (query: SearchQuery): Promise<Result<SearchPage, KoiError>> => {
       const embedding = await config.embedder.embed(query.text);
 
       // Over-fetch to allow for post-filtering and hasMore detection


### PR DESCRIPTION
## Summary

- **Remove runtime tuning from L0**: `maxEntries`, `cleanupIntervalMs` removed from `DelegationConfig` (moved to L2 in-memory registry config)
- **Remove pay concern leak**: `maxBudget` removed from `DelegationScope`
- **Async-compatible `RevocationRegistry`**: `isRevoked` returns `boolean | Promise<boolean>`, `revoke` returns `void | Promise<void>` — enables remote backends
- **Remove forced materialization**: `revokedIds()` removed from `RevocationRegistry` interface (kept on concrete `InMemoryRegistry` type)
- **Move algorithms to L2**: `FusionStrategy`, `FusionFunction`, `ScoreNormalizer` moved to `@koi/search` (`fusion-types.ts`)
- **Unify error system**: `SearchError`/`SearchOutcome` deleted, all search contracts use `Result<T, KoiError>`
- **DRY**: `SandboxTier` deleted, `TrustTier` used everywhere
- **Tighten ECS types**: `MemoryComponent` now uses `string` + `MemoryResult` (was `unknown`), `GovernanceUsage` gains `counters?` escape hatch

**Net effect**: ~830 → ~790 LOC, ~80 → ~74 types in L0. 27 files changed, +130 / -253 lines.

## Test plan

- [x] `@koi/core` builds clean (22/22 packages)
- [x] 439 tests pass, 0 fail across core, delegation, search, sandbox
- [x] Biome lint passes
- [x] Pre-push typecheck + build hooks pass
- [ ] Verify no downstream consumers outside this repo break