### PR TITLE
feat: @koi/scheduler — 3 gap fixes (timeout, crash recovery, cron persistence)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,14 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/scheduler": {
+      "name": "@koi/scheduler",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "croner": "9.0.0",
+      },
+    },
     "packages/search": {
       "name": "@koi/search",
       "version": "0.0.0",
@@ -282,6 +290,8 @@
     "@koi/middleware-permissions": ["@koi/middleware-permissions@workspace:packages/middleware-permissions"],
 
     "@koi/sandbox": ["@koi/sandbox@workspace:packages/sandbox"],
+
+    "@koi/scheduler": ["@koi/scheduler@workspace:packages/scheduler"],
 
     "@koi/search": ["@koi/search@workspace:packages/search"],
 
@@ -432,6 +442,8 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "croner": ["croner@9.0.0", "", {}, "sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,6 +152,24 @@ export type {
   SandboxResult,
   SandboxTier,
 } from "./sandbox.js";
+// scheduler — types
+export type {
+  CronSchedule,
+  ScheduledTask,
+  ScheduleId,
+  SchedulerConfig,
+  SchedulerEvent,
+  SchedulerStats,
+  ScheduleStore,
+  TaskFilter,
+  TaskId,
+  TaskOptions,
+  TaskScheduler,
+  TaskStatus,
+  TaskStore,
+} from "./scheduler.js";
+// scheduler — runtime values (branded constructors + defaults)
+export { DEFAULT_SCHEDULER_CONFIG, scheduleId, taskId } from "./scheduler.js";
 // search value types
 export type {
   FusionFunction,

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -1,0 +1,232 @@
+/**
+ * Scheduler contract — pluggable task scheduling, priority queue, cron,
+ * and dead-letter queue for agent message dispatch.
+ *
+ * A "task" in Koi = deliver input to an agent (new or existing) at a
+ * scheduled time/priority. The scheduler is a message dispatch service,
+ * not arbitrary code execution.
+ *
+ * Exception: branded type constructors (taskId, scheduleId) are permitted
+ * in L0 as zero-logic identity casts for type safety.
+ * Exception: DEFAULT_SCHEDULER_CONFIG is a pure readonly data constant
+ * derived from L0 type definitions.
+ */
+
+import type { AgentId } from "./ecs.js";
+import type { EngineInput } from "./engine.js";
+import type { KoiError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Branded types
+// ---------------------------------------------------------------------------
+
+declare const __taskBrand: unique symbol;
+
+/** Branded string type for scheduled task identifiers. */
+export type TaskId = string & { readonly [__taskBrand]: "TaskId" };
+
+declare const __scheduleBrand: unique symbol;
+
+/** Branded string type for cron schedule identifiers. */
+export type ScheduleId = string & { readonly [__scheduleBrand]: "ScheduleId" };
+
+// ---------------------------------------------------------------------------
+// Branded type constructors (zero-logic casts)
+// ---------------------------------------------------------------------------
+
+/** Create a branded TaskId from a plain string. */
+export function taskId(id: string): TaskId {
+  return id as TaskId;
+}
+
+/** Create a branded ScheduleId from a plain string. */
+export function scheduleId(id: string): ScheduleId {
+  return id as ScheduleId;
+}
+
+// ---------------------------------------------------------------------------
+// Task status state machine
+// ---------------------------------------------------------------------------
+
+export type TaskStatus = "pending" | "running" | "completed" | "failed" | "dead_letter";
+
+// ---------------------------------------------------------------------------
+// Scheduled task — "deliver input to agent"
+// ---------------------------------------------------------------------------
+
+export interface ScheduledTask {
+  readonly id: TaskId;
+  readonly agentId: AgentId;
+  readonly input: EngineInput;
+  readonly mode: "spawn" | "dispatch";
+  /** 0 = highest priority. */
+  readonly priority: number;
+  readonly status: TaskStatus;
+  readonly createdAt: number;
+  /** Unix timestamp ms for delayed execution. */
+  readonly scheduledAt?: number | undefined;
+  readonly startedAt?: number | undefined;
+  readonly completedAt?: number | undefined;
+  readonly retries: number;
+  readonly maxRetries: number;
+  /** Per-execution timeout in milliseconds. */
+  readonly timeoutMs?: number | undefined;
+  readonly lastError?: KoiError | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Submit options
+// ---------------------------------------------------------------------------
+
+export interface TaskOptions {
+  /** Priority level (0 = highest). Default: 5. */
+  readonly priority?: number | undefined;
+  /** Defer execution by this many milliseconds. */
+  readonly delayMs?: number | undefined;
+  /** Maximum retry attempts. Default: 3. */
+  readonly maxRetries?: number | undefined;
+  /** Per-execution timeout in milliseconds. */
+  readonly timeoutMs?: number | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Cron schedule definition
+// ---------------------------------------------------------------------------
+
+export interface CronSchedule {
+  readonly id: ScheduleId;
+  /** Cron expression (e.g., "0 0 * * *"). */
+  readonly expression: string;
+  readonly agentId: AgentId;
+  readonly input: EngineInput;
+  readonly mode: "spawn" | "dispatch";
+  readonly taskOptions?: TaskOptions | undefined;
+  readonly timezone?: string | undefined;
+  readonly paused: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Task filter for queries
+// ---------------------------------------------------------------------------
+
+export interface TaskFilter {
+  readonly status?: TaskStatus | undefined;
+  readonly agentId?: AgentId | undefined;
+  readonly priority?: number | undefined;
+  readonly limit?: number | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler events (discriminated union)
+// ---------------------------------------------------------------------------
+
+export type SchedulerEvent =
+  | { readonly kind: "task:submitted"; readonly task: ScheduledTask }
+  | { readonly kind: "task:started"; readonly taskId: TaskId }
+  | { readonly kind: "task:completed"; readonly taskId: TaskId; readonly result: unknown }
+  | { readonly kind: "task:failed"; readonly taskId: TaskId; readonly error: KoiError }
+  | { readonly kind: "task:dead_letter"; readonly taskId: TaskId; readonly error: KoiError }
+  | { readonly kind: "task:cancelled"; readonly taskId: TaskId }
+  | { readonly kind: "task:recovered"; readonly taskId: TaskId; readonly retriesUsed: number }
+  | { readonly kind: "schedule:created"; readonly schedule: CronSchedule }
+  | { readonly kind: "schedule:removed"; readonly scheduleId: ScheduleId };
+
+// ---------------------------------------------------------------------------
+// Pluggable persistence backend
+// ---------------------------------------------------------------------------
+
+export interface TaskStore extends AsyncDisposable {
+  readonly save: (task: ScheduledTask) => void | Promise<void>;
+  readonly load: (id: TaskId) => ScheduledTask | undefined | Promise<ScheduledTask | undefined>;
+  readonly remove: (id: TaskId) => void | Promise<void>;
+  readonly updateStatus: (
+    id: TaskId,
+    status: TaskStatus,
+    patch?: Partial<Pick<ScheduledTask, "startedAt" | "completedAt" | "lastError" | "retries">>,
+  ) => void | Promise<void>;
+  readonly query: (
+    filter: TaskFilter,
+  ) => readonly ScheduledTask[] | Promise<readonly ScheduledTask[]>;
+  readonly loadPending: () => readonly ScheduledTask[] | Promise<readonly ScheduledTask[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Main scheduler contract
+// ---------------------------------------------------------------------------
+
+export interface TaskScheduler extends AsyncDisposable {
+  readonly submit: (
+    agentId: AgentId,
+    input: EngineInput,
+    mode: "spawn" | "dispatch",
+    options?: TaskOptions,
+  ) => TaskId | Promise<TaskId>;
+  readonly cancel: (id: TaskId) => boolean | Promise<boolean>;
+  readonly schedule: (
+    expression: string,
+    agentId: AgentId,
+    input: EngineInput,
+    mode: "spawn" | "dispatch",
+    options?: TaskOptions & { readonly timezone?: string | undefined },
+  ) => ScheduleId | Promise<ScheduleId>;
+  readonly unschedule: (id: ScheduleId) => boolean | Promise<boolean>;
+  readonly query: (
+    filter: TaskFilter,
+  ) => readonly ScheduledTask[] | Promise<readonly ScheduledTask[]>;
+  readonly stats: () => SchedulerStats;
+  readonly watch: (listener: (event: SchedulerEvent) => void) => () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+export interface SchedulerStats {
+  readonly pending: number;
+  readonly running: number;
+  readonly completed: number;
+  readonly failed: number;
+  readonly deadLettered: number;
+  readonly activeSchedules: number;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface SchedulerConfig {
+  readonly maxConcurrent: number;
+  readonly defaultPriority: number;
+  readonly defaultMaxRetries: number;
+  readonly baseRetryDelayMs: number;
+  readonly maxRetryDelayMs: number;
+  readonly retryJitterMs: number;
+  readonly pollIntervalMs: number;
+  /** Threshold (ms) after which a "running" task is considered stale and eligible for recovery. */
+  readonly staleTaskThresholdMs: number;
+}
+
+/** Default scheduler configuration. */
+export const DEFAULT_SCHEDULER_CONFIG: SchedulerConfig = Object.freeze({
+  maxConcurrent: 10,
+  defaultPriority: 5,
+  defaultMaxRetries: 3,
+  baseRetryDelayMs: 1_000,
+  maxRetryDelayMs: 60_000,
+  retryJitterMs: 500,
+  pollIntervalMs: 1_000,
+  staleTaskThresholdMs: 300_000,
+});
+
+// ---------------------------------------------------------------------------
+// Pluggable schedule persistence (opt-in, separate from TaskStore)
+// ---------------------------------------------------------------------------
+
+/** Persistence backend for cron schedule definitions. */
+export interface ScheduleStore extends AsyncDisposable {
+  readonly saveSchedule: (schedule: CronSchedule) => void | Promise<void>;
+  readonly removeSchedule: (id: ScheduleId) => void | Promise<void>;
+  readonly loadSchedules: () => readonly CronSchedule[] | Promise<readonly CronSchedule[]>;
+}

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@koi/scheduler",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "croner": "9.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/scheduler/src/__tests__/clock.test.ts
+++ b/packages/scheduler/src/__tests__/clock.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { createFakeClock, createSystemClock } from "../clock.js";
+
+describe("FakeClock", () => {
+  test("now returns start time initially", () => {
+    const clock = createFakeClock(1000);
+    expect(clock.now()).toBe(1000);
+    expect(clock.currentTime()).toBe(1000);
+  });
+
+  test("tick advances time", () => {
+    const clock = createFakeClock(0);
+    clock.tick(500);
+    expect(clock.now()).toBe(500);
+  });
+
+  test("setTimeout fires callback after delay", () => {
+    const clock = createFakeClock(0);
+    let called = false; // let: set to true when callback fires
+    clock.setTimeout(() => {
+      called = true;
+    }, 100);
+
+    clock.tick(50);
+    expect(called).toBe(false);
+
+    clock.tick(60);
+    expect(called).toBe(true);
+  });
+
+  test("clearTimeout prevents callback from firing", () => {
+    const clock = createFakeClock(0);
+    let called = false; // let: set to true when callback fires
+    const id = clock.setTimeout(() => {
+      called = true;
+    }, 100);
+
+    clock.clearTimeout(id);
+    clock.tick(200);
+    expect(called).toBe(false);
+  });
+
+  test("setInterval fires repeatedly", () => {
+    const clock = createFakeClock(0);
+    let count = 0; // let: incremented on each callback
+    clock.setInterval(() => {
+      count += 1;
+    }, 100);
+
+    clock.tick(350);
+    expect(count).toBe(3);
+  });
+
+  test("clearInterval stops repeating", () => {
+    const clock = createFakeClock(0);
+    let count = 0; // let: incremented on each callback
+    const id = clock.setInterval(() => {
+      count += 1;
+    }, 100);
+
+    clock.tick(250);
+    expect(count).toBe(2);
+
+    clock.clearInterval(id);
+    clock.tick(200);
+    expect(count).toBe(2);
+  });
+});
+
+describe("SystemClock", () => {
+  test("now returns current time", () => {
+    const clock = createSystemClock();
+    const before = Date.now();
+    const now = clock.now();
+    const after = Date.now();
+
+    expect(now).toBeGreaterThanOrEqual(before);
+    expect(now).toBeLessThanOrEqual(after);
+  });
+
+  test("setTimeout and clearTimeout work", () => {
+    const clock = createSystemClock();
+    let called = false; // let: set on callback
+    const id = clock.setTimeout(() => {
+      called = true;
+    }, 10_000);
+    clock.clearTimeout(id);
+    // Not testing timing — just verifying no errors
+    expect(called).toBe(false);
+  });
+
+  test("setInterval and clearInterval work", () => {
+    const clock = createSystemClock();
+    let count = 0; // let: incremented on callback
+    const id = clock.setInterval(() => {
+      count += 1;
+    }, 10_000);
+    clock.clearInterval(id);
+    // Not testing timing — just verifying no errors
+    expect(count).toBe(0);
+  });
+});

--- a/packages/scheduler/src/__tests__/cron.integration.test.ts
+++ b/packages/scheduler/src/__tests__/cron.integration.test.ts
@@ -1,0 +1,190 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { SchedulerConfig, SchedulerEvent } from "@koi/core";
+import { agentId, DEFAULT_SCHEDULER_CONFIG } from "@koi/core";
+import type { TaskDispatcher } from "../scheduler.js";
+import { createScheduler } from "../scheduler.js";
+import { createSqliteTaskStore } from "../sqlite-store.js";
+
+describe("Cron integration", () => {
+  let dispose: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (dispose !== undefined) {
+      await dispose();
+      dispose = undefined;
+    }
+  });
+
+  test("valid cron expression accepted", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    const id = await scheduler.schedule(
+      "* * * * *",
+      agentId("a1"),
+      { kind: "text", text: "cron" },
+      "spawn",
+    );
+    expect(typeof id).toBe("string");
+    expect(id).toContain("sched_");
+  });
+
+  test("invalid cron expression throws", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    expect(
+      scheduler.schedule("invalid cron", agentId("a1"), { kind: "text", text: "bad" }, "spawn"),
+    ).rejects.toThrow();
+  });
+
+  test("schedule + unschedule lifecycle", async () => {
+    const events: SchedulerEvent[] = [];
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    const id = await scheduler.schedule(
+      "* * * * *",
+      agentId("a1"),
+      { kind: "text", text: "cron" },
+      "spawn",
+    );
+
+    expect(scheduler.stats().activeSchedules).toBe(1);
+
+    const removed = await scheduler.unschedule(id);
+    expect(removed).toBe(true);
+    expect(scheduler.stats().activeSchedules).toBe(0);
+
+    // Verify events
+    const created = events.filter((e) => e.kind === "schedule:created");
+    const removedEvents = events.filter((e) => e.kind === "schedule:removed");
+    expect(created.length).toBe(1);
+    expect(removedEvents.length).toBe(1);
+  });
+
+  test("unschedule returns false for unknown schedule", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    const { scheduleId } = await import("@koi/core");
+    const removed = await scheduler.unschedule(scheduleId("nonexistent"));
+    expect(removed).toBe(false);
+  });
+
+  test("schedule after dispose throws", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+    const scheduler = createScheduler(config, store, dispatcher);
+
+    await scheduler[Symbol.asyncDispose]();
+
+    expect(
+      scheduler.schedule(
+        "* * * * *",
+        agentId("a1"),
+        { kind: "text", text: "after dispose" },
+        "spawn",
+      ),
+    ).rejects.toThrow("Scheduler is disposed");
+  });
+
+  // Gap 3: schedule persistence across restart
+  test("schedule persists across scheduler restart", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher1 = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+
+    // Create scheduler with scheduleStore, schedule a cron
+    const scheduler1 = createScheduler(config, store, dispatcher1, undefined, store);
+    await scheduler1.schedule(
+      "* * * * *",
+      agentId("a1"),
+      { kind: "text", text: "persistent" },
+      "spawn",
+    );
+    expect(scheduler1.stats().activeSchedules).toBe(1);
+
+    // Dispose first scheduler
+    await scheduler1[Symbol.asyncDispose]();
+
+    // Create new scheduler on same db — should restore the schedule
+    const store2 = createSqliteTaskStore(db);
+    const dispatcher2 = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const scheduler2 = createScheduler(config, store2, dispatcher2, undefined, store2);
+    dispose = async () => scheduler2[Symbol.asyncDispose]();
+
+    // Wait for init
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(scheduler2.stats().activeSchedules).toBe(1);
+  });
+
+  test("unschedule removes from schedule store", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+
+    const scheduler = createScheduler(config, store, dispatcher, undefined, store);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    const id = await scheduler.schedule(
+      "* * * * *",
+      agentId("a1"),
+      { kind: "text", text: "temp" },
+      "spawn",
+    );
+
+    await scheduler.unschedule(id);
+
+    // Verify store is empty
+    const schedules = await store.loadSchedules();
+    expect(schedules).toHaveLength(0);
+  });
+
+  test("no scheduleStore — schedule works without persistence", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 50 };
+
+    // No scheduleStore passed
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    const id = await scheduler.schedule(
+      "* * * * *",
+      agentId("a1"),
+      { kind: "text", text: "ephemeral" },
+      "spawn",
+    );
+
+    expect(scheduler.stats().activeSchedules).toBe(1);
+
+    const removed = await scheduler.unschedule(id);
+    expect(removed).toBe(true);
+    expect(scheduler.stats().activeSchedules).toBe(0);
+  });
+});

--- a/packages/scheduler/src/__tests__/heap.test.ts
+++ b/packages/scheduler/src/__tests__/heap.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { createMinHeap } from "../heap.js";
+
+const numCompare = (a: number, b: number): number => a - b;
+
+describe("MinHeap", () => {
+  test("insert maintains heap property — extractMin returns smallest", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(5);
+    heap.insert(3);
+    heap.insert(7);
+    heap.insert(1);
+
+    expect(heap.extractMin()).toBe(1);
+    expect(heap.extractMin()).toBe(3);
+    expect(heap.extractMin()).toBe(5);
+    expect(heap.extractMin()).toBe(7);
+  });
+
+  test("peek returns smallest without removing", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(10);
+    heap.insert(2);
+
+    expect(heap.peek()).toBe(2);
+    expect(heap.size()).toBe(2);
+    expect(heap.peek()).toBe(2);
+  });
+
+  test("empty heap returns undefined for peek and extractMin", () => {
+    const heap = createMinHeap<number>(numCompare);
+
+    expect(heap.peek()).toBeUndefined();
+    expect(heap.extractMin()).toBeUndefined();
+  });
+
+  test("size tracks insertions and extractions", () => {
+    const heap = createMinHeap<number>(numCompare);
+    expect(heap.size()).toBe(0);
+
+    heap.insert(1);
+    heap.insert(2);
+    expect(heap.size()).toBe(2);
+
+    heap.extractMin();
+    expect(heap.size()).toBe(1);
+  });
+
+  test("toArray returns copy of internal data", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(3);
+    heap.insert(1);
+    heap.insert(2);
+
+    const arr = heap.toArray();
+    expect(arr.length).toBe(3);
+    // Should contain all elements (heap order, not sorted)
+    expect(arr).toContain(1);
+    expect(arr).toContain(2);
+    expect(arr).toContain(3);
+  });
+
+  test("stability: equal-priority items extracted in insertion order", () => {
+    const heap = createMinHeap<{ readonly p: number; readonly seq: number }>((a, b) => {
+      const pd = a.p - b.p;
+      if (pd !== 0) return pd;
+      return a.seq - b.seq;
+    });
+
+    heap.insert({ p: 1, seq: 0 });
+    heap.insert({ p: 1, seq: 1 });
+    heap.insert({ p: 1, seq: 2 });
+
+    expect(heap.extractMin()?.seq).toBe(0);
+    expect(heap.extractMin()?.seq).toBe(1);
+    expect(heap.extractMin()?.seq).toBe(2);
+  });
+
+  test("large insert/extract sequence (100 items)", () => {
+    const heap = createMinHeap<number>(numCompare);
+    const input = Array.from({ length: 100 }, (_, i) => 100 - i);
+
+    for (const n of input) {
+      heap.insert(n);
+    }
+
+    const output: number[] = [];
+    while (heap.size() > 0) {
+      const val = heap.extractMin();
+      if (val !== undefined) output.push(val);
+    }
+
+    // Should be sorted ascending
+    for (let i = 1; i < output.length; i++) {
+      expect(output[i]).toBeGreaterThanOrEqual(output[i - 1] ?? 0);
+    }
+    expect(output.length).toBe(100);
+    expect(output[0]).toBe(1);
+    expect(output[99]).toBe(100);
+  });
+
+  test("remove deletes matching element", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(5);
+    heap.insert(3);
+    heap.insert(7);
+
+    const removed = heap.remove((n) => n === 3);
+    expect(removed).toBe(true);
+    expect(heap.size()).toBe(2);
+    expect(heap.extractMin()).toBe(5);
+    expect(heap.extractMin()).toBe(7);
+  });
+
+  test("remove returns false when element not found", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(1);
+    heap.insert(2);
+
+    expect(heap.remove((n) => n === 99)).toBe(false);
+    expect(heap.size()).toBe(2);
+  });
+
+  test("extractMin from single-element heap", () => {
+    const heap = createMinHeap<number>(numCompare);
+    heap.insert(42);
+    expect(heap.extractMin()).toBe(42);
+    expect(heap.size()).toBe(0);
+  });
+});

--- a/packages/scheduler/src/__tests__/retry.test.ts
+++ b/packages/scheduler/src/__tests__/retry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { computeRetryDelay } from "../retry.js";
+
+const config = {
+  baseRetryDelayMs: 1_000,
+  maxRetryDelayMs: 60_000,
+  retryJitterMs: 500,
+} as const;
+
+describe("computeRetryDelay", () => {
+  test("attempt 0 returns baseDelay + jitter", () => {
+    const delay = computeRetryDelay(0, config);
+    // base = 1000 * 2^0 = 1000, jitter in [0, 500)
+    expect(delay).toBeGreaterThanOrEqual(1_000);
+    expect(delay).toBeLessThan(1_500);
+  });
+
+  test("exponential growth per attempt", () => {
+    const d0 = computeRetryDelay(0, { ...config, retryJitterMs: 0 });
+    const d1 = computeRetryDelay(1, { ...config, retryJitterMs: 0 });
+    const d2 = computeRetryDelay(2, { ...config, retryJitterMs: 0 });
+
+    expect(d0).toBe(1_000);
+    expect(d1).toBe(2_000);
+    expect(d2).toBe(4_000);
+  });
+
+  test("capped at maxRetryDelayMs", () => {
+    const delay = computeRetryDelay(20, { ...config, retryJitterMs: 0 });
+    expect(delay).toBe(60_000);
+  });
+
+  test("jitter is bounded by retryJitterMs", () => {
+    // Run multiple times to verify bounds
+    for (let i = 0; i < 50; i++) {
+      const delay = computeRetryDelay(0, config);
+      expect(delay).toBeGreaterThanOrEqual(1_000);
+      expect(delay).toBeLessThan(1_500);
+    }
+  });
+
+  test("zero jitter returns exact exponential", () => {
+    const delay = computeRetryDelay(3, { ...config, retryJitterMs: 0 });
+    expect(delay).toBe(8_000); // 1000 * 2^3
+  });
+});

--- a/packages/scheduler/src/__tests__/scheduler.integration.test.ts
+++ b/packages/scheduler/src/__tests__/scheduler.integration.test.ts
@@ -1,0 +1,75 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { SchedulerConfig } from "@koi/core";
+import { agentId, DEFAULT_SCHEDULER_CONFIG } from "@koi/core";
+import type { TaskDispatcher } from "../scheduler.js";
+import { createScheduler } from "../scheduler.js";
+import { createSqliteTaskStore } from "../sqlite-store.js";
+
+describe("Scheduler integration (real SQLite + SystemClock)", () => {
+  let dispose: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (dispose !== undefined) {
+      await dispose();
+      dispose = undefined;
+    }
+  });
+
+  test("submit delayed task → persist → new scheduler loads and dispatches", async () => {
+    const db = new Database(":memory:");
+    const store1 = createSqliteTaskStore(db);
+    const dispatcher1 = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 5_000,
+    };
+
+    const scheduler1 = createScheduler(config, store1, dispatcher1);
+    // Use delayMs so the immediate poll skips it (scheduledAt is in the future)
+    await scheduler1.submit(agentId("a1"), { kind: "text", text: "persisted" }, "spawn", {
+      delayMs: 100,
+    });
+    await scheduler1[Symbol.asyncDispose]();
+
+    // Verify task persisted as pending
+    const pending = await store1.loadPending();
+    expect(pending.length).toBeGreaterThanOrEqual(1);
+
+    // Create new scheduler on same db — should pick up pending task
+    const store2 = createSqliteTaskStore(db);
+    const dispatcher2 = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config2: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 50,
+    };
+    const scheduler2 = createScheduler(config2, store2, dispatcher2);
+    dispose = async () => scheduler2[Symbol.asyncDispose]();
+
+    // Wait for delay to expire + poll + dispatch
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(dispatcher2).toHaveBeenCalledTimes(1);
+  });
+
+  test("submit and dispatch with real system clock", async () => {
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 50,
+    };
+
+    const scheduler = createScheduler(config, store, dispatcher);
+    dispose = async () => scheduler[Symbol.asyncDispose]();
+
+    await scheduler.submit(agentId("a1"), { kind: "text", text: "real" }, "dispatch");
+
+    // Immediate poll dispatches; allow microtasks
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+    expect(dispatcher.mock.calls[0]?.[2]).toBe("dispatch");
+  });
+});

--- a/packages/scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/scheduler/src/__tests__/scheduler.test.ts
@@ -1,0 +1,544 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { EngineInput, SchedulerConfig, SchedulerEvent } from "@koi/core";
+import { agentId, DEFAULT_SCHEDULER_CONFIG, taskId } from "@koi/core";
+import { createFakeClock } from "../clock.js";
+import type { TaskDispatcher } from "../scheduler.js";
+import { createScheduler } from "../scheduler.js";
+import { createSqliteTaskStore } from "../sqlite-store.js";
+
+const TEXT_INPUT: EngineInput = { kind: "text", text: "hello" };
+
+function setup(overrides?: Partial<SchedulerConfig>): {
+  readonly clock: ReturnType<typeof createFakeClock>;
+  readonly db: Database;
+  readonly store: ReturnType<typeof createSqliteTaskStore>;
+  readonly dispatcher: ReturnType<typeof mock<TaskDispatcher>>;
+  readonly config: SchedulerConfig;
+  readonly scheduler: ReturnType<typeof createScheduler>;
+} {
+  const clock = createFakeClock(1000);
+  const db = new Database(":memory:");
+  const store = createSqliteTaskStore(db);
+  const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+  const config: SchedulerConfig = {
+    ...DEFAULT_SCHEDULER_CONFIG,
+    pollIntervalMs: 100,
+    ...overrides,
+  };
+  const scheduler = createScheduler(config, store, dispatcher, clock);
+
+  return { clock, db, store, dispatcher, config, scheduler } as const;
+}
+
+describe("TaskScheduler", () => {
+  let teardown: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (teardown !== undefined) {
+      await teardown();
+      teardown = undefined;
+    }
+  });
+
+  test("submit returns a TaskId", async () => {
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    const id = await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn");
+    expect(typeof id).toBe("string");
+    expect(id).toContain("task_");
+  });
+
+  test("delayed task appears in pending query", async () => {
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    const id = await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 5000 });
+
+    const tasks = await scheduler.query({ status: "pending" });
+    expect(tasks.length).toBeGreaterThanOrEqual(1);
+    expect(tasks.some((t) => t.id === id)).toBe(true);
+  });
+
+  test("submit with no delay dispatches immediately", async () => {
+    const { scheduler, dispatcher } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn");
+
+    // Immediate poll dispatches; allow microtasks to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+    expect(dispatcher.mock.calls[0]?.[0]).toBe(agentId("a1"));
+  });
+
+  test("priority ordering: higher priority dispatched first", async () => {
+    const callOrder: string[] = [];
+    const orderedDispatcher = mock<TaskDispatcher>(async (aid) => {
+      callOrder.push(aid);
+      return "ok";
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+
+    // Use maxConcurrent=1 so only one dispatches at a time during poll
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      maxConcurrent: 1,
+    };
+    const scheduler = createScheduler(config, store, orderedDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    // Submit both with delay so they queue up without dispatching
+    await scheduler.submit(agentId("low"), TEXT_INPUT, "spawn", { priority: 10, delayMs: 200 });
+    await scheduler.submit(agentId("high"), TEXT_INPUT, "spawn", { priority: 1, delayMs: 200 });
+
+    // Advance past delay + poll interval to dispatch
+    clock.tick(350);
+    await new Promise((r) => setTimeout(r, 20));
+
+    // First dispatch completes, releasing semaphore for second
+    clock.tick(150);
+    await new Promise((r) => setTimeout(r, 20));
+
+    // High priority should be dispatched first
+    expect(callOrder[0]).toBe("high");
+    expect(callOrder[1]).toBe("low");
+  });
+
+  test("cancel delayed task before execution prevents dispatch", async () => {
+    const { scheduler, clock, dispatcher } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    // Use delay so the task sits in the heap
+    const id = await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 5000 });
+    const cancelled = await scheduler.cancel(id);
+    expect(cancelled).toBe(true);
+
+    clock.tick(6000);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatcher).toHaveBeenCalledTimes(0);
+  });
+
+  test("retry on failure re-queues with backoff", async () => {
+    let callCount = 0; // let: incremented on each dispatch call
+    const failDispatcher = mock<TaskDispatcher>(async () => {
+      callCount += 1;
+      if (callCount <= 2) {
+        throw new Error("fail");
+      }
+      return "ok";
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      baseRetryDelayMs: 100,
+      maxRetryDelayMs: 1000,
+      retryJitterMs: 0,
+    };
+    const scheduler = createScheduler(config, store, failDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { maxRetries: 3 });
+
+    // First dispatch happens immediately via poll() in submit()
+    await new Promise((r) => setTimeout(r, 10));
+    expect(callCount).toBe(1);
+
+    // Retry after backoff: 100ms * 2^0 = 100ms
+    clock.tick(200);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(callCount).toBe(2);
+
+    // Retry after backoff: 100ms * 2^1 = 200ms
+    clock.tick(300);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(callCount).toBe(3);
+  });
+
+  test("dead letter after maxRetries exhausted", async () => {
+    const events: SchedulerEvent[] = [];
+    const failDispatcher = mock<TaskDispatcher>(async () => {
+      throw new Error("always fails");
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      baseRetryDelayMs: 50,
+      maxRetryDelayMs: 200,
+      retryJitterMs: 0,
+    };
+    const scheduler = createScheduler(config, store, failDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { maxRetries: 1 });
+
+    // Immediate dispatch (fails, retries exhausted with maxRetries=1)
+    await new Promise((r) => setTimeout(r, 10));
+
+    const deadLetterEvents = events.filter((e) => e.kind === "task:dead_letter");
+    expect(deadLetterEvents.length).toBe(1);
+  });
+
+  test("concurrency bounded by maxConcurrent", async () => {
+    let concurrent = 0; // let: tracks concurrent dispatches
+    let maxConcurrentSeen = 0; // let: tracks peak concurrency
+
+    const slowDispatcher = mock<TaskDispatcher>(async () => {
+      concurrent += 1;
+      maxConcurrentSeen = Math.max(maxConcurrentSeen, concurrent);
+      await new Promise((r) => setTimeout(r, 50));
+      concurrent -= 1;
+      return "ok";
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      maxConcurrent: 2,
+    };
+    const scheduler = createScheduler(config, store, slowDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    // Submit 5 tasks
+    for (let i = 0; i < 5; i++) {
+      await scheduler.submit(agentId(`a${String(i)}`), TEXT_INPUT, "spawn");
+    }
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Should not exceed maxConcurrent
+    expect(maxConcurrentSeen).toBeLessThanOrEqual(2);
+  });
+
+  test("stats reflect current state", async () => {
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    const initial = scheduler.stats();
+    expect(initial.pending).toBe(0);
+    expect(initial.running).toBe(0);
+    expect(initial.completed).toBe(0);
+    expect(initial.activeSchedules).toBe(0);
+
+    // Delayed task stays pending in the heap
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 5000 });
+    const afterSubmit = scheduler.stats();
+    expect(afterSubmit.pending).toBe(1);
+  });
+
+  test("watch receives events in order", async () => {
+    const events: SchedulerEvent[] = [];
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    scheduler.watch((e) => events.push(e));
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn");
+    // Immediate poll dispatches; allow microtasks to resolve
+    await new Promise((r) => setTimeout(r, 10));
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain("task:submitted");
+    expect(kinds).toContain("task:started");
+    expect(kinds).toContain("task:completed");
+
+    // Verify order: submitted before started before completed
+    const submittedIdx = kinds.indexOf("task:submitted");
+    const startedIdx = kinds.indexOf("task:started");
+    const completedIdx = kinds.indexOf("task:completed");
+    expect(submittedIdx).toBeLessThan(startedIdx);
+    expect(startedIdx).toBeLessThan(completedIdx);
+  });
+
+  test("delayed task not dispatched until scheduledAt", async () => {
+    const { scheduler, clock, dispatcher } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 500 });
+
+    // Immediate poll skips delayed task
+    await new Promise((r) => setTimeout(r, 10));
+    expect(dispatcher).toHaveBeenCalledTimes(0);
+
+    // Advance past delay
+    clock.tick(600);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispose stops all processing", async () => {
+    const { scheduler, clock, dispatcher } = setup();
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 5000 });
+    await scheduler[Symbol.asyncDispose]();
+
+    clock.tick(6000);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatcher).toHaveBeenCalledTimes(0);
+  });
+
+  test("submit after dispose throws", async () => {
+    const { scheduler } = setup();
+    await scheduler[Symbol.asyncDispose]();
+
+    expect(scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn")).rejects.toThrow(
+      "Scheduler is disposed",
+    );
+  });
+
+  test("unwatch stops event delivery", async () => {
+    const events: SchedulerEvent[] = [];
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    const unwatch = scheduler.watch((e) => events.push(e));
+    // Use delayed task so poll() in submit doesn't dispatch
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { delayMs: 5000 });
+    unwatch();
+
+    // Should only have the submitted event (before unwatch)
+    expect(events.length).toBe(1);
+    expect(events[0]?.kind).toBe("task:submitted");
+  });
+
+  test("cancel returns false for non-existent task", async () => {
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    const result = await scheduler.cancel(taskId("nonexistent"));
+    expect(result).toBe(false);
+  });
+
+  // Gap 1: timeoutMs enforcement
+  test("timeout fires when dispatcher exceeds timeoutMs", async () => {
+    const events: SchedulerEvent[] = [];
+    const slowDispatcher = mock<TaskDispatcher>(async () => {
+      // Simulate slow work — will be interrupted by fake clock timeout
+      await new Promise((r) => setTimeout(r, 5000));
+      return "ok";
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+    };
+    const scheduler = createScheduler(config, store, slowDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", {
+      timeoutMs: 200,
+      maxRetries: 1,
+    });
+
+    // Let submit's immediate poll fire the dispatcher
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Advance clock past timeout to trigger it
+    clock.tick(300);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const deadLetters = events.filter((e) => e.kind === "task:dead_letter");
+    expect(deadLetters.length).toBe(1);
+    expect((deadLetters[0] as { readonly error: { readonly code: string } }).error.code).toBe(
+      "TIMEOUT",
+    );
+  });
+
+  test("timeout + retry increments retries", async () => {
+    const events: SchedulerEvent[] = [];
+    const slowDispatcher = mock<TaskDispatcher>(async () => {
+      await new Promise((r) => setTimeout(r, 5000));
+      return "ok";
+    });
+
+    const clock = createFakeClock(1000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      baseRetryDelayMs: 50,
+      maxRetryDelayMs: 200,
+      retryJitterMs: 0,
+    };
+    const scheduler = createScheduler(config, store, slowDispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", {
+      timeoutMs: 100,
+      maxRetries: 3,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Trigger first timeout
+    clock.tick(150);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const failedEvents = events.filter((e) => e.kind === "task:failed");
+    expect(failedEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("no timeout when timeoutMs is omitted", async () => {
+    const { scheduler, dispatcher } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    await scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn");
+
+    // Allow dispatch
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(dispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  test("submit rejects timeoutMs <= 0", async () => {
+    const { scheduler } = setup();
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+
+    expect(scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { timeoutMs: 0 })).rejects.toThrow(
+      "timeoutMs must be a positive number",
+    );
+
+    expect(
+      scheduler.submit(agentId("a1"), TEXT_INPUT, "spawn", { timeoutMs: -100 }),
+    ).rejects.toThrow("timeoutMs must be a positive number");
+  });
+
+  // Gap 2: stale task recovery
+  test("stale running task recovered on initialize", async () => {
+    const events: SchedulerEvent[] = [];
+    const clock = createFakeClock(500_000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+
+    // Pre-seed a stale running task (startedAt is old enough)
+    await store.save({
+      id: taskId("stale_1"),
+      agentId: agentId("a1"),
+      input: TEXT_INPUT,
+      mode: "spawn",
+      priority: 5,
+      status: "running",
+      createdAt: 1000,
+      startedAt: 1000, // 499s ago with clock at 500_000
+      retries: 0,
+      maxRetries: 3,
+    });
+
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      staleTaskThresholdMs: 300_000, // 5 min
+    };
+    const scheduler = createScheduler(config, store, dispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    // Wait for init to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    const recovered = events.filter((e) => e.kind === "task:recovered");
+    expect(recovered.length).toBe(1);
+    expect(
+      (recovered[0] as { readonly taskId: string; readonly retriesUsed: number }).retriesUsed,
+    ).toBe(1);
+  });
+
+  test("stale running task dead-lettered when retries exhausted", async () => {
+    const events: SchedulerEvent[] = [];
+    const clock = createFakeClock(500_000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+
+    // Pre-seed stale task at max retries
+    await store.save({
+      id: taskId("stale_2"),
+      agentId: agentId("a1"),
+      input: TEXT_INPUT,
+      mode: "spawn",
+      priority: 5,
+      status: "running",
+      createdAt: 1000,
+      startedAt: 1000,
+      retries: 2,
+      maxRetries: 3,
+    });
+
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      staleTaskThresholdMs: 300_000,
+    };
+    const scheduler = createScheduler(config, store, dispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const deadLetters = events.filter((e) => e.kind === "task:dead_letter");
+    expect(deadLetters.length).toBe(1);
+  });
+
+  test("non-stale running task is not recovered", async () => {
+    const events: SchedulerEvent[] = [];
+    const clock = createFakeClock(2000);
+    const db = new Database(":memory:");
+    const store = createSqliteTaskStore(db);
+
+    // Task started 1s ago — well within staleTaskThresholdMs
+    await store.save({
+      id: taskId("fresh_1"),
+      agentId: agentId("a1"),
+      input: TEXT_INPUT,
+      mode: "spawn",
+      priority: 5,
+      status: "running",
+      createdAt: 1000,
+      startedAt: 1000,
+      retries: 0,
+      maxRetries: 3,
+    });
+
+    const dispatcher = mock<TaskDispatcher>(() => Promise.resolve("ok"));
+    const config: SchedulerConfig = {
+      ...DEFAULT_SCHEDULER_CONFIG,
+      pollIntervalMs: 100,
+      staleTaskThresholdMs: 300_000,
+    };
+    const scheduler = createScheduler(config, store, dispatcher, clock);
+    teardown = async () => scheduler[Symbol.asyncDispose]();
+    scheduler.watch((e) => events.push(e));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const recovered = events.filter((e) => e.kind === "task:recovered");
+    expect(recovered.length).toBe(0);
+  });
+});

--- a/packages/scheduler/src/__tests__/semaphore.test.ts
+++ b/packages/scheduler/src/__tests__/semaphore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createSemaphore } from "../semaphore.js";
+
+describe("Semaphore", () => {
+  test("acquire succeeds up to maxConcurrent", () => {
+    const sem = createSemaphore(3);
+    expect(sem.acquire()).toBe(true);
+    expect(sem.acquire()).toBe(true);
+    expect(sem.acquire()).toBe(true);
+    expect(sem.acquire()).toBe(false);
+  });
+
+  test("release allows next acquire", () => {
+    const sem = createSemaphore(1);
+    expect(sem.acquire()).toBe(true);
+    expect(sem.acquire()).toBe(false);
+
+    sem.release();
+    expect(sem.acquire()).toBe(true);
+  });
+
+  test("available count is accurate", () => {
+    const sem = createSemaphore(3);
+    expect(sem.available()).toBe(3);
+
+    sem.acquire();
+    expect(sem.available()).toBe(2);
+
+    sem.acquire();
+    expect(sem.available()).toBe(1);
+
+    sem.release();
+    expect(sem.available()).toBe(2);
+  });
+
+  test("release below zero is a no-op", () => {
+    const sem = createSemaphore(2);
+    sem.release();
+    // Should not go negative — available should still be max
+    expect(sem.available()).toBe(2);
+  });
+
+  test("throws on maxConcurrent < 1", () => {
+    expect(() => createSemaphore(0)).toThrow("maxConcurrent must be at least 1");
+  });
+});

--- a/packages/scheduler/src/__tests__/sqlite-store.test.ts
+++ b/packages/scheduler/src/__tests__/sqlite-store.test.ts
@@ -1,0 +1,250 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { CronSchedule, ScheduledTask } from "@koi/core";
+import { agentId, scheduleId, taskId } from "@koi/core";
+import type { SqliteTaskStore } from "../sqlite-store.js";
+import { createSqliteTaskStore } from "../sqlite-store.js";
+
+function makeTask(overrides?: Partial<ScheduledTask>): ScheduledTask {
+  return {
+    id: taskId("task_1"),
+    agentId: agentId("agent_1"),
+    input: { kind: "text", text: "hello" },
+    mode: "spawn",
+    priority: 5,
+    status: "pending",
+    createdAt: 1000,
+    retries: 0,
+    maxRetries: 3,
+    ...overrides,
+  };
+}
+
+describe("SqliteTaskStore", () => {
+  let db: Database;
+  let store: SqliteTaskStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    store = createSqliteTaskStore(db);
+  });
+
+  test("save and load round-trip", async () => {
+    const task = makeTask();
+    await store.save(task);
+    const loaded = await store.load(taskId("task_1"));
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.id).toBe(taskId("task_1"));
+    expect(loaded?.agentId).toBe(agentId("agent_1"));
+    expect(loaded?.input).toEqual({ kind: "text", text: "hello" });
+    expect(loaded?.mode).toBe("spawn");
+    expect(loaded?.priority).toBe(5);
+    expect(loaded?.status).toBe("pending");
+  });
+
+  test("load returns undefined for non-existent task", async () => {
+    const loaded = await store.load(taskId("nonexistent"));
+    expect(loaded).toBeUndefined();
+  });
+
+  test("query by status", async () => {
+    await store.save(makeTask({ id: taskId("t1"), status: "pending" }));
+    await store.save(makeTask({ id: taskId("t2"), status: "running" }));
+    await store.save(makeTask({ id: taskId("t3"), status: "pending" }));
+
+    const pending = await store.query({ status: "pending" });
+    expect(pending).toHaveLength(2);
+  });
+
+  test("query by agentId", async () => {
+    await store.save(makeTask({ id: taskId("t1"), agentId: agentId("a1") }));
+    await store.save(makeTask({ id: taskId("t2"), agentId: agentId("a2") }));
+    await store.save(makeTask({ id: taskId("t3"), agentId: agentId("a1") }));
+
+    const results = await store.query({ agentId: agentId("a1") });
+    expect(results).toHaveLength(2);
+  });
+
+  test("query with limit", async () => {
+    await store.save(makeTask({ id: taskId("t1") }));
+    await store.save(makeTask({ id: taskId("t2") }));
+    await store.save(makeTask({ id: taskId("t3") }));
+
+    const results = await store.query({ limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  test("updateStatus changes status and patch fields", async () => {
+    await store.save(makeTask());
+    await store.updateStatus(taskId("task_1"), "running", { startedAt: 2000 });
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.status).toBe("running");
+    expect(loaded?.startedAt).toBe(2000);
+  });
+
+  test("updateStatus with lastError patch", async () => {
+    await store.save(makeTask());
+    const error = {
+      code: "EXTERNAL" as const,
+      message: "boom",
+      retryable: true,
+    };
+    await store.updateStatus(taskId("task_1"), "failed", { lastError: error, retries: 1 });
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.status).toBe("failed");
+    expect(loaded?.lastError?.message).toBe("boom");
+    expect(loaded?.retries).toBe(1);
+  });
+
+  test("loadPending returns tasks ordered by priority then createdAt", async () => {
+    await store.save(makeTask({ id: taskId("t1"), priority: 5, createdAt: 100 }));
+    await store.save(makeTask({ id: taskId("t2"), priority: 1, createdAt: 200 }));
+    await store.save(makeTask({ id: taskId("t3"), priority: 5, createdAt: 50 }));
+    await store.save(makeTask({ id: taskId("t4"), status: "running" }));
+
+    const pending = await store.loadPending();
+    expect(pending).toHaveLength(3);
+    expect(pending[0]?.id).toBe(taskId("t2")); // priority 1
+    expect(pending[1]?.id).toBe(taskId("t3")); // priority 5, createdAt 50
+    expect(pending[2]?.id).toBe(taskId("t1")); // priority 5, createdAt 100
+  });
+
+  test("remove deletes task", async () => {
+    await store.save(makeTask());
+    await store.remove(taskId("task_1"));
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded).toBeUndefined();
+  });
+
+  test("idempotent table creation", async () => {
+    // Creating a second store on the same db should not throw
+    const store2 = createSqliteTaskStore(db);
+    await store2.save(makeTask({ id: taskId("t2") }));
+    const loaded = await store2.load(taskId("t2"));
+    expect(loaded).toBeDefined();
+  });
+
+  test("save with metadata round-trips correctly", async () => {
+    await store.save(
+      makeTask({
+        metadata: { foo: "bar", count: 42 },
+      }),
+    );
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.metadata).toEqual({ foo: "bar", count: 42 });
+  });
+
+  test("save with scheduledAt round-trips correctly", async () => {
+    await store.save(makeTask({ scheduledAt: 5000 }));
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.scheduledAt).toBe(5000);
+  });
+
+  test("purge removes completed tasks older than threshold", async () => {
+    const now = Date.now();
+    await store.save(
+      makeTask({ id: taskId("old"), status: "completed", completedAt: now - 10_000 }),
+    );
+    await store.save(makeTask({ id: taskId("new"), status: "completed", completedAt: now }));
+    await store.save(makeTask({ id: taskId("pending"), status: "pending" }));
+
+    store.purge(5_000); // remove tasks completed more than 5s ago
+
+    expect(await store.load(taskId("old"))).toBeUndefined();
+    expect(await store.load(taskId("new"))).toBeDefined();
+    expect(await store.load(taskId("pending"))).toBeDefined();
+  });
+
+  test("purge removes dead_letter tasks older than threshold", async () => {
+    const now = Date.now();
+    await store.save(
+      makeTask({ id: taskId("dl"), status: "dead_letter", completedAt: now - 10_000 }),
+    );
+
+    store.purge(5_000);
+
+    expect(await store.load(taskId("dl"))).toBeUndefined();
+  });
+
+  // Gap 1: timeoutMs persistence
+  test("save with timeoutMs round-trips correctly", async () => {
+    await store.save(makeTask({ timeoutMs: 5000 }));
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.timeoutMs).toBe(5000);
+  });
+
+  test("save without timeoutMs returns undefined", async () => {
+    await store.save(makeTask());
+
+    const loaded = await store.load(taskId("task_1"));
+    expect(loaded?.timeoutMs).toBeUndefined();
+  });
+
+  // Gap 3: schedule persistence
+  test("saveSchedule and loadSchedules round-trip", async () => {
+    const schedule: CronSchedule = {
+      id: scheduleId("sched_1"),
+      expression: "0 0 * * *",
+      agentId: agentId("agent_1"),
+      input: { kind: "text", text: "cron" },
+      mode: "spawn",
+      paused: false,
+    };
+
+    await store.saveSchedule(schedule);
+    const loaded = await store.loadSchedules();
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.id).toBe(scheduleId("sched_1"));
+    expect(loaded[0]?.expression).toBe("0 0 * * *");
+    expect(loaded[0]?.agentId).toBe(agentId("agent_1"));
+    expect(loaded[0]?.input).toEqual({ kind: "text", text: "cron" });
+    expect(loaded[0]?.mode).toBe("spawn");
+    expect(loaded[0]?.paused).toBe(false);
+  });
+
+  test("saveSchedule with taskOptions and timezone", async () => {
+    const schedule: CronSchedule = {
+      id: scheduleId("sched_2"),
+      expression: "*/5 * * * *",
+      agentId: agentId("agent_2"),
+      input: { kind: "text", text: "timed" },
+      mode: "dispatch",
+      taskOptions: { priority: 1, maxRetries: 5 },
+      timezone: "America/New_York",
+      paused: true,
+    };
+
+    await store.saveSchedule(schedule);
+    const loaded = await store.loadSchedules();
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.taskOptions).toEqual({ priority: 1, maxRetries: 5 });
+    expect(loaded[0]?.timezone).toBe("America/New_York");
+    expect(loaded[0]?.paused).toBe(true);
+  });
+
+  test("removeSchedule deletes schedule", async () => {
+    const schedule: CronSchedule = {
+      id: scheduleId("sched_3"),
+      expression: "0 0 * * *",
+      agentId: agentId("agent_1"),
+      input: { kind: "text", text: "cron" },
+      mode: "spawn",
+      paused: false,
+    };
+
+    await store.saveSchedule(schedule);
+    await store.removeSchedule(scheduleId("sched_3"));
+    const loaded = await store.loadSchedules();
+
+    expect(loaded).toHaveLength(0);
+  });
+});

--- a/packages/scheduler/src/__tests__/timer.test.ts
+++ b/packages/scheduler/src/__tests__/timer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { createFakeClock } from "../clock.js";
+import { createPeriodicTimer } from "../timer.js";
+
+describe("createPeriodicTimer", () => {
+  test("fires callback at interval", () => {
+    const clock = createFakeClock(0);
+    let count = 0; // let: incremented on each callback
+    createPeriodicTimer(clock, 100, () => {
+      count += 1;
+    });
+
+    clock.tick(350);
+    expect(count).toBe(3);
+  });
+
+  test("stop prevents further callbacks", () => {
+    const clock = createFakeClock(0);
+    let count = 0; // let: incremented on each callback
+    const timer = createPeriodicTimer(clock, 100, () => {
+      count += 1;
+    });
+
+    clock.tick(250);
+    expect(count).toBe(2);
+
+    timer.stop();
+    clock.tick(200);
+    expect(count).toBe(2);
+  });
+
+  test("double stop is a no-op", () => {
+    const clock = createFakeClock(0);
+    const timer = createPeriodicTimer(clock, 100, () => {});
+
+    timer.stop();
+    timer.stop(); // should not throw
+  });
+
+  test("throws on interval < 1ms", () => {
+    const clock = createFakeClock(0);
+    expect(() => createPeriodicTimer(clock, 0, () => {})).toThrow("Interval must be at least 1ms");
+  });
+
+  test("asyncDispose stops the timer", async () => {
+    const clock = createFakeClock(0);
+    let count = 0; // let: incremented on each callback
+    const timer = createPeriodicTimer(clock, 100, () => {
+      count += 1;
+    });
+
+    clock.tick(150);
+    expect(count).toBe(1);
+
+    await timer[Symbol.asyncDispose]();
+    clock.tick(200);
+    expect(count).toBe(1);
+  });
+});

--- a/packages/scheduler/src/clock.ts
+++ b/packages/scheduler/src/clock.ts
@@ -1,0 +1,122 @@
+/**
+ * Clock abstraction for testable time-dependent code.
+ *
+ * SystemClock delegates to global functions (production).
+ * FakeClock provides manual tick(ms) for deterministic tests.
+ */
+
+// ---------------------------------------------------------------------------
+// Clock interface
+// ---------------------------------------------------------------------------
+
+export interface Clock {
+  readonly now: () => number;
+  readonly setTimeout: (callback: () => void, ms: number) => number;
+  readonly setInterval: (callback: () => void, ms: number) => number;
+  readonly clearTimeout: (id: number) => void;
+  readonly clearInterval: (id: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// FakeClock (for tests)
+// ---------------------------------------------------------------------------
+
+export interface FakeClock extends Clock {
+  readonly tick: (ms: number) => void;
+  readonly currentTime: () => number;
+}
+
+interface PendingTimer {
+  readonly callback: () => void;
+  readonly fireAt: number;
+  readonly interval: number | undefined;
+  readonly id: number;
+}
+
+export function createFakeClock(startTime: number = 0): FakeClock {
+  let time = startTime; // let: advances on tick()
+  let nextId = 1; // let: incremented on each timer creation
+  let timers = new Map<number, PendingTimer>(); // let: replaced immutably
+
+  function scheduleTimer(callback: () => void, ms: number, interval: number | undefined): number {
+    const id = nextId;
+    nextId += 1;
+    const updated = new Map(timers);
+    updated.set(id, { callback, fireAt: time + ms, interval, id });
+    timers = updated;
+    return id;
+  }
+
+  return {
+    now: () => time,
+    currentTime: () => time,
+
+    setTimeout: (callback, ms) => scheduleTimer(callback, ms, undefined),
+
+    setInterval: (callback, ms) => scheduleTimer(callback, ms, ms),
+
+    clearTimeout: (id) => {
+      const updated = new Map(timers);
+      updated.delete(id);
+      timers = updated;
+    },
+
+    clearInterval: (id) => {
+      const updated = new Map(timers);
+      updated.delete(id);
+      timers = updated;
+    },
+
+    tick: (ms) => {
+      const target = time + ms;
+      // Process timers in order of fire time
+      while (time < target) {
+        // Find earliest timer that fires before target
+        let earliest: PendingTimer | undefined;
+        for (const t of timers.values()) {
+          if (t.fireAt <= target && (earliest === undefined || t.fireAt < earliest.fireAt)) {
+            earliest = t;
+          }
+        }
+
+        if (earliest === undefined || earliest.fireAt > target) {
+          time = target;
+          break;
+        }
+
+        time = earliest.fireAt;
+        const cb = earliest.callback;
+        const interval = earliest.interval;
+        const timerId = earliest.id;
+
+        if (interval !== undefined) {
+          // Reschedule interval timer
+          const updated = new Map(timers);
+          updated.set(timerId, { callback: cb, fireAt: time + interval, interval, id: timerId });
+          timers = updated;
+        } else {
+          // Remove one-shot timer
+          const updated = new Map(timers);
+          updated.delete(timerId);
+          timers = updated;
+        }
+
+        cb();
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SystemClock (production)
+// ---------------------------------------------------------------------------
+
+export function createSystemClock(): Clock {
+  return {
+    now: () => Date.now(),
+    setTimeout: (cb, ms) => setTimeout(cb, ms) as unknown as number,
+    setInterval: (cb, ms) => setInterval(cb, ms) as unknown as number,
+    clearTimeout: (id) => clearTimeout(id),
+    clearInterval: (id) => clearInterval(id),
+  };
+}

--- a/packages/scheduler/src/heap.ts
+++ b/packages/scheduler/src/heap.ts
@@ -1,0 +1,114 @@
+/**
+ * Generic min-heap (priority queue) backed by a flat array.
+ *
+ * Comparator returns negative if a should come before b.
+ */
+
+export interface MinHeap<T> {
+  readonly insert: (item: T) => void;
+  readonly extractMin: () => T | undefined;
+  readonly peek: () => T | undefined;
+  readonly size: () => number;
+  readonly toArray: () => readonly T[];
+  readonly remove: (predicate: (item: T) => boolean) => boolean;
+}
+
+export function createMinHeap<T>(compare: (a: T, b: T) => number): MinHeap<T> {
+  const data: T[] = []; // internal mutable array for heap operations
+
+  function swap(i: number, j: number): void {
+    const a = data[i];
+    const b = data[j];
+    if (a === undefined || b === undefined) return;
+    data[i] = b;
+    data[j] = a;
+  }
+
+  function siftUp(index: number): void {
+    let i = index; // let: moves up toward root
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      const current = data[i];
+      const parentItem = data[parent];
+      if (current !== undefined && parentItem !== undefined && compare(current, parentItem) < 0) {
+        swap(i, parent);
+        i = parent;
+      } else {
+        break;
+      }
+    }
+  }
+
+  function siftDown(index: number): void {
+    let i = index; // let: moves down toward leaves
+    const len = data.length;
+    while (true) {
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      let smallest = i; // let: tracks smallest of parent/children
+
+      const leftItem = data[left];
+      const smallestItem = data[smallest];
+      if (
+        left < len &&
+        leftItem !== undefined &&
+        smallestItem !== undefined &&
+        compare(leftItem, smallestItem) < 0
+      ) {
+        smallest = left;
+      }
+      const rightItem = data[right];
+      const smallestAfterLeft = data[smallest];
+      if (
+        right < len &&
+        rightItem !== undefined &&
+        smallestAfterLeft !== undefined &&
+        compare(rightItem, smallestAfterLeft) < 0
+      ) {
+        smallest = right;
+      }
+      if (smallest === i) break;
+      swap(i, smallest);
+      i = smallest;
+    }
+  }
+
+  return {
+    insert: (item) => {
+      data.push(item);
+      siftUp(data.length - 1);
+    },
+
+    extractMin: () => {
+      if (data.length === 0) return undefined;
+      if (data.length === 1) return data.pop();
+      const min = data[0];
+      const last = data.pop();
+      if (min === undefined || last === undefined) return undefined;
+      data[0] = last;
+      siftDown(0);
+      return min;
+    },
+
+    peek: () => (data.length > 0 ? data[0] : undefined),
+
+    size: () => data.length,
+
+    toArray: () => [...data],
+
+    remove: (predicate) => {
+      const index = data.findIndex(predicate);
+      if (index === -1) return false;
+      if (index === data.length - 1) {
+        data.pop();
+        return true;
+      }
+      const popped = data.pop();
+      if (popped === undefined) return false;
+      data[index] = popped;
+      siftDown(index);
+      siftUp(index);
+      return true;
+    },
+  };
+}

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @koi/scheduler — L2 task scheduling package.
+ *
+ * Provides priority queue, cron scheduling, retry with backoff,
+ * dead-letter queue, and bounded concurrency for agent dispatch.
+ */
+
+export type { Clock, FakeClock } from "./clock.js";
+export { createFakeClock, createSystemClock } from "./clock.js";
+export type { MinHeap } from "./heap.js";
+export { createMinHeap } from "./heap.js";
+export { computeRetryDelay } from "./retry.js";
+export type { TaskDispatcher } from "./scheduler.js";
+export { createScheduler } from "./scheduler.js";
+export type { Semaphore } from "./semaphore.js";
+export { createSemaphore } from "./semaphore.js";
+export type { SqliteTaskStore } from "./sqlite-store.js";
+export { createSqliteTaskStore } from "./sqlite-store.js";

--- a/packages/scheduler/src/retry.ts
+++ b/packages/scheduler/src/retry.ts
@@ -1,0 +1,17 @@
+/**
+ * Exponential backoff retry delay calculation.
+ *
+ * Formula: min(maxDelay, baseDelay * 2^attempt) + random(0, jitter)
+ * Pure function, no side effects.
+ */
+
+import type { SchedulerConfig } from "@koi/core";
+
+export function computeRetryDelay(
+  attempt: number,
+  config: Pick<SchedulerConfig, "baseRetryDelayMs" | "maxRetryDelayMs" | "retryJitterMs">,
+): number {
+  const exponential = Math.min(config.maxRetryDelayMs, config.baseRetryDelayMs * 2 ** attempt);
+  const jitter = Math.floor(Math.random() * config.retryJitterMs);
+  return exponential + jitter;
+}

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -1,0 +1,493 @@
+/**
+ * Task scheduler — priority queue, cron scheduling, retry with backoff,
+ * dead-letter queue, and bounded concurrency.
+ *
+ * SQLite is source of truth; in-memory heap is a hot cache of pending tasks.
+ */
+
+import type {
+  AgentId,
+  CronSchedule,
+  EngineInput,
+  KoiError,
+  ScheduledTask,
+  ScheduleId,
+  SchedulerConfig,
+  SchedulerEvent,
+  SchedulerStats,
+  ScheduleStore,
+  TaskFilter,
+  TaskId,
+  TaskOptions,
+  TaskScheduler,
+  TaskStore,
+} from "@koi/core";
+import { scheduleId, taskId } from "@koi/core";
+import { Cron } from "croner";
+import type { Clock } from "./clock.js";
+import { createSystemClock } from "./clock.js";
+import { createMinHeap } from "./heap.js";
+import { computeRetryDelay } from "./retry.js";
+import { createSemaphore } from "./semaphore.js";
+import { createPeriodicTimer } from "./timer.js";
+
+// ---------------------------------------------------------------------------
+// Task dispatcher signature
+// ---------------------------------------------------------------------------
+
+export type TaskDispatcher = (
+  agentId: AgentId,
+  input: EngineInput,
+  mode: "spawn" | "dispatch",
+) => Promise<unknown>;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createScheduler(
+  config: SchedulerConfig,
+  store: TaskStore,
+  dispatcher: TaskDispatcher,
+  clock?: Clock,
+  scheduleStore?: ScheduleStore,
+): TaskScheduler {
+  const clk = clock ?? createSystemClock();
+  let disposed = false; // let: set to true on dispose
+
+  // ---------------------------------------------------------------------------
+  // Internal state
+  // ---------------------------------------------------------------------------
+
+  const heap = createMinHeap<ScheduledTask>((a, b) => {
+    const pd = a.priority - b.priority;
+    if (pd !== 0) return pd;
+    return a.createdAt - b.createdAt;
+  });
+
+  const crons = new Map<string, Cron>(); // scheduleId → Cron instance
+  const cronMeta = new Map<string, CronSchedule>(); // scheduleId → metadata
+  const semaphore = createSemaphore(config.maxConcurrent);
+  // P9 fix: mutable Set with idempotent unsubscribe (internal state, not shared)
+  const listeners = new Set<(event: SchedulerEvent) => void>();
+
+  // Stats counters
+  let completedCount = 0; // let: incremented on task completion
+  let failedCount = 0; // let: incremented on task failure
+  let deadLetteredCount = 0; // let: incremented on dead letter
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function emit(event: SchedulerEvent): void {
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+
+  function generateTaskId(): TaskId {
+    return taskId(`task_${clk.now()}_${Math.random().toString(36).slice(2, 10)}`);
+  }
+
+  function generateScheduleId(): ScheduleId {
+    return scheduleId(`sched_${clk.now()}_${Math.random().toString(36).slice(2, 10)}`);
+  }
+
+  /** Race a promise against a clock-based timeout. Returns the result or throws TIMEOUT KoiError. */
+  function executeWithTimeout<T>(promise: Promise<T>, timeoutMs: number | undefined): Promise<T> {
+    if (timeoutMs === undefined) return promise;
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false; // let: guard flag — first settlement wins
+
+      const timerId = clk.setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        const err: KoiError = {
+          code: "TIMEOUT",
+          message: `Task execution timed out after ${String(timeoutMs)}ms`,
+          retryable: true,
+        };
+        reject(err);
+      }, timeoutMs);
+
+      promise.then(
+        (value) => {
+          if (settled) return;
+          settled = true;
+          clk.clearTimeout(timerId);
+          resolve(value);
+        },
+        (error: unknown) => {
+          if (settled) return;
+          settled = true;
+          clk.clearTimeout(timerId);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dispatch a single task
+  // ---------------------------------------------------------------------------
+
+  // P2 fix: outer try/catch for infrastructure errors (store failures);
+  // re-insert task into heap so it's not silently orphaned.
+  async function dispatchTask(task: ScheduledTask): Promise<void> {
+    try {
+      const now = clk.now();
+      await store.updateStatus(task.id, "running", { startedAt: now });
+      emit({ kind: "task:started", taskId: task.id });
+
+      try {
+        const result = await executeWithTimeout(
+          dispatcher(task.agentId, task.input, task.mode),
+          task.timeoutMs,
+        );
+
+        await store.updateStatus(task.id, "completed", { completedAt: clk.now() });
+        completedCount += 1;
+        emit({ kind: "task:completed", taskId: task.id, result });
+      } catch (err: unknown) {
+        // Timeout errors arrive as KoiError objects with code "TIMEOUT"
+        const isTimeoutError =
+          typeof err === "object" &&
+          err !== null &&
+          "code" in err &&
+          (err as KoiError).code === "TIMEOUT";
+
+        const koiError: KoiError = isTimeoutError
+          ? (err as KoiError)
+          : {
+              code: "EXTERNAL",
+              message: err instanceof Error ? err.message : String(err),
+              retryable: true,
+              cause: err,
+            };
+
+        const nextRetries = task.retries + 1;
+        if (nextRetries < task.maxRetries) {
+          // Retry: re-queue with backoff
+          const delay = computeRetryDelay(task.retries, config);
+          const retask: ScheduledTask = {
+            ...task,
+            status: "pending",
+            retries: nextRetries,
+            scheduledAt: clk.now() + delay,
+            lastError: koiError,
+          };
+          await store.save(retask);
+          heap.insert(retask);
+          failedCount += 1;
+          emit({ kind: "task:failed", taskId: task.id, error: koiError });
+        } else {
+          // Dead letter
+          await store.updateStatus(task.id, "dead_letter", {
+            lastError: koiError,
+            retries: nextRetries,
+          });
+          deadLetteredCount += 1;
+          emit({ kind: "task:dead_letter", taskId: task.id, error: koiError });
+        }
+      }
+    } catch (_infraError: unknown) {
+      // Infrastructure failure (store error) — re-insert for retry on next poll
+      heap.insert(task);
+    } finally {
+      semaphore.release();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Poll loop — process ready tasks from the heap
+  // ---------------------------------------------------------------------------
+
+  function poll(): void {
+    if (disposed) return;
+
+    const now = clk.now();
+    while (true) {
+      const next = heap.peek();
+      if (next === undefined) break;
+
+      // Check if task is scheduled for future
+      if (next.scheduledAt !== undefined && next.scheduledAt > now) break;
+
+      if (!semaphore.acquire()) break;
+
+      const task = heap.extractMin();
+      if (task === undefined) {
+        semaphore.release();
+        break;
+      }
+      // Fire and forget — errors handled inside dispatchTask
+      void dispatchTask(task);
+    }
+  }
+
+  const pollTimer = createPeriodicTimer(clk, config.pollIntervalMs, poll);
+
+  // ---------------------------------------------------------------------------
+  // Initialize: load pending tasks from store into heap
+  // ---------------------------------------------------------------------------
+
+  async function initialize(): Promise<void> {
+    // Load pending tasks into heap
+    const pending = await store.loadPending();
+    for (const task of pending) {
+      heap.insert(task);
+    }
+
+    // Gap 2: recover stale "running" tasks
+    const running = await store.query({ status: "running" });
+    const now = clk.now();
+    for (const task of running) {
+      const startedAt = task.startedAt ?? task.createdAt;
+      if (now - startedAt < config.staleTaskThresholdMs) continue;
+
+      const nextRetries = task.retries + 1;
+      if (nextRetries < task.maxRetries) {
+        // Recoverable — reset to pending, increment retries
+        const recovered: ScheduledTask = {
+          ...task,
+          status: "pending",
+          retries: nextRetries,
+        };
+        await store.save(recovered);
+        heap.remove((t) => t.id === task.id); // Remove stale version if present
+        heap.insert(recovered);
+        emit({ kind: "task:recovered", taskId: task.id, retriesUsed: nextRetries });
+      } else {
+        // Retries exhausted — dead letter
+        const koiError: KoiError = {
+          code: "TIMEOUT",
+          message: "Task stale after crash — retries exhausted",
+          retryable: false,
+        };
+        await store.updateStatus(task.id, "dead_letter", {
+          lastError: koiError,
+          retries: nextRetries,
+        });
+        deadLetteredCount += 1;
+        emit({ kind: "task:dead_letter", taskId: task.id, error: koiError });
+      }
+    }
+
+    // Gap 3: restore persisted cron schedules
+    if (scheduleStore !== undefined) {
+      const schedules = await scheduleStore.loadSchedules();
+      for (const meta of schedules) {
+        if (meta.paused) continue;
+        const cronOptions =
+          meta.timezone !== undefined
+            ? ({ timezone: meta.timezone, paused: false } as const)
+            : ({ paused: false } as const);
+
+        const cronJob = new Cron(meta.expression, cronOptions, () => {
+          void submit(meta.agentId, meta.input, meta.mode, meta.taskOptions);
+        });
+
+        crons.set(meta.id, cronJob);
+        cronMeta.set(meta.id, meta);
+      }
+    }
+  }
+
+  // Start initialization
+  const initPromise = initialize();
+
+  // ---------------------------------------------------------------------------
+  // Public interface
+  // ---------------------------------------------------------------------------
+
+  async function submit(
+    agentIdVal: AgentId,
+    input: EngineInput,
+    mode: "spawn" | "dispatch",
+    options?: TaskOptions,
+  ): Promise<TaskId> {
+    if (disposed) {
+      throw new Error("Scheduler is disposed");
+    }
+
+    await initPromise;
+
+    if (options?.timeoutMs !== undefined && options.timeoutMs <= 0) {
+      throw new Error("timeoutMs must be a positive number");
+    }
+
+    const id = generateTaskId();
+    const now = clk.now();
+    const task: ScheduledTask = {
+      id,
+      agentId: agentIdVal,
+      input,
+      mode,
+      priority: options?.priority ?? config.defaultPriority,
+      status: "pending",
+      createdAt: now,
+      scheduledAt: options?.delayMs !== undefined ? now + options.delayMs : undefined,
+      retries: 0,
+      maxRetries: options?.maxRetries ?? config.defaultMaxRetries,
+      timeoutMs: options?.timeoutMs,
+      metadata: options?.metadata,
+    };
+
+    await store.save(task);
+    heap.insert(task);
+    emit({ kind: "task:submitted", task });
+
+    // P1 fix: immediately attempt dispatch for zero-delay tasks
+    poll();
+
+    return id;
+  }
+
+  async function cancel(id: TaskId): Promise<boolean> {
+    if (disposed) return false;
+
+    await initPromise;
+
+    const removed = heap.remove((t) => t.id === id);
+    if (removed) {
+      await store.updateStatus(id, "completed", { completedAt: clk.now() });
+      emit({ kind: "task:cancelled", taskId: id });
+    }
+    return removed;
+  }
+
+  async function schedule(
+    expression: string,
+    agentIdVal: AgentId,
+    input: EngineInput,
+    mode: "spawn" | "dispatch",
+    options?: TaskOptions & { readonly timezone?: string | undefined },
+  ): Promise<ScheduleId> {
+    if (disposed) {
+      throw new Error("Scheduler is disposed");
+    }
+
+    await initPromise;
+
+    if (options?.timeoutMs !== undefined && options.timeoutMs <= 0) {
+      throw new Error("timeoutMs must be a positive number");
+    }
+
+    const id = generateScheduleId();
+
+    const cronOptions =
+      options?.timezone !== undefined
+        ? ({ timezone: options.timezone, paused: false } as const)
+        : ({ paused: false } as const);
+
+    const cronJob = new Cron(expression, cronOptions, () => {
+      void submit(agentIdVal, input, mode, options);
+    });
+
+    crons.set(id, cronJob);
+
+    const meta: CronSchedule = {
+      id,
+      expression,
+      agentId: agentIdVal,
+      input,
+      mode,
+      taskOptions: options,
+      timezone: options?.timezone,
+      paused: false,
+    };
+    cronMeta.set(id, meta);
+
+    try {
+      if (scheduleStore !== undefined) {
+        await scheduleStore.saveSchedule(meta);
+      }
+    } catch (err: unknown) {
+      // Roll back in-memory state on persistence failure
+      cronJob.stop();
+      crons.delete(id);
+      cronMeta.delete(id);
+      throw new Error("Failed to persist schedule", { cause: err });
+    }
+
+    emit({ kind: "schedule:created", schedule: meta });
+    return id;
+  }
+
+  async function unschedule(id: ScheduleId): Promise<boolean> {
+    const job = crons.get(id);
+    if (job === undefined) return false;
+
+    job.stop();
+    crons.delete(id);
+    cronMeta.delete(id);
+
+    try {
+      if (scheduleStore !== undefined) {
+        await scheduleStore.removeSchedule(id);
+      }
+    } catch {
+      // Schedule already stopped in memory — log but don't fail.
+      // On restart, orphaned DB record will be re-loaded and can be removed.
+    }
+
+    emit({ kind: "schedule:removed", scheduleId: id });
+    return true;
+  }
+
+  async function query(filter: TaskFilter): Promise<readonly ScheduledTask[]> {
+    await initPromise;
+    return store.query(filter);
+  }
+
+  function stats(): SchedulerStats {
+    return {
+      pending: heap.size(),
+      running: config.maxConcurrent - semaphore.available(),
+      completed: completedCount,
+      failed: failedCount,
+      deadLettered: deadLetteredCount,
+      activeSchedules: crons.size,
+    };
+  }
+
+  // P9 fix: idempotent unsubscribe, no Set copy on hot path
+  function watch(listener: (event: SchedulerEvent) => void): () => void {
+    listeners.add(listener);
+    let removed = false; // let: set to true on first unsubscribe
+    return () => {
+      if (removed) return;
+      removed = true;
+      listeners.delete(listener);
+    };
+  }
+
+  async function dispose(): Promise<void> {
+    disposed = true;
+
+    // Stop poll timer
+    pollTimer.stop();
+
+    // Stop all cron jobs
+    for (const job of crons.values()) {
+      job.stop();
+    }
+    crons.clear();
+    cronMeta.clear();
+
+    listeners.clear();
+  }
+
+  return {
+    submit,
+    cancel,
+    schedule,
+    unschedule,
+    query,
+    stats,
+    watch,
+    [Symbol.asyncDispose]: dispose,
+  };
+}

--- a/packages/scheduler/src/semaphore.ts
+++ b/packages/scheduler/src/semaphore.ts
@@ -1,0 +1,33 @@
+/**
+ * Simple counter-based bounded concurrency semaphore.
+ */
+
+export interface Semaphore {
+  readonly acquire: () => boolean;
+  readonly release: () => void;
+  readonly available: () => number;
+}
+
+export function createSemaphore(maxConcurrent: number): Semaphore {
+  if (maxConcurrent < 1) {
+    throw new Error("maxConcurrent must be at least 1");
+  }
+
+  let inUse = 0; // let: incremented on acquire, decremented on release
+
+  return {
+    acquire: () => {
+      if (inUse >= maxConcurrent) return false;
+      inUse += 1;
+      return true;
+    },
+
+    release: () => {
+      if (inUse > 0) {
+        inUse -= 1;
+      }
+    },
+
+    available: () => maxConcurrent - inUse,
+  };
+}

--- a/packages/scheduler/src/sqlite-store.ts
+++ b/packages/scheduler/src/sqlite-store.ts
@@ -1,0 +1,388 @@
+/**
+ * SQLite-backed TaskStore implementation.
+ *
+ * Uses Bun's built-in bun:sqlite for zero-dependency persistence.
+ * Schema auto-created on first use (idempotent).
+ */
+
+import type { Database } from "bun:sqlite";
+import type {
+  CronSchedule,
+  EngineInput,
+  KoiError,
+  ScheduledTask,
+  ScheduleId,
+  ScheduleStore,
+  TaskFilter,
+  TaskId,
+  TaskOptions,
+  TaskStatus,
+  TaskStore,
+} from "@koi/core";
+import { agentId, scheduleId, taskId } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const CREATE_TASKS_TABLE = `
+CREATE TABLE IF NOT EXISTS koi_tasks (
+  id          TEXT PRIMARY KEY,
+  agent_id    TEXT NOT NULL,
+  input       TEXT NOT NULL,
+  mode        TEXT NOT NULL CHECK (mode IN ('spawn', 'dispatch')),
+  priority    INTEGER NOT NULL DEFAULT 5,
+  status      TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'completed', 'failed', 'dead_letter')),
+  created_at  INTEGER NOT NULL,
+  scheduled_at INTEGER,
+  started_at  INTEGER,
+  completed_at INTEGER,
+  retries     INTEGER NOT NULL DEFAULT 0,
+  max_retries INTEGER NOT NULL DEFAULT 3,
+  timeout_ms  INTEGER,
+  last_error  TEXT,
+  metadata    TEXT
+);
+`;
+
+const CREATE_SCHEDULES_TABLE = `
+CREATE TABLE IF NOT EXISTS koi_schedules (
+  id          TEXT PRIMARY KEY,
+  expression  TEXT NOT NULL,
+  agent_id    TEXT NOT NULL,
+  input       TEXT NOT NULL,
+  mode        TEXT NOT NULL CHECK (mode IN ('spawn', 'dispatch')),
+  task_options TEXT,
+  timezone    TEXT,
+  paused      INTEGER NOT NULL DEFAULT 0
+);
+`;
+
+const CREATE_INDEX = `
+CREATE INDEX IF NOT EXISTS idx_koi_tasks_status_priority ON koi_tasks (status, priority, created_at);
+`;
+
+// Migration for existing DBs that lack timeout_ms column
+const MIGRATE_TIMEOUT_MS = `
+ALTER TABLE koi_tasks ADD COLUMN timeout_ms INTEGER;
+`;
+
+// ---------------------------------------------------------------------------
+// Row ↔ ScheduledTask mapping
+// ---------------------------------------------------------------------------
+
+interface TaskRow {
+  readonly id: string;
+  readonly agent_id: string;
+  readonly input: string;
+  readonly mode: string;
+  readonly priority: number;
+  readonly status: string;
+  readonly created_at: number;
+  readonly scheduled_at: number | null;
+  readonly started_at: number | null;
+  readonly completed_at: number | null;
+  readonly retries: number;
+  readonly max_retries: number;
+  readonly timeout_ms: number | null;
+  readonly last_error: string | null;
+  readonly metadata: string | null;
+}
+
+interface ScheduleRow {
+  readonly id: string;
+  readonly expression: string;
+  readonly agent_id: string;
+  readonly input: string;
+  readonly mode: string;
+  readonly task_options: string | null;
+  readonly timezone: string | null;
+  readonly paused: number;
+}
+
+function rowToTask(row: TaskRow): ScheduledTask {
+  return {
+    id: taskId(row.id),
+    agentId: agentId(row.agent_id),
+    input: JSON.parse(row.input) as EngineInput,
+    mode: row.mode as "spawn" | "dispatch",
+    priority: row.priority,
+    status: row.status as TaskStatus,
+    createdAt: row.created_at,
+    scheduledAt: row.scheduled_at ?? undefined,
+    startedAt: row.started_at ?? undefined,
+    completedAt: row.completed_at ?? undefined,
+    retries: row.retries,
+    maxRetries: row.max_retries,
+    timeoutMs: row.timeout_ms ?? undefined,
+    lastError: row.last_error !== null ? (JSON.parse(row.last_error) as KoiError) : undefined,
+    metadata:
+      row.metadata !== null
+        ? (JSON.parse(row.metadata) as Readonly<Record<string, unknown>>)
+        : undefined,
+  };
+}
+
+function rowToSchedule(row: ScheduleRow): CronSchedule {
+  return {
+    id: scheduleId(row.id),
+    expression: row.expression,
+    agentId: agentId(row.agent_id),
+    input: JSON.parse(row.input) as EngineInput,
+    mode: row.mode as "spawn" | "dispatch",
+    taskOptions:
+      row.task_options !== null ? (JSON.parse(row.task_options) as TaskOptions) : undefined,
+    timezone: row.timezone ?? undefined,
+    paused: row.paused !== 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public type — extends TaskStore with purge capability
+// ---------------------------------------------------------------------------
+
+/** SqliteTaskStore narrows TaskStore to sync returns and adds purge() + ScheduleStore. */
+export type SqliteTaskStore = TaskStore &
+  ScheduleStore & {
+    /** Delete completed/dead_letter tasks older than the given timestamp. */
+    readonly purge: (olderThanMs: number) => void;
+  };
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createSqliteTaskStore(db: Database): SqliteTaskStore {
+  // Auto-create schema
+  db.run(CREATE_TASKS_TABLE);
+  db.run(CREATE_INDEX);
+  db.run(CREATE_SCHEDULES_TABLE);
+
+  // Migrate existing DBs: add timeout_ms column if missing
+  try {
+    db.run(MIGRATE_TIMEOUT_MS);
+  } catch {
+    // Column already exists — ignore
+  }
+
+  // Prepared statements
+  const insertStmt = db.prepare<
+    void,
+    {
+      $id: string;
+      $agent_id: string;
+      $input: string;
+      $mode: string;
+      $priority: number;
+      $status: string;
+      $created_at: number;
+      $scheduled_at: number | null;
+      $started_at: number | null;
+      $completed_at: number | null;
+      $retries: number;
+      $max_retries: number;
+      $timeout_ms: number | null;
+      $last_error: string | null;
+      $metadata: string | null;
+    }
+  >(
+    `INSERT OR REPLACE INTO koi_tasks
+      (id, agent_id, input, mode, priority, status, created_at, scheduled_at, started_at, completed_at, retries, max_retries, timeout_ms, last_error, metadata)
+     VALUES ($id, $agent_id, $input, $mode, $priority, $status, $created_at, $scheduled_at, $started_at, $completed_at, $retries, $max_retries, $timeout_ms, $last_error, $metadata)`,
+  );
+
+  const loadStmt = db.prepare<TaskRow, { $id: string }>("SELECT * FROM koi_tasks WHERE id = $id");
+
+  const removeStmt = db.prepare<void, { $id: string }>("DELETE FROM koi_tasks WHERE id = $id");
+
+  const loadPendingStmt = db.prepare<TaskRow, []>(
+    "SELECT * FROM koi_tasks WHERE status = 'pending' ORDER BY priority ASC, created_at ASC",
+  );
+
+  // P3 fix: single prepared statement with COALESCE for updateStatus hot path
+  const updateStatusStmt = db.prepare<
+    void,
+    {
+      $id: string;
+      $status: string;
+      $started_at: number | null;
+      $completed_at: number | null;
+      $last_error: string | null;
+      $retries: number | null;
+    }
+  >(
+    `UPDATE koi_tasks SET
+      status = $status,
+      started_at = COALESCE($started_at, started_at),
+      completed_at = COALESCE($completed_at, completed_at),
+      last_error = COALESCE($last_error, last_error),
+      retries = COALESCE($retries, retries)
+    WHERE id = $id`,
+  );
+
+  // P5 fix: prepared statement for TTL purge of terminal tasks
+  const purgeStmt = db.prepare<void, { $before: number }>(
+    "DELETE FROM koi_tasks WHERE status IN ('completed', 'dead_letter') AND completed_at < $before",
+  );
+
+  // Schedule statements
+  const insertScheduleStmt = db.prepare<
+    void,
+    {
+      $id: string;
+      $expression: string;
+      $agent_id: string;
+      $input: string;
+      $mode: string;
+      $task_options: string | null;
+      $timezone: string | null;
+      $paused: number;
+    }
+  >(
+    `INSERT OR REPLACE INTO koi_schedules
+      (id, expression, agent_id, input, mode, task_options, timezone, paused)
+     VALUES ($id, $expression, $agent_id, $input, $mode, $task_options, $timezone, $paused)`,
+  );
+
+  const removeScheduleStmt = db.prepare<void, { $id: string }>(
+    "DELETE FROM koi_schedules WHERE id = $id",
+  );
+
+  const loadSchedulesStmt = db.prepare<ScheduleRow, []>("SELECT * FROM koi_schedules");
+
+  function save(task: ScheduledTask): void {
+    insertStmt.run({
+      $id: task.id,
+      $agent_id: task.agentId,
+      $input: JSON.stringify(task.input),
+      $mode: task.mode,
+      $priority: task.priority,
+      $status: task.status,
+      $created_at: task.createdAt,
+      $scheduled_at: task.scheduledAt ?? null,
+      $started_at: task.startedAt ?? null,
+      $completed_at: task.completedAt ?? null,
+      $retries: task.retries,
+      $max_retries: task.maxRetries,
+      $timeout_ms: task.timeoutMs ?? null,
+      $last_error: task.lastError !== undefined ? JSON.stringify(task.lastError) : null,
+      $metadata: task.metadata !== undefined ? JSON.stringify(task.metadata) : null,
+    });
+  }
+
+  function load(id: TaskId): ScheduledTask | undefined {
+    const row = loadStmt.get({ $id: id });
+    return row !== null ? rowToTask(row) : undefined;
+  }
+
+  function remove(id: TaskId): void {
+    removeStmt.run({ $id: id });
+  }
+
+  // P3 fix: use prepared statement instead of dynamic SQL construction
+  function updateStatus(
+    id: TaskId,
+    status: TaskStatus,
+    patch?: Partial<Pick<ScheduledTask, "startedAt" | "completedAt" | "lastError" | "retries">>,
+  ): void {
+    updateStatusStmt.run({
+      $id: id,
+      $status: status,
+      $started_at: patch?.startedAt ?? null,
+      $completed_at: patch?.completedAt ?? null,
+      $last_error: patch?.lastError !== undefined ? JSON.stringify(patch.lastError) : null,
+      $retries: patch?.retries ?? null,
+    });
+  }
+
+  // P7 fix: finalize dynamically-prepared statements after use
+  function query(filter: TaskFilter): readonly ScheduledTask[] {
+    const conditions: string[] = [];
+    const values: (string | number)[] = [];
+
+    if (filter.status !== undefined) {
+      conditions.push("status = ?");
+      values.push(filter.status);
+    }
+    if (filter.agentId !== undefined) {
+      conditions.push("agent_id = ?");
+      values.push(filter.agentId);
+    }
+    if (filter.priority !== undefined) {
+      conditions.push("priority = ?");
+      values.push(filter.priority);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limitClause = filter.limit !== undefined ? `LIMIT ${String(filter.limit)}` : "";
+    const sql = `SELECT * FROM koi_tasks ${where} ORDER BY priority ASC, created_at ASC ${limitClause}`;
+
+    const stmt = db.prepare<TaskRow, (string | number)[]>(sql);
+    try {
+      return stmt.all(...values).map(rowToTask);
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  function loadPending(): readonly ScheduledTask[] {
+    return loadPendingStmt.all().map(rowToTask);
+  }
+
+  // P5 fix: purge terminal tasks older than the given duration
+  function purge(olderThanMs: number): void {
+    purgeStmt.run({ $before: Date.now() - olderThanMs });
+  }
+
+  // ---------------------------------------------------------------------------
+  // ScheduleStore implementation
+  // ---------------------------------------------------------------------------
+
+  function saveSchedule(schedule: CronSchedule): void {
+    insertScheduleStmt.run({
+      $id: schedule.id,
+      $expression: schedule.expression,
+      $agent_id: schedule.agentId,
+      $input: JSON.stringify(schedule.input),
+      $mode: schedule.mode,
+      $task_options:
+        schedule.taskOptions !== undefined ? JSON.stringify(schedule.taskOptions) : null,
+      $timezone: schedule.timezone ?? null,
+      $paused: schedule.paused ? 1 : 0,
+    });
+  }
+
+  function removeSchedule(id: ScheduleId): void {
+    removeScheduleStmt.run({ $id: id });
+  }
+
+  function loadSchedules(): readonly CronSchedule[] {
+    return loadSchedulesStmt.all().map(rowToSchedule);
+  }
+
+  async function dispose(): Promise<void> {
+    insertStmt.finalize();
+    loadStmt.finalize();
+    removeStmt.finalize();
+    loadPendingStmt.finalize();
+    updateStatusStmt.finalize();
+    purgeStmt.finalize();
+    insertScheduleStmt.finalize();
+    removeScheduleStmt.finalize();
+    loadSchedulesStmt.finalize();
+  }
+
+  return {
+    save,
+    load,
+    remove,
+    updateStatus,
+    query,
+    loadPending,
+    purge,
+    saveSchedule,
+    removeSchedule,
+    loadSchedules,
+    [Symbol.asyncDispose]: dispose,
+  };
+}

--- a/packages/scheduler/src/timer.ts
+++ b/packages/scheduler/src/timer.ts
@@ -1,0 +1,37 @@
+/**
+ * Periodic timer utility with disposal support.
+ */
+
+import type { Clock } from "./clock.js";
+
+export interface PeriodicTimer extends AsyncDisposable {
+  readonly stop: () => void;
+}
+
+export function createPeriodicTimer(
+  clock: Clock,
+  intervalMs: number,
+  callback: () => void,
+): PeriodicTimer {
+  if (intervalMs < 1) {
+    throw new Error("Interval must be at least 1ms");
+  }
+
+  let stopped = false; // let: set to true on stop()
+  const id = clock.setInterval(() => {
+    if (!stopped) {
+      callback();
+    }
+  }, intervalMs);
+
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    clock.clearInterval(id);
+  }
+
+  return {
+    stop,
+    [Symbol.asyncDispose]: async () => stop(),
+  };
+}

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/scheduler/tsup.config.ts
+++ b/packages/scheduler/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "packages/search" },
     { "path": "packages/forge" },
     { "path": "packages/artifact-client" },
-    { "path": "packages/mcp" }
+    { "path": "packages/mcp" },
+    { "path": "packages/scheduler" }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the full `@koi/scheduler` L2 package: priority queue, cron scheduling, retry with exponential backoff, dead-letter queue, bounded concurrency, and SQLite persistence.

Includes 3 gap fixes identified via competitive analysis against OpenClaw and NanoClaw:

1. **`timeoutMs` enforcement** — `dispatchTask()` races the dispatcher against a clock-based timeout with settled-flag race protection. Timeout produces a retryable `TIMEOUT` KoiError.
2. **Stale task recovery** — `initialize()` detects orphaned `status='running'` tasks older than `staleTaskThresholdMs` (default 5 min) and re-queues them for retry or dead-letters if retries exhausted.
3. **Cron schedule persistence** — New opt-in `ScheduleStore` interface (L0) with SQLite implementation. `schedule()`/`unschedule()` persist with failure rollback. `initialize()` restores cron jobs on restart.

Closes #115

### L0 changes (`@koi/core`)
- `timeoutMs?: number` on `ScheduledTask`
- `staleTaskThresholdMs: number` on `SchedulerConfig` (default: 300_000)
- `task:recovered` event on `SchedulerEvent` union
- New `ScheduleStore` interface (separate from `TaskStore`)

### L2 changes (`@koi/scheduler`)
- `executeWithTimeout()` helper using `clk.setTimeout` + settled-flag guard
- Stale task recovery loop in `initialize()` with heap dedup
- `timeout_ms INTEGER` column + `ALTER TABLE` migration
- `koi_schedules` table + prepared statements
- `unschedule()` now async (returns `Promise<boolean>`)
- `timeoutMs > 0` validation in both `submit()` and `schedule()`
- Try/catch rollback on `scheduleStore` failures

## Test plan

- [x] 85 tests pass (70 existing + 15 new), 0 failures
- [x] 98.25% line coverage, 96.82% function coverage
- [x] Typecheck clean (`bun run --filter=@koi/scheduler typecheck`)
- [x] Lint clean (`bun run --filter=@koi/scheduler lint`)
- [x] SQLite round-trip for `timeoutMs` field
- [x] Timeout fires with fake clock → `task:failed` with TIMEOUT code
- [x] Timeout + dead letter when `maxRetries` exhausted
- [x] Stale task recovered → `task:recovered` event
- [x] Stale task dead-lettered when retries exhausted
- [x] Non-stale running task skipped
- [x] Schedule persists across scheduler restart
- [x] Unschedule removes from store
- [x] No `scheduleStore` → ephemeral behavior (backward compatible)
- [x] `timeoutMs <= 0` rejected in both `submit()` and `schedule()`
- [x] Zero L0 function bodies (except branded casts + frozen constants)
- [x] L2 imports only from `@koi/core`