### PR TITLE
feat: engine-claude stream event mapper + SDK query controls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,17 @@
         "@koi/hash": "workspace:*",
       },
     },
+    "packages/engine-claude": {
+      "name": "@koi/engine-claude",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.37",
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/engine-loop": {
       "name": "@koi/engine-loop",
       "version": "0.0.0",
@@ -297,6 +308,8 @@
     "esbuild",
   ],
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.50", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-zVQzJbicfTmvS6uarFQYYVYiYedKE0FgXmhiGC1oSLm6OkIbuuKM7XV4fXEFxPZHcWQc7ZYv6HA2/P5HOE7b2Q=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
@@ -451,6 +464,38 @@
 
     "@google/genai": ["@google/genai@1.42.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw=="],
 
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -476,6 +521,8 @@
     "@koi/delegation": ["@koi/delegation@workspace:packages/delegation"],
 
     "@koi/engine": ["@koi/engine@workspace:packages/engine"],
+
+    "@koi/engine-claude": ["@koi/engine-claude@workspace:packages/engine-claude"],
 
     "@koi/engine-loop": ["@koi/engine-loop@workspace:packages/engine-loop"],
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -64,8 +64,9 @@ export type EngineEvent =
       readonly kind: "tool_call_start";
       readonly toolName: string;
       readonly callId: string;
-      readonly args: JsonObject;
+      readonly args?: JsonObject;
     }
+  | { readonly kind: "tool_call_delta"; readonly callId: string; readonly delta: string }
   | {
       readonly kind: "tool_call_end";
       readonly callId: string;

--- a/packages/engine-claude/__tests__/contract.test.ts
+++ b/packages/engine-claude/__tests__/contract.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Engine contract compliance tests for @koi/engine-claude.
+ *
+ * Verifies the Claude adapter satisfies all L0 contract invariants
+ * using a mocked SDK.
+ */
+
+import { describe } from "bun:test";
+import { testEngineAdapter } from "@koi/test-utils";
+import type { SdkFunctions } from "../src/adapter.js";
+import { createClaudeAdapter } from "../src/adapter.js";
+import type { SdkMessage } from "../src/event-map.js";
+
+function createContractSdk(): SdkFunctions {
+  return {
+    query: async function* (_params: { prompt: string }): AsyncGenerator<SdkMessage> {
+      yield { type: "system", subtype: "init", session_id: "contract-sess" };
+      // Assistant with tool call
+      yield {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Let me search." },
+            { type: "tool_use", id: "call-1", name: "search", input: { q: "test" } },
+          ],
+        },
+      };
+      // User message with tool result (triggers tool_call_end + turn_end)
+      yield {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "call-1", content: "Search results..." }],
+        },
+      };
+      // Final assistant response
+      yield {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Here are the results." }],
+        },
+      };
+      yield {
+        type: "result",
+        subtype: "success",
+        result: "Here are the results.",
+        session_id: "contract-sess",
+        num_turns: 1,
+        duration_ms: 100,
+        usage: { input_tokens: 10, output_tokens: 20 },
+      };
+    },
+  };
+}
+
+describe("@koi/engine-claude contract", () => {
+  testEngineAdapter({
+    createAdapter: () => createClaudeAdapter({}, createContractSdk()),
+  });
+});

--- a/packages/engine-claude/__tests__/integration.test.ts
+++ b/packages/engine-claude/__tests__/integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for @koi/engine-claude.
+ *
+ * These tests require a real Claude Agent SDK and API key.
+ * They are gated behind the KOI_CLAUDE_INTEGRATION environment variable.
+ *
+ * Usage:
+ *   KOI_CLAUDE_INTEGRATION=true ANTHROPIC_API_KEY=sk-... bun test packages/engine-claude/__tests__/integration.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput } from "@koi/core";
+
+const INTEGRATION_ENABLED = process.env.KOI_CLAUDE_INTEGRATION === "true";
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+describe.skipIf(!INTEGRATION_ENABLED)("@koi/engine-claude integration", () => {
+  test("real SDK query with simple prompt", async () => {
+    // Dynamic import to avoid failures when SDK is not fully configured
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    const { createClaudeAdapter } = await import("../src/adapter.js");
+
+    const adapter = createClaudeAdapter(
+      {
+        model: "claude-sonnet-4-5-20250929",
+        maxTurns: 1,
+        permissionMode: "bypassPermissions",
+      },
+      { query },
+    );
+
+    const events = await collectEvents(
+      adapter.stream({ kind: "text", text: "Reply with exactly: Hello Koi" }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+    expect(output?.metrics.inputTokens).toBeGreaterThan(0);
+    expect(output?.metrics.outputTokens).toBeGreaterThan(0);
+  }, 60_000);
+
+  test("session resume works", async () => {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    const { createClaudeAdapter } = await import("../src/adapter.js");
+
+    const adapter = createClaudeAdapter(
+      {
+        model: "claude-sonnet-4-5-20250929",
+        maxTurns: 1,
+        permissionMode: "bypassPermissions",
+      },
+      { query },
+    );
+
+    // First query
+    await collectEvents(adapter.stream({ kind: "text", text: "Remember the word: pineapple" }));
+
+    const state = await adapter.saveState?.();
+    expect(state).toBeDefined();
+    if (state === undefined) return;
+
+    // Resume
+    const events2 = await collectEvents(
+      adapter.stream({
+        kind: "resume",
+        state,
+      }),
+    );
+
+    const output = findDoneOutput(events2);
+    expect(output).toBeDefined();
+  }, 120_000);
+
+  test("metrics populated from real API response", async () => {
+    const { query } = await import("@anthropic-ai/claude-agent-sdk");
+    const { createClaudeAdapter } = await import("../src/adapter.js");
+
+    const adapter = createClaudeAdapter(
+      {
+        model: "claude-sonnet-4-5-20250929",
+        maxTurns: 1,
+        permissionMode: "bypassPermissions",
+      },
+      { query },
+    );
+
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Say hello" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.metrics.totalTokens).toBeGreaterThan(0);
+    expect(output?.metrics.durationMs).toBeGreaterThan(0);
+    expect(output?.metrics.turns).toBeGreaterThanOrEqual(1);
+  }, 60_000);
+});

--- a/packages/engine-claude/package.json
+++ b/packages/engine-claude/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/engine-claude",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.37"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/engine-claude/src/adapter.test.ts
+++ b/packages/engine-claude/src/adapter.test.ts
@@ -1,0 +1,817 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput } from "@koi/core";
+import type { SdkFunctions, SdkQuery } from "./adapter.js";
+import { createClaudeAdapter } from "./adapter.js";
+import type { SdkMessage } from "./event-map.js";
+import type { ClaudeAdapterConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+/**
+ * Create a mock SDK that yields the given messages.
+ */
+function createMockSdk(messages: readonly SdkMessage[]): SdkFunctions {
+  return {
+    query: async function* (_params: { prompt: string }) {
+      for (const msg of messages) {
+        yield msg;
+      }
+    },
+  };
+}
+
+/**
+ * Create an SDK init system message.
+ */
+function initMessage(sessionId: string): SdkMessage {
+  return { type: "system", subtype: "init", session_id: sessionId };
+}
+
+/**
+ * Create an SDK result message.
+ */
+function resultMessage(
+  subtype: string,
+  overrides?: Partial<{
+    result: string;
+    session_id: string;
+    num_turns: number;
+    duration_ms: number;
+    usage: { input_tokens: number; output_tokens: number };
+  }>,
+): SdkMessage {
+  return {
+    type: "result",
+    subtype,
+    result: overrides?.result ?? "Done",
+    session_id: overrides?.session_id ?? "sess-1",
+    num_turns: overrides?.num_turns ?? 1,
+    duration_ms: overrides?.duration_ms ?? 100,
+    usage: overrides?.usage ?? { input_tokens: 10, output_tokens: 5 },
+  };
+}
+
+/**
+ * Create an SDK assistant message.
+ */
+function assistantMessage(
+  content: readonly {
+    type: string;
+    text?: string;
+    id?: string;
+    name?: string;
+    input?: Record<string, unknown>;
+  }[],
+): SdkMessage {
+  return {
+    type: "assistant",
+    message: { content },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core adapter behavior
+// ---------------------------------------------------------------------------
+
+describe("createClaudeAdapter", () => {
+  test("returns adapter with correct engineId", () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    expect(adapter.engineId).toBe("claude");
+  });
+
+  test("has no terminals (non-cooperating adapter)", () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    expect(adapter.terminals).toBeUndefined();
+  });
+});
+
+describe("stream", () => {
+  test("yields events from SDK messages", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      assistantMessage([{ type: "text", text: "Hello!" }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hi" }));
+
+    const textDeltas = events.filter((e) => e.kind === "text_delta");
+    expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+  });
+
+  test("emits done event on SDK result", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      resultMessage("success", {
+        result: "Task complete",
+        num_turns: 3,
+        duration_ms: 5000,
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Do something" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+    expect(output?.metrics.inputTokens).toBe(100);
+    expect(output?.metrics.outputTokens).toBe(50);
+    expect(output?.metrics.turns).toBe(3);
+  });
+
+  test("captures session ID from init message", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-abc-123"),
+      resultMessage("success", { session_id: "sess-abc-123" }),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    await collectEvents(adapter.stream({ kind: "text", text: "Hello" }));
+
+    const state = await adapter.saveState?.();
+    expect(state).toBeDefined();
+    const data = state?.data as { sessionId: string };
+    expect(data.sessionId).toBe("sess-abc-123");
+  });
+
+  test("handles messages input kind", async () => {
+    const sdk = createMockSdk([initMessage("sess-1"), resultMessage("success")]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(
+      adapter.stream({
+        kind: "messages",
+        messages: [
+          {
+            content: [{ kind: "text", text: "Hello" }],
+            senderId: "user",
+            timestamp: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+  });
+
+  test("emits synthetic done when SDK yields no events", async () => {
+    const sdk = createMockSdk([]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hello" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("error");
+  });
+
+  test("emits error done when SDK throws", async () => {
+    const sdk: SdkFunctions = {
+      // biome-ignore lint/correctness/useYield: intentionally throws before yielding
+      query: async function* () {
+        throw new Error("SDK connection failed");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hello" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("error");
+    expect(output?.metadata?.error).toBe("SDK connection failed");
+  });
+
+  test("maps error_max_budget_usd to interrupted stop reason", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      resultMessage("error_max_budget_usd", {
+        usage: { input_tokens: 50000, output_tokens: 20000 },
+      }),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Expensive task" }));
+
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("interrupted");
+  });
+
+  test("maps error_max_turns to max_turns stop reason", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      resultMessage("error_max_turns", { num_turns: 25 }),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Long task" }));
+
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("max_turns");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Turn tracking
+// ---------------------------------------------------------------------------
+
+describe("turn tracking", () => {
+  test("emits turn_end between assistant→user→assistant sequences", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      // Turn 0: assistant with tool call
+      assistantMessage([
+        { type: "text", text: "Let me search." },
+        { type: "tool_use", id: "call-1", name: "search", input: { q: "test" } },
+      ]),
+      // User message with tool result → triggers turn_end
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "call-1", content: "Found results" }],
+        },
+      } as SdkMessage,
+      // Turn 1: final assistant response
+      assistantMessage([{ type: "text", text: "Here are the results." }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Search" }));
+
+    const turnEnds = events.filter(
+      (e): e is EngineEvent & { readonly kind: "turn_end" } => e.kind === "turn_end",
+    );
+    expect(turnEnds).toHaveLength(1);
+    expect(turnEnds[0]?.turnIndex).toBe(0);
+  });
+
+  test("increments turnIndex across multiple turns", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      // Turn 0
+      assistantMessage([{ type: "tool_use", id: "call-1", name: "search", input: { q: "a" } }]),
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "call-1", content: "result A" }],
+        },
+      } as SdkMessage,
+      // Turn 1
+      assistantMessage([{ type: "tool_use", id: "call-2", name: "read", input: { path: "x" } }]),
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "call-2", content: "result B" }],
+        },
+      } as SdkMessage,
+      // Final response
+      assistantMessage([{ type: "text", text: "Done." }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Multi-turn" }));
+
+    const turnEnds = events.filter(
+      (e): e is EngineEvent & { readonly kind: "turn_end" } => e.kind === "turn_end",
+    );
+    expect(turnEnds).toHaveLength(2);
+    expect(turnEnds[0]?.turnIndex).toBe(0);
+    expect(turnEnds[1]?.turnIndex).toBe(1);
+  });
+
+  test("does not emit turn_end for text-only conversations", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      assistantMessage([{ type: "text", text: "Hello!" }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hi" }));
+
+    const turnEnds = events.filter((e) => e.kind === "turn_end");
+    expect(turnEnds).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent run guard
+// ---------------------------------------------------------------------------
+
+describe("concurrent run guard", () => {
+  test("throws when a second stream is started while first is running", async () => {
+    let resolveQuery: (() => void) | undefined;
+
+    const sdk: SdkFunctions = {
+      query: async function* () {
+        await new Promise<void>((r) => {
+          resolveQuery = r;
+        });
+        yield resultMessage("success");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    // Start the first run
+    const firstRun = adapter.stream({ kind: "text", text: "first" });
+    const iterator = firstRun[Symbol.asyncIterator]();
+    const firstNext = iterator.next();
+
+    // Attempt a second run
+    await expect(collectEvents(adapter.stream({ kind: "text", text: "second" }))).rejects.toThrow(
+      "concurrent",
+    );
+
+    // Cleanup
+    resolveQuery?.();
+    await firstNext;
+    let done = false;
+    while (!done) {
+      const result = await iterator.next();
+      done = result.done ?? false;
+    }
+  });
+
+  test("allows sequential runs after first completes", async () => {
+    const sdk = createMockSdk([initMessage("sess-1"), resultMessage("success")]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    const events1 = await collectEvents(adapter.stream({ kind: "text", text: "first" }));
+    expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+
+    const events2 = await collectEvents(adapter.stream({ kind: "text", text: "second" }));
+    expect(findDoneOutput(events2)?.stopReason).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State management
+// ---------------------------------------------------------------------------
+
+describe("saveState and loadState", () => {
+  test("saveState returns state with correct engineId", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    const state = await adapter.saveState?.();
+    expect(state?.engineId).toBe("claude");
+  });
+
+  test("saveState returns session ID in EngineState", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-saved"),
+      resultMessage("success", { session_id: "sess-saved" }),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    await collectEvents(adapter.stream({ kind: "text", text: "Hello" }));
+
+    const state = await adapter.saveState?.();
+    const data = state?.data as { sessionId: string };
+    expect(data.sessionId).toBe("sess-saved");
+  });
+
+  test("loadState stores session ID for resume", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    await adapter.loadState?.({
+      engineId: "claude",
+      data: { sessionId: "sess-loaded" },
+    });
+
+    const state = await adapter.saveState?.();
+    const data = state?.data as { sessionId: string };
+    expect(data.sessionId).toBe("sess-loaded");
+  });
+
+  test("loadState rejects state from different engine", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    await expect(adapter.loadState?.({ engineId: "other-engine", data: {} })).rejects.toThrow(
+      "Cannot load state",
+    );
+  });
+
+  test("stream with resume kind uses stored session ID", async () => {
+    let capturedOptions: Record<string, unknown> | undefined;
+
+    const sdk: SdkFunctions = {
+      query: async function* (params: { prompt: string; options?: Record<string, unknown> }) {
+        capturedOptions = params.options;
+        yield resultMessage("success");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+    await adapter.loadState?.({
+      engineId: "claude",
+      data: { sessionId: "sess-resume" },
+    });
+
+    await collectEvents(
+      adapter.stream({
+        kind: "resume",
+        state: { engineId: "claude", data: { sessionId: "sess-resume" } },
+      }),
+    );
+
+    expect(capturedOptions?.resume).toBe("sess-resume");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispose
+// ---------------------------------------------------------------------------
+
+describe("dispose", () => {
+  test("dispose can be called without error", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    await adapter.dispose?.();
+  });
+
+  test("dispose is idempotent", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    await adapter.dispose?.();
+    await adapter.dispose?.();
+    await adapter.dispose?.();
+  });
+
+  test("stream after dispose emits interrupted stop reason", async () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    await adapter.dispose?.();
+
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "After dispose" }));
+
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("interrupted");
+  });
+
+  test("dispose aborts active query", async () => {
+    let aborted = false;
+
+    const sdk: SdkFunctions = {
+      query: async function* (params: { prompt: string; options?: Record<string, unknown> }) {
+        const controller = params.options?.abortController as AbortController | undefined;
+        controller?.signal.addEventListener("abort", () => {
+          aborted = true;
+        });
+        // Simulate a long-running query
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        yield resultMessage("success");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    // Start streaming in the background
+    const streamPromise = collectEvents(adapter.stream({ kind: "text", text: "Long task" }));
+
+    // Dispose while streaming
+    await new Promise<void>((r) => setTimeout(r, 10));
+    await adapter.dispose?.();
+
+    // Wait for stream to complete
+    await streamPromise;
+
+    expect(aborted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config integration
+// ---------------------------------------------------------------------------
+
+describe("config integration", () => {
+  test("sdkOverrides take precedence over derived config", async () => {
+    let capturedOptions: Record<string, unknown> | undefined;
+
+    const sdk: SdkFunctions = {
+      query: async function* (params: { prompt: string; options?: Record<string, unknown> }) {
+        capturedOptions = params.options;
+        yield resultMessage("success");
+      },
+    };
+
+    const config: ClaudeAdapterConfig = {
+      model: "claude-sonnet-4-5-20250929",
+      sdkOverrides: { model: "claude-opus-4-6" },
+    };
+
+    const adapter = createClaudeAdapter(config, sdk);
+    await collectEvents(adapter.stream({ kind: "text", text: "Test" }));
+
+    expect(capturedOptions?.model).toBe("claude-opus-4-6");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controls lifecycle
+// ---------------------------------------------------------------------------
+
+describe("controls", () => {
+  test("controls is undefined when not streaming", () => {
+    const sdk = createMockSdk([]);
+    const adapter = createClaudeAdapter({}, sdk);
+
+    expect(adapter.controls).toBeUndefined();
+  });
+
+  test("controls is available during streaming", async () => {
+    let resolveQuery: (() => void) | undefined;
+
+    const sdk: SdkFunctions = {
+      query: async function* () {
+        await new Promise<void>((r) => {
+          resolveQuery = r;
+        });
+        yield resultMessage("success");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    // Start streaming in background
+    const stream = adapter.stream({ kind: "text", text: "Hi" });
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    // Give the async generator a tick to start
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    // Capture controls while stream is active
+    const controlsDuringStream = adapter.controls;
+
+    // Cleanup
+    resolveQuery?.();
+    await nextPromise;
+    let done = false;
+    while (!done) {
+      const result = await iterator.next();
+      done = result.done ?? false;
+    }
+
+    expect(controlsDuringStream).toBeDefined();
+  });
+
+  test("controls is undefined after streaming completes", async () => {
+    const sdk = createMockSdk([initMessage("sess-1"), resultMessage("success")]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    await collectEvents(adapter.stream({ kind: "text", text: "Hi" }));
+
+    expect(adapter.controls).toBeUndefined();
+  });
+
+  test("interrupt delegates to query's interrupt method", async () => {
+    let interruptCalled = false;
+    let resolveQuery: (() => void) | undefined;
+
+    const sdk: SdkFunctions = {
+      query: (_params: { prompt: string }): SdkQuery => {
+        const iterable: SdkQuery = {
+          async *[Symbol.asyncIterator]() {
+            await new Promise<void>((r) => {
+              resolveQuery = r;
+            });
+            yield resultMessage("success");
+          },
+          interrupt: async () => {
+            interruptCalled = true;
+          },
+        };
+        return iterable;
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    // Start streaming
+    const stream = adapter.stream({ kind: "text", text: "Hi" });
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    // Call interrupt via controls
+    await adapter.controls?.interrupt();
+
+    // Cleanup
+    resolveQuery?.();
+    await nextPromise;
+    let done = false;
+    while (!done) {
+      const result = await iterator.next();
+      done = result.done ?? false;
+    }
+
+    expect(interruptCalled).toBe(true);
+  });
+
+  test("setModel delegates to query's setModel method", async () => {
+    let capturedModel: string | undefined;
+    let resolveQuery: (() => void) | undefined;
+
+    const sdk: SdkFunctions = {
+      query: (_params: { prompt: string }): SdkQuery => {
+        const iterable: SdkQuery = {
+          async *[Symbol.asyncIterator]() {
+            await new Promise<void>((r) => {
+              resolveQuery = r;
+            });
+            yield resultMessage("success");
+          },
+          setModel: async (model?: string) => {
+            capturedModel = model;
+          },
+        };
+        return iterable;
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    const stream = adapter.stream({ kind: "text", text: "Hi" });
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    await adapter.controls?.setModel("claude-opus-4-6");
+
+    resolveQuery?.();
+    await nextPromise;
+    let done = false;
+    while (!done) {
+      const result = await iterator.next();
+      done = result.done ?? false;
+    }
+
+    expect(capturedModel).toBe("claude-opus-4-6");
+  });
+
+  test("controls methods are no-ops when query has no control methods", async () => {
+    let resolveQuery: (() => void) | undefined;
+
+    // Mock SDK returns plain AsyncIterable with no control methods
+    const sdk: SdkFunctions = {
+      query: async function* () {
+        await new Promise<void>((r) => {
+          resolveQuery = r;
+        });
+        yield resultMessage("success");
+      },
+    };
+
+    const adapter = createClaudeAdapter({}, sdk);
+
+    const stream = adapter.stream({ kind: "text", text: "Hi" });
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    // Should not throw — gracefully no-ops
+    await adapter.controls?.interrupt();
+    await adapter.controls?.setModel("test");
+    await adapter.controls?.setPermissionMode("default");
+    await adapter.controls?.stopTask("task-1");
+
+    resolveQuery?.();
+    await nextPromise;
+    let done = false;
+    while (!done) {
+      const result = await iterator.next();
+      done = result.done ?? false;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming integration (stream_event messages)
+// ---------------------------------------------------------------------------
+
+describe("streaming integration", () => {
+  test("stream_event messages produce granular events", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      // Streaming events
+      {
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hel" } },
+      },
+      {
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "lo!" } },
+      },
+      // Complete assistant message (should be suppressed)
+      assistantMessage([{ type: "text", text: "Hello!" }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hi" }));
+
+    const textDeltas = events.filter(
+      (e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta",
+    );
+
+    // Should get granular deltas from stream_event, not the complete assistant message
+    expect(textDeltas).toHaveLength(2);
+    expect(textDeltas[0]?.delta).toBe("Hel");
+    expect(textDeltas[1]?.delta).toBe("lo!");
+  });
+
+  test("assistant messages pass through when no stream_event precedes them", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      assistantMessage([{ type: "text", text: "Direct response" }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Hi" }));
+
+    const textDeltas = events.filter((e) => e.kind === "text_delta");
+    expect(textDeltas).toHaveLength(1);
+  });
+
+  test("stream_event tool_call_start events are emitted", async () => {
+    const sdk = createMockSdk([
+      initMessage("sess-1"),
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "call-1", name: "search" },
+        },
+      },
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"q":"test"}' },
+        },
+      },
+      {
+        type: "stream_event",
+        event: { type: "content_block_stop", index: 0 },
+      },
+      // Complete assistant (suppressed)
+      assistantMessage([{ type: "tool_use", id: "call-1", name: "search", input: { q: "test" } }]),
+      resultMessage("success"),
+    ]);
+
+    const adapter = createClaudeAdapter({}, sdk);
+    const events = await collectEvents(adapter.stream({ kind: "text", text: "Search" }));
+
+    const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+    expect(toolStarts).toHaveLength(1);
+
+    const toolDeltas = events.filter((e) => e.kind === "tool_call_delta");
+    expect(toolDeltas).toHaveLength(1);
+  });
+});

--- a/packages/engine-claude/src/adapter.ts
+++ b/packages/engine-claude/src/adapter.ts
@@ -1,0 +1,311 @@
+/**
+ * Claude Agent SDK engine adapter — main factory function.
+ *
+ * Creates an EngineAdapter that delegates to the Claude Agent SDK's query()
+ * function, mapping SDK messages to Koi EngineEvents via streaming passthrough.
+ */
+
+import type { EngineEvent, EngineInput, EngineState } from "@koi/core";
+import type { SdkMessage } from "./event-map.js";
+import { createMessageMapper } from "./event-map.js";
+import type { McpBridgeConfig, SdkOptions } from "./policy-map.js";
+import { buildSdkOptions } from "./policy-map.js";
+import type {
+  ClaudeAdapterConfig,
+  ClaudeEngineAdapter,
+  ClaudeQueryControls,
+  ClaudeSessionState,
+} from "./types.js";
+
+const ENGINE_ID = "claude" as const;
+
+// ---------------------------------------------------------------------------
+// SDK function types — thin wrappers to avoid leaking SDK types
+// ---------------------------------------------------------------------------
+
+/**
+ * SDK query result — extends AsyncIterable with optional control methods
+ * that proxy the real SDK Query object.
+ *
+ * All control methods are optional so callers returning a bare
+ * AsyncIterable still satisfy this interface.
+ */
+export interface SdkQuery extends AsyncIterable<SdkMessage> {
+  readonly interrupt?: () => Promise<void>;
+  readonly setModel?: (model?: string) => Promise<void>;
+  readonly setPermissionMode?: (mode: string) => Promise<void>;
+  readonly stopTask?: (taskId: string) => Promise<void>;
+  readonly close?: () => void;
+}
+
+/**
+ * SDK query function shape. Accepts prompt + options, returns an SdkQuery
+ * (AsyncIterable with optional control methods).
+ */
+export type SdkQueryFn = (params: {
+  readonly prompt: string;
+  readonly options?: SdkOptions;
+}) => SdkQuery;
+
+/**
+ * Optional SDK functions for MCP bridge creation.
+ */
+export interface SdkFunctions {
+  readonly query: SdkQueryFn;
+  readonly createSdkMcpServer?: (config: {
+    readonly name: string;
+    readonly version: string;
+    readonly tools: readonly unknown[];
+  }) => unknown;
+  readonly tool?: (
+    name: string,
+    description: string,
+    schema: unknown,
+    handler: (args: Readonly<Record<string, unknown>>) => Promise<unknown>,
+  ) => unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Input → prompt conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a text prompt from EngineInput.
+ */
+function inputToPrompt(input: EngineInput): string {
+  switch (input.kind) {
+    case "text":
+      return input.text;
+    case "messages": {
+      // Concatenate all text content blocks from the messages
+      const parts: string[] = [];
+      for (const msg of input.messages) {
+        for (const block of msg.content) {
+          if (block.kind === "text") {
+            parts.push(block.text);
+          }
+        }
+      }
+      return parts.join("\n");
+    }
+    case "resume":
+      // Resume input — prompt is empty; session ID drives the continuation
+      return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Claude Agent SDK engine adapter.
+ *
+ * @param config - Adapter configuration (Koi-native)
+ * @param sdk - SDK function bindings (query, createSdkMcpServer, tool)
+ * @param mcpBridge - Optional pre-built MCP bridge for Koi tools
+ * @returns EngineAdapter implementation
+ */
+export function createClaudeAdapter(
+  config: ClaudeAdapterConfig,
+  sdk: SdkFunctions,
+  mcpBridge?: McpBridgeConfig,
+): ClaudeEngineAdapter {
+  // let: toggled by dispose() — lifecycle flag
+  let disposed = false;
+  // let: guards against concurrent runs
+  let running = false;
+  // let: tracks active AbortController for cancellation
+  let activeAbortController: AbortController | undefined;
+  // let: tracks active SDK query for control method delegation
+  let activeQuery: SdkQuery | undefined;
+  // Session state for resume support
+  const sessionState: { sessionId: string | undefined } = { sessionId: undefined };
+
+  async function* runStream(input: EngineInput): AsyncGenerator<EngineEvent, void, undefined> {
+    if (running) {
+      throw new Error(
+        "ClaudeAdapter does not support concurrent runs. Wait for the current run to complete.",
+      );
+    }
+    if (disposed) {
+      yield {
+        kind: "done",
+        output: {
+          content: [],
+          stopReason: "interrupted",
+          metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+        },
+      };
+      return;
+    }
+
+    running = true;
+    const abortController = new AbortController();
+    activeAbortController = abortController;
+
+    // Fresh message mapper per run — holds StreamEventMapper state
+    const mapper = createMessageMapper();
+
+    try {
+      const prompt = inputToPrompt(input);
+
+      // Determine resume session ID
+      const resumeSessionId =
+        input.kind === "resume"
+          ? (extractSessionIdFromState(input.state) ?? sessionState.sessionId)
+          : undefined;
+
+      const options = buildSdkOptions(config, mcpBridge, resumeSessionId, abortController);
+
+      const queryIterable = sdk.query({ prompt, options });
+      activeQuery = queryIterable;
+      let receivedDone = false;
+
+      // Turn boundary tracking: a turn ends when a user message (tool results)
+      // follows an assistant message, signaling the assistant's tool calls completed.
+      let turnIndex = 0;
+      let sawAssistant = false;
+
+      for await (const message of queryIterable) {
+        if (abortController.signal.aborted) break;
+
+        // Detect turn boundary before mapping: user after assistant = turn end
+        const msgType = (message as { readonly type: string }).type;
+        if (msgType === "user" && sawAssistant) {
+          yield { kind: "turn_end", turnIndex };
+          turnIndex += 1;
+          sawAssistant = false;
+        }
+        if (msgType === "assistant") {
+          sawAssistant = true;
+        }
+
+        const result = mapper.map(message);
+
+        // Capture session ID from init or result messages
+        if (result.sessionId !== undefined) {
+          sessionState.sessionId = result.sessionId;
+        }
+
+        for (const event of result.events) {
+          yield event;
+        }
+
+        if (result.isDone) {
+          receivedDone = true;
+        }
+      }
+
+      // Synthetic done event if SDK yielded no result
+      if (!receivedDone) {
+        yield {
+          kind: "done",
+          output: {
+            content: [],
+            stopReason: abortController.signal.aborted ? "interrupted" : "error",
+            metrics: {
+              totalTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              turns: 0,
+              durationMs: 0,
+            },
+          },
+        };
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      yield {
+        kind: "done",
+        output: {
+          content: [{ kind: "text", text: `Error: ${message}` }],
+          stopReason: "error",
+          metrics: {
+            totalTokens: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            turns: 0,
+            durationMs: 0,
+          },
+          metadata: {
+            error: message,
+            ...(error instanceof Error && error.cause !== undefined
+              ? { cause: String(error.cause) }
+              : {}),
+          },
+        },
+      };
+    } finally {
+      activeQuery = undefined;
+      running = false;
+      activeAbortController = undefined;
+    }
+  }
+
+  // Controls proxy — delegates to activeQuery's methods when available
+  const controls: ClaudeQueryControls = {
+    interrupt: async (): Promise<void> => {
+      await activeQuery?.interrupt?.();
+    },
+    setModel: async (model?: string): Promise<void> => {
+      await activeQuery?.setModel?.(model);
+    },
+    setPermissionMode: async (mode: string): Promise<void> => {
+      await activeQuery?.setPermissionMode?.(mode);
+    },
+    stopTask: async (taskId: string): Promise<void> => {
+      await activeQuery?.stopTask?.(taskId);
+    },
+  };
+
+  const adapter: ClaudeEngineAdapter = {
+    engineId: ENGINE_ID,
+
+    // Non-cooperating adapter — no terminals
+    // The SDK manages its own model/tool calls internally
+
+    stream: (input: EngineInput): AsyncIterable<EngineEvent> => {
+      return runStream(input);
+    },
+
+    get controls(): ClaudeQueryControls | undefined {
+      return running ? controls : undefined;
+    },
+
+    saveState: async (): Promise<EngineState> => {
+      const data: ClaudeSessionState = { sessionId: sessionState.sessionId };
+      return { engineId: ENGINE_ID, data };
+    },
+
+    loadState: async (state: EngineState): Promise<void> => {
+      if (state.engineId !== ENGINE_ID) {
+        throw new Error(`Cannot load state from engine "${state.engineId}" into "${ENGINE_ID}"`);
+      }
+      const data = state.data as ClaudeSessionState | undefined;
+      if (data?.sessionId !== undefined) {
+        sessionState.sessionId = data.sessionId;
+      }
+    },
+
+    dispose: async (): Promise<void> => {
+      disposed = true;
+      if (activeAbortController !== undefined) {
+        activeAbortController.abort();
+      }
+    },
+  };
+
+  return adapter;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractSessionIdFromState(state: EngineState): string | undefined {
+  if (typeof state.data !== "object" || state.data === null) return undefined;
+  const record = state.data as Record<string, unknown>;
+  if (typeof record.sessionId === "string") return record.sessionId;
+  return undefined;
+}

--- a/packages/engine-claude/src/event-map.test.ts
+++ b/packages/engine-claude/src/event-map.test.ts
@@ -1,0 +1,932 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent } from "@koi/core";
+import type {
+  SdkAssistantMessage,
+  SdkResultMessage,
+  SdkStreamEvent,
+  SdkStreamEventMessage,
+  SdkSystemMessage,
+  SdkUserMessage,
+} from "./event-map.js";
+import {
+  createMessageMapper,
+  createStreamEventMapper,
+  mapAssistantMessage,
+  mapResultMessage,
+  mapSdkMessage,
+  mapStopReason,
+  mapUserMessage,
+} from "./event-map.js";
+
+// ---------------------------------------------------------------------------
+// mapStopReason
+// ---------------------------------------------------------------------------
+
+describe("mapStopReason", () => {
+  test("maps success → completed", () => {
+    expect(mapStopReason("success")).toBe("completed");
+  });
+
+  test("maps error_max_turns → max_turns", () => {
+    expect(mapStopReason("error_max_turns")).toBe("max_turns");
+  });
+
+  test("maps error_max_budget_usd → interrupted", () => {
+    expect(mapStopReason("error_max_budget_usd")).toBe("interrupted");
+  });
+
+  test("maps error_during_execution → error", () => {
+    expect(mapStopReason("error_during_execution")).toBe("error");
+  });
+
+  test("maps error_max_structured_output_retries → error", () => {
+    expect(mapStopReason("error_max_structured_output_retries")).toBe("error");
+  });
+
+  test("maps unknown subtype → error (default guard)", () => {
+    expect(mapStopReason("something_unexpected")).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapAssistantMessage
+// ---------------------------------------------------------------------------
+
+describe("mapAssistantMessage", () => {
+  test("extracts text_delta from text content blocks", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Hello, world!" }],
+      },
+    };
+
+    const events = mapAssistantMessage(msg);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "text_delta", delta: "Hello, world!" });
+  });
+
+  test("extracts tool_call_start from tool_use blocks", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "call-123",
+            name: "search",
+            input: { query: "test" },
+          },
+        ],
+      },
+    };
+
+    const events = mapAssistantMessage(msg);
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as EngineEvent & { readonly kind: "tool_call_start" };
+    expect(event.kind).toBe("tool_call_start");
+    expect(event.toolName).toBe("search");
+    expect(event.callId).toBe("call-123");
+    expect(event.args).toEqual({ query: "test" });
+  });
+
+  test("handles mixed text and tool_use blocks", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Let me search for that." },
+          { type: "tool_use", id: "call-1", name: "search", input: { q: "test" } },
+          { type: "text", text: "Found the results." },
+        ],
+      },
+    };
+
+    const events = mapAssistantMessage(msg);
+
+    expect(events).toHaveLength(3);
+    expect(events[0]?.kind).toBe("text_delta");
+    expect(events[1]?.kind).toBe("tool_call_start");
+    expect(events[2]?.kind).toBe("text_delta");
+  });
+
+  test("returns empty array for message with no content", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: { content: [] },
+    };
+
+    expect(mapAssistantMessage(msg)).toHaveLength(0);
+  });
+
+  test("returns empty array for message without message property", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+    };
+
+    expect(mapAssistantMessage(msg)).toHaveLength(0);
+  });
+
+  test("skips text blocks with empty text", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "" }],
+      },
+    };
+
+    expect(mapAssistantMessage(msg)).toHaveLength(0);
+  });
+
+  test("skips tool_use blocks missing id or name", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", input: { q: "test" } }],
+      },
+    };
+
+    expect(mapAssistantMessage(msg)).toHaveLength(0);
+  });
+
+  test("defaults tool_use input to empty object", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", id: "call-1", name: "read" }],
+      },
+    };
+
+    const events = mapAssistantMessage(msg);
+    const event = events[0] as EngineEvent & { readonly kind: "tool_call_start" };
+    expect(event.args).toEqual({});
+  });
+
+  test("ignores unknown block types gracefully", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Hello" },
+          { type: "thinking", text: "reasoning..." },
+        ],
+      },
+    };
+
+    const events = mapAssistantMessage(msg);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("text_delta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapResultMessage
+// ---------------------------------------------------------------------------
+
+describe("mapResultMessage", () => {
+  test("maps success result to done event", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      result: "Task completed successfully.",
+      num_turns: 5,
+      duration_ms: 10000,
+      usage: { input_tokens: 2000, output_tokens: 800 },
+    };
+
+    const event = mapResultMessage(msg);
+
+    expect(event.kind).toBe("done");
+    if (event.kind === "done") {
+      expect(event.output.stopReason).toBe("completed");
+      expect(event.output.metrics.inputTokens).toBe(2000);
+      expect(event.output.metrics.outputTokens).toBe(800);
+      expect(event.output.metrics.totalTokens).toBe(2800);
+      expect(event.output.metrics.turns).toBe(5);
+      expect(event.output.content).toHaveLength(1);
+    }
+  });
+
+  test("maps error_max_turns to max_turns stop reason", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "error_max_turns",
+      errors: ["Hit max turns limit"],
+      num_turns: 25,
+      duration_ms: 60000,
+      usage: { input_tokens: 50000, output_tokens: 20000 },
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.stopReason).toBe("max_turns");
+    }
+  });
+
+  test("maps error_max_budget_usd to interrupted stop reason", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "error_max_budget_usd",
+      num_turns: 10,
+      duration_ms: 30000,
+      total_cost_usd: 5.0,
+      usage: { input_tokens: 30000, output_tokens: 10000 },
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.stopReason).toBe("interrupted");
+      expect(event.output.metadata?.totalCostUsd).toBe(5.0);
+    }
+  });
+
+  test("maps error_during_execution to error stop reason", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "error_during_execution",
+      errors: ["Runtime error occurred"],
+      num_turns: 2,
+      duration_ms: 5000,
+      usage: { input_tokens: 500, output_tokens: 100 },
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.stopReason).toBe("error");
+    }
+  });
+
+  test("handles result with empty result text", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      result: "",
+      num_turns: 1,
+      duration_ms: 1000,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.content).toHaveLength(0);
+    }
+  });
+
+  test("handles result with missing result text", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      num_turns: 1,
+      duration_ms: 1000,
+      usage: {},
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.content).toHaveLength(0);
+      expect(event.output.metrics.inputTokens).toBe(0);
+    }
+  });
+
+  test("includes rich metadata when present", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      result: "Done",
+      num_turns: 1,
+      duration_ms: 1000,
+      duration_api_ms: 800,
+      total_cost_usd: 0.02,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 10,
+      },
+      modelUsage: { "claude-sonnet-4-5-20250929": { input_tokens: 100 } },
+    };
+
+    const event = mapResultMessage(msg);
+    if (event.kind === "done") {
+      expect(event.output.metadata).toBeDefined();
+      expect(event.output.metadata?.totalCostUsd).toBe(0.02);
+      expect(event.output.metadata?.apiDurationMs).toBe(800);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createStreamEventMapper
+// ---------------------------------------------------------------------------
+
+describe("createStreamEventMapper", () => {
+  test("maps content_block_start with tool_use to tool_call_start", () => {
+    const mapper = createStreamEventMapper();
+
+    const event: SdkStreamEvent = {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "call-1", name: "search" },
+    };
+
+    const events = mapper.map(event);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      kind: "tool_call_start",
+      toolName: "search",
+      callId: "call-1",
+    });
+  });
+
+  test("maps content_block_delta with text_delta", () => {
+    const mapper = createStreamEventMapper();
+
+    const event: SdkStreamEvent = {
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: "Hello" },
+    };
+
+    const events = mapper.map(event);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: "text_delta", delta: "Hello" });
+  });
+
+  test("maps content_block_delta with input_json_delta to tool_call_delta", () => {
+    const mapper = createStreamEventMapper();
+
+    // First register the tool call
+    mapper.map({
+      type: "content_block_start",
+      index: 1,
+      content_block: { type: "tool_use", id: "call-2", name: "write" },
+    });
+
+    // Then receive the delta
+    const events = mapper.map({
+      type: "content_block_delta",
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '{"path":' },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      kind: "tool_call_delta",
+      callId: "call-2",
+      delta: '{"path":',
+    });
+  });
+
+  test("ignores input_json_delta without prior tool_call_start", () => {
+    const mapper = createStreamEventMapper();
+
+    const events = mapper.map({
+      type: "content_block_delta",
+      index: 99,
+      delta: { type: "input_json_delta", partial_json: '{"q":' },
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("cleans up tool call tracking on content_block_stop", () => {
+    const mapper = createStreamEventMapper();
+
+    mapper.map({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "call-1", name: "read" },
+    });
+
+    mapper.map({ type: "content_block_stop", index: 0 });
+
+    // Delta after stop should not find the tool
+    const events = mapper.map({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: "data" },
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("ignores unknown event types", () => {
+    const mapper = createStreamEventMapper();
+
+    const events = mapper.map({ type: "message_start" });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("handles empty text_delta", () => {
+    const mapper = createStreamEventMapper();
+
+    const events = mapper.map({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: "" },
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("handles content_block_start without content_block", () => {
+    const mapper = createStreamEventMapper();
+
+    const events = mapper.map({ type: "content_block_start" });
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("handles content_block_delta without delta", () => {
+    const mapper = createStreamEventMapper();
+
+    const events = mapper.map({ type: "content_block_delta" });
+
+    expect(events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapUserMessage
+// ---------------------------------------------------------------------------
+
+describe("mapUserMessage", () => {
+  test("extracts tool_call_end from tool_result blocks", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "call-1", content: "Search results here" }],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      kind: "tool_call_end",
+      callId: "call-1",
+      result: "Search results here",
+    });
+  });
+
+  test("returns empty for user message without tool_result", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "text", text: "Hello" }],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+    expect(events).toHaveLength(0);
+  });
+
+  test("handles string content in tool_result", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "call-2", content: "plain text result" }],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as EngineEvent & { readonly kind: "tool_call_end" };
+    expect(event.result).toBe("plain text result");
+  });
+
+  test("handles array content in tool_result", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call-3",
+            content: [
+              { type: "text", text: "part one" },
+              { type: "text", text: " part two" },
+            ],
+          },
+        ],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as EngineEvent & { readonly kind: "tool_call_end" };
+    expect(event.result).toBe("part one part two");
+  });
+
+  test("returns empty for user message with no content", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: { content: [] },
+    };
+
+    expect(mapUserMessage(msg)).toHaveLength(0);
+  });
+
+  test("returns empty for user message without message property", () => {
+    const msg: SdkUserMessage = { type: "user" };
+
+    expect(mapUserMessage(msg)).toHaveLength(0);
+  });
+
+  test("extracts multiple tool_call_end events", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [
+          { type: "tool_result", tool_use_id: "call-a", content: "result A" },
+          { type: "tool_result", tool_use_id: "call-b", content: "result B" },
+        ],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+    expect(events).toHaveLength(2);
+    expect((events[0] as EngineEvent & { readonly kind: "tool_call_end" }).callId).toBe("call-a");
+    expect((events[1] as EngineEvent & { readonly kind: "tool_call_end" }).callId).toBe("call-b");
+  });
+
+  test("defaults to empty string when content is undefined", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "call-4" }],
+      },
+    };
+
+    const events = mapUserMessage(msg);
+    expect(events).toHaveLength(1);
+    const event = events[0] as EngineEvent & { readonly kind: "tool_call_end" };
+    expect(event.result).toBe("");
+  });
+
+  test("skips tool_result blocks without tool_use_id", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", content: "orphan result" }],
+      },
+    };
+
+    expect(mapUserMessage(msg)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapSdkMessage
+// ---------------------------------------------------------------------------
+
+describe("mapSdkMessage", () => {
+  test("maps system init message and captures session_id", () => {
+    const msg: SdkSystemMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "sess-abc-123",
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.sessionId).toBe("sess-abc-123");
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+
+  test("maps system message without init subtype (unknown subtypes ignored)", () => {
+    const msg: SdkSystemMessage = {
+      type: "system",
+      subtype: "heartbeat",
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.sessionId).toBeUndefined();
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+
+  test("emits custom event for compact_boundary", () => {
+    const msg: SdkSystemMessage = {
+      type: "system",
+      subtype: "compact_boundary",
+      session_id: "sess-compact",
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("custom");
+    const event = result.events[0] as EngineEvent & { readonly kind: "custom" };
+    expect(event.type).toBe("compact_boundary");
+    expect((event.data as Record<string, unknown>).sessionId).toBe("sess-compact");
+    expect(result.isDone).toBe(false);
+  });
+
+  test("includes compact_metadata in compact_boundary data", () => {
+    const msg: SdkSystemMessage = {
+      type: "system",
+      subtype: "compact_boundary",
+      session_id: "sess-compact-2",
+      compact_metadata: { trigger: "token_limit", pre_tokens: 50000 },
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0] as EngineEvent & { readonly kind: "custom" };
+    const data = event.data as Record<string, unknown>;
+    expect(data.compactMetadata).toEqual({ trigger: "token_limit", pre_tokens: 50000 });
+  });
+
+  test("maps assistant message to events", () => {
+    const msg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("text_delta");
+    expect(result.isDone).toBe(false);
+  });
+
+  test("maps result message to done event", () => {
+    const msg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      session_id: "sess-xyz",
+      result: "Done!",
+      num_turns: 1,
+      duration_ms: 500,
+      usage: { input_tokens: 50, output_tokens: 20 },
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("done");
+    expect(result.sessionId).toBe("sess-xyz");
+    expect(result.isDone).toBe(true);
+  });
+
+  test("handles user messages with tool_result blocks", () => {
+    const msg: SdkUserMessage = {
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "call-1", content: "result data" }],
+      },
+    };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("tool_call_end");
+    expect(result.isDone).toBe(false);
+  });
+
+  test("ignores unknown message types", () => {
+    const msg = { type: "unknown_type" };
+
+    const result = mapSdkMessage(msg);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMessageMapper
+// ---------------------------------------------------------------------------
+
+describe("createMessageMapper", () => {
+  test("routes stream_event to StreamEventMapper for text_delta", () => {
+    const mapper = createMessageMapper();
+
+    const msg: SdkStreamEventMessage = {
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hello" },
+      },
+    };
+
+    const result = mapper.map(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({ kind: "text_delta", delta: "Hello" });
+    expect(result.isDone).toBe(false);
+  });
+
+  test("routes stream_event to StreamEventMapper for tool_call_start", () => {
+    const mapper = createMessageMapper();
+
+    const msg: SdkStreamEventMessage = {
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "call-1", name: "search" },
+      },
+    };
+
+    const result = mapper.map(msg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({
+      kind: "tool_call_start",
+      toolName: "search",
+      callId: "call-1",
+    });
+  });
+
+  test("routes stream_event to StreamEventMapper for tool_call_delta", () => {
+    const mapper = createMessageMapper();
+
+    // Register the tool call first
+    mapper.map({
+      type: "stream_event",
+      event: {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "call-1", name: "write" },
+      },
+    });
+
+    // Then receive delta
+    const result = mapper.map({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"path":' },
+      },
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({
+      kind: "tool_call_delta",
+      callId: "call-1",
+      delta: '{"path":',
+    });
+  });
+
+  test("returns empty events for stream_event with undefined event", () => {
+    const mapper = createMessageMapper();
+
+    const msg: SdkStreamEventMessage = {
+      type: "stream_event",
+    };
+
+    const result = mapper.map(msg);
+
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+
+  test("suppresses assistant message after stream_event (duplicate prevention)", () => {
+    const mapper = createMessageMapper();
+
+    // First: stream events deliver the content
+    mapper.map({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hello!" },
+      },
+    });
+
+    // Then: complete assistant message arrives (duplicate)
+    const assistantMsg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    };
+
+    const result = mapper.map(assistantMsg);
+
+    // Should be suppressed — empty events
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+
+  test("does not suppress assistant message when no stream_event preceded it", () => {
+    const mapper = createMessageMapper();
+
+    const assistantMsg: SdkAssistantMessage = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    };
+
+    const result = mapper.map(assistantMsg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({ kind: "text_delta", delta: "Hello!" });
+  });
+
+  test("passes through non-stream, non-assistant messages unchanged", () => {
+    const mapper = createMessageMapper();
+
+    const systemMsg: SdkSystemMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "sess-123",
+    };
+
+    const result = mapper.map(systemMsg);
+
+    expect(result.sessionId).toBe("sess-123");
+    expect(result.events).toHaveLength(0);
+    expect(result.isDone).toBe(false);
+  });
+
+  test("passes through result messages unchanged", () => {
+    const mapper = createMessageMapper();
+
+    const resultMsg: SdkResultMessage = {
+      type: "result",
+      subtype: "success",
+      result: "Done",
+      num_turns: 1,
+      duration_ms: 100,
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    const result = mapper.map(resultMsg);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("done");
+    expect(result.isDone).toBe(true);
+  });
+
+  test("resets streaming flag after suppressed assistant, allowing next assistant through", () => {
+    const mapper = createMessageMapper();
+
+    // Stream event activates streaming
+    mapper.map({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "First" },
+      },
+    });
+
+    // First assistant is suppressed
+    mapper.map({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "First" }] },
+    } as SdkAssistantMessage);
+
+    // Second assistant (no preceding stream_event) should go through
+    const result = mapper.map({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Second" }] },
+    } as SdkAssistantMessage);
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({ kind: "text_delta", delta: "Second" });
+  });
+
+  test("handles interleaved stream and non-stream turns", () => {
+    const mapper = createMessageMapper();
+
+    // Turn 1: streamed
+    mapper.map({
+      type: "stream_event",
+      event: { type: "content_block_delta", delta: { type: "text_delta", text: "A" } },
+    });
+    const suppressed = mapper.map({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "A" }] },
+    } as SdkAssistantMessage);
+    expect(suppressed.events).toHaveLength(0);
+
+    // User message in between
+    const userResult = mapper.map({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "call-1", content: "ok" }] },
+    } as SdkUserMessage);
+    expect(userResult.events).toHaveLength(1);
+
+    // Turn 2: not streamed — assistant should pass through
+    const passThrough = mapper.map({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "B" }] },
+    } as SdkAssistantMessage);
+    expect(passThrough.events).toHaveLength(1);
+    expect(passThrough.events[0]).toEqual({ kind: "text_delta", delta: "B" });
+  });
+});

--- a/packages/engine-claude/src/event-map.ts
+++ b/packages/engine-claude/src/event-map.ts
@@ -1,0 +1,447 @@
+/**
+ * SDKMessage → EngineEvent mapping.
+ *
+ * Converts Claude Agent SDK streaming messages into Koi EngineEvents.
+ * Separated into text, tool, and result mappers for testability.
+ */
+
+import type { EngineEvent, EngineOutput, EngineStopReason, JsonObject } from "@koi/core";
+import type { SdkResultFields } from "./metrics.js";
+import { mapMetrics, mapRichMetadata } from "./metrics.js";
+
+// ---------------------------------------------------------------------------
+// SDK message shapes — minimal structural types to avoid SDK type import leaks
+// ---------------------------------------------------------------------------
+
+/** Partial content block element (for array-shaped tool_result content). */
+export interface SdkContentBlockElement {
+  readonly type: string;
+  readonly text?: string;
+}
+
+/** Partial assistant message content block. */
+export interface SdkContentBlock {
+  readonly type: string;
+  readonly id?: string;
+  readonly name?: string;
+  readonly text?: string;
+  readonly input?: Readonly<Record<string, unknown>>;
+  readonly partial_json?: string;
+  /** tool_result blocks: the ID of the tool_use this result corresponds to. */
+  readonly tool_use_id?: string;
+  /** tool_result blocks: the result content (string or structured array). */
+  readonly content?: string | readonly SdkContentBlockElement[];
+}
+
+/** Partial assistant message from SDK streaming. */
+export interface SdkAssistantMessage {
+  readonly type: "assistant";
+  readonly message?: {
+    readonly content?: readonly SdkContentBlock[];
+  };
+  readonly parent_tool_use_id?: string;
+}
+
+/** Streaming event from SDK (content_block_start/delta/stop). */
+export interface SdkStreamEvent {
+  readonly type: string;
+  readonly index?: number;
+  readonly content_block?: SdkContentBlock;
+  readonly delta?: {
+    readonly type?: string;
+    readonly text?: string;
+    readonly partial_json?: string;
+  };
+}
+
+/** SDK result message. */
+export interface SdkResultMessage {
+  readonly type: "result";
+  readonly subtype: string;
+  readonly session_id?: string;
+  readonly result?: string;
+  readonly errors?: readonly string[];
+  readonly permission_denials?: readonly {
+    readonly tool_name: string;
+    readonly tool_use_id: string;
+  }[];
+  readonly num_turns?: number;
+  readonly duration_ms?: number;
+  readonly duration_api_ms?: number;
+  readonly total_cost_usd?: number;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+    readonly cache_creation_input_tokens?: number;
+  };
+  readonly modelUsage?: Readonly<Record<string, unknown>>;
+}
+
+/** SDK user message (contains tool results). */
+export interface SdkUserMessage {
+  readonly type: "user";
+  readonly message?: {
+    readonly content?: readonly SdkContentBlock[];
+  };
+  readonly parent_tool_use_id?: string;
+}
+
+/** SDK system message. */
+export interface SdkSystemMessage {
+  readonly type: "system";
+  readonly subtype?: string;
+  readonly session_id?: string;
+  readonly compact_metadata?: {
+    readonly trigger: string;
+    readonly pre_tokens: number;
+  };
+}
+
+/** SDK partial assistant message with streaming event (includePartialMessages: true). */
+export interface SdkStreamEventMessage {
+  readonly type: "stream_event";
+  readonly event?: SdkStreamEvent;
+  readonly session_id?: string;
+}
+
+/** Union of SDK message types we handle. */
+export type SdkMessage =
+  | SdkAssistantMessage
+  | SdkUserMessage
+  | SdkResultMessage
+  | SdkSystemMessage
+  | SdkStreamEventMessage
+  | { readonly type: string };
+
+// ---------------------------------------------------------------------------
+// Result subtype → EngineStopReason mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map SDK result subtype to EngineStopReason with exhaustive switch.
+ */
+export function mapStopReason(subtype: string): EngineStopReason {
+  switch (subtype) {
+    case "success":
+      return "completed";
+    case "error_max_turns":
+      return "max_turns";
+    case "error_max_budget_usd":
+      return "interrupted";
+    case "error_during_execution":
+      return "error";
+    case "error_max_structured_output_retries":
+      return "error";
+    default:
+      return "error";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Assistant message → EngineEvent[] mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract EngineEvents from a complete assistant message (non-streaming).
+ *
+ * For each text block → text_delta event.
+ * For each tool_use block → tool_call_start (with args) event.
+ */
+export function mapAssistantMessage(msg: SdkAssistantMessage): readonly EngineEvent[] {
+  const content = msg.message?.content;
+  if (content === undefined || content.length === 0) return [];
+
+  const events: EngineEvent[] = [];
+
+  for (const block of content) {
+    switch (block.type) {
+      case "text":
+        if (block.text !== undefined && block.text.length > 0) {
+          events.push({ kind: "text_delta", delta: block.text });
+        }
+        break;
+      case "tool_use":
+        if (block.id !== undefined && block.name !== undefined) {
+          events.push({
+            kind: "tool_call_start",
+            toolName: block.name,
+            callId: block.id,
+            args: (block.input ?? {}) as JsonObject,
+          });
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// User message → tool_call_end EngineEvents
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract tool_call_end events from a user message containing tool_result blocks.
+ *
+ * The SDK sends tool execution results inside user messages. Each tool_result
+ * block maps to a tool_call_end event with the execution result.
+ */
+export function mapUserMessage(msg: SdkUserMessage): readonly EngineEvent[] {
+  const content = msg.message?.content;
+  if (content === undefined || content.length === 0) return [];
+
+  const events: EngineEvent[] = [];
+
+  for (const block of content) {
+    if (block.type === "tool_result" && block.tool_use_id !== undefined) {
+      const resultText =
+        typeof block.content === "string"
+          ? block.content
+          : Array.isArray(block.content)
+            ? block.content.map((c) => c.text ?? "").join("")
+            : "";
+      events.push({
+        kind: "tool_call_end",
+        callId: block.tool_use_id,
+        result: resultText,
+      });
+    }
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Result message → done EngineEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Map SDK result message to a `done` EngineEvent.
+ */
+export function mapResultMessage(msg: SdkResultMessage): EngineEvent {
+  const stopReason = mapStopReason(msg.subtype);
+  const resultFields: SdkResultFields = msg;
+  const metrics = mapMetrics(resultFields);
+  const metadata = mapRichMetadata(resultFields);
+
+  const resultText = msg.result ?? "";
+  const output: EngineOutput = {
+    content: resultText.length > 0 ? [{ kind: "text", text: resultText }] : [],
+    stopReason,
+    metrics,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+
+  return { kind: "done", output };
+}
+
+// ---------------------------------------------------------------------------
+// Streaming event mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateful event mapper for SDK streaming messages.
+ *
+ * Tracks tool call context across content_block_start/delta/stop events
+ * and emits corresponding EngineEvents.
+ */
+export interface StreamEventMapper {
+  /** Map a single SDK stream event to zero or more EngineEvents. */
+  readonly map: (event: SdkStreamEvent) => readonly EngineEvent[];
+}
+
+/**
+ * Create a streaming event mapper that converts SDK content block events
+ * to EngineEvents.
+ */
+export function createStreamEventMapper(): StreamEventMapper {
+  // Track active tool call IDs by content block index
+  const activeToolCalls = new Map<number, { readonly callId: string; readonly toolName: string }>();
+
+  return {
+    map(event: SdkStreamEvent): readonly EngineEvent[] {
+      switch (event.type) {
+        case "content_block_start": {
+          const block = event.content_block;
+          if (block === undefined) return [];
+
+          if (block.type === "tool_use" && block.id !== undefined && block.name !== undefined) {
+            if (event.index !== undefined) {
+              activeToolCalls.set(event.index, { callId: block.id, toolName: block.name });
+            }
+            return [
+              {
+                kind: "tool_call_start",
+                toolName: block.name,
+                callId: block.id,
+              },
+            ];
+          }
+          return [];
+        }
+
+        case "content_block_delta": {
+          const delta = event.delta;
+          if (delta === undefined) return [];
+
+          if (delta.type === "text_delta" && delta.text !== undefined && delta.text.length > 0) {
+            return [{ kind: "text_delta", delta: delta.text }];
+          }
+
+          if (delta.type === "input_json_delta" && delta.partial_json !== undefined) {
+            const toolInfo =
+              event.index !== undefined ? activeToolCalls.get(event.index) : undefined;
+            if (toolInfo !== undefined) {
+              return [
+                {
+                  kind: "tool_call_delta",
+                  callId: toolInfo.callId,
+                  delta: delta.partial_json,
+                },
+              ];
+            }
+          }
+          return [];
+        }
+
+        case "content_block_stop": {
+          if (event.index !== undefined) {
+            activeToolCalls.delete(event.index);
+          }
+          return [];
+        }
+
+        default:
+          return [];
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level message mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a full SDK message to EngineEvents.
+ *
+ * Returns the events plus optional session_id if this was an init message.
+ */
+export interface MapResult {
+  readonly events: readonly EngineEvent[];
+  readonly sessionId?: string;
+  readonly isDone: boolean;
+}
+
+/**
+ * Map a single SDK message to EngineEvents and metadata.
+ */
+export function mapSdkMessage(msg: SdkMessage): MapResult {
+  switch (msg.type) {
+    case "system": {
+      const systemMsg = msg as SdkSystemMessage;
+      if (systemMsg.subtype === "init" && systemMsg.session_id !== undefined) {
+        return { events: [], sessionId: systemMsg.session_id, isDone: false };
+      }
+      if (systemMsg.subtype === "compact_boundary") {
+        return {
+          events: [
+            {
+              kind: "custom",
+              type: "compact_boundary",
+              data: {
+                sessionId: systemMsg.session_id,
+                ...(systemMsg.compact_metadata !== undefined
+                  ? { compactMetadata: systemMsg.compact_metadata }
+                  : {}),
+              },
+            },
+          ],
+          isDone: false,
+        };
+      }
+      return { events: [], isDone: false };
+    }
+
+    case "user": {
+      const userMsg = msg as SdkUserMessage;
+      const events = mapUserMessage(userMsg);
+      return { events, isDone: false };
+    }
+
+    case "assistant": {
+      const assistantMsg = msg as SdkAssistantMessage;
+      const events = mapAssistantMessage(assistantMsg);
+      return { events, isDone: false };
+    }
+
+    case "result": {
+      const resultMsg = msg as SdkResultMessage;
+      const doneEvent = mapResultMessage(resultMsg);
+      return {
+        events: [doneEvent],
+        ...(resultMsg.session_id !== undefined ? { sessionId: resultMsg.session_id } : {}),
+        isDone: true,
+      };
+    }
+
+    default:
+      return { events: [], isDone: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stateful message mapper (wraps stream + complete message handling)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateful message mapper that routes `stream_event` messages to
+ * the internal `StreamEventMapper` and suppresses duplicate `assistant`
+ * messages when streaming is active.
+ */
+export interface MessageMapper {
+  /** Map a single SDK message to EngineEvents and metadata. */
+  readonly map: (msg: SdkMessage) => MapResult;
+}
+
+/**
+ * Create a stateful message mapper.
+ *
+ * Holds a `StreamEventMapper` internally and tracks whether streaming
+ * is active. When streaming is active, complete `assistant` messages
+ * are suppressed to avoid duplicate events (the stream events already
+ * emitted the granular version).
+ */
+export function createMessageMapper(): MessageMapper {
+  const streamMapper = createStreamEventMapper();
+  // let: toggled when first stream_event arrives, reset on assistant/result
+  let streamingActive = false;
+
+  return {
+    map(msg: SdkMessage): MapResult {
+      if (msg.type === "stream_event") {
+        const streamMsg = msg as SdkStreamEventMessage;
+        if (streamMsg.event === undefined) {
+          return { events: [], isDone: false };
+        }
+        streamingActive = true;
+        const events = streamMapper.map(streamMsg.event);
+        return { events, isDone: false };
+      }
+
+      if (msg.type === "assistant" && streamingActive) {
+        // Suppress the complete assistant message — stream events
+        // already emitted the granular text_delta / tool_call_start events
+        streamingActive = false;
+        return { events: [], isDone: false };
+      }
+
+      // Reset streaming flag on non-stream messages
+      streamingActive = false;
+      return mapSdkMessage(msg);
+    },
+  };
+}

--- a/packages/engine-claude/src/index.ts
+++ b/packages/engine-claude/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * @koi/engine-claude — Claude Agent SDK engine adapter (Layer 2).
+ *
+ * A non-cooperating EngineAdapter that delegates to the Claude Agent SDK's
+ * query() function, mapping SDK messages to Koi EngineEvents. The SDK manages
+ * its own model/tool calls internally; Koi tools are bridged via an in-process
+ * MCP server.
+ */
+
+export type { SdkFunctions, SdkQuery, SdkQueryFn } from "./adapter.js";
+export { createClaudeAdapter } from "./adapter.js";
+export type {
+  MapResult,
+  MessageMapper,
+  SdkAssistantMessage,
+  SdkContentBlock,
+  SdkMessage,
+  SdkResultMessage,
+  SdkStreamEvent,
+  SdkStreamEventMessage,
+  SdkSystemMessage,
+  StreamEventMapper,
+} from "./event-map.js";
+export {
+  createMessageMapper,
+  createStreamEventMapper,
+  mapAssistantMessage,
+  mapResultMessage,
+  mapSdkMessage,
+  mapStopReason,
+} from "./event-map.js";
+export type { SdkResultFields } from "./metrics.js";
+export { mapMetrics, mapRichMetadata } from "./metrics.js";
+export type { McpBridgeConfig, SdkOptions } from "./policy-map.js";
+export { buildSdkOptions } from "./policy-map.js";
+export type { ToolBridgeDescriptor, ToolRegistry } from "./tool-bridge.js";
+export { buildToolRegistry, createToolBridgeMcpServer, executeBridgedTool } from "./tool-bridge.js";
+export type {
+  ClaudeAdapterConfig,
+  ClaudeEngineAdapter,
+  ClaudeQueryControls,
+  ClaudeSessionState,
+} from "./types.js";

--- a/packages/engine-claude/src/metrics.test.ts
+++ b/packages/engine-claude/src/metrics.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import type { SdkResultFields } from "./metrics.js";
+import { mapMetrics, mapRichMetadata } from "./metrics.js";
+
+describe("mapMetrics", () => {
+  test("maps core fields correctly without cache tokens", () => {
+    const result: SdkResultFields = {
+      num_turns: 3,
+      duration_ms: 5000,
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+      },
+    };
+
+    const metrics = mapMetrics(result);
+
+    expect(metrics.inputTokens).toBe(1000);
+    expect(metrics.outputTokens).toBe(500);
+    expect(metrics.totalTokens).toBe(1500);
+    expect(metrics.turns).toBe(3);
+    expect(metrics.durationMs).toBe(5000);
+  });
+
+  test("includes cache_read and cache_creation in inputTokens", () => {
+    const result: SdkResultFields = {
+      num_turns: 2,
+      duration_ms: 3000,
+      usage: {
+        input_tokens: 50,
+        output_tokens: 200,
+        cache_read_input_tokens: 10000,
+        cache_creation_input_tokens: 500,
+      },
+    };
+
+    const metrics = mapMetrics(result);
+
+    // inputTokens = uncached(50) + cache_read(10000) + cache_creation(500)
+    expect(metrics.inputTokens).toBe(10550);
+    expect(metrics.outputTokens).toBe(200);
+    expect(metrics.totalTokens).toBe(10750);
+  });
+
+  test("handles cache_read only (no cache_creation)", () => {
+    const result: SdkResultFields = {
+      num_turns: 1,
+      duration_ms: 1000,
+      usage: {
+        input_tokens: 20,
+        output_tokens: 100,
+        cache_read_input_tokens: 30000,
+      },
+    };
+
+    const metrics = mapMetrics(result);
+
+    expect(metrics.inputTokens).toBe(30020);
+    expect(metrics.totalTokens).toBe(30120);
+  });
+
+  test("handles missing optional fields with defaults", () => {
+    const result: SdkResultFields = {};
+
+    const metrics = mapMetrics(result);
+
+    expect(metrics.inputTokens).toBe(0);
+    expect(metrics.outputTokens).toBe(0);
+    expect(metrics.totalTokens).toBe(0);
+    expect(metrics.turns).toBe(0);
+    expect(metrics.durationMs).toBe(0);
+  });
+
+  test("handles partial usage with missing fields", () => {
+    const result: SdkResultFields = {
+      num_turns: 1,
+      usage: {
+        input_tokens: 100,
+      },
+    };
+
+    const metrics = mapMetrics(result);
+
+    expect(metrics.inputTokens).toBe(100);
+    expect(metrics.outputTokens).toBe(0);
+    expect(metrics.totalTokens).toBe(100);
+  });
+});
+
+describe("mapRichMetadata", () => {
+  test("includes cost, cache, and model usage", () => {
+    const result: SdkResultFields = {
+      total_cost_usd: 0.05,
+      duration_api_ms: 3000,
+      modelUsage: { "claude-sonnet-4-5-20250929": { input_tokens: 500 } },
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 100,
+      },
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.totalCostUsd).toBe(0.05);
+    expect(metadata.apiDurationMs).toBe(3000);
+    expect(metadata.modelUsage).toEqual({ "claude-sonnet-4-5-20250929": { input_tokens: 500 } });
+    expect(metadata.cacheReadTokens).toBe(200);
+    expect(metadata.cacheCreationTokens).toBe(100);
+  });
+
+  test("omits undefined fields", () => {
+    const result: SdkResultFields = {};
+
+    const metadata = mapRichMetadata(result);
+
+    expect(Object.keys(metadata)).toHaveLength(0);
+  });
+
+  test("includes only populated fields", () => {
+    const result: SdkResultFields = {
+      total_cost_usd: 0.01,
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.totalCostUsd).toBe(0.01);
+    expect(metadata.apiDurationMs).toBeUndefined();
+    expect(metadata.modelUsage).toBeUndefined();
+  });
+
+  test("includes errors array when present", () => {
+    const result: SdkResultFields = {
+      errors: ["Runtime error occurred", "Second error"],
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.errors).toEqual(["Runtime error occurred", "Second error"]);
+  });
+
+  test("includes permission_denials when present", () => {
+    const result: SdkResultFields = {
+      permission_denials: [
+        { tool_name: "bash", tool_use_id: "call-1" },
+        { tool_name: "write", tool_use_id: "call-2" },
+      ],
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.permissionDenials).toEqual([
+      { tool_name: "bash", tool_use_id: "call-1" },
+      { tool_name: "write", tool_use_id: "call-2" },
+    ]);
+  });
+
+  test("omits errors when empty array", () => {
+    const result: SdkResultFields = {
+      errors: [],
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.errors).toBeUndefined();
+  });
+
+  test("omits permission_denials when empty array", () => {
+    const result: SdkResultFields = {
+      permission_denials: [],
+    };
+
+    const metadata = mapRichMetadata(result);
+
+    expect(metadata.permissionDenials).toBeUndefined();
+  });
+});

--- a/packages/engine-claude/src/metrics.ts
+++ b/packages/engine-claude/src/metrics.ts
@@ -1,0 +1,85 @@
+/**
+ * SDKResultMessage → EngineMetrics mapping.
+ *
+ * Maps the Claude Agent SDK's result format to Koi's EngineMetrics + rich metadata.
+ */
+
+import type { EngineMetrics, JsonObject } from "@koi/core";
+
+/**
+ * SDK result shape — only the fields we consume.
+ * Avoids importing SDK types directly into our public surface.
+ */
+export interface SdkResultFields {
+  readonly num_turns?: number;
+  readonly duration_ms?: number;
+  readonly duration_api_ms?: number;
+  readonly total_cost_usd?: number;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+    readonly cache_creation_input_tokens?: number;
+  };
+  readonly modelUsage?: Readonly<Record<string, unknown>>;
+  readonly errors?: readonly string[];
+  readonly permission_denials?: readonly {
+    readonly tool_name: string;
+    readonly tool_use_id: string;
+  }[];
+}
+
+/**
+ * Map SDK result fields to Koi EngineMetrics.
+ *
+ * `inputTokens` is the total tokens processed (cached + uncached), matching
+ * the OpenAI / LangChain / LiteLLM convention. Anthropic's `input_tokens`
+ * field only counts uncached tokens — we add cache_read and cache_creation
+ * to get the true total. Cache breakdowns remain in `mapRichMetadata`.
+ */
+export function mapMetrics(result: SdkResultFields): EngineMetrics {
+  const uncached = result.usage?.input_tokens ?? 0;
+  const cacheRead = result.usage?.cache_read_input_tokens ?? 0;
+  const cacheCreate = result.usage?.cache_creation_input_tokens ?? 0;
+  const inputTokens = uncached + cacheRead + cacheCreate;
+  const outputTokens = result.usage?.output_tokens ?? 0;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    turns: result.num_turns ?? 0,
+    durationMs: result.duration_ms ?? 0,
+  };
+}
+
+/**
+ * Map SDK result fields to rich metadata for EngineOutput.metadata.
+ */
+export function mapRichMetadata(result: SdkResultFields): JsonObject {
+  const metadata: Record<string, unknown> = {};
+
+  if (result.total_cost_usd !== undefined) {
+    metadata.totalCostUsd = result.total_cost_usd;
+  }
+  if (result.duration_api_ms !== undefined) {
+    metadata.apiDurationMs = result.duration_api_ms;
+  }
+  if (result.modelUsage !== undefined) {
+    metadata.modelUsage = result.modelUsage;
+  }
+  if (result.usage?.cache_read_input_tokens !== undefined) {
+    metadata.cacheReadTokens = result.usage.cache_read_input_tokens;
+  }
+  if (result.usage?.cache_creation_input_tokens !== undefined) {
+    metadata.cacheCreationTokens = result.usage.cache_creation_input_tokens;
+  }
+  if (result.errors !== undefined && result.errors.length > 0) {
+    metadata.errors = result.errors;
+  }
+  if (result.permission_denials !== undefined && result.permission_denials.length > 0) {
+    metadata.permissionDenials = result.permission_denials;
+  }
+
+  return metadata as JsonObject;
+}

--- a/packages/engine-claude/src/policy-map.test.ts
+++ b/packages/engine-claude/src/policy-map.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import type { McpBridgeConfig } from "./policy-map.js";
+import { buildSdkOptions } from "./policy-map.js";
+import type { ClaudeAdapterConfig } from "./types.js";
+
+describe("buildSdkOptions", () => {
+  test("maps all config fields to SDK options", () => {
+    const config: ClaudeAdapterConfig = {
+      model: "claude-sonnet-4-5-20250929",
+      maxTurns: 10,
+      maxBudgetUsd: 1.0,
+      cwd: "/tmp/test",
+      systemPrompt: "You are helpful.",
+      permissionMode: "acceptEdits",
+      allowedTools: ["Read", "Edit"],
+      disallowedTools: ["Bash"],
+    };
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    expect(options.model).toBe("claude-sonnet-4-5-20250929");
+    expect(options.maxTurns).toBe(10);
+    expect(options.maxBudgetUsd).toBe(1.0);
+    expect(options.cwd).toBe("/tmp/test");
+    expect(options.systemPrompt).toBe("You are helpful.");
+    expect(options.permissionMode).toBe("acceptEdits");
+    expect(options.allowedTools).toEqual(["Read", "Edit"]);
+    expect(options.disallowedTools).toEqual(["Bash"]);
+  });
+
+  test("always sets includePartialMessages to true", () => {
+    const config: ClaudeAdapterConfig = {};
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    expect(options.includePartialMessages).toBe(true);
+  });
+
+  test("includes MCP bridge when provided", () => {
+    const config: ClaudeAdapterConfig = {};
+    const mcpBridge: McpBridgeConfig = {
+      type: "sdk",
+      name: "koi_tools",
+      instance: {},
+    };
+
+    const options = buildSdkOptions(config, mcpBridge, undefined, undefined);
+
+    expect(options.mcpServers).toBeDefined();
+    const servers = options.mcpServers as Record<string, unknown>;
+    expect(servers.koi_tools).toBe(mcpBridge);
+  });
+
+  test("excludes MCP bridge when not provided", () => {
+    const config: ClaudeAdapterConfig = {};
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    expect(options.mcpServers).toBeUndefined();
+  });
+
+  test("includes resume session ID when provided", () => {
+    const config: ClaudeAdapterConfig = {};
+
+    const options = buildSdkOptions(config, undefined, "sess-123", undefined);
+
+    expect(options.resume).toBe("sess-123");
+  });
+
+  test("excludes resume when not provided", () => {
+    const config: ClaudeAdapterConfig = {};
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    expect(options.resume).toBeUndefined();
+  });
+
+  test("includes abort controller when provided", () => {
+    const config: ClaudeAdapterConfig = {};
+    const controller = new AbortController();
+
+    const options = buildSdkOptions(config, undefined, undefined, controller);
+
+    expect(options.abortController).toBe(controller);
+  });
+
+  test("sdkOverrides are merged last and can override derived config", () => {
+    const config: ClaudeAdapterConfig = {
+      model: "claude-sonnet-4-5-20250929",
+      sdkOverrides: {
+        model: "claude-opus-4-6",
+        includePartialMessages: false,
+        customField: "custom-value",
+      },
+    };
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    // sdkOverrides take precedence
+    expect(options.model).toBe("claude-opus-4-6");
+    expect(options.includePartialMessages).toBe(false);
+    expect(options.customField).toBe("custom-value");
+  });
+
+  test("omits undefined config fields", () => {
+    const config: ClaudeAdapterConfig = {
+      model: "test-model",
+    };
+
+    const options = buildSdkOptions(config, undefined, undefined, undefined);
+
+    expect(options.model).toBe("test-model");
+    expect(options.maxTurns).toBeUndefined();
+    expect(options.maxBudgetUsd).toBeUndefined();
+    expect(options.cwd).toBeUndefined();
+    expect(options.systemPrompt).toBeUndefined();
+    expect(options.permissionMode).toBeUndefined();
+    expect(options.allowedTools).toBeUndefined();
+    expect(options.disallowedTools).toBeUndefined();
+  });
+});

--- a/packages/engine-claude/src/policy-map.ts
+++ b/packages/engine-claude/src/policy-map.ts
@@ -1,0 +1,76 @@
+/**
+ * Koi config → Claude Agent SDK Options mapping.
+ *
+ * Translates ClaudeAdapterConfig fields into the SDK Options shape,
+ * with MCP bridge server integration and sdkOverrides applied last.
+ */
+
+import type { ClaudeAdapterConfig } from "./types.js";
+
+/**
+ * Minimal SDK Options shape — avoids importing SDK types into adapter API.
+ * The real SDK Options type is a superset of this.
+ */
+export interface SdkOptions {
+  readonly model?: string;
+  readonly maxTurns?: number;
+  readonly maxBudgetUsd?: number;
+  readonly cwd?: string;
+  readonly systemPrompt?: string;
+  readonly permissionMode?: string;
+  readonly allowedTools?: readonly string[];
+  readonly disallowedTools?: readonly string[];
+  readonly includePartialMessages?: boolean;
+  readonly mcpServers?: Readonly<Record<string, unknown>>;
+  readonly resume?: string;
+  readonly abortController?: AbortController;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * MCP server config for the in-process Koi tool bridge.
+ */
+export interface McpBridgeConfig {
+  readonly type: "sdk";
+  readonly name: string;
+  readonly instance: unknown;
+}
+
+/**
+ * Build SDK Options from Koi adapter config.
+ *
+ * @param config - The Koi adapter configuration
+ * @param mcpBridge - Optional MCP bridge server config for Koi tools
+ * @param resumeSessionId - Optional session ID for resuming a conversation
+ * @param abortController - Optional AbortController for cancellation
+ * @returns SDK-compatible options object
+ */
+export function buildSdkOptions(
+  config: ClaudeAdapterConfig,
+  mcpBridge: McpBridgeConfig | undefined,
+  resumeSessionId: string | undefined,
+  abortController: AbortController | undefined,
+): SdkOptions {
+  return {
+    ...(config.model !== undefined ? { model: config.model } : {}),
+    ...(config.maxTurns !== undefined ? { maxTurns: config.maxTurns } : {}),
+    ...(config.maxBudgetUsd !== undefined ? { maxBudgetUsd: config.maxBudgetUsd } : {}),
+    ...(config.cwd !== undefined ? { cwd: config.cwd } : {}),
+    ...(config.systemPrompt !== undefined ? { systemPrompt: config.systemPrompt } : {}),
+    ...(config.permissionMode !== undefined ? { permissionMode: config.permissionMode } : {}),
+    ...(config.allowedTools !== undefined ? { allowedTools: [...config.allowedTools] } : {}),
+    ...(config.disallowedTools !== undefined
+      ? { disallowedTools: [...config.disallowedTools] }
+      : {}),
+    // Always enable fine-grained streaming
+    includePartialMessages: true,
+    // MCP bridge server for Koi tools
+    ...(mcpBridge !== undefined ? { mcpServers: { koi_tools: mcpBridge } } : {}),
+    // Session resumption
+    ...(resumeSessionId !== undefined ? { resume: resumeSessionId } : {}),
+    // Abort controller
+    ...(abortController !== undefined ? { abortController } : {}),
+    // SDK overrides applied last — can override anything
+    ...config.sdkOverrides,
+  };
+}

--- a/packages/engine-claude/src/tool-bridge.test.ts
+++ b/packages/engine-claude/src/tool-bridge.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test";
+import type { Agent, JsonObject, Tool, ToolDescriptor } from "@koi/core";
+import type { ToolRegistry } from "./tool-bridge.js";
+import { buildToolRegistry, createToolBridgeMcpServer, executeBridgedTool } from "./tool-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockTool(descriptor: ToolDescriptor, executeResult: unknown = "ok"): Tool {
+  return {
+    descriptor,
+    trustTier: "sandbox",
+    execute: async (_args: JsonObject) => executeResult,
+  };
+}
+
+function createMockAgent(tools: ReadonlyMap<string, Tool>): Agent {
+  return {
+    id: "test-agent" as ReturnType<typeof import("@koi/core").agentId>,
+    manifest: {} as Agent["manifest"],
+    query: (prefix: string) => {
+      if (!prefix.startsWith("tool:")) return new Map();
+      const result = new Map<string, unknown>();
+      for (const [name, tool] of tools) {
+        result.set(`tool:${name}`, tool);
+      }
+      return result;
+    },
+    get: (_token: unknown) => undefined,
+    attach: () => {},
+    detach: () => false,
+  } as unknown as Agent;
+}
+
+// ---------------------------------------------------------------------------
+// buildToolRegistry
+// ---------------------------------------------------------------------------
+
+describe("buildToolRegistry", () => {
+  test("builds registry from agent tool components", () => {
+    const tools = new Map<string, Tool>();
+    tools.set(
+      "search",
+      createMockTool({
+        name: "search",
+        description: "Search for content",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      }),
+    );
+    tools.set(
+      "write",
+      createMockTool({
+        name: "write",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" }, content: { type: "string" } },
+        },
+      }),
+    );
+
+    const agent = createMockAgent(tools);
+    const registry = buildToolRegistry(agent);
+
+    expect(registry.tools.size).toBe(2);
+    expect(registry.descriptors).toHaveLength(2);
+
+    const searchDesc = registry.descriptors.find((d) => d.name === "search");
+    expect(searchDesc).toBeDefined();
+    expect(searchDesc?.description).toBe("Search for content");
+  });
+
+  test("returns empty registry when agent has no tools", () => {
+    const agent = createMockAgent(new Map());
+    const registry = buildToolRegistry(agent);
+
+    expect(registry.tools.size).toBe(0);
+    expect(registry.descriptors).toHaveLength(0);
+  });
+
+  test("preserves inputSchema from tool descriptor", () => {
+    const tools = new Map<string, Tool>();
+    tools.set(
+      "simple",
+      createMockTool({
+        name: "simple",
+        description: "A simple tool",
+        inputSchema: { type: "object", properties: {} },
+      }),
+    );
+
+    const agent = createMockAgent(tools);
+    const registry = buildToolRegistry(agent);
+
+    expect(registry.descriptors).toHaveLength(1);
+    expect(registry.descriptors[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  test("uses description from tool descriptor", () => {
+    const tools = new Map<string, Tool>();
+    tools.set(
+      "mytool",
+      createMockTool({
+        name: "mytool",
+        description: "My tool description",
+        inputSchema: { type: "object" },
+      }),
+    );
+
+    const agent = createMockAgent(tools);
+    const registry = buildToolRegistry(agent);
+
+    expect(registry.descriptors[0]?.description).toBe("My tool description");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeBridgedTool
+// ---------------------------------------------------------------------------
+
+describe("executeBridgedTool", () => {
+  test("executes tool and returns MCP text content", async () => {
+    const tools = new Map<string, Tool>();
+    tools.set("echo", {
+      descriptor: { name: "echo", description: "Echo back", inputSchema: { type: "object" } },
+      trustTier: "sandbox",
+      execute: async (args: JsonObject) => `Echo: ${String(args.text)}`,
+    });
+
+    const registry: ToolRegistry = {
+      tools,
+      descriptors: [{ name: "echo", description: "Echo back", inputSchema: { type: "object" } }],
+    };
+
+    const result = await executeBridgedTool(registry, "echo", { text: "hello" });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.text).toBe("Echo: hello");
+  });
+
+  test("returns error for unknown tool", async () => {
+    const registry: ToolRegistry = {
+      tools: new Map(),
+      descriptors: [],
+    };
+
+    const result = await executeBridgedTool(registry, "nonexistent", {});
+
+    expect(result.content[0]?.text).toContain("Unknown tool");
+    expect(result.content[0]?.text).toContain("nonexistent");
+  });
+
+  test("handles tool execution errors gracefully", async () => {
+    const tools = new Map<string, Tool>();
+    tools.set("failing", {
+      descriptor: { name: "failing", description: "Always fails", inputSchema: { type: "object" } },
+      trustTier: "sandbox",
+      execute: async () => {
+        throw new Error("Tool exploded");
+      },
+    });
+
+    const registry: ToolRegistry = {
+      tools,
+      descriptors: [{ name: "failing", description: "Fails", inputSchema: { type: "object" } }],
+    };
+
+    const result = await executeBridgedTool(registry, "failing", {});
+
+    expect(result.content[0]?.text).toContain("Tool execution error");
+    expect(result.content[0]?.text).toContain("Tool exploded");
+  });
+
+  test("serializes non-string results as JSON", async () => {
+    const tools = new Map<string, Tool>();
+    tools.set("json-tool", {
+      descriptor: {
+        name: "json-tool",
+        description: "Returns JSON",
+        inputSchema: { type: "object" },
+      },
+      trustTier: "sandbox",
+      execute: async () => ({ key: "value", count: 42 }),
+    });
+
+    const registry: ToolRegistry = {
+      tools,
+      descriptors: [{ name: "json-tool", description: "JSON", inputSchema: { type: "object" } }],
+    };
+
+    const result = await executeBridgedTool(registry, "json-tool", {});
+
+    expect(result.content[0]?.text).toBe('{"key":"value","count":42}');
+  });
+
+  test("handles non-Error throws", async () => {
+    const tools = new Map<string, Tool>();
+    tools.set("string-throw", {
+      descriptor: {
+        name: "string-throw",
+        description: "Throws string",
+        inputSchema: { type: "object" },
+      },
+      trustTier: "sandbox",
+      execute: async () => {
+        throw "raw string error";
+      },
+    });
+
+    const registry: ToolRegistry = {
+      tools,
+      descriptors: [
+        { name: "string-throw", description: "Throws", inputSchema: { type: "object" } },
+      ],
+    };
+
+    const result = await executeBridgedTool(registry, "string-throw", {});
+
+    expect(result.content[0]?.text).toContain("raw string error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createToolBridgeMcpServer
+// ---------------------------------------------------------------------------
+
+describe("createToolBridgeMcpServer", () => {
+  test("creates MCP server config with tool bridge", () => {
+    const tools = new Map<string, Tool>();
+    tools.set(
+      "search",
+      createMockTool({
+        name: "search",
+        description: "Search",
+        inputSchema: { type: "object" },
+      }),
+    );
+    const agent = createMockAgent(tools);
+
+    const mockTools: unknown[] = [];
+    const mockCreateServer = (config: { name: string }) => ({ serverName: config.name });
+    const mockToolFn = (name: string, desc: string, schema: unknown, handler: unknown) => {
+      const toolDef = { name, desc, schema, handler };
+      mockTools.push(toolDef);
+      return toolDef;
+    };
+
+    const result = createToolBridgeMcpServer(agent, mockCreateServer, mockToolFn);
+
+    expect(result).toBeDefined();
+    expect(result?.config.type).toBe("sdk");
+    expect(result?.config.name).toBe("koi_tools");
+    expect(mockTools).toHaveLength(1);
+  });
+
+  test("returns undefined when agent has no tools", () => {
+    const agent = createMockAgent(new Map());
+
+    const result = createToolBridgeMcpServer(
+      agent,
+      () => ({}),
+      () => ({}),
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  test("includes all tool descriptors in the MCP server", () => {
+    const tools = new Map<string, Tool>();
+    tools.set(
+      "read",
+      createMockTool({
+        name: "read",
+        description: "Read file",
+        inputSchema: { type: "object" },
+      }),
+    );
+    tools.set(
+      "write",
+      createMockTool({
+        name: "write",
+        description: "Write file",
+        inputSchema: { type: "object" },
+      }),
+    );
+    const agent = createMockAgent(tools);
+
+    const registeredTools: string[] = [];
+    const mockCreateServer = () => ({});
+    const mockToolFn = (name: string) => {
+      registeredTools.push(name);
+      return {};
+    };
+
+    createToolBridgeMcpServer(agent, mockCreateServer, mockToolFn);
+
+    expect(registeredTools).toContain("read");
+    expect(registeredTools).toContain("write");
+    expect(registeredTools).toHaveLength(2);
+  });
+});

--- a/packages/engine-claude/src/tool-bridge.ts
+++ b/packages/engine-claude/src/tool-bridge.ts
@@ -1,0 +1,132 @@
+/**
+ * Koi tools → MCP server bridge.
+ *
+ * Creates an in-process MCP server that exposes Koi tool components
+ * to the Claude Agent SDK, enabling the SDK to call Koi-registered tools.
+ */
+
+import type { Agent, Tool } from "@koi/core";
+import type { McpBridgeConfig } from "./policy-map.js";
+
+/**
+ * Tool registry for the MCP bridge — maps tool names to Koi Tool components.
+ */
+export interface ToolRegistry {
+  readonly tools: ReadonlyMap<string, Tool>;
+  readonly descriptors: readonly ToolBridgeDescriptor[];
+}
+
+/**
+ * A tool descriptor suitable for MCP tool definition.
+ */
+export interface ToolBridgeDescriptor {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Build a tool registry from an agent's tool components.
+ *
+ * Queries the agent for all tool components and builds a lookup map.
+ */
+export function buildToolRegistry(agent: Agent): ToolRegistry {
+  const toolComponents = agent.query("tool:");
+  const tools = new Map<string, Tool>();
+  const descriptors: ToolBridgeDescriptor[] = [];
+
+  for (const [key, component] of toolComponents) {
+    const tool = component as Tool;
+    const toolName = key.replace("tool:", "");
+
+    tools.set(toolName, tool);
+    descriptors.push({
+      name: toolName,
+      description: tool.descriptor.description,
+      inputSchema: tool.descriptor.inputSchema as Readonly<Record<string, unknown>>,
+    });
+  }
+
+  return { tools, descriptors };
+}
+
+/**
+ * Execute a tool from the registry by name.
+ *
+ * Returns the result as an MCP-compatible text content response.
+ */
+export async function executeBridgedTool(
+  registry: ToolRegistry,
+  toolName: string,
+  args: Readonly<Record<string, unknown>>,
+): Promise<{ readonly content: readonly { readonly type: "text"; readonly text: string }[] }> {
+  const tool = registry.tools.get(toolName);
+  if (tool === undefined) {
+    return {
+      content: [{ type: "text", text: `Error: Unknown tool "${toolName}"` }],
+    };
+  }
+
+  try {
+    const result = await tool.execute(args);
+    const text = typeof result === "string" ? result : JSON.stringify(result);
+    return { content: [{ type: "text", text }] };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Tool execution error: ${message}` }],
+    };
+  }
+}
+
+/**
+ * Create an in-process MCP server config that bridges Koi tools to the SDK.
+ *
+ * Returns `undefined` if the agent has no tool components,
+ * meaning no MCP bridge is needed.
+ *
+ * @param agent - The Koi agent to bridge tools from
+ * @param createMcpServerFn - The SDK's createSdkMcpServer function
+ * @param toolFn - The SDK's tool() helper function
+ * @returns MCP server config or undefined if no tools
+ */
+export function createToolBridgeMcpServer(
+  agent: Agent,
+  createMcpServerFn: (config: {
+    readonly name: string;
+    readonly version: string;
+    readonly tools: readonly unknown[];
+  }) => unknown,
+  toolFn: (
+    name: string,
+    description: string,
+    schema: unknown,
+    handler: (args: Readonly<Record<string, unknown>>) => Promise<unknown>,
+  ) => unknown,
+): { readonly config: McpBridgeConfig; readonly registry: ToolRegistry } | undefined {
+  const registry = buildToolRegistry(agent);
+
+  if (registry.descriptors.length === 0) {
+    return undefined;
+  }
+
+  const mcpTools = registry.descriptors.map((desc) =>
+    toolFn(desc.name, desc.description, desc.inputSchema, async (args) =>
+      executeBridgedTool(registry, desc.name, args),
+    ),
+  );
+
+  const server = createMcpServerFn({
+    name: "koi_tools",
+    version: "1.0.0",
+    tools: mcpTools,
+  });
+
+  const config: McpBridgeConfig = {
+    type: "sdk",
+    name: "koi_tools",
+    instance: server,
+  };
+
+  return { config, registry };
+}

--- a/packages/engine-claude/src/types.ts
+++ b/packages/engine-claude/src/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Configuration and extended types for the Claude Agent SDK engine adapter.
+ */
+
+import type { EngineAdapter } from "@koi/core";
+
+/**
+ * Configuration for creating a Claude Agent SDK engine adapter.
+ *
+ * Uses Koi-native naming with an opaque `sdkOverrides` escape hatch
+ * for advanced SDK-specific tuning.
+ */
+export interface ClaudeAdapterConfig {
+  /** Model identifier (e.g., "claude-sonnet-4-5-20250929"). */
+  readonly model?: string;
+  /** Maximum conversation turns before stopping. */
+  readonly maxTurns?: number;
+  /** Maximum budget in USD for the query. */
+  readonly maxBudgetUsd?: number;
+  /** Working directory for the SDK subprocess. */
+  readonly cwd?: string;
+  /** Custom system prompt. */
+  readonly systemPrompt?: string;
+  /** SDK permission mode. Mapped from Koi permissions config. */
+  readonly permissionMode?: "default" | "acceptEdits" | "bypassPermissions";
+  /** Allowed built-in SDK tools (e.g., ["Read", "Edit", "Bash", "Glob", "Grep"]). */
+  readonly allowedTools?: readonly string[];
+  /** Disallowed built-in SDK tools. */
+  readonly disallowedTools?: readonly string[];
+  /**
+   * Opaque SDK-specific overrides. Merged last into SDK Options.
+   * Use for advanced tuning without leaking SDK types into the adapter API.
+   */
+  readonly sdkOverrides?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Internal state tracked across calls for session resumption.
+ */
+export interface ClaudeSessionState {
+  readonly sessionId: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// SDK Query Controls
+// ---------------------------------------------------------------------------
+
+/**
+ * Control methods available on an active Claude SDK query.
+ *
+ * These proxy the real SDK `Query` object's control methods.
+ * Only available while a `stream()` call is active.
+ */
+export interface ClaudeQueryControls {
+  /** Interrupt the current turn (keeps the session alive). */
+  readonly interrupt: () => Promise<void>;
+  /** Change the model for subsequent turns. */
+  readonly setModel: (model?: string) => Promise<void>;
+  /** Change the SDK permission mode. */
+  readonly setPermissionMode: (mode: string) => Promise<void>;
+  /** Stop a specific background task by ID. */
+  readonly stopTask: (taskId: string) => Promise<void>;
+}
+
+/**
+ * Extended engine adapter that exposes Claude SDK query controls.
+ *
+ * L0 consumers see plain `EngineAdapter` — no vendor leak.
+ * L2 consumers importing from `@koi/engine-claude` get the wider type
+ * with `.controls` available during active streams.
+ */
+export interface ClaudeEngineAdapter extends EngineAdapter {
+  /** Available only while a stream() is active. undefined otherwise. */
+  readonly controls: ClaudeQueryControls | undefined;
+}

--- a/packages/engine-claude/tsconfig.json
+++ b/packages/engine-claude/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/engine-claude/tsup.config.ts
+++ b/packages/engine-claude/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/engine-loop/src/loop-adapter.ts
+++ b/packages/engine-loop/src/loop-adapter.ts
@@ -318,7 +318,16 @@ async function* streamModelAndCollect(
             kind: "tool_call_start" as const,
             toolName: chunk.toolName,
             callId: chunk.callId,
-            args: {},
+          },
+        };
+        break;
+      case "tool_call_delta":
+        yield {
+          kind: "event" as const,
+          event: {
+            kind: "tool_call_delta" as const,
+            callId: chunk.callId,
+            delta: chunk.delta,
           },
         };
         break;
@@ -328,7 +337,7 @@ async function* streamModelAndCollect(
       case "done":
         finalResponse = chunk.response;
         break;
-      // thinking_delta, tool_call_delta, usage — internal, not forwarded as EngineEvent
+      // thinking_delta, usage — internal, not forwarded as EngineEvent
       default:
         break;
     }

--- a/packages/engine-pi/src/event-bridge.test.ts
+++ b/packages/engine-pi/src/event-bridge.test.ts
@@ -181,6 +181,33 @@ describe("createEventSubscriber", () => {
     });
   });
 
+  test("maps toolcall_delta to tool_call_delta event", async () => {
+    const queue = new AsyncQueue<EngineEvent>();
+    const metrics = createMetricsAccumulator();
+    const subscriber = createEventSubscriber(queue, metrics);
+
+    const partial = makePartialMessage({
+      content: [{ type: "toolCall", id: "call-1", name: "search", arguments: {} }],
+    });
+
+    subscriber(
+      makeMessageUpdate({
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '{"query":"test"}',
+        partial,
+      }),
+    );
+    subscriber({ type: "agent_end", messages: [] });
+
+    const events = await collectEvents(queue);
+    expect(events[0]).toEqual({
+      kind: "tool_call_delta",
+      callId: "call-1",
+      delta: '{"query":"test"}',
+    });
+  });
+
   test("maps toolcall_start to tool_call_start event", async () => {
     const queue = new AsyncQueue<EngineEvent>();
     const metrics = createMetricsAccumulator();

--- a/packages/engine-pi/src/event-bridge.ts
+++ b/packages/engine-pi/src/event-bridge.ts
@@ -202,8 +202,21 @@ export function createEventSubscriber(
             metrics.addUsage(errMsg.usage.input, errMsg.usage.output);
             break;
           }
+          case "toolcall_delta":
+            queue.push({
+              kind: "tool_call_delta",
+              callId: (() => {
+                const tc = findToolCallByContentIndex(
+                  assistantEvent.partial.content,
+                  assistantEvent.contentIndex,
+                );
+                return tc?.id ?? "";
+              })(),
+              delta: assistantEvent.delta,
+            });
+            break;
           // text_start, text_end, thinking_start, thinking_end,
-          // toolcall_delta, toolcall_end, start → no-op for Koi events
+          // toolcall_end, start → no-op for Koi events
           default:
             break;
         }

--- a/packages/test-utils/src/engine-contract.ts
+++ b/packages/test-utils/src/engine-contract.ts
@@ -155,6 +155,53 @@ export function testEngineAdapter(options: EngineContractOptions): void {
   );
 
   test(
+    "tool_call_delta events have non-empty delta and valid callId",
+    async () => {
+      const adapter = await createAdapter();
+      const events = await collectEvents(adapter.stream(input));
+
+      const deltas = events.filter(
+        (e): e is EngineEvent & { readonly kind: "tool_call_delta" } =>
+          e.kind === "tool_call_delta",
+      );
+      for (const delta of deltas) {
+        expect(typeof delta.callId).toBe("string");
+        expect(delta.callId.length).toBeGreaterThan(0);
+        expect(typeof delta.delta).toBe("string");
+        expect(delta.delta.length).toBeGreaterThan(0);
+      }
+    },
+    timeoutMs,
+  );
+
+  test(
+    "tool_call_delta events reference a known tool_call_start callId",
+    async () => {
+      const adapter = await createAdapter();
+      const events = await collectEvents(adapter.stream(input));
+
+      const startIds = new Set(
+        events
+          .filter(
+            (e): e is EngineEvent & { readonly kind: "tool_call_start" } =>
+              e.kind === "tool_call_start",
+          )
+          .map((s) => s.callId),
+      );
+
+      const deltas = events.filter(
+        (e): e is EngineEvent & { readonly kind: "tool_call_delta" } =>
+          e.kind === "tool_call_delta",
+      );
+
+      for (const delta of deltas) {
+        expect(startIds.has(delta.callId)).toBe(true);
+      }
+    },
+    timeoutMs,
+  );
+
+  test(
     "all events have a valid kind",
     async () => {
       const adapter = await createAdapter();
@@ -162,6 +209,7 @@ export function testEngineAdapter(options: EngineContractOptions): void {
       const validKinds = new Set([
         "text_delta",
         "tool_call_start",
+        "tool_call_delta",
         "tool_call_end",
         "turn_end",
         "done",

--- a/scripts/e2e-engine-claude.ts
+++ b/scripts/e2e-engine-claude.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env bun
+/**
+ * E2E test script for @koi/engine-claude — validates event mappings against
+ * the real Claude Agent SDK.
+ *
+ * Tests the 6-gap event coverage:
+ *   Gap 1: tool_call_end emitted from SDK user messages (tool results)
+ *   Gap 2: turn_end emitted on assistant→user boundary
+ *   Gap 3: User message handling (SDK "user" type with tool_result blocks)
+ *   Gap 4: errors[] in metadata (via maxTurns exhaustion)
+ *   Gap 5: permission_denials in metadata (non-deterministic, observation only)
+ *   Gap 6: compact_boundary (impractical for E2E, skipped)
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-engine-claude.ts
+ */
+
+import type { EngineEvent, EngineOutput } from "@koi/core";
+import type { ClaudeAdapterConfig } from "../packages/engine-claude/src/types.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping E2E tests.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting engine-claude E2E tests...");
+console.log("[e2e] ANTHROPIC_API_KEY: set");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean): void {
+  results.push({ name, passed: condition });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const doneEvent = events.find(
+    (e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done",
+  );
+  return doneEvent?.output;
+}
+
+function countByKind(events: readonly EngineEvent[]): Readonly<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const e of events) {
+    counts[e.kind] = (counts[e.kind] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function printEventSummary(events: readonly EngineEvent[]): void {
+  const counts = countByKind(events);
+  console.log(`  Events: ${events.length} total`);
+  for (const [kind, count] of Object.entries(counts)) {
+    console.log(`    ${kind}: ${count}`);
+  }
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// SDK + adapter import
+// ---------------------------------------------------------------------------
+
+// Resolve SDK from engine-claude's node_modules (isolated linker means
+// the root can't see workspace-scoped deps directly).
+const sdkPath = new URL(
+  "../packages/engine-claude/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs",
+  import.meta.url,
+).pathname;
+const { query } = await import(sdkPath);
+const { createClaudeAdapter } = await import("../packages/engine-claude/src/adapter.js");
+
+// ---------------------------------------------------------------------------
+// Shared config — bypassPermissions requires the safety flag via sdkOverrides
+// ---------------------------------------------------------------------------
+
+// The SDK spawns a Claude Code subprocess. Auto-detect the CLI path.
+const { execSync } = await import("node:child_process");
+const CLAUDE_CLI_PATH = execSync("which claude", { encoding: "utf-8" }).trim();
+console.log(`[e2e] Claude CLI: ${CLAUDE_CLI_PATH}\n`);
+
+const BASE_CONFIG: ClaudeAdapterConfig = {
+  model: "claude-sonnet-4-5-20250929",
+  permissionMode: "bypassPermissions",
+  sdkOverrides: {
+    allowDangerouslySkipPermissions: true,
+    executable: "node",
+    pathToClaudeCodeExecutable: CLAUDE_CLI_PATH,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Test 1 — Tool call flow (Gaps 1, 2, 3)
+// ---------------------------------------------------------------------------
+
+console.log("[test] Tool call flow (gaps 1, 2, 3)");
+
+const test1Events = await withTimeout(
+  async () => {
+    const adapter = createClaudeAdapter(
+      { ...BASE_CONFIG, maxTurns: 3, allowedTools: ["Bash"] },
+      { query },
+    );
+
+    return collectEvents(
+      adapter.stream({
+        kind: "text",
+        text: "Use the Bash tool to run: echo hello-koi",
+      }),
+    );
+  },
+  120_000,
+  "Test 1",
+);
+
+printEventSummary(test1Events);
+
+// Gap 1: tool_call_end emitted
+const toolCallStarts = test1Events.filter(
+  (e): e is EngineEvent & { readonly kind: "tool_call_start" } => e.kind === "tool_call_start",
+);
+const toolCallEnds = test1Events.filter(
+  (e): e is EngineEvent & { readonly kind: "tool_call_end" } => e.kind === "tool_call_end",
+);
+
+assert(
+  "tool_call_start emitted with Bash",
+  toolCallStarts.length > 0 && toolCallStarts.some((e) => e.toolName === "Bash"),
+);
+
+assert(
+  "tool_call_end paired with matching callId",
+  toolCallEnds.length > 0 &&
+    toolCallStarts.every((start) => toolCallEnds.some((end) => end.callId === start.callId)),
+);
+
+assert(
+  "tool_call_end has non-empty result",
+  toolCallEnds.length > 0 && toolCallEnds.every((e) => e.result !== undefined && e.result !== null),
+);
+
+// Gap 2: turn_end emitted
+const turnEnds = test1Events.filter(
+  (e): e is EngineEvent & { readonly kind: "turn_end" } => e.kind === "turn_end",
+);
+
+assert(
+  "turn_end emitted (turnIndex=0)",
+  turnEnds.length > 0 && (turnEnds[0]?.turnIndex ?? -1) === 0,
+);
+
+// Every tool_call_start.callId has a matching tool_call_end.callId (contract)
+const startIds = new Set(toolCallStarts.map((e) => e.callId));
+const endIds = new Set(toolCallEnds.map((e) => e.callId));
+const allPaired = [...startIds].every((id) => endIds.has(id));
+assert("every tool_call_start.callId has matching tool_call_end", allPaired);
+
+// done event
+const output1 = findDoneOutput(test1Events);
+assert('done with stopReason "completed"', output1?.stopReason === "completed");
+
+// ---------------------------------------------------------------------------
+// Test 2 — Text-only baseline (negative control)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test] Text-only baseline");
+
+const test2Events = await withTimeout(
+  async () => {
+    const adapter = createClaudeAdapter({ ...BASE_CONFIG, maxTurns: 1 }, { query });
+
+    return collectEvents(adapter.stream({ kind: "text", text: "Reply with exactly: pong" }));
+  },
+  60_000,
+  "Test 2",
+);
+
+printEventSummary(test2Events);
+
+const test2Counts = countByKind(test2Events);
+
+assert("text_delta emitted", (test2Counts.text_delta ?? 0) > 0);
+assert("no tool_call_start events", (test2Counts.tool_call_start ?? 0) === 0);
+assert("no turn_end events", (test2Counts.turn_end ?? 0) === 0);
+
+const output2 = findDoneOutput(test2Events);
+assert('done with stopReason "completed"', output2?.stopReason === "completed");
+
+// ---------------------------------------------------------------------------
+// Test 3 — Metrics and metadata populated (reuses Test 1 data)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test] Metrics populated");
+
+assert("inputTokens > 0", (output1?.metrics.inputTokens ?? 0) > 0);
+assert("outputTokens > 0", (output1?.metrics.outputTokens ?? 0) > 0);
+assert(
+  "totalTokens = input + output",
+  output1?.metrics.totalTokens ===
+    (output1?.metrics.inputTokens ?? 0) + (output1?.metrics.outputTokens ?? 0),
+);
+assert("turns >= 1", (output1?.metrics.turns ?? 0) >= 1);
+assert("durationMs > 0", (output1?.metrics.durationMs ?? 0) > 0);
+assert("output.content.length > 0", (output1?.content.length ?? 0) > 0);
+
+// ---------------------------------------------------------------------------
+// Test 4 — maxTurns exhaustion (Gap 4: errors[] in metadata)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test] maxTurns exhaustion (gap 4)");
+
+const test4Events = await withTimeout(
+  async () => {
+    const adapter = createClaudeAdapter(
+      { ...BASE_CONFIG, maxTurns: 1, allowedTools: ["Bash"] },
+      { query },
+    );
+
+    return collectEvents(
+      adapter.stream({
+        kind: "text",
+        text: "Use the Bash tool to run: echo step1 && then use Bash again to run: echo step2. You MUST run both commands.",
+      }),
+    );
+  },
+  120_000,
+  "Test 4",
+);
+
+printEventSummary(test4Events);
+
+const output4 = findDoneOutput(test4Events);
+// maxTurns: 1 with a tool-using prompt should exhaust turns
+// The SDK may return "error_max_turns" → mapped to "max_turns" stopReason
+// OR it may complete in 1 turn if the model decides to. Either way, we verify
+// the done event exists and metadata structure is valid.
+assert("done event emitted", output4 !== undefined);
+assert(
+  'stopReason is "max_turns" or "completed"',
+  output4?.stopReason === "max_turns" || output4?.stopReason === "completed",
+);
+// If max_turns, check for errors in metadata (SDK may or may not populate errors[])
+if (output4?.stopReason === "max_turns") {
+  const _errors = output4.metadata?.errors;
+  // The SDK's error_max_turns result includes an errors[] array, but it may be
+  // empty if the only issue is hitting the turn limit (no runtime errors).
+  // We verify the metadata object exists — that proves mapRichMetadata ran.
+  assert("metadata present on max_turns result", output4.metadata !== undefined);
+} else {
+  console.log("  (model completed within 1 turn — max_turns not triggered)");
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n[e2e] Results: ${passed}/${total} passed`);
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}`);
+    }
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes #169

- **Wire stream event mapper**: `createMessageMapper()` factory routes `stream_event` SDK messages to granular `EngineEvent`s (token-by-token `text_delta`, `tool_call_delta`) and suppresses duplicate `assistant` messages when streaming is active
- **Expose SDK query controls**: `ClaudeEngineAdapter.controls` getter provides `interrupt()`, `setModel()`, `setPermissionMode()`, `stopTask()` — available only during active `stream()` calls
- **L0 EngineEvent additions**: `tool_call_delta` event kind, `tool_call_start.args` now optional (streaming starts tool calls before args arrive)

## Key types

| Type | Location | Purpose |
|------|----------|---------|
| `SdkStreamEventMessage` | event-map.ts | SDK partial message with streaming event |
| `MessageMapper` | event-map.ts | Stateful mapper wrapping StreamEventMapper + duplicate suppression |
| `SdkQuery` | adapter.ts | AsyncIterable + optional control methods |
| `ClaudeQueryControls` | types.ts | interrupt, setModel, setPermissionMode, stopTask |
| `ClaudeEngineAdapter` | types.ts | EngineAdapter + controls getter |

## Architecture

- Zero layer violations — L2 imports only from L0
- No vendor types in public API
- Fresh `MessageMapper` per `stream()` call (no state leak across runs)
- Controls proxy delegates to `activeQuery` via optional chaining (no-ops gracefully when SDK lacks methods)
- Non-cooperating adapter — SDK manages its own loop; remaining per-call gaps tracked in sub-issues

## Related issues

- Closes #169 (`@koi/engine-claude` adapter)
- Remaining SDK surface gaps tracked as sub-tasks: #237 (HITL), #238 (live introspection), #239 (MCP lifecycle)

## Test plan

- [x] 138 unit tests pass, 99.3% line coverage
- [x] Biome lint/format clean
- [x] `turbo run build` — 47/47 tasks pass
- [x] Layer audit: zero violations
- [ ] E2E with live SDK: `ANTHROPIC_API_KEY=sk-... bun scripts/e2e-engine-claude.ts`