### PR TITLE
feat: two-stage ack for long-running agent turns

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -230,6 +230,16 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-turn-ack": {
+      "name": "@koi/middleware-turn-ack",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/model-router": {
       "name": "@koi/model-router",
       "version": "0.0.0",
@@ -549,6 +559,8 @@
     "@koi/middleware-pay": ["@koi/middleware-pay@workspace:packages/middleware-pay"],
 
     "@koi/middleware-permissions": ["@koi/middleware-permissions@workspace:packages/middleware-permissions"],
+
+    "@koi/middleware-turn-ack": ["@koi/middleware-turn-ack@workspace:packages/middleware-turn-ack"],
 
     "@koi/model-router": ["@koi/model-router@workspace:packages/model-router"],
 

--- a/packages/channel-cli/src/cli-channel.test.ts
+++ b/packages/channel-cli/src/cli-channel.test.ts
@@ -401,6 +401,17 @@ describe("createCliChannel", () => {
     await channel.disconnect();
   });
 
+  test("does not implement sendStatus (backward-compatible)", () => {
+    const streams = createMockStreams();
+    activeStreams = [...activeStreams, streams.input, streams.output, streams.errorOutput];
+    const channel = createCliChannel({
+      input: streams.input,
+      output: streams.output,
+      errorOutput: streams.errorOutput,
+    });
+    expect(channel.sendStatus).toBeUndefined();
+  });
+
   test("connect is idempotent", async () => {
     const streams = createMockStreams();
     activeStreams = [...activeStreams, streams.input, streams.output, streams.errorOutput];

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -2,6 +2,7 @@
  * Channel adapter contract — I/O interface to users.
  */
 
+import type { JsonObject } from "./common.js";
 import type { InboundMessage, OutboundMessage } from "./message.js";
 
 export interface ChannelCapabilities {
@@ -16,6 +17,18 @@ export interface ChannelCapabilities {
 
 export type MessageHandler = (message: InboundMessage) => Promise<void>;
 
+export type ChannelStatusKind = "processing" | "idle" | "error";
+
+export interface ChannelStatus {
+  readonly kind: ChannelStatusKind;
+  readonly turnIndex: number;
+  /** Correlates to the inbound message that triggered this turn. */
+  readonly messageRef?: string;
+  /** Human-readable hint for rich UIs: "thinking", "calling search", etc. */
+  readonly detail?: string;
+  readonly metadata?: JsonObject;
+}
+
 export interface ChannelAdapter {
   readonly name: string;
   readonly capabilities: ChannelCapabilities;
@@ -23,4 +36,5 @@ export interface ChannelAdapter {
   readonly disconnect: () => Promise<void>;
   readonly send: (message: OutboundMessage) => Promise<void>;
   readonly onMessage: (handler: MessageHandler) => () => void;
+  readonly sendStatus?: (status: ChannelStatus) => Promise<void>;
 }

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Exhaustiveness and shape tests for EngineEvent and ChannelStatus types.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ChannelStatus, ChannelStatusKind, EngineEvent } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// EngineEvent exhaustiveness (compile-time + runtime)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compile-time exhaustiveness check: if a new variant is added to EngineEvent
+ * but this function is not updated, TypeScript will error on the `never` branch.
+ */
+function engineEventLabel(event: EngineEvent): string {
+  switch (event.kind) {
+    case "turn_start":
+      return "start";
+    case "text_delta":
+      return "delta";
+    case "tool_call_start":
+      return "tcs";
+    case "tool_call_delta":
+      return "tcd";
+    case "tool_call_end":
+      return "tce";
+    case "turn_end":
+      return "end";
+    case "done":
+      return "done";
+    case "custom":
+      return "custom";
+    default: {
+      const _exhaustive: never = event;
+      return String(_exhaustive);
+    }
+  }
+}
+
+describe("EngineEvent exhaustiveness", () => {
+  test("turn_start variant is handled", () => {
+    const event: EngineEvent = { kind: "turn_start", turnIndex: 0 };
+    expect(engineEventLabel(event)).toBe("start");
+  });
+
+  test("text_delta variant is handled", () => {
+    const event: EngineEvent = { kind: "text_delta", delta: "hi" };
+    expect(engineEventLabel(event)).toBe("delta");
+  });
+
+  test("tool_call_start variant is handled", () => {
+    const event: EngineEvent = {
+      kind: "tool_call_start",
+      toolName: "calc",
+      callId: "c1",
+      args: {},
+    };
+    expect(engineEventLabel(event)).toBe("tcs");
+  });
+
+  test("tool_call_delta variant is handled", () => {
+    const event: EngineEvent = { kind: "tool_call_delta", callId: "c1", delta: "{}" };
+    expect(engineEventLabel(event)).toBe("tcd");
+  });
+
+  test("tool_call_end variant is handled", () => {
+    const event: EngineEvent = { kind: "tool_call_end", callId: "c1", result: 42 };
+    expect(engineEventLabel(event)).toBe("tce");
+  });
+
+  test("turn_end variant is handled", () => {
+    const event: EngineEvent = { kind: "turn_end", turnIndex: 0 };
+    expect(engineEventLabel(event)).toBe("end");
+  });
+
+  test("done variant is handled", () => {
+    const event: EngineEvent = {
+      kind: "done",
+      output: {
+        content: [],
+        stopReason: "completed",
+        metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+      },
+    };
+    expect(engineEventLabel(event)).toBe("done");
+  });
+
+  test("custom variant is handled", () => {
+    const event: EngineEvent = { kind: "custom", type: "x", data: null };
+    expect(engineEventLabel(event)).toBe("custom");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChannelStatus shape tests
+// ---------------------------------------------------------------------------
+
+describe("ChannelStatus shape", () => {
+  test("processing status has required fields", () => {
+    const status: ChannelStatus = { kind: "processing", turnIndex: 0 };
+    expect(status.kind).toBe("processing");
+    expect(status.turnIndex).toBe(0);
+  });
+
+  test("idle status with optional fields", () => {
+    const status: ChannelStatus = {
+      kind: "idle",
+      turnIndex: 1,
+      messageRef: "msg-123",
+      detail: "done thinking",
+      metadata: { source: "test" },
+    };
+    expect(status.kind).toBe("idle");
+    expect(status.turnIndex).toBe(1);
+    expect(status.messageRef).toBe("msg-123");
+    expect(status.detail).toBe("done thinking");
+    expect(status.metadata).toEqual({ source: "test" });
+  });
+
+  test("error status is valid", () => {
+    const status: ChannelStatus = { kind: "error", turnIndex: 0 };
+    expect(status.kind).toBe("error");
+  });
+
+  test("ChannelStatusKind type covers all values", () => {
+    const kinds: readonly ChannelStatusKind[] = ["processing", "idle", "error"];
+    expect(kinds).toHaveLength(3);
+  });
+});

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -72,6 +72,7 @@ export type EngineEvent =
       readonly callId: string;
       readonly result: unknown;
     }
+  | { readonly kind: "turn_start"; readonly turnIndex: number }
   | { readonly kind: "turn_end"; readonly turnIndex: number }
   | { readonly kind: "done"; readonly output: EngineOutput }
   | { readonly kind: "custom"; readonly type: string; readonly data: unknown };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,13 @@ export type {
   ToolArtifact,
 } from "./brick-store.js";
 // channel
-export type { ChannelAdapter, ChannelCapabilities, MessageHandler } from "./channel.js";
+export type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  ChannelStatus,
+  ChannelStatusKind,
+  MessageHandler,
+} from "./channel.js";
 // common
 export type { JsonObject } from "./common.js";
 // config

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -2,6 +2,7 @@
  * Middleware contract — sole interposition layer for model/tool calls.
  */
 
+import type { ChannelStatus } from "./channel.js";
 import type { JsonObject } from "./common.js";
 import type { InboundMessage } from "./message.js";
 
@@ -17,6 +18,8 @@ export interface TurnContext {
   readonly messages: readonly InboundMessage[];
   readonly metadata: JsonObject;
   readonly requestApproval?: ApprovalHandler;
+  /** Optional callback to notify channels of turn status. Injected by L1 if configured. */
+  readonly sendStatus?: (status: ChannelStatus) => Promise<void>;
 }
 
 export interface ModelRequest {

--- a/packages/engine/src/__tests__/integration.test.ts
+++ b/packages/engine/src/__tests__/integration.test.ts
@@ -110,7 +110,14 @@ describe("full lifecycle integration", () => {
 
     const collected = await collectEvents(runtime.run({ kind: "text", text: "hello" }));
 
-    expect(collected.map((e) => e.kind)).toEqual(["text_delta", "text_delta", "turn_end", "done"]);
+    expect(collected.map((e) => e.kind)).toEqual([
+      "turn_start",
+      "text_delta",
+      "text_delta",
+      "turn_end",
+      "turn_start",
+      "done",
+    ]);
     expect(runtime.agent.state).toBe("terminated");
   });
 
@@ -307,7 +314,7 @@ describe("input types integration", () => {
     });
 
     const events = await collectEvents(runtime.run({ kind: "text", text: "hello" }));
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2); // turn_start + done
   });
 
   test("accepts messages input", async () => {
@@ -328,7 +335,7 @@ describe("input types integration", () => {
         ],
       }),
     );
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2); // turn_start + done
   });
 });
 

--- a/packages/engine/src/koi.test.ts
+++ b/packages/engine/src/koi.test.ts
@@ -165,12 +165,12 @@ describe("createKoi run lifecycle", () => {
     });
 
     const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
-    expect(events.map((e) => e.kind)).toEqual(["text_delta", "done"]);
+    expect(events.map((e) => e.kind)).toEqual(["turn_start", "text_delta", "done"]);
     expect(runtime.agent.state).toBe("terminated");
   });
 
-  test("yields all events from adapter", async () => {
-    const expectedEvents: readonly EngineEvent[] = [
+  test("yields all events from adapter (plus turn_start)", async () => {
+    const adapterEvents: readonly EngineEvent[] = [
       { kind: "text_delta", delta: "Hello " },
       { kind: "text_delta", delta: "world" },
       { kind: "turn_end", turnIndex: 0 },
@@ -179,21 +179,30 @@ describe("createKoi run lifecycle", () => {
 
     const runtime = await createKoi({
       manifest: testManifest(),
-      adapter: mockAdapter(expectedEvents),
+      adapter: mockAdapter(adapterEvents),
     });
 
     const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
-    expect(events).toEqual(expectedEvents);
+    // turn_start is injected by L1 before adapter events; second turn_start after turn_end
+    expect(events.map((e) => e.kind)).toEqual([
+      "turn_start",
+      "text_delta",
+      "text_delta",
+      "turn_end",
+      "turn_start",
+      "done",
+    ]);
   });
 
-  test("handles empty event stream", async () => {
+  test("handles empty event stream (still emits turn_start)", async () => {
     const runtime = await createKoi({
       manifest: testManifest(),
       adapter: mockAdapter([]),
     });
 
     const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
-    expect(events).toEqual([]);
+    // L1 emits turn_start, then adapter is exhausted → session ends
+    expect(events.map((e) => e.kind)).toEqual(["turn_start"]);
     expect(runtime.agent.state).toBe("terminated");
   });
 });
@@ -387,8 +396,9 @@ describe("createKoi terminal injection", () => {
     });
 
     const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
-    expect(events).toHaveLength(1);
-    expect(events[0]?.kind).toBe("done");
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("turn_start");
+    expect(events[1]?.kind).toBe("done");
   });
 
   test("default tool terminal finds and executes agent tools", async () => {
@@ -1714,7 +1724,270 @@ describe("createKoi live forge resolution", () => {
   });
 });
 
-// onBeforeTurn tests removed — inline iterator (main) does not call onBeforeTurn.
+// ---------------------------------------------------------------------------
+// createKoi — turn_start event emission
+// ---------------------------------------------------------------------------
+
+describe("createKoi turn_start emission", () => {
+  test("turn_start is always first event", async () => {
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([
+        { kind: "text_delta", delta: "Hello" },
+        { kind: "done", output: doneOutput() },
+      ]),
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(events[0]?.kind).toBe("turn_start");
+  });
+
+  test("turn_start has correct turnIndex", async () => {
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([{ kind: "done", output: doneOutput() }]),
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const turnStart = events[0];
+    expect(turnStart?.kind).toBe("turn_start");
+    if (turnStart?.kind === "turn_start") {
+      expect(turnStart.turnIndex).toBe(0);
+    }
+  });
+
+  test("empty adapter stream still gets turn_start", async () => {
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([]),
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("turn_start");
+  });
+
+  test("error stream: turn_start emitted before error", async () => {
+    const { KoiEngineError } = await import("./errors.js");
+    const adapter: EngineAdapter = {
+      engineId: "crash-adapter",
+      stream: () => ({
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<EngineEvent>> {
+              throw KoiEngineError.from("TIMEOUT", "max turns");
+            },
+          };
+        },
+      }),
+    };
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(events[0]?.kind).toBe("turn_start");
+    expect(events[1]?.kind).toBe("done");
+  });
+
+  test("multi-turn: turn_start for each turn", async () => {
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([
+        { kind: "text_delta", delta: "t0" },
+        { kind: "turn_end", turnIndex: 0 },
+        { kind: "text_delta", delta: "t1" },
+        { kind: "turn_end", turnIndex: 1 },
+        { kind: "done", output: doneOutput() },
+      ]),
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      "turn_start",
+      "text_delta",
+      "turn_end",
+      "turn_start",
+      "text_delta",
+      "turn_end",
+      "turn_start",
+      "done",
+    ]);
+
+    // Verify turnIndex values
+    const turnStarts = events.filter((e) => e.kind === "turn_start");
+    if (turnStarts[0]?.kind === "turn_start") expect(turnStarts[0].turnIndex).toBe(0);
+    if (turnStarts[1]?.kind === "turn_start") expect(turnStarts[1].turnIndex).toBe(1);
+    if (turnStarts[2]?.kind === "turn_start") expect(turnStarts[2].turnIndex).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createKoi — onBeforeTurn hook wiring
+// ---------------------------------------------------------------------------
+
+describe("createKoi onBeforeTurn hooks", () => {
+  test("calls onBeforeTurn before first turn", async () => {
+    const onBeforeTurn = mock(() => Promise.resolve());
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([{ kind: "done", output: doneOutput() }]),
+      middleware: [{ name: "test-mw", onBeforeTurn }],
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(onBeforeTurn).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onBeforeTurn for each turn", async () => {
+    const onBeforeTurn = mock(() => Promise.resolve());
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([
+        { kind: "turn_end", turnIndex: 0 },
+        { kind: "turn_end", turnIndex: 1 },
+        { kind: "done", output: doneOutput() },
+      ]),
+      middleware: [{ name: "test-mw", onBeforeTurn }],
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    // 3 turns: initial + after each turn_end
+    expect(onBeforeTurn).toHaveBeenCalledTimes(3);
+  });
+
+  test("onBeforeTurn receives sendStatus from options", async () => {
+    const sendStatus = mock(() => Promise.resolve());
+    let capturedCtx: TurnContext | undefined;
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([{ kind: "done", output: doneOutput() }]),
+      middleware: [
+        {
+          name: "ctx-capture",
+          onBeforeTurn: async (ctx) => {
+            capturedCtx = ctx;
+          },
+        },
+      ],
+      sendStatus,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.sendStatus).toBe(sendStatus);
+  });
+
+  test("onBeforeTurn fires before turn_start event is yielded", async () => {
+    const order: string[] = [];
+    const onBeforeTurn = mock(async () => {
+      order.push("hook");
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([{ kind: "done", output: doneOutput() }]),
+      middleware: [{ name: "test-mw", onBeforeTurn }],
+    });
+
+    for await (const event of runtime.run({ kind: "text", text: "test" })) {
+      if (event.kind === "turn_start") {
+        order.push("event");
+      }
+    }
+
+    expect(order).toEqual(["hook", "event"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createKoi — sendStatus threading
+// ---------------------------------------------------------------------------
+
+describe("createKoi sendStatus threading", () => {
+  test("sendStatus is threaded into cooperating adapter TurnContext", async () => {
+    const sendStatus = mock(() => Promise.resolve());
+    let capturedCtx: TurnContext | undefined;
+
+    const mw: KoiMiddleware = {
+      name: "ctx-capture",
+      wrapModelCall: async (ctx, req, next) => {
+        capturedCtx = ctx;
+        return next(req);
+      },
+    };
+
+    const modelTerminal = mock(() => Promise.resolve({ content: "ok", model: "test" }));
+    const adapter: EngineAdapter = {
+      engineId: "status-adapter",
+      terminals: { modelCall: modelTerminal },
+      stream: (input: EngineInput) => ({
+        async *[Symbol.asyncIterator]() {
+          if (input.callHandlers) {
+            await input.callHandlers.modelCall({ messages: [] });
+          }
+          yield { kind: "done" as const, output: doneOutput() };
+        },
+      }),
+    };
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      middleware: [mw],
+      sendStatus,
+      loopDetection: false,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.sendStatus).toBe(sendStatus);
+  });
+
+  test("no sendStatus means TurnContext.sendStatus is undefined", async () => {
+    let capturedCtx: TurnContext | undefined;
+
+    const mw: KoiMiddleware = {
+      name: "ctx-capture",
+      wrapModelCall: async (ctx, req, next) => {
+        capturedCtx = ctx;
+        return next(req);
+      },
+    };
+
+    const modelTerminal = mock(() => Promise.resolve({ content: "ok", model: "test" }));
+    const adapter: EngineAdapter = {
+      engineId: "no-status-adapter",
+      terminals: { modelCall: modelTerminal },
+      stream: (input: EngineInput) => ({
+        async *[Symbol.asyncIterator]() {
+          if (input.callHandlers) {
+            await input.callHandlers.modelCall({ messages: [] });
+          }
+          yield { kind: "done" as const, output: doneOutput() };
+        },
+      }),
+    };
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      middleware: [mw],
+      loopDetection: false,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.sendStatus).toBeUndefined();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // createKoi — concurrent run() guard (#12A)
@@ -1770,7 +2043,7 @@ describe("createKoi concurrent run guard", () => {
     await collectEvents(runtime.run({ kind: "text", text: "first" }));
     // Second run should work
     const events = await collectEvents(runtime.run({ kind: "text", text: "second" }));
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2); // turn_start + done
   });
 });
 

--- a/packages/engine/src/koi.ts
+++ b/packages/engine/src/koi.ts
@@ -150,6 +150,9 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
           // giving the consumer a chance to inject tools/middleware between turns
           let pendingForgeRefresh = false;
 
+          // let justified: mutable flag — true when a turn_start event should be emitted
+          let shouldEmitTurnStart = true;
+
           // let justified: mutable middleware chain refs, updated at turn boundaries
           let activeToolChain: (ctx: TurnContext, req: ToolRequest) => Promise<ToolResponse>;
           let activeModelChain: (ctx: TurnContext, req: ModelRequest) => Promise<ModelResponse>;
@@ -232,10 +235,15 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
                         messages: inputMessages,
                         metadata: {},
                       };
-                      cachedTurnCtx =
-                        options.approvalHandler !== undefined
-                          ? { ...base, requestApproval: options.approvalHandler }
-                          : base;
+                      cachedTurnCtx = {
+                        ...base,
+                        ...(options.approvalHandler !== undefined
+                          ? { requestApproval: options.approvalHandler }
+                          : {}),
+                        ...(options.sendStatus !== undefined
+                          ? { sendStatus: options.sendStatus }
+                          : {}),
+                      };
                       return cachedTurnCtx;
                     };
                     const rawModelTerminal = adapter.terminals.modelCall;
@@ -316,6 +324,26 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
                   }
                 }
 
+                // Emit turn_start event with onBeforeTurn hooks
+                if (shouldEmitTurnStart) {
+                  shouldEmitTurnStart = false;
+                  const turnCtx: TurnContext = {
+                    session: sessionCtx,
+                    turnIndex: currentTurnIndex,
+                    messages: input.kind === "messages" ? input.messages : [],
+                    metadata: {},
+                    ...(options.approvalHandler !== undefined
+                      ? { requestApproval: options.approvalHandler }
+                      : {}),
+                    ...(options.sendStatus !== undefined ? { sendStatus: options.sendStatus } : {}),
+                  };
+                  await runTurnHooks(allMiddleware, "onBeforeTurn", turnCtx);
+                  return {
+                    done: false,
+                    value: { kind: "turn_start", turnIndex: currentTurnIndex },
+                  };
+                }
+
                 if (!iterator) {
                   done = true;
                   running = false;
@@ -337,7 +365,8 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
                 // Process turn_end events
                 if (event.kind === "turn_end") {
                   currentTurnIndex = event.turnIndex + 1;
-                  const turnCtx = {
+                  shouldEmitTurnStart = true;
+                  const turnCtx: TurnContext = {
                     session: sessionCtx,
                     turnIndex: event.turnIndex,
                     messages: [],
@@ -345,6 +374,7 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
                     ...(options.approvalHandler !== undefined
                       ? { requestApproval: options.approvalHandler }
                       : {}),
+                    ...(options.sendStatus !== undefined ? { sendStatus: options.sendStatus } : {}),
                   };
 
                   // Defer forge refresh to the start of the next next() call,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -6,6 +6,7 @@ import type {
   Agent,
   AgentManifest,
   ApprovalHandler,
+  ChannelStatus,
   ComponentProvider,
   EngineAdapter,
   EngineEvent,
@@ -213,6 +214,8 @@ export interface CreateKoiOptions {
   readonly forge?: ForgeRuntime;
   /** Optional shared process accounter for cross-agent spawn accounting. */
   readonly processAccounter?: ProcessAccounter;
+  /** Optional status handler for turn lifecycle notifications. L1 threads this into TurnContext. */
+  readonly sendStatus?: (status: ChannelStatus) => Promise<void>;
 }
 
 export interface KoiRuntime {

--- a/packages/middleware-turn-ack/package.json
+++ b/packages/middleware-turn-ack/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/middleware-turn-ack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-turn-ack/src/config.test.ts
+++ b/packages/middleware-turn-ack/src/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { validateConfig } from "./config.js";
+
+describe("validateConfig", () => {
+  test("accepts empty config", () => {
+    const result = validateConfig({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts valid debounceMs", () => {
+    const result = validateConfig({ debounceMs: 200 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.debounceMs).toBe(200);
+    }
+  });
+
+  test("accepts zero debounceMs", () => {
+    const result = validateConfig({ debounceMs: 0 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects negative debounceMs", () => {
+    const result = validateConfig({ debounceMs: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("debounceMs");
+    }
+  });
+
+  test("rejects Infinity debounceMs", () => {
+    const result = validateConfig({ debounceMs: Infinity });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects NaN debounceMs", () => {
+    const result = validateConfig({ debounceMs: NaN });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("accepts config with onError callback", () => {
+    const result = validateConfig({ onError: () => {} });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/middleware-turn-ack/src/config.ts
+++ b/packages/middleware-turn-ack/src/config.ts
@@ -1,0 +1,32 @@
+/**
+ * Configuration for TurnAckMiddleware.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+
+export interface TurnAckConfig {
+  /** Debounce threshold in ms. Ack is skipped if turn completes within this time. Default: 100. */
+  readonly debounceMs?: number;
+  /** Send "processing" status with tool name detail on each tool call. Default: true. */
+  readonly toolStatus?: boolean;
+  /** Called when sendStatus fails (e.g., channel disconnected). Default: console.warn. */
+  readonly onError?: (error: unknown) => void;
+}
+
+export function validateConfig(config: TurnAckConfig): Result<TurnAckConfig, KoiError> {
+  if (
+    config.debounceMs !== undefined &&
+    (config.debounceMs < 0 || !Number.isFinite(config.debounceMs))
+  ) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "debounceMs must be a non-negative finite number",
+        retryable: false,
+        context: { debounceMs: config.debounceMs },
+      },
+    };
+  }
+  return { ok: true, value: config };
+}

--- a/packages/middleware-turn-ack/src/index.ts
+++ b/packages/middleware-turn-ack/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @koi/middleware-turn-ack — Two-stage acknowledgement for long-running agent turns (Layer 2)
+ *
+ * Sends "processing" status after a configurable debounce delay,
+ * and "idle" status when the turn completes.
+ * Depends on @koi/core only.
+ */
+
+export type { TurnAckConfig } from "./config.js";
+export { validateConfig } from "./config.js";
+export { createTurnAckMiddleware } from "./turn-ack.js";

--- a/packages/middleware-turn-ack/src/turn-ack.test.ts
+++ b/packages/middleware-turn-ack/src/turn-ack.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ChannelStatus, ToolRequest, ToolResponse, TurnContext } from "@koi/core";
+import { createMockTurnContext } from "@koi/test-utils";
+import { createTurnAckMiddleware } from "./turn-ack.js";
+
+/** Typed sendStatus mock matching the ChannelStatus signature. */
+function mockSendStatus(
+  impl: (_s: ChannelStatus) => Promise<void> = () => Promise.resolve(),
+): ReturnType<typeof mock<(_s: ChannelStatus) => Promise<void>>> {
+  return mock(impl);
+}
+
+/** Creates a TurnContext with a mock sendStatus. */
+function ctxWithStatus(turnIndex = 0, sendStatus = mockSendStatus()): TurnContext {
+  return createMockTurnContext({ turnIndex, sendStatus });
+}
+
+/** Advances fake timers by the given ms. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("createTurnAckMiddleware", () => {
+  test("happy path: sends processing then idle for slow turn", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 50 });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+
+    // Wait for debounce to fire
+    await delay(80);
+
+    // "processing" should have been sent
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "processing", turnIndex: 0 });
+
+    // Turn completes
+    await mw.onAfterTurn?.(ctx);
+
+    // "idle" should also be sent
+    expect(sendStatus).toHaveBeenCalledTimes(2);
+    expect(sendStatus.mock.calls[1]?.[0]).toEqual({ kind: "idle", turnIndex: 0 });
+  });
+
+  test("fast turn debounce: processing skipped, only idle sent", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 100 });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+    // Turn completes before debounce fires
+    await delay(20);
+    await mw.onAfterTurn?.(ctx);
+
+    // Wait past the debounce threshold to make sure processing doesn't fire
+    await delay(150);
+
+    // Only "idle" should have been sent (no "processing")
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "idle", turnIndex: 0 });
+  });
+
+  test("slow turn: ack sent after debounce threshold", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 50 });
+    const ctx = ctxWithStatus(2, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+
+    // Not yet fired
+    await delay(20);
+    expect(sendStatus).toHaveBeenCalledTimes(0);
+
+    // Now past debounce
+    await delay(50);
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "processing", turnIndex: 2 });
+
+    await mw.onAfterTurn?.(ctx);
+    expect(sendStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("no sendStatus: no-op, no errors", async () => {
+    const mw = createTurnAckMiddleware();
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+
+    // Should not throw
+    await mw.onBeforeTurn?.(ctx);
+    await mw.onAfterTurn?.(ctx);
+  });
+
+  test("sendStatus throws: catches and calls onError", async () => {
+    const error = new Error("channel disconnected");
+    const sendStatus = mockSendStatus(() => Promise.reject(error));
+    const onError = mock((_e: unknown) => {});
+    const mw = createTurnAckMiddleware({ debounceMs: 10, onError });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+    await delay(30);
+
+    // Give the catch handler time to execute
+    await delay(10);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBe(error);
+
+    // onAfterTurn idle also fails
+    await mw.onAfterTurn?.(ctx);
+    await delay(10);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  test("custom debounce threshold", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 200 });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+
+    // At 150ms, still within debounce — not fired
+    await delay(150);
+    expect(sendStatus).toHaveBeenCalledTimes(0);
+
+    // At 250ms, past debounce — fired
+    await delay(100);
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "processing", turnIndex: 0 });
+
+    await mw.onAfterTurn?.(ctx);
+  });
+
+  test("AbortController cleanup: no leaked timers", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 100 });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    await mw.onBeforeTurn?.(ctx);
+    // End turn immediately (aborts the debounce timer)
+    await mw.onAfterTurn?.(ctx);
+
+    // Wait well past debounce
+    await delay(200);
+
+    // Only "idle" should have been sent (debounce timer was aborted)
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "idle", turnIndex: 0 });
+  });
+
+  test("wrapToolCall sends processing status with tool name", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware();
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    const toolRequest: ToolRequest = { toolId: "web-search", input: { q: "test" } };
+    const next = mock(async (_req: ToolRequest): Promise<ToolResponse> => ({ output: "result" }));
+
+    const result = await mw.wrapToolCall?.(ctx, toolRequest, next);
+
+    expect(result).toEqual({ output: "result" });
+    expect(next).toHaveBeenCalledTimes(1);
+    // Give fire-and-forget promise time to resolve
+    await delay(10);
+    expect(sendStatus).toHaveBeenCalledTimes(1);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({
+      kind: "processing",
+      turnIndex: 0,
+      detail: "calling web-search",
+    });
+  });
+
+  test("wrapToolCall skipped when toolStatus is false", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ toolStatus: false });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    const toolRequest: ToolRequest = { toolId: "calc", input: {} };
+    const next = mock(async (_req: ToolRequest): Promise<ToolResponse> => ({ output: 42 }));
+
+    await mw.wrapToolCall?.(ctx, toolRequest, next);
+    await delay(10);
+
+    expect(sendStatus).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("wrapToolCall no-ops without sendStatus", async () => {
+    const mw = createTurnAckMiddleware();
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+
+    const toolRequest: ToolRequest = { toolId: "calc", input: {} };
+    const next = mock(async (_req: ToolRequest): Promise<ToolResponse> => ({ output: 1 }));
+
+    const result = await mw.wrapToolCall?.(ctx, toolRequest, next);
+    expect(result).toEqual({ output: 1 });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("wrapToolCall error in sendStatus does not block tool call", async () => {
+    const sendStatus = mockSendStatus(() => Promise.reject(new Error("channel down")));
+    const onError = mock((_e: unknown) => {});
+    const mw = createTurnAckMiddleware({ onError });
+    const ctx = ctxWithStatus(0, sendStatus);
+
+    const toolRequest: ToolRequest = { toolId: "dangerous", input: {} };
+    const next = mock(async (_req: ToolRequest): Promise<ToolResponse> => ({ output: "ok" }));
+
+    const result = await mw.wrapToolCall?.(ctx, toolRequest, next);
+    expect(result).toEqual({ output: "ok" });
+
+    await delay(10);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("multiple turns: each turn gets independent ack lifecycle", async () => {
+    const sendStatus = mockSendStatus();
+    const mw = createTurnAckMiddleware({ debounceMs: 30 });
+
+    // Turn 0 — slow
+    const ctx0 = ctxWithStatus(0, sendStatus);
+    await mw.onBeforeTurn?.(ctx0);
+    await delay(60);
+    await mw.onAfterTurn?.(ctx0);
+
+    // Turn 0 should have processing + idle
+    expect(sendStatus).toHaveBeenCalledTimes(2);
+    expect(sendStatus.mock.calls[0]?.[0]).toEqual({ kind: "processing", turnIndex: 0 });
+    expect(sendStatus.mock.calls[1]?.[0]).toEqual({ kind: "idle", turnIndex: 0 });
+
+    // Turn 1 — fast (debounce skipped)
+    const ctx1 = ctxWithStatus(1, sendStatus);
+    await mw.onBeforeTurn?.(ctx1);
+    await delay(5);
+    await mw.onAfterTurn?.(ctx1);
+
+    // Wait for any lingering timers
+    await delay(60);
+
+    // Turn 1 should only have idle (total: 3 calls)
+    expect(sendStatus).toHaveBeenCalledTimes(3);
+    expect(sendStatus.mock.calls[2]?.[0]).toEqual({ kind: "idle", turnIndex: 1 });
+  });
+});

--- a/packages/middleware-turn-ack/src/turn-ack.ts
+++ b/packages/middleware-turn-ack/src/turn-ack.ts
@@ -1,0 +1,74 @@
+/**
+ * TurnAckMiddleware — two-stage acknowledgement for long-running agent turns.
+ *
+ * Stage 1: "processing" status sent after a debounce delay (skipped for fast turns).
+ * Stage 2: "idle" status sent when the turn completes.
+ *
+ * sendStatus calls are fire-and-forget — they never block the turn.
+ */
+
+import type { KoiMiddleware, ToolHandler, ToolRequest, ToolResponse, TurnContext } from "@koi/core";
+import type { TurnAckConfig } from "./config.js";
+
+export function createTurnAckMiddleware(config?: TurnAckConfig): KoiMiddleware {
+  const debounceMs = config?.debounceMs ?? 100;
+  const toolStatus = config?.toolStatus ?? true;
+  const onError =
+    config?.onError ?? ((e: unknown) => console.warn("TurnAck: sendStatus failed", e));
+
+  // Per-turn state: AbortController for debounce cleanup
+  // let justified: mutable state reset per turn for debounce timer lifecycle
+  let turnAbort: AbortController | undefined;
+
+  return {
+    name: "turn-ack",
+    priority: 50,
+
+    async onBeforeTurn(ctx: TurnContext): Promise<void> {
+      if (ctx.sendStatus === undefined) return;
+
+      // Clean up any previous turn's abort controller
+      turnAbort?.abort();
+      turnAbort = new AbortController();
+      const { signal } = turnAbort;
+      const sendStatus = ctx.sendStatus;
+      const turnIndex = ctx.turnIndex;
+
+      // Debounce: wait debounceMs before sending "processing" status
+      // If the turn completes before the timer fires, the abort cancels it
+      setTimeout(() => {
+        if (signal.aborted) return;
+        sendStatus({ kind: "processing", turnIndex }).catch((e: unknown) => onError(e));
+      }, debounceMs);
+    },
+
+    async onAfterTurn(ctx: TurnContext): Promise<void> {
+      // Abort any pending debounce timer
+      turnAbort?.abort();
+      turnAbort = undefined;
+
+      if (ctx.sendStatus === undefined) return;
+
+      // Fire-and-forget idle status
+      ctx.sendStatus({ kind: "idle", turnIndex: ctx.turnIndex }).catch((e: unknown) => onError(e));
+    },
+
+    async wrapToolCall(
+      ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      if (toolStatus && ctx.sendStatus !== undefined) {
+        // Fire-and-forget: notify channel that a tool is executing
+        ctx
+          .sendStatus({
+            kind: "processing",
+            turnIndex: ctx.turnIndex,
+            detail: `calling ${request.toolId}`,
+          })
+          .catch((e: unknown) => onError(e));
+      }
+      return next(request);
+    },
+  };
+}

--- a/packages/middleware-turn-ack/tsconfig.json
+++ b/packages/middleware-turn-ack/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-turn-ack/tsup.config.ts
+++ b/packages/middleware-turn-ack/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Closes #150

Adds application-level turn lifecycle signals so users know their message is being processed. Implements debounced "processing" status after a configurable threshold (default 100ms) and "idle" status on turn completion.

- **L0 (@koi/core):** Add `turn_start` to `EngineEvent`, `ChannelStatus`/`ChannelStatusKind` types, optional `sendStatus` on `TurnContext`
- **L1 (@koi/engine):** Emit `turn_start` events, wire `onBeforeTurn` hooks (previously defined but never called), thread `sendStatus` into all `TurnContext` construction sites
- **L2 (@koi/middleware-turn-ack — new package):** `createTurnAckMiddleware` with debounce + `AbortController` cleanup, `wrapToolCall` for tool-execution status, fire-and-forget pattern

## Design decisions

| # | Decision |
|---|----------|
| 1 | `sendStatus` is fire-and-forget (`.catch()`, never `await`) — zero latency impact on turns |
| 2 | Debounce via `AbortController` + `setTimeout` — simpler than `Promise.race`, no leaked timers |
| 3 | `wrapToolCall` sends tool name as `detail` field — enables rich "calling web-search" UIs |
| 4 | Priority 50 — runs after guards (0-2) but before business middleware (100+) |
| 5 | `onBeforeTurn` fix is structural — the hook existed in the contract but was never invoked |

## Test plan

- [x] 12 edge-case tests for `@koi/middleware-turn-ack` (debounce, abort, error, multi-turn, tool status)
- [x] 7 config validation tests
- [x] 12 new L0 exhaustiveness + shape tests for `EngineEvent` and `ChannelStatus`
- [x] 11 new L1 tests (`turn_start` emission, `onBeforeTurn` hooks, `sendStatus` threading)
- [x] Updated all existing event sequence assertions to include `turn_start`
- [x] Backward-compat test: CLI channel without `sendStatus` still works
- [x] Full build (48/48), test, and typecheck pass