### PR TITLE
perf: fix 5 performance issues across search and gateway

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -171,9 +171,12 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
             }
           : { ...currentSession, remoteSeq: readyFrame.seq, lastHeartbeat: Date.now() };
       currentSession = routedSession;
-      await store.set(currentSession);
       dispatchFrame(currentSession, readyFrame);
       conn.send(buildAckFrame(currentSession.seq, readyFrame.id));
+    }
+    // Persist final session state once (dispatch/ack use in-memory state)
+    if (acceptance.ready.length > 0) {
+      await store.set(currentSession);
     }
   }
 

--- a/packages/gateway/src/transport.ts
+++ b/packages/gateway/src/transport.ts
@@ -63,6 +63,7 @@ export function createBunTransport(): BunTransport {
     listen(port: number, handler: TransportHandler): Promise<void> {
       // Map from Bun's ServerWebSocket id → TransportConnection
       const connMap = new Map<string, TransportConnection>();
+      const decoder = new TextDecoder();
 
       server = Bun.serve({
         port,
@@ -92,7 +93,7 @@ export function createBunTransport(): BunTransport {
             const id = (ws.data as { readonly id: string }).id;
             const conn = connMap.get(id);
             if (conn === undefined) return;
-            const data = typeof message === "string" ? message : new TextDecoder().decode(message);
+            const data = typeof message === "string" ? message : decoder.decode(message);
             handler.onMessage(conn, data);
           },
           close(ws, code, reason) {

--- a/packages/search/src/__tests__/e2e.test.ts
+++ b/packages/search/src/__tests__/e2e.test.ts
@@ -224,4 +224,37 @@ describe("E2E: createSearch full pipeline", () => {
 
     search.close();
   });
+
+  test("embed is called once per document during indexing, not twice", async () => {
+    let embedCallCount = 0;
+    const base = createMockEmbedder();
+    const countingEmbedder: Embedder = {
+      dimensions: base.dimensions,
+      embed: async (text: string) => {
+        embedCallCount++;
+        return base.embed(text);
+      },
+      embedMany: async (texts: readonly string[]) => {
+        embedCallCount += texts.length;
+        return base.embedMany(texts);
+      },
+    };
+
+    const search = createSearch({ embedder: countingEmbedder });
+    const docs = [
+      { id: "a", content: "alpha document" },
+      { id: "b", content: "beta document" },
+      { id: "c", content: "gamma document" },
+    ] as const;
+
+    embedCallCount = 0;
+    await search.indexer.index(docs);
+
+    // Each doc should be embedded exactly once (3 docs = 3 embeds from the
+    // index wrapper). The sqlite-indexer receives enriched docs with
+    // pre-computed embeddings so it should not re-embed single-chunk docs.
+    expect(embedCallCount).toBe(3);
+
+    search.close();
+  });
 });

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -18,6 +18,7 @@ import type { TemporalDecayConfig } from "./hybrid/temporal-decay.js";
 import type { ChunkerConfig } from "./indexer/chunker.js";
 import { createSqliteIndexer } from "./indexer/sqlite-indexer.js";
 import type { QueryExpansionConfig } from "./query/expand.js";
+import type { IndexDocument } from "./types.js";
 import { createVectorStore } from "./vector/sqlite-vec.js";
 import { createVectorRetriever } from "./vector/vector-retriever.js";
 
@@ -109,7 +110,8 @@ export function createSearch(config: KoiSearchConfig): KoiSearch {
   // Wrap the indexer to also update BM25 + content stores
   const indexer: Indexer = {
     index: async (documents) => {
-      // Update BM25 index and content store
+      // Compute embeddings once and enrich documents for downstream consumers
+      const enriched: IndexDocument[] = [];
       for (const doc of documents) {
         const tokens = defaultTokenize(doc.content);
         bm25Index = bm25Index.add(doc.id, tokens);
@@ -120,17 +122,14 @@ export function createSearch(config: KoiSearchConfig): KoiSearch {
         });
         contentStore.set(doc.id, doc.content);
 
-        // Also insert into vector store
-        if (doc.embedding) {
-          vectorStore.insert(doc.id, doc.embedding, doc.metadata ?? {});
-        } else {
-          const emb = await embedder.embed(doc.content);
-          vectorStore.insert(doc.id, emb, doc.metadata ?? {});
-        }
+        // Compute embedding once — reuse pre-computed if available
+        const emb = doc.embedding ?? (await embedder.embed(doc.content));
+        vectorStore.insert(doc.id, emb, doc.metadata ?? {});
+        enriched.push({ ...doc, embedding: emb });
       }
 
-      // Also run through sqlite indexer for FTS5
-      return sqliteIndexer.index(documents);
+      // Pass enriched docs so sqliteIndexer skips re-embedding single-chunk docs
+      return sqliteIndexer.index(enriched);
     },
     remove: async (ids) => {
       for (const id of ids) {

--- a/packages/search/src/vector/sqlite-vec.test.ts
+++ b/packages/search/src/vector/sqlite-vec.test.ts
@@ -161,4 +161,21 @@ describe("VectorStore", () => {
     expect(results[0]?.metadata).toEqual({ title: "test" });
     store.close();
   });
+
+  test("batch metadata query returns correct metadata for multiple hits", () => {
+    const store = createVectorStore({ dbPath: ":memory:", dimensions: dims });
+    // Insert several docs with distinct metadata
+    for (let i = 0; i < 20; i++) {
+      store.insert(`doc${i}`, makeEmbedding(i, dims), { index: i, label: `item-${i}` });
+    }
+
+    // Search should return multiple hits, each with correct metadata (batch-fetched)
+    const results = store.search(makeEmbedding(0, dims), 10);
+    expect(results.length).toBe(10);
+    for (const hit of results) {
+      const idx = Number(hit.id.replace("doc", ""));
+      expect(hit.metadata).toEqual({ index: idx, label: `item-${idx}` });
+    }
+    store.close();
+  });
 });

--- a/packages/search/src/vector/sqlite-vec.ts
+++ b/packages/search/src/vector/sqlite-vec.ts
@@ -101,7 +101,21 @@ export function createVectorStore(config: VectorStoreConfig): VectorStore {
     : db.prepare("INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)");
   const deleteMeta = db.prepare("DELETE FROM chunks_meta WHERE id = ?");
   const deleteVec = db.prepare("DELETE FROM chunks_vec WHERE id = ?");
-  const selectMeta = db.prepare("SELECT metadata FROM chunks_meta WHERE id = ?");
+  const selectAllVec = db.prepare("SELECT id, embedding FROM chunks_vec");
+
+  /** Batch-fetch metadata for a set of IDs in one query. */
+  function batchGetMeta(ids: readonly string[]): ReadonlyMap<string, Record<string, unknown>> {
+    if (ids.length === 0) return new Map();
+    const placeholders = ids.map(() => "?").join(",");
+    const rows = db
+      .prepare(`SELECT id, metadata FROM chunks_meta WHERE id IN (${placeholders})`)
+      .all(...ids) as readonly { id: string; metadata: string }[];
+    const map = new Map<string, Record<string, unknown>>();
+    for (const row of rows) {
+      map.set(row.id, JSON.parse(row.metadata) as Record<string, unknown>);
+    }
+    return map;
+  }
 
   function searchNative(embedding: readonly number[], limit: number): readonly VectorHit[] {
     const blob = serializeEmbedding(embedding);
@@ -115,9 +129,9 @@ export function createVectorStore(config: VectorStoreConfig): VectorStore {
       )
       .all(blob, limit) as readonly { id: string; distance: number }[];
 
+    const metaMap = batchGetMeta(rows.map((r) => r.id));
     return rows.map((row) => {
-      const metaRow = selectMeta.get(row.id) as { metadata: string } | undefined;
-      const metadata = metaRow ? (JSON.parse(metaRow.metadata) as Record<string, unknown>) : {};
+      const metadata = metaMap.get(row.id) ?? {};
       // Convert distance to similarity score in [0, 1]: smaller distance = higher score
       const score = 1 / (1 + row.distance);
       return { id: row.id, score, metadata };
@@ -125,7 +139,6 @@ export function createVectorStore(config: VectorStoreConfig): VectorStore {
   }
 
   function searchBruteForce(embedding: readonly number[], limit: number): readonly VectorHit[] {
-    const selectAllVec = db.prepare("SELECT id, embedding FROM chunks_vec");
     const rows = selectAllVec.all() as readonly { id: string; embedding: Uint8Array }[];
     const scored: { id: string; score: number }[] = [];
 
@@ -138,9 +151,9 @@ export function createVectorStore(config: VectorStoreConfig): VectorStore {
     scored.sort((a, b) => b.score - a.score);
     const top = scored.slice(0, limit);
 
+    const metaMap = batchGetMeta(top.map((h) => h.id));
     return top.map((hit) => {
-      const metaRow = selectMeta.get(hit.id) as { metadata: string } | undefined;
-      const metadata = metaRow ? (JSON.parse(metaRow.metadata) as Record<string, unknown>) : {};
+      const metadata = metaMap.get(hit.id) ?? {};
       return { id: hit.id, score: hit.score, metadata };
     });
   }


### PR DESCRIPTION
## Summary

- **Eliminate duplicate embedding during indexing** (`@koi/search`): compute embedding once per doc, pass enriched docs to sqlite-indexer so it skips re-embedding single-chunk documents
- **Batch N+1 metadata lookups in vector search** (`@koi/search`): replace per-hit `selectMeta.get()` with a single `WHERE id IN (...)` query in both `searchNative` and `searchBruteForce`
- **Hoist `selectAllVec` prepared statement** (`@koi/search`): move to outer closure alongside other prepared statements instead of re-creating per call
- **Move session persistence outside ready-frame loop** (`@koi/gateway`): accumulate session state through the loop, write once after — N ready frames = 1 store write instead of N
- **Hoist `TextDecoder` allocation** (`@koi/gateway`): one instance per listener scope instead of one per binary WebSocket message

## Test plan

- [x] `bun test packages/search/` — 162 pass, 0 fail (98% func / 97% line coverage)
- [x] `bun test packages/gateway/` — 215 pass, 0 fail (99% func / 98% line coverage)
- [x] New regression test: batch metadata query returns correct metadata for 20 docs
- [x] New regression test: embed called exactly once per doc during indexing (not twice)
- [x] Pre-push hook: build + typecheck + tests all green