### PR TITLE
feat: add Resolver.source() — Level 3 progressive disclosure

### DIFF
--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -79,6 +79,8 @@ import type {
   // middleware
   SessionContext,
   SkillMetadata,
+  SourceBundle,
+  SourceLanguage,
   SpawnCheck,
   // ecs
   SubsystemToken,
@@ -191,7 +193,10 @@ type _TypeGuard =
   | AssertDefined<EvictionCandidate>
   | AssertDefined<EvictionReason>
   | AssertDefined<EvictionResult>
-  | AssertDefined<EvictionPolicy>;
+  | AssertDefined<EvictionPolicy>
+  // resolver source types
+  | AssertDefined<SourceBundle>
+  | AssertDefined<SourceLanguage>;
 
 describe("export inventory", () => {
   test("all runtime values are defined", () => {

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -31,6 +31,8 @@ import type {
   Result,
   RevocationRegistry,
   ScopeChecker,
+  SourceBundle,
+  SourceLanguage,
   SpawnCheck,
   SubsystemToken,
   Tool,
@@ -1103,5 +1105,94 @@ describe("ModelConfig fallbacks", () => {
     };
     // @ts-expect-error — cannot assign to readonly property
     config.fallbacks = [];
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SourceBundle and SourceLanguage type tests
+// ---------------------------------------------------------------------------
+
+describe("SourceBundle", () => {
+  test("minimal SourceBundle without files", () => {
+    const bundle: SourceBundle = { content: "return 1;", language: "typescript" };
+    expect(bundle.content).toBe("return 1;");
+    expect(bundle.language).toBe("typescript");
+    expect(bundle.files).toBeUndefined();
+  });
+
+  test("SourceBundle with files", () => {
+    const bundle: SourceBundle = {
+      content: "return 1;",
+      language: "typescript",
+      files: { "helper.ts": "export const x = 1;" },
+    };
+    expect(bundle.files).toBeDefined();
+  });
+
+  test("SourceBundle properties are readonly", () => {
+    const bundle: SourceBundle = { content: "x", language: "json" };
+    // @ts-expect-error — cannot assign to readonly property
+    bundle.content = "y";
+    // @ts-expect-error — cannot assign to readonly property
+    bundle.language = "yaml";
+  });
+});
+
+describe("SourceLanguage", () => {
+  test("accepts all valid language literals", () => {
+    const langs: readonly SourceLanguage[] = [
+      "typescript",
+      "javascript",
+      "markdown",
+      "yaml",
+      "json",
+    ];
+    expect(langs).toHaveLength(5);
+  });
+});
+
+describe("Resolver.source", () => {
+  test("source is optional on Resolver", () => {
+    type ToolMeta = { readonly name: string };
+    const r: Resolver<ToolMeta, Tool> = {
+      discover: async () => [],
+      load: async () => ({
+        ok: true,
+        value: {
+          descriptor: { name: "t", description: "d", inputSchema: {} },
+          trustTier: "sandbox",
+          execute: async () => ({}),
+        },
+      }),
+    };
+    expect(r.source).toBeUndefined();
+  });
+
+  test("source returns Result<SourceBundle, KoiError>", async () => {
+    type ToolMeta = { readonly name: string };
+    const r: Resolver<ToolMeta, Tool> = {
+      discover: async () => [],
+      load: async () => ({
+        ok: true,
+        value: {
+          descriptor: { name: "t", description: "d", inputSchema: {} },
+          trustTier: "sandbox",
+          execute: async () => ({}),
+        },
+      }),
+      source: async () => ({
+        ok: true,
+        value: { content: "return 1;", language: "typescript" },
+      }),
+    };
+    expect(r.source).toBeDefined();
+    const result = await r.source?.("t");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe("return 1;");
+      expect(result.value.language).toBe("typescript");
+    }
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -244,7 +244,7 @@ export type {
 // model provider
 export type { ModelCapabilities, ModelProvider, ModelTarget } from "./model-provider.js";
 // resolver
-export type { Resolver } from "./resolver.js";
+export type { Resolver, SourceBundle, SourceLanguage } from "./resolver.js";
 // sandbox executor — code execution in isolation (forge verification contract)
 export type {
   SandboxError,

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -4,8 +4,25 @@
 
 import type { KoiError, Result } from "./errors.js";
 
+// ---------------------------------------------------------------------------
+// Source types — Level 3 progressive disclosure (full source code)
+// ---------------------------------------------------------------------------
+
+export type SourceLanguage = "typescript" | "javascript" | "markdown" | "yaml" | "json";
+
+export interface SourceBundle {
+  readonly content: string;
+  readonly language: SourceLanguage;
+  readonly files?: Readonly<Record<string, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver contract
+// ---------------------------------------------------------------------------
+
 export interface Resolver<TMeta, TFull> {
   readonly discover: () => Promise<readonly TMeta[]>;
   readonly load: (id: string) => Promise<Result<TFull, KoiError>>;
   readonly onChange?: (listener: () => void) => () => void;
+  readonly source?: (id: string) => Promise<Result<SourceBundle, KoiError>>;
 }

--- a/packages/forge/src/forge-resolver.test.ts
+++ b/packages/forge/src/forge-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { createForgeResolver } from "./forge-resolver.js";
+import { createForgeResolver, extractSource } from "./forge-resolver.js";
 import { createInMemoryForgeStore } from "./memory-store.js";
-import type { ToolArtifact } from "./types.js";
+import type { AgentArtifact, CompositeArtifact, SkillArtifact, ToolArtifact } from "./types.js";
 
 function createBrick(overrides?: Partial<ToolArtifact>): ToolArtifact {
   return {
@@ -20,6 +20,66 @@ function createBrick(overrides?: Partial<ToolArtifact>): ToolArtifact {
     contentHash: "test-hash",
     implementation: "return 1;",
     inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+function createSkillBrick(overrides?: Partial<SkillArtifact>): SkillArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "skill",
+    name: "test-skill",
+    description: "A test skill",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    contentHash: "test-hash",
+    content: "# How to greet\nSay hello.",
+    ...overrides,
+  };
+}
+
+function createAgentBrick(overrides?: Partial<AgentArtifact>): AgentArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "agent",
+    name: "test-agent",
+    description: "A test agent",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    contentHash: "test-hash",
+    manifestYaml: "name: test-agent\nversion: 0.0.1",
+    ...overrides,
+  };
+}
+
+function createCompositeBrick(overrides?: Partial<CompositeArtifact>): CompositeArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "composite",
+    name: "test-composite",
+    description: "A test composite",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    contentHash: "test-hash",
+    brickIds: ["brick_a", "brick_b"],
     ...overrides,
   };
 }
@@ -90,5 +150,88 @@ describe("createForgeResolver", () => {
     };
     const resolver = createForgeResolver(failingStore);
     await expect(resolver.discover()).rejects.toThrow("store down");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSource
+// ---------------------------------------------------------------------------
+
+describe("extractSource", () => {
+  test("tool brick returns implementation as typescript", () => {
+    const brick = createBrick({ implementation: "return 42;" });
+    const bundle = extractSource(brick);
+    expect(bundle.content).toBe("return 42;");
+    expect(bundle.language).toBe("typescript");
+    expect(bundle.files).toBeUndefined();
+  });
+
+  test("skill brick returns content as markdown", () => {
+    const brick = createSkillBrick({ content: "# Greeting\nSay hi." });
+    const bundle = extractSource(brick);
+    expect(bundle.content).toBe("# Greeting\nSay hi.");
+    expect(bundle.language).toBe("markdown");
+  });
+
+  test("agent brick returns manifestYaml as yaml", () => {
+    const brick = createAgentBrick({ manifestYaml: "name: agent\nversion: 1.0" });
+    const bundle = extractSource(brick);
+    expect(bundle.content).toBe("name: agent\nversion: 1.0");
+    expect(bundle.language).toBe("yaml");
+  });
+
+  test("composite brick returns JSON brickIds as json", () => {
+    const brick = createCompositeBrick({ brickIds: ["a", "b", "c"] });
+    const bundle = extractSource(brick);
+    expect(bundle.language).toBe("json");
+    expect(JSON.parse(bundle.content)).toEqual(["a", "b", "c"]);
+  });
+
+  test("includes companion files when present", () => {
+    const files = { "helper.ts": "export const x = 1;" };
+    const brick = createBrick({ files });
+    const bundle = extractSource(brick);
+    expect(bundle.files).toEqual(files);
+  });
+
+  test("omits files field when not present on brick", () => {
+    const brick = createBrick();
+    const bundle = extractSource(brick);
+    expect("files" in bundle).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ForgeResolver.source()
+// ---------------------------------------------------------------------------
+
+describe("ForgeResolver.source()", () => {
+  test("source returns content for tool brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "t1", implementation: "return 42;" }));
+
+    const resolver = createForgeResolver(store);
+    expect(resolver.source).toBeDefined();
+    const result = await resolver.source?.("t1");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe("return 42;");
+      expect(result.value.language).toBe("typescript");
+    }
+  });
+
+  test("source returns NOT_FOUND for missing id", async () => {
+    const store = createInMemoryForgeStore();
+    const resolver = createForgeResolver(store);
+    expect(resolver.source).toBeDefined();
+    const result = await resolver.source?.("nonexistent");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
   });
 });

--- a/packages/forge/src/forge-resolver.ts
+++ b/packages/forge/src/forge-resolver.ts
@@ -3,7 +3,32 @@
  * Implements the L0 Resolver<BrickArtifact, BrickArtifact> interface.
  */
 
-import type { BrickArtifact, ForgeStore, KoiError, Resolver, Result } from "@koi/core";
+import type {
+  BrickArtifact,
+  ForgeStore,
+  KoiError,
+  Resolver,
+  Result,
+  SourceBundle,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Source extraction — pure function, exhaustive over BrickArtifact union
+// ---------------------------------------------------------------------------
+
+export function extractSource(brick: BrickArtifact): SourceBundle {
+  const files = brick.files !== undefined ? { files: brick.files } : {};
+  switch (brick.kind) {
+    case "tool":
+      return { content: brick.implementation, language: "typescript", ...files };
+    case "skill":
+      return { content: brick.content, language: "markdown", ...files };
+    case "agent":
+      return { content: brick.manifestYaml, language: "yaml", ...files };
+    case "composite":
+      return { content: JSON.stringify(brick.brickIds, null, 2), language: "json", ...files };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -24,5 +49,13 @@ export function createForgeResolver(store: ForgeStore): Resolver<BrickArtifact, 
     return store.load(id);
   };
 
-  return { discover, load };
+  const source = async (id: string): Promise<Result<SourceBundle, KoiError>> => {
+    const result = await store.load(id);
+    if (!result.ok) {
+      return result;
+    }
+    return { ok: true, value: extractSource(result.value) };
+  };
+
+  return { discover, load, source };
 }

--- a/packages/mcp/src/resolver.test.ts
+++ b/packages/mcp/src/resolver.test.ts
@@ -162,4 +162,10 @@ describe("createMcpResolver", () => {
       expect(result2.value.descriptor.name).toBe("mcp/github/create_pr");
     }
   });
+
+  test("source is not defined on MCP resolver", () => {
+    const managers = createTestManagers();
+    const resolver = createMcpResolver(managers);
+    expect(resolver.source).toBeUndefined();
+  });
 });

--- a/packages/node/src/tools/local-resolver.test.ts
+++ b/packages/node/src/tools/local-resolver.test.ts
@@ -105,4 +105,45 @@ describe("LocalResolver", () => {
       }
     });
   });
+
+  describe("source", () => {
+    it("returns JSON content for directory tool", async () => {
+      const resolver = createLocalResolver({
+        directories: [testDir],
+        builtins: { filesystem: false, shell: false },
+      });
+      const result = await resolver.source("calculator");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.language).toBe("json");
+        const parsed = JSON.parse(result.value.content);
+        expect(parsed.name).toBe("calculator");
+      }
+    });
+
+    it("returns NOT_FOUND with actionable message for built-in tool", async () => {
+      const resolver = createLocalResolver({
+        directories: [],
+        builtins: { filesystem: true, shell: false },
+      });
+      const result = await resolver.source("filesystem");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+        expect(result.error.message).toContain("Shadow pattern");
+      }
+    });
+
+    it("returns NOT_FOUND for unknown tool", async () => {
+      const resolver = createLocalResolver({
+        directories: [],
+        builtins: { filesystem: false, shell: false },
+      });
+      const result = await resolver.source("nonexistent");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    });
+  });
 });

--- a/packages/node/src/tools/local-resolver.ts
+++ b/packages/node/src/tools/local-resolver.ts
@@ -5,7 +5,7 @@
  * Priority: local config > built-in defaults (first-wins).
  */
 
-import type { KoiError, Result, Tool, ToolDescriptor } from "@koi/core";
+import type { KoiError, Result, SourceBundle, Tool, ToolDescriptor } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core";
 import type { ToolResolverConfig } from "../types.js";
 import { createFilesystemTool } from "./filesystem.js";
@@ -26,6 +26,7 @@ export interface LocalResolver {
   /** Synchronous list of already-discovered tools. Empty if discover() hasn't been called. */
   readonly list: () => readonly ToolMeta[];
   readonly load: (id: string) => Promise<Result<Tool, KoiError>>;
+  readonly source: (id: string) => Promise<Result<SourceBundle, KoiError>>;
   readonly onChange?: (listener: () => void) => () => void;
 }
 
@@ -36,6 +37,7 @@ export interface LocalResolver {
 export function createLocalResolver(config: ToolResolverConfig): LocalResolver {
   const tools = new Map<string, Tool>();
   const toolSources = new Map<string, "builtin" | "directory">();
+  const toolPaths = new Map<string, string>();
   // let: lazy discovery flag, set once after initial scan
   let discovered = false;
 
@@ -119,6 +121,7 @@ export function createLocalResolver(config: ToolResolverConfig): LocalResolver {
 
           tools.set(name, tool);
           toolSources.set(name, "directory");
+          toolPaths.set(name, filePath);
         } catch {
           // Skip malformed tool definitions
         }
@@ -161,6 +164,59 @@ export function createLocalResolver(config: ToolResolverConfig): LocalResolver {
         };
       }
       return { ok: true, value: tool };
+    },
+
+    async source(id) {
+      await ensureDiscovered();
+      const src = toolSources.get(id);
+      if (src === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `Tool not found: ${id}`,
+            retryable: RETRYABLE_DEFAULTS.NOT_FOUND,
+            context: { toolId: id },
+          },
+        };
+      }
+      if (src === "builtin") {
+        return {
+          ok: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `Built-in tool "${id}" has no readable source. Use Shadow pattern to override.`,
+            retryable: RETRYABLE_DEFAULTS.NOT_FOUND,
+            context: { toolId: id, source: "builtin" },
+          },
+        };
+      }
+      const filePath = toolPaths.get(id);
+      if (filePath === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: "INTERNAL",
+            message: `No file path tracked for directory tool: ${id}`,
+            retryable: false,
+            context: { toolId: id },
+          },
+        };
+      }
+      try {
+        const content = await Bun.file(filePath).text();
+        return { ok: true, value: { content, language: "json" as const } };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: {
+            code: "INTERNAL",
+            message: `Failed to read source for tool "${id}": ${e instanceof Error ? e.message : String(e)}`,
+            retryable: false,
+            context: { toolId: id, filePath },
+          },
+        };
+      }
     },
   };
 }

--- a/scripts/e2e-source.ts
+++ b/scripts/e2e-source.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env bun
+/**
+ * Manual E2E test — Resolver.source() with real LLM call.
+ *
+ * Validates the complete source() pipeline:
+ *   1. ForgeResolver.source() for all 4 brick kinds
+ *   2. LocalResolver.source() for directory + built-in tools
+ *   3. Real LLM (Claude Haiku) reads source and reasons about it
+ *   4. Real LLM identifies a bug in source code (the Fork use case)
+ *
+ * Run:
+ *   bun scripts/e2e-source.ts          (reads ANTHROPIC_API_KEY from .env)
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SourceBundle, ToolArtifact } from "../packages/core/src/index.js";
+import { createForgeResolver } from "../packages/forge/src/forge-resolver.js";
+import { createInMemoryForgeStore } from "../packages/forge/src/memory-store.js";
+import { createLocalResolver } from "../packages/node/src/tools/local-resolver.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+if (!ANTHROPIC_KEY) {
+  console.error("ERROR: ANTHROPIC_API_KEY not set. Skipping LLM tests.");
+  console.error("Set ANTHROPIC_API_KEY in .env or environment.");
+}
+
+let passed = 0;
+let failed = 0;
+
+function ok(name: string): void {
+  passed++;
+  console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+}
+
+function fail(name: string, error: unknown): void {
+  failed++;
+  console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+  if (error instanceof Error) {
+    console.log(`    ${error.message}`);
+    if (error.cause) console.log(`    cause: ${JSON.stringify(error.cause)}`);
+  } else if (typeof error === "object" && error !== null) {
+    console.log(`    ${JSON.stringify(error, null, 2)}`);
+  } else {
+    console.log(`    ${String(error)}`);
+  }
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createToolBrick(overrides?: Partial<ToolArtifact>): ToolArtifact {
+  return {
+    id: `brick_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "tool",
+    name: "fibonacci",
+    description: "Computes the Nth Fibonacci number using dynamic programming",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: ["math"],
+    usageCount: 0,
+    contentHash: "abc123",
+    implementation: [
+      "function fibonacci(n: number): number {",
+      "  if (n <= 1) return n;",
+      "  let a = 0, b = 1;",
+      "  for (let i = 2; i <= n; i++) {",
+      "    const c = a + b;",
+      "    a = b;",
+      "    b = c;",
+      "  }",
+      "  return b;",
+      "}",
+      "return fibonacci(input.n);",
+    ].join("\n"),
+    inputSchema: { type: "object", properties: { n: { type: "number" } } },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Part 1: ForgeResolver.source() — all 4 brick kinds
+// ---------------------------------------------------------------------------
+
+async function testForgeResolverSource(): Promise<void> {
+  console.log("\n\x1b[1mPart 1: ForgeResolver.source()\x1b[0m");
+
+  // Tool → typescript
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "fib-1" }));
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("fib-1");
+    assert(result.ok === true, "expected ok");
+    if (!result.ok) throw new Error("unreachable");
+    assert(
+      result.value.language === "typescript",
+      `expected typescript, got ${result.value.language}`,
+    );
+    assert(result.value.content.includes("fibonacci"), "expected fibonacci in content");
+    ok("tool brick → typescript source");
+  } catch (e: unknown) {
+    fail("tool brick → typescript source", e);
+  }
+
+  // Skill → markdown
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save({
+      id: "skill-1",
+      kind: "skill",
+      name: "greeting-guide",
+      description: "How to greet",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "a1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      contentHash: "h1",
+      content: "# Greeting Guide\n\nSay hello warmly.",
+    });
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("skill-1");
+    assert(result.ok === true, "expected ok");
+    if (!result.ok) throw new Error("unreachable");
+    assert(result.value.language === "markdown", `expected markdown, got ${result.value.language}`);
+    assert(result.value.content.includes("# Greeting Guide"), "expected heading in content");
+    ok("skill brick → markdown source");
+  } catch (e: unknown) {
+    fail("skill brick → markdown source", e);
+  }
+
+  // Agent → yaml
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save({
+      id: "agent-1",
+      kind: "agent",
+      name: "math-agent",
+      description: "Math",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "a1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      contentHash: "h2",
+      manifestYaml: "name: math-agent\nversion: 0.0.1\nmodel: gpt-4o-mini",
+    });
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("agent-1");
+    assert(result.ok === true, "expected ok");
+    if (!result.ok) throw new Error("unreachable");
+    assert(result.value.language === "yaml", `expected yaml, got ${result.value.language}`);
+    assert(result.value.content.includes("math-agent"), "expected agent name in content");
+    ok("agent brick → yaml source");
+  } catch (e: unknown) {
+    fail("agent brick → yaml source", e);
+  }
+
+  // Composite → json
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save({
+      id: "comp-1",
+      kind: "composite",
+      name: "math-suite",
+      description: "Combined",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "a1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      contentHash: "h3",
+      brickIds: ["fib-1", "skill-1"],
+    });
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("comp-1");
+    assert(result.ok === true, "expected ok");
+    if (!result.ok) throw new Error("unreachable");
+    assert(result.value.language === "json", `expected json, got ${result.value.language}`);
+    const ids = JSON.parse(result.value.content) as readonly string[];
+    assert(ids.includes("fib-1"), "expected fib-1 in brickIds");
+    ok("composite brick → json source");
+  } catch (e: unknown) {
+    fail("composite brick → json source", e);
+  }
+
+  // NOT_FOUND
+  try {
+    const store = createInMemoryForgeStore();
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("nonexistent");
+    assert(result.ok === false, "expected error");
+    if (result.ok) throw new Error("unreachable");
+    assert(result.error.code === "NOT_FOUND", `expected NOT_FOUND, got ${result.error.code}`);
+    ok("missing brick → NOT_FOUND");
+  } catch (e: unknown) {
+    fail("missing brick → NOT_FOUND", e);
+  }
+
+  // Companion files
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createToolBrick({ id: "with-files", files: { "helper.ts": "export const PI = 3.14;" } }),
+    );
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const result = await resolver.source("with-files");
+    assert(result.ok === true, "expected ok");
+    if (!result.ok) throw new Error("unreachable");
+    assert(result.value.files !== undefined, "expected files");
+    const helperContent = result.value.files?.["helper.ts"];
+    assert(helperContent !== undefined, "expected helper.ts in files");
+    assert(helperContent.includes("PI"), "expected PI in helper");
+    ok("companion files included");
+  } catch (e: unknown) {
+    fail("companion files included", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Part 2: LocalResolver.source()
+// ---------------------------------------------------------------------------
+
+async function testLocalResolverSource(): Promise<void> {
+  console.log("\n\x1b[1mPart 2: LocalResolver.source()\x1b[0m");
+
+  const testDir = await mkdtemp(join(tmpdir(), "koi-source-e2e-"));
+  await Bun.write(
+    join(testDir, "calc.tool.json"),
+    JSON.stringify({
+      name: "calculator",
+      description: "A simple calculator",
+      inputSchema: { type: "object", properties: { expression: { type: "string" } } },
+      command: 'echo "result"',
+    }),
+  );
+
+  try {
+    // Directory tool → JSON
+    try {
+      const resolver = createLocalResolver({
+        directories: [testDir],
+        builtins: { filesystem: false, shell: false },
+      });
+      const result = await resolver.source("calculator");
+      assert(result.ok === true, "expected ok");
+      if (!result.ok) throw new Error("unreachable");
+      assert(result.value.language === "json", `expected json, got ${result.value.language}`);
+      const parsed = JSON.parse(result.value.content) as { readonly name: string };
+      assert(parsed.name === "calculator", `expected calculator, got ${parsed.name}`);
+      ok("directory tool → JSON source");
+    } catch (e: unknown) {
+      fail("directory tool → JSON source", e);
+    }
+
+    // Built-in → NOT_FOUND with Shadow pattern message
+    try {
+      const resolver = createLocalResolver({
+        directories: [],
+        builtins: { filesystem: true, shell: false },
+      });
+      const result = await resolver.source("filesystem");
+      assert(result.ok === false, "expected error");
+      if (result.ok) throw new Error("unreachable");
+      assert(result.error.code === "NOT_FOUND", `expected NOT_FOUND, got ${result.error.code}`);
+      assert(result.error.message.includes("Shadow pattern"), "expected Shadow pattern hint");
+      ok("built-in tool → NOT_FOUND with Shadow pattern message");
+    } catch (e: unknown) {
+      fail("built-in tool → NOT_FOUND with Shadow pattern message", e);
+    }
+
+    // Unknown → NOT_FOUND
+    try {
+      const resolver = createLocalResolver({
+        directories: [],
+        builtins: { filesystem: false, shell: false },
+      });
+      const result = await resolver.source("nonexistent");
+      assert(result.ok === false, "expected error");
+      if (result.ok) throw new Error("unreachable");
+      assert(result.error.code === "NOT_FOUND", `expected NOT_FOUND, got ${result.error.code}`);
+      ok("unknown tool → NOT_FOUND");
+    } catch (e: unknown) {
+      fail("unknown tool → NOT_FOUND", e);
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Part 3: Real LLM (Anthropic Claude) reads source() output and reasons
+// ---------------------------------------------------------------------------
+
+interface AnthropicResponse {
+  readonly content: readonly { readonly type: string; readonly text?: string }[];
+}
+
+async function callClaude(prompt: string): Promise<string> {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": ANTHROPIC_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 256,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Anthropic API ${response.status}: ${body}`);
+  }
+  const data = (await response.json()) as AnthropicResponse;
+  return data.content
+    .filter(
+      (c): c is { readonly type: string; readonly text: string } =>
+        c.type === "text" && c.text !== undefined,
+    )
+    .map((c) => c.text)
+    .join("");
+}
+
+async function testLlmReadsSource(): Promise<void> {
+  if (!ANTHROPIC_KEY) {
+    console.log("\n\x1b[1mPart 3: LLM reads source (SKIPPED — no ANTHROPIC_API_KEY)\x1b[0m");
+    return;
+  }
+
+  console.log("\n\x1b[1mPart 3: Real LLM (Claude) reads source() output\x1b[0m");
+
+  // Test 3a: LLM reads fibonacci source from resolver and explains it
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "fib-tool" }));
+    const resolver = createForgeResolver(store);
+
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const sourceResult = await resolver.source("fib-tool");
+    assert(sourceResult.ok === true, "source() failed");
+    if (!sourceResult.ok) throw new Error("unreachable");
+
+    const bundle: SourceBundle = sourceResult.value;
+    assert(bundle.language === "typescript", `expected typescript, got ${bundle.language}`);
+
+    const explanation = await callClaude(
+      [
+        "Below is a tool's TypeScript source code.",
+        "Explain in ONE sentence what this tool does. Include the algorithm name if recognizable.",
+        "",
+        "```typescript",
+        bundle.content,
+        "```",
+      ].join("\n"),
+    );
+
+    console.log(`    LLM said: "${explanation.slice(0, 200)}"`);
+
+    const lower = explanation.toLowerCase();
+    assert(lower.includes("fibonacci") || lower.includes("fib"), "LLM should mention fibonacci");
+    ok("LLM reads fibonacci source and explains it correctly");
+  } catch (e: unknown) {
+    fail("LLM reads fibonacci source and explains it correctly", e);
+  }
+
+  // Test 3b: LLM identifies a bug in source() output (the Fork use case)
+  try {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createToolBrick({
+        id: "buggy-fib",
+        name: "buggy-fibonacci",
+        implementation: [
+          "function fibonacci(n: number): number {",
+          "  if (n <= 1) return n;",
+          "  let a = 0, b = 1;",
+          "  for (let i = 1; i <= n; i++) {  // BUG: should start at 2",
+          "    const c = a + b;",
+          "    a = b;",
+          "    b = c;",
+          "  }",
+          "  return b;",
+          "}",
+          "return fibonacci(input.n);",
+        ].join("\n"),
+      }),
+    );
+
+    const resolver = createForgeResolver(store);
+    assert(resolver.source !== undefined, "source should be defined");
+    if (resolver.source === undefined) throw new Error("unreachable");
+    const sourceResult = await resolver.source("buggy-fib");
+    assert(sourceResult.ok === true, "source() failed");
+    if (!sourceResult.ok) throw new Error("unreachable");
+
+    const review = await callClaude(
+      [
+        "Review this TypeScript code for bugs. The function should compute Fibonacci numbers.",
+        "fibonacci(0)=0, fibonacci(1)=1, fibonacci(2)=1, fibonacci(3)=2, fibonacci(5)=5.",
+        "",
+        "```typescript",
+        sourceResult.value.content,
+        "```",
+        "",
+        "If there's a bug, explain it in ONE sentence. Focus on loop initialization.",
+      ].join("\n"),
+    );
+
+    console.log(`    LLM said: "${review.slice(0, 200)}"`);
+
+    const lower = review.toLowerCase();
+    assert(
+      lower.includes("1") ||
+        lower.includes("2") ||
+        lower.includes("off") ||
+        lower.includes("start") ||
+        lower.includes("loop") ||
+        lower.includes("bug") ||
+        lower.includes("iteration") ||
+        lower.includes("extra"),
+      "LLM should identify the loop bug",
+    );
+    ok("LLM identifies off-by-one bug in source code");
+  } catch (e: unknown) {
+    fail("LLM identifies off-by-one bug in source code", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log("=== Resolver.source() E2E Test ===");
+
+await testForgeResolverSource();
+await testLocalResolverSource();
+await testLlmReadsSource();
+
+console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Closes #217

Adds `source()` as the third level of progressive disclosure on the `Resolver` interface, enabling agents to read full source code of any brick for the **Fork modification pattern** (discover → load → source → modify → re-forge).

- Add `SourceLanguage` type and `SourceBundle` interface to `@koi/core` (L0, types only)
- Implement `extractSource()` pure function + `source()` in `ForgeResolver` — exhaustive over all 4 `BrickArtifact` kinds (tool→typescript, skill→markdown, agent→yaml, composite→json)
- Implement `toolPaths` tracking + `source()` in `LocalResolver` — returns JSON for directory tools, actionable NOT_FOUND for built-ins ("Use Shadow pattern to override")
- MCP resolver intentionally omits `source` (explicit absence test)
- E2E test script with real Claude Haiku API calls verifying agents can consume source bundles

## Design Decisions

| Decision | Choice |
|----------|--------|
| Return type | `SourceBundle { content, language, files? }` |
| Optionality | Optional (`readonly source?: ...`) — same pattern as `onChange` |
| Language type | `SourceLanguage` string union |
| Composite source | `JSON.stringify(brickIds)` — composition IS the source |
| Caching | None at resolver — store backends handle caching |
| Content limit | None at resolver — middleware handles token budgets |

## Test Plan

- [x] Type-level tests for `SourceBundle`, `SourceLanguage`, `Resolver.source` optionality
- [x] Export assertions for new types in `@koi/core`
- [x] `extractSource()` for all 4 brick kinds + companion files
- [x] `ForgeResolver.source()` happy path + NOT_FOUND
- [x] `LocalResolver.source()` for directory/builtin/unknown tools
- [x] `McpResolver.source` intentional absence
- [x] E2E with real Claude Haiku (explain fibonacci, identify bug)
- [x] Anti-leak verification (L0 zero imports, no function bodies, all readonly)
- [x] Build + typecheck + test pass for core, forge, node, mcp

## Anti-Leak Checklist

- [x] `@koi/core` has zero `import` statements from other packages
- [x] No `function` bodies or `class` in `@koi/core` (types/interfaces only)
- [x] L2 packages only import from `@koi/core` (L0), never from `@koi/engine` or peer L2
- [x] All interface properties are `readonly`