### PR TITLE
feat: add @koi/tracing — OpenTelemetry distributed tracing middleware

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -493,6 +493,19 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/tracing": {
+      "name": "@koi/tracing",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@opentelemetry/api": "^1.9.0",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+        "@opentelemetry/sdk-trace-base": "^2.5.0",
+        "@opentelemetry/sdk-trace-node": "^2.5.0",
+      },
+    },
     "packages/validation": {
       "name": "@koi/validation",
       "version": "0.0.0",
@@ -808,6 +821,8 @@
 
     "@koi/test-utils": ["@koi/test-utils@workspace:packages/test-utils"],
 
+    "@koi/tracing": ["@koi/tracing@workspace:packages/tracing"],
+
     "@koi/validation": ["@koi/validation@workspace:packages/validation"],
 
     "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.54.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.54.0" } }, "sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ=="],
@@ -819,6 +834,20 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.12.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.5.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.5.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.5.1", "", { "dependencies": { "@opentelemetry/core": "2.5.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.5.1", "", { "dependencies": { "@opentelemetry/core": "2.5.1", "@opentelemetry/resources": "2.5.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.5.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.5.1", "@opentelemetry/core": "2.5.1", "@opentelemetry/sdk-trace-base": "2.5.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.114.0", "", { "os": "android", "cpu": "arm" }, "sha512-O64coa+5VuqhwQV5t7PcgiY1ubGy35QZSMi+GrXewCRbi7MMzQcuyfv2xg1FV7Kj7SR47+gg/eC9xrOph2Pbcg=="],
 

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/tracing",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*",
+    "@opentelemetry/sdk-trace-base": "^2.5.0",
+    "@opentelemetry/sdk-trace-node": "^2.5.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/tracing/src/__tests__/integration.test.ts
+++ b/packages/tracing/src/__tests__/integration.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runId, sessionId } from "@koi/core";
+import {
+  createMockModelHandler,
+  createMockSessionContext,
+  createMockToolHandler,
+  createMockTurnContext,
+} from "@koi/test-utils";
+import type { Tracer } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { createTracingMiddleware } from "../tracing.js";
+
+/** Asserts that an optional middleware hook is defined. */
+function assertDefined<T>(value: T | undefined, name: string): T {
+  if (value === undefined) {
+    throw new Error(`Expected ${name} to be defined`);
+  }
+  return value;
+}
+
+describe("tracing integration", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let tracer: Tracer;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    tracer = provider.getTracer("@koi/integration");
+  });
+
+  afterEach(async () => {
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  test("full session lifecycle produces correct span tree", async () => {
+    const middleware = createTracingMiddleware({ tracer });
+    const onSessionStart = assertDefined(middleware.onSessionStart, "onSessionStart");
+    const onSessionEnd = assertDefined(middleware.onSessionEnd, "onSessionEnd");
+    const onBeforeTurn = assertDefined(middleware.onBeforeTurn, "onBeforeTurn");
+    const onAfterTurn = assertDefined(middleware.onAfterTurn, "onAfterTurn");
+    const wrapModelCall = assertDefined(middleware.wrapModelCall, "wrapModelCall");
+    const wrapToolCall = assertDefined(middleware.wrapToolCall, "wrapToolCall");
+
+    const sessionCtx = createMockSessionContext({ sessionId: sessionId("int-sess-1") });
+    const turnCtx = createMockTurnContext({
+      turnIndex: 0,
+      session: {
+        sessionId: sessionId("int-sess-1"),
+        runId: runId("run-test-1"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+
+    await onSessionStart(sessionCtx);
+    await onBeforeTurn(turnCtx);
+    await wrapModelCall(turnCtx, { messages: [] }, createMockModelHandler());
+    await wrapToolCall(turnCtx, { toolId: "search", input: {} }, createMockToolHandler());
+    await onAfterTurn(turnCtx);
+    await onSessionEnd(sessionCtx);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(4); // session + turn + model + tool
+
+    const sessionSpan = spans.find((s) => s.name === "koi.session");
+    const turnSpan = spans.find((s) => s.name === "koi.turn");
+    const modelSpan = spans.find((s) => s.name === "gen_ai.chat");
+    const toolSpan = spans.find((s) => s.name === "koi.tool_call");
+
+    expect(sessionSpan).toBeDefined();
+    expect(turnSpan).toBeDefined();
+    expect(modelSpan).toBeDefined();
+    expect(toolSpan).toBeDefined();
+
+    // Verify hierarchy: session -> turn -> model/tool
+    if (sessionSpan && turnSpan && modelSpan && toolSpan) {
+      expect(turnSpan.parentSpanContext?.spanId).toBe(sessionSpan.spanContext().spanId);
+      expect(modelSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+      expect(toolSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+    }
+  });
+
+  test("concurrent sessions have isolated span contexts", async () => {
+    const middleware = createTracingMiddleware({ tracer });
+    const onSessionStart = assertDefined(middleware.onSessionStart, "onSessionStart");
+    const onSessionEnd = assertDefined(middleware.onSessionEnd, "onSessionEnd");
+    const onBeforeTurn = assertDefined(middleware.onBeforeTurn, "onBeforeTurn");
+    const onAfterTurn = assertDefined(middleware.onAfterTurn, "onAfterTurn");
+    const wrapModelCall = assertDefined(middleware.wrapModelCall, "wrapModelCall");
+
+    const sess1 = createMockSessionContext({ sessionId: sessionId("sess-A") });
+    const sess2 = createMockSessionContext({ sessionId: sessionId("sess-B") });
+    const turn1 = createMockTurnContext({
+      turnIndex: 0,
+      session: {
+        sessionId: sessionId("sess-A"),
+        runId: runId("run-A"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+    const turn2 = createMockTurnContext({
+      turnIndex: 0,
+      session: {
+        sessionId: sessionId("sess-B"),
+        runId: runId("run-B"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+
+    await onSessionStart(sess1);
+    await onSessionStart(sess2);
+
+    await onBeforeTurn(turn1);
+    await onBeforeTurn(turn2);
+    await wrapModelCall(turn1, { messages: [] }, createMockModelHandler());
+    await wrapModelCall(turn2, { messages: [] }, createMockModelHandler());
+    await onAfterTurn(turn1);
+    await onAfterTurn(turn2);
+
+    await onSessionEnd(sess1);
+    await onSessionEnd(sess2);
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpans = spans.filter((s) => s.name === "koi.session");
+    const turnSpans = spans.filter((s) => s.name === "koi.turn");
+    const modelSpans = spans.filter((s) => s.name === "gen_ai.chat");
+
+    expect(sessionSpans).toHaveLength(2);
+    expect(turnSpans).toHaveLength(2);
+    expect(modelSpans).toHaveLength(2);
+
+    const sessASpan = sessionSpans.find((s) => s.attributes["koi.session.id"] === "sess-A");
+    const sessBSpan = sessionSpans.find((s) => s.attributes["koi.session.id"] === "sess-B");
+    expect(sessASpan).toBeDefined();
+    expect(sessBSpan).toBeDefined();
+
+    if (sessASpan && sessBSpan) {
+      const turnA = turnSpans.find(
+        (s) => s.parentSpanContext?.spanId === sessASpan.spanContext().spanId,
+      );
+      const turnB = turnSpans.find(
+        (s) => s.parentSpanContext?.spanId === sessBSpan.spanContext().spanId,
+      );
+      expect(turnA).toBeDefined();
+      expect(turnB).toBeDefined();
+
+      if (turnA && turnB) {
+        const modelA = modelSpans.find(
+          (s) => s.parentSpanContext?.spanId === turnA.spanContext().spanId,
+        );
+        const modelB = modelSpans.find(
+          (s) => s.parentSpanContext?.spanId === turnB.spanContext().spanId,
+        );
+        expect(modelA).toBeDefined();
+        expect(modelB).toBeDefined();
+      }
+    }
+  });
+
+  test("noop behavior without TracerProvider", async () => {
+    // Use the default global tracer (no provider registered = noop)
+    const noopMiddleware = createTracingMiddleware({ serviceName: "@koi/noop" });
+    const onSessionStart = assertDefined(noopMiddleware.onSessionStart, "onSessionStart");
+    const onSessionEnd = assertDefined(noopMiddleware.onSessionEnd, "onSessionEnd");
+    const onBeforeTurn = assertDefined(noopMiddleware.onBeforeTurn, "onBeforeTurn");
+    const onAfterTurn = assertDefined(noopMiddleware.onAfterTurn, "onAfterTurn");
+    const wrapModelCall = assertDefined(noopMiddleware.wrapModelCall, "wrapModelCall");
+
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler({ content: "passthrough" });
+
+    await onSessionStart(sessionCtx);
+    await onBeforeTurn(turnCtx);
+    const response = await wrapModelCall(turnCtx, { messages: [] }, next);
+    await onAfterTurn(turnCtx);
+    await onSessionEnd(sessionCtx);
+
+    // Response passes through untouched
+    expect(response.content).toBe("passthrough");
+    // No spans in our test exporter (the noop tracer doesn't report to our exporter)
+    // This verifies no errors occurred
+  });
+
+  test("multiple turns in single session produce sibling turn spans", async () => {
+    const middleware = createTracingMiddleware({ tracer });
+    const onSessionStart = assertDefined(middleware.onSessionStart, "onSessionStart");
+    const onSessionEnd = assertDefined(middleware.onSessionEnd, "onSessionEnd");
+    const onBeforeTurn = assertDefined(middleware.onBeforeTurn, "onBeforeTurn");
+    const onAfterTurn = assertDefined(middleware.onAfterTurn, "onAfterTurn");
+    const wrapModelCall = assertDefined(middleware.wrapModelCall, "wrapModelCall");
+
+    const sessionCtx = createMockSessionContext({ sessionId: sessionId("multi-turn") });
+
+    await onSessionStart(sessionCtx);
+
+    const turn0 = createMockTurnContext({
+      turnIndex: 0,
+      session: {
+        sessionId: sessionId("multi-turn"),
+        runId: runId("run-multi"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+    await onBeforeTurn(turn0);
+    await wrapModelCall(turn0, { messages: [] }, createMockModelHandler());
+    await onAfterTurn(turn0);
+
+    const turn1 = createMockTurnContext({
+      turnIndex: 1,
+      session: {
+        sessionId: sessionId("multi-turn"),
+        runId: runId("run-multi"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+    await onBeforeTurn(turn1);
+    await wrapModelCall(turn1, { messages: [] }, createMockModelHandler());
+    await onAfterTurn(turn1);
+
+    await onSessionEnd(sessionCtx);
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpan = spans.find((s) => s.name === "koi.session");
+    const turnSpans = spans.filter((s) => s.name === "koi.turn");
+
+    expect(turnSpans).toHaveLength(2);
+    expect(sessionSpan).toBeDefined();
+
+    if (sessionSpan) {
+      for (const ts of turnSpans) {
+        expect(ts.parentSpanContext?.spanId).toBe(sessionSpan.spanContext().spanId);
+      }
+    }
+
+    const indices = turnSpans.map((ts) => ts.attributes["koi.turn.index"]);
+    expect(indices).toContain(0);
+    expect(indices).toContain(1);
+  });
+});

--- a/packages/tracing/src/config.test.ts
+++ b/packages/tracing/src/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { validateConfig } from "./config.js";
+
+describe("validateConfig", () => {
+  test("returns ok for valid empty config object", () => {
+    const result = validateConfig({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns ok for config with all valid fields", () => {
+    const result = validateConfig({
+      serviceName: "my-service",
+      captureContent: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.serviceName).toBe("my-service");
+      expect(result.value.captureContent).toBe(true);
+    }
+  });
+
+  test("returns error for null config", () => {
+    const result = validateConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null");
+    }
+  });
+
+  test("returns error for undefined config", () => {
+    const result = validateConfig(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("returns error for non-string serviceName", () => {
+    const result = validateConfig({ serviceName: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("serviceName");
+    }
+  });
+
+  test("returns error for non-boolean captureContent", () => {
+    const result = validateConfig({ captureContent: "yes" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("captureContent");
+    }
+  });
+
+  test("returns error for non-object config (number)", () => {
+    const result = validateConfig(42);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+});

--- a/packages/tracing/src/config.ts
+++ b/packages/tracing/src/config.ts
@@ -1,0 +1,66 @@
+/**
+ * Tracing middleware configuration and validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { Tracer } from "@opentelemetry/api";
+
+export interface TracingConfig {
+  /** OTel service name. Default: "@koi/agent". Ignored when `tracer` is provided. */
+  readonly serviceName?: string;
+  /** When true, attach request/response content as span attributes. Default: false. */
+  readonly captureContent?: boolean;
+  /** Optional filter applied to content before attaching. Only used when captureContent is true. */
+  readonly contentFilter?: (data: unknown) => unknown;
+  /** Bring your own OTel Tracer instance. Overrides serviceName. */
+  readonly tracer?: Tracer;
+  /** Extra root-level attributes added to every span. */
+  readonly attributes?: Readonly<Record<string, string>>;
+  /** Called when tracing itself errors. Tracing errors never propagate to the application. */
+  readonly onError?: (error: unknown) => void;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+export function validateConfig(config: unknown): Result<TracingConfig, KoiError> {
+  if (!isRecord(config)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "TracingConfig must be a non-null object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (config.serviceName !== undefined && typeof config.serviceName !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "serviceName must be a string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (config.captureContent !== undefined && typeof config.captureContent !== "boolean") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "captureContent must be a boolean",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  // Safe narrowing: all validated fields are checked above, remaining optional
+  // fields (tracer, contentFilter, attributes, onError) are typed via the
+  // TracingConfig interface and validated by the TypeScript compiler at call sites.
+  return { ok: true, value: config as TracingConfig };
+}

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @koi/tracing — OpenTelemetry distributed tracing middleware (L2).
+ *
+ * Emits OTel spans for session lifecycle, turns, model calls, and tool calls.
+ * Zero-cost when no TracerProvider is registered.
+ * Depends on @koi/core and @opentelemetry/api.
+ */
+
+export type { TracingConfig } from "./config.js";
+export { validateConfig } from "./config.js";
+export { createTracingMiddleware } from "./tracing.js";

--- a/packages/tracing/src/semantic-conventions.ts
+++ b/packages/tracing/src/semantic-conventions.ts
@@ -1,0 +1,26 @@
+/**
+ * OpenTelemetry semantic convention attribute names for GenAI and Koi.
+ *
+ * GenAI conventions follow the OpenTelemetry GenAI semantic conventions spec.
+ * Koi-specific attributes use the `koi.` namespace prefix.
+ */
+
+// --- GenAI semantic conventions ---
+export const GEN_AI_OPERATION_NAME = "gen_ai.operation.name" as const;
+export const GEN_AI_SYSTEM = "gen_ai.system" as const;
+export const GEN_AI_REQUEST_MODEL = "gen_ai.request.model" as const;
+export const GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature" as const;
+export const GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens" as const;
+export const GEN_AI_RESPONSE_MODEL = "gen_ai.response.model" as const;
+export const GEN_AI_RESPONSE_FINISH_REASON = "gen_ai.response.finish_reason" as const;
+export const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens" as const;
+export const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens" as const;
+
+// --- Koi-specific attributes ---
+export const KOI_SESSION_ID = "koi.session.id" as const;
+export const KOI_AGENT_ID = "koi.agent.id" as const;
+export const KOI_TURN_INDEX = "koi.turn.index" as const;
+export const KOI_TOOL_ID = "koi.tool.id" as const;
+export const KOI_MIDDLEWARE_NAME = "koi.middleware.name" as const;
+export const KOI_REQUEST_CONTENT = "koi.request.content" as const;
+export const KOI_RESPONSE_CONTENT = "koi.response.content" as const;

--- a/packages/tracing/src/span-context.test.ts
+++ b/packages/tracing/src/span-context.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { createSpanContextStore } from "./span-context.js";
+
+/** Creates a minimal mock Span for testing store operations. */
+function mockSpan(id: string): import("@opentelemetry/api").Span {
+  return { id, end: () => {} } as unknown as import("@opentelemetry/api").Span;
+}
+
+describe("createSpanContextStore", () => {
+  test("set and get return the stored span", () => {
+    const store = createSpanContextStore();
+    const span = mockSpan("s1");
+
+    store.set("key1", span);
+    expect(store.get("key1")).toBe(span);
+  });
+
+  test("get returns undefined for unknown key", () => {
+    const store = createSpanContextStore();
+    expect(store.get("unknown")).toBeUndefined();
+  });
+
+  test("delete removes the span and returns true", () => {
+    const store = createSpanContextStore();
+    store.set("key1", mockSpan("s1"));
+
+    expect(store.delete("key1")).toBe(true);
+    expect(store.get("key1")).toBeUndefined();
+  });
+
+  test("delete returns false for unknown key", () => {
+    const store = createSpanContextStore();
+    expect(store.delete("unknown")).toBe(false);
+  });
+
+  test("size reflects current entry count", () => {
+    const store = createSpanContextStore();
+    expect(store.size()).toBe(0);
+
+    store.set("k1", mockSpan("s1"));
+    store.set("k2", mockSpan("s2"));
+    expect(store.size()).toBe(2);
+
+    store.delete("k1");
+    expect(store.size()).toBe(1);
+  });
+
+  test("evicts oldest entry when maxSize exceeded", () => {
+    const store = createSpanContextStore(3);
+
+    store.set("k1", mockSpan("s1"));
+    store.set("k2", mockSpan("s2"));
+    store.set("k3", mockSpan("s3"));
+    expect(store.size()).toBe(3);
+
+    // Adding a 4th entry should evict k1 (oldest)
+    store.set("k4", mockSpan("s4"));
+    expect(store.size()).toBe(3);
+    expect(store.get("k1")).toBeUndefined();
+    expect(store.get("k2")).toBeDefined();
+    expect(store.get("k4")).toBeDefined();
+  });
+
+  test("re-setting same key moves it to newest position", () => {
+    const store = createSpanContextStore(3);
+
+    store.set("k1", mockSpan("s1"));
+    store.set("k2", mockSpan("s2"));
+    store.set("k3", mockSpan("s3"));
+
+    // Re-set k1 — makes it newest
+    const updatedSpan = mockSpan("s1-updated");
+    store.set("k1", updatedSpan);
+    expect(store.get("k1")).toBe(updatedSpan);
+
+    // Adding k4 should now evict k2 (the oldest), not k1
+    store.set("k4", mockSpan("s4"));
+    expect(store.get("k1")).toBe(updatedSpan);
+    expect(store.get("k2")).toBeUndefined();
+    expect(store.get("k3")).toBeDefined();
+    expect(store.get("k4")).toBeDefined();
+  });
+});

--- a/packages/tracing/src/span-context.ts
+++ b/packages/tracing/src/span-context.ts
@@ -1,0 +1,45 @@
+/**
+ * Span context store — closure-based Map wrapper with max-size eviction.
+ *
+ * Stores active OTel spans keyed by session/turn identifiers.
+ * When the store exceeds `maxSize`, the oldest entry (by insertion order) is evicted.
+ */
+
+import type { Span } from "@opentelemetry/api";
+
+const DEFAULT_MAX_SIZE = 1000;
+
+export interface SpanContextStore {
+  readonly set: (key: string, span: Span) => void;
+  readonly get: (key: string) => Span | undefined;
+  readonly delete: (key: string) => boolean;
+  readonly size: () => number;
+}
+
+export function createSpanContextStore(maxSize: number = DEFAULT_MAX_SIZE): SpanContextStore {
+  const map = new Map<string, Span>();
+
+  const set = (key: string, span: Span): void => {
+    // Delete first so re-insertion moves the key to the end (newest)
+    map.delete(key);
+    map.set(key, span);
+
+    if (map.size > maxSize) {
+      // Evict oldest entry (first key in iteration order) and end its span
+      const oldest = map.entries().next();
+      if (!oldest.done) {
+        const [oldestKey, evictedSpan] = oldest.value;
+        evictedSpan.end();
+        map.delete(oldestKey);
+      }
+    }
+  };
+
+  const get = (key: string): Span | undefined => map.get(key);
+
+  const del = (key: string): boolean => map.delete(key);
+
+  const size = (): number => map.size;
+
+  return { set, get, delete: del, size };
+}

--- a/packages/tracing/src/test-setup.ts
+++ b/packages/tracing/src/test-setup.ts
@@ -1,0 +1,33 @@
+/**
+ * Test infrastructure for OTel span collection.
+ *
+ * Re-exports InMemorySpanExporter + NodeTracerProvider setup for use in
+ * E2E scripts that cannot directly depend on OTel SDK packages.
+ */
+
+import type { Tracer } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+export type { ReadableSpan };
+
+export interface TestTracer {
+  readonly tracer: Tracer;
+  readonly getFinishedSpans: () => readonly ReadableSpan[];
+  readonly shutdown: () => Promise<void>;
+}
+
+export function createTestTracer(name: string = "@koi/e2e-tracing"): TestTracer {
+  const exporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const tracer = provider.getTracer(name);
+
+  return {
+    tracer,
+    getFinishedSpans: () => exporter.getFinishedSpans(),
+    shutdown: () => provider.shutdown(),
+  };
+}

--- a/packages/tracing/src/tracing.test.ts
+++ b/packages/tracing/src/tracing.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runId, sessionId } from "@koi/core";
+import type { KoiMiddleware, ModelChunk, ModelRequest, ModelResponse } from "@koi/core/middleware";
+import {
+  createMockModelHandler,
+  createMockSessionContext,
+  createMockToolHandler,
+  createMockTurnContext,
+} from "@koi/test-utils";
+import type { Tracer } from "@opentelemetry/api";
+import { InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_REQUEST_MODEL,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  KOI_AGENT_ID,
+  KOI_REQUEST_CONTENT,
+  KOI_RESPONSE_CONTENT,
+  KOI_SESSION_ID,
+  KOI_TOOL_ID,
+  KOI_TURN_INDEX,
+} from "./semantic-conventions.js";
+import { createTracingMiddleware } from "./tracing.js";
+
+/** Asserts that an optional middleware hook is defined. */
+function assertDefined<T>(value: T | undefined, name: string): T {
+  if (value === undefined) {
+    throw new Error(`Expected ${name} to be defined`);
+  }
+  return value;
+}
+
+/** Typed accessors for the optional middleware hooks under test. */
+function hooks(mw: KoiMiddleware) {
+  return {
+    onSessionStart: assertDefined(mw.onSessionStart, "onSessionStart"),
+    onSessionEnd: assertDefined(mw.onSessionEnd, "onSessionEnd"),
+    onBeforeTurn: assertDefined(mw.onBeforeTurn, "onBeforeTurn"),
+    onAfterTurn: assertDefined(mw.onAfterTurn, "onAfterTurn"),
+    wrapModelCall: assertDefined(mw.wrapModelCall, "wrapModelCall"),
+    wrapModelStream: assertDefined(mw.wrapModelStream, "wrapModelStream"),
+    wrapToolCall: assertDefined(mw.wrapToolCall, "wrapToolCall"),
+  };
+}
+
+/** Creates a test TracerProvider + Exporter + Tracer bundle. */
+function createTestTracer(): {
+  readonly exporter: InMemorySpanExporter;
+  readonly provider: NodeTracerProvider;
+  readonly tracer: Tracer;
+} {
+  const exporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const tracer = provider.getTracer("@koi/test");
+  return { exporter, provider, tracer };
+}
+
+describe("createTracingMiddleware", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let tracer: Tracer;
+  let middleware: KoiMiddleware;
+
+  beforeEach(() => {
+    const t = createTestTracer();
+    exporter = t.exporter;
+    provider = t.provider;
+    tracer = t.tracer;
+    middleware = createTracingMiddleware({ tracer });
+  });
+
+  afterEach(async () => {
+    exporter.reset();
+    await provider.shutdown();
+  });
+
+  test("creates session span on onSessionStart", async () => {
+    const ctx = createMockSessionContext({ sessionId: sessionId("sess-1"), agentId: "agent-1" });
+    const h = hooks(middleware);
+
+    await h.onSessionStart(ctx);
+    await h.onSessionEnd(ctx);
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpan = spans.find((s) => s.name === "koi.session");
+    expect(sessionSpan).toBeDefined();
+    expect(sessionSpan?.attributes[KOI_SESSION_ID]).toBe("sess-1");
+    expect(sessionSpan?.attributes[KOI_AGENT_ID]).toBe("agent-1");
+  });
+
+  test("ends session span on onSessionEnd", async () => {
+    const ctx = createMockSessionContext();
+    const h = hooks(middleware);
+
+    await h.onSessionStart(ctx);
+    await h.onSessionEnd(ctx);
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpan = spans.find((s) => s.name === "koi.session");
+    expect(sessionSpan).toBeDefined();
+    expect(sessionSpan?.endTime).toBeDefined();
+  });
+
+  test("creates turn span as child of session span", async () => {
+    const sessionCtx = createMockSessionContext({ sessionId: sessionId("sess-1") });
+    const turnCtx = createMockTurnContext({
+      turnIndex: 0,
+      session: {
+        sessionId: sessionId("sess-1"),
+        runId: runId("run-test-1"),
+        agentId: "agent-test-1",
+        metadata: {},
+      },
+    });
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const spans = exporter.getFinishedSpans();
+    const sessionSpan = spans.find((s) => s.name === "koi.session");
+    const turnSpan = spans.find((s) => s.name === "koi.turn");
+
+    expect(sessionSpan).toBeDefined();
+    expect(turnSpan).toBeDefined();
+    expect(turnSpan?.attributes[KOI_TURN_INDEX]).toBe(0);
+    if (sessionSpan && turnSpan) {
+      expect(turnSpan.parentSpanContext?.spanId).toBe(sessionSpan.spanContext().spanId);
+    }
+  });
+
+  test("ends turn span on onAfterTurn", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const turnSpan = exporter.getFinishedSpans().find((s) => s.name === "koi.turn");
+    expect(turnSpan).toBeDefined();
+    expect(turnSpan?.endTime).toBeDefined();
+  });
+
+  test("creates model call span as child of turn span", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler();
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.wrapModelCall(turnCtx, { messages: [], model: "gpt-4" }, next);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const spans = exporter.getFinishedSpans();
+    const turnSpan = spans.find((s) => s.name === "koi.turn");
+    const modelSpan = spans.find((s) => s.name === "gen_ai.chat");
+
+    expect(modelSpan).toBeDefined();
+    expect(modelSpan?.attributes[GEN_AI_OPERATION_NAME]).toBe("chat");
+    expect(modelSpan?.attributes[GEN_AI_REQUEST_MODEL]).toBe("gpt-4");
+
+    if (turnSpan && modelSpan) {
+      expect(modelSpan.parentSpanContext?.spanId).toBe(turnSpan.spanContext().spanId);
+    }
+  });
+
+  test("records token usage on model call span", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler({
+      model: "gpt-4",
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.wrapModelCall(turnCtx, { messages: [] }, next);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const modelSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.chat");
+    expect(modelSpan).toBeDefined();
+    expect(modelSpan?.attributes[GEN_AI_RESPONSE_MODEL]).toBe("gpt-4");
+    expect(modelSpan?.attributes[GEN_AI_USAGE_INPUT_TOKENS]).toBe(100);
+    expect(modelSpan?.attributes[GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(50);
+  });
+
+  test("records error on model call failure", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const failingNext = async (_req: ModelRequest): Promise<ModelResponse> => {
+      throw new Error("model exploded");
+    };
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+
+    await expect(h.wrapModelCall(turnCtx, { messages: [] }, failingNext)).rejects.toThrow(
+      "model exploded",
+    );
+
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const modelSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.chat");
+    expect(modelSpan).toBeDefined();
+    expect(modelSpan?.status.code).toBe(2); // SpanStatusCode.ERROR = 2
+    expect(modelSpan?.events.length).toBeGreaterThan(0);
+    expect(modelSpan?.events[0]?.name).toBe("exception");
+  });
+
+  test("creates tool call span with correct attributes", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockToolHandler({ output: { result: "ok" } });
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.wrapToolCall(turnCtx, { toolId: "web-search", input: { q: "koi" } }, next);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const toolSpan = exporter.getFinishedSpans().find((s) => s.name === "koi.tool_call");
+    expect(toolSpan).toBeDefined();
+    expect(toolSpan?.attributes[KOI_TOOL_ID]).toBe("web-search");
+  });
+
+  test("records error on tool call failure", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const failingNext = async () => {
+      throw new Error("tool crashed");
+    };
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+
+    await expect(
+      h.wrapToolCall(turnCtx, { toolId: "broken", input: {} }, failingNext),
+    ).rejects.toThrow("tool crashed");
+
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const toolSpan = exporter.getFinishedSpans().find((s) => s.name === "koi.tool_call");
+    expect(toolSpan).toBeDefined();
+    expect(toolSpan?.status.code).toBe(2); // ERROR
+    expect(toolSpan?.events[0]?.name).toBe("exception");
+  });
+
+  test("handles streaming model call", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const h = hooks(middleware);
+
+    const mockChunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "hello" },
+      { kind: "text_delta", delta: " world" },
+      {
+        kind: "done",
+        response: {
+          content: "hello world",
+          model: "gpt-4",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      },
+    ];
+    const streamNext = async function* (_request: ModelRequest): AsyncIterable<ModelChunk> {
+      for (const chunk of mockChunks) {
+        yield chunk;
+      }
+    };
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+
+    const chunks: ModelChunk[] = [];
+    for await (const chunk of h.wrapModelStream(turnCtx, { messages: [] }, streamNext)) {
+      chunks.push(chunk);
+    }
+
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    expect(chunks).toHaveLength(3);
+
+    const streamSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.stream");
+    expect(streamSpan).toBeDefined();
+    expect(streamSpan?.attributes[GEN_AI_USAGE_INPUT_TOKENS]).toBe(10);
+    expect(streamSpan?.attributes[GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(5);
+  });
+
+  test("handles streaming error mid-stream", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const h = hooks(middleware);
+
+    const streamNext = async function* (_request: ModelRequest): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta" as const, delta: "partial" };
+      throw new Error("stream failed");
+    };
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+
+    const chunks: ModelChunk[] = [];
+    await expect(async () => {
+      for await (const chunk of h.wrapModelStream(turnCtx, { messages: [] }, streamNext)) {
+        chunks.push(chunk);
+      }
+    }).toThrow("stream failed");
+
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    expect(chunks).toHaveLength(1);
+
+    const streamSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.stream");
+    expect(streamSpan).toBeDefined();
+    expect(streamSpan?.status.code).toBe(2); // ERROR
+    expect(streamSpan?.events[0]?.name).toBe("exception");
+  });
+
+  test("does not capture content by default", async () => {
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler();
+    const h = hooks(middleware);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.wrapModelCall(turnCtx, { messages: [] }, next);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const modelSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.chat");
+    expect(modelSpan).toBeDefined();
+    expect(modelSpan?.attributes[KOI_REQUEST_CONTENT]).toBeUndefined();
+    expect(modelSpan?.attributes[KOI_RESPONSE_CONTENT]).toBeUndefined();
+  });
+
+  test("captures content when captureContent enabled", async () => {
+    const mw = createTracingMiddleware({ tracer, captureContent: true });
+    const sessionCtx = createMockSessionContext();
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler({ content: "response text" });
+    const h = hooks(mw);
+
+    await h.onSessionStart(sessionCtx);
+    await h.onBeforeTurn(turnCtx);
+    await h.wrapModelCall(turnCtx, { messages: [] }, next);
+    await h.onAfterTurn(turnCtx);
+    await h.onSessionEnd(sessionCtx);
+
+    const modelSpan = exporter.getFinishedSpans().find((s) => s.name === "gen_ai.chat");
+    expect(modelSpan).toBeDefined();
+    expect(modelSpan?.attributes[KOI_REQUEST_CONTENT]).toBeDefined();
+    expect(modelSpan?.attributes[KOI_RESPONSE_CONTENT]).toBeDefined();
+    const responseContent = modelSpan?.attributes[KOI_RESPONSE_CONTENT];
+    expect(typeof responseContent === "string" && responseContent.includes("response text")).toBe(
+      true,
+    );
+  });
+
+  test("tracing errors do not propagate to application", async () => {
+    const errors: unknown[] = [];
+    const brokenTracer = {
+      startSpan: () => {
+        throw new Error("tracer broken");
+      },
+    } as unknown as Tracer;
+
+    const mw = createTracingMiddleware({
+      tracer: brokenTracer,
+      onError: (e) => errors.push(e),
+    });
+    const turnCtx = createMockTurnContext();
+    const next = createMockModelHandler({ content: "still works" });
+    const h = hooks(mw);
+
+    const response = await h.wrapModelCall(turnCtx, { messages: [] }, next);
+    expect(response.content).toBe("still works");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tracing/src/tracing.ts
+++ b/packages/tracing/src/tracing.ts
@@ -1,0 +1,294 @@
+/**
+ * Tracing middleware factory — bridges Koi middleware hooks to OpenTelemetry spans.
+ *
+ * Creates a span hierarchy: Session → Turn → Model Call / Model Stream / Tool Call.
+ * Zero-cost when no TracerProvider is registered (OTel API returns noop spans).
+ * Tracing errors are isolated — they never propagate to the application.
+ */
+
+import type {
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  SessionContext,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { context, type Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import type { TracingConfig } from "./config.js";
+import {
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_REQUEST_MAX_TOKENS,
+  GEN_AI_REQUEST_MODEL,
+  GEN_AI_REQUEST_TEMPERATURE,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  KOI_AGENT_ID,
+  KOI_REQUEST_CONTENT,
+  KOI_RESPONSE_CONTENT,
+  KOI_SESSION_ID,
+  KOI_TOOL_ID,
+  KOI_TURN_INDEX,
+} from "./semantic-conventions.js";
+import { createSpanContextStore } from "./span-context.js";
+
+const DEFAULT_SERVICE_NAME = "@koi/agent";
+
+function sessionKey(ctx: SessionContext): string {
+  return ctx.sessionId;
+}
+
+function turnKey(ctx: TurnContext): string {
+  return `${ctx.session.sessionId}:${ctx.turnIndex}`;
+}
+
+function safeSerialize(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+export function createTracingMiddleware(config: TracingConfig = {}): KoiMiddleware {
+  const tracer = config.tracer ?? trace.getTracer(config.serviceName ?? DEFAULT_SERVICE_NAME);
+  const extraAttributes = config.attributes ?? {};
+  const hasExtraAttributes = Object.keys(extraAttributes).length > 0;
+  const captureContent = config.captureContent ?? false;
+  const contentFilter = config.contentFilter;
+  const onError = config.onError;
+
+  const sessionSpans = createSpanContextStore();
+  const turnSpans = createSpanContextStore();
+
+  function startChildSpan(
+    name: string,
+    parentSpan: Span | undefined,
+    attributes: Record<string, string | number>,
+  ): Span {
+    const parentCtx =
+      parentSpan !== undefined ? trace.setSpan(context.active(), parentSpan) : context.active();
+
+    const mergedAttrs = hasExtraAttributes ? { ...extraAttributes, ...attributes } : attributes;
+    return tracer.startSpan(name, { attributes: mergedAttrs }, parentCtx);
+  }
+
+  function recordContent(span: Span, request: unknown, response: unknown): void {
+    if (!captureContent || !span.isRecording()) {
+      return;
+    }
+
+    try {
+      const requestData = contentFilter ? contentFilter(request) : request;
+      const responseData = contentFilter ? contentFilter(response) : response;
+
+      span.setAttribute(KOI_REQUEST_CONTENT, safeSerialize(requestData));
+      span.setAttribute(KOI_RESPONSE_CONTENT, safeSerialize(responseData));
+    } catch (e: unknown) {
+      onError?.(e);
+    }
+  }
+
+  const middleware: KoiMiddleware = {
+    name: "tracing",
+    // 450: after audit@300, before event-trace@475, before default@500
+    priority: 450,
+
+    async onSessionStart(ctx: SessionContext): Promise<void> {
+      try {
+        const span = tracer.startSpan("koi.session", {
+          attributes: {
+            ...extraAttributes,
+            [KOI_SESSION_ID]: ctx.sessionId,
+            [KOI_AGENT_ID]: ctx.agentId,
+          },
+        });
+        sessionSpans.set(sessionKey(ctx), span);
+      } catch (e: unknown) {
+        onError?.(e);
+      }
+    },
+
+    async onSessionEnd(ctx: SessionContext): Promise<void> {
+      try {
+        const span = sessionSpans.get(sessionKey(ctx));
+        if (span !== undefined) {
+          span.end();
+          sessionSpans.delete(sessionKey(ctx));
+        }
+      } catch (e: unknown) {
+        onError?.(e);
+      }
+    },
+
+    async onBeforeTurn(ctx: TurnContext): Promise<void> {
+      try {
+        const sessionSpan = sessionSpans.get(sessionKey(ctx.session));
+        const span = startChildSpan("koi.turn", sessionSpan, {
+          [KOI_SESSION_ID]: ctx.session.sessionId,
+          [KOI_AGENT_ID]: ctx.session.agentId,
+          [KOI_TURN_INDEX]: ctx.turnIndex,
+        });
+        turnSpans.set(turnKey(ctx), span);
+      } catch (e: unknown) {
+        onError?.(e);
+      }
+    },
+
+    async onAfterTurn(ctx: TurnContext): Promise<void> {
+      try {
+        const span = turnSpans.get(turnKey(ctx));
+        if (span !== undefined) {
+          span.end();
+          turnSpans.delete(turnKey(ctx));
+        }
+      } catch (e: unknown) {
+        onError?.(e);
+      }
+    },
+
+    async wrapModelCall(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      // let: assigned in try, used across try/catch/finally
+      let span: Span | undefined;
+      try {
+        const turnSpan = turnSpans.get(turnKey(ctx));
+        const attrs: Record<string, string | number> = {
+          [GEN_AI_OPERATION_NAME]: "chat",
+        };
+        if (request.model !== undefined) {
+          attrs[GEN_AI_REQUEST_MODEL] = request.model;
+        }
+        if (request.temperature !== undefined) {
+          attrs[GEN_AI_REQUEST_TEMPERATURE] = request.temperature;
+        }
+        if (request.maxTokens !== undefined) {
+          attrs[GEN_AI_REQUEST_MAX_TOKENS] = request.maxTokens;
+        }
+        span = startChildSpan("gen_ai.chat", turnSpan, attrs);
+      } catch (e: unknown) {
+        onError?.(e);
+        return next(request);
+      }
+
+      try {
+        const response = await next(request);
+        if (span.isRecording()) {
+          if (response.model !== undefined) {
+            span.setAttribute(GEN_AI_RESPONSE_MODEL, response.model);
+          }
+          if (response.usage !== undefined) {
+            span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, response.usage.inputTokens);
+            span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, response.usage.outputTokens);
+          }
+          recordContent(span, request, response);
+        }
+        return response;
+      } catch (e: unknown) {
+        if (span.isRecording()) {
+          span.recordException(e instanceof Error ? e : new Error(String(e)));
+          span.setStatus({ code: SpanStatusCode.ERROR, message: String(e) });
+        }
+        throw e;
+      } finally {
+        span.end();
+      }
+    },
+
+    async *wrapModelStream(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      // let: assigned in try, used across try/catch/finally
+      let span: Span | undefined;
+      try {
+        const turnSpan = turnSpans.get(turnKey(ctx));
+        const attrs: Record<string, string | number> = {
+          [GEN_AI_OPERATION_NAME]: "chat",
+        };
+        if (request.model !== undefined) {
+          attrs[GEN_AI_REQUEST_MODEL] = request.model;
+        }
+        span = startChildSpan("gen_ai.stream", turnSpan, attrs);
+      } catch (e: unknown) {
+        onError?.(e);
+        yield* next(request);
+        return;
+      }
+
+      try {
+        // let: accumulates the final response from the stream's done chunk
+        let lastResponse: ModelResponse | undefined;
+        for await (const chunk of next(request)) {
+          if (chunk.kind === "done") {
+            lastResponse = chunk.response;
+          }
+          yield chunk;
+        }
+
+        if (span.isRecording() && lastResponse !== undefined) {
+          if (lastResponse.model !== undefined) {
+            span.setAttribute(GEN_AI_RESPONSE_MODEL, lastResponse.model);
+          }
+          if (lastResponse.usage !== undefined) {
+            span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, lastResponse.usage.inputTokens);
+            span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, lastResponse.usage.outputTokens);
+          }
+          recordContent(span, request, lastResponse);
+        }
+      } catch (e: unknown) {
+        if (span.isRecording()) {
+          span.recordException(e instanceof Error ? e : new Error(String(e)));
+          span.setStatus({ code: SpanStatusCode.ERROR, message: String(e) });
+        }
+        throw e;
+      } finally {
+        span.end();
+      }
+    },
+
+    async wrapToolCall(
+      ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      // let: assigned in try, used across try/catch/finally
+      let span: Span | undefined;
+      try {
+        const turnSpan = turnSpans.get(turnKey(ctx));
+        span = startChildSpan("koi.tool_call", turnSpan, {
+          [KOI_TOOL_ID]: request.toolId,
+        });
+      } catch (e: unknown) {
+        onError?.(e);
+        return next(request);
+      }
+
+      try {
+        const response = await next(request);
+        recordContent(span, request, response);
+        return response;
+      } catch (e: unknown) {
+        if (span.isRecording()) {
+          span.recordException(e instanceof Error ? e : new Error(String(e)));
+          span.setStatus({ code: SpanStatusCode.ERROR, message: String(e) });
+        }
+        throw e;
+      } finally {
+        span.end();
+      }
+    },
+  };
+
+  return middleware;
+}

--- a/packages/tracing/tsconfig.json
+++ b/packages/tracing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tracing/tsup.config.ts
+++ b/packages/tracing/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/e2e-tracing.ts
+++ b/scripts/e2e-tracing.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env bun
+/**
+ * Manual E2E test: @koi/tracing → real LLM call → OTel span verification.
+ *
+ * Assembles a real agent with the tracing middleware, makes one Anthropic
+ * API call, and verifies the full span hierarchy:
+ *   Session → Turn → Model Call (gen_ai.chat)
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-tracing.ts
+ */
+
+import type { EngineEvent, ModelRequest } from "../packages/core/src/index.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createLoopAdapter } from "../packages/engine-loop/src/loop-adapter.js";
+import { createAnthropicAdapter } from "../packages/model-router/src/adapters/anthropic.js";
+import {
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  KOI_AGENT_ID,
+  KOI_SESSION_ID,
+  KOI_TURN_INDEX,
+} from "../packages/tracing/src/semantic-conventions.js";
+import type { ReadableSpan } from "../packages/tracing/src/test-setup.js";
+import { createTestTracer } from "../packages/tracing/src/test-setup.js";
+import { createTracingMiddleware } from "../packages/tracing/src/tracing.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping.");
+  process.exit(1);
+}
+
+console.log("[e2e] Starting tracing E2E test...\n");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean): void {
+  results.push({ name, passed: condition });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+}
+
+function printReport(): void {
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  const total = results.length;
+
+  console.log(`\n${"\u2500".repeat(60)}`);
+  console.log(`Results: ${passed}/${total} passed, ${failed} failed`);
+  console.log("\u2500".repeat(60));
+
+  if (failed > 0) {
+    console.log("\nFailed tests:");
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  - ${r.name}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Set up OTel tracing infrastructure
+// ---------------------------------------------------------------------------
+
+console.log("[setup] Initializing OTel tracing...");
+
+const testTracer = createTestTracer();
+
+console.log("[setup] Tracer ready\n");
+
+// ---------------------------------------------------------------------------
+// 2. Assemble agent with tracing middleware
+// ---------------------------------------------------------------------------
+
+console.log("[setup] Assembling agent with tracing middleware...");
+
+const anthropic = createAnthropicAdapter({ apiKey: API_KEY });
+const modelCall = (request: ModelRequest) =>
+  anthropic.complete({ ...request, model: "claude-sonnet-4-5-20250929" });
+
+const loopAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+const tracingMiddleware = createTracingMiddleware({
+  tracer: testTracer.tracer,
+  captureContent: true,
+  onError: (e) => console.error("[tracing-error]", e),
+});
+
+const runtime = await createKoi({
+  manifest: {
+    name: "tracing-e2e",
+    version: "0.1.0",
+    model: { name: "claude-sonnet-4-5" },
+  },
+  adapter: loopAdapter,
+  middleware: [tracingMiddleware],
+  loopDetection: false,
+});
+
+console.log(`[setup] Agent assembled (state: ${runtime.agent.state})`);
+console.log(`[setup] Sending: "Say hello in exactly 3 words."\n`);
+
+// ---------------------------------------------------------------------------
+// 3. Run a real LLM call
+// ---------------------------------------------------------------------------
+
+let fullResponse = "";
+const events: EngineEvent[] = [];
+
+for await (const event of runtime.run({
+  kind: "text",
+  text: "Say hello in exactly 3 words.",
+})) {
+  events.push(event);
+  if (event.kind === "text_delta") {
+    fullResponse += event.delta;
+    process.stdout.write(event.delta);
+  } else if (event.kind === "done") {
+    console.log(
+      `\n\n  [done] stopReason=${event.output.stopReason} turns=${event.output.metrics.turns}`,
+    );
+    console.log(
+      `  [done] tokens: ${event.output.metrics.inputTokens} in / ${event.output.metrics.outputTokens} out`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Verify spans
+// ---------------------------------------------------------------------------
+
+console.log("\n[test] Verifying tracing spans...\n");
+
+const spans = testTracer.getFinishedSpans();
+
+assert("at least 1 span exported", spans.length >= 1);
+assert("response is non-empty", fullResponse.length > 0);
+
+// --- Session span ---
+const sessionSpan = spans.find((s) => s.name === "koi.session");
+assert("session span exists", sessionSpan !== undefined);
+assert(
+  "session span has koi.session.id attribute",
+  sessionSpan?.attributes[KOI_SESSION_ID] !== undefined,
+);
+assert(
+  "session span has koi.agent.id attribute",
+  sessionSpan?.attributes[KOI_AGENT_ID] !== undefined,
+);
+
+// --- Turn span ---
+const turnSpan = spans.find((s) => s.name === "koi.turn");
+assert("turn span exists", turnSpan !== undefined);
+assert("turn span has koi.turn.index = 0", turnSpan?.attributes[KOI_TURN_INDEX] === 0);
+
+// --- Turn is child of Session ---
+if (sessionSpan && turnSpan) {
+  assert(
+    "turn span is child of session span",
+    turnSpan.parentSpanContext?.spanId === sessionSpan.spanContext().spanId,
+  );
+}
+
+// --- Model call span ---
+const modelSpan = spans.find((s) => s.name === "gen_ai.chat");
+assert("model call span exists", modelSpan !== undefined);
+assert(
+  'model call has gen_ai.operation.name = "chat"',
+  modelSpan?.attributes[GEN_AI_OPERATION_NAME] === "chat",
+);
+// Note: gen_ai.request.model may be absent when model is set by the adapter
+// (modelCall wrapper) rather than on the incoming ModelRequest object.
+// gen_ai.response.model is the reliable indicator — it's set from the response.
+assert(
+  "model call has gen_ai.response.model (from LLM response)",
+  typeof modelSpan?.attributes[GEN_AI_RESPONSE_MODEL] === "string",
+);
+assert(
+  "model call has gen_ai.usage.input_tokens > 0",
+  typeof modelSpan?.attributes[GEN_AI_USAGE_INPUT_TOKENS] === "number" &&
+    modelSpan.attributes[GEN_AI_USAGE_INPUT_TOKENS] > 0,
+);
+assert(
+  "model call has gen_ai.usage.output_tokens > 0",
+  typeof modelSpan?.attributes[GEN_AI_USAGE_OUTPUT_TOKENS] === "number" &&
+    modelSpan.attributes[GEN_AI_USAGE_OUTPUT_TOKENS] > 0,
+);
+
+// --- Model call is child of Turn ---
+if (turnSpan && modelSpan) {
+  assert(
+    "model call span is child of turn span",
+    modelSpan.parentSpanContext?.spanId === turnSpan.spanContext().spanId,
+  );
+}
+
+// --- Content capture ---
+assert(
+  "model call has captured request content",
+  modelSpan?.attributes["koi.request.content"] !== undefined,
+);
+assert(
+  "model call has captured response content",
+  modelSpan?.attributes["koi.response.content"] !== undefined,
+);
+
+// --- Done event ---
+const doneEvent = events.find((e) => e.kind === "done");
+assert(
+  "run completed successfully",
+  doneEvent?.kind === "done" && doneEvent.output.stopReason === "completed",
+);
+
+// ---------------------------------------------------------------------------
+// 5. Print span tree
+// ---------------------------------------------------------------------------
+
+console.log("\n[trace] Span tree:\n");
+
+function printSpan(span: ReadableSpan, depth: number): void {
+  const prefix = "  ".repeat(depth);
+  const durationMs =
+    Number(span.endTime[0] - span.startTime[0]) * 1000 +
+    (span.endTime[1] - span.startTime[1]) / 1e6;
+  console.log(`${prefix}[${span.name}] (${durationMs.toFixed(1)}ms)`);
+
+  for (const [key, value] of Object.entries(span.attributes)) {
+    if (key.startsWith("koi.request.content") || key.startsWith("koi.response.content")) {
+      const strVal = String(value);
+      console.log(`${prefix}  ${key} = ${strVal.slice(0, 80)}${strVal.length > 80 ? "..." : ""}`);
+    } else {
+      console.log(`${prefix}  ${key} = ${value}`);
+    }
+  }
+}
+
+// Build parent→children map
+const childMap = new Map<string, ReadableSpan[]>();
+for (const span of spans) {
+  const parentId = span.parentSpanContext?.spanId;
+  if (parentId !== undefined) {
+    const children = childMap.get(parentId) ?? [];
+    children.push(span);
+    childMap.set(parentId, children);
+  }
+}
+
+function printTree(span: ReadableSpan, depth: number): void {
+  printSpan(span, depth);
+  const children = childMap.get(span.spanContext().spanId) ?? [];
+  for (const child of children) {
+    printTree(child, depth + 1);
+  }
+}
+
+const rootSpans = spans.filter(
+  (s) =>
+    s.parentSpanContext === undefined ||
+    !spans.some((other) => other.spanContext().spanId === s.parentSpanContext?.spanId),
+);
+
+for (const root of rootSpans) {
+  printTree(root, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Cleanup + report
+// ---------------------------------------------------------------------------
+
+await testTracer.shutdown();
+
+printReport();
+
+const failed = results.filter((r) => !r.passed).length;
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log("\n[e2e] TRACING E2E VALIDATION PASSED");


### PR DESCRIPTION
## Summary

Implements `@koi/tracing` — an L2 OpenTelemetry distributed tracing middleware that bridges Koi middleware hooks to OTel spans for external observability (Jaeger, Datadog, Grafana Tempo, etc.).

- **Span hierarchy**: `Session → Turn → Model Call / Model Stream / Tool Call`
- **Zero-cost**: When no `TracerProvider` is registered, OTel API returns noop spans — no overhead
- **Error-isolated**: Every hook is wrapped in try/catch — tracing never crashes the application
- **Content capture**: Opt-in via `captureContent: true` with optional `contentFilter` for PII
- **Bounded memory**: `SpanContextStore` uses LRU eviction at 1000 entries with automatic span cleanup
- **Priority 450**: Runs after audit@300, before event-trace@475

### New files (10 source + 1 E2E script)

| File | Purpose |
|------|---------|
| `packages/tracing/src/tracing.ts` | `createTracingMiddleware()` factory |
| `packages/tracing/src/config.ts` | `TracingConfig` interface + `validateConfig()` |
| `packages/tracing/src/span-context.ts` | Bounded Map wrapper with LRU eviction |
| `packages/tracing/src/semantic-conventions.ts` | GenAI + Koi OTel attribute constants |
| `packages/tracing/src/index.ts` | Public API exports |
| `packages/tracing/src/test-setup.ts` | OTel test infrastructure helper |
| `packages/tracing/src/tracing.test.ts` | 14 per-hook unit tests |
| `packages/tracing/src/config.test.ts` | 7 config validation tests |
| `packages/tracing/src/span-context.test.ts` | 7 store lifecycle + eviction tests |
| `packages/tracing/src/__tests__/integration.test.ts` | 4 full lifecycle E2E tests |
| `scripts/e2e-tracing.ts` | Manual E2E with real Anthropic API call |

### Layer compliance

- L2 package: imports only `@koi/core` (L0) and `@opentelemetry/api`
- No imports from `@koi/engine` (L1) or peer L2 packages
- All interface properties `readonly`
- `@koi/core` untouched

### Test results

- **32/32 unit/integration tests pass** (98.28% line coverage, 100% function coverage)
- **17/17 E2E assertions pass** with real Anthropic API call — verified full span hierarchy with real token usage data

## Test plan

- [x] `bun test packages/tracing/src/` — 32 tests pass
- [x] `bunx turbo run typecheck --filter=@koi/tracing` — clean
- [x] `bunx biome check packages/tracing/` — clean
- [x] `bunx turbo run build --filter=@koi/tracing` — ESM + .d.ts success
- [x] E2E: `ANTHROPIC_API_KEY=... bun scripts/e2e-tracing.ts` — 17/17 pass
- [x] Layer check: no L1/L2 peer imports
- [ ] CI pipeline

Closes #37