### PR TITLE
feat: cascade routing with pre-request complexity classifier

### DIFF
--- a/packages/model-router/src/__tests__/cascade-classifier-e2e.test.ts
+++ b/packages/model-router/src/__tests__/cascade-classifier-e2e.test.ts
@@ -1,0 +1,379 @@
+/**
+ * E2E test for the pre-request complexity classifier + cascade router.
+ *
+ * Validates the full pipeline with real LLM calls:
+ *   Classifier → tier slicing → withCascade → real model response
+ *
+ * Uses a 2-tier cascade (both OpenAI to avoid cross-provider issues):
+ *   Tier 0 (LIGHT):  OpenAI gpt-4o-mini  (cheap)
+ *   Tier 1 (HEAVY):  OpenAI gpt-4o       (more capable)
+ *
+ * Gated on OPENAI_API_KEY.
+ *
+ * Run:
+ *   OPENAI_API_KEY=... bun test src/__tests__/cascade-classifier-e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import { createOpenAIAdapter } from "../adapters/openai.js";
+import type { CascadeEvaluator } from "../cascade/cascade-types.js";
+import { createComplexityClassifier } from "../cascade/complexity-classifier.js";
+import { createKeywordEvaluator } from "../cascade/evaluators.js";
+import type { ResolvedRouterConfig } from "../config.js";
+import type { ProviderAdapter } from "../provider-adapter.js";
+import { createModelRouter } from "../router.js";
+
+// ---------------------------------------------------------------------------
+// Env gate
+// ---------------------------------------------------------------------------
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const HAS_KEYS = OPENAI_KEY.length > 0;
+
+const describeE2E = HAS_KEYS ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(text: string, maxTokens = 30): ModelRequest {
+  return {
+    messages: [
+      {
+        content: [{ kind: "text" as const, text }],
+        senderId: "e2e-user",
+        timestamp: Date.now(),
+      },
+    ],
+    maxTokens,
+    temperature: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared setup: 2-tier OpenAI cascade (gpt-4o-mini → gpt-4o)
+// ---------------------------------------------------------------------------
+
+function createCascadeRouter(evaluator: CascadeEvaluator): {
+  readonly router: ReturnType<typeof createModelRouter>;
+  readonly config: ResolvedRouterConfig;
+} {
+  const classifier = createComplexityClassifier();
+
+  const config: ResolvedRouterConfig = {
+    targets: [
+      {
+        provider: "openai-cheap",
+        model: "gpt-4o-mini",
+        weight: 1,
+        enabled: true,
+        adapterConfig: { apiKey: OPENAI_KEY },
+      },
+      {
+        provider: "openai-expensive",
+        model: "gpt-4o",
+        weight: 1,
+        enabled: true,
+        adapterConfig: { apiKey: OPENAI_KEY },
+      },
+    ],
+    strategy: "cascade",
+    retry: {
+      maxRetries: 1,
+      backoffMultiplier: 2,
+      initialDelayMs: 100,
+      maxBackoffMs: 1000,
+      jitter: false,
+    },
+    circuitBreaker: {
+      failureThreshold: 3,
+      cooldownMs: 60_000,
+      failureWindowMs: 60_000,
+      failureStatusCodes: [429, 500, 502, 503, 504],
+    },
+    cascade: {
+      tiers: [{ targetId: "openai-cheap:gpt-4o-mini" }, { targetId: "openai-expensive:gpt-4o" }],
+      confidenceThreshold: 0.7,
+      maxEscalations: 1,
+      budgetLimitTokens: 0,
+      evaluatorTimeoutMs: 10_000,
+    },
+  };
+
+  const adapters = new Map<string, ProviderAdapter>([
+    ["openai-cheap", createOpenAIAdapter({ apiKey: OPENAI_KEY })],
+    ["openai-expensive", createOpenAIAdapter({ apiKey: OPENAI_KEY })],
+  ]);
+
+  const router = createModelRouter(config, adapters, {
+    evaluator,
+    classifier,
+  });
+
+  return { router, config };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: cascade with complexity classifier", () => {
+  // -------------------------------------------------------------------------
+  // Test 1: Simple prompt → classifier routes to LIGHT → cheap model
+  // -------------------------------------------------------------------------
+
+  test(
+    "simple prompt classified LIGHT → cheap tier responds successfully",
+    async () => {
+      const evaluator: CascadeEvaluator = () => ({ confidence: 0.95 });
+      const { router } = createCascadeRouter(evaluator);
+
+      const classifier = createComplexityClassifier();
+      const classification = classifier(makeRequest("Reply with one word: hello"), 2);
+
+      console.log("[LIGHT test] classification:", {
+        score: classification.score.toFixed(3),
+        confidence: classification.confidence.toFixed(3),
+        tier: classification.tier,
+        index: classification.recommendedTierIndex,
+      });
+
+      expect(classification.tier).toBe("LIGHT");
+      expect(classification.recommendedTierIndex).toBe(0);
+
+      const result = await router.route(makeRequest("Reply with one word: hello"));
+
+      if (!result.ok) {
+        console.error("[LIGHT test] route error:", result.error);
+      }
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`Route failed: ${result.error.message}`);
+
+      console.log("[LIGHT test] response:", {
+        content: result.value.content.slice(0, 100),
+        model: result.value.model,
+      });
+
+      expect(result.value.content.length).toBeGreaterThan(0);
+
+      // Metrics: cheap tier should have been called
+      const metrics = router.getMetrics();
+      expect(metrics.totalRequests).toBe(1);
+      expect(metrics.requestsByTarget["openai-cheap:gpt-4o-mini"] ?? 0).toBeGreaterThanOrEqual(1);
+
+      router.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 2: Complex prompt → classifier routes to HEAVY → skips cheap
+  // -------------------------------------------------------------------------
+
+  test(
+    "complex prompt classified HEAVY → skips cheap tier, routes to expensive",
+    async () => {
+      const evaluator: CascadeEvaluator = () => ({ confidence: 0.95 });
+      const { router } = createCascadeRouter(evaluator);
+
+      const complexPrompt =
+        "Analyze and evaluate the trade-offs of distributed consensus algorithms. " +
+        "Compare Raft vs Paxos and prove which is more suitable for a microservices architecture.";
+
+      const classifier = createComplexityClassifier();
+      const classification = classifier(makeRequest(complexPrompt), 2);
+
+      console.log("[HEAVY test] classification:", {
+        score: classification.score.toFixed(3),
+        confidence: classification.confidence.toFixed(3),
+        tier: classification.tier,
+        index: classification.recommendedTierIndex,
+      });
+
+      expect(classification.tier).toBe("HEAVY");
+      expect(classification.recommendedTierIndex).toBe(1);
+
+      const result = await router.route(makeRequest(complexPrompt, 100));
+
+      if (!result.ok) {
+        console.error("[HEAVY test] route error:", result.error);
+      }
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`Route failed: ${result.error.message}`);
+
+      console.log("[HEAVY test] response:", {
+        content: `${result.value.content.slice(0, 100)}...`,
+        model: result.value.model,
+      });
+
+      expect(result.value.content.length).toBeGreaterThan(0);
+
+      // Metrics: cheap tier should NOT have been called — classifier skipped it
+      const metrics = router.getMetrics();
+      expect(metrics.requestsByTarget["openai-cheap:gpt-4o-mini"] ?? 0).toBe(0);
+      expect(metrics.requestsByTarget["openai-expensive:gpt-4o"] ?? 0).toBeGreaterThanOrEqual(1);
+
+      router.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 3: Classifier + evaluator — LIGHT start, evaluator escalates
+  // -------------------------------------------------------------------------
+
+  test(
+    "classifier + evaluator: LIGHT tier with evaluator escalation",
+    async () => {
+      // Evaluator rejects cheap model, accepts expensive
+      const evaluator: CascadeEvaluator = (_req, response) => {
+        if (response.model?.includes("gpt-4o-mini")) {
+          return { confidence: 0.2, reason: "Cheap model insufficient" };
+        }
+        return { confidence: 0.95, reason: "Expensive model adequate" };
+      };
+      const { router } = createCascadeRouter(evaluator);
+
+      const result = await router.route(makeRequest("What is the capital of France?"));
+
+      if (!result.ok) {
+        console.error("[ESCALATION test] route error:", result.error);
+      }
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(`Route failed: ${result.error.message}`);
+
+      console.log("[ESCALATION test] response:", {
+        content: result.value.content.slice(0, 100),
+        model: result.value.model,
+      });
+
+      expect(result.value.content.length).toBeGreaterThan(0);
+
+      // Both tiers should have been called (cheap tried, then escalated)
+      const metrics = router.getMetrics();
+      expect(metrics.requestsByTarget["openai-cheap:gpt-4o-mini"] ?? 0).toBeGreaterThanOrEqual(1);
+      expect(metrics.requestsByTarget["openai-expensive:gpt-4o"] ?? 0).toBeGreaterThanOrEqual(1);
+      expect(metrics.cascade?.totalEscalations).toBeGreaterThanOrEqual(1);
+
+      router.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 4: Classifier confidence — verify sigmoid values for varied prompts
+  // -------------------------------------------------------------------------
+
+  test("classifier produces valid confidence values for varied prompts", () => {
+    const classifier = createComplexityClassifier();
+
+    const prompts = [
+      { text: "hello", expectedTier: "LIGHT" as const },
+      { text: "what is 2+2?", expectedTier: "LIGHT" as const },
+      { text: "thanks", expectedTier: "LIGHT" as const },
+      {
+        text: "first check the database schema, then deploy the api pipeline as json",
+        expectedTier: "MEDIUM" as const,
+      },
+      {
+        text: "analyze and evaluate this distributed consensus algorithm with formal proof",
+        expectedTier: "HEAVY" as const,
+      },
+      {
+        text: "forward this to the team and check status",
+        expectedTier: "LIGHT" as const,
+      },
+    ];
+
+    console.log("\n[CONFIDENCE test] Classification results:");
+    console.log("─".repeat(90));
+    console.log(
+      "Prompt".padEnd(55) + "Score".padEnd(8) + "Conf".padEnd(8) + "Tier".padEnd(8) + "Expected",
+    );
+    console.log("─".repeat(90));
+
+    for (const { text, expectedTier } of prompts) {
+      const result = classifier(makeRequest(text), 3);
+
+      const displayText = text.length > 52 ? `${text.slice(0, 49)}...` : text;
+      console.log(
+        displayText.padEnd(55) +
+          result.score.toFixed(3).padEnd(8) +
+          result.confidence.toFixed(3).padEnd(8) +
+          result.tier.padEnd(8) +
+          expectedTier,
+      );
+
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(1);
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+      expect(result.tier).toBe(expectedTier);
+      expect(result.dimensions).toBeDefined();
+    }
+
+    console.log("─".repeat(90));
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: Keyword evaluator + classifier (realistic production combo)
+  // -------------------------------------------------------------------------
+
+  test(
+    "realistic setup: keyword evaluator + classifier with real calls",
+    async () => {
+      const evaluator = createKeywordEvaluator();
+      const { router } = createCascadeRouter(evaluator);
+
+      // Simple prompt — should use cheap tier and get accepted
+      const simpleResult = await router.route(makeRequest("Reply with exactly one word: hello"));
+
+      if (!simpleResult.ok) {
+        console.error("[KEYWORD E2E] simple error:", simpleResult.error);
+      }
+      expect(simpleResult.ok).toBe(true);
+      if (!simpleResult.ok) throw new Error("Simple route failed");
+
+      console.log("[KEYWORD E2E] simple:", {
+        content: simpleResult.value.content.slice(0, 50),
+        model: simpleResult.value.model,
+      });
+
+      expect(simpleResult.value.content.length).toBeGreaterThan(0);
+
+      // Complex prompt — classifier should skip to expensive tier
+      const complexResult = await router.route(
+        makeRequest(
+          "Analyze the trade-offs between Raft and Paxos consensus algorithms and evaluate their suitability",
+          100,
+        ),
+      );
+
+      if (!complexResult.ok) {
+        console.error("[KEYWORD E2E] complex error:", complexResult.error);
+      }
+      expect(complexResult.ok).toBe(true);
+      if (!complexResult.ok) throw new Error("Complex route failed");
+
+      console.log("[KEYWORD E2E] complex:", {
+        content: `${complexResult.value.content.slice(0, 100)}...`,
+        model: complexResult.value.model,
+      });
+
+      expect(complexResult.value.content.length).toBeGreaterThan(0);
+
+      const metrics = router.getMetrics();
+      console.log("[KEYWORD E2E] metrics:", {
+        totalRequests: metrics.totalRequests,
+        requestsByTarget: metrics.requestsByTarget,
+        escalations: metrics.cascade?.totalEscalations,
+      });
+
+      router.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/model-router/src/__tests__/cascade-integration.test.ts
+++ b/packages/model-router/src/__tests__/cascade-integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Integration tests for cascade routing strategy.
+ *
+ * Tests end-to-end flows through the router with cascade config,
+ * including multi-tier escalation, circuit breaker interaction,
+ * and middleware integration.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { KoiError, ModelRequest, ModelResponse } from "@koi/core";
+import type { CascadeEvaluator, ResolvedCascadeConfig } from "../cascade/cascade-types.js";
+import { createKeywordEvaluator } from "../cascade/evaluators.js";
+import type { ResolvedRouterConfig, ResolvedTargetConfig } from "../config.js";
+import { createModelRouterMiddleware } from "../middleware.js";
+import type { ProviderAdapter } from "../provider-adapter.js";
+import { createModelRouter } from "../router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(text = "Hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "test-user", timestamp: 0 }],
+  };
+}
+
+function makeResponse(content: string, model: string): ModelResponse {
+  return { content, model, usage: { inputTokens: 100, outputTokens: 50 } };
+}
+
+function makeTarget(
+  provider: string,
+  model: string,
+  overrides?: Partial<ResolvedTargetConfig>,
+): ResolvedTargetConfig {
+  return {
+    provider,
+    model,
+    weight: 1,
+    enabled: true,
+    adapterConfig: { apiKey: "sk-test" },
+    ...overrides,
+  };
+}
+
+function makeCascadeConfig(
+  targets: readonly ResolvedTargetConfig[],
+  cascadeOverrides?: Partial<ResolvedCascadeConfig>,
+): ResolvedRouterConfig {
+  const targetIds = targets.map((t) => `${t.provider}:${t.model}`);
+  return {
+    targets,
+    strategy: "cascade",
+    retry: {
+      maxRetries: 0,
+      backoffMultiplier: 2,
+      initialDelayMs: 10,
+      maxBackoffMs: 100,
+      jitter: false,
+    },
+    circuitBreaker: {
+      failureThreshold: 2,
+      cooldownMs: 60_000,
+      failureWindowMs: 60_000,
+      failureStatusCodes: [429, 500, 502, 503, 504],
+    },
+    cascade: {
+      tiers: targetIds.map((id) => ({ targetId: id })),
+      confidenceThreshold: 0.7,
+      maxEscalations: targetIds.length - 1,
+      budgetLimitTokens: 0,
+      evaluatorTimeoutMs: 5_000,
+      ...cascadeOverrides,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Full 3-tier cascade
+// ---------------------------------------------------------------------------
+
+describe("cascade integration: full 3-tier", () => {
+  test("cheap model low confidence → medium model accepted", async () => {
+    const evaluator: CascadeEvaluator = (_req, response) => {
+      // Cheap model → low confidence, medium model → high confidence
+      if (response.content.includes("cheap")) {
+        return { confidence: 0.3, reason: "Cheap model response too brief" };
+      }
+      return { confidence: 0.85, reason: "Medium model adequate" };
+    };
+
+    const targets = [
+      makeTarget("cheap-provider", "cheap-model"),
+      makeTarget("medium-provider", "medium-model"),
+      makeTarget("expensive-provider", "expensive-model"),
+    ];
+
+    const cheapAdapter: ProviderAdapter = {
+      id: "cheap-provider",
+      complete: mock(() => Promise.resolve(makeResponse("cheap answer", "cheap-model"))),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+    const mediumAdapter: ProviderAdapter = {
+      id: "medium-provider",
+      complete: mock(() => Promise.resolve(makeResponse("detailed medium answer", "medium-model"))),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+    const expensiveAdapter: ProviderAdapter = {
+      id: "expensive-provider",
+      complete: mock(() => Promise.resolve(makeResponse("expensive answer", "expensive-model"))),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+
+    const adapters = new Map<string, ProviderAdapter>([
+      ["cheap-provider", cheapAdapter],
+      ["medium-provider", mediumAdapter],
+      ["expensive-provider", expensiveAdapter],
+    ]);
+
+    const config = makeCascadeConfig(targets);
+    const router = createModelRouter(config, adapters, { evaluator });
+
+    const result = await router.route(makeRequest("What is 2+2?"));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("detailed medium answer");
+    expect(result.value.model).toBe("medium-model");
+
+    // Verify only 2 adapters were called (cheap + medium, NOT expensive)
+    expect(cheapAdapter.complete).toHaveBeenCalledTimes(1);
+    expect(mediumAdapter.complete).toHaveBeenCalledTimes(1);
+    expect(expensiveAdapter.complete).not.toHaveBeenCalled();
+
+    // Verify metrics
+    const metrics = router.getMetrics();
+    expect(metrics.totalRequests).toBe(1);
+    expect(metrics.totalFailures).toBe(0);
+    expect(metrics.cascade).toBeDefined();
+    expect(metrics.cascade?.totalEscalations).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Cascade with circuit breaker
+// ---------------------------------------------------------------------------
+
+describe("cascade integration: circuit breaker", () => {
+  test("circuit-broken cheap tier skips to medium directly", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const failFn = () => {
+      throw { code: "EXTERNAL", message: "down", retryable: false } satisfies KoiError;
+    };
+
+    const targets = [
+      makeTarget("cheap-provider", "cheap-model"),
+      makeTarget("medium-provider", "medium-model"),
+    ];
+
+    const cheapAdapter: ProviderAdapter = {
+      id: "cheap-provider",
+      complete: mock(failFn),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+    const mediumAdapter: ProviderAdapter = {
+      id: "medium-provider",
+      complete: mock(() => Promise.resolve(makeResponse("medium ok", "medium-model"))),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+
+    const adapters = new Map<string, ProviderAdapter>([
+      ["cheap-provider", cheapAdapter],
+      ["medium-provider", mediumAdapter],
+    ]);
+
+    const config = makeCascadeConfig(targets);
+    const router = createModelRouter(config, adapters, { evaluator });
+
+    // First two calls: cheap fails, falls through to medium
+    await router.route(makeRequest());
+    await router.route(makeRequest());
+
+    // After 2 failures, circuit breaker opens for cheap tier
+    const health = router.getHealth();
+    expect(health.get("cheap-provider:cheap-model")?.state).toBe("OPEN");
+
+    // Reset call counts
+    (cheapAdapter.complete as ReturnType<typeof mock>).mockClear();
+    (mediumAdapter.complete as ReturnType<typeof mock>).mockClear();
+
+    // Third call: cheap tier should be skipped by circuit breaker
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("medium ok");
+
+    // Cheap adapter should NOT have been called (circuit breaker is OPEN)
+    expect(cheapAdapter.complete).not.toHaveBeenCalled();
+    expect(mediumAdapter.complete).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Cascade via middleware
+// ---------------------------------------------------------------------------
+
+describe("cascade integration: middleware", () => {
+  test("createModelRouterMiddleware with cascade strategy works end-to-end", async () => {
+    const evaluator = createKeywordEvaluator();
+
+    const targets = [makeTarget("openai", "gpt-4o-mini"), makeTarget("openai", "gpt-4o")];
+
+    const adapter: ProviderAdapter = {
+      id: "openai",
+      complete: mock((req: ModelRequest) => {
+        if (req.model === "gpt-4o-mini") {
+          // Cheap model: uncertain response → low confidence from keyword evaluator
+          return Promise.resolve(
+            makeResponse("I'm not sure, it depends on context", "gpt-4o-mini"),
+          );
+        }
+        // Expensive model: confident response
+        return Promise.resolve(makeResponse("The answer is definitively 42", "gpt-4o"));
+      }),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "done" };
+      },
+    };
+
+    const adapters = new Map<string, ProviderAdapter>([["openai", adapter]]);
+
+    const config = makeCascadeConfig(targets);
+    const router = createModelRouter(config, adapters, { evaluator });
+    const mw = createModelRouterMiddleware(router);
+
+    expect(mw.name).toBe("model-router");
+
+    if (!mw.wrapModelCall) throw new Error("Expected wrapModelCall");
+    const next = mock(() => Promise.resolve(makeResponse("unused", "unused")));
+
+    const result = await mw.wrapModelCall(
+      {} as Parameters<typeof mw.wrapModelCall>[0],
+      makeRequest("What is 2+2?"),
+      next,
+    );
+
+    // The keyword evaluator should detect "I'm not sure" and "it depends" → low confidence
+    // → escalate to gpt-4o (last tier, accepted without evaluation)
+    expect(result.content).toBe("The answer is definitively 42");
+    expect(result.model).toBe("gpt-4o");
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/packages/model-router/src/cascade/cascade-metrics.test.ts
+++ b/packages/model-router/src/cascade/cascade-metrics.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelResponse } from "@koi/core";
+import { createCascadeMetricsTracker } from "./cascade-metrics.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResponse(opts?: { inputTokens?: number; outputTokens?: number }): ModelResponse {
+  return {
+    content: "test",
+    model: "test-model",
+    ...(opts
+      ? { usage: { inputTokens: opts.inputTokens ?? 0, outputTokens: opts.outputTokens ?? 0 } }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createCascadeMetricsTracker
+// ---------------------------------------------------------------------------
+
+describe("createCascadeMetricsTracker", () => {
+  test("starts with zero metrics", () => {
+    const tracker = createCascadeMetricsTracker([{ targetId: "openai:gpt-4o-mini" }]);
+    const metrics = tracker.getMetrics();
+
+    expect(metrics.totalRequests).toBe(0);
+    expect(metrics.totalEscalations).toBe(0);
+    expect(metrics.totalEstimatedCost).toBe(0);
+    expect(metrics.tiers).toHaveLength(1);
+    expect(metrics.tiers[0]?.requests).toBe(0);
+  });
+
+  test("tracks single tier request", () => {
+    const tracker = createCascadeMetricsTracker([{ targetId: "openai:gpt-4o-mini" }]);
+
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 100, outputTokens: 50 }),
+      false,
+    );
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.totalRequests).toBe(1);
+    expect(metrics.totalEscalations).toBe(0);
+    expect(metrics.tiers[0]?.requests).toBe(1);
+    expect(metrics.tiers[0]?.totalInputTokens).toBe(100);
+    expect(metrics.tiers[0]?.totalOutputTokens).toBe(50);
+  });
+
+  test("tracks multi-tier with escalation", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini" },
+      { targetId: "openai:gpt-4o" },
+    ]);
+
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 100, outputTokens: 50 }),
+      true,
+    );
+    tracker.record("openai:gpt-4o", makeResponse({ inputTokens: 200, outputTokens: 100 }), false);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.totalRequests).toBe(2);
+    expect(metrics.totalEscalations).toBe(1);
+    expect(metrics.tiers[0]?.escalations).toBe(1);
+    expect(metrics.tiers[1]?.escalations).toBe(0);
+  });
+
+  test("calculates estimated cost from costPerToken", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini", costPerInputToken: 0.001, costPerOutputToken: 0.002 },
+    ]);
+
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 1000, outputTokens: 500 }),
+      false,
+    );
+
+    const metrics = tracker.getMetrics();
+    // 1000 * 0.001 + 500 * 0.002 = 1.0 + 1.0 = 2.0
+    expect(metrics.totalEstimatedCost).toBeCloseTo(2.0, 5);
+    expect(metrics.tiers[0]?.estimatedCost).toBeCloseTo(2.0, 5);
+  });
+
+  test("missing usage data results in zero cost", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini", costPerInputToken: 0.001, costPerOutputToken: 0.002 },
+    ]);
+
+    tracker.record("openai:gpt-4o-mini", makeResponse(), false);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.totalEstimatedCost).toBe(0);
+  });
+
+  test("snapshot is immutable (returns fresh copy)", () => {
+    const tracker = createCascadeMetricsTracker([{ targetId: "openai:gpt-4o-mini" }]);
+
+    const before = tracker.getMetrics();
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 100, outputTokens: 50 }),
+      false,
+    );
+    const after = tracker.getMetrics();
+
+    expect(before.totalRequests).toBe(0);
+    expect(after.totalRequests).toBe(1);
+  });
+
+  test("ignores record for unknown tier", () => {
+    const tracker = createCascadeMetricsTracker([{ targetId: "openai:gpt-4o-mini" }]);
+
+    tracker.record("unknown:model", makeResponse({ inputTokens: 100, outputTokens: 50 }), false);
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.totalRequests).toBe(0);
+  });
+});

--- a/packages/model-router/src/cascade/cascade-metrics.ts
+++ b/packages/model-router/src/cascade/cascade-metrics.ts
@@ -1,0 +1,90 @@
+/**
+ * Cost tracking for cascade routing.
+ *
+ * Tracks per-tier request counts, escalations, token usage,
+ * and estimated costs.
+ */
+
+import type { ModelResponse } from "@koi/core";
+import type { CascadeCostMetrics, CascadeTierConfig, TierCostMetrics } from "./cascade-types.js";
+
+interface TierMetricsSnapshot {
+  readonly requests: number;
+  readonly escalations: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+}
+
+export interface CascadeMetricsTracker {
+  readonly record: (tierId: string, response: ModelResponse, escalated: boolean) => void;
+  readonly getMetrics: () => CascadeCostMetrics;
+}
+
+export function createCascadeMetricsTracker(
+  tiers: readonly CascadeTierConfig[],
+): CascadeMetricsTracker {
+  const tierMetrics = new Map<string, TierMetricsSnapshot>();
+  const tierConfigs = new Map<string, CascadeTierConfig>();
+
+  for (const tier of tiers) {
+    tierMetrics.set(tier.targetId, {
+      requests: 0,
+      escalations: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+    });
+    tierConfigs.set(tier.targetId, tier);
+  }
+
+  return {
+    record(tierId: string, response: ModelResponse, escalated: boolean): void {
+      const prev = tierMetrics.get(tierId);
+      if (!prev) return;
+
+      tierMetrics.set(tierId, {
+        requests: prev.requests + 1,
+        escalations: prev.escalations + (escalated ? 1 : 0),
+        totalInputTokens: prev.totalInputTokens + (response.usage?.inputTokens ?? 0),
+        totalOutputTokens: prev.totalOutputTokens + (response.usage?.outputTokens ?? 0),
+      });
+    },
+
+    getMetrics(): CascadeCostMetrics {
+      let totalRequests = 0;
+      let totalEscalations = 0;
+      let totalEstimatedCost = 0;
+
+      const tierSnapshots: TierCostMetrics[] = [];
+
+      for (const tier of tiers) {
+        const metrics = tierMetrics.get(tier.targetId);
+        if (!metrics) continue;
+
+        const config = tierConfigs.get(tier.targetId);
+        const estimatedCost =
+          metrics.totalInputTokens * (config?.costPerInputToken ?? 0) +
+          metrics.totalOutputTokens * (config?.costPerOutputToken ?? 0);
+
+        tierSnapshots.push({
+          tierId: tier.targetId,
+          requests: metrics.requests,
+          escalations: metrics.escalations,
+          totalInputTokens: metrics.totalInputTokens,
+          totalOutputTokens: metrics.totalOutputTokens,
+          estimatedCost,
+        });
+
+        totalRequests += metrics.requests;
+        totalEscalations += metrics.escalations;
+        totalEstimatedCost += estimatedCost;
+      }
+
+      return {
+        tiers: tierSnapshots,
+        totalRequests,
+        totalEscalations,
+        totalEstimatedCost,
+      };
+    },
+  };
+}

--- a/packages/model-router/src/cascade/cascade-types.ts
+++ b/packages/model-router/src/cascade/cascade-types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types for the cascade routing strategy.
+ *
+ * Cascade tries the cheapest model first, evaluates response quality
+ * via a pluggable confidence evaluator, and escalates to progressively
+ * more expensive models only when confidence is insufficient.
+ */
+
+import type { JsonObject, ModelRequest, ModelResponse } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of evaluating a model response for confidence.
+ * Confidence is a number between 0.0 (no confidence) and 1.0 (full confidence).
+ */
+export interface CascadeEvaluationResult {
+  readonly confidence: number;
+  readonly reason?: string;
+  readonly metadata?: JsonObject;
+}
+
+/**
+ * Evaluates a model response and returns a confidence score.
+ * May be sync (keyword matching) or async (LLM-based evaluation).
+ */
+export type CascadeEvaluator = (
+  request: ModelRequest,
+  response: ModelResponse,
+) => CascadeEvaluationResult | Promise<CascadeEvaluationResult>;
+
+// ---------------------------------------------------------------------------
+// Tier configuration
+// ---------------------------------------------------------------------------
+
+export interface CascadeTierConfig {
+  readonly targetId: string;
+  readonly costPerInputToken?: number;
+  readonly costPerOutputToken?: number;
+  readonly timeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Cascade configuration (user-facing + resolved)
+// ---------------------------------------------------------------------------
+
+export interface CascadeConfig {
+  readonly tiers: readonly CascadeTierConfig[];
+  readonly confidenceThreshold: number;
+  readonly maxEscalations?: number;
+  readonly budgetLimitTokens?: number;
+  readonly evaluatorTimeoutMs?: number;
+}
+
+export interface ResolvedCascadeConfig {
+  readonly tiers: readonly CascadeTierConfig[];
+  readonly confidenceThreshold: number;
+  readonly maxEscalations: number;
+  readonly budgetLimitTokens: number;
+  readonly evaluatorTimeoutMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Cascade execution results
+// ---------------------------------------------------------------------------
+
+export interface CascadeAttempt {
+  readonly tierId: string;
+  readonly success: boolean;
+  readonly confidence?: number;
+  readonly escalated: boolean;
+  readonly error?: string;
+  readonly durationMs: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+}
+
+export interface CascadeResult {
+  readonly response: ModelResponse;
+  readonly tierId: string;
+  readonly tierIndex: number;
+  readonly confidence: number;
+  readonly attempts: readonly CascadeAttempt[];
+  readonly totalEscalations: number;
+}
+
+// ---------------------------------------------------------------------------
+// Cost metrics
+// ---------------------------------------------------------------------------
+
+export interface TierCostMetrics {
+  readonly tierId: string;
+  readonly requests: number;
+  readonly escalations: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly estimatedCost: number;
+}
+
+export interface CascadeCostMetrics {
+  readonly tiers: readonly TierCostMetrics[];
+  readonly totalRequests: number;
+  readonly totalEscalations: number;
+  readonly totalEstimatedCost: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-request complexity classification
+// ---------------------------------------------------------------------------
+
+export type ComplexityTier = "LIGHT" | "MEDIUM" | "HEAVY";
+
+export interface ClassificationResult {
+  readonly score: number;
+  /** Sigmoid-mapped confidence in the tier assignment (0.0–1.0). Low values indicate the score is near a tier boundary. */
+  readonly confidence: number;
+  readonly tier: ComplexityTier;
+  readonly recommendedTierIndex: number;
+  readonly reason: string;
+  readonly dimensions?: JsonObject;
+}
+
+/**
+ * Synchronous pre-request classifier that scores request complexity.
+ * Must complete in <1ms — pure heuristics, zero LLM calls.
+ * Receives `tierCount` so it can compute `recommendedTierIndex` without knowing config internals.
+ */
+export type CascadeClassifier = (request: ModelRequest, tierCount: number) => ClassificationResult;

--- a/packages/model-router/src/cascade/cascade.test.ts
+++ b/packages/model-router/src/cascade/cascade.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ModelRequest, ModelResponse } from "@koi/core";
+import type { CircuitBreaker, CircuitBreakerSnapshot } from "../circuit-breaker.js";
+import { withCascade } from "./cascade.js";
+import type {
+  CascadeEvaluator,
+  CascadeTierConfig,
+  ResolvedCascadeConfig,
+} from "./cascade-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(text = "test"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "test-user", timestamp: 0 }],
+  };
+}
+
+function makeResponse(
+  content: string,
+  opts?: {
+    inputTokens?: number;
+    outputTokens?: number;
+  },
+): ModelResponse {
+  return {
+    content,
+    model: "test-model",
+    ...(opts
+      ? { usage: { inputTokens: opts.inputTokens ?? 0, outputTokens: opts.outputTokens ?? 0 } }
+      : {}),
+  };
+}
+
+function makeTiers(...ids: readonly string[]): readonly CascadeTierConfig[] {
+  return ids.map((id) => ({ targetId: id }));
+}
+
+function makeConfig(overrides?: Partial<ResolvedCascadeConfig>): ResolvedCascadeConfig {
+  return {
+    tiers: makeTiers("cheap:model", "medium:model", "expensive:model"),
+    confidenceThreshold: 0.7,
+    maxEscalations: 2,
+    budgetLimitTokens: 0,
+    evaluatorTimeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+function makeOpenCircuitBreaker(): CircuitBreaker {
+  return {
+    isAllowed: () => false,
+    recordSuccess: () =>
+      ({
+        state: "OPEN",
+        failureCount: 0,
+        lastFailureAt: undefined,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    recordFailure: () =>
+      ({
+        state: "OPEN",
+        failureCount: 1,
+        lastFailureAt: 0,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    getSnapshot: () =>
+      ({
+        state: "OPEN",
+        failureCount: 0,
+        lastFailureAt: undefined,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    reset: () => {},
+  };
+}
+
+function makeClosedCircuitBreaker(): CircuitBreaker {
+  return {
+    isAllowed: () => true,
+    recordSuccess: () =>
+      ({
+        state: "CLOSED",
+        failureCount: 0,
+        lastFailureAt: undefined,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    recordFailure: () =>
+      ({
+        state: "CLOSED",
+        failureCount: 1,
+        lastFailureAt: 0,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    getSnapshot: () =>
+      ({
+        state: "CLOSED",
+        failureCount: 0,
+        lastFailureAt: undefined,
+        lastTransitionAt: 0,
+      }) satisfies CircuitBreakerSnapshot,
+    reset: () => {},
+  };
+}
+
+const noCBs = new Map<string, CircuitBreaker>();
+
+// ---------------------------------------------------------------------------
+// withCascade
+// ---------------------------------------------------------------------------
+
+describe("withCascade", () => {
+  test("cheap model accepted when confidence >= threshold", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`response from ${tier.targetId}`)),
+    );
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "expensive:model"), maxEscalations: 1 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.tierId).toBe("cheap:model");
+    expect(result.value.confidence).toBe(0.9);
+    expect(result.value.totalEscalations).toBe(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("escalates from cheap to medium when confidence is low", async () => {
+    let callCount = 0;
+    const evaluator: CascadeEvaluator = () => {
+      callCount++;
+      // First call (cheap) → low confidence, second call won't happen (last tier)
+      return { confidence: callCount === 1 ? 0.3 : 0.9 };
+    };
+
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`response from ${tier.targetId}`)),
+    );
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "medium:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig(),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Second tier (medium) evaluated and accepted
+    expect(result.value.tierId).toBe("medium:model");
+    expect(result.value.totalEscalations).toBe(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns last tier response without evaluation", async () => {
+    const evaluator: CascadeEvaluator = mock(() => ({ confidence: 0.1 }));
+
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`from ${tier.targetId}`)),
+    );
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "expensive:model"), maxEscalations: 1 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Last tier is accepted with confidence 1 (no evaluation)
+    expect(result.value.tierId).toBe("expensive:model");
+    expect(result.value.confidence).toBe(1);
+  });
+
+  test("provider error on cheap tier skips to next", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const fn = mock((tier: CascadeTierConfig) => {
+      if (tier.targetId === "cheap:model") {
+        return Promise.reject(new Error("provider down"));
+      }
+      return Promise.resolve(makeResponse("from medium"));
+    });
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "medium:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "medium:model"), maxEscalations: 1 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Medium is last tier, accepted without evaluation
+    expect(result.value.tierId).toBe("medium:model");
+    expect(result.value.attempts[0]?.success).toBe(false);
+    expect(result.value.attempts[0]?.error).toContain("provider down");
+  });
+
+  test("all tiers fail with errors returns error result", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const fn = mock(() => Promise.reject(new Error("all down")));
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "expensive:model"), maxEscalations: 1 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.code).toBe("EXTERNAL");
+    expect(result.error.message).toContain("All");
+    expect(result.error.message).toContain("cascade tiers failed");
+  });
+
+  test("circuit breaker open on cheap tier skips to next", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`from ${tier.targetId}`)),
+    );
+
+    const cbs = new Map<string, CircuitBreaker>([
+      ["cheap:model", makeOpenCircuitBreaker()],
+      ["expensive:model", makeClosedCircuitBreaker()],
+    ]);
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "expensive:model"), maxEscalations: 1 }),
+      cbs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.tierId).toBe("expensive:model");
+    // Only called once (expensive), cheap was skipped
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("evaluator throws treats as confidence 0.0 (fail-open)", async () => {
+    const evaluator: CascadeEvaluator = () => {
+      throw new Error("evaluator broke");
+    };
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`from ${tier.targetId}`)),
+    );
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("cheap:model", "expensive:model"), maxEscalations: 1 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Cheap evaluator failed → confidence 0 → escalated to expensive (last tier, accepted)
+    expect(result.value.tierId).toBe("expensive:model");
+    expect(result.value.totalEscalations).toBe(1);
+  });
+
+  test("budget exhausted returns best response so far", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.3 });
+    const fn = mock(() =>
+      Promise.resolve(makeResponse("response", { inputTokens: 5000, outputTokens: 5000 })),
+    );
+
+    const config = makeConfig({
+      tiers: makeTiers("cheap:model", "expensive:model"),
+      maxEscalations: 1,
+      budgetLimitTokens: 5000,
+    });
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "expensive:model"),
+      fn,
+      evaluator,
+      config,
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Budget exceeded after first tier, return what we have
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("single tier returns immediately without evaluation", async () => {
+    const evaluator: CascadeEvaluator = mock(() => ({ confidence: 0.1 }));
+    const fn = mock(() => Promise.resolve(makeResponse("only response")));
+
+    const result = await withCascade(
+      makeTiers("only:model"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("only:model"), maxEscalations: 0 }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.tierId).toBe("only:model");
+    expect(result.value.confidence).toBe(1);
+    // Evaluator should NOT have been called (single/last tier)
+    expect(evaluator).not.toHaveBeenCalled();
+  });
+
+  test("max escalations limit returns best response below threshold", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.3 });
+    const fn = mock((tier: CascadeTierConfig) =>
+      Promise.resolve(makeResponse(`from ${tier.targetId}`)),
+    );
+
+    const config = makeConfig({
+      tiers: makeTiers("cheap:model", "medium:model", "expensive:model"),
+      maxEscalations: 1,
+      confidenceThreshold: 0.9,
+    });
+
+    const result = await withCascade(
+      makeTiers("cheap:model", "medium:model", "expensive:model"),
+      fn,
+      evaluator,
+      config,
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // After cheap (escalate) → medium (max escalations hit, return best)
+    expect(result.value.totalEscalations).toBe(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("empty tiers returns validation error", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 1 });
+    const fn = mock(() => Promise.resolve(makeResponse("test")));
+
+    const result = await withCascade(
+      [],
+      fn,
+      evaluator,
+      makeConfig({ tiers: [] }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("attempts array records all tiers visited", async () => {
+    let evalCount = 0;
+    const evaluator: CascadeEvaluator = () => {
+      evalCount++;
+      return { confidence: evalCount === 1 ? 0.2 : 0.9 };
+    };
+
+    const fn = mock(() => Promise.resolve(makeResponse("resp")));
+
+    const result = await withCascade(
+      makeTiers("tier1", "tier2", "tier3"),
+      fn,
+      evaluator,
+      makeConfig({ tiers: makeTiers("tier1", "tier2", "tier3") }),
+      noCBs,
+      makeRequest(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.attempts).toHaveLength(2);
+    expect(result.value.attempts[0]?.tierId).toBe("tier1");
+    expect(result.value.attempts[0]?.escalated).toBe(true);
+    expect(result.value.attempts[1]?.tierId).toBe("tier2");
+    expect(result.value.attempts[1]?.escalated).toBe(false);
+  });
+});

--- a/packages/model-router/src/cascade/cascade.ts
+++ b/packages/model-router/src/cascade/cascade.ts
@@ -1,0 +1,299 @@
+/**
+ * Cascade orchestration — cheap-first escalation.
+ *
+ * Tries the cheapest model first, evaluates response quality,
+ * and escalates to progressively more expensive models only
+ * when confidence is insufficient.
+ */
+
+import type { KoiError, ModelRequest, ModelResponse, Result } from "@koi/core";
+import type { CircuitBreaker } from "../circuit-breaker.js";
+import type {
+  CascadeAttempt,
+  CascadeEvaluator,
+  CascadeResult,
+  CascadeTierConfig,
+  ResolvedCascadeConfig,
+} from "./cascade-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates response confidence with timeout and fail-open semantics.
+ * Returns 0.0 on evaluator error or timeout (fail-open → escalate).
+ * Cleans up the timer to prevent leaks.
+ */
+async function evaluateWithTimeout(
+  evaluator: CascadeEvaluator,
+  request: ModelRequest,
+  response: ModelResponse,
+  timeoutMs: number,
+): Promise<number> {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      Promise.resolve(evaluator(request, response)),
+      new Promise<never>((_, reject) => {
+        timerId = setTimeout(
+          () => reject(new Error(`Evaluator timeout after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+    return result.confidence;
+  } catch (_error: unknown) {
+    // Fail-open: evaluator error or timeout → confidence 0.0 → escalate
+    return 0;
+  } finally {
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+  }
+}
+
+function buildSuccessResult(
+  response: ModelResponse,
+  tierId: string,
+  tierIndex: number,
+  confidence: number,
+  attempts: readonly CascadeAttempt[],
+  totalEscalations: number,
+): Result<CascadeResult, KoiError> {
+  return {
+    ok: true,
+    value: { response, tierId, tierIndex, confidence, attempts, totalEscalations },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main cascade orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes a cascade routing strategy across ordered tiers.
+ *
+ * @param tiers - Ordered list of tiers (cheapest first)
+ * @param fn - Function to call a tier and get a response
+ * @param evaluator - Confidence evaluator function
+ * @param config - Resolved cascade configuration
+ * @param circuitBreakers - Map of target ID → CircuitBreaker
+ * @param request - Original model request (forwarded to evaluator)
+ * @param clock - Injectable clock for timing
+ */
+export async function withCascade(
+  tiers: readonly CascadeTierConfig[],
+  fn: (tier: CascadeTierConfig) => Promise<ModelResponse>,
+  evaluator: CascadeEvaluator,
+  config: ResolvedCascadeConfig,
+  circuitBreakers: ReadonlyMap<string, CircuitBreaker>,
+  request: ModelRequest,
+  clock: () => number = Date.now,
+): Promise<Result<CascadeResult, KoiError>> {
+  if (tiers.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "No tiers configured for cascade routing",
+        retryable: false,
+      },
+    };
+  }
+
+  // Filter to circuit-breaker-allowed tiers; graceful degradation if all are open
+  const allowedTiers = tiers.filter((t) => {
+    const cb = circuitBreakers.get(t.targetId);
+    return cb === undefined || cb.isAllowed();
+  });
+  // Fallback: if all breakers are open, try all tiers anyway
+  const candidates = allowedTiers.length > 0 ? allowedTiers : tiers;
+
+  const attempts: CascadeAttempt[] = [];
+  let totalEscalations = 0;
+  let bestResponse:
+    | {
+        readonly response: ModelResponse;
+        readonly confidence: number;
+        readonly tierIndex: number;
+        readonly tierId: string;
+      }
+    | undefined;
+  let totalTokens = 0;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const tier = candidates[i];
+    if (!tier) continue;
+
+    const startMs = clock();
+    const cb = circuitBreakers.get(tier.targetId);
+
+    try {
+      const response = await fn(tier);
+      const durationMs = clock() - startMs;
+
+      // Track token usage for budget
+      const inputTokens = response.usage?.inputTokens ?? 0;
+      const outputTokens = response.usage?.outputTokens ?? 0;
+      totalTokens += inputTokens + outputTokens;
+
+      cb?.recordSuccess();
+
+      const isLastCandidate = i === candidates.length - 1;
+
+      // If this is the last candidate, accept without evaluation
+      if (isLastCandidate) {
+        attempts.push({
+          tierId: tier.targetId,
+          success: true,
+          confidence: 1,
+          escalated: false,
+          durationMs,
+          inputTokens,
+          outputTokens,
+        });
+        return buildSuccessResult(response, tier.targetId, i, 1, attempts, totalEscalations);
+      }
+
+      // Check budget before evaluation
+      if (config.budgetLimitTokens > 0 && totalTokens > config.budgetLimitTokens) {
+        attempts.push({
+          tierId: tier.targetId,
+          success: true,
+          confidence: 0,
+          escalated: false,
+          durationMs,
+          inputTokens,
+          outputTokens,
+        });
+        const best = bestResponse ?? {
+          response,
+          confidence: 0,
+          tierIndex: i,
+          tierId: tier.targetId,
+        };
+        return buildSuccessResult(
+          best.response,
+          best.tierId,
+          best.tierIndex,
+          best.confidence,
+          attempts,
+          totalEscalations,
+        );
+      }
+
+      // Evaluate confidence (with timeout + fail-open)
+      const confidence = await evaluateWithTimeout(
+        evaluator,
+        request,
+        response,
+        config.evaluatorTimeoutMs,
+      );
+
+      // Track best response seen
+      if (!bestResponse || confidence > bestResponse.confidence) {
+        bestResponse = { response, confidence, tierIndex: i, tierId: tier.targetId };
+      }
+
+      // Accept if confidence meets threshold
+      if (confidence >= config.confidenceThreshold) {
+        attempts.push({
+          tierId: tier.targetId,
+          success: true,
+          confidence,
+          escalated: false,
+          durationMs,
+          inputTokens,
+          outputTokens,
+        });
+        return buildSuccessResult(
+          response,
+          tier.targetId,
+          i,
+          confidence,
+          attempts,
+          totalEscalations,
+        );
+      }
+
+      // Max escalations check — return best response so far
+      if (totalEscalations >= config.maxEscalations) {
+        attempts.push({
+          tierId: tier.targetId,
+          success: true,
+          confidence,
+          escalated: false,
+          durationMs,
+          inputTokens,
+          outputTokens,
+        });
+        const best = bestResponse;
+        return buildSuccessResult(
+          best.response,
+          best.tierId,
+          best.tierIndex,
+          best.confidence,
+          attempts,
+          totalEscalations,
+        );
+      }
+
+      // Escalate to next tier
+      totalEscalations++;
+      attempts.push({
+        tierId: tier.targetId,
+        success: true,
+        confidence,
+        escalated: true,
+        durationMs,
+        inputTokens,
+        outputTokens,
+      });
+    } catch (error: unknown) {
+      const durationMs = clock() - startMs;
+      cb?.recordFailure();
+
+      attempts.push({
+        tierId: tier.targetId,
+        success: false,
+        escalated: i < candidates.length - 1,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs,
+      });
+
+      if (i < candidates.length - 1) {
+        totalEscalations++;
+      }
+    }
+  }
+
+  // All tiers exhausted — return best response if we have one
+  if (bestResponse) {
+    return buildSuccessResult(
+      bestResponse.response,
+      bestResponse.tierId,
+      bestResponse.tierIndex,
+      bestResponse.confidence,
+      attempts,
+      totalEscalations,
+    );
+  }
+
+  // Complete failure
+  return {
+    ok: false,
+    error: {
+      code: "EXTERNAL",
+      message: `All ${attempts.length} cascade tiers failed: ${attempts.map((a) => `${a.tierId}: ${a.error ?? "unknown"}`).join("; ")}`,
+      retryable: false,
+      context: {
+        attempts: attempts.map((a) => ({
+          tierId: a.tierId,
+          error: a.error,
+          durationMs: a.durationMs,
+        })),
+      },
+    },
+  };
+}

--- a/packages/model-router/src/cascade/complexity-classifier.test.ts
+++ b/packages/model-router/src/cascade/complexity-classifier.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import { createComplexityClassifier } from "./complexity-classifier.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function userMsg(text: string): ModelRequest {
+  return {
+    messages: [
+      {
+        content: [{ kind: "text" as const, text }],
+        senderId: "user-1",
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+function systemAndUserMsg(system: string, user: string): ModelRequest {
+  return {
+    messages: [
+      {
+        content: [{ kind: "text" as const, text: system }],
+        senderId: "system",
+        timestamp: Date.now(),
+      },
+      {
+        content: [{ kind: "text" as const, text: user }],
+        senderId: "user-1",
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+function multiUserMsg(...texts: readonly string[]): ModelRequest {
+  return {
+    messages: texts.map((text) => ({
+      content: [{ kind: "text" as const, text }],
+      senderId: "user-1",
+      timestamp: Date.now(),
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createComplexityClassifier", () => {
+  const classify = createComplexityClassifier();
+
+  // -------------------------------------------------------------------------
+  // Text extraction
+  // -------------------------------------------------------------------------
+
+  describe("text extraction", () => {
+    test("extracts only user messages (not system/assistant senderId)", () => {
+      const request = systemAndUserMsg(
+        "You are an expert analyst who must analyze and evaluate everything",
+        "hello",
+      );
+      const result = classify(request, 3);
+      // System message has heavy keywords but should be ignored
+      expect(result.tier).toBe("LIGHT");
+    });
+
+    test("extracts text from multiple user messages", () => {
+      const request = multiUserMsg(
+        "analyze this algorithm",
+        "then compare it with the alternative approach",
+      );
+      const result = classify(request, 3);
+      // "analyze" + "compare" = 2 reasoning keywords → override forces HEAVY
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("ignores non-text content blocks (image, file)", () => {
+      const request: ModelRequest = {
+        messages: [
+          {
+            content: [
+              { kind: "image" as const, url: "https://example.com/img.png" },
+              { kind: "text" as const, text: "hello" },
+            ],
+            senderId: "user-1",
+            timestamp: Date.now(),
+          },
+        ],
+      };
+      const result = classify(request, 3);
+      expect(result.tier).toBe("LIGHT");
+    });
+
+    test("returns LIGHT for empty/whitespace-only user text", () => {
+      const request = userMsg("   ");
+      const result = classify(request, 3);
+      expect(result.tier).toBe("LIGHT");
+      expect(result.score).toBe(0);
+    });
+
+    test("returns LIGHT for no messages", () => {
+      const request: ModelRequest = { messages: [] };
+      const result = classify(request, 3);
+      expect(result.tier).toBe("LIGHT");
+      expect(result.score).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dimension scoring
+  // -------------------------------------------------------------------------
+
+  describe("dimension scoring", () => {
+    test("reasoning keywords score high", () => {
+      const result = classify(userMsg("analyze this data and evaluate the results"), 3);
+      // 2+ reasoning keywords → override fires → HEAVY
+      expect(result.score).toBeGreaterThanOrEqual(0.6);
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("code presence scores high (dimension level)", () => {
+      const result = classify(
+        userMsg("```typescript\nfunction add(a: number, b: number) { return a + b; }\n```"),
+        3,
+      );
+      // Code fence = 0.8 dimension score, weighted at 0.28 → ~0.22 contribution
+      const codeDim = result.dimensions?.code as number;
+      expect(codeDim).toBeGreaterThanOrEqual(0.8);
+      expect(result.score).toBeGreaterThan(0.1);
+    });
+
+    test("multi-step patterns score high (dimension level)", () => {
+      const result = classify(
+        userMsg("first gather the data, then process it, finally output the results"),
+        3,
+      );
+      const multiStepDim = result.dimensions?.multiStep as number;
+      expect(multiStepDim).toBeGreaterThanOrEqual(1.0);
+      expect(result.score).toBeGreaterThan(0.2);
+    });
+
+    test("simple indicators reduce score", () => {
+      const helloResult = classify(userMsg("hello"), 3);
+      const analyzeResult = classify(userMsg("analyze this complex problem"), 3);
+      expect(helloResult.score).toBeLessThan(analyzeResult.score);
+    });
+
+    test("technical terms score high (dimension level)", () => {
+      const result = classify(
+        userMsg("explain kubernetes cluster orchestration and microservices architecture"),
+        3,
+      );
+      const techDim = result.dimensions?.technical as number;
+      expect(techDim).toBeGreaterThanOrEqual(1.0);
+      expect(result.score).toBeGreaterThan(0.15);
+    });
+
+    test("output format keywords score high (dimension level)", () => {
+      const result = classify(userMsg("return the data as JSON with a structured table"), 3);
+      const formatDim = result.dimensions?.outputFormat as number;
+      expect(formatDim).toBeGreaterThanOrEqual(1.0);
+    });
+
+    test("relay indicators reduce score (push toward LIGHT)", () => {
+      const relayResult = classify(userMsg("forward this to the team and check status"), 3);
+      const neutralResult = classify(userMsg("process this request for the team"), 3);
+      expect(relayResult.score).toBeLessThan(neutralResult.score);
+    });
+
+    test("relay keywords produce LIGHT for pass-through requests", () => {
+      const result = classify(userMsg("check my inbox and mark as read"), 3);
+      expect(result.tier).toBe("LIGHT");
+      const relayDim = result.dimensions?.relay as number;
+      expect(relayDim).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Override rules
+  // -------------------------------------------------------------------------
+
+  describe("override rules", () => {
+    test("2+ reasoning keywords forces HEAVY", () => {
+      const result = classify(userMsg("analyze and evaluate and compare these approaches"), 3);
+      expect(result.tier).toBe("HEAVY");
+      expect(result.score).toBeGreaterThanOrEqual(0.6);
+    });
+
+    test("estimated >50K tokens forces HEAVY", () => {
+      // ~50K tokens ≈ ~200K chars at 4 chars/token
+      const longText = "word ".repeat(50_000);
+      const result = classify(userMsg(longText), 3);
+      expect(result.tier).toBe("HEAVY");
+      expect(result.score).toBeGreaterThanOrEqual(0.6);
+    });
+
+    test("reasoning + high technical forces HEAVY", () => {
+      const result = classify(
+        userMsg("implement a distributed consensus algorithm with formal proof"),
+        3,
+      );
+      // "proof" → reasoning > 0, "distributed"+"consensus"+"algorithm" → technical >= 0.8
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("code + multiStep + reasoning forces HEAVY", () => {
+      const result = classify(
+        userMsg(
+          "analyze this code:\n```js\nfunction x() {}\n```\nFirst refactor it, then add tests",
+        ),
+        3,
+      );
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("overrides never lower the score", () => {
+      // A request that's already HEAVY stays HEAVY
+      const result = classify(
+        userMsg("analyze and evaluate and compare and prove this distributed consensus algorithm"),
+        3,
+      );
+      expect(result.tier).toBe("HEAVY");
+      expect(result.score).toBeGreaterThanOrEqual(0.6);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tier mapping
+  // -------------------------------------------------------------------------
+
+  describe("tier mapping", () => {
+    test("low score → LIGHT tier, index 0", () => {
+      const result = classify(userMsg("hello"), 3);
+      expect(result.tier).toBe("LIGHT");
+      expect(result.recommendedTierIndex).toBe(0);
+    });
+
+    test("medium score → MEDIUM tier, middle index", () => {
+      // Fires multiStep (1.0) + outputFormat (0.5) + technical (0.5) → MEDIUM
+      const result = classify(userMsg("first check the database, then return results as json"), 3);
+      expect(result.tier).toBe("MEDIUM");
+      expect(result.recommendedTierIndex).toBe(1);
+    });
+
+    test("high score → HEAVY tier, last index", () => {
+      const result = classify(
+        userMsg("analyze and evaluate this distributed consensus algorithm with formal proof"),
+        3,
+      );
+      expect(result.tier).toBe("HEAVY");
+      expect(result.recommendedTierIndex).toBe(2);
+    });
+
+    test("single tier always returns index 0", () => {
+      const result = classify(userMsg("analyze and evaluate this complex distributed system"), 1);
+      expect(result.recommendedTierIndex).toBe(0);
+    });
+
+    test("two tiers: LIGHT=0, MEDIUM/HEAVY=1", () => {
+      const light = classify(userMsg("hello"), 2);
+      expect(light.recommendedTierIndex).toBe(0);
+
+      const heavy = classify(
+        userMsg("analyze and evaluate this distributed consensus algorithm"),
+        2,
+      );
+      expect(heavy.recommendedTierIndex).toBe(1);
+    });
+
+    test("three tiers: LIGHT=0, MEDIUM=1, HEAVY=2", () => {
+      const light = classify(userMsg("hello"), 3);
+      expect(light.recommendedTierIndex).toBe(0);
+
+      const heavy = classify(
+        userMsg("analyze and evaluate this distributed consensus algorithm with formal proof"),
+        3,
+      );
+      expect(heavy.recommendedTierIndex).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sigmoid confidence
+  // -------------------------------------------------------------------------
+
+  describe("sigmoid confidence", () => {
+    test("high confidence for score far from boundaries", () => {
+      // "hello" scores ~0 → far from medium boundary (0.25) → high confidence
+      const result = classify(userMsg("hello"), 3);
+      expect(result.confidence).toBeGreaterThan(0.85);
+    });
+
+    test("high confidence for deep HEAVY score (override)", () => {
+      const result = classify(
+        userMsg("analyze and evaluate this distributed consensus algorithm with formal proof"),
+        3,
+      );
+      // Override fired → tier is HEAVY regardless of confidence
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("low confidence near MEDIUM boundary falls back to MEDIUM", () => {
+      // Craft a score just below the medium threshold (0.25) where confidence < 0.70
+      // outputFormat alone with weight 0.20: "json" = 0.5 dim * 0.20 = 0.10
+      // + technical "api" = 0.5 dim * 0.20 = 0.10
+      // Total ≈ 0.20 — close to 0.25 boundary → low confidence → MEDIUM fallback
+      const result = classify(userMsg("return the api response as json"), 3);
+      // Score is near the 0.25 boundary, should fall back to MEDIUM
+      if (result.confidence < 0.7) {
+        expect(result.tier).toBe("MEDIUM");
+      }
+    });
+
+    test("low confidence near HEAVY boundary falls back to MEDIUM", () => {
+      // Craft a score just above the heavy threshold (0.60) without triggering overrides
+      // Use custom classifier with confidence enabled but no overrides that would fire
+      const custom = createComplexityClassifier({
+        // Disable overrides by requiring impossible keyword count
+        heavyReasoningKeywordCount: 999,
+      });
+      // multiStep (1.0 * 0.24 = 0.24) + technical (1.0 * 0.20 = 0.20) +
+      // outputFormat (0.5 * 0.20 = 0.10) + imperativeVerbs (0.5 * 0.06 = 0.03)
+      // ≈ 0.57 — near the 0.60 boundary
+      const result = custom(
+        userMsg("first build the database schema, then deploy the api pipeline as json"),
+        3,
+      );
+      if (result.confidence < 0.7) {
+        expect(result.tier).toBe("MEDIUM");
+      }
+    });
+
+    test("overrides bypass confidence fallback", () => {
+      // 2+ reasoning keywords → override fires → stays HEAVY even if score lands on boundary
+      const result = classify(userMsg("analyze and evaluate this"), 3);
+      expect(result.tier).toBe("HEAVY");
+      // Override fired, so confidence doesn't downgrade to MEDIUM
+    });
+
+    test("confidence threshold 0 disables fallback", () => {
+      const noFallback = createComplexityClassifier({
+        confidenceThreshold: 0,
+      });
+      // Score near boundary but confidence check is disabled
+      const result = noFallback(userMsg("return the api response as json"), 3);
+      // Should use raw tier mapping, not MEDIUM fallback
+      const rawTier = result.score >= 0.6 ? "HEAVY" : result.score >= 0.25 ? "MEDIUM" : "LIGHT";
+      expect(result.tier).toBe(rawTier);
+    });
+
+    test("confidence is in [0, 1] range", () => {
+      const light = classify(userMsg("hi"), 3);
+      expect(light.confidence).toBeGreaterThanOrEqual(0);
+      expect(light.confidence).toBeLessThanOrEqual(1);
+
+      const heavy = classify(
+        userMsg("analyze evaluate compare prove this distributed consensus algorithm"),
+        3,
+      );
+      expect(heavy.confidence).toBeGreaterThanOrEqual(0);
+      expect(heavy.confidence).toBeLessThanOrEqual(1);
+    });
+
+    test("empty input has confidence 1", () => {
+      const result = classify(userMsg("   "), 3);
+      expect(result.confidence).toBe(1);
+    });
+
+    test("custom sigmoid steepness changes confidence curve", () => {
+      const steep = createComplexityClassifier({ sigmoidSteepness: 50 });
+      const gentle = createComplexityClassifier({ sigmoidSteepness: 5 });
+
+      // Same input — steeper sigmoid = higher confidence for same distance
+      const steepResult = steep(userMsg("hello"), 3);
+      const gentleResult = gentle(userMsg("hello"), 3);
+      expect(steepResult.confidence).toBeGreaterThan(gentleResult.confidence);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Real-world prompts
+  // -------------------------------------------------------------------------
+
+  describe("real-world prompts", () => {
+    test('"hello" → LIGHT', () => {
+      const result = classify(userMsg("hello"), 3);
+      expect(result.tier).toBe("LIGHT");
+    });
+
+    test('"what is the capital of France" → LIGHT', () => {
+      const result = classify(userMsg("what is the capital of France"), 3);
+      expect(result.tier).toBe("LIGHT");
+    });
+
+    test('"implement a distributed consensus algorithm with formal proof" → HEAVY', () => {
+      const result = classify(
+        userMsg("implement a distributed consensus algorithm with formal proof"),
+        3,
+      );
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test("long prompt with code blocks → HEAVY", () => {
+      const prompt = `
+Please analyze this code and refactor it:
+
+\`\`\`typescript
+class DatabaseConnectionPool {
+  private connections: Connection[] = [];
+  private maxSize: number;
+
+  constructor(config: PoolConfig) {
+    this.maxSize = config.maxSize;
+  }
+
+  async acquire(): Promise<Connection> {
+    if (this.connections.length > 0) {
+      return this.connections.pop()!;
+    }
+    return this.createNewConnection();
+  }
+
+  async release(conn: Connection): Promise<void> {
+    if (this.connections.length < this.maxSize) {
+      this.connections.push(conn);
+    } else {
+      await conn.close();
+    }
+  }
+}
+\`\`\`
+
+First analyze the current implementation for issues, then refactor to use immutable patterns, finally add proper error handling.
+      `.trim();
+      const result = classify(userMsg(prompt), 3);
+      expect(result.tier).toBe("HEAVY");
+    });
+
+    test('"thanks" → LIGHT', () => {
+      const result = classify(userMsg("thanks"), 3);
+      expect(result.tier).toBe("LIGHT");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Custom options
+  // -------------------------------------------------------------------------
+
+  describe("custom options", () => {
+    test("custom tier thresholds change boundaries", () => {
+      const lenient = createComplexityClassifier({
+        tierThresholds: { medium: 0.8, heavy: 0.95 },
+      });
+      // Something that would normally be MEDIUM becomes LIGHT with higher thresholds
+      const result = lenient(userMsg("first check the database, then return results as json"), 3);
+      expect(result.tier).toBe("LIGHT");
+    });
+
+    test("custom weights override defaults", () => {
+      const codeHeavy = createComplexityClassifier({
+        weights: { code: 0.8 },
+      });
+      const result = codeHeavy(userMsg("```typescript\nconst x = 1;\n```"), 3);
+      // Code dimension with much higher weight: 0.8 * 0.80 = 0.64
+      expect(result.score).toBeGreaterThan(0.5);
+    });
+
+    test("custom keywords per dimension", () => {
+      const custom = createComplexityClassifier({
+        keywords: {
+          reasoning: ["foobar", "bazqux"],
+        },
+      });
+      // Default reasoning keywords shouldn't score
+      const defaultResult = custom(userMsg("analyze this data"), 3);
+      // Custom keywords should score
+      const customResult = custom(userMsg("foobar this bazqux that"), 3);
+      expect(customResult.score).toBeGreaterThan(defaultResult.score);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Result shape
+  // -------------------------------------------------------------------------
+
+  describe("result shape", () => {
+    test("includes all required fields", () => {
+      const result = classify(userMsg("hello"), 3);
+      expect(typeof result.score).toBe("number");
+      expect(typeof result.confidence).toBe("number");
+      expect(typeof result.tier).toBe("string");
+      expect(typeof result.recommendedTierIndex).toBe("number");
+      expect(typeof result.reason).toBe("string");
+      expect(result.reason.length).toBeGreaterThan(0);
+    });
+
+    test("score is clamped to [0, 1]", () => {
+      const light = classify(userMsg("hi"), 3);
+      expect(light.score).toBeGreaterThanOrEqual(0);
+      expect(light.score).toBeLessThanOrEqual(1);
+
+      const heavy = classify(
+        userMsg(
+          "analyze evaluate compare prove this distributed consensus quantum genomics algorithm " +
+            "complex ".repeat(100),
+        ),
+        3,
+      );
+      expect(heavy.score).toBeGreaterThanOrEqual(0);
+      expect(heavy.score).toBeLessThanOrEqual(1);
+    });
+
+    test("dimensions object contains per-dimension scores", () => {
+      const result = classify(userMsg("analyze this code"), 3);
+      expect(result.dimensions).toBeDefined();
+      expect(typeof result.dimensions?.reasoning).toBe("number");
+      expect(typeof result.dimensions?.code).toBe("number");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Performance
+  // -------------------------------------------------------------------------
+
+  describe("performance", () => {
+    test("classifies in < 1ms", () => {
+      const request = userMsg("implement a distributed consensus algorithm with formal proof");
+      const start = performance.now();
+      for (let i = 0; i < 100; i++) {
+        classify(request, 3);
+      }
+      const elapsed = performance.now() - start;
+      // 100 iterations should be well under 100ms → each under 1ms
+      expect(elapsed).toBeLessThan(100);
+    });
+  });
+});

--- a/packages/model-router/src/cascade/complexity-classifier.ts
+++ b/packages/model-router/src/cascade/complexity-classifier.ts
@@ -1,0 +1,550 @@
+/**
+ * Pre-request complexity classifier for cascade routing.
+ *
+ * Scores request complexity using 14 heuristic dimensions in <1ms
+ * (pure text analysis, zero LLM calls). The cascade router uses
+ * the result to skip cheap tiers for obviously complex requests.
+ */
+
+import type { JsonObject, ModelRequest } from "@koi/core";
+import type { CascadeClassifier, ClassificationResult, ComplexityTier } from "./cascade-types.js";
+
+// ---------------------------------------------------------------------------
+// Dimension keys
+// ---------------------------------------------------------------------------
+
+export type DimensionKey =
+  | "reasoning"
+  | "code"
+  | "multiStep"
+  | "technical"
+  | "outputFormat"
+  | "domain"
+  | "tokenCount"
+  | "questionComplexity"
+  | "imperativeVerbs"
+  | "constraints"
+  | "creative"
+  | "simpleIndicators"
+  | "relay"
+  | "agentic";
+
+/** Typed array of all dimension keys — avoids `Object.keys()` + `as` assertion. */
+const DIMENSION_KEYS: readonly DimensionKey[] = [
+  "reasoning",
+  "code",
+  "multiStep",
+  "technical",
+  "outputFormat",
+  "domain",
+  "tokenCount",
+  "questionComplexity",
+  "imperativeVerbs",
+  "constraints",
+  "creative",
+  "simpleIndicators",
+  "relay",
+  "agentic",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Default keyword lists
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KEYWORDS: Readonly<Record<DimensionKey, readonly string[]>> = {
+  reasoning: [
+    "analyze",
+    "prove",
+    "proof",
+    "compare",
+    "evaluate",
+    "explain why",
+    "reason about",
+    "trade-off",
+    "tradeoff",
+    "trade off",
+    "pros and cons",
+    "justify",
+    "critique",
+    "assess",
+    "deduce",
+    "verify",
+    "theorem",
+    "derive",
+  ],
+  code: [
+    "function",
+    "class",
+    "import",
+    "interface",
+    "const ",
+    "let ",
+    "return",
+    "async",
+    "await",
+    "=>",
+    "def ",
+    "fn ",
+    "struct",
+  ],
+  multiStep: [
+    "first",
+    "then",
+    "finally",
+    "step 1",
+    "step 2",
+    "step 3",
+    "next",
+    "after that",
+    "afterwards",
+    "subsequently",
+    "1.",
+    "2.",
+    "3.",
+  ],
+  technical: [
+    "kubernetes",
+    "algorithm",
+    "distributed",
+    "microservices",
+    "architecture",
+    "database",
+    "concurrent",
+    "latency",
+    "throughput",
+    "scalability",
+    "replication",
+    "consensus",
+    "optimization",
+    "compilation",
+    "runtime",
+    "caching",
+    "indexing",
+    "schema",
+    "pipeline",
+    "protocol",
+    "middleware",
+    "api",
+    "deployment",
+    "container",
+  ],
+  outputFormat: [
+    "json",
+    "yaml",
+    "table",
+    "csv",
+    "structured",
+    "markdown",
+    "xml",
+    "html",
+    "formatted",
+  ],
+  domain: [
+    "genomics",
+    "fpga",
+    "quantum",
+    "neural network",
+    "cryptography",
+    "blockchain",
+    "bioinformatics",
+    "differential equation",
+    "linear algebra",
+    "topology",
+  ],
+  tokenCount: [], // scored by char count, not keywords
+  questionComplexity: [], // scored by ? count, not keywords
+  imperativeVerbs: [
+    "build",
+    "implement",
+    "deploy",
+    "refactor",
+    "create",
+    "design",
+    "develop",
+    "construct",
+    "integrate",
+    "migrate",
+    "write",
+    "configure",
+    "optimize",
+  ],
+  constraints: [
+    "must",
+    "requires",
+    "restricted",
+    "cannot",
+    "shall not",
+    "only if",
+    "mandatory",
+    "constraint",
+    "limitation",
+  ],
+  creative: [
+    "story",
+    "poem",
+    "brainstorm",
+    "creative",
+    "imagine",
+    "fiction",
+    "narrative",
+    "artistic",
+  ],
+  simpleIndicators: [
+    "hello",
+    " hi ",
+    " hey ",
+    "what is",
+    "define ",
+    "thanks",
+    "thank you",
+    " yes",
+    " no ",
+    " ok ",
+    " okay ",
+    " sure ",
+    "good morning",
+    "good evening",
+  ],
+  relay: [
+    "forward this",
+    "pass along",
+    "relay this",
+    "escalate to",
+    "hand off",
+    "check status",
+    "check my",
+    "send this to",
+    "notify ",
+    "ping ",
+    "remind me",
+    "set a reminder",
+    "check inbox",
+    "mark as read",
+    "mark as done",
+  ],
+  agentic: [
+    "triage all",
+    "batch process",
+    "audit everything",
+    "scan all",
+    "process each",
+    "for every",
+    "iterate over",
+    "crawl",
+    "aggregate all",
+  ],
+} as const;
+
+// ---------------------------------------------------------------------------
+// Default weights
+// ---------------------------------------------------------------------------
+// Scaled ~2x from plan ratios so that 2-3 active dimensions reach MEDIUM
+// territory. The raw sum is clamped to [0, 1] after computation.
+
+const DEFAULT_WEIGHTS: Readonly<Record<DimensionKey, number>> = {
+  reasoning: 0.36,
+  code: 0.28,
+  multiStep: 0.24,
+  technical: 0.2,
+  outputFormat: 0.2,
+  domain: 0.16,
+  tokenCount: 0.16,
+  agentic: 0.1,
+  questionComplexity: 0.1,
+  constraints: 0.08,
+  imperativeVerbs: 0.06,
+  creative: 0.06,
+  simpleIndicators: -0.2,
+  relay: -0.18,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Default tier thresholds
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MEDIUM_THRESHOLD = 0.25;
+const DEFAULT_HEAVY_THRESHOLD = 0.6;
+const DEFAULT_CHARS_PER_TOKEN = 4;
+const DEFAULT_HEAVY_TOKEN_THRESHOLD = 50_000;
+const DEFAULT_HEAVY_REASONING_KEYWORD_COUNT = 2;
+
+// Keyword saturation threshold: 2 matches = full score
+const DEFAULT_KEYWORD_SATURATION = 2;
+
+// Sigmoid confidence: steepness controls how quickly confidence rises away from boundaries
+const DEFAULT_SIGMOID_STEEPNESS = 15;
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface ComplexityClassifierOptions {
+  readonly tierThresholds?: {
+    readonly medium?: number;
+    readonly heavy?: number;
+  };
+  readonly weights?: Partial<Readonly<Record<DimensionKey, number>>>;
+  readonly keywords?: Partial<Readonly<Record<DimensionKey, readonly string[]>>>;
+  readonly charsPerToken?: number;
+  readonly heavyTokenThreshold?: number;
+  readonly heavyReasoningKeywordCount?: number;
+  /** Steepness of the sigmoid curve for confidence mapping. Higher = sharper transition. Default: 15. */
+  readonly sigmoidSteepness?: number;
+  /** Confidence below this threshold triggers MEDIUM fallback. Default: 0.70. Set to 0 to disable. */
+  readonly confidenceThreshold?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Text extraction — user messages only
+// ---------------------------------------------------------------------------
+
+function extractUserText(request: ModelRequest): string {
+  return request.messages
+    .filter((msg) => msg.senderId !== "system" && msg.senderId !== "assistant")
+    .flatMap((msg) => msg.content.filter((b) => b.kind === "text").map((b) => b.text))
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Dimension scorers
+// ---------------------------------------------------------------------------
+
+function countKeywordMatches(textLower: string, keywords: readonly string[]): number {
+  let count = 0;
+  for (const kw of keywords) {
+    if (textLower.includes(kw)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/** Saturating keyword scorer: returns 0–1.0, saturating at `threshold` matches. */
+function keywordScore(textLower: string, keywords: readonly string[], threshold: number): number {
+  const matches = countKeywordMatches(textLower, keywords);
+  return Math.min(matches / threshold, 1.0);
+}
+
+function scoreCode(textLower: string, keywords: readonly string[]): number {
+  // Strong signal: backtick code fences
+  const hasFence = textLower.includes("```");
+  const fenceScore = hasFence ? 0.8 : 0;
+  const kwScore = keywordScore(textLower, keywords, 4);
+  return Math.min(Math.max(fenceScore, kwScore), 1.0);
+}
+
+function scoreTokenCount(charCount: number, saturationChars: number): number {
+  if (charCount <= 0) return 0;
+  return Math.min(charCount / saturationChars, 1.0);
+}
+
+function scoreQuestionComplexity(text: string): number {
+  let count = 0;
+  for (const ch of text) {
+    if (ch === "?") count++;
+  }
+  if (count === 0) return 0;
+  if (count === 1) return 0.2;
+  if (count === 2) return 0.5;
+  return 1.0;
+}
+
+// ---------------------------------------------------------------------------
+// Sigmoid confidence
+// ---------------------------------------------------------------------------
+
+/** Maps distance from nearest tier boundary to confidence via sigmoid. */
+function computeConfidence(
+  score: number,
+  mediumThreshold: number,
+  heavyThreshold: number,
+  steepness: number,
+): number {
+  const distToMedium = Math.abs(score - mediumThreshold);
+  const distToHeavy = Math.abs(score - heavyThreshold);
+  const minDist = Math.min(distToMedium, distToHeavy);
+  return 1 / (1 + Math.exp(-steepness * minDist));
+}
+
+// ---------------------------------------------------------------------------
+// Tier mapping
+// ---------------------------------------------------------------------------
+
+function mapTier(score: number, mediumThreshold: number, heavyThreshold: number): ComplexityTier {
+  if (score >= heavyThreshold) return "HEAVY";
+  if (score >= mediumThreshold) return "MEDIUM";
+  return "LIGHT";
+}
+
+function mapTierIndex(tier: ComplexityTier, tierCount: number): number {
+  if (tierCount <= 1) return 0;
+  if (tierCount === 2) return tier === "LIGHT" ? 0 : 1;
+  // 3+ tiers
+  if (tier === "LIGHT") return 0;
+  if (tier === "MEDIUM") return Math.floor(tierCount / 2);
+  return tierCount - 1;
+}
+
+function buildReason(tier: ComplexityTier, topDimensions: readonly string[]): string {
+  if (topDimensions.length === 0) return `Classified as ${tier}: minimal signal detected`;
+  return `Classified as ${tier}: top signals — ${topDimensions.join(", ")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a synchronous complexity classifier for pre-request cascade routing.
+ * All scoring is heuristic-based and completes in <1ms.
+ */
+export function createComplexityClassifier(
+  options?: ComplexityClassifierOptions,
+): CascadeClassifier {
+  const mediumThreshold = options?.tierThresholds?.medium ?? DEFAULT_MEDIUM_THRESHOLD;
+  const heavyThreshold = options?.tierThresholds?.heavy ?? DEFAULT_HEAVY_THRESHOLD;
+  const charsPerToken = options?.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  const heavyTokenThreshold = options?.heavyTokenThreshold ?? DEFAULT_HEAVY_TOKEN_THRESHOLD;
+  const heavyReasoningCount =
+    options?.heavyReasoningKeywordCount ?? DEFAULT_HEAVY_REASONING_KEYWORD_COUNT;
+  const sigmoidSteepness = options?.sigmoidSteepness ?? DEFAULT_SIGMOID_STEEPNESS;
+  const confidenceThreshold = options?.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+  const saturationChars = heavyTokenThreshold * charsPerToken;
+
+  // Merge keyword overrides
+  const keywords: Readonly<Record<DimensionKey, readonly string[]>> = {
+    ...DEFAULT_KEYWORDS,
+    ...options?.keywords,
+  };
+
+  // Merge weight overrides
+  const weights: Readonly<Record<DimensionKey, number>> = {
+    ...DEFAULT_WEIGHTS,
+    ...options?.weights,
+  };
+
+  const sat = DEFAULT_KEYWORD_SATURATION;
+
+  return (request: ModelRequest, tierCount: number): ClassificationResult => {
+    const text = extractUserText(request);
+    const trimmed = text.trim();
+
+    // Fast path: empty input
+    if (trimmed.length === 0) {
+      return {
+        score: 0,
+        confidence: 1,
+        tier: "LIGHT",
+        recommendedTierIndex: 0,
+        reason: "Classified as LIGHT: empty input",
+        dimensions: {},
+      };
+    }
+
+    const textLower = trimmed.toLowerCase();
+
+    // Padded text for word-boundary matching of short simpleIndicator keywords
+    // (e.g. " hi " won't false-match "history"). Other dimensions use unpadded text.
+    const textPadded = ` ${textLower} `;
+
+    // Score each dimension (0.0–1.0 per dimension)
+    const dimensions: Record<string, number> = {
+      reasoning: keywordScore(textLower, keywords.reasoning, sat),
+      code: scoreCode(textLower, keywords.code),
+      multiStep: keywordScore(textLower, keywords.multiStep, sat),
+      technical: keywordScore(textLower, keywords.technical, sat),
+      outputFormat: keywordScore(textLower, keywords.outputFormat, sat),
+      domain: keywordScore(textLower, keywords.domain, sat),
+      tokenCount: scoreTokenCount(trimmed.length, saturationChars),
+      questionComplexity: scoreQuestionComplexity(trimmed),
+      imperativeVerbs: keywordScore(textLower, keywords.imperativeVerbs, sat),
+      constraints: keywordScore(textLower, keywords.constraints, sat),
+      creative: keywordScore(textLower, keywords.creative, sat),
+      simpleIndicators: keywordScore(textPadded, keywords.simpleIndicators, sat),
+      relay: keywordScore(textPadded, keywords.relay, sat),
+      agentic: keywordScore(textLower, keywords.agentic, sat),
+    };
+
+    // Weighted sum
+    let rawScore = 0;
+    for (const key of DIMENSION_KEYS) {
+      const dimScore = dimensions[key];
+      if (dimScore !== undefined) {
+        rawScore += dimScore * weights[key];
+      }
+    }
+
+    // Clamp to [0, 1]
+    let score = Math.max(0, Math.min(rawScore, 1.0));
+
+    // Override rules (only raise, never lower). Track whether any fired.
+    let overrideFired = false;
+
+    const reasoningMatches = countKeywordMatches(textLower, keywords.reasoning);
+    if (reasoningMatches >= heavyReasoningCount) {
+      score = Math.max(score, heavyThreshold);
+      overrideFired = true;
+    }
+
+    const estimatedTokens = trimmed.length / charsPerToken;
+    if (estimatedTokens > heavyTokenThreshold) {
+      score = Math.max(score, heavyThreshold);
+      overrideFired = true;
+    }
+
+    // Combined override: analytical + deeply technical → HEAVY
+    const reasoningDim = dimensions.reasoning ?? 0;
+    const technicalDim = dimensions.technical ?? 0;
+    if (reasoningDim > 0 && technicalDim >= 0.8) {
+      score = Math.max(score, heavyThreshold);
+      overrideFired = true;
+    }
+
+    // Combined override: code refactoring with multi-step analysis → HEAVY
+    const codeDim = dimensions.code ?? 0;
+    const multiStepDim = dimensions.multiStep ?? 0;
+    if (codeDim >= 0.5 && multiStepDim >= 0.5 && reasoningDim > 0) {
+      score = Math.max(score, heavyThreshold);
+      overrideFired = true;
+    }
+
+    // Final clamp
+    score = Math.min(score, 1.0);
+
+    // Sigmoid confidence: how far is the score from the nearest tier boundary?
+    const confidence = computeConfidence(score, mediumThreshold, heavyThreshold, sigmoidSteepness);
+
+    // Low-confidence fallback: when near a boundary and no override fired,
+    // default to MEDIUM as the safe middle ground.
+    let tier: ComplexityTier;
+    if (!overrideFired && confidenceThreshold > 0 && confidence < confidenceThreshold) {
+      tier = "MEDIUM";
+    } else {
+      tier = mapTier(score, mediumThreshold, heavyThreshold);
+    }
+
+    const recommendedTierIndex = mapTierIndex(tier, tierCount);
+
+    // Build top dimensions for reason string
+    const topDimensions = Object.entries(dimensions)
+      .filter(([key, val]) => val > 0 && key !== "simpleIndicators" && key !== "relay")
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([key]) => key);
+
+    const reason =
+      !overrideFired && confidenceThreshold > 0 && confidence < confidenceThreshold
+        ? `Low confidence (${(confidence * 100).toFixed(0)}%), defaulting to MEDIUM: top signals — ${topDimensions.join(", ") || "none"}`
+        : buildReason(tier, topDimensions);
+
+    return {
+      score,
+      confidence,
+      tier,
+      recommendedTierIndex,
+      reason,
+      dimensions: dimensions satisfies JsonObject,
+    };
+  };
+}

--- a/packages/model-router/src/cascade/evaluators.test.ts
+++ b/packages/model-router/src/cascade/evaluators.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ModelRequest, ModelResponse } from "@koi/core";
+import type { ProviderAdapter } from "../provider-adapter.js";
+import type { CascadeEvaluator } from "./cascade-types.js";
+import {
+  composeEvaluators,
+  createKeywordEvaluator,
+  createLengthHeuristicEvaluator,
+  createVerbalizedEvaluator,
+} from "./evaluators.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(): ModelRequest {
+  return {
+    messages: [
+      { content: [{ kind: "text" as const, text: "test" }], senderId: "user", timestamp: 0 },
+    ],
+  };
+}
+
+function makeResponse(content: string): ModelResponse {
+  return { content, model: "test-model" };
+}
+
+// ---------------------------------------------------------------------------
+// createLengthHeuristicEvaluator
+// ---------------------------------------------------------------------------
+
+describe("createLengthHeuristicEvaluator", () => {
+  const evaluator = createLengthHeuristicEvaluator();
+
+  test("empty response returns confidence 0", async () => {
+    const result = await evaluator(makeRequest(), makeResponse(""));
+    expect(result).toEqual(expect.objectContaining({ confidence: 0 }));
+  });
+
+  test("whitespace-only response returns confidence 0", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("   "));
+    expect(result).toEqual(expect.objectContaining({ confidence: 0 }));
+  });
+
+  test("response below minLength returns confidence 0", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("short"));
+    expect(result).toEqual(expect.objectContaining({ confidence: 0 }));
+  });
+
+  test("response at target length returns confidence 1", async () => {
+    const content = "a".repeat(200);
+    const result = await evaluator(makeRequest(), makeResponse(content));
+    expect(result).toEqual(expect.objectContaining({ confidence: 1 }));
+  });
+
+  test("response above target length returns confidence 1", async () => {
+    const content = "a".repeat(500);
+    const result = await evaluator(makeRequest(), makeResponse(content));
+    expect(result).toEqual(expect.objectContaining({ confidence: 1 }));
+  });
+
+  test("response between min and target returns interpolated confidence", async () => {
+    // Default min=10, target=200. Length 105 → (105-10)/(200-10) = 95/190 = 0.5
+    const content = "a".repeat(105);
+    const result = await evaluator(makeRequest(), makeResponse(content));
+    expect(result.confidence).toBeCloseTo(0.5, 1);
+  });
+
+  test("response at exact minLength boundary returns confidence 0", async () => {
+    // Length exactly 10 → (10-10)/(200-10) = 0
+    const content = "a".repeat(10);
+    const result = await evaluator(makeRequest(), makeResponse(content));
+    expect(result.confidence).toBeCloseTo(0, 5);
+  });
+
+  test("custom options override defaults", async () => {
+    const custom = createLengthHeuristicEvaluator({ minLength: 5, targetLength: 50 });
+    // Length 27.5 → midpoint → but we need integer
+    const content = "a".repeat(28);
+    const result = await custom(makeRequest(), makeResponse(content));
+    // (28-5)/(50-5) = 23/45 ≈ 0.511
+    expect(result.confidence).toBeGreaterThan(0.4);
+    expect(result.confidence).toBeLessThan(0.6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createKeywordEvaluator
+// ---------------------------------------------------------------------------
+
+describe("createKeywordEvaluator", () => {
+  const evaluator = createKeywordEvaluator();
+
+  test("no markers found returns confidence 1", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("The answer is 42."));
+    expect(result.confidence).toBe(1);
+  });
+
+  test("one marker found reduces confidence by penalty", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("I'm not sure, but maybe 42."));
+    expect(result.confidence).toBe(0.8);
+  });
+
+  test("multiple markers reduce confidence cumulatively", async () => {
+    const result = await evaluator(
+      makeRequest(),
+      makeResponse("I'm not sure and I don't know. It depends on context."),
+    );
+    // 3 markers × 0.2 = 0.6 penalty → confidence 0.4
+    expect(result.confidence).toBeCloseTo(0.4, 5);
+  });
+
+  test("confidence is clamped to 0 floor", async () => {
+    const result = await evaluator(
+      makeRequest(),
+      makeResponse(
+        "I'm not sure, I don't know, it depends, I cannot, I can't, as an AI language model.",
+      ),
+    );
+    expect(result.confidence).toBe(0);
+  });
+
+  test("case insensitive matching", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("I'M NOT SURE about that."));
+    expect(result.confidence).toBe(0.8);
+  });
+
+  test("empty response returns confidence 1", async () => {
+    const result = await evaluator(makeRequest(), makeResponse(""));
+    expect(result.confidence).toBe(1);
+  });
+
+  test("custom markers and penalty", async () => {
+    const custom = createKeywordEvaluator({
+      uncertaintyMarkers: ["maybe", "perhaps"],
+      penaltyPerMarker: 0.5,
+    });
+    const result = await custom(makeRequest(), makeResponse("maybe perhaps"));
+    expect(result.confidence).toBe(0);
+  });
+
+  test("returns matched markers in metadata", async () => {
+    const result = await evaluator(makeRequest(), makeResponse("I apologize for the confusion."));
+    expect(result.metadata).toBeDefined();
+    const metadata = result.metadata as Record<string, unknown>;
+    expect(metadata.matchCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createVerbalizedEvaluator
+// ---------------------------------------------------------------------------
+
+describe("createVerbalizedEvaluator", () => {
+  function makeAdapter(response: string): ProviderAdapter {
+    return {
+      id: "test",
+      complete: mock(() => Promise.resolve({ content: response, model: "test" })),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "completed" };
+      },
+    };
+  }
+
+  test("parses numeric confidence response", async () => {
+    const adapter = makeAdapter("0.73");
+    const evaluator = createVerbalizedEvaluator(adapter);
+    const result = await evaluator(makeRequest(), makeResponse("Hello world"));
+    expect(result.confidence).toBeCloseTo(0.73, 5);
+  });
+
+  test("non-numeric response returns 0.5", async () => {
+    const adapter = makeAdapter("high confidence");
+    const evaluator = createVerbalizedEvaluator(adapter);
+    const result = await evaluator(makeRequest(), makeResponse("Hello world"));
+    expect(result.confidence).toBe(0.5);
+  });
+
+  test("empty response returns 0.5", async () => {
+    const adapter = makeAdapter("");
+    const evaluator = createVerbalizedEvaluator(adapter);
+    const result = await evaluator(makeRequest(), makeResponse("Hello world"));
+    expect(result.confidence).toBe(0.5);
+  });
+
+  test("response > 1 returns 0.5", async () => {
+    const adapter = makeAdapter("2.5");
+    const evaluator = createVerbalizedEvaluator(adapter);
+    const result = await evaluator(makeRequest(), makeResponse("Hello world"));
+    expect(result.confidence).toBe(0.5);
+  });
+
+  test("response < 0 returns 0.5", async () => {
+    const adapter = makeAdapter("-0.3");
+    const evaluator = createVerbalizedEvaluator(adapter);
+    const result = await evaluator(makeRequest(), makeResponse("Hello world"));
+    expect(result.confidence).toBe(0.5);
+  });
+
+  test("calls adapter with correct messages", async () => {
+    const adapter = makeAdapter("0.9");
+    const completeFn = adapter.complete as ReturnType<typeof mock>;
+    const evaluator = createVerbalizedEvaluator(adapter);
+
+    await evaluator(makeRequest(), makeResponse("My answer is 42"));
+
+    expect(completeFn).toHaveBeenCalledTimes(1);
+    const callArgs = completeFn.mock.calls[0]?.[0] as ModelRequest;
+    expect(callArgs.messages.length).toBeGreaterThan(1);
+  });
+
+  test("adapter error propagates", async () => {
+    const adapter: ProviderAdapter = {
+      id: "test",
+      complete: () => Promise.reject(new Error("adapter failed")),
+      async *stream() {
+        yield { kind: "finish" as const, reason: "completed" };
+      },
+    };
+    const evaluator = createVerbalizedEvaluator(adapter);
+
+    await expect(evaluator(makeRequest(), makeResponse("test"))).rejects.toThrow("adapter failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeEvaluators
+// ---------------------------------------------------------------------------
+
+describe("composeEvaluators", () => {
+  const highConfidence: CascadeEvaluator = () => ({ confidence: 0.9, reason: "high" });
+  const lowConfidence: CascadeEvaluator = () => ({ confidence: 0.3, reason: "low" });
+
+  test("min strategy returns minimum confidence", async () => {
+    const composed = composeEvaluators([highConfidence, lowConfidence], "min");
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBe(0.3);
+  });
+
+  test("average strategy returns mean confidence", async () => {
+    const composed = composeEvaluators([highConfidence, lowConfidence], "average");
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBeCloseTo(0.6, 5);
+  });
+
+  test("weighted strategy uses provided weights", async () => {
+    const composed = composeEvaluators(
+      [
+        { evaluator: highConfidence, weight: 3 },
+        { evaluator: lowConfidence, weight: 1 },
+      ],
+      "weighted",
+    );
+    const result = await composed(makeRequest(), makeResponse("test"));
+    // (0.9*3 + 0.3*1) / 4 = 3.0 / 4 = 0.75
+    expect(result.confidence).toBeCloseTo(0.75, 5);
+  });
+
+  test("default strategy is min", async () => {
+    const composed = composeEvaluators([highConfidence, lowConfidence]);
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBe(0.3);
+  });
+
+  test("skips failing evaluator and uses remaining", async () => {
+    const failing: CascadeEvaluator = () => {
+      throw new Error("evaluator broke");
+    };
+    const composed = composeEvaluators([failing, highConfidence], "min");
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBe(0.9);
+  });
+
+  test("all evaluators failing returns confidence 0", async () => {
+    const failing: CascadeEvaluator = () => {
+      throw new Error("broke");
+    };
+    const composed = composeEvaluators([failing], "min");
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBe(0);
+    expect(result.reason).toContain("All evaluators failed");
+  });
+
+  test("empty evaluators array returns confidence 0", async () => {
+    const composed = composeEvaluators([], "min");
+    const result = await composed(makeRequest(), makeResponse("test"));
+    expect(result.confidence).toBe(0);
+  });
+});

--- a/packages/model-router/src/cascade/evaluators.ts
+++ b/packages/model-router/src/cascade/evaluators.ts
@@ -1,0 +1,227 @@
+/**
+ * Confidence evaluator factory functions for cascade routing.
+ *
+ * Three built-in evaluators + a compositor:
+ * - Length heuristic: scores based on response content length
+ * - Keyword: penalizes uncertainty/refusal markers
+ * - Verbalized: asks an LLM to self-rate confidence
+ * - Compose: aggregates multiple evaluators
+ */
+
+import type { ModelRequest, ModelResponse } from "@koi/core";
+import type { ProviderAdapter } from "../provider-adapter.js";
+import type { CascadeEvaluationResult, CascadeEvaluator } from "./cascade-types.js";
+
+// ---------------------------------------------------------------------------
+// Length heuristic evaluator
+// ---------------------------------------------------------------------------
+
+export interface LengthHeuristicOptions {
+  readonly minLength?: number;
+  readonly targetLength?: number;
+}
+
+const LENGTH_DEFAULTS = {
+  minLength: 10,
+  targetLength: 200,
+} as const;
+
+export function createLengthHeuristicEvaluator(options?: LengthHeuristicOptions): CascadeEvaluator {
+  const minLength = options?.minLength ?? LENGTH_DEFAULTS.minLength;
+  const targetLength = options?.targetLength ?? LENGTH_DEFAULTS.targetLength;
+
+  return (_request: ModelRequest, response: ModelResponse): CascadeEvaluationResult => {
+    const length = response.content.trim().length;
+
+    if (length < minLength) {
+      return { confidence: 0, reason: `Response too short (${length} < ${minLength})` };
+    }
+
+    if (length >= targetLength) {
+      return { confidence: 1, reason: "Response meets target length" };
+    }
+
+    // Linear interpolation between minLength and targetLength
+    const confidence = (length - minLength) / (targetLength - minLength);
+    return {
+      confidence,
+      reason: `Length ${length} between min ${minLength} and target ${targetLength}`,
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Keyword evaluator
+// ---------------------------------------------------------------------------
+
+export interface KeywordEvaluatorOptions {
+  readonly uncertaintyMarkers?: readonly string[];
+  readonly penaltyPerMarker?: number;
+}
+
+const DEFAULT_UNCERTAINTY_MARKERS: readonly string[] = [
+  "i'm not sure",
+  "i don't know",
+  "it depends",
+  "i cannot",
+  "i can't",
+  "as an ai",
+  "i apologize",
+  "i'm unable",
+  "i am not sure",
+  "i am unable",
+] as const;
+
+const KEYWORD_DEFAULTS = {
+  penaltyPerMarker: 0.2,
+} as const;
+
+export function createKeywordEvaluator(options?: KeywordEvaluatorOptions): CascadeEvaluator {
+  const markers = options?.uncertaintyMarkers ?? DEFAULT_UNCERTAINTY_MARKERS;
+  const penalty = options?.penaltyPerMarker ?? KEYWORD_DEFAULTS.penaltyPerMarker;
+
+  return (_request: ModelRequest, response: ModelResponse): CascadeEvaluationResult => {
+    const lower = response.content.toLowerCase();
+    let matchCount = 0;
+    const matched: string[] = [];
+
+    for (const marker of markers) {
+      if (lower.includes(marker.toLowerCase())) {
+        matchCount++;
+        matched.push(marker);
+      }
+    }
+
+    const confidence = Math.max(0, Math.min(1, 1 - matchCount * penalty));
+    return {
+      confidence,
+      reason:
+        matchCount > 0 ? `Matched markers: ${matched.join(", ")}` : "No uncertainty markers found",
+      metadata: { matchCount, matched },
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Verbalized evaluator
+// ---------------------------------------------------------------------------
+
+export interface VerbalizedEvaluatorOptions {
+  readonly timeoutMs?: number;
+  readonly model?: string;
+}
+
+const CONFIDENCE_PROMPT =
+  "Rate your confidence in the above answer from 0.0 to 1.0. " +
+  "Reply with ONLY a decimal number, nothing else.";
+
+export function createVerbalizedEvaluator(
+  adapter: ProviderAdapter,
+  options?: VerbalizedEvaluatorOptions,
+): CascadeEvaluator {
+  return async (
+    request: ModelRequest,
+    response: ModelResponse,
+  ): Promise<CascadeEvaluationResult> => {
+    const evalRequest: ModelRequest = {
+      messages: [
+        ...request.messages,
+        {
+          content: [{ kind: "text" as const, text: response.content }],
+          senderId: "assistant",
+          timestamp: Date.now(),
+        },
+        {
+          content: [{ kind: "text" as const, text: CONFIDENCE_PROMPT }],
+          senderId: "system",
+          timestamp: Date.now(),
+        },
+      ],
+      ...(options?.model !== undefined ? { model: options.model } : {}),
+      ...(options?.timeoutMs !== undefined
+        ? { signal: AbortSignal.timeout(options.timeoutMs) }
+        : {}),
+    };
+
+    const evalResponse = await adapter.complete(evalRequest);
+    const parsed = Number.parseFloat(evalResponse.content.trim());
+
+    if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
+      return {
+        confidence: 0.5,
+        reason: `Non-numeric or out-of-range response: "${evalResponse.content.trim()}"`,
+      };
+    }
+
+    return { confidence: parsed, reason: "Verbalized confidence" };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Evaluator composition
+// ---------------------------------------------------------------------------
+
+export type CompositionStrategy = "min" | "average" | "weighted";
+
+export interface WeightedEvaluator {
+  readonly evaluator: CascadeEvaluator;
+  readonly weight: number;
+}
+
+export function composeEvaluators(
+  evaluators: readonly (CascadeEvaluator | WeightedEvaluator)[],
+  strategy: CompositionStrategy = "min",
+): CascadeEvaluator {
+  return async (
+    request: ModelRequest,
+    response: ModelResponse,
+  ): Promise<CascadeEvaluationResult> => {
+    const results: { readonly confidence: number; readonly weight: number }[] = [];
+    const skipped: string[] = [];
+
+    for (const entry of evaluators) {
+      const evaluator = typeof entry === "function" ? entry : entry.evaluator;
+      const weight = typeof entry === "function" ? 1 : entry.weight;
+
+      try {
+        const result = await evaluator(request, response);
+        results.push({ confidence: result.confidence, weight });
+      } catch (error: unknown) {
+        // Skip failing evaluators — degrade gracefully, record for diagnostics
+        skipped.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    if (results.length === 0) {
+      return {
+        confidence: 0,
+        reason: `All evaluators failed: ${skipped.join("; ")}`,
+      };
+    }
+
+    let confidence: number;
+    switch (strategy) {
+      case "min":
+        confidence = Math.min(...results.map((r) => r.confidence));
+        break;
+      case "average":
+        confidence = results.reduce((sum, r) => sum + r.confidence, 0) / results.length;
+        break;
+      case "weighted": {
+        const totalWeight = results.reduce((sum, r) => sum + r.weight, 0);
+        confidence =
+          totalWeight > 0
+            ? results.reduce((sum, r) => sum + r.confidence * r.weight, 0) / totalWeight
+            : 0;
+        break;
+      }
+    }
+
+    const skipNote =
+      skipped.length > 0 ? ` (${skipped.length} skipped: ${skipped.join("; ")})` : "";
+    return {
+      confidence,
+      reason: `Composed (${strategy}): ${results.map((r) => r.confidence.toFixed(2)).join(", ")}${skipNote}`,
+    };
+  };
+}

--- a/packages/model-router/src/config.test.ts
+++ b/packages/model-router/src/config.test.ts
@@ -179,4 +179,191 @@ describe("validateRouterConfig", () => {
     if (result.ok) throw new Error("Expected error");
     expect(result.error.message).toContain("Model router config validation failed");
   });
+
+  test("accepts cascade strategy", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cascade config
+// ---------------------------------------------------------------------------
+
+describe("cascade config", () => {
+  test("valid cascade config passes", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget, { ...validTarget, provider: "anthropic", model: "claude" }],
+      strategy: "cascade",
+      cascade: {
+        tiers: [
+          { targetId: "openai:gpt-4o", costPerInputToken: 0.001 },
+          { targetId: "anthropic:claude", costPerInputToken: 0.01 },
+        ],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.cascade).toBeDefined();
+    expect(result.value.cascade?.tiers).toHaveLength(2);
+    expect(result.value.cascade?.confidenceThreshold).toBe(0.7);
+  });
+
+  test("cascade strategy without cascade config field fails", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("cascade config is required");
+  });
+
+  test("empty tiers array fails", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("threshold < 0 fails", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: -0.1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("threshold > 1 fails", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 1.5,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("tier referencing non-existent target fails", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "anthropic:claude" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.message).toContain("unknown target");
+    expect(result.error.message).toContain("anthropic:claude");
+  });
+
+  test("non-cascade strategy ignores cascade field", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    // Cascade config is still resolved if present (even for non-cascade strategies)
+    expect(result.value.cascade).toBeDefined();
+  });
+
+  test("resolves default maxEscalations to tiers.length - 1", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget, { ...validTarget, provider: "anthropic", model: "claude" }],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }, { targetId: "anthropic:claude" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.cascade?.maxEscalations).toBe(1);
+  });
+
+  test("resolves default budgetLimitTokens to 0 (unlimited)", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.cascade?.budgetLimitTokens).toBe(0);
+  });
+
+  test("resolves default evaluatorTimeoutMs to 10_000", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 0.7,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.cascade?.evaluatorTimeoutMs).toBe(10_000);
+  });
+
+  test("preserves explicit cascade overrides", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "cascade",
+      cascade: {
+        tiers: [{ targetId: "openai:gpt-4o" }],
+        confidenceThreshold: 0.8,
+        maxEscalations: 5,
+        budgetLimitTokens: 100_000,
+        evaluatorTimeoutMs: 5_000,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.cascade?.confidenceThreshold).toBe(0.8);
+    expect(result.value.cascade?.maxEscalations).toBe(5);
+    expect(result.value.cascade?.budgetLimitTokens).toBe(100_000);
+    expect(result.value.cascade?.evaluatorTimeoutMs).toBe(5_000);
+  });
 });

--- a/packages/model-router/src/config.ts
+++ b/packages/model-router/src/config.ts
@@ -5,11 +5,16 @@
 import type { KoiError, Result } from "@koi/core";
 import { validateWith } from "@koi/validation";
 import { z } from "zod";
+import type {
+  CascadeConfig,
+  CascadeTierConfig,
+  ResolvedCascadeConfig,
+} from "./cascade/cascade-types.js";
 import { type CircuitBreakerConfig, DEFAULT_CIRCUIT_BREAKER_CONFIG } from "./circuit-breaker.js";
 import type { ProviderAdapterConfig } from "./provider-adapter.js";
 import { DEFAULT_RETRY_CONFIG, type RetryConfig } from "./retry.js";
 
-export type RoutingStrategy = "fallback" | "round-robin" | "weighted";
+export type RoutingStrategy = "fallback" | "round-robin" | "weighted" | "cascade";
 
 export interface ModelTargetConfig {
   readonly provider: string;
@@ -24,6 +29,7 @@ export interface ModelRouterConfig {
   readonly strategy: RoutingStrategy;
   readonly retry?: Partial<RetryConfig>;
   readonly circuitBreaker?: Partial<CircuitBreakerConfig>;
+  readonly cascade?: CascadeConfig;
 }
 
 export interface ResolvedRouterConfig {
@@ -31,6 +37,7 @@ export interface ResolvedRouterConfig {
   readonly strategy: RoutingStrategy;
   readonly retry: RetryConfig;
   readonly circuitBreaker: CircuitBreakerConfig;
+  readonly cascade?: ResolvedCascadeConfig;
 }
 
 export interface ResolvedTargetConfig {
@@ -75,11 +82,32 @@ const circuitBreakerSchema = z.object({
   failureStatusCodes: z.array(z.number().int()).optional(),
 });
 
+const cascadeTierSchema = z.object({
+  targetId: z.string().min(1),
+  costPerInputToken: z.number().min(0).optional(),
+  costPerOutputToken: z.number().min(0).optional(),
+  timeoutMs: z.number().int().positive().optional(),
+});
+
+const cascadeSchema = z.object({
+  tiers: z.array(cascadeTierSchema).min(1),
+  confidenceThreshold: z.number().min(0).max(1),
+  maxEscalations: z.number().int().min(0).optional(),
+  budgetLimitTokens: z.number().int().min(0).optional(),
+  evaluatorTimeoutMs: z.number().int().positive().optional(),
+});
+
 const routerConfigSchema = z.object({
   targets: z.array(targetSchema).min(1),
-  strategy: z.union([z.literal("fallback"), z.literal("round-robin"), z.literal("weighted")]),
+  strategy: z.union([
+    z.literal("fallback"),
+    z.literal("round-robin"),
+    z.literal("weighted"),
+    z.literal("cascade"),
+  ]),
   retry: retrySchema.optional(),
   circuitBreaker: circuitBreakerSchema.optional(),
+  cascade: cascadeSchema.optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -127,6 +155,53 @@ export function validateRouterConfig(raw: unknown): Result<ResolvedRouterConfig,
       DEFAULT_CIRCUIT_BREAKER_CONFIG.failureStatusCodes,
   };
 
+  // Cascade cross-validation
+  if (config.strategy === "cascade" && !config.cascade) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message:
+          'Model router config validation failed: cascade config is required when strategy is "cascade"',
+        retryable: false,
+      },
+    };
+  }
+
+  // Resolve cascade config (if present)
+  let resolvedCascade: ResolvedCascadeConfig | undefined;
+  if (config.cascade) {
+    // Validate tier targetIds reference existing targets
+    const targetIds = new Set(resolvedTargets.map((t) => `${t.provider}:${t.model}`));
+    for (const tier of config.cascade.tiers) {
+      if (!targetIds.has(tier.targetId)) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: `Model router config validation failed: cascade tier references unknown target "${tier.targetId}". Available: ${[...targetIds].join(", ")}`,
+            retryable: false,
+          },
+        };
+      }
+    }
+
+    const cascadeTiers: readonly CascadeTierConfig[] = config.cascade.tiers.map((t) => ({
+      targetId: t.targetId,
+      ...(t.costPerInputToken !== undefined ? { costPerInputToken: t.costPerInputToken } : {}),
+      ...(t.costPerOutputToken !== undefined ? { costPerOutputToken: t.costPerOutputToken } : {}),
+      ...(t.timeoutMs !== undefined ? { timeoutMs: t.timeoutMs } : {}),
+    }));
+
+    resolvedCascade = {
+      tiers: cascadeTiers,
+      confidenceThreshold: config.cascade.confidenceThreshold,
+      maxEscalations: config.cascade.maxEscalations ?? config.cascade.tiers.length - 1,
+      budgetLimitTokens: config.cascade.budgetLimitTokens ?? 0,
+      evaluatorTimeoutMs: config.cascade.evaluatorTimeoutMs ?? 10_000,
+    };
+  }
+
   return {
     ok: true,
     value: {
@@ -134,6 +209,7 @@ export function validateRouterConfig(raw: unknown): Result<ResolvedRouterConfig,
       strategy: config.strategy,
       retry: resolvedRetry,
       circuitBreaker: resolvedCB,
+      ...(resolvedCascade !== undefined ? { cascade: resolvedCascade } : {}),
     },
   };
 }

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -2,7 +2,7 @@
  * @koi/model-router — Multi-provider LLM routing with failover (Layer 2)
  *
  * World Service that routes model calls across multiple LLM providers
- * with retry, fallback chains, and circuit breaker resilience.
+ * with retry, fallback chains, cascade escalation, and circuit breaker resilience.
  *
  * Depends on @koi/core (for types) and @koi/validation (for config validation).
  */
@@ -14,6 +14,38 @@ export {
   createOpenRouterAdapter,
   type OpenRouterAdapterConfig,
 } from "./adapters/openrouter.js";
+export { createCascadeMetricsTracker } from "./cascade/cascade-metrics.js";
+// Cascade
+export type {
+  CascadeAttempt,
+  CascadeClassifier,
+  CascadeConfig,
+  CascadeCostMetrics,
+  CascadeEvaluationResult,
+  CascadeEvaluator,
+  CascadeResult,
+  CascadeTierConfig,
+  ClassificationResult,
+  ComplexityTier,
+  ResolvedCascadeConfig,
+  TierCostMetrics,
+} from "./cascade/cascade-types.js";
+export {
+  type ComplexityClassifierOptions,
+  createComplexityClassifier,
+  type DimensionKey,
+} from "./cascade/complexity-classifier.js";
+export {
+  type CompositionStrategy,
+  composeEvaluators,
+  createKeywordEvaluator,
+  createLengthHeuristicEvaluator,
+  createVerbalizedEvaluator,
+  type KeywordEvaluatorOptions,
+  type LengthHeuristicOptions,
+  type VerbalizedEvaluatorOptions,
+  type WeightedEvaluator,
+} from "./cascade/evaluators.js";
 // Resilience
 export {
   type CircuitBreaker,
@@ -42,4 +74,9 @@ export { createModelRouterMiddleware } from "./middleware.js";
 export type { ProviderAdapter, ProviderAdapterConfig, StreamChunk } from "./provider-adapter.js";
 export { calculateBackoff, type RetryConfig, withRetry } from "./retry.js";
 // Router
-export { createModelRouter, type ModelRouter, type RouterMetrics } from "./router.js";
+export {
+  createModelRouter,
+  type ModelRouter,
+  type ModelRouterOptions,
+  type RouterMetrics,
+} from "./router.js";

--- a/packages/model-router/src/router-cascade.test.ts
+++ b/packages/model-router/src/router-cascade.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for cascade strategy routing, including pre-request classifier integration.
+ * Extracted from router.test.ts to stay under the 800-line file limit.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { ModelRequest, ModelResponse } from "@koi/core";
+import type { CascadeClassifier, CascadeEvaluator } from "./cascade/cascade-types.js";
+import type { ResolvedRouterConfig, ResolvedTargetConfig } from "./config.js";
+import type { ProviderAdapter, StreamChunk } from "./provider-adapter.js";
+import { createModelRouter } from "./router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers (shared with router.test.ts — duplicated to keep files independent)
+// ---------------------------------------------------------------------------
+
+function makeRequest(text = "Hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "test-user", timestamp: 0 }],
+  };
+}
+
+function makeResponse(content: string, model = "test-model"): ModelResponse {
+  return { content, model };
+}
+
+function makeTarget(
+  provider: string,
+  model: string,
+  overrides?: Partial<ResolvedTargetConfig>,
+): ResolvedTargetConfig {
+  return {
+    provider,
+    model,
+    weight: 1,
+    enabled: true,
+    adapterConfig: { apiKey: "sk-test" },
+    ...overrides,
+  };
+}
+
+function makeConfig(
+  targets: readonly ResolvedTargetConfig[],
+  overrides?: Partial<ResolvedRouterConfig>,
+): ResolvedRouterConfig {
+  return {
+    targets,
+    strategy: "fallback",
+    retry: {
+      maxRetries: 0,
+      backoffMultiplier: 2,
+      initialDelayMs: 10,
+      maxBackoffMs: 100,
+      jitter: false,
+    },
+    circuitBreaker: {
+      failureThreshold: 3,
+      cooldownMs: 10_000,
+      failureWindowMs: 10_000,
+      failureStatusCodes: [429, 500, 502, 503, 504],
+    },
+    ...overrides,
+  };
+}
+
+function makeAdapter(id: string, completeFn: ProviderAdapter["complete"]): ProviderAdapter {
+  return {
+    id,
+    complete: completeFn,
+    async *stream(_request: ModelRequest): AsyncGenerator<StreamChunk> {
+      yield { kind: "text_delta", text: "streamed" };
+      yield { kind: "finish", reason: "completed" };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cascade strategy tests
+// ---------------------------------------------------------------------------
+
+describe("cascade strategy", () => {
+  function makeCascadeConfig(
+    targets: readonly ResolvedTargetConfig[],
+    overrides?: Partial<ResolvedRouterConfig>,
+  ): ResolvedRouterConfig {
+    const targetIds = targets.map((t) => `${t.provider}:${t.model}`);
+    return makeConfig(targets, {
+      strategy: "cascade",
+      cascade: {
+        tiers: targetIds.map((id) => ({ targetId: id })),
+        confidenceThreshold: 0.7,
+        maxEscalations: targetIds.length - 1,
+        budgetLimitTokens: 0,
+        evaluatorTimeoutMs: 5_000,
+      },
+      ...overrides,
+    });
+  }
+
+  test("routes to cheapest tier first when confidence is high", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const cheapFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("cheap answer", "gpt-4o-mini")),
+    );
+    const expensiveFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("expensive answer", "gpt-4o")),
+    );
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", (req: ModelRequest) => {
+          if (req.model === "gpt-4o-mini") return cheapFn(req);
+          return expensiveFn(req);
+        }),
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("cheap answer");
+    expect(cheapFn).toHaveBeenCalledTimes(1);
+    expect(expensiveFn).not.toHaveBeenCalled();
+  });
+
+  test("escalates when evaluator returns low confidence", async () => {
+    let evalCount = 0;
+    const evaluator: CascadeEvaluator = () => {
+      evalCount++;
+      return { confidence: evalCount === 1 ? 0.2 : 0.9 };
+    };
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("anthropic", "claude"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", () => Promise.resolve(makeResponse("cheap", "gpt-4o-mini"))),
+      ],
+      [
+        "anthropic",
+        makeAdapter("anthropic", () => Promise.resolve(makeResponse("expensive", "claude"))),
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("expensive");
+  });
+
+  test("returns cheap response when confidence is high", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.95 });
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", () => Promise.resolve(makeResponse("cheap ok", "gpt-4o-mini"))),
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("cheap ok");
+  });
+
+  test("routeStream with cascade uses fallback behavior", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const config = makeCascadeConfig([makeTarget("openai", "gpt-4o")]);
+    const adapter = makeAdapter("openai", () => Promise.resolve(makeResponse("hi", "gpt-4o")));
+
+    const router = createModelRouter(config, new Map([["openai", adapter]]), { evaluator });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of router.routeStream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.kind).toBe("text_delta");
+  });
+
+  test("cascade metrics include escalation counts", async () => {
+    let evalCount = 0;
+    const evaluator: CascadeEvaluator = () => {
+      evalCount++;
+      return { confidence: evalCount === 1 ? 0.2 : 0.9 };
+    };
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("anthropic", "claude"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", () => Promise.resolve(makeResponse("cheap", "gpt-4o-mini"))),
+      ],
+      [
+        "anthropic",
+        makeAdapter("anthropic", () => Promise.resolve(makeResponse("expensive", "claude"))),
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator });
+    await router.route(makeRequest());
+
+    const metrics = router.getMetrics();
+    expect(metrics.cascade).toBeDefined();
+    expect(metrics.cascade?.totalEscalations).toBeGreaterThanOrEqual(1);
+  });
+
+  test("missing evaluator with cascade strategy throws", () => {
+    const config = makeCascadeConfig([makeTarget("openai", "gpt-4o")]);
+    const adapter = makeAdapter("openai", () => Promise.resolve(makeResponse("hi", "gpt-4o")));
+
+    expect(() => createModelRouter(config, new Map([["openai", adapter]]))).toThrow(
+      "Cascade strategy requires an evaluator",
+    );
+  });
+
+  test("accepts legacy clock parameter (backwards compatibility)", async () => {
+    const config = makeConfig([makeTarget("openai", "gpt-4o")]);
+    const adapter = makeAdapter("openai", () => Promise.resolve(makeResponse("hi", "gpt-4o")));
+    const customClock = () => 1000;
+
+    const router = createModelRouter(config, new Map([["openai", adapter]]), customClock);
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-request classifier integration
+  // -------------------------------------------------------------------------
+
+  test("classifier skips cheap tier for complex request", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const cheapFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("cheap answer", "gpt-4o-mini")),
+    );
+    const expensiveFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("expensive answer", "gpt-4o")),
+    );
+
+    const classifier: CascadeClassifier = (_req, _tierCount) => ({
+      score: 0.8,
+      confidence: 0.95,
+      tier: "HEAVY",
+      recommendedTierIndex: 1,
+      reason: "test: forced HEAVY",
+    });
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", (req: ModelRequest) => {
+          if (req.model === "gpt-4o-mini") return cheapFn(req);
+          return expensiveFn(req);
+        }),
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator, classifier });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("expensive answer");
+    expect(cheapFn).not.toHaveBeenCalled();
+    expect(expensiveFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("classifier returning index 0 uses all tiers normally", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const cheapFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("cheap answer", "gpt-4o-mini")),
+    );
+
+    const classifier: CascadeClassifier = (_req, _tierCount) => ({
+      score: 0.1,
+      confidence: 0.95,
+      tier: "LIGHT",
+      recommendedTierIndex: 0,
+      reason: "test: forced LIGHT",
+    });
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      ["openai", makeAdapter("openai", (req: ModelRequest) => cheapFn(req))],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator, classifier });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("cheap answer");
+    expect(cheapFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("cascade works without classifier (backwards compatible)", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const cheapFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("cheap answer", "gpt-4o-mini")),
+    );
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      ["openai", makeAdapter("openai", (req: ModelRequest) => cheapFn(req))],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.content).toBe("cheap answer");
+  });
+
+  test("classifier + evaluator together: classifier starts at MEDIUM, evaluator escalates", async () => {
+    let evalCount = 0;
+    const evaluator: CascadeEvaluator = () => {
+      evalCount++;
+      return { confidence: evalCount === 1 ? 0.2 : 0.9 };
+    };
+
+    const cheapFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("cheap", "gpt-4o-mini")),
+    );
+    const mediumFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("medium", "gpt-4o")),
+    );
+    const expensiveFn = mock((_req: ModelRequest) =>
+      Promise.resolve(makeResponse("expensive", "claude")),
+    );
+
+    const classifier: CascadeClassifier = (_req, _tierCount) => ({
+      score: 0.5,
+      confidence: 0.85,
+      tier: "MEDIUM",
+      recommendedTierIndex: 1,
+      reason: "test: forced MEDIUM",
+    });
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+      makeTarget("anthropic", "claude"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        makeAdapter("openai", (req: ModelRequest) => {
+          if (req.model === "gpt-4o-mini") return cheapFn(req);
+          return mediumFn(req);
+        }),
+      ],
+      ["anthropic", makeAdapter("anthropic", (req: ModelRequest) => expensiveFn(req))],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator, classifier });
+    const result = await router.route(makeRequest());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(cheapFn).not.toHaveBeenCalled();
+    expect(mediumFn).toHaveBeenCalledTimes(1);
+    expect(expensiveFn).toHaveBeenCalledTimes(1);
+    expect(result.value.content).toBe("expensive");
+  });
+});

--- a/packages/model-router/src/router.test.ts
+++ b/packages/model-router/src/router.test.ts
@@ -467,3 +467,7 @@ describe("dispose", () => {
     expect(healthAfter.get("openai:gpt-4o")?.state).toBe("CLOSED");
   });
 });
+
+// ---------------------------------------------------------------------------
+// cascade strategy — see router-cascade.test.ts for full cascade tests
+// ---------------------------------------------------------------------------

--- a/packages/model-router/src/router.ts
+++ b/packages/model-router/src/router.ts
@@ -1,9 +1,15 @@
 /**
  * Main ModelRouter service — routes model calls across providers
- * with retry, fallback, and circuit breaker resilience.
+ * with retry, fallback, cascade, and circuit breaker resilience.
  */
 
 import type { KoiError, ModelRequest, ModelResponse, Result } from "@koi/core";
+import { withCascade } from "./cascade/cascade.js";
+import type {
+  CascadeClassifier,
+  CascadeCostMetrics,
+  CascadeEvaluator,
+} from "./cascade/cascade-types.js";
 import {
   type CircuitBreaker,
   type CircuitBreakerSnapshot,
@@ -19,6 +25,7 @@ export interface RouterMetrics {
   readonly totalFailures: number;
   readonly requestsByTarget: Readonly<Record<string, number>>;
   readonly failuresByTarget: Readonly<Record<string, number>>;
+  readonly cascade?: CascadeCostMetrics;
 }
 
 export interface ModelRouter {
@@ -27,6 +34,12 @@ export interface ModelRouter {
   readonly getHealth: () => ReadonlyMap<string, CircuitBreakerSnapshot>;
   readonly getMetrics: () => RouterMetrics;
   readonly dispose: () => void;
+}
+
+export interface ModelRouterOptions {
+  readonly evaluator?: CascadeEvaluator;
+  readonly classifier?: CascadeClassifier;
+  readonly clock?: () => number;
 }
 
 function targetId(t: ResolvedTargetConfig): string {
@@ -40,13 +53,26 @@ function targetId(t: ResolvedTargetConfig): string {
  *
  * @param config - Resolved router configuration
  * @param adapters - Map of provider ID → ProviderAdapter
- * @param clock - Injectable clock for deterministic testing
+ * @param clockOrOptions - Injectable clock (deprecated) or options object
  */
 export function createModelRouter(
   config: ResolvedRouterConfig,
   adapters: ReadonlyMap<string, ProviderAdapter>,
-  clock: () => number = Date.now,
+  clockOrOptions?: (() => number) | ModelRouterOptions,
 ): ModelRouter {
+  // Support both legacy clock parameter and new options object
+  const options: ModelRouterOptions =
+    typeof clockOrOptions === "function" ? { clock: clockOrOptions } : (clockOrOptions ?? {});
+
+  const clock = options.clock ?? Date.now;
+
+  // Validate cascade requires evaluator
+  if (config.strategy === "cascade" && !options.evaluator) {
+    throw new Error(
+      "Cascade strategy requires an evaluator. Pass { evaluator } in the options parameter.",
+    );
+  }
+
   // Validate that all configured providers have adapters
   for (const target of config.targets) {
     if (!adapters.has(target.provider)) {
@@ -85,15 +111,15 @@ export function createModelRouter(
   let totalRequests = 0;
   let totalFailures = 0;
 
-  async function executeForTarget(
-    target: FallbackTarget,
-    request: ModelRequest,
-  ): Promise<ModelResponse> {
-    const targetConfig = targetConfigById.get(target.id);
+  // Cascade metrics tracking
+  let cascadeEscalations = 0;
+
+  async function executeForTargetId(id: string, request: ModelRequest): Promise<ModelResponse> {
+    const targetConfig = targetConfigById.get(id);
     if (!targetConfig) {
       throw {
         code: "NOT_FOUND",
-        message: `Target config not found: ${target.id}`,
+        message: `Target config not found: ${id}`,
         retryable: false,
       } satisfies KoiError;
     }
@@ -108,7 +134,7 @@ export function createModelRouter(
     }
 
     // Track metrics
-    requestsByTarget[target.id] = (requestsByTarget[target.id] ?? 0) + 1;
+    requestsByTarget[id] = (requestsByTarget[id] ?? 0) + 1;
 
     const modelRequest: ModelRequest = {
       ...request,
@@ -122,9 +148,38 @@ export function createModelRouter(
     async route(request: ModelRequest): Promise<Result<ModelResponse, KoiError>> {
       totalRequests++;
 
+      if (config.strategy === "cascade" && config.cascade && options.evaluator) {
+        // Pre-request classification: skip cheap tiers for complex requests
+        const allTiers = config.cascade.tiers;
+        const classification = options.classifier?.(request, allTiers.length);
+        const classifiedTiers = classification
+          ? allTiers.slice(classification.recommendedTierIndex)
+          : allTiers;
+        // Ensure at least one tier remains
+        const tiers = classifiedTiers.length > 0 ? classifiedTiers : allTiers;
+
+        const result = await withCascade(
+          tiers,
+          (tier) => executeForTargetId(tier.targetId, request),
+          options.evaluator,
+          config.cascade,
+          circuitBreakers,
+          request,
+          clock,
+        );
+
+        if (!result.ok) {
+          totalFailures++;
+          return result;
+        }
+
+        cascadeEscalations += result.value.totalEscalations;
+        return { ok: true, value: result.value.response };
+      }
+
       const result = await withFallback(
         fallbackTargets,
-        (target) => executeForTarget(target, request),
+        (target) => executeForTargetId(target.id, request),
         circuitBreakers,
         clock,
       );
@@ -138,6 +193,7 @@ export function createModelRouter(
     },
 
     async *routeStream(request: ModelRequest): AsyncGenerator<StreamChunk> {
+      // Stream uses fallback behavior for all strategies (cascade v1 limitation)
       const errors: KoiError[] = [];
 
       for (const target of enabledFallbackTargets) {
@@ -187,12 +243,33 @@ export function createModelRouter(
     },
 
     getMetrics(): RouterMetrics {
-      return {
+      const base: RouterMetrics = {
         totalRequests,
         totalFailures,
         requestsByTarget: { ...requestsByTarget },
         failuresByTarget: { ...failuresByTarget },
       };
+
+      if (config.strategy === "cascade" && config.cascade) {
+        return {
+          ...base,
+          cascade: {
+            tiers: config.cascade.tiers.map((t) => ({
+              tierId: t.targetId,
+              requests: requestsByTarget[t.targetId] ?? 0,
+              escalations: 0,
+              totalInputTokens: 0,
+              totalOutputTokens: 0,
+              estimatedCost: 0,
+            })),
+            totalRequests,
+            totalEscalations: cascadeEscalations,
+            totalEstimatedCost: 0,
+          },
+        };
+      }
+
+      return base;
     },
 
     dispose(): void {


### PR DESCRIPTION
## Summary

- Add **cascade routing strategy** to `@koi/model-router` — cheap-first escalation with post-response quality evaluation
- Add **pre-request complexity classifier** (14-dimension heuristic scorer, <1ms) that skips cheap tiers for obviously complex requests, avoiding wasted tokens
- Add **sigmoid confidence mapping** that defaults near-boundary scores to MEDIUM tier as a safety net
- Add cascade evaluator factories (keyword, length-heuristic, verbalized) for post-response quality checking

## New files

| File | Purpose |
|------|---------|
| `cascade/cascade-types.ts` | Contract types: `CascadeEvaluator`, `CascadeClassifier`, `CascadeConfig`, `ClassificationResult` |
| `cascade/cascade.ts` | `withCascade()` tier-walking engine |
| `cascade/evaluators.ts` | Keyword, length-heuristic, and verbalized evaluator factories |
| `cascade/complexity-classifier.ts` | 14-dimension weighted heuristic scorer with sigmoid confidence |
| `cascade/cascade-metrics.ts` | Per-tier cost tracking |
| `router-cascade.test.ts` | Cascade strategy integration tests (extracted from router.test.ts for 800-line limit) |
| `__tests__/cascade-integration.test.ts` | Integration tests for cascade pipeline |
| `__tests__/cascade-classifier-e2e.test.ts` | E2E tests with real OpenAI calls (gated on API key) |

## Modified files

| File | Change |
|------|--------|
| `config.ts` | Add `"cascade"` to `RoutingStrategy`, add cascade Zod schema + cross-validation |
| `router.ts` | Add `ModelRouterOptions` with `evaluator`/`classifier`, tier slicing before `withCascade()` |
| `index.ts` | Export all new cascade types and factories |

## Architecture

```
Request → [Classifier] → skip cheap tiers → [withCascade] → [Post-Response Evaluator]
                                                  ↑
                                          (unchanged — validates output quality)
```

- Classifier runs in **router** before `withCascade()` — ~5 lines of tier slicing
- Zero changes to `withCascade()` itself
- Backwards compatible: cascade works without classifier, legacy `clock` parameter still accepted
- No layer leakage: all imports from `@koi/core` (L0) and `@koi/validation` (L0u) only

## Test plan

- [x] 45 complexity classifier unit tests (dimensions, overrides, tier mapping, sigmoid confidence)
- [x] 28 router unit tests (fallback, circuit breaker, metrics)
- [x] 29 config validation tests (cascade schema, cross-validation)
- [x] 10 cascade strategy integration tests (tier routing, escalation, classifier + evaluator)
- [x] 5 E2E tests with real OpenAI API calls (gated on `OPENAI_API_KEY`)
- [x] Typecheck clean, lint clean, build clean
- [x] 100% function coverage, 99.2% line coverage on complexity-classifier.ts

Closes #52