### PR TITLE
feat(model-router): add local provider adapters, auto-discovery, and cost tracking

### DIFF
--- a/packages/model-router/src/__tests__/e2e.test.ts
+++ b/packages/model-router/src/__tests__/e2e.test.ts
@@ -83,12 +83,7 @@ async function collectStream(
 // Block 1: Individual adapters
 // ---------------------------------------------------------------------------
 
-const describeOpenAI = HAS_OPENAI ? describe : describe.skip;
-const describeAnthropic = HAS_ANTHROPIC ? describe : describe.skip;
-const describeOpenRouter = HAS_OPENROUTER ? describe : describe.skip;
-const describeAll = HAS_ALL ? describe : describe.skip;
-
-describeOpenAI("e2e: OpenAI adapter", () => {
+describe.skipIf(!HAS_OPENAI)("e2e: OpenAI adapter", () => {
   const adapter = createOpenAIAdapter({ apiKey: OPENAI_KEY });
 
   test(
@@ -118,7 +113,7 @@ describeOpenAI("e2e: OpenAI adapter", () => {
   );
 });
 
-describeAnthropic("e2e: Anthropic adapter", () => {
+describe.skipIf(!HAS_ANTHROPIC)("e2e: Anthropic adapter", () => {
   const adapter = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
 
   test(
@@ -156,7 +151,7 @@ describeAnthropic("e2e: Anthropic adapter", () => {
   );
 });
 
-describeOpenRouter("e2e: OpenRouter adapter", () => {
+describe.skipIf(!HAS_OPENROUTER)("e2e: OpenRouter adapter", () => {
   const adapter = createOpenRouterAdapter({
     apiKey: OPENROUTER_KEY,
     appName: "koi-e2e-test",
@@ -214,7 +209,7 @@ describeOpenRouter("e2e: OpenRouter adapter", () => {
 // Block 2: Full router pipeline (needs all 3 keys)
 // ---------------------------------------------------------------------------
 
-describeAll("e2e: router pipeline", () => {
+describe.skipIf(!HAS_ALL)("e2e: router pipeline", () => {
   test(
     "primary target succeeds on first try",
     async () => {

--- a/packages/model-router/src/adapters/anthropic.ts
+++ b/packages/model-router/src/adapters/anthropic.ts
@@ -8,6 +8,14 @@
 import type { KoiError, ModelRequest, ModelResponse } from "@koi/core";
 import { normalizeToPlainText } from "../normalize.js";
 import type { ProviderAdapter, ProviderAdapterConfig, StreamChunk } from "../provider-adapter.js";
+import {
+  fetchWithTimeout,
+  handleAbortError,
+  handleStreamAbortError,
+  parseRetryAfter,
+  parseSSEStream,
+  streamFetch,
+} from "./shared.js";
 
 const DEFAULT_BASE_URL = "https://api.anthropic.com";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -95,6 +103,15 @@ export function createAnthropicAdapter(config: ProviderAdapterConfig): ProviderA
   const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
+  function buildHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      ...(config.apiKey !== undefined ? { "x-api-key": config.apiKey } : {}),
+      "anthropic-version": ANTHROPIC_VERSION,
+      ...config.headers,
+    };
+  }
+
   return {
     id: "anthropic",
 
@@ -102,69 +119,62 @@ export function createAnthropicAdapter(config: ProviderAdapterConfig): ProviderA
       const body = toAnthropicRequest(request);
       const url = `${baseUrl}/v1/messages`;
 
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
+      let clearTimer: (() => void) | undefined;
       try {
-        const response = await fetch(url, {
+        const result = await fetchWithTimeout({
+          url,
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": config.apiKey,
-            "anthropic-version": ANTHROPIC_VERSION,
-            ...config.headers,
-          },
+          headers: buildHeaders(),
           body: JSON.stringify(body),
-          signal: effectiveSignal,
+          timeoutMs,
+          signal: request.signal,
         });
+        clearTimer = result.clearTimer;
 
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
+        if (!result.response.ok) {
+          const errorBody = await result.response.text().catch(() => "");
           let errorType: string | undefined;
           try {
-            const parsed = JSON.parse(errorBody) as { readonly error?: { readonly type?: string } };
+            const parsed = JSON.parse(errorBody) as {
+              readonly error?: { readonly type?: string };
+            };
             errorType = parsed.error?.type;
           } catch {
             // ignore parse error
           }
 
-          const retryAfterStr = response.headers.get("retry-after");
-          const retryAfterMs = retryAfterStr
-            ? Math.ceil(Number.parseFloat(retryAfterStr) * 1000)
-            : undefined;
-
+          const retryAfterMs = parseRetryAfter(result.response.headers);
           const retryAfterValue =
-            retryAfterMs && !Number.isNaN(retryAfterMs) ? retryAfterMs : undefined;
+            retryAfterMs !== undefined && !Number.isNaN(retryAfterMs) ? retryAfterMs : undefined;
+
           throw {
-            code: mapAnthropicError(response.status, errorType),
-            message: `Anthropic API error ${response.status}: ${errorBody}`,
-            retryable: response.status === 429 || response.status === 529 || response.status >= 500,
+            code: mapAnthropicError(result.response.status, errorType),
+            message: `Anthropic API error ${result.response.status}: ${errorBody}`,
+            retryable:
+              result.response.status === 429 ||
+              result.response.status === 529 ||
+              result.response.status >= 500,
             ...(retryAfterValue !== undefined && { retryAfterMs: retryAfterValue }),
-            context: { statusCode: response.status, errorType },
+            context: { statusCode: result.response.status, errorType },
           } satisfies KoiError;
         }
 
-        const json = (await response.json()) as AnthropicResponse;
+        const json = (await result.response.json()) as AnthropicResponse;
         return fromAnthropicResponse(json);
       } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          const isCallerAbort = request.signal?.aborted === true;
-          throw {
-            code: isCallerAbort ? "EXTERNAL" : "TIMEOUT",
-            message: isCallerAbort
-              ? "Anthropic request cancelled"
-              : `Anthropic request timed out after ${timeoutMs}ms`,
-            retryable: !isCallerAbort,
-          } satisfies KoiError;
+        // KoiError objects thrown above should pass through
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          "message" in error &&
+          "retryable" in error
+        ) {
+          throw error;
         }
-        throw error;
+        throw handleAbortError(error, "Anthropic", timeoutMs, request.signal);
       } finally {
-        clearTimeout(timer);
+        clearTimer?.();
       }
     },
 
@@ -172,65 +182,35 @@ export function createAnthropicAdapter(config: ProviderAdapterConfig): ProviderA
       const body = { ...toAnthropicRequest(request), stream: true };
       const url = `${baseUrl}/v1/messages`;
 
-      const controller = new AbortController();
-      // Idle timeout: resets on each chunk so long-running healthy streams aren't killed
-      let timer = setTimeout(() => controller.abort(), timeoutMs);
-      const resetTimer = (): void => {
-        clearTimeout(timer);
-        timer = setTimeout(() => controller.abort(), timeoutMs);
-      };
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
+      let clearTimer: (() => void) | undefined;
       try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": config.apiKey,
-            "anthropic-version": ANTHROPIC_VERSION,
-            ...config.headers,
-          },
+        const result = await streamFetch({
+          url,
+          headers: buildHeaders(),
           body: JSON.stringify(body),
-          signal: effectiveSignal,
+          timeoutMs,
+          signal: request.signal,
         });
+        clearTimer = result.clearTimer;
 
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
+        if (!result.response.ok) {
+          const errorBody = await result.response.text().catch(() => "");
           yield {
             kind: "error",
-            message: `Anthropic API error ${response.status}: ${errorBody}`,
-            statusCode: response.status,
+            message: `Anthropic API error ${result.response.status}: ${errorBody}`,
+            statusCode: result.response.status,
           };
           return;
         }
 
-        if (!response.body) {
+        if (!result.response.body) {
           yield { kind: "error", message: "No response body for streaming" };
           return;
         }
 
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          resetTimer();
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed || !trimmed.startsWith("data: ")) continue;
-            const data = trimmed.slice(6);
-
+        const chunks = parseSSEStream<StreamChunk>(
+          result.response.body,
+          (data) => {
             try {
               const event = JSON.parse(data) as {
                 readonly type: string;
@@ -239,34 +219,28 @@ export function createAnthropicAdapter(config: ProviderAdapterConfig): ProviderA
               };
 
               if (event.type === "content_block_delta" && event.delta?.text) {
-                yield { kind: "text_delta", text: event.delta.text };
-              } else if (event.type === "message_delta") {
-                yield { kind: "finish", reason: "completed" };
-              } else if (event.type === "message_start" && event.usage) {
-                // message_start contains initial usage (input tokens)
+                return { kind: "text_delta", text: event.delta.text };
               }
+              if (event.type === "message_delta") {
+                return { kind: "finish", reason: "completed" };
+              }
+              // message_start contains initial usage (input tokens) — no chunk emitted
             } catch {
               // Ignore malformed SSE data
             }
-          }
+            return undefined;
+          },
+          result.resetTimer,
+        );
+
+        for await (const chunk of chunks) {
+          yield chunk;
         }
       } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          const isCallerAbort = request.signal?.aborted === true;
-          yield {
-            kind: "error",
-            message: isCallerAbort
-              ? "Anthropic stream cancelled"
-              : `Anthropic stream idle timeout after ${timeoutMs}ms`,
-          };
-        } else {
-          yield {
-            kind: "error",
-            message: error instanceof Error ? error.message : String(error),
-          };
-        }
+        const message = handleStreamAbortError(error, "Anthropic", timeoutMs, request.signal);
+        yield { kind: "error", message };
       } finally {
-        clearTimeout(timer);
+        clearTimer?.();
       }
     },
   };

--- a/packages/model-router/src/adapters/discover.test.ts
+++ b/packages/model-router/src/adapters/discover.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { discoverLocalProviders } from "./discover.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchByUrl(
+  urlHandlers: Record<
+    string,
+    () => Promise<{ ok: boolean; status: number; json?: () => Promise<unknown> }>
+  >,
+): void {
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+    // Respect abort signal
+    if (init?.signal?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    const handler = urlHandlers[url];
+    if (handler) return handler();
+
+    throw new TypeError("fetch failed: Connection refused");
+  }) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// discoverLocalProviders
+// ---------------------------------------------------------------------------
+
+describe("discoverLocalProviders", () => {
+  test("discovers Ollama when /api/tags responds ok", async () => {
+    mockFetchByUrl({
+      "http://localhost:11434/api/tags": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ models: [{ name: "llama3.2:3b" }] }),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["ollama"] });
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.kind).toBe("ollama");
+    expect(providers[0]?.baseUrl).toBe("http://localhost:11434");
+  });
+
+  test("discovers vLLM when /health responds ok", async () => {
+    mockFetchByUrl({
+      "http://localhost:8000/health": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(new Error("no json")),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["vllm"] });
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.kind).toBe("vllm");
+    expect(providers[0]?.baseUrl).toBe("http://localhost:8000");
+  });
+
+  test("discovers LM Studio when /v1/models responds ok", async () => {
+    mockFetchByUrl({
+      "http://localhost:1234/v1/models": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: [{ id: "lmstudio-community/Llama-3.2-3B" }] }),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["lm-studio"] });
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.kind).toBe("lm-studio");
+    expect(providers[0]?.baseUrl).toBe("http://localhost:1234");
+  });
+
+  test("returns empty array when no providers found", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed: Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const providers = await discoverLocalProviders();
+
+    expect(providers).toHaveLength(0);
+  });
+
+  test("respects custom timeout", async () => {
+    // Use a very short timeout to ensure it triggers
+    globalThis.fetch = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const providers = await discoverLocalProviders({ timeoutMs: 50 });
+
+    expect(providers).toHaveLength(0);
+  }, 10_000);
+
+  test("filters by providers option", async () => {
+    const capturedUrls: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      capturedUrls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ models: [] }),
+      };
+    }) as unknown as typeof fetch;
+
+    await discoverLocalProviders({ providers: ["ollama"] });
+
+    // Should only have called fetch for Ollama's URL
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain("localhost:11434");
+  });
+
+  test("extracts model names from Ollama /api/tags", async () => {
+    mockFetchByUrl({
+      "http://localhost:11434/api/tags": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              models: [
+                { name: "llama3.2:3b" },
+                { name: "codellama:7b" },
+                { name: "mistral:latest" },
+              ],
+            }),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["ollama"] });
+
+    expect(providers[0]?.models).toEqual(["llama3.2:3b", "codellama:7b", "mistral:latest"]);
+  });
+
+  test("extracts model names from /v1/models", async () => {
+    mockFetchByUrl({
+      "http://localhost:1234/v1/models": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              data: [
+                { id: "lmstudio-community/Llama-3.2-3B" },
+                { id: "lmstudio-community/Mistral-7B" },
+              ],
+            }),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["lm-studio"] });
+
+    expect(providers[0]?.models).toEqual([
+      "lmstudio-community/Llama-3.2-3B",
+      "lmstudio-community/Mistral-7B",
+    ]);
+  });
+
+  test("handles JSON parse error gracefully", async () => {
+    mockFetchByUrl({
+      "http://localhost:8000/health": () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(new SyntaxError("Unexpected end of JSON")),
+        }),
+    });
+
+    const providers = await discoverLocalProviders({ providers: ["vllm"] });
+
+    // Should still discover the provider, just with empty models
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.kind).toBe("vllm");
+    expect(providers[0]?.models).toEqual([]);
+  });
+
+  test("probes all providers concurrently", async () => {
+    const callOrder: string[] = [];
+
+    mockFetchByUrl({
+      "http://localhost:11434/api/tags": async () => {
+        callOrder.push("ollama");
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ models: [] }),
+        };
+      },
+      "http://localhost:8000/health": async () => {
+        callOrder.push("vllm");
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(new Error("no json")),
+        };
+      },
+      "http://localhost:1234/v1/models": async () => {
+        callOrder.push("lm-studio");
+        return {
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: [] }),
+        };
+      },
+    });
+
+    const providers = await discoverLocalProviders();
+
+    // All three should be discovered
+    expect(providers).toHaveLength(3);
+    // All probes should have been initiated (order may vary due to concurrency)
+    expect(callOrder).toHaveLength(3);
+    expect(callOrder).toContain("ollama");
+    expect(callOrder).toContain("vllm");
+    expect(callOrder).toContain("lm-studio");
+  });
+});

--- a/packages/model-router/src/adapters/discover.ts
+++ b/packages/model-router/src/adapters/discover.ts
@@ -1,0 +1,128 @@
+/**
+ * Auto-discovery of local inference servers.
+ *
+ * Probes well-known local endpoints (Ollama, vLLM, LM Studio) in parallel
+ * and returns which providers are running and what models they serve.
+ */
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+
+export type LocalProviderKind = "ollama" | "vllm" | "lm-studio";
+
+export interface DiscoveredProvider {
+  readonly kind: LocalProviderKind;
+  readonly baseUrl: string;
+  readonly models: readonly string[];
+}
+
+export interface DiscoverOptions {
+  readonly timeoutMs?: number | undefined;
+  readonly providers?: readonly LocalProviderKind[] | undefined;
+}
+
+interface ProviderProfile {
+  readonly kind: LocalProviderKind;
+  readonly baseUrl: string;
+  readonly healthPath: string;
+}
+
+const KNOWN_PROFILES: readonly ProviderProfile[] = [
+  { kind: "ollama", baseUrl: "http://localhost:11434", healthPath: "/api/tags" },
+  { kind: "vllm", baseUrl: "http://localhost:8000", healthPath: "/health" },
+  { kind: "lm-studio", baseUrl: "http://localhost:1234", healthPath: "/v1/models" },
+] as const;
+
+/**
+ * Type guard: narrows unknown to a plain object with string-keyed properties.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Extracts model names from an Ollama /api/tags response.
+ */
+function extractOllamaModels(json: unknown): readonly string[] {
+  if (!isRecord(json)) return [];
+  const { models } = json;
+  if (!Array.isArray(models)) return [];
+  return models
+    .filter(isRecord)
+    .map((m) => m.name)
+    .filter((name): name is string => typeof name === "string");
+}
+
+/**
+ * Extracts model IDs from an OpenAI-compatible /v1/models response.
+ */
+function extractOpenAIModels(json: unknown): readonly string[] {
+  if (!isRecord(json)) return [];
+  const { data } = json;
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter(isRecord)
+    .map((m) => m.id)
+    .filter((id): id is string => typeof id === "string");
+}
+
+/**
+ * Extracts model names from a health check response based on provider kind.
+ */
+function extractModels(kind: LocalProviderKind, json: unknown): readonly string[] {
+  if (kind === "ollama") return extractOllamaModels(json);
+  return extractOpenAIModels(json);
+}
+
+/**
+ * Probes a single provider endpoint.
+ */
+async function probeProvider(
+  profile: ProviderProfile,
+  timeoutMs: number,
+): Promise<DiscoveredProvider | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = `${profile.baseUrl}${profile.healthPath}`;
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return undefined;
+
+    let models: readonly string[] = [];
+    try {
+      const json: unknown = await response.json();
+      models = extractModels(profile.kind, json);
+    } catch {
+      // vLLM /health returns empty body — models stay empty
+    }
+
+    return { kind: profile.kind, baseUrl: profile.baseUrl, models };
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Discovers locally running inference servers.
+ *
+ * Probes Ollama, vLLM, and LM Studio in parallel. Returns only healthy
+ * providers. The caller decides which adapters to create from the results.
+ */
+export async function discoverLocalProviders(
+  options?: DiscoverOptions,
+): Promise<readonly DiscoveredProvider[]> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const filterSet = options?.providers ? new Set(options.providers) : undefined;
+
+  const profiles = filterSet ? KNOWN_PROFILES.filter((p) => filterSet.has(p.kind)) : KNOWN_PROFILES;
+
+  const results = await Promise.allSettled(
+    profiles.map((profile) => probeProvider(profile, timeoutMs)),
+  );
+
+  return results
+    .map((r) => (r.status === "fulfilled" ? r.value : undefined))
+    .filter((p): p is DiscoveredProvider => p !== undefined);
+}

--- a/packages/model-router/src/adapters/lm-studio.test.ts
+++ b/packages/model-router/src/adapters/lm-studio.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import type { StreamChunk } from "../provider-adapter.js";
+import { createLMStudioAdapter } from "./lm-studio.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeRequest(text = "hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "user", timestamp: 0 }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// construction
+// ---------------------------------------------------------------------------
+
+describe("createLMStudioAdapter", () => {
+  test("has id 'lm-studio'", () => {
+    const adapter = createLMStudioAdapter();
+    expect(adapter.id).toBe("lm-studio");
+  });
+
+  test("exposes checkHealth method", () => {
+    const adapter = createLMStudioAdapter();
+    expect(adapter.checkHealth).toBeFunction();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete
+// ---------------------------------------------------------------------------
+
+describe("complete", () => {
+  test("sends request to default LM Studio URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "lmstudio-community/Meta-Llama-3.2-3B",
+            choices: [{ message: { role: "assistant", content: "Hello!" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const result = await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://localhost:1234/v1/chat/completions");
+    expect(result.content).toBe("Hello!");
+    expect(result.model).toBe("lmstudio-community/Meta-Llama-3.2-3B");
+    expect(result.usage?.inputTokens).toBe(10);
+  });
+
+  test("uses custom baseUrl", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter({ baseUrl: "http://gpu-server:1234" });
+    await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://gpu-server:1234/v1/chat/completions");
+  });
+
+  test("does not send Authorization header", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    await adapter.complete(makeRequest());
+
+    expect(capturedHeaders.Authorization).toBeUndefined();
+  });
+
+  test("returns EXTERNAL error when LM Studio is not running", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed: Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(TypeError);
+    }
+  });
+
+  test("returns TIMEOUT error after configured timeout", async () => {
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter({ timeoutMs: 100 });
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown timeout error");
+    } catch (error: unknown) {
+      const koiError = error as { code: string; message: string; retryable: boolean };
+      expect(koiError.code).toBe("TIMEOUT");
+      expect(koiError.message).toContain("timed out");
+      expect(koiError.retryable).toBe(true);
+    }
+  }, 10_000);
+});
+
+// ---------------------------------------------------------------------------
+// stream
+// ---------------------------------------------------------------------------
+
+describe("stream", () => {
+  test("yields text_delta and finish chunks from SSE", async () => {
+    const encoder = new TextEncoder();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"choices":[{"delta":{"content":"Hi there"},"finish_reason":null}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const textChunks = chunks.filter((c) => c.kind === "text_delta");
+    expect(textChunks.length).toBeGreaterThan(0);
+    if (textChunks[0]?.kind === "text_delta") {
+      expect(textChunks[0].text).toBe("Hi there");
+    }
+
+    expect(chunks.some((c) => c.kind === "finish")).toBe(true);
+  });
+
+  test("yields error chunk on connection error", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.kind === "error")).toBe(true);
+    const errorChunk = chunks.find((c) => c.kind === "error");
+    if (errorChunk?.kind === "error") {
+      expect(errorChunk.message).toContain("Connection refused");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkHealth
+// ---------------------------------------------------------------------------
+
+describe("checkHealth", () => {
+  test("returns true when LM Studio responds with ok", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(true);
+  });
+
+  test("returns false when LM Studio is down", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("returns false on non-ok response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({ ok: false, status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("calls /v1/models on the base URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter({ baseUrl: "http://gpu-box:1234" });
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://gpu-box:1234/v1/models");
+  });
+
+  test("uses default base URL for health check", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter();
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://localhost:1234/v1/models");
+  });
+
+  test("returns false on timeout", async () => {
+    globalThis.fetch = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createLMStudioAdapter({ healthCheckTimeoutMs: 100 });
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  }, 10_000);
+});

--- a/packages/model-router/src/adapters/lm-studio.ts
+++ b/packages/model-router/src/adapters/lm-studio.ts
@@ -1,0 +1,59 @@
+/**
+ * LM Studio provider adapter.
+ *
+ * Connects to a local LM Studio instance via its OpenAI-compatible API.
+ * No authentication required. Implements health checking via /v1/models.
+ */
+
+import type { ProviderAdapter } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
+
+const DEFAULT_BASE_URL = "http://localhost:1234";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const HEALTH_CHECK_TIMEOUT_MS = 3_000;
+
+export interface LMStudioAdapterConfig {
+  readonly baseUrl?: string | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
+  readonly healthCheckTimeoutMs?: number | undefined;
+}
+
+/**
+ * Creates an LM Studio provider adapter.
+ *
+ * Uses the OpenAI-compatible API at `/v1/chat/completions`.
+ * No API key required. Implements `checkHealth()` via `GET /v1/models`.
+ */
+export function createLMStudioAdapter(config?: LMStudioAdapterConfig): ProviderAdapter {
+  const baseUrl = config?.baseUrl ?? DEFAULT_BASE_URL;
+  const healthCheckTimeoutMs = config?.healthCheckTimeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
+
+  const compat = createOpenAICompatibleAdapter({
+    baseUrl: `${baseUrl}/v1`,
+    timeoutMs: config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    headers: config?.headers,
+    providerName: "LM Studio",
+  });
+
+  return {
+    id: "lm-studio",
+    complete: compat.complete,
+    stream: compat.stream,
+
+    async checkHealth(): Promise<boolean> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), healthCheckTimeoutMs);
+      try {
+        const response = await fetch(`${baseUrl}/v1/models`, {
+          signal: controller.signal,
+        });
+        return response.ok;
+      } catch {
+        return false;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/model-router/src/adapters/ollama.test.ts
+++ b/packages/model-router/src/adapters/ollama.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import type { StreamChunk } from "../provider-adapter.js";
+import { createOllamaAdapter } from "./ollama.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeRequest(text = "hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "user", timestamp: 0 }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// construction
+// ---------------------------------------------------------------------------
+
+describe("createOllamaAdapter", () => {
+  test("has id 'ollama'", () => {
+    const adapter = createOllamaAdapter();
+    expect(adapter.id).toBe("ollama");
+  });
+
+  test("exposes checkHealth method", () => {
+    const adapter = createOllamaAdapter();
+    expect(adapter.checkHealth).toBeFunction();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete
+// ---------------------------------------------------------------------------
+
+describe("complete", () => {
+  test("sends request to default Ollama URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2:3b",
+            choices: [{ message: { role: "assistant", content: "Hello!" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const result = await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://localhost:11434/v1/chat/completions");
+    expect(result.content).toBe("Hello!");
+    expect(result.model).toBe("llama3.2:3b");
+    expect(result.usage?.inputTokens).toBe(10);
+  });
+
+  test("uses custom baseUrl", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter({ baseUrl: "http://gpu-server:11434" });
+    await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://gpu-server:11434/v1/chat/completions");
+  });
+
+  test("does not send Authorization header", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    await adapter.complete(makeRequest());
+
+    expect(capturedHeaders.Authorization).toBeUndefined();
+  });
+
+  test("returns EXTERNAL error when Ollama is not running", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed: Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(TypeError);
+    }
+  });
+
+  test("returns TIMEOUT error after configured timeout", async () => {
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter({ timeoutMs: 100 });
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown timeout error");
+    } catch (error: unknown) {
+      const koiError = error as { code: string; message: string; retryable: boolean };
+      expect(koiError.code).toBe("TIMEOUT");
+      expect(koiError.message).toContain("timed out");
+      expect(koiError.retryable).toBe(true);
+    }
+  }, 10_000);
+});
+
+// ---------------------------------------------------------------------------
+// stream
+// ---------------------------------------------------------------------------
+
+describe("stream", () => {
+  test("yields text_delta and finish chunks from SSE", async () => {
+    const encoder = new TextEncoder();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"choices":[{"delta":{"content":"Hi there"},"finish_reason":null}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const textChunks = chunks.filter((c) => c.kind === "text_delta");
+    expect(textChunks.length).toBeGreaterThan(0);
+    if (textChunks[0]?.kind === "text_delta") {
+      expect(textChunks[0].text).toBe("Hi there");
+    }
+
+    expect(chunks.some((c) => c.kind === "finish")).toBe(true);
+  });
+
+  test("yields error chunk on connection error", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.kind === "error")).toBe(true);
+    const errorChunk = chunks.find((c) => c.kind === "error");
+    if (errorChunk?.kind === "error") {
+      expect(errorChunk.message).toContain("Connection refused");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkHealth
+// ---------------------------------------------------------------------------
+
+describe("checkHealth", () => {
+  test("returns true when Ollama responds with ok", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(true);
+  });
+
+  test("returns false when Ollama is down", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("returns false on non-ok response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({ ok: false, status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("calls /api/tags on the base URL (not /v1/ prefix)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter({ baseUrl: "http://gpu-box:11434" });
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://gpu-box:11434/api/tags");
+  });
+
+  test("uses default base URL for health check", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter();
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://localhost:11434/api/tags");
+  });
+
+  test("returns false on timeout", async () => {
+    globalThis.fetch = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOllamaAdapter({ healthCheckTimeoutMs: 100 });
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  }, 10_000);
+});

--- a/packages/model-router/src/adapters/ollama.ts
+++ b/packages/model-router/src/adapters/ollama.ts
@@ -1,0 +1,59 @@
+/**
+ * Ollama provider adapter.
+ *
+ * Connects to a local Ollama instance via its OpenAI-compatible API.
+ * No authentication required. Implements health checking via /api/tags.
+ */
+
+import type { ProviderAdapter } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
+
+const DEFAULT_BASE_URL = "http://localhost:11434";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const HEALTH_CHECK_TIMEOUT_MS = 3_000;
+
+export interface OllamaAdapterConfig {
+  readonly baseUrl?: string | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
+  readonly healthCheckTimeoutMs?: number | undefined;
+}
+
+/**
+ * Creates an Ollama provider adapter.
+ *
+ * Uses the OpenAI-compatible API at `/v1/chat/completions`.
+ * No API key required. Implements `checkHealth()` via `GET /api/tags`.
+ */
+export function createOllamaAdapter(config?: OllamaAdapterConfig): ProviderAdapter {
+  const baseUrl = config?.baseUrl ?? DEFAULT_BASE_URL;
+  const healthCheckTimeoutMs = config?.healthCheckTimeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
+
+  const compat = createOpenAICompatibleAdapter({
+    baseUrl: `${baseUrl}/v1`,
+    timeoutMs: config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    headers: config?.headers,
+    providerName: "Ollama",
+  });
+
+  return {
+    id: "ollama",
+    complete: compat.complete,
+    stream: compat.stream,
+
+    async checkHealth(): Promise<boolean> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), healthCheckTimeoutMs);
+      try {
+        const response = await fetch(`${baseUrl}/api/tags`, {
+          signal: controller.signal,
+        });
+        return response.ok;
+      } catch {
+        return false;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/model-router/src/adapters/openai-compat.test.ts
+++ b/packages/model-router/src/adapters/openai-compat.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import type { StreamChunk } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockFetch(response: {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly body: unknown;
+  readonly headers?: Record<string, string>;
+}): ReturnType<typeof mock> {
+  const fn = mock(() =>
+    Promise.resolve({
+      ok: response.ok,
+      status: response.status,
+      headers: new Headers(response.headers ?? {}),
+      json: () => Promise.resolve(response.body),
+      text: () => Promise.resolve(JSON.stringify(response.body)),
+    }),
+  );
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function makeRequest(text = "hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "user", timestamp: 0 }],
+  };
+}
+
+describe("createOpenAICompatibleAdapter", () => {
+  test("complete sends request to base URL + /chat/completions", async () => {
+    const fetchFn = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        id: "gen-1",
+        model: "test-model",
+        choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+    });
+
+    const result = await adapter.complete(makeRequest());
+
+    expect(result.content).toBe("hi");
+    expect(result.model).toBe("test-model");
+    expect(result.usage?.inputTokens).toBe(5);
+
+    const calledUrl = (fetchFn.mock.calls[0] as [string, unknown])[0];
+    expect(calledUrl).toBe("http://localhost:11434/v1/chat/completions");
+  });
+
+  test("complete works without apiKey (no auth header)", async () => {
+    const fetchFn = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        id: "gen-1",
+        model: "llama3",
+        choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+      },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Ollama",
+    });
+
+    await adapter.complete(makeRequest());
+
+    const calledInit = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  test("complete includes Bearer token when apiKey provided", async () => {
+    const fetchFn = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        id: "gen-1",
+        model: "gpt-4o",
+        choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+      },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test-key",
+      providerName: "OpenAI",
+    });
+
+    await adapter.complete(makeRequest());
+
+    const calledInit = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-test-key");
+  });
+
+  test("complete uses defaultModel when request has no model", async () => {
+    const fetchFn = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        id: "gen-1",
+        model: "llama3.2",
+        choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+      },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+      defaultModel: "llama3.2",
+    });
+
+    await adapter.complete(makeRequest());
+
+    const calledBody = JSON.parse(
+      (fetchFn.mock.calls[0] as [string, RequestInit])[1].body as string,
+    ) as { model: string };
+    expect(calledBody.model).toBe("llama3.2");
+  });
+
+  test("complete throws KoiError on non-ok response", async () => {
+    mockFetch({
+      ok: false,
+      status: 429,
+      body: { error: { message: "Rate limited" } },
+      headers: { "retry-after": "2" },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "TestProvider",
+    });
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown");
+    } catch (error: unknown) {
+      const koiError = error as {
+        code: string;
+        message: string;
+        retryable: boolean;
+        retryAfterMs?: number;
+      };
+      expect(koiError.code).toBe("RATE_LIMIT");
+      expect(koiError.message).toContain("TestProvider API error 429");
+      expect(koiError.retryable).toBe(true);
+      expect(koiError.retryAfterMs).toBe(2000);
+    }
+  });
+
+  test("complete throws TIMEOUT error on abort", async () => {
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+      timeoutMs: 100,
+    });
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown timeout error");
+    } catch (error: unknown) {
+      const koiError = error as { code: string; message: string; retryable: boolean };
+      expect(koiError.code).toBe("TIMEOUT");
+      expect(koiError.message).toContain("timed out");
+      expect(koiError.retryable).toBe(true);
+    }
+  }, 10_000);
+
+  test("complete includes custom headers", async () => {
+    const fetchFn = mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        id: "gen-1",
+        model: "test",
+        choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+      },
+    });
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+      headers: { "X-Custom": "my-value" },
+    });
+
+    await adapter.complete(makeRequest());
+
+    const calledInit = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const headers = calledInit.headers as Record<string, string>;
+    expect(headers["X-Custom"]).toBe("my-value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stream
+// ---------------------------------------------------------------------------
+
+describe("stream", () => {
+  test("yields text_delta and finish chunks from SSE", async () => {
+    const encoder = new TextEncoder();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+    });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.kind === "text_delta")).toBe(true);
+    expect(chunks.some((c) => c.kind === "finish")).toBe(true);
+    const textChunk = chunks.find((c) => c.kind === "text_delta");
+    if (textChunk?.kind === "text_delta") {
+      expect(textChunk.text).toBe("Hello");
+    }
+  });
+
+  test("yields error chunk on non-ok response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        text: () => Promise.resolve("Internal Server Error"),
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "TestProvider",
+    });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.kind).toBe("error");
+    if (chunks[0]?.kind === "error") {
+      expect(chunks[0].message).toContain("TestProvider API error 500");
+    }
+  });
+
+  test("yields error chunk when response body is null", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: null,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+    });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.kind).toBe("error");
+    if (chunks[0]?.kind === "error") {
+      expect(chunks[0].message).toContain("No response body");
+    }
+  });
+
+  test("yields finish_reason from stream chunks", async () => {
+    const encoder = new TextEncoder();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n'),
+        );
+        controller.enqueue(
+          encoder.encode('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'),
+        );
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+    });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const finishChunk = chunks.find((c) => c.kind === "finish");
+    expect(finishChunk).toBeDefined();
+    if (finishChunk?.kind === "finish") {
+      expect(finishChunk.reason).toBe("stop");
+    }
+  });
+
+  test("yields error on idle timeout during stream", async () => {
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      const mockStream = new ReadableStream({
+        pull() {
+          return new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          });
+        },
+      });
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = createOpenAICompatibleAdapter({
+      baseUrl: "http://localhost:11434/v1",
+      providerName: "Test",
+      timeoutMs: 100,
+    });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.kind === "error")).toBe(true);
+    const errorChunk = chunks.find((c) => c.kind === "error");
+    if (errorChunk?.kind === "error") {
+      expect(errorChunk.message).toContain("timeout");
+    }
+  }, 10_000);
+});

--- a/packages/model-router/src/adapters/openai-compat.ts
+++ b/packages/model-router/src/adapters/openai-compat.ts
@@ -1,0 +1,186 @@
+/**
+ * OpenAI-compatible base adapter.
+ *
+ * Creates a ProviderAdapter that speaks the OpenAI chat completions API format.
+ * Used by OpenAI, OpenRouter, and Ollama adapters — each configures provider-specific
+ * defaults (base URL, auth, headers) and delegates here.
+ */
+
+import type { KoiError, ModelRequest, ModelResponse } from "@koi/core";
+import type { ProviderAdapter, StreamChunk } from "../provider-adapter.js";
+import { fromOpenAIResponse, toOpenAIRequest } from "./openai.js";
+import {
+  fetchWithTimeout,
+  handleAbortError,
+  handleStreamAbortError,
+  mapStatusToErrorCode,
+  parseRetryAfter,
+  parseSSEStream,
+  streamFetch,
+} from "./shared.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface OpenAICompatibleConfig {
+  readonly baseUrl: string;
+  readonly timeoutMs?: number | undefined;
+  readonly apiKey?: string | undefined;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
+  readonly providerName: string;
+  readonly defaultModel?: string | undefined;
+}
+
+/**
+ * Creates a ProviderAdapter using the OpenAI-compatible chat completions API.
+ *
+ * Reuses `toOpenAIRequest`/`fromOpenAIResponse` from the OpenAI adapter for
+ * request/response transformation. Auth is optional for local providers (Ollama).
+ */
+export function createOpenAICompatibleAdapter(
+  config: OpenAICompatibleConfig,
+): Pick<ProviderAdapter, "complete" | "stream"> {
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  function buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (config.apiKey) {
+      headers.Authorization = `Bearer ${config.apiKey}`;
+    }
+    return { ...headers, ...config.headers };
+  }
+
+  return {
+    async complete(request: ModelRequest): Promise<ModelResponse> {
+      const requestWithModel: ModelRequest = config.defaultModel
+        ? { ...request, model: request.model ?? config.defaultModel }
+        : request;
+      const body = toOpenAIRequest(requestWithModel);
+      const url = `${config.baseUrl}/chat/completions`;
+
+      let clearTimer: (() => void) | undefined;
+      try {
+        const result = await fetchWithTimeout({
+          url,
+          method: "POST",
+          headers: buildHeaders(),
+          body: JSON.stringify(body),
+          timeoutMs,
+          signal: request.signal,
+        });
+        clearTimer = result.clearTimer;
+
+        if (!result.response.ok) {
+          const errorBody = await result.response.text().catch(() => "");
+          const retryAfterMs = parseRetryAfter(result.response.headers);
+          throw {
+            code: mapStatusToErrorCode(result.response.status),
+            message: `${config.providerName} API error ${result.response.status}: ${errorBody}`,
+            retryable: result.response.status === 429 || result.response.status >= 500,
+            ...(retryAfterMs !== undefined && { retryAfterMs }),
+            context: { statusCode: result.response.status },
+          } satisfies KoiError;
+        }
+
+        const json = (await result.response.json()) as Parameters<typeof fromOpenAIResponse>[0];
+        return fromOpenAIResponse(json);
+      } catch (error: unknown) {
+        // KoiError objects thrown above should pass through
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          "message" in error &&
+          "retryable" in error
+        ) {
+          throw error;
+        }
+        throw handleAbortError(error, config.providerName, timeoutMs, request.signal);
+      } finally {
+        clearTimer?.();
+      }
+    },
+
+    async *stream(request: ModelRequest): AsyncGenerator<StreamChunk> {
+      const requestWithModel: ModelRequest = config.defaultModel
+        ? { ...request, model: request.model ?? config.defaultModel }
+        : request;
+      const body = { ...toOpenAIRequest(requestWithModel), stream: true };
+      const url = `${config.baseUrl}/chat/completions`;
+
+      let clearTimer: (() => void) | undefined;
+      try {
+        const result = await streamFetch({
+          url,
+          headers: buildHeaders(),
+          body: JSON.stringify(body),
+          timeoutMs,
+          signal: request.signal,
+        });
+        clearTimer = result.clearTimer;
+
+        if (!result.response.ok) {
+          const errorBody = await result.response.text().catch(() => "");
+          yield {
+            kind: "error",
+            message: `${config.providerName} API error ${result.response.status}: ${errorBody}`,
+            statusCode: result.response.status,
+          };
+          return;
+        }
+
+        if (!result.response.body) {
+          yield { kind: "error", message: "No response body for streaming" };
+          return;
+        }
+
+        const chunks = parseSSEStream<StreamChunk>(
+          result.response.body,
+          (data) => {
+            if (data === "[DONE]") {
+              return { kind: "finish", reason: "completed" };
+            }
+
+            try {
+              const parsed = JSON.parse(data) as {
+                readonly choices: readonly {
+                  readonly delta: { readonly content?: string };
+                  readonly finish_reason?: string | null;
+                }[];
+              };
+              const delta = parsed.choices[0]?.delta.content;
+              if (delta) {
+                return { kind: "text_delta", text: delta };
+              }
+              const finishReason = parsed.choices[0]?.finish_reason;
+              if (finishReason) {
+                return { kind: "finish", reason: finishReason };
+              }
+            } catch {
+              // Ignore malformed SSE data
+            }
+            return undefined;
+          },
+          result.resetTimer,
+        );
+
+        for await (const chunk of chunks) {
+          yield chunk;
+          // If we yielded a finish from [DONE], stop
+          if (chunk.kind === "finish" && chunk.reason === "completed") return;
+        }
+      } catch (error: unknown) {
+        const message = handleStreamAbortError(
+          error,
+          config.providerName,
+          timeoutMs,
+          request.signal,
+        );
+        yield { kind: "error", message };
+      } finally {
+        clearTimer?.();
+      }
+    },
+  };
+}

--- a/packages/model-router/src/adapters/openai.ts
+++ b/packages/model-router/src/adapters/openai.ts
@@ -5,9 +5,13 @@
  * Uses raw fetch — no SDK dependency.
  */
 
-import type { KoiError, ModelRequest, ModelResponse } from "@koi/core";
+import type { ModelRequest, ModelResponse } from "@koi/core";
 import { normalizeToPlainText } from "../normalize.js";
-import type { ProviderAdapter, ProviderAdapterConfig, StreamChunk } from "../provider-adapter.js";
+import type { ProviderAdapter, ProviderAdapterConfig } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
+
+// Re-export shared mapStatusToErrorCode for backward compatibility
+export { mapStatusToErrorCode } from "./shared.js";
 
 const DEFAULT_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -80,197 +84,23 @@ export function fromOpenAIResponse(response: OpenAIChatResponse): ModelResponse 
 }
 
 /**
- * Maps an HTTP status code to a KoiErrorCode.
- */
-export function mapStatusToErrorCode(status: number): KoiError["code"] {
-  if (status === 401 || status === 403) return "PERMISSION";
-  if (status === 404) return "NOT_FOUND";
-  if (status === 429) return "RATE_LIMIT";
-  if (status === 408 || status === 504) return "TIMEOUT";
-  if (status >= 500) return "EXTERNAL";
-  return "EXTERNAL";
-}
-
-/**
- * Extracts Retry-After header value as milliseconds.
- */
-function parseRetryAfter(headers: Headers): number | undefined {
-  const value = headers.get("retry-after");
-  if (!value) return undefined;
-  const seconds = Number.parseFloat(value);
-  if (Number.isNaN(seconds)) return undefined;
-  return Math.ceil(seconds * 1000);
-}
-
-/**
  * Creates an OpenAI provider adapter.
+ *
+ * Delegates to the shared OpenAI-compatible base adapter with OpenAI-specific defaults.
  */
 export function createOpenAIAdapter(config: ProviderAdapterConfig): ProviderAdapter {
-  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
-  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const compat = createOpenAICompatibleAdapter({
+    baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    apiKey: config.apiKey,
+    headers: config.headers,
+    providerName: "OpenAI",
+    defaultModel: "gpt-4o",
+  });
 
   return {
     id: "openai",
-
-    async complete(request: ModelRequest): Promise<ModelResponse> {
-      const body = toOpenAIRequest(request);
-      const url = `${baseUrl}/chat/completions`;
-
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.apiKey}`,
-            ...config.headers,
-          },
-          body: JSON.stringify(body),
-          signal: effectiveSignal,
-        });
-
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
-          const retryAfterMs = parseRetryAfter(response.headers);
-          throw {
-            code: mapStatusToErrorCode(response.status),
-            message: `OpenAI API error ${response.status}: ${errorBody}`,
-            retryable: response.status === 429 || response.status >= 500,
-            ...(retryAfterMs !== undefined && { retryAfterMs }),
-            context: { statusCode: response.status },
-          } satisfies KoiError;
-        }
-
-        const json = (await response.json()) as OpenAIChatResponse;
-        return fromOpenAIResponse(json);
-      } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          // Discriminate caller-initiated cancel from internal timeout
-          const isCallerAbort = request.signal?.aborted === true;
-          throw {
-            code: isCallerAbort ? "EXTERNAL" : "TIMEOUT",
-            message: isCallerAbort
-              ? "OpenAI request cancelled"
-              : `OpenAI request timed out after ${timeoutMs}ms`,
-            retryable: !isCallerAbort,
-          } satisfies KoiError;
-        }
-        throw error;
-      } finally {
-        clearTimeout(timer);
-      }
-    },
-
-    async *stream(request: ModelRequest): AsyncGenerator<StreamChunk> {
-      const body = { ...toOpenAIRequest(request), stream: true };
-      const url = `${baseUrl}/chat/completions`;
-
-      const controller = new AbortController();
-      // Idle timeout: resets on each chunk so long-running healthy streams aren't killed
-      let timer = setTimeout(() => controller.abort(), timeoutMs);
-      const resetTimer = (): void => {
-        clearTimeout(timer);
-        timer = setTimeout(() => controller.abort(), timeoutMs);
-      };
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.apiKey}`,
-            ...config.headers,
-          },
-          body: JSON.stringify(body),
-          signal: effectiveSignal,
-        });
-
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
-          yield {
-            kind: "error",
-            message: `OpenAI API error ${response.status}: ${errorBody}`,
-            statusCode: response.status,
-          };
-          return;
-        }
-
-        if (!response.body) {
-          yield { kind: "error", message: "No response body for streaming" };
-          return;
-        }
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          resetTimer();
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed || !trimmed.startsWith("data: ")) continue;
-            const data = trimmed.slice(6);
-            if (data === "[DONE]") {
-              yield { kind: "finish", reason: "completed" };
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(data) as {
-                readonly choices: readonly {
-                  readonly delta: { readonly content?: string };
-                  readonly finish_reason?: string | null;
-                }[];
-              };
-              const delta = parsed.choices[0]?.delta.content;
-              if (delta) {
-                yield { kind: "text_delta", text: delta };
-              }
-              if (parsed.choices[0]?.finish_reason) {
-                yield { kind: "finish", reason: parsed.choices[0].finish_reason };
-              }
-            } catch {
-              // Ignore malformed SSE data
-            }
-          }
-        }
-      } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          const isCallerAbort = request.signal?.aborted === true;
-          yield {
-            kind: "error",
-            message: isCallerAbort
-              ? "OpenAI stream cancelled"
-              : `OpenAI stream idle timeout after ${timeoutMs}ms`,
-          };
-        } else {
-          yield {
-            kind: "error",
-            message: error instanceof Error ? error.message : String(error),
-          };
-        }
-      } finally {
-        clearTimeout(timer);
-      }
-    },
+    complete: compat.complete,
+    stream: compat.stream,
   };
 }

--- a/packages/model-router/src/adapters/openrouter.ts
+++ b/packages/model-router/src/adapters/openrouter.ts
@@ -1,13 +1,12 @@
 /**
  * OpenRouter provider adapter.
  *
- * OpenRouter exposes an OpenAI-compatible API, so we reuse the OpenAI
- * request/response transforms. Only the auth headers and base URL differ.
+ * OpenRouter exposes an OpenAI-compatible API, so we delegate to the shared
+ * OpenAI-compatible base adapter with OpenRouter-specific headers.
  */
 
-import type { KoiError, ModelRequest, ModelResponse } from "@koi/core";
-import type { ProviderAdapter, ProviderAdapterConfig, StreamChunk } from "../provider-adapter.js";
-import { fromOpenAIResponse, mapStatusToErrorCode, toOpenAIRequest } from "./openai.js";
+import type { ProviderAdapter, ProviderAdapterConfig } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
 
 const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -21,13 +20,10 @@ export interface OpenRouterAdapterConfig extends ProviderAdapterConfig {
 }
 
 /**
- * Builds the header map for an OpenRouter request.
+ * Builds the extra header map for OpenRouter requests.
  */
-function buildHeaders(config: OpenRouterAdapterConfig): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${config.apiKey}`,
-  };
+function buildOpenRouterHeaders(config: OpenRouterAdapterConfig): Record<string, string> {
+  const headers: Record<string, string> = {};
 
   if (config.referer) {
     headers["HTTP-Referer"] = config.referer;
@@ -40,188 +36,24 @@ function buildHeaders(config: OpenRouterAdapterConfig): Record<string, string> {
 }
 
 /**
- * Extracts Retry-After header value as milliseconds.
- */
-function parseRetryAfter(headers: Headers): number | undefined {
-  const value = headers.get("retry-after");
-  if (!value) return undefined;
-  const seconds = Number.parseFloat(value);
-  if (Number.isNaN(seconds)) return undefined;
-  return Math.ceil(seconds * 1000);
-}
-
-/**
  * Creates an OpenRouter provider adapter.
  *
- * OpenRouter is OpenAI-compatible, so this adapter delegates request/response
- * transformation to the shared OpenAI helpers and adds OpenRouter-specific
- * headers (`HTTP-Referer`, `X-Title`).
+ * Delegates to the shared OpenAI-compatible base adapter with
+ * OpenRouter-specific headers (`HTTP-Referer`, `X-Title`).
  */
 export function createOpenRouterAdapter(config: OpenRouterAdapterConfig): ProviderAdapter {
-  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
-  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const compat = createOpenAICompatibleAdapter({
+    baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    apiKey: config.apiKey,
+    headers: buildOpenRouterHeaders(config),
+    providerName: "OpenRouter",
+    defaultModel: DEFAULT_MODEL,
+  });
 
   return {
     id: "openrouter",
-
-    async complete(request: ModelRequest): Promise<ModelResponse> {
-      const requestWithModel: ModelRequest = {
-        ...request,
-        model: request.model ?? DEFAULT_MODEL,
-      };
-      const body = toOpenAIRequest(requestWithModel);
-      const url = `${baseUrl}/chat/completions`;
-
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: buildHeaders(config),
-          body: JSON.stringify(body),
-          signal: effectiveSignal,
-        });
-
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
-          const retryAfterMs = parseRetryAfter(response.headers);
-          throw {
-            code: mapStatusToErrorCode(response.status),
-            message: `OpenRouter API error ${response.status}: ${errorBody}`,
-            retryable: response.status === 429 || response.status >= 500,
-            ...(retryAfterMs !== undefined && { retryAfterMs }),
-            context: { statusCode: response.status },
-          } satisfies KoiError;
-        }
-
-        const json = (await response.json()) as Parameters<typeof fromOpenAIResponse>[0];
-        return fromOpenAIResponse(json);
-      } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          const isCallerAbort = request.signal?.aborted === true;
-          throw {
-            code: isCallerAbort ? "EXTERNAL" : "TIMEOUT",
-            message: isCallerAbort
-              ? "OpenRouter request cancelled"
-              : `OpenRouter request timed out after ${timeoutMs}ms`,
-            retryable: !isCallerAbort,
-          } satisfies KoiError;
-        }
-        throw error;
-      } finally {
-        clearTimeout(timer);
-      }
-    },
-
-    async *stream(request: ModelRequest): AsyncGenerator<StreamChunk> {
-      const requestWithModel: ModelRequest = {
-        ...request,
-        model: request.model ?? DEFAULT_MODEL,
-      };
-      const body = { ...toOpenAIRequest(requestWithModel), stream: true };
-      const url = `${baseUrl}/chat/completions`;
-
-      const controller = new AbortController();
-      // Idle timeout: resets on each chunk so long-running healthy streams aren't killed
-      let timer = setTimeout(() => controller.abort(), timeoutMs);
-      const resetTimer = (): void => {
-        clearTimeout(timer);
-        timer = setTimeout(() => controller.abort(), timeoutMs);
-      };
-      // Compose caller signal with local timeout controller
-      const effectiveSignal =
-        request.signal !== undefined
-          ? AbortSignal.any([request.signal, controller.signal])
-          : controller.signal;
-
-      try {
-        const response = await fetch(url, {
-          method: "POST",
-          headers: buildHeaders(config),
-          body: JSON.stringify(body),
-          signal: effectiveSignal,
-        });
-
-        if (!response.ok) {
-          const errorBody = await response.text().catch(() => "");
-          yield {
-            kind: "error",
-            message: `OpenRouter API error ${response.status}: ${errorBody}`,
-            statusCode: response.status,
-          };
-          return;
-        }
-
-        if (!response.body) {
-          yield { kind: "error", message: "No response body for streaming" };
-          return;
-        }
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          resetTimer();
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed || !trimmed.startsWith("data: ")) continue;
-            const data = trimmed.slice(6);
-            if (data === "[DONE]") {
-              yield { kind: "finish", reason: "completed" };
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(data) as {
-                readonly choices: readonly {
-                  readonly delta: { readonly content?: string };
-                  readonly finish_reason?: string | null;
-                }[];
-              };
-              const delta = parsed.choices[0]?.delta.content;
-              if (delta) {
-                yield { kind: "text_delta", text: delta };
-              }
-              if (parsed.choices[0]?.finish_reason) {
-                yield { kind: "finish", reason: parsed.choices[0].finish_reason };
-              }
-            } catch {
-              // Ignore malformed SSE data
-            }
-          }
-        }
-      } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === "AbortError") {
-          const isCallerAbort = request.signal?.aborted === true;
-          yield {
-            kind: "error",
-            message: isCallerAbort
-              ? "OpenRouter stream cancelled"
-              : `OpenRouter stream idle timeout after ${timeoutMs}ms`,
-          };
-        } else {
-          yield {
-            kind: "error",
-            message: error instanceof Error ? error.message : String(error),
-          };
-        }
-      } finally {
-        clearTimeout(timer);
-      }
-    },
+    complete: compat.complete,
+    stream: compat.stream,
   };
 }

--- a/packages/model-router/src/adapters/shared.test.ts
+++ b/packages/model-router/src/adapters/shared.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, test } from "bun:test";
+import {
+  fetchWithTimeout,
+  handleAbortError,
+  handleStreamAbortError,
+  mapStatusToErrorCode,
+  parseRetryAfter,
+  parseSSEStream,
+  streamFetch,
+} from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// mapStatusToErrorCode
+// ---------------------------------------------------------------------------
+
+describe("mapStatusToErrorCode", () => {
+  test("401 → PERMISSION", () => {
+    expect(mapStatusToErrorCode(401)).toBe("PERMISSION");
+  });
+
+  test("403 → PERMISSION", () => {
+    expect(mapStatusToErrorCode(403)).toBe("PERMISSION");
+  });
+
+  test("404 → NOT_FOUND", () => {
+    expect(mapStatusToErrorCode(404)).toBe("NOT_FOUND");
+  });
+
+  test("429 → RATE_LIMIT", () => {
+    expect(mapStatusToErrorCode(429)).toBe("RATE_LIMIT");
+  });
+
+  test("408 → TIMEOUT", () => {
+    expect(mapStatusToErrorCode(408)).toBe("TIMEOUT");
+  });
+
+  test("504 → TIMEOUT", () => {
+    expect(mapStatusToErrorCode(504)).toBe("TIMEOUT");
+  });
+
+  test("500 → EXTERNAL", () => {
+    expect(mapStatusToErrorCode(500)).toBe("EXTERNAL");
+  });
+
+  test("502 → EXTERNAL", () => {
+    expect(mapStatusToErrorCode(502)).toBe("EXTERNAL");
+  });
+
+  test("400 → EXTERNAL (default)", () => {
+    expect(mapStatusToErrorCode(400)).toBe("EXTERNAL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRetryAfter
+// ---------------------------------------------------------------------------
+
+describe("parseRetryAfter", () => {
+  test("returns milliseconds from seconds value", () => {
+    const headers = new Headers({ "retry-after": "5.5" });
+    expect(parseRetryAfter(headers)).toBe(5500);
+  });
+
+  test("returns undefined when header missing", () => {
+    const headers = new Headers();
+    expect(parseRetryAfter(headers)).toBeUndefined();
+  });
+
+  test("returns undefined for non-numeric value", () => {
+    const headers = new Headers({ "retry-after": "not-a-number" });
+    expect(parseRetryAfter(headers)).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    const headers = new Headers({ "retry-after": "" });
+    expect(parseRetryAfter(headers)).toBeUndefined();
+  });
+
+  test("ceils fractional milliseconds", () => {
+    const headers = new Headers({ "retry-after": "1.1" });
+    expect(parseRetryAfter(headers)).toBe(1100);
+  });
+
+  test("handles integer seconds", () => {
+    const headers = new Headers({ "retry-after": "3" });
+    expect(parseRetryAfter(headers)).toBe(3000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleAbortError
+// ---------------------------------------------------------------------------
+
+describe("handleAbortError", () => {
+  test("returns TIMEOUT error for internal timeout abort", () => {
+    const error = new DOMException("The operation was aborted.", "AbortError");
+    const result = handleAbortError(error, "TestProvider", 5000);
+
+    expect(result.code).toBe("TIMEOUT");
+    expect(result.message).toContain("timed out after 5000ms");
+    expect(result.retryable).toBe(true);
+  });
+
+  test("returns EXTERNAL error for caller-initiated abort", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const error = new DOMException("The operation was aborted.", "AbortError");
+    const result = handleAbortError(error, "TestProvider", 5000, controller.signal);
+
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("cancelled");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("re-throws non-abort errors", () => {
+    const error = new Error("network failure");
+    expect(() => handleAbortError(error, "TestProvider", 5000)).toThrow("network failure");
+  });
+
+  test("includes provider name in error message", () => {
+    const error = new DOMException("The operation was aborted.", "AbortError");
+    const result = handleAbortError(error, "Ollama", 10000);
+    expect(result.message).toContain("Ollama");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleStreamAbortError
+// ---------------------------------------------------------------------------
+
+describe("handleStreamAbortError", () => {
+  test("returns idle timeout message for internal abort", () => {
+    const error = new DOMException("The operation was aborted.", "AbortError");
+    const msg = handleStreamAbortError(error, "TestProvider", 5000);
+    expect(msg).toContain("idle timeout after 5000ms");
+  });
+
+  test("returns cancelled message for caller abort", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const error = new DOMException("The operation was aborted.", "AbortError");
+    const msg = handleStreamAbortError(error, "TestProvider", 5000, controller.signal);
+    expect(msg).toContain("cancelled");
+  });
+
+  test("returns error message for non-abort Error", () => {
+    const error = new Error("socket hang up");
+    const msg = handleStreamAbortError(error, "TestProvider", 5000);
+    expect(msg).toBe("socket hang up");
+  });
+
+  test("converts non-Error to string", () => {
+    const msg = handleStreamAbortError(42, "TestProvider", 5000);
+    expect(msg).toBe("42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSSEStream
+// ---------------------------------------------------------------------------
+
+describe("parseSSEStream", () => {
+  function makeStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  test("parses data lines from SSE stream", async () => {
+    const stream = makeStream(["data: hello\n\n", "data: world\n\n"]);
+    const results: string[] = [];
+    for await (const item of parseSSEStream(stream, (data) => data)) {
+      results.push(item);
+    }
+    expect(results).toEqual(["hello", "world"]);
+  });
+
+  test("ignores non-data lines", async () => {
+    const stream = makeStream(["event: test\n", "data: hello\n\n", ": comment\n", "data: end\n\n"]);
+    const results: string[] = [];
+    for await (const item of parseSSEStream(stream, (data) => data)) {
+      results.push(item);
+    }
+    expect(results).toEqual(["hello", "end"]);
+  });
+
+  test("ignores empty lines", async () => {
+    const stream = makeStream(["\n\ndata: hello\n\n\n"]);
+    const results: string[] = [];
+    for await (const item of parseSSEStream(stream, (data) => data)) {
+      results.push(item);
+    }
+    expect(results).toEqual(["hello"]);
+  });
+
+  test("handles partial lines across chunks", async () => {
+    const stream = makeStream(["dat", "a: split-across\n\n"]);
+    const results: string[] = [];
+    for await (const item of parseSSEStream(stream, (data) => data)) {
+      results.push(item);
+    }
+    expect(results).toEqual(["split-across"]);
+  });
+
+  test("parseLine returning undefined skips the line", async () => {
+    const stream = makeStream(["data: skip\n", "data: keep\n\n"]);
+    const results: string[] = [];
+    for await (const item of parseSSEStream(stream, (data) =>
+      data === "skip" ? undefined : data,
+    )) {
+      results.push(item);
+    }
+    expect(results).toEqual(["keep"]);
+  });
+
+  test("calls onChunk for each raw chunk", async () => {
+    const stream = makeStream(["data: a\n\n", "data: b\n\n"]);
+    let chunkCount = 0;
+    const results: string[] = [];
+    for await (const item of parseSSEStream(
+      stream,
+      (data) => data,
+      () => {
+        chunkCount++;
+      },
+    )) {
+      results.push(item);
+    }
+    expect(chunkCount).toBe(2);
+    expect(results).toEqual(["a", "b"]);
+  });
+
+  test("handles JSON data lines", async () => {
+    const stream = makeStream(['data: {"key":"value"}\n\n']);
+    const results: Record<string, string>[] = [];
+    for await (const item of parseSSEStream<Record<string, string>>(stream, (data) => {
+      try {
+        return JSON.parse(data) as Record<string, string>;
+      } catch {
+        return undefined;
+      }
+    })) {
+      results.push(item);
+    }
+    expect(results).toEqual([{ key: "value" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchWithTimeout
+// ---------------------------------------------------------------------------
+
+describe("fetchWithTimeout", () => {
+  const originalFetch = globalThis.fetch;
+
+  test("passes request parameters to fetch", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await fetchWithTimeout({
+        url: "https://example.com/api",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"key":"value"}',
+        timeoutMs: 5000,
+      });
+      result.clearTimer();
+
+      expect(capturedUrl).toBe("https://example.com/api");
+      expect(capturedInit?.method).toBe("POST");
+      expect(capturedInit?.body).toBe('{"key":"value"}');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("clearTimer prevents timer leak", async () => {
+    globalThis.fetch = (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch;
+
+    try {
+      const result = await fetchWithTimeout({
+        url: "https://example.com",
+        method: "GET",
+        headers: {},
+        timeoutMs: 5000,
+      });
+      // Should not throw
+      result.clearTimer();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamFetch
+// ---------------------------------------------------------------------------
+
+describe("streamFetch", () => {
+  const originalFetch = globalThis.fetch;
+
+  test("returns response and timer controls", async () => {
+    globalThis.fetch = (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch;
+
+    try {
+      const result = await streamFetch({
+        url: "https://example.com/stream",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+        timeoutMs: 5000,
+      });
+
+      expect(result.response.status).toBe(200);
+      expect(typeof result.resetTimer).toBe("function");
+      expect(typeof result.clearTimer).toBe("function");
+      result.clearTimer();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/model-router/src/adapters/shared.ts
+++ b/packages/model-router/src/adapters/shared.ts
@@ -1,0 +1,235 @@
+/**
+ * Shared HTTP + SSE utilities for provider adapters.
+ *
+ * Consolidates fetch-with-timeout, SSE stream parsing, retry-after parsing,
+ * and abort error handling to eliminate duplication across adapters.
+ */
+
+import type { KoiError } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Fetch with timeout + signal composition
+// ---------------------------------------------------------------------------
+
+export interface FetchWithTimeoutOptions {
+  readonly url: string;
+  readonly method: "GET" | "POST";
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body?: string | undefined;
+  readonly timeoutMs: number;
+  readonly signal?: AbortSignal | undefined;
+}
+
+export interface FetchWithTimeoutResult {
+  readonly response: Response;
+  readonly clearTimer: () => void;
+}
+
+/**
+ * Fetches a URL with a timeout and optional caller-provided AbortSignal.
+ *
+ * Composes the caller signal with an internal timeout AbortController via
+ * `AbortSignal.any()`. Returns the response and a `clearTimer` callback
+ * that the caller must invoke to prevent timer leaks.
+ */
+export async function fetchWithTimeout(
+  options: FetchWithTimeoutOptions,
+): Promise<FetchWithTimeoutResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  const effectiveSignal =
+    options.signal !== undefined
+      ? AbortSignal.any([options.signal, controller.signal])
+      : controller.signal;
+
+  const response = await fetch(options.url, {
+    method: options.method,
+    headers: { ...options.headers },
+    ...(options.body !== undefined ? { body: options.body } : {}),
+    signal: effectiveSignal,
+  });
+
+  return {
+    response,
+    clearTimer: () => clearTimeout(timer),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Idle-timeout streaming fetch
+// ---------------------------------------------------------------------------
+
+export interface StreamFetchOptions {
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+  readonly timeoutMs: number;
+  readonly signal?: AbortSignal | undefined;
+}
+
+export interface StreamFetchResult {
+  readonly response: Response;
+  readonly resetTimer: () => void;
+  readonly clearTimer: () => void;
+}
+
+/**
+ * Fetches a URL for streaming with an idle timeout that resets on each chunk.
+ *
+ * Unlike `fetchWithTimeout`, the timer resets every time `resetTimer()` is
+ * called, so long-running healthy streams are not killed.
+ */
+export async function streamFetch(options: StreamFetchOptions): Promise<StreamFetchResult> {
+  const controller = new AbortController();
+  // let: idle timer, encapsulated — resets on each SSE chunk
+  let timer = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  const resetTimer = (): void => {
+    clearTimeout(timer);
+    timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  };
+
+  const effectiveSignal =
+    options.signal !== undefined
+      ? AbortSignal.any([options.signal, controller.signal])
+      : controller.signal;
+
+  const response = await fetch(options.url, {
+    method: "POST",
+    headers: { ...options.headers },
+    body: options.body,
+    signal: effectiveSignal,
+  });
+
+  return {
+    response,
+    resetTimer,
+    clearTimer: () => clearTimeout(timer),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Abort error discrimination
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminates caller-initiated abort from internal timeout and returns
+ * a typed KoiError.
+ */
+export function handleAbortError(
+  error: unknown,
+  providerName: string,
+  timeoutMs: number,
+  callerSignal?: AbortSignal | undefined,
+): KoiError {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    const isCallerAbort = callerSignal?.aborted === true;
+    return {
+      code: isCallerAbort ? "EXTERNAL" : "TIMEOUT",
+      message: isCallerAbort
+        ? `${providerName} request cancelled`
+        : `${providerName} request timed out after ${timeoutMs}ms`,
+      retryable: !isCallerAbort,
+    };
+  }
+  // Not an abort error — re-throw as-is
+  throw error;
+}
+
+/**
+ * Variant of handleAbortError for streaming, which uses "stream" language.
+ */
+export function handleStreamAbortError(
+  error: unknown,
+  providerName: string,
+  timeoutMs: number,
+  callerSignal?: AbortSignal | undefined,
+): string {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    const isCallerAbort = callerSignal?.aborted === true;
+    return isCallerAbort
+      ? `${providerName} stream cancelled`
+      : `${providerName} stream idle timeout after ${timeoutMs}ms`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP status → KoiErrorCode mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps an HTTP status code to a KoiErrorCode.
+ */
+export function mapStatusToErrorCode(status: number): KoiError["code"] {
+  if (status === 401 || status === 403) return "PERMISSION";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 429) return "RATE_LIMIT";
+  if (status === 408 || status === 504) return "TIMEOUT";
+  if (status >= 500) return "EXTERNAL";
+  return "EXTERNAL";
+}
+
+// ---------------------------------------------------------------------------
+// Retry-After header parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts Retry-After header value as milliseconds.
+ */
+export function parseRetryAfter(headers: Headers): number | undefined {
+  const value = headers.get("retry-after");
+  if (!value) return undefined;
+  const seconds = Number.parseFloat(value);
+  if (Number.isNaN(seconds)) return undefined;
+  return Math.ceil(seconds * 1000);
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Generic SSE stream parser. Reads chunks from a ReadableStream, buffers
+ * lines, and yields parsed events via the provided `parseLine` callback.
+ *
+ * @param body - The response body stream
+ * @param parseLine - Parses a `data: ...` payload string into T, or undefined to skip
+ * @param onChunk - Called on each raw chunk for idle timeout reset
+ */
+export async function* parseSSEStream<T>(
+  body: ReadableStream<Uint8Array>,
+  parseLine: (data: string) => T | undefined,
+  onChunk?: () => void,
+): AsyncGenerator<T> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  // let: line buffer accumulates partial lines across chunks
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      onChunk?.();
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data: ")) continue;
+        const data = trimmed.slice(6);
+
+        const parsed = parseLine(data);
+        if (parsed !== undefined) {
+          yield parsed;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/model-router/src/adapters/vllm.test.ts
+++ b/packages/model-router/src/adapters/vllm.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import type { StreamChunk } from "../provider-adapter.js";
+import { createVLLMAdapter } from "./vllm.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function makeRequest(text = "hello"): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text" as const, text }], senderId: "user", timestamp: 0 }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// construction
+// ---------------------------------------------------------------------------
+
+describe("createVLLMAdapter", () => {
+  test("has id 'vllm'", () => {
+    const adapter = createVLLMAdapter();
+    expect(adapter.id).toBe("vllm");
+  });
+
+  test("exposes checkHealth method", () => {
+    const adapter = createVLLMAdapter();
+    expect(adapter.checkHealth).toBeFunction();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// complete
+// ---------------------------------------------------------------------------
+
+describe("complete", () => {
+  test("sends request to default vLLM URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "meta-llama/Llama-3.2-3B",
+            choices: [{ message: { role: "assistant", content: "Hello!" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const result = await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://localhost:8000/v1/chat/completions");
+    expect(result.content).toBe("Hello!");
+    expect(result.model).toBe("meta-llama/Llama-3.2-3B");
+    expect(result.usage?.inputTokens).toBe(10);
+  });
+
+  test("uses custom baseUrl", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter({ baseUrl: "http://gpu-server:8000" });
+    await adapter.complete(makeRequest());
+
+    expect(capturedUrl).toBe("http://gpu-server:8000/v1/chat/completions");
+  });
+
+  test("does not send Authorization header", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            id: "gen-1",
+            model: "llama3.2",
+            choices: [{ message: { role: "assistant", content: "hi" }, finish_reason: "stop" }],
+          }),
+        text: () => Promise.resolve(""),
+      };
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    await adapter.complete(makeRequest());
+
+    expect(capturedHeaders.Authorization).toBeUndefined();
+  });
+
+  test("returns EXTERNAL error when vLLM is not running", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed: Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(TypeError);
+    }
+  });
+
+  test("returns TIMEOUT error after configured timeout", async () => {
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter({ timeoutMs: 100 });
+
+    try {
+      await adapter.complete(makeRequest());
+      expect.unreachable("should have thrown timeout error");
+    } catch (error: unknown) {
+      const koiError = error as { code: string; message: string; retryable: boolean };
+      expect(koiError.code).toBe("TIMEOUT");
+      expect(koiError.message).toContain("timed out");
+      expect(koiError.retryable).toBe(true);
+    }
+  }, 10_000);
+});
+
+// ---------------------------------------------------------------------------
+// stream
+// ---------------------------------------------------------------------------
+
+describe("stream", () => {
+  test("yields text_delta and finish chunks from SSE", async () => {
+    const encoder = new TextEncoder();
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"choices":[{"delta":{"content":"Hi there"},"finish_reason":null}]}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const textChunks = chunks.filter((c) => c.kind === "text_delta");
+    expect(textChunks.length).toBeGreaterThan(0);
+    if (textChunks[0]?.kind === "text_delta") {
+      expect(textChunks[0].text).toBe("Hi there");
+    }
+
+    expect(chunks.some((c) => c.kind === "finish")).toBe(true);
+  });
+
+  test("yields error chunk on connection error", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("Connection refused")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of adapter.stream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.kind === "error")).toBe(true);
+    const errorChunk = chunks.find((c) => c.kind === "error");
+    if (errorChunk?.kind === "error") {
+      expect(errorChunk.message).toContain("Connection refused");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkHealth
+// ---------------------------------------------------------------------------
+
+describe("checkHealth", () => {
+  test("returns true when vLLM responds with ok", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(true);
+  });
+
+  test("returns false when vLLM is down", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("fetch failed")),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("returns false on non-ok response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve({ ok: false, status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  });
+
+  test("calls /health on the base URL (not /v1/ prefix)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter({ baseUrl: "http://gpu-box:8000" });
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://gpu-box:8000/health");
+  });
+
+  test("uses default base URL for health check", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = mock(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter();
+    await adapter.checkHealth?.();
+
+    expect(capturedUrl).toBe("http://localhost:8000/health");
+  });
+
+  test("returns false on timeout", async () => {
+    globalThis.fetch = mock(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const adapter = createVLLMAdapter({ healthCheckTimeoutMs: 100 });
+    const healthy = await adapter.checkHealth?.();
+    expect(healthy).toBe(false);
+  }, 10_000);
+});

--- a/packages/model-router/src/adapters/vllm.ts
+++ b/packages/model-router/src/adapters/vllm.ts
@@ -1,0 +1,59 @@
+/**
+ * vLLM provider adapter.
+ *
+ * Connects to a local vLLM instance via its OpenAI-compatible API.
+ * No authentication required. Implements health checking via /health.
+ */
+
+import type { ProviderAdapter } from "../provider-adapter.js";
+import { createOpenAICompatibleAdapter } from "./openai-compat.js";
+
+const DEFAULT_BASE_URL = "http://localhost:8000";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const HEALTH_CHECK_TIMEOUT_MS = 3_000;
+
+export interface VLLMAdapterConfig {
+  readonly baseUrl?: string | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
+  readonly healthCheckTimeoutMs?: number | undefined;
+}
+
+/**
+ * Creates a vLLM provider adapter.
+ *
+ * Uses the OpenAI-compatible API at `/v1/chat/completions`.
+ * No API key required. Implements `checkHealth()` via `GET /health`.
+ */
+export function createVLLMAdapter(config?: VLLMAdapterConfig): ProviderAdapter {
+  const baseUrl = config?.baseUrl ?? DEFAULT_BASE_URL;
+  const healthCheckTimeoutMs = config?.healthCheckTimeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
+
+  const compat = createOpenAICompatibleAdapter({
+    baseUrl: `${baseUrl}/v1`,
+    timeoutMs: config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    headers: config?.headers,
+    providerName: "vLLM",
+  });
+
+  return {
+    id: "vllm",
+    complete: compat.complete,
+    stream: compat.stream,
+
+    async checkHealth(): Promise<boolean> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), healthCheckTimeoutMs);
+      try {
+        const response = await fetch(`${baseUrl}/health`, {
+          signal: controller.signal,
+        });
+        return response.ok;
+      } catch {
+        return false;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/model-router/src/cascade/cascade-metrics.test.ts
+++ b/packages/model-router/src/cascade/cascade-metrics.test.ts
@@ -120,4 +120,60 @@ describe("createCascadeMetricsTracker", () => {
     const metrics = tracker.getMetrics();
     expect(metrics.totalRequests).toBe(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // estimatedCostSavings
+  // ---------------------------------------------------------------------------
+
+  test("computes estimatedCostSavings when cheap tier handles most requests", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini", costPerInputToken: 0.001, costPerOutputToken: 0.002 },
+      { targetId: "openai:gpt-4o", costPerInputToken: 0.01, costPerOutputToken: 0.03 },
+    ]);
+
+    // Cheap tier handles a request
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 1000, outputTokens: 500 }),
+      false,
+    );
+
+    const metrics = tracker.getMetrics();
+    // Actual cost: 1000 * 0.001 + 500 * 0.002 = 1.0 + 1.0 = 2.0
+    // Hypothetical (all at max rate): 1000 * 0.01 + 500 * 0.03 = 10.0 + 15.0 = 25.0
+    // Savings: 25.0 - 2.0 = 23.0
+    expect(metrics.estimatedCostSavings).toBeCloseTo(23.0, 5);
+  });
+
+  test("estimatedCostSavings is zero when all requests go to most expensive tier", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini", costPerInputToken: 0.001, costPerOutputToken: 0.002 },
+      { targetId: "openai:gpt-4o", costPerInputToken: 0.01, costPerOutputToken: 0.03 },
+    ]);
+
+    // Expensive tier handles the request
+    tracker.record("openai:gpt-4o", makeResponse({ inputTokens: 1000, outputTokens: 500 }), false);
+
+    const metrics = tracker.getMetrics();
+    // Actual cost: 1000 * 0.01 + 500 * 0.03 = 10.0 + 15.0 = 25.0
+    // Hypothetical: same = 25.0
+    // Savings: 0
+    expect(metrics.estimatedCostSavings).toBeCloseTo(0, 5);
+  });
+
+  test("estimatedCostSavings is zero when no cost config set", () => {
+    const tracker = createCascadeMetricsTracker([
+      { targetId: "openai:gpt-4o-mini" },
+      { targetId: "openai:gpt-4o" },
+    ]);
+
+    tracker.record(
+      "openai:gpt-4o-mini",
+      makeResponse({ inputTokens: 1000, outputTokens: 500 }),
+      false,
+    );
+
+    const metrics = tracker.getMetrics();
+    expect(metrics.estimatedCostSavings).toBe(0);
+  });
 });

--- a/packages/model-router/src/cascade/cascade-metrics.ts
+++ b/packages/model-router/src/cascade/cascade-metrics.ts
@@ -26,6 +26,10 @@ export function createCascadeMetricsTracker(
   const tierMetrics = new Map<string, TierMetricsSnapshot>();
   const tierConfigs = new Map<string, CascadeTierConfig>();
 
+  // Precompute max cost rates — tiers is immutable, so this is stable
+  let maxInputRate = 0;
+  let maxOutputRate = 0;
+
   for (const tier of tiers) {
     tierMetrics.set(tier.targetId, {
       requests: 0,
@@ -34,6 +38,11 @@ export function createCascadeMetricsTracker(
       totalOutputTokens: 0,
     });
     tierConfigs.set(tier.targetId, tier);
+
+    const inputRate = tier.costPerInputToken ?? 0;
+    const outputRate = tier.costPerOutputToken ?? 0;
+    if (inputRate > maxInputRate) maxInputRate = inputRate;
+    if (outputRate > maxOutputRate) maxOutputRate = outputRate;
   }
 
   return {
@@ -53,6 +62,8 @@ export function createCascadeMetricsTracker(
       let totalRequests = 0;
       let totalEscalations = 0;
       let totalEstimatedCost = 0;
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
 
       const tierSnapshots: TierCostMetrics[] = [];
 
@@ -77,13 +88,20 @@ export function createCascadeMetricsTracker(
         totalRequests += metrics.requests;
         totalEscalations += metrics.escalations;
         totalEstimatedCost += estimatedCost;
+        totalInputTokens += metrics.totalInputTokens;
+        totalOutputTokens += metrics.totalOutputTokens;
       }
+
+      // Cost savings: hypothetical cost if all tokens used the most expensive tier
+      const hypotheticalCost = totalInputTokens * maxInputRate + totalOutputTokens * maxOutputRate;
+      const estimatedCostSavings = Math.max(hypotheticalCost - totalEstimatedCost, 0);
 
       return {
         tiers: tierSnapshots,
         totalRequests,
         totalEscalations,
         totalEstimatedCost,
+        estimatedCostSavings,
       };
     },
   };

--- a/packages/model-router/src/cascade/cascade-types.ts
+++ b/packages/model-router/src/cascade/cascade-types.ts
@@ -104,6 +104,7 @@ export interface CascadeCostMetrics {
   readonly totalRequests: number;
   readonly totalEscalations: number;
   readonly totalEstimatedCost: number;
+  readonly estimatedCostSavings: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/model-router/src/config.test.ts
+++ b/packages/model-router/src/config.test.ts
@@ -130,13 +130,13 @@ describe("validateRouterConfig", () => {
     expect(result.ok).toBe(false);
   });
 
-  test("rejects target without apiKey", () => {
+  test("accepts target without apiKey (for local providers)", () => {
     const result = validateRouterConfig({
-      targets: [{ provider: "openai", model: "gpt-4o", adapterConfig: {} }],
+      targets: [{ provider: "ollama", model: "llama3.2", adapterConfig: {} }],
       strategy: "fallback",
     });
 
-    expect(result.ok).toBe(false);
+    expect(result.ok).toBe(true);
   });
 
   test("rejects null input", () => {
@@ -365,5 +365,141 @@ describe("cascade config", () => {
     expect(result.value.cascade?.maxEscalations).toBe(5);
     expect(result.value.cascade?.budgetLimitTokens).toBe(100_000);
     expect(result.value.cascade?.evaluatorTimeoutMs).toBe(5_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capabilities config
+// ---------------------------------------------------------------------------
+
+describe("capabilities config", () => {
+  test("accepts target with capabilities", () => {
+    const result = validateRouterConfig({
+      targets: [
+        {
+          ...validTarget,
+          capabilities: {
+            streaming: true,
+            functionCalling: true,
+            vision: false,
+            maxContextTokens: 128_000,
+          },
+        },
+      ],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.targets[0]?.capabilities?.streaming).toBe(true);
+    expect(result.value.targets[0]?.capabilities?.vision).toBe(false);
+    expect(result.value.targets[0]?.capabilities?.maxContextTokens).toBe(128_000);
+  });
+
+  test("capabilities are optional (not present by default)", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.targets[0]?.capabilities).toBeUndefined();
+  });
+
+  test("rejects invalid capability values", () => {
+    const result = validateRouterConfig({
+      targets: [
+        {
+          ...validTarget,
+          capabilities: { maxContextTokens: -1 },
+        },
+      ],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// health probe config
+// ---------------------------------------------------------------------------
+
+describe("health probe config", () => {
+  test("accepts health probe configuration", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+      healthProbe: {
+        intervalMs: 15_000,
+        onlyLocal: true,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.healthProbe?.intervalMs).toBe(15_000);
+    expect(result.value.healthProbe?.onlyLocal).toBe(true);
+  });
+
+  test("health probe is optional", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.healthProbe).toBeUndefined();
+  });
+
+  test("accepts empty health probe (uses defaults)", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+      healthProbe: {},
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cost config
+// ---------------------------------------------------------------------------
+
+describe("cost config", () => {
+  test("accepts costPerInputToken and costPerOutputToken on targets", () => {
+    const result = validateRouterConfig({
+      targets: [{ ...validTarget, costPerInputToken: 0.001, costPerOutputToken: 0.002 }],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.targets[0]?.costPerInputToken).toBe(0.001);
+    expect(result.value.targets[0]?.costPerOutputToken).toBe(0.002);
+  });
+
+  test("rejects negative cost values", () => {
+    const result = validateRouterConfig({
+      targets: [{ ...validTarget, costPerInputToken: -0.001 }],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("cost fields are optional", () => {
+    const result = validateRouterConfig({
+      targets: [validTarget],
+      strategy: "fallback",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.targets[0]?.costPerInputToken).toBeUndefined();
+    expect(result.value.targets[0]?.costPerOutputToken).toBeUndefined();
   });
 });

--- a/packages/model-router/src/config.ts
+++ b/packages/model-router/src/config.ts
@@ -22,6 +22,23 @@ export interface ModelTargetConfig {
   readonly weight?: number;
   readonly enabled?: boolean;
   readonly adapterConfig: ProviderAdapterConfig;
+  readonly capabilities?: ModelCapabilitiesPartial | undefined;
+  readonly costPerInputToken?: number | undefined;
+  readonly costPerOutputToken?: number | undefined;
+}
+
+export interface ModelCapabilitiesPartial {
+  readonly streaming?: boolean | undefined;
+  readonly functionCalling?: boolean | undefined;
+  readonly vision?: boolean | undefined;
+  readonly jsonMode?: boolean | undefined;
+  readonly maxContextTokens?: number | undefined;
+  readonly maxOutputTokens?: number | undefined;
+}
+
+export interface HealthProbeConfig {
+  readonly intervalMs?: number | undefined;
+  readonly onlyLocal?: boolean | undefined;
 }
 
 export interface ModelRouterConfig {
@@ -30,6 +47,7 @@ export interface ModelRouterConfig {
   readonly retry?: Partial<RetryConfig>;
   readonly circuitBreaker?: Partial<CircuitBreakerConfig>;
   readonly cascade?: CascadeConfig;
+  readonly healthProbe?: HealthProbeConfig;
 }
 
 export interface ResolvedRouterConfig {
@@ -38,6 +56,7 @@ export interface ResolvedRouterConfig {
   readonly retry: RetryConfig;
   readonly circuitBreaker: CircuitBreakerConfig;
   readonly cascade?: ResolvedCascadeConfig;
+  readonly healthProbe?: HealthProbeConfig;
 }
 
 export interface ResolvedTargetConfig {
@@ -46,6 +65,9 @@ export interface ResolvedTargetConfig {
   readonly weight: number;
   readonly enabled: boolean;
   readonly adapterConfig: ProviderAdapterConfig;
+  readonly capabilities?: ModelCapabilitiesPartial | undefined;
+  readonly costPerInputToken?: number | undefined;
+  readonly costPerOutputToken?: number | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -53,11 +75,22 @@ export interface ResolvedTargetConfig {
 // ---------------------------------------------------------------------------
 
 const adapterConfigSchema = z.object({
-  apiKey: z.string().min(1),
+  apiKey: z.string().min(1).optional(),
   baseUrl: z.string().url().optional(),
   timeoutMs: z.number().int().positive().optional(),
   headers: z.record(z.string(), z.string()).optional(),
 });
+
+const capabilitiesSchema = z
+  .object({
+    streaming: z.boolean().optional(),
+    functionCalling: z.boolean().optional(),
+    vision: z.boolean().optional(),
+    jsonMode: z.boolean().optional(),
+    maxContextTokens: z.number().int().positive().optional(),
+    maxOutputTokens: z.number().int().positive().optional(),
+  })
+  .optional();
 
 const targetSchema = z.object({
   provider: z.string().min(1),
@@ -65,6 +98,9 @@ const targetSchema = z.object({
   weight: z.number().min(0).max(1).optional(),
   enabled: z.boolean().optional(),
   adapterConfig: adapterConfigSchema,
+  capabilities: capabilitiesSchema,
+  costPerInputToken: z.number().min(0).optional(),
+  costPerOutputToken: z.number().min(0).optional(),
 });
 
 const retrySchema = z.object({
@@ -97,6 +133,13 @@ const cascadeSchema = z.object({
   evaluatorTimeoutMs: z.number().int().positive().optional(),
 });
 
+const healthProbeSchema = z
+  .object({
+    intervalMs: z.number().int().positive().optional(),
+    onlyLocal: z.boolean().optional(),
+  })
+  .optional();
+
 const routerConfigSchema = z.object({
   targets: z.array(targetSchema).min(1),
   strategy: z.union([
@@ -108,6 +151,7 @@ const routerConfigSchema = z.object({
   retry: retrySchema.optional(),
   circuitBreaker: circuitBreakerSchema.optional(),
   cascade: cascadeSchema.optional(),
+  healthProbe: healthProbeSchema,
 });
 
 // ---------------------------------------------------------------------------
@@ -134,6 +178,9 @@ export function validateRouterConfig(raw: unknown): Result<ResolvedRouterConfig,
       timeoutMs: t.adapterConfig.timeoutMs,
       headers: t.adapterConfig.headers,
     },
+    ...(t.capabilities !== undefined ? { capabilities: t.capabilities } : {}),
+    ...(t.costPerInputToken !== undefined ? { costPerInputToken: t.costPerInputToken } : {}),
+    ...(t.costPerOutputToken !== undefined ? { costPerOutputToken: t.costPerOutputToken } : {}),
   }));
 
   const resolvedRetry: RetryConfig = {
@@ -210,6 +257,7 @@ export function validateRouterConfig(raw: unknown): Result<ResolvedRouterConfig,
       retry: resolvedRetry,
       circuitBreaker: resolvedCB,
       ...(resolvedCascade !== undefined ? { cascade: resolvedCascade } : {}),
+      ...(config.healthProbe !== undefined ? { healthProbe: config.healthProbe } : {}),
     },
   };
 }

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -8,12 +8,36 @@
  */
 
 export { createAnthropicAdapter } from "./adapters/anthropic.js";
+// Auto-discovery
+export {
+  type DiscoveredProvider,
+  type DiscoverOptions,
+  discoverLocalProviders,
+  type LocalProviderKind,
+} from "./adapters/discover.js";
 // Provider adapters
+export { createLMStudioAdapter, type LMStudioAdapterConfig } from "./adapters/lm-studio.js";
+export { createOllamaAdapter, type OllamaAdapterConfig } from "./adapters/ollama.js";
 export { createOpenAIAdapter } from "./adapters/openai.js";
+export {
+  createOpenAICompatibleAdapter,
+  type OpenAICompatibleConfig,
+} from "./adapters/openai-compat.js";
 export {
   createOpenRouterAdapter,
   type OpenRouterAdapterConfig,
 } from "./adapters/openrouter.js";
+// Shared adapter utilities
+export {
+  type FetchWithTimeoutOptions,
+  type FetchWithTimeoutResult,
+  fetchWithTimeout,
+  handleAbortError,
+  mapStatusToErrorCode,
+  parseRetryAfter,
+  parseSSEStream,
+} from "./adapters/shared.js";
+export { createVLLMAdapter, type VLLMAdapterConfig } from "./adapters/vllm.js";
 export { createCascadeMetricsTracker } from "./cascade/cascade-metrics.js";
 // Cascade
 export type {
@@ -56,6 +80,8 @@ export {
 } from "./circuit-breaker.js";
 // Config
 export type {
+  HealthProbeConfig,
+  ModelCapabilitiesPartial,
   ModelRouterConfig,
   ModelTargetConfig,
   ResolvedRouterConfig,

--- a/packages/model-router/src/middleware.test.ts
+++ b/packages/model-router/src/middleware.test.ts
@@ -29,6 +29,7 @@ function makeRouter(routeFn: ModelRouter["route"]): ModelRouter {
       totalFailures: 0,
       requestsByTarget: {},
       failuresByTarget: {},
+      totalEstimatedCost: 0,
     }),
     dispose: () => {},
   };

--- a/packages/model-router/src/provider-adapter.ts
+++ b/packages/model-router/src/provider-adapter.ts
@@ -8,7 +8,7 @@
 import type { JsonObject, ModelRequest, ModelResponse } from "@koi/core";
 
 export interface ProviderAdapterConfig {
-  readonly apiKey: string;
+  readonly apiKey?: string | undefined;
   readonly baseUrl?: string | undefined;
   readonly timeoutMs?: number | undefined;
   readonly headers?: Readonly<Record<string, string>> | undefined;

--- a/packages/model-router/src/router-cascade.test.ts
+++ b/packages/model-router/src/router-cascade.test.ts
@@ -346,6 +346,56 @@ describe("cascade strategy", () => {
     expect(result.value.content).toBe("cheap answer");
   });
 
+  test("classifier-based streaming selects correct starting tier", async () => {
+    const evaluator: CascadeEvaluator = () => ({ confidence: 0.9 });
+    const cheapStreamFn = mock(async function* (): AsyncGenerator<StreamChunk> {
+      yield { kind: "text_delta", text: "cheap stream" };
+      yield { kind: "finish", reason: "completed" };
+    });
+    const expensiveStreamFn = mock(async function* (): AsyncGenerator<StreamChunk> {
+      yield { kind: "text_delta", text: "expensive stream" };
+      yield { kind: "finish", reason: "completed" };
+    });
+
+    const classifier: CascadeClassifier = (_req, _tierCount) => ({
+      score: 0.8,
+      confidence: 0.95,
+      tier: "HEAVY",
+      recommendedTierIndex: 1,
+      reason: "test: forced HEAVY",
+    });
+
+    const config = makeCascadeConfig([
+      makeTarget("openai", "gpt-4o-mini"),
+      makeTarget("openai", "gpt-4o"),
+    ]);
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        {
+          id: "openai",
+          complete: () => Promise.resolve(makeResponse("hi", "gpt-4o")),
+          stream: (req: ModelRequest) =>
+            req.model === "gpt-4o-mini" ? cheapStreamFn() : expensiveStreamFn(),
+        },
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters, { evaluator, classifier });
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of router.routeStream(makeRequest())) {
+      chunks.push(chunk);
+    }
+
+    const textChunk = chunks.find((c) => c.kind === "text_delta");
+    if (textChunk?.kind === "text_delta") {
+      expect(textChunk.text).toBe("expensive stream");
+    }
+    expect(cheapStreamFn).not.toHaveBeenCalled();
+    expect(expensiveStreamFn).toHaveBeenCalledTimes(1);
+  });
+
   test("classifier + evaluator together: classifier starts at MEDIUM, evaluator escalates", async () => {
     let evalCount = 0;
     const evaluator: CascadeEvaluator = () => {

--- a/packages/model-router/src/router.test.ts
+++ b/packages/model-router/src/router.test.ts
@@ -469,5 +469,344 @@ describe("dispose", () => {
 });
 
 // ---------------------------------------------------------------------------
+// failuresByTarget metrics
+// ---------------------------------------------------------------------------
+
+describe("failuresByTarget metrics", () => {
+  test("tracks per-target failures", async () => {
+    const failFn = () => {
+      throw { code: "EXTERNAL", message: "down", retryable: false } satisfies KoiError;
+    };
+    const fallbackFn = () => Promise.resolve(makeResponse("ok", "claude"));
+
+    const config = makeConfig([makeTarget("openai", "gpt-4o"), makeTarget("anthropic", "claude")]);
+    const adapters = new Map<string, ProviderAdapter>([
+      ["openai", makeAdapter("openai", failFn)],
+      ["anthropic", makeAdapter("anthropic", fallbackFn)],
+    ]);
+    const router = createModelRouter(config, adapters);
+
+    await router.route(makeRequest());
+
+    const metrics = router.getMetrics();
+    expect(metrics.failuresByTarget["openai:gpt-4o"]).toBe(1);
+    expect(metrics.failuresByTarget["anthropic:claude"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capability matching in streaming
+// ---------------------------------------------------------------------------
+
+describe("capability matching", () => {
+  test("skips targets that lack vision when request has images", async () => {
+    async function* noVisionStream(): AsyncGenerator<StreamChunk> {
+      yield { kind: "text_delta", text: "no vision" };
+      yield { kind: "finish", reason: "completed" };
+    }
+    async function* visionStream(): AsyncGenerator<StreamChunk> {
+      yield { kind: "text_delta", text: "vision ok" };
+      yield { kind: "finish", reason: "completed" };
+    }
+
+    const config = makeConfig([
+      makeTarget("openai", "gpt-4o-mini", {
+        capabilities: { vision: false },
+      }),
+      makeTarget("openai", "gpt-4o", {
+        capabilities: { vision: true },
+      }),
+    ]);
+
+    const adapters = new Map<string, ProviderAdapter>([
+      [
+        "openai",
+        {
+          id: "openai",
+          complete: (req: ModelRequest) =>
+            Promise.resolve(
+              req.model === "gpt-4o-mini"
+                ? makeResponse("no vision", "gpt-4o-mini")
+                : makeResponse("vision ok", "gpt-4o"),
+            ),
+          stream: (req: ModelRequest) =>
+            req.model === "gpt-4o-mini" ? noVisionStream() : visionStream(),
+        },
+      ],
+    ]);
+
+    const router = createModelRouter(config, adapters);
+
+    // Request with image content — should skip gpt-4o-mini
+    const imageRequest: ModelRequest = {
+      messages: [
+        {
+          content: [
+            { kind: "text" as const, text: "describe this" },
+            { kind: "image" as const, url: "data:image/png;base64,base64data" },
+          ],
+          senderId: "test-user",
+          timestamp: 0,
+        },
+      ],
+    };
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of router.routeStream(imageRequest)) {
+      chunks.push(chunk);
+    }
+
+    const textChunk = chunks.find((c) => c.kind === "text_delta");
+    if (textChunk?.kind === "text_delta") {
+      expect(textChunk.text).toBe("vision ok");
+    }
+  });
+
+  test("allows targets without declared capabilities (fail-open)", async () => {
+    // No capabilities declared — should be treated as compatible
+    const config = makeConfig([makeTarget("openai", "gpt-4o")]);
+    const adapter = makeAdapter("openai", () => Promise.resolve(makeResponse("ok", "gpt-4o")));
+    const router = createModelRouter(config, new Map([["openai", adapter]]));
+
+    const imageRequest: ModelRequest = {
+      messages: [
+        {
+          content: [
+            { kind: "text" as const, text: "describe" },
+            { kind: "image" as const, url: "data:image/png;base64,data" },
+          ],
+          senderId: "test-user",
+          timestamp: 0,
+        },
+      ],
+    };
+
+    const chunks: StreamChunk[] = [];
+    for await (const chunk of router.routeStream(imageRequest)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks[0]?.kind).toBe("text_delta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// health probing
+// ---------------------------------------------------------------------------
+
+describe("health probing", () => {
+  test("health probe triggers circuit breaker on unhealthy adapter", async () => {
+    const adapter: ProviderAdapter = {
+      id: "ollama",
+      complete: () => Promise.resolve(makeResponse("hi", "llama3.2")),
+      async *stream(): AsyncGenerator<StreamChunk> {
+        yield { kind: "text_delta", text: "streamed" };
+        yield { kind: "finish", reason: "completed" };
+      },
+      checkHealth: mock(() => Promise.resolve(false)),
+    };
+
+    const config = makeConfig(
+      [
+        makeTarget("ollama", "llama3.2", {
+          adapterConfig: { baseUrl: "http://localhost:11434" },
+        }),
+      ],
+      {
+        healthProbe: { intervalMs: 100, onlyLocal: true },
+        circuitBreaker: {
+          failureThreshold: 1,
+          cooldownMs: 60_000,
+          failureWindowMs: 60_000,
+          failureStatusCodes: [429, 500, 502, 503, 504],
+        },
+      },
+    );
+
+    const router = createModelRouter(config, new Map([["ollama", adapter]]));
+
+    // Wait for initial probe to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const health = router.getHealth();
+    const ollamaHealth = health.get("ollama:llama3.2");
+    expect(ollamaHealth?.state).toBe("OPEN");
+
+    router.dispose();
+  });
+
+  test("health probe records success for healthy adapter", async () => {
+    const adapter: ProviderAdapter = {
+      id: "ollama",
+      complete: () => Promise.resolve(makeResponse("hi", "llama3.2")),
+      async *stream(): AsyncGenerator<StreamChunk> {
+        yield { kind: "text_delta", text: "streamed" };
+        yield { kind: "finish", reason: "completed" };
+      },
+      checkHealth: mock(() => Promise.resolve(true)),
+    };
+
+    const config = makeConfig(
+      [
+        makeTarget("ollama", "llama3.2", {
+          adapterConfig: { baseUrl: "http://localhost:11434" },
+        }),
+      ],
+      {
+        healthProbe: { intervalMs: 100, onlyLocal: true },
+      },
+    );
+
+    const router = createModelRouter(config, new Map([["ollama", adapter]]));
+
+    // Wait for initial probe
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const health = router.getHealth();
+    expect(health.get("ollama:llama3.2")?.state).toBe("CLOSED");
+
+    router.dispose();
+  });
+
+  test("dispose clears health probe timer", async () => {
+    const adapter: ProviderAdapter = {
+      id: "ollama",
+      complete: () => Promise.resolve(makeResponse("hi", "llama3.2")),
+      async *stream(): AsyncGenerator<StreamChunk> {
+        yield { kind: "text_delta", text: "streamed" };
+        yield { kind: "finish", reason: "completed" };
+      },
+      checkHealth: mock(() => Promise.resolve(true)),
+    };
+
+    const config = makeConfig(
+      [
+        makeTarget("ollama", "llama3.2", {
+          adapterConfig: { baseUrl: "http://localhost:11434" },
+        }),
+      ],
+      {
+        healthProbe: { intervalMs: 100, onlyLocal: true },
+      },
+    );
+
+    const router = createModelRouter(config, new Map([["ollama", adapter]]));
+    router.dispose();
+
+    // After dispose, checkHealth should not be called again
+    const callCount = (adapter.checkHealth as ReturnType<typeof mock>).mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const callCountAfter = (adapter.checkHealth as ReturnType<typeof mock>).mock.calls.length;
+
+    // Allow 1 more call from the initial probe that may have already been scheduled
+    expect(callCountAfter - callCount).toBeLessThanOrEqual(1);
+  });
+
+  test("health probe skips cloud targets when onlyLocal is true", async () => {
+    const cloudAdapter: ProviderAdapter = {
+      id: "openai",
+      complete: () => Promise.resolve(makeResponse("hi", "gpt-4o")),
+      async *stream(): AsyncGenerator<StreamChunk> {
+        yield { kind: "text_delta", text: "streamed" };
+        yield { kind: "finish", reason: "completed" };
+      },
+      checkHealth: mock(() => Promise.resolve(true)),
+    };
+
+    const config = makeConfig(
+      [
+        makeTarget("openai", "gpt-4o", {
+          adapterConfig: { apiKey: "sk-test", baseUrl: "https://api.openai.com/v1" },
+        }),
+      ],
+      {
+        healthProbe: { intervalMs: 100, onlyLocal: true },
+      },
+    );
+
+    const router = createModelRouter(config, new Map([["openai", cloudAdapter]]));
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Cloud adapter's checkHealth should not have been called
+    expect((cloudAdapter.checkHealth as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+
+    router.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// totalEstimatedCost
+// ---------------------------------------------------------------------------
+
+describe("totalEstimatedCost", () => {
+  test("tracks fallback route costs", async () => {
+    const config = makeConfig([
+      makeTarget("openai", "gpt-4o", {
+        costPerInputToken: 0.01,
+        costPerOutputToken: 0.03,
+      }),
+    ]);
+
+    const adapter = makeAdapter("openai", () =>
+      Promise.resolve({
+        content: "hi",
+        model: "gpt-4o",
+        usage: { inputTokens: 100, outputTokens: 50 },
+      }),
+    );
+    const router = createModelRouter(config, new Map([["openai", adapter]]));
+
+    await router.route(makeRequest());
+
+    const metrics = router.getMetrics();
+    // 100 * 0.01 + 50 * 0.03 = 1.0 + 1.5 = 2.5
+    expect(metrics.totalEstimatedCost).toBeCloseTo(2.5, 5);
+  });
+
+  test("accumulates across requests", async () => {
+    const config = makeConfig([
+      makeTarget("openai", "gpt-4o", {
+        costPerInputToken: 0.01,
+        costPerOutputToken: 0.03,
+      }),
+    ]);
+
+    const adapter = makeAdapter("openai", () =>
+      Promise.resolve({
+        content: "hi",
+        model: "gpt-4o",
+        usage: { inputTokens: 100, outputTokens: 50 },
+      }),
+    );
+    const router = createModelRouter(config, new Map([["openai", adapter]]));
+
+    await router.route(makeRequest());
+    await router.route(makeRequest());
+
+    const metrics = router.getMetrics();
+    // 2 * (100 * 0.01 + 50 * 0.03) = 2 * 2.5 = 5.0
+    expect(metrics.totalEstimatedCost).toBeCloseTo(5.0, 5);
+  });
+
+  test("is zero when no cost config", async () => {
+    const config = makeConfig([makeTarget("openai", "gpt-4o")]);
+    const adapter = makeAdapter("openai", () =>
+      Promise.resolve({
+        content: "hi",
+        model: "gpt-4o",
+        usage: { inputTokens: 100, outputTokens: 50 },
+      }),
+    );
+    const router = createModelRouter(config, new Map([["openai", adapter]]));
+
+    await router.route(makeRequest());
+
+    const metrics = router.getMetrics();
+    expect(metrics.totalEstimatedCost).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cascade strategy — see router-cascade.test.ts for full cascade tests
 // ---------------------------------------------------------------------------

--- a/packages/model-router/src/router.ts
+++ b/packages/model-router/src/router.ts
@@ -5,6 +5,7 @@
 
 import type { KoiError, ModelRequest, ModelResponse, Result } from "@koi/core";
 import { withCascade } from "./cascade/cascade.js";
+import { createCascadeMetricsTracker } from "./cascade/cascade-metrics.js";
 import type {
   CascadeClassifier,
   CascadeCostMetrics,
@@ -25,6 +26,7 @@ export interface RouterMetrics {
   readonly totalFailures: number;
   readonly requestsByTarget: Readonly<Record<string, number>>;
   readonly failuresByTarget: Readonly<Record<string, number>>;
+  readonly totalEstimatedCost: number;
   readonly cascade?: CascadeCostMetrics;
 }
 
@@ -44,6 +46,16 @@ export interface ModelRouterOptions {
 
 function targetId(t: ResolvedTargetConfig): string {
   return `${t.provider}:${t.model}`;
+}
+
+/**
+ * Checks whether a URL is a local/loopback address.
+ */
+function isLocalUrl(url?: string): boolean {
+  return (
+    url !== undefined &&
+    (url.includes("localhost") || url.includes("127.0.0.1") || url.includes("[::1]"))
+  );
 }
 
 /**
@@ -105,14 +117,65 @@ export function createModelRouter(
     circuitBreakers.set(t.id, createCircuitBreaker(config.circuitBreaker, clock));
   }
 
-  // Mutable metrics (encapsulated)
+  // Mutable metrics (encapsulated — justified per circuit-breaker.ts precedent:
+  // internal mutation behind immutable public interface, single-threaded runtime)
   const requestsByTarget: Record<string, number> = {};
   const failuresByTarget: Record<string, number> = {};
+  // let: perf counters, encapsulated behind immutable RouterMetrics
   let totalRequests = 0;
   let totalFailures = 0;
+  let fallbackCostTotal = 0;
 
-  // Cascade metrics tracking
-  let cascadeEscalations = 0;
+  // Cascade metrics tracking — wired to CascadeMetricsTracker
+  const cascadeTracker =
+    config.strategy === "cascade" && config.cascade
+      ? createCascadeMetricsTracker(config.cascade.tiers)
+      : undefined;
+
+  // Health probe timer for local targets
+  let healthProbeTimer: ReturnType<typeof setInterval> | undefined;
+
+  if (config.healthProbe) {
+    const intervalMs = config.healthProbe.intervalMs ?? 30_000;
+    const onlyLocal = config.healthProbe.onlyLocal !== false;
+
+    // Identify targets that support health checks
+    const probeTargets = config.targets.filter((t) => {
+      if (onlyLocal && !isLocalUrl(t.adapterConfig.baseUrl)) {
+        return false;
+      }
+      const adapter = adapters.get(t.provider);
+      return adapter?.checkHealth !== undefined;
+    });
+
+    if (probeTargets.length > 0) {
+      const probe = async (): Promise<void> => {
+        await Promise.allSettled(
+          probeTargets.map(async (target) => {
+            const id = targetId(target);
+            const adapter = adapters.get(target.provider);
+            const cb = circuitBreakers.get(id);
+            if (!adapter?.checkHealth || !cb) return;
+
+            try {
+              const healthy = await adapter.checkHealth();
+              if (healthy) {
+                cb.recordSuccess();
+              } else {
+                cb.recordFailure();
+              }
+            } catch {
+              cb.recordFailure();
+            }
+          }),
+        );
+      };
+
+      // Initial probe
+      void probe();
+      healthProbeTimer = setInterval(probe, intervalMs);
+    }
+  }
 
   async function executeForTargetId(id: string, request: ModelRequest): Promise<ModelResponse> {
     const targetConfig = targetConfigById.get(id);
@@ -141,7 +204,49 @@ export function createModelRouter(
       model: targetConfig.model,
     };
 
-    return withRetry(() => adapter.complete(modelRequest), config.retry, clock);
+    try {
+      return await withRetry(() => adapter.complete(modelRequest), config.retry, clock);
+    } catch (error: unknown) {
+      failuresByTarget[id] = (failuresByTarget[id] ?? 0) + 1;
+      throw error;
+    }
+  }
+
+  /**
+   * Determines ordered target list for streaming, taking cascade
+   * classification into account when available.
+   */
+  function getStreamTargets(request: ModelRequest): readonly FallbackTarget[] {
+    if (config.strategy === "cascade" && config.cascade && options.classifier) {
+      const allTiers = config.cascade.tiers;
+      const classification = options.classifier(request, allTiers.length);
+      const startIndex = classification.recommendedTierIndex;
+      const tierTargets: readonly FallbackTarget[] = allTiers.slice(startIndex).map((t) => ({
+        id: t.targetId,
+        enabled: true,
+      }));
+      return tierTargets.length > 0 ? tierTargets : enabledFallbackTargets;
+    }
+    return enabledFallbackTargets;
+  }
+
+  /**
+   * Checks whether a target can handle the features required by the request.
+   * If the target has no declared capabilities, it is assumed to support everything
+   * (fail-open to prevent false negatives).
+   */
+  function targetSupportsRequest(
+    targetConfig: ResolvedTargetConfig,
+    request: ModelRequest,
+  ): boolean {
+    const caps = targetConfig.capabilities;
+    if (!caps) return true; // No capabilities declared → assume compatible
+
+    // Check vision: if request contains image blocks, target needs vision
+    const needsVision = request.messages.some((m) => m.content.some((b) => b.kind === "image"));
+    if (needsVision && caps.vision === false) return false;
+
+    return true;
   }
 
   return {
@@ -173,7 +278,27 @@ export function createModelRouter(
           return result;
         }
 
-        cascadeEscalations += result.value.totalEscalations;
+        // Record cascade metrics via tracker
+        if (cascadeTracker) {
+          for (const attempt of result.value.attempts) {
+            if (attempt.success) {
+              const tierResponse: ModelResponse = {
+                content: result.value.response.content,
+                model: result.value.response.model,
+                ...(attempt.inputTokens !== undefined || attempt.outputTokens !== undefined
+                  ? {
+                      usage: {
+                        inputTokens: attempt.inputTokens ?? 0,
+                        outputTokens: attempt.outputTokens ?? 0,
+                      },
+                    }
+                  : {}),
+              };
+              cascadeTracker.record(attempt.tierId, tierResponse, attempt.escalated);
+            }
+          }
+        }
+
         return { ok: true, value: result.value.response };
       }
 
@@ -189,19 +314,34 @@ export function createModelRouter(
         return result;
       }
 
+      // Accumulate fallback cost from target's cost config + usage
+      const successAttempt = result.value.attempts.find((a) => a.success);
+      const successTargetConfig = successAttempt
+        ? targetConfigById.get(successAttempt.targetId)
+        : undefined;
+      const usage = result.value.value.usage;
+      if (successTargetConfig && usage) {
+        fallbackCostTotal +=
+          (usage.inputTokens ?? 0) * (successTargetConfig.costPerInputToken ?? 0) +
+          (usage.outputTokens ?? 0) * (successTargetConfig.costPerOutputToken ?? 0);
+      }
+
       return { ok: true, value: result.value.value };
     },
 
     async *routeStream(request: ModelRequest): AsyncGenerator<StreamChunk> {
-      // Stream uses fallback behavior for all strategies (cascade v1 limitation)
+      const orderedTargets = getStreamTargets(request);
       const errors: KoiError[] = [];
 
-      for (const target of enabledFallbackTargets) {
+      for (const target of orderedTargets) {
         const cb = circuitBreakers.get(target.id);
         if (cb && !cb.isAllowed()) continue;
 
         const targetConfig = targetConfigById.get(target.id);
         if (!targetConfig) continue;
+
+        // Capability matching: skip incompatible targets
+        if (!targetSupportsRequest(targetConfig, request)) continue;
 
         const adapter = adapters.get(targetConfig.provider);
         if (!adapter) continue;
@@ -243,36 +383,32 @@ export function createModelRouter(
     },
 
     getMetrics(): RouterMetrics {
-      const base: RouterMetrics = {
+      if (cascadeTracker) {
+        const cascadeMetrics = cascadeTracker.getMetrics();
+        return {
+          totalRequests,
+          totalFailures,
+          requestsByTarget: { ...requestsByTarget },
+          failuresByTarget: { ...failuresByTarget },
+          totalEstimatedCost: cascadeMetrics.totalEstimatedCost,
+          cascade: cascadeMetrics,
+        };
+      }
+
+      return {
         totalRequests,
         totalFailures,
         requestsByTarget: { ...requestsByTarget },
         failuresByTarget: { ...failuresByTarget },
+        totalEstimatedCost: fallbackCostTotal,
       };
-
-      if (config.strategy === "cascade" && config.cascade) {
-        return {
-          ...base,
-          cascade: {
-            tiers: config.cascade.tiers.map((t) => ({
-              tierId: t.targetId,
-              requests: requestsByTarget[t.targetId] ?? 0,
-              escalations: 0,
-              totalInputTokens: 0,
-              totalOutputTokens: 0,
-              estimatedCost: 0,
-            })),
-            totalRequests,
-            totalEscalations: cascadeEscalations,
-            totalEstimatedCost: 0,
-          },
-        };
-      }
-
-      return base;
     },
 
     dispose(): void {
+      if (healthProbeTimer) {
+        clearInterval(healthProbeTimer);
+        healthProbeTimer = undefined;
+      }
       for (const cb of circuitBreakers.values()) {
         cb.reset();
       }


### PR DESCRIPTION
## Summary

Implements the three phases of edge/hybrid model routing gap-fill identified in issue #54:

- **Phase 1: vLLM + LM Studio adapters** — New `createVLLMAdapter()` and `createLMStudioAdapter()` factory functions, both built on a shared `createOpenAICompatibleAdapter` base extracted from the existing OpenAI/OpenRouter adapters. Includes Ollama adapter refactored onto the same base. Each adapter has health checking, streaming, and timeout support.
- **Phase 2: Auto-discovery** — `discoverLocalProviders()` probes localhost for running Ollama, vLLM, and LM Studio servers in parallel, returning discovered providers with model lists. Filtering by provider kind is supported.
- **Phase 3: Cost tracking** — `costPerInputToken`/`costPerOutputToken` fields on target config, `totalEstimatedCost` on `RouterMetrics` (works for both fallback and cascade strategies), and `estimatedCostSavings` on cascade metrics comparing actual cost against hypothetical all-expensive-tier cost.

Also refactors OpenAI and OpenRouter adapters to share common SSE streaming and response mapping logic via `shared.ts`, eliminating ~400 lines of duplication.

Closes #54

## Changes

- **New files**: `ollama.ts`, `vllm.ts`, `lm-studio.ts`, `openai-compat.ts`, `shared.ts`, `discover.ts` (+ tests for each)
- **Modified**: `config.ts` (cost fields), `router.ts` (cost accumulation, parallel health probes, capability matching), `cascade-metrics.ts` (cost savings), `index.ts` (exports)
- **Refactored**: `openai.ts`, `openrouter.ts` now delegate to shared utilities

## Test plan

- [x] 378 unit tests pass (`bun test --cwd packages/model-router`)
- [x] TypeScript strict mode passes (`bun run --filter @koi/model-router typecheck`)
- [x] Biome lint/format passes (`bunx biome check packages/model-router/src`)
- [x] E2E validated with real OpenAI + Anthropic API calls (adapter complete/stream, cross-provider fallback, cost tracking accumulation)
- [x] Layer leakage audit: zero L0/L1/L2 violations
- [x] Performance review: no critical issues
- [ ] Local provider E2E (requires running Ollama/vLLM/LM Studio)