### PR TITLE
feat(forge): enforce ForgeScope at query time

### DIFF
--- a/packages/forge/src/forge-resolver.test.ts
+++ b/packages/forge/src/forge-resolver.test.ts
@@ -90,14 +90,14 @@ describe("createForgeResolver", () => {
     await store.save(createBrick({ id: "b1" }));
     await store.save(createBrick({ id: "b2" }));
 
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     const results = await resolver.discover();
     expect(results).toHaveLength(2);
   });
 
   test("discover returns empty when store is empty", async () => {
     const store = createInMemoryForgeStore();
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     const results = await resolver.discover();
     expect(results).toHaveLength(0);
   });
@@ -106,7 +106,7 @@ describe("createForgeResolver", () => {
     const store = createInMemoryForgeStore();
     await store.save(createBrick({ id: "b1", name: "my-tool" }));
 
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     const result = await resolver.load("b1");
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -116,7 +116,7 @@ describe("createForgeResolver", () => {
 
   test("load returns NOT_FOUND for missing id", async () => {
     const store = createInMemoryForgeStore();
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     const result = await resolver.load("nonexistent");
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -148,8 +148,74 @@ describe("createForgeResolver", () => {
         error: { code: "INTERNAL" as const, message: "store down", retryable: false },
       }),
     };
-    const resolver = createForgeResolver(failingStore);
+    const resolver = createForgeResolver(failingStore, { agentId: "agent-1" });
     await expect(resolver.discover()).rejects.toThrow("store down");
+  });
+
+  test("discover excludes agent-scoped bricks not owned by caller", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent", createdBy: "agent-1" }));
+    await store.save(createBrick({ id: "b2", scope: "agent", createdBy: "agent-2" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const results = await resolver.discover();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("b1");
+  });
+
+  test("discover includes global-scoped bricks for any caller", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "global", createdBy: "other-agent" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const results = await resolver.discover();
+    expect(results).toHaveLength(1);
+  });
+
+  test("load returns NOT_FOUND for another agent's agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent", createdBy: "agent-2" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const result = await resolver.load("b1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("load succeeds for own agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent", createdBy: "agent-1" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const result = await resolver.load("b1");
+    expect(result.ok).toBe(true);
+  });
+
+  test("source returns NOT_FOUND for another agent's agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent", createdBy: "agent-2" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const result = await resolver.source?.("b1");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+
+  test("source succeeds for own agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: "b1", scope: "agent", createdBy: "agent-1" }));
+
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
+    const result = await resolver.source?.("b1");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(true);
   });
 });
 
@@ -210,7 +276,7 @@ describe("ForgeResolver.source()", () => {
     const store = createInMemoryForgeStore();
     await store.save(createBrick({ id: "t1", implementation: "return 42;" }));
 
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     expect(resolver.source).toBeDefined();
     const result = await resolver.source?.("t1");
     expect(result).toBeDefined();
@@ -224,7 +290,7 @@ describe("ForgeResolver.source()", () => {
 
   test("source returns NOT_FOUND for missing id", async () => {
     const store = createInMemoryForgeStore();
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     expect(resolver.source).toBeDefined();
     const result = await resolver.source?.("nonexistent");
     expect(result).toBeDefined();

--- a/packages/forge/src/forge-resolver.ts
+++ b/packages/forge/src/forge-resolver.ts
@@ -11,6 +11,7 @@ import type {
   Result,
   SourceBundle,
 } from "@koi/core";
+import { filterByAgentScope, isVisibleToAgent } from "./scope-filter.js";
 
 // ---------------------------------------------------------------------------
 // Source extraction — pure function, exhaustive over BrickArtifact union
@@ -34,7 +35,30 @@ export function extractSource(brick: BrickArtifact): SourceBundle {
 // Public API
 // ---------------------------------------------------------------------------
 
-export function createForgeResolver(store: ForgeStore): Resolver<BrickArtifact, BrickArtifact> {
+export interface ForgeResolverContext {
+  readonly agentId: string;
+}
+
+/**
+ * Returns NOT_FOUND if the brick exists but is not visible to the caller.
+ * This avoids leaking brick existence to unauthorized agents.
+ */
+function notFoundError(id: string): Result<never, KoiError> {
+  return {
+    ok: false,
+    error: { code: "NOT_FOUND", message: `Brick not found: ${id}`, retryable: false },
+  };
+}
+
+export function createForgeResolver(
+  store: ForgeStore,
+  context: ForgeResolverContext,
+): Resolver<BrickArtifact, BrickArtifact> {
+  if (!context.agentId) {
+    throw new Error("ForgeResolver requires a non-empty agentId in context");
+  }
+  const { agentId } = context;
+
   const discover = async (): Promise<readonly BrickArtifact[]> => {
     const result = await store.search({});
     if (!result.ok) {
@@ -42,18 +66,20 @@ export function createForgeResolver(store: ForgeStore): Resolver<BrickArtifact, 
         cause: result.error,
       });
     }
-    return result.value;
+    return filterByAgentScope(result.value, agentId);
   };
 
   const load = async (id: string): Promise<Result<BrickArtifact, KoiError>> => {
-    return store.load(id);
+    const result = await store.load(id);
+    if (!result.ok) return result;
+    if (!isVisibleToAgent(result.value, agentId)) return notFoundError(id);
+    return result;
   };
 
   const source = async (id: string): Promise<Result<SourceBundle, KoiError>> => {
     const result = await store.load(id);
-    if (!result.ok) {
-      return result;
-    }
+    if (!result.ok) return result;
+    if (!isVisibleToAgent(result.value, agentId)) return notFoundError(id);
     return { ok: true, value: extractSource(result.value) };
   };
 

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -66,6 +66,7 @@ export type {
   ForgeComponentProviderInstance,
 } from "./forge-component-provider.js";
 export { brickToTool, createForgeComponentProvider } from "./forge-component-provider.js";
+export type { ForgeResolverContext } from "./forge-resolver.js";
 export { createForgeResolver } from "./forge-resolver.js";
 // runtime values — usage tracking middleware
 export type { ForgeUsageMiddlewareConfig } from "./forge-usage-middleware.js";
@@ -81,6 +82,7 @@ export type { IntegrityMismatch, IntegrityOk, IntegrityResult } from "./integrit
 export { loadAndVerify, verifyBrickIntegrity } from "./integrity.js";
 // runtime values — storage
 export { createInMemoryForgeStore } from "./memory-store.js";
+export { filterByAgentScope, isVisibleToAgent } from "./scope-filter.js";
 // runtime values — store change notification
 export { createMemoryStoreChangeNotifier } from "./store-notifier.js";
 export { createComposeForgeTool } from "./tools/compose-forge.js";

--- a/packages/forge/src/scope-filter.test.ts
+++ b/packages/forge/src/scope-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolArtifact } from "@koi/core";
+import { filterByAgentScope, isVisibleToAgent } from "./scope-filter.js";
+
+function createBrick(overrides?: Partial<ToolArtifact>): ToolArtifact {
+  return {
+    id: "brick_test",
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    contentHash: "test-hash",
+    implementation: "return 1;",
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+describe("isVisibleToAgent", () => {
+  test("returns true for global-scoped bricks", () => {
+    const brick = createBrick({ scope: "global", createdBy: "other-agent" });
+    expect(isVisibleToAgent(brick, "agent-1")).toBe(true);
+  });
+
+  test("returns true for zone-scoped bricks (Phase 2 passthrough)", () => {
+    const brick = createBrick({ scope: "zone", createdBy: "other-agent" });
+    expect(isVisibleToAgent(brick, "agent-1")).toBe(true);
+  });
+
+  test("returns true for agent-scoped brick matching creator", () => {
+    const brick = createBrick({ scope: "agent", createdBy: "agent-1" });
+    expect(isVisibleToAgent(brick, "agent-1")).toBe(true);
+  });
+
+  test("returns false for agent-scoped brick from different agent", () => {
+    const brick = createBrick({ scope: "agent", createdBy: "agent-2" });
+    expect(isVisibleToAgent(brick, "agent-1")).toBe(false);
+  });
+});
+
+describe("filterByAgentScope", () => {
+  test("filters mixed-scope array correctly", () => {
+    const bricks = [
+      createBrick({ id: "b1", scope: "global", createdBy: "other" }),
+      createBrick({ id: "b2", scope: "agent", createdBy: "agent-1" }),
+      createBrick({ id: "b3", scope: "agent", createdBy: "agent-2" }),
+      createBrick({ id: "b4", scope: "zone", createdBy: "other" }),
+    ];
+    const filtered = filterByAgentScope(bricks, "agent-1");
+    expect(filtered).toHaveLength(3);
+    expect(filtered.map((b) => b.id)).toEqual(["b1", "b2", "b4"]);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(filterByAgentScope([], "agent-1")).toHaveLength(0);
+  });
+});

--- a/packages/forge/src/scope-filter.ts
+++ b/packages/forge/src/scope-filter.ts
@@ -1,0 +1,42 @@
+/**
+ * Scope-based visibility filtering for forge bricks.
+ *
+ * Pure functions used by search_forge and ForgeResolver to enforce
+ * agent-scoped brick visibility. Zone scope is deferred (Phase 2).
+ */
+
+import type { BrickArtifact } from "@koi/core";
+
+/**
+ * Returns true if the given brick is visible to the specified agent.
+ * - `global` and `zone` scoped bricks are visible to all agents.
+ * - `agent` scoped bricks are only visible to their creator.
+ *
+ * Fail-closed: unknown scope values deny access.
+ */
+export function isVisibleToAgent(brick: BrickArtifact, agentId: string): boolean {
+  switch (brick.scope) {
+    case "global":
+      return true;
+    case "zone":
+      return true; // Phase 2: add zone-level check
+    case "agent":
+      return brick.createdBy === agentId;
+    default: {
+      // Fail closed: unknown scope denies access
+      const _exhaustive: never = brick.scope;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+/**
+ * Filters an array of bricks to only those visible to the specified agent.
+ */
+export function filterByAgentScope(
+  bricks: readonly BrickArtifact[],
+  agentId: string,
+): readonly BrickArtifact[] {
+  return bricks.filter((b) => isVisibleToAgent(b, agentId));
+}

--- a/packages/forge/src/tools/compose-forge.test.ts
+++ b/packages/forge/src/tools/compose-forge.test.ts
@@ -423,4 +423,40 @@ describe("createComposeForgeTool", () => {
       expect(loadResult.value.tags).toEqual(["group", "v1"]);
     }
   });
+
+  test("rejects composing another agent's agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "brick_own", createdBy: "agent-1" }));
+    await store.save(
+      createToolBrick({ id: "brick_foreign", createdBy: "agent-2", scope: "agent" }),
+    );
+
+    const tool = createComposeForgeTool(createDeps({ store }));
+    const result = (await tool.execute({
+      name: "sneaky-composite",
+      description: "Trying to compose foreign brick",
+      brickIds: ["brick_own", "brick_foreign"],
+    })) as { readonly ok: false; readonly error: { readonly code: string } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("LOAD_FAILED");
+  });
+
+  test("allows composing another agent's global-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "brick_own", createdBy: "agent-1" }));
+    await store.save(
+      createToolBrick({ id: "brick_global", createdBy: "agent-2", scope: "global" }),
+    );
+
+    const tool = createComposeForgeTool(createDeps({ store }));
+    const result = (await tool.execute({
+      name: "valid-composite",
+      description: "Composing with global brick",
+      brickIds: ["brick_own", "brick_global"],
+    })) as { readonly ok: true; readonly value: ForgeResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.kind).toBe("composite");
+  });
 });

--- a/packages/forge/src/tools/compose-forge.ts
+++ b/packages/forge/src/tools/compose-forge.ts
@@ -8,6 +8,7 @@ import type { BrickArtifact, Result, Tool, TrustTier } from "@koi/core";
 import type { ForgeError } from "../errors.js";
 import { staticError, storeError } from "../errors.js";
 import { TRUST_ORDER } from "../governance.js";
+import { isVisibleToAgent } from "../scope-filter.js";
 import type {
   CompositeArtifact,
   CompositionBrickInfo,
@@ -96,14 +97,18 @@ async function composeForgeHandler(
     };
   }
 
-  // Validate all referenced bricks exist (parallel loading — 14A)
+  // Validate all referenced bricks exist and are visible (parallel loading — 14A)
   const loadResults = await Promise.all(compositeInput.brickIds.map((id) => deps.store.load(id)));
 
   const loadedBricks: BrickArtifact[] = [];
   const missingIds: string[] = [];
   for (let i = 0; i < loadResults.length; i++) {
     const loadResult = loadResults[i];
-    if (loadResult === undefined || !loadResult.ok) {
+    if (
+      loadResult === undefined ||
+      !loadResult.ok ||
+      !isVisibleToAgent(loadResult.value, deps.context.agentId)
+    ) {
       const brickId = compositeInput.brickIds[i];
       if (brickId !== undefined) {
         missingIds.push(brickId);

--- a/packages/forge/src/tools/promote-forge.test.ts
+++ b/packages/forge/src/tools/promote-forge.test.ts
@@ -947,4 +947,49 @@ describe("createPromoteForgeTool", () => {
 
     expect(result.ok).toBe(true);
   });
+
+  test("rejects promoting another agent's agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createToolBrick({ id: "brick_foreign", createdBy: "agent-2", scope: "agent" }),
+    );
+
+    const tool = createPromoteForgeTool(createDeps({ store }));
+    const result = (await tool.execute({
+      brickId: "brick_foreign",
+      targetTrustTier: "verified",
+    })) as { readonly ok: false; readonly error: { readonly code: string } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("LOAD_FAILED");
+  });
+
+  test("allows promoting own agent-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "brick_own", createdBy: "agent-1", scope: "agent" }));
+
+    const tool = createPromoteForgeTool(createDeps({ store }));
+    const result = (await tool.execute({
+      brickId: "brick_own",
+      targetTrustTier: "verified",
+    })) as { readonly ok: true; readonly value: PromoteResult };
+
+    expect(result.ok).toBe(true);
+    expect(result.value.changes.trustTier).toBeDefined();
+  });
+
+  test("allows promoting another agent's global-scoped brick", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createToolBrick({ id: "brick_global", createdBy: "agent-2", scope: "global" }),
+    );
+
+    const tool = createPromoteForgeTool(createDeps({ store }));
+    const result = (await tool.execute({
+      brickId: "brick_global",
+      targetTrustTier: "verified",
+    })) as { readonly ok: true; readonly value: PromoteResult };
+
+    expect(result.ok).toBe(true);
+  });
 });

--- a/packages/forge/src/tools/promote-forge.ts
+++ b/packages/forge/src/tools/promote-forge.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { ForgeError } from "../errors.js";
 import { governanceError, storeError } from "../errors.js";
 import { checkScopePromotion, TRUST_ORDER } from "../governance.js";
+import { isVisibleToAgent } from "../scope-filter.js";
 import type { PromoteChange, PromoteResult } from "../types.js";
 import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
 import { createForgeTool, parseForgeInput } from "./shared.js";
@@ -150,9 +151,16 @@ async function promoteForgeHandler(
 
   const obj = parsed.value;
 
-  // Load the brick
+  // Load the brick (returns NOT_FOUND for invisible bricks to avoid leaking existence)
   const loadResult = await deps.store.load(obj.brickId);
   if (!loadResult.ok) {
+    return {
+      ok: false,
+      error: storeError("LOAD_FAILED", `Brick not found: ${obj.brickId}`),
+    };
+  }
+
+  if (!isVisibleToAgent(loadResult.value, deps.context.agentId)) {
     return {
       ok: false,
       error: storeError("LOAD_FAILED", `Brick not found: ${obj.brickId}`),

--- a/packages/forge/src/tools/search-forge.test.ts
+++ b/packages/forge/src/tools/search-forge.test.ts
@@ -215,4 +215,71 @@ describe("createSearchForgeTool", () => {
     expect(result.error.stage).toBe("store");
     expect(result.error.code).toBe("SEARCH_FAILED");
   });
+
+  test("agent-scoped brick only visible to creator", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "b1", scope: "agent", createdBy: "agent-1" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+  });
+
+  test("agent-scoped brick hidden from different agent", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "b1", scope: "agent", createdBy: "agent-2" }));
+
+    const tool = createSearchForgeTool(
+      createDeps({
+        store,
+        context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+      }),
+    );
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(0);
+  });
+
+  test("global-scoped brick visible regardless of agentId", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "b1", scope: "global", createdBy: "agent-2" }));
+
+    const tool = createSearchForgeTool(
+      createDeps({
+        store,
+        context: { agentId: "agent-1", depth: 0, sessionId: "session-1", forgesThisSession: 0 },
+      }),
+    );
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+  });
+
+  test("mixed scope query returns correct subset", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: "b1", scope: "global", createdBy: "other" }));
+    await store.save(createToolBrick({ id: "b2", scope: "agent", createdBy: "agent-1" }));
+    await store.save(createToolBrick({ id: "b3", scope: "agent", createdBy: "other" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(2);
+    const ids = result.value.map((b) => b.id);
+    expect(ids).toContain("b1");
+    expect(ids).toContain("b2");
+  });
 });

--- a/packages/forge/src/tools/search-forge.ts
+++ b/packages/forge/src/tools/search-forge.ts
@@ -5,6 +5,7 @@
 import type { Result, Tool } from "@koi/core";
 import type { ForgeError } from "../errors.js";
 import { staticError } from "../errors.js";
+import { filterByAgentScope } from "../scope-filter.js";
 import type { BrickArtifact, ForgeQuery } from "../types.js";
 import type { ForgeDeps, ForgeToolConfig } from "./shared.js";
 import { createForgeTool } from "./shared.js";
@@ -63,7 +64,8 @@ async function searchForgeHandler(
     };
   }
 
-  return { ok: true, value: result.value };
+  const filtered = filterByAgentScope(result.value, deps.context.agentId);
+  return { ok: true, value: filtered };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/e2e-scope-enforcement-pi.ts
+++ b/scripts/e2e-scope-enforcement-pi.ts
@@ -1,0 +1,774 @@
+#!/usr/bin/env bun
+/**
+ * E2E: ForgeScope Enforcement with Pi-Engine (Real LLM).
+ *
+ * Validates that agent-scoped bricks are invisible to other agents across
+ * all access paths: search_forge, ForgeResolver (discover/load/source),
+ * compose_forge, and promote_forge.
+ *
+ * Flow:
+ *   Test 1: Alpha forges a "secret-calc" tool  → agent-scoped, owned by alpha
+ *   Test 2: Beta searches for bricks           → must NOT see alpha's agent-scoped brick
+ *   Test 3: Alpha promotes to global           → scope updated
+ *   Test 4: Beta searches again                → now sees the global-scoped brick
+ *   Test 5: Alpha forges a 2nd agent-scoped brick "private-util"
+ *   Test 6: Beta tries to compose with alpha's agent-scoped brick → must fail
+ *   Test 7: Beta tries to promote alpha's agent-scoped brick     → must fail
+ *   Test 8: ForgeResolver respects scope (discover/load/source)
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-scope-enforcement-pi.ts
+ */
+
+import type { ComponentProvider, EngineEvent } from "../packages/core/src/index.js";
+import { toolToken } from "../packages/core/src/index.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { createDefaultForgeConfig } from "../packages/forge/src/config.js";
+import { createForgeResolver } from "../packages/forge/src/forge-resolver.js";
+import { createInMemoryForgeStore } from "../packages/forge/src/memory-store.js";
+import { createComposeForgeTool } from "../packages/forge/src/tools/compose-forge.js";
+import { createForgeToolTool } from "../packages/forge/src/tools/forge-tool.js";
+import { createPromoteForgeTool } from "../packages/forge/src/tools/promote-forge.js";
+import { createSearchForgeTool } from "../packages/forge/src/tools/search-forge.js";
+import type { ForgeDeps } from "../packages/forge/src/tools/shared.js";
+import type { SandboxExecutor, TieredSandboxExecutor } from "../packages/forge/src/types.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting ForgeScope enforcement pi-engine E2E tests...\n");
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  const suffix = detail && !condition ? ` \u2014 ${detail}` : "";
+  console.log(`  ${tag}  ${name}${suffix}`);
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Shared infrastructure
+// ---------------------------------------------------------------------------
+
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const TIMEOUT_MS = 90_000;
+
+const store = createInMemoryForgeStore();
+
+/** Eval executor — runs forged code via `new Function()`. No sandbox isolation (dev only). */
+const executor: SandboxExecutor = {
+  execute: async (code, input, _timeout) => {
+    try {
+      const fn = new Function("input", code) as (input: unknown) => unknown;
+      const output = await Promise.resolve(fn(input));
+      return { ok: true as const, value: { output, durationMs: 1 } };
+    } catch (err: unknown) {
+      return {
+        ok: false as const,
+        error: {
+          code: "CRASH" as const,
+          message: err instanceof Error ? err.message : String(err),
+          durationMs: 1,
+        },
+      };
+    }
+  },
+};
+
+const tieredExecutor: TieredSandboxExecutor = {
+  forTier: (tier) => ({
+    executor,
+    requestedTier: tier,
+    resolvedTier: tier,
+    fallback: false,
+  }),
+};
+
+const config = createDefaultForgeConfig({
+  maxForgesPerSession: 50,
+  scopePromotion: {
+    requireHumanApproval: false,
+    minTrustForZone: "sandbox",
+    minTrustForGlobal: "sandbox",
+  },
+});
+
+function makeDeps(agentId: string, forgesThisSession: number): ForgeDeps {
+  return {
+    store,
+    executor: tieredExecutor,
+    verifiers: [],
+    config,
+    context: {
+      agentId,
+      depth: 0,
+      sessionId: `e2e-scope-${agentId}-${Date.now()}`,
+      forgesThisSession,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(iter: AsyncIterable<EngineEvent>): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iter) {
+    events.push(event);
+  }
+  return events;
+}
+
+function extractToolStarts(
+  events: readonly EngineEvent[],
+): ReadonlyArray<EngineEvent & { readonly kind: "tool_call_start" }> {
+  return events.filter(
+    (e): e is EngineEvent & { readonly kind: "tool_call_start" } => e.kind === "tool_call_start",
+  );
+}
+
+function extractToolEnds(
+  events: readonly EngineEvent[],
+): ReadonlyArray<Extract<EngineEvent, { readonly kind: "tool_call_end" }>> {
+  return events.filter(
+    (e): e is Extract<EngineEvent, { readonly kind: "tool_call_end" }> =>
+      e.kind === "tool_call_end",
+  );
+}
+
+function makePrimordialProvider(deps: ForgeDeps): ComponentProvider {
+  const forgeTool = createForgeToolTool(deps);
+  const promoteTool = createPromoteForgeTool(deps);
+  const searchTool = createSearchForgeTool(deps);
+  const composeTool = createComposeForgeTool(deps);
+
+  const entries: ReadonlyArray<[string, unknown]> = [
+    [toolToken("forge_tool"), forgeTool],
+    [toolToken("promote_forge"), promoteTool],
+    [toolToken("search_forge"), searchTool],
+    [toolToken("compose_forge"), composeTool],
+  ];
+
+  return {
+    name: "forge-primordials",
+    attach: async (): Promise<ReadonlyMap<string, unknown>> => new Map(entries),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Agent Alpha forges an agent-scoped "secret-calc" tool
+// ---------------------------------------------------------------------------
+
+console.log("[test 1] Alpha forges an agent-scoped 'secret-calc' tool via real LLM\n");
+
+try {
+  const alphaDeps = makeDeps("alpha-agent", 0);
+  const primordialProvider = makePrimordialProvider(alphaDeps);
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: [
+      "You are a tool-forging agent. You have ONE task: use the forge_tool tool to create a tool.",
+      "Call forge_tool with EXACTLY these arguments:",
+      '  name: "secret-calc"',
+      '  description: "A secret calculator that triples a number"',
+      '  inputSchema: { "type": "object", "properties": { "n": { "type": "number" } }, "required": ["n"] }',
+      '  implementation: "const n = input.n || 0; return { result: n * 3 };"',
+      "Do NOT say anything before calling the tool. Just call it immediately.",
+    ].join("\n"),
+    getApiKey: async () => API_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: { name: "Alpha", version: "0.1.0", model: { name: E2E_MODEL } },
+    adapter,
+    providers: [primordialProvider],
+    loopDetection: false,
+    limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+  });
+
+  const events = await withTimeout(
+    () => collectEvents(runtime.run({ kind: "text", text: "Forge the secret-calc tool now." })),
+    TIMEOUT_MS,
+    "Test 1",
+  );
+
+  const toolStarts = extractToolStarts(events);
+  const forgeStarts = toolStarts.filter((e) => e.toolName === "forge_tool");
+  assert("Alpha called forge_tool", forgeStarts.length >= 1, `got ${forgeStarts.length} calls`);
+
+  const searchResult = await store.search({ kind: "tool", text: "secret-calc" });
+  const hasBrick = searchResult.ok && searchResult.value.length >= 1;
+  assert("store contains 'secret-calc' brick", hasBrick);
+
+  if (searchResult.ok && searchResult.value[0] !== undefined) {
+    const brick = searchResult.value[0];
+    assert("brick scope is 'agent' (default)", brick.scope === "agent", `got ${brick.scope}`);
+    assert(
+      "brick createdBy is alpha-agent",
+      brick.createdBy === "alpha-agent",
+      `got ${brick.createdBy}`,
+    );
+    console.log(`    Brick ID: ${brick.id}`);
+  }
+} catch (err: unknown) {
+  assert("Test 1 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Beta searches — must NOT see alpha's agent-scoped brick
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 2] Beta searches for bricks — alpha's agent-scoped brick must be invisible\n");
+
+try {
+  const betaDeps = makeDeps("beta-agent", 0);
+  const primordialProvider = makePrimordialProvider(betaDeps);
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: [
+      "You have ONE task: use the search_forge tool to search for ALL bricks.",
+      "Call search_forge with an empty object {} as input.",
+      "After getting the result, report exactly how many bricks were found.",
+      "Do NOT say anything before calling the tool. Just call it immediately.",
+    ].join("\n"),
+    getApiKey: async () => API_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: { name: "Beta", version: "0.1.0", model: { name: E2E_MODEL } },
+    adapter,
+    providers: [primordialProvider],
+    loopDetection: false,
+    limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+  });
+
+  const events = await withTimeout(
+    () => collectEvents(runtime.run({ kind: "text", text: "Search for all bricks now." })),
+    TIMEOUT_MS,
+    "Test 2",
+  );
+
+  const toolStarts = extractToolStarts(events);
+  const searchStarts = toolStarts.filter((e) => e.toolName === "search_forge");
+  assert("Beta called search_forge", searchStarts.length >= 1, `got ${searchStarts.length} calls`);
+
+  // Verify the search_forge result returned empty (beta can't see alpha's agent-scoped brick)
+  const toolEnds = extractToolEnds(events);
+  const searchCallId = searchStarts[0]?.callId;
+  const searchEnd =
+    searchCallId !== undefined ? toolEnds.find((e) => e.callId === searchCallId) : toolEnds[0];
+
+  if (searchEnd !== undefined) {
+    const output = JSON.stringify(searchEnd.result ?? "");
+    // The result should be ok:true with an empty value array
+    const hasSecretCalc = output.includes("secret-calc");
+    assert(
+      "Beta's search result does NOT contain 'secret-calc'",
+      !hasSecretCalc,
+      `output: ${output.slice(0, 300)}`,
+    );
+  } else {
+    assert("search_forge tool_call_end emitted", false, "no tool_call_end found");
+  }
+} catch (err: unknown) {
+  assert("Test 2 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Alpha promotes brick to global scope
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 3] Alpha promotes secret-calc to global scope\n");
+
+let secretCalcBrickId: string | undefined;
+
+try {
+  const searchResult = await store.search({ kind: "tool", text: "secret-calc" });
+  if (!searchResult.ok || searchResult.value.length === 0) {
+    assert("Test 3 requires secret-calc brick", false, "brick not found");
+  } else {
+    secretCalcBrickId = searchResult.value[0]?.id;
+    if (secretCalcBrickId === undefined) {
+      assert("brick has ID", false, "brick ID is undefined");
+    } else {
+      const alphaDeps = makeDeps("alpha-agent", 1);
+      const primordialProvider = makePrimordialProvider(alphaDeps);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: [
+          "You have ONE task: use the promote_forge tool to promote a brick.",
+          `Call promote_forge with these arguments:`,
+          `  brickId: "${secretCalcBrickId}"`,
+          `  targetScope: "global"`,
+          "Do NOT say anything before calling the tool. Just call it immediately.",
+        ].join("\n"),
+        getApiKey: async () => API_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: { name: "Alpha-Promote", version: "0.1.0", model: { name: E2E_MODEL } },
+        adapter,
+        providers: [primordialProvider],
+        loopDetection: false,
+        limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+      });
+
+      const events = await withTimeout(
+        () =>
+          collectEvents(runtime.run({ kind: "text", text: "Promote the brick to global now." })),
+        TIMEOUT_MS,
+        "Test 3",
+      );
+
+      const toolStarts = extractToolStarts(events);
+      const promoteStarts = toolStarts.filter((e) => e.toolName === "promote_forge");
+      assert(
+        "Alpha called promote_forge",
+        promoteStarts.length >= 1,
+        `got ${promoteStarts.length} calls`,
+      );
+
+      const loadResult = await store.load(secretCalcBrickId);
+      if (loadResult.ok) {
+        assert(
+          "brick scope is now 'global'",
+          loadResult.value.scope === "global",
+          `got ${loadResult.value.scope}`,
+        );
+      } else {
+        assert("brick loaded after promotion", false, "load failed");
+      }
+    }
+  }
+} catch (err: unknown) {
+  assert("Test 3 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Beta searches again — now sees the global-scoped brick
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 4] Beta searches again — now sees the global-scoped brick\n");
+
+try {
+  const betaDeps = makeDeps("beta-agent", 0);
+  const primordialProvider = makePrimordialProvider(betaDeps);
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: [
+      "You have ONE task: use the search_forge tool to search for ALL bricks.",
+      "Call search_forge with an empty object {} as input.",
+      "After getting the result, report the names of all bricks found.",
+      "Do NOT say anything before calling the tool. Just call it immediately.",
+    ].join("\n"),
+    getApiKey: async () => API_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: { name: "Beta-Search-2", version: "0.1.0", model: { name: E2E_MODEL } },
+    adapter,
+    providers: [primordialProvider],
+    loopDetection: false,
+    limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+  });
+
+  const events = await withTimeout(
+    () => collectEvents(runtime.run({ kind: "text", text: "Search for all bricks now." })),
+    TIMEOUT_MS,
+    "Test 4",
+  );
+
+  const toolStarts = extractToolStarts(events);
+  const searchStarts = toolStarts.filter((e) => e.toolName === "search_forge");
+  assert("Beta called search_forge", searchStarts.length >= 1, `got ${searchStarts.length} calls`);
+
+  const toolEnds = extractToolEnds(events);
+  const searchCallId = searchStarts[0]?.callId;
+  const searchEnd =
+    searchCallId !== undefined ? toolEnds.find((e) => e.callId === searchCallId) : toolEnds[0];
+
+  if (searchEnd !== undefined) {
+    const output = JSON.stringify(searchEnd.result ?? "");
+    assert(
+      "Beta's search result NOW contains 'secret-calc'",
+      output.includes("secret-calc"),
+      `output: ${output.slice(0, 300)}`,
+    );
+  } else {
+    assert("search_forge tool_call_end emitted", false, "no tool_call_end found");
+  }
+} catch (err: unknown) {
+  assert("Test 4 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Alpha forges a 2nd agent-scoped brick "private-util"
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 5] Alpha forges a 2nd agent-scoped brick 'private-util'\n");
+
+try {
+  const alphaDeps = makeDeps("alpha-agent", 2);
+  const primordialProvider = makePrimordialProvider(alphaDeps);
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: [
+      "You have ONE task: use the forge_tool tool to create a tool.",
+      "Call forge_tool with EXACTLY these arguments:",
+      '  name: "private-util"',
+      '  description: "A private utility that adds 10 to a number"',
+      '  inputSchema: { "type": "object", "properties": { "n": { "type": "number" } }, "required": ["n"] }',
+      '  implementation: "const n = input.n || 0; return { result: n + 10 };"',
+      "Do NOT say anything before calling the tool. Just call it immediately.",
+    ].join("\n"),
+    getApiKey: async () => API_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: { name: "Alpha-Forge-2", version: "0.1.0", model: { name: E2E_MODEL } },
+    adapter,
+    providers: [primordialProvider],
+    loopDetection: false,
+    limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+  });
+
+  const events = await withTimeout(
+    () => collectEvents(runtime.run({ kind: "text", text: "Forge the private-util tool now." })),
+    TIMEOUT_MS,
+    "Test 5",
+  );
+
+  const toolStarts = extractToolStarts(events);
+  assert(
+    "Alpha called forge_tool",
+    toolStarts.some((e) => e.toolName === "forge_tool"),
+  );
+
+  const searchResult = await store.search({ text: "private-util" });
+  assert("store contains 'private-util'", searchResult.ok && searchResult.value.length >= 1);
+} catch (err: unknown) {
+  assert("Test 5 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Beta tries to compose with alpha's agent-scoped brick → must fail
+// ---------------------------------------------------------------------------
+
+console.log(
+  "\n[test 6] Beta tries to compose with alpha's agent-scoped 'private-util' → must fail\n",
+);
+
+try {
+  // Find the private-util brick ID (direct store query bypasses scope — test infra only)
+  const searchResult = await store.search({ text: "private-util" });
+  if (!searchResult.ok || searchResult.value.length === 0) {
+    assert("Test 6 requires private-util brick", false, "not found");
+  } else {
+    const privateUtilId = searchResult.value[0]?.id;
+    if (privateUtilId === undefined) {
+      assert("private-util has ID", false, "ID undefined");
+    } else {
+      // Also need a brick Beta owns to compose with
+      const betaDeps = makeDeps("beta-agent", 0);
+
+      // Beta forges its own brick first (programmatic, no LLM needed)
+      const betaForgeResult = await store.save({
+        id: "brick_beta_own",
+        kind: "tool",
+        name: "beta-tool",
+        description: "Beta's own tool",
+        scope: "agent",
+        trustTier: "sandbox",
+        lifecycle: "active",
+        createdBy: "beta-agent",
+        createdAt: Date.now(),
+        version: "0.0.1",
+        tags: [],
+        usageCount: 0,
+        contentHash: "beta-hash",
+        implementation: "return 1;",
+        inputSchema: { type: "object" },
+      });
+      assert("Beta's own brick saved", betaForgeResult.ok);
+
+      const primordialProvider = makePrimordialProvider(betaDeps);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: [
+          "You have ONE task: use the compose_forge tool to compose two bricks.",
+          "Call compose_forge with EXACTLY these arguments:",
+          '  name: "sneaky-composite"',
+          '  description: "Trying to compose with foreign brick"',
+          `  brickIds: ["brick_beta_own", "${privateUtilId}"]`,
+          "Do NOT say anything before calling the tool. Just call it immediately.",
+        ].join("\n"),
+        getApiKey: async () => API_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: { name: "Beta-Compose", version: "0.1.0", model: { name: E2E_MODEL } },
+        adapter,
+        providers: [primordialProvider],
+        loopDetection: false,
+        limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+      });
+
+      const events = await withTimeout(
+        () => collectEvents(runtime.run({ kind: "text", text: "Compose the bricks now." })),
+        TIMEOUT_MS,
+        "Test 6",
+      );
+
+      const toolStarts = extractToolStarts(events);
+      const composeStarts = toolStarts.filter((e) => e.toolName === "compose_forge");
+      assert(
+        "Beta called compose_forge",
+        composeStarts.length >= 1,
+        `got ${composeStarts.length} calls`,
+      );
+
+      // The compose result should contain an error about the foreign brick not being found
+      const toolEnds = extractToolEnds(events);
+      const composeCallId = composeStarts[0]?.callId;
+      const composeEnd =
+        composeCallId !== undefined
+          ? toolEnds.find((e) => e.callId === composeCallId)
+          : toolEnds[0];
+
+      if (composeEnd !== undefined) {
+        const output = JSON.stringify(composeEnd.result ?? "");
+        assert(
+          "compose_forge failed (foreign brick treated as not found)",
+          output.includes("not found") ||
+            output.includes("LOAD_FAILED") ||
+            output.includes('"ok":false'),
+          `output: ${output.slice(0, 300)}`,
+        );
+      } else {
+        assert("compose_forge tool_call_end emitted", false, "no tool_call_end found");
+      }
+    }
+  }
+} catch (err: unknown) {
+  assert("Test 6 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Beta tries to promote alpha's agent-scoped brick → must fail
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 7] Beta tries to promote alpha's agent-scoped 'private-util' → must fail\n");
+
+try {
+  const searchResult = await store.search({ text: "private-util" });
+  if (!searchResult.ok || searchResult.value.length === 0) {
+    assert("Test 7 requires private-util brick", false, "not found");
+  } else {
+    const privateUtilId = searchResult.value[0]?.id;
+    if (privateUtilId === undefined) {
+      assert("private-util has ID", false, "ID undefined");
+    } else {
+      const betaDeps = makeDeps("beta-agent", 0);
+      const primordialProvider = makePrimordialProvider(betaDeps);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: [
+          "You have ONE task: use the promote_forge tool to promote a brick.",
+          `Call promote_forge with these arguments:`,
+          `  brickId: "${privateUtilId}"`,
+          `  targetScope: "global"`,
+          "Do NOT say anything before calling the tool. Just call it immediately.",
+        ].join("\n"),
+        getApiKey: async () => API_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: { name: "Beta-Promote", version: "0.1.0", model: { name: E2E_MODEL } },
+        adapter,
+        providers: [primordialProvider],
+        loopDetection: false,
+        limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+      });
+
+      const events = await withTimeout(
+        () =>
+          collectEvents(runtime.run({ kind: "text", text: "Promote the brick to global now." })),
+        TIMEOUT_MS,
+        "Test 7",
+      );
+
+      const toolStarts = extractToolStarts(events);
+      const promoteStarts = toolStarts.filter((e) => e.toolName === "promote_forge");
+      assert(
+        "Beta called promote_forge",
+        promoteStarts.length >= 1,
+        `got ${promoteStarts.length} calls`,
+      );
+
+      // The promote result should fail
+      const toolEnds = extractToolEnds(events);
+      const promoteCallId = promoteStarts[0]?.callId;
+      const promoteEnd =
+        promoteCallId !== undefined
+          ? toolEnds.find((e) => e.callId === promoteCallId)
+          : toolEnds[0];
+
+      if (promoteEnd !== undefined) {
+        const output = JSON.stringify(promoteEnd.result ?? "");
+        assert(
+          "promote_forge failed (foreign brick treated as not found)",
+          output.includes("not found") ||
+            output.includes("LOAD_FAILED") ||
+            output.includes('"ok":false'),
+          `output: ${output.slice(0, 300)}`,
+        );
+      } else {
+        assert("promote_forge tool_call_end emitted", false, "no tool_call_end found");
+      }
+
+      // Verify the brick's scope is still "agent" (not promoted)
+      const loadResult = await store.load(privateUtilId);
+      if (loadResult.ok) {
+        assert(
+          "private-util scope is still 'agent' (unchanged)",
+          loadResult.value.scope === "agent",
+          `got ${loadResult.value.scope}`,
+        );
+      }
+    }
+  }
+} catch (err: unknown) {
+  assert("Test 7 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: ForgeResolver respects scope (discover/load/source) — no LLM needed
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 8] ForgeResolver respects scope (discover/load/source)\n");
+
+try {
+  // Alpha's resolver should see both bricks
+  const alphaResolver = createForgeResolver(store, { agentId: "alpha-agent" });
+  const alphaDiscover = await alphaResolver.discover();
+  const alphaNames = alphaDiscover.map((b) => b.name);
+  assert(
+    "Alpha resolver discovers 'secret-calc'",
+    alphaNames.includes("secret-calc"),
+    `found: [${alphaNames.join(", ")}]`,
+  );
+  assert(
+    "Alpha resolver discovers 'private-util'",
+    alphaNames.includes("private-util"),
+    `found: [${alphaNames.join(", ")}]`,
+  );
+
+  // Beta's resolver should see global bricks but NOT alpha's agent-scoped brick
+  const betaResolver = createForgeResolver(store, { agentId: "beta-agent" });
+  const betaDiscover = await betaResolver.discover();
+  const betaNames = betaDiscover.map((b) => b.name);
+  assert(
+    "Beta resolver discovers 'secret-calc' (now global)",
+    betaNames.includes("secret-calc"),
+    `found: [${betaNames.join(", ")}]`,
+  );
+  assert(
+    "Beta resolver does NOT discover 'private-util' (agent-scoped by alpha)",
+    !betaNames.includes("private-util"),
+    `found: [${betaNames.join(", ")}]`,
+  );
+
+  // Beta's resolver: load alpha's agent-scoped brick → NOT_FOUND
+  const privateUtilSearch = await store.search({ text: "private-util" });
+  if (privateUtilSearch.ok && privateUtilSearch.value[0] !== undefined) {
+    const privateUtilId = privateUtilSearch.value[0].id;
+
+    const loadResult = await betaResolver.load(privateUtilId);
+    assert("Beta load() of alpha's agent-scoped brick returns NOT_FOUND", !loadResult.ok);
+    if (!loadResult.ok) {
+      assert(
+        "error code is NOT_FOUND",
+        loadResult.error.code === "NOT_FOUND",
+        `got ${loadResult.error.code}`,
+      );
+    }
+
+    // source() also blocked
+    const sourceResult = await betaResolver.source?.(privateUtilId);
+    assert(
+      "Beta source() of alpha's agent-scoped brick returns NOT_FOUND",
+      sourceResult !== undefined && !sourceResult.ok,
+    );
+
+    // Alpha CAN load/source its own brick
+    const alphaLoadResult = await alphaResolver.load(privateUtilId);
+    assert("Alpha load() of own agent-scoped brick succeeds", alphaLoadResult.ok);
+
+    const alphaSourceResult = await alphaResolver.source?.(privateUtilId);
+    assert("Alpha source() of own agent-scoped brick succeeds", alphaSourceResult?.ok);
+  }
+
+  // Beta's resolver: load beta's own brick → succeeds
+  const betaLoadOwn = await betaResolver.load("brick_beta_own");
+  assert("Beta load() of own brick succeeds", betaLoadOwn.ok);
+} catch (err: unknown) {
+  assert("Test 8 completed without error", false, err instanceof Error ? err.message : String(err));
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n[e2e] Results: ${passed}/${total} passed`);
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}${r.detail ? ` \u2014 ${r.detail}` : ""}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e] All ForgeScope enforcement E2E tests passed!");

--- a/scripts/e2e-source.ts
+++ b/scripts/e2e-source.ts
@@ -103,7 +103,7 @@ async function testForgeResolverSource(): Promise<void> {
   try {
     const store = createInMemoryForgeStore();
     await store.save(createToolBrick({ id: "fib-1" }));
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("fib-1");
@@ -138,7 +138,7 @@ async function testForgeResolverSource(): Promise<void> {
       contentHash: "h1",
       content: "# Greeting Guide\n\nSay hello warmly.",
     });
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "a1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("skill-1");
@@ -170,7 +170,7 @@ async function testForgeResolverSource(): Promise<void> {
       contentHash: "h2",
       manifestYaml: "name: math-agent\nversion: 0.0.1\nmodel: gpt-4o-mini",
     });
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "a1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("agent-1");
@@ -202,7 +202,7 @@ async function testForgeResolverSource(): Promise<void> {
       contentHash: "h3",
       brickIds: ["fib-1", "skill-1"],
     });
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "a1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("comp-1");
@@ -219,7 +219,7 @@ async function testForgeResolverSource(): Promise<void> {
   // NOT_FOUND
   try {
     const store = createInMemoryForgeStore();
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "any" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("nonexistent");
@@ -237,7 +237,7 @@ async function testForgeResolverSource(): Promise<void> {
     await store.save(
       createToolBrick({ id: "with-files", files: { "helper.ts": "export const PI = 3.14;" } }),
     );
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const result = await resolver.source("with-files");
@@ -372,7 +372,7 @@ async function testLlmReadsSource(): Promise<void> {
   try {
     const store = createInMemoryForgeStore();
     await store.save(createToolBrick({ id: "fib-tool" }));
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
 
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
@@ -426,7 +426,7 @@ async function testLlmReadsSource(): Promise<void> {
       }),
     );
 
-    const resolver = createForgeResolver(store);
+    const resolver = createForgeResolver(store, { agentId: "agent-1" });
     assert(resolver.source !== undefined, "source should be defined");
     if (resolver.source === undefined) throw new Error("unreachable");
     const sourceResult = await resolver.source("buggy-fib");


### PR DESCRIPTION
## Summary

Closes #207

- **New `scope-filter.ts`** — shared pure functions (`isVisibleToAgent`, `filterByAgentScope`) with exhaustive switch for fail-closed enforcement
- **`search_forge`** — filters store results by agent scope after `store.search()`
- **`ForgeResolver`** — now requires `ForgeResolverContext { agentId }`. `discover()`, `load()`, and `source()` all enforce scope visibility, returning `NOT_FOUND` for invisible bricks (avoids leaking existence)
- **`compose_forge`** — rejects foreign agent-scoped bricks during composition
- **`promote_forge`** — rejects foreign agent-scoped bricks before validation
- Phase 1 only: `agent` + `global` scope. Zone scope passes through (Phase 2 deferred)
- No L0 (`@koi/core`) or `ForgeStore` interface changes

## Test plan

- [x] `scope-filter.test.ts` — 6 unit tests (global visible, zone passthrough, agent-match, agent-mismatch, mixed filter, empty array)
- [x] `search-forge.test.ts` — 4 new tests (agent-scoped visible/hidden, global visible, mixed subset)
- [x] `forge-resolver.test.ts` — 6 new tests (discover excludes/includes, load/source NOT_FOUND for foreign, succeeds for own)
- [x] `compose-forge.test.ts` — 2 new tests (rejects foreign agent-scoped, allows global)
- [x] `promote-forge.test.ts` — 3 new tests (rejects foreign, allows own, allows global)
- [x] All 15 `createForgeResolver` call sites updated with context param
- [x] E2E test with real Pi engine + Anthropic Haiku (`scripts/e2e-scope-enforcement-pi.ts`) — 28/28 assertions pass
- [x] `bunx turbo build` — clean
- [x] `bunx turbo test --filter=@koi/forge` — 549 tests pass