### PR TITLE
feat: add @koi/middleware-sandbox (L2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,6 +373,17 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-sandbox": {
+      "name": "@koi/middleware-sandbox",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-soul": {
       "name": "@koi/middleware-soul",
       "version": "0.0.0",
@@ -932,6 +943,8 @@
     "@koi/middleware-pay": ["@koi/middleware-pay@workspace:packages/middleware-pay"],
 
     "@koi/middleware-permissions": ["@koi/middleware-permissions@workspace:packages/middleware-permissions"],
+
+    "@koi/middleware-sandbox": ["@koi/middleware-sandbox@workspace:packages/middleware-sandbox"],
 
     "@koi/middleware-soul": ["@koi/middleware-soul@workspace:packages/middleware-soul"],
 

--- a/packages/middleware-sandbox/package.json
+++ b/packages/middleware-sandbox/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/middleware-sandbox",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-sandbox/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-sandbox/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,50 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-sandbox API surface . has stable type surface 1`] = `
+"import { TrustTier } from '@koi/core/ecs';
+import { Result, KoiError } from '@koi/core/errors';
+import { SandboxProfile, ResourceLimits } from '@koi/core/sandbox-profile';
+import { KoiMiddleware } from '@koi/core/middleware';
+
+/**
+ * Sandbox middleware configuration and validation.
+ */
+
+/** Max output bytes before truncation (1 MB). */
+declare const DEFAULT_OUTPUT_LIMIT_BYTES = 1048576;
+/** Grace period added to profile timeout (5 s). */
+declare const DEFAULT_TIMEOUT_GRACE_MS = 5000;
+/** Tiers that skip sandbox wrapping entirely. */
+declare const DEFAULT_SKIP_TIERS: readonly TrustTier[];
+interface SandboxMiddlewareConfig {
+    /** Maps trust tier to sandbox profile (required). */
+    readonly profileFor: (tier: TrustTier) => SandboxProfile;
+    /** Resolves tool ID to its trust tier — caller provides ECS closure (required). */
+    readonly tierFor: (toolId: string) => TrustTier | undefined;
+    /** Max output bytes before truncation (default: 1_048_576 = 1 MB). */
+    readonly outputLimitBytes?: number | undefined;
+    /** Grace period added to profile timeout (default: 5_000 ms). */
+    readonly timeoutGraceMs?: number | undefined;
+    /** Tiers to skip entirely — fast pass-through (default: ["promoted"]). */
+    readonly skipTiers?: readonly TrustTier[] | undefined;
+    /** Per-tool resource limit overrides. */
+    readonly perToolOverrides?: ReadonlyMap<string, Partial<ResourceLimits>> | undefined;
+    /** If true, unknown tools (tierFor returns undefined) are treated as sandbox (default: true). */
+    readonly failClosedOnLookupError?: boolean | undefined;
+    /** Called when middleware detects a sandbox violation (timeout). */
+    readonly onSandboxError?: ((toolId: string, tier: TrustTier, code: string, message: string) => void) | undefined;
+    /** Called after every sandboxed tool execution with metrics. */
+    readonly onSandboxMetrics?: ((toolId: string, tier: TrustTier, durationMs: number, outputBytes: number, truncated: boolean) => void) | undefined;
+}
+declare function validateConfig(config: unknown): Result<SandboxMiddlewareConfig, KoiError>;
+
+/**
+ * Sandbox policy middleware — defense-in-depth timeout, output truncation,
+ * error classification, and observability for sandboxed tool execution.
+ */
+
+declare function createSandboxMiddleware(config: SandboxMiddlewareConfig): KoiMiddleware;
+
+export { DEFAULT_OUTPUT_LIMIT_BYTES, DEFAULT_SKIP_TIERS, DEFAULT_TIMEOUT_GRACE_MS, type SandboxMiddlewareConfig, createSandboxMiddleware, validateConfig };
+"
+`;

--- a/packages/middleware-sandbox/src/__tests__/api-surface.test.ts
+++ b/packages/middleware-sandbox/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware-sandbox/src/config.test.ts
+++ b/packages/middleware-sandbox/src/config.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for SandboxMiddlewareConfig validation.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { TrustTier } from "@koi/core/ecs";
+import type { SandboxProfile } from "@koi/core/sandbox-profile";
+import { validateConfig } from "./config.js";
+
+const stubProfile: SandboxProfile = {
+  tier: "sandbox",
+  filesystem: {},
+  network: { allow: false },
+  resources: { timeoutMs: 100 },
+};
+
+const validConfig = {
+  profileFor: (_tier: TrustTier) => stubProfile,
+  tierFor: (_toolId: string) => "sandbox" as const,
+};
+
+describe("validateConfig", () => {
+  it("accepts a valid config with required fields only", () => {
+    const result = validateConfig(validConfig);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid config with all optional fields", () => {
+    const result = validateConfig({
+      ...validConfig,
+      outputLimitBytes: 512,
+      timeoutGraceMs: 1000,
+      skipTiers: ["promoted"],
+      perToolOverrides: new Map(),
+      failClosedOnLookupError: false,
+      onSandboxError: () => {},
+      onSandboxMetrics: () => {},
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects null", () => {
+    const result = validateConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  it("rejects undefined", () => {
+    const result = validateConfig(undefined);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-object", () => {
+    const result = validateConfig("string");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing profileFor", () => {
+    const result = validateConfig({ tierFor: validConfig.tierFor });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("profileFor");
+    }
+  });
+
+  it("rejects non-function profileFor", () => {
+    const result = validateConfig({ ...validConfig, profileFor: "not-a-fn" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("profileFor");
+    }
+  });
+
+  it("rejects missing tierFor", () => {
+    const result = validateConfig({ profileFor: validConfig.profileFor });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("tierFor");
+    }
+  });
+
+  it("rejects non-function tierFor", () => {
+    const result = validateConfig({ ...validConfig, tierFor: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("tierFor");
+    }
+  });
+
+  it("rejects non-positive outputLimitBytes", () => {
+    const result = validateConfig({ ...validConfig, outputLimitBytes: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("outputLimitBytes");
+    }
+  });
+
+  it("rejects Infinity outputLimitBytes", () => {
+    const result = validateConfig({ ...validConfig, outputLimitBytes: Infinity });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("finite");
+    }
+  });
+
+  it("rejects NaN outputLimitBytes", () => {
+    const result = validateConfig({ ...validConfig, outputLimitBytes: NaN });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects negative timeoutGraceMs", () => {
+    const result = validateConfig({ ...validConfig, timeoutGraceMs: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("timeoutGraceMs");
+    }
+  });
+
+  it("rejects Infinity timeoutGraceMs", () => {
+    const result = validateConfig({ ...validConfig, timeoutGraceMs: Infinity });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts zero timeoutGraceMs", () => {
+    const result = validateConfig({ ...validConfig, timeoutGraceMs: 0 });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects non-array skipTiers", () => {
+    const result = validateConfig({ ...validConfig, skipTiers: "promoted" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("skipTiers");
+    }
+  });
+
+  it("rejects skipTiers with invalid tier values", () => {
+    const result = validateConfig({ ...validConfig, skipTiers: ["sandbox", "invalid-tier"] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("valid TrustTier");
+    }
+  });
+
+  it("rejects non-boolean failClosedOnLookupError", () => {
+    const result = validateConfig({ ...validConfig, failClosedOnLookupError: "yes" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("failClosedOnLookupError");
+    }
+  });
+
+  it("rejects non-function onSandboxError", () => {
+    const result = validateConfig({ ...validConfig, onSandboxError: "callback" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("onSandboxError");
+    }
+  });
+
+  it("rejects non-function onSandboxMetrics", () => {
+    const result = validateConfig({ ...validConfig, onSandboxMetrics: 42 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("onSandboxMetrics");
+    }
+  });
+});

--- a/packages/middleware-sandbox/src/config.ts
+++ b/packages/middleware-sandbox/src/config.ts
@@ -1,0 +1,132 @@
+/**
+ * Sandbox middleware configuration and validation.
+ */
+
+import type { TrustTier } from "@koi/core/ecs";
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ResourceLimits, SandboxProfile } from "@koi/core/sandbox-profile";
+
+/** Max output bytes before truncation (1 MB). */
+export const DEFAULT_OUTPUT_LIMIT_BYTES = 1_048_576;
+
+/** Grace period added to profile timeout (5 s). */
+export const DEFAULT_TIMEOUT_GRACE_MS = 5_000;
+
+/** Tiers that skip sandbox wrapping entirely. */
+export const DEFAULT_SKIP_TIERS: readonly TrustTier[] = ["promoted"] as const;
+
+const VALID_TRUST_TIERS = new Set<string>(["sandbox", "verified", "promoted"]);
+
+export interface SandboxMiddlewareConfig {
+  /** Maps trust tier to sandbox profile (required). */
+  readonly profileFor: (tier: TrustTier) => SandboxProfile;
+  /** Resolves tool ID to its trust tier — caller provides ECS closure (required). */
+  readonly tierFor: (toolId: string) => TrustTier | undefined;
+  /** Max output bytes before truncation (default: 1_048_576 = 1 MB). */
+  readonly outputLimitBytes?: number | undefined;
+  /** Grace period added to profile timeout (default: 5_000 ms). */
+  readonly timeoutGraceMs?: number | undefined;
+  /** Tiers to skip entirely — fast pass-through (default: ["promoted"]). */
+  readonly skipTiers?: readonly TrustTier[] | undefined;
+  /** Per-tool resource limit overrides. */
+  readonly perToolOverrides?: ReadonlyMap<string, Partial<ResourceLimits>> | undefined;
+  /** If true, unknown tools (tierFor returns undefined) are treated as sandbox (default: true). */
+  readonly failClosedOnLookupError?: boolean | undefined;
+  /** Called when middleware detects a sandbox violation (timeout). */
+  readonly onSandboxError?:
+    | ((toolId: string, tier: TrustTier, code: string, message: string) => void)
+    | undefined;
+  /** Called after every sandboxed tool execution with metrics. */
+  readonly onSandboxMetrics?:
+    | ((
+        toolId: string,
+        tier: TrustTier,
+        durationMs: number,
+        outputBytes: number,
+        truncated: boolean,
+      ) => void)
+    | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: { code: "VALIDATION", message, retryable: RETRYABLE_DEFAULTS.VALIDATION },
+  };
+}
+
+export function validateConfig(config: unknown): Result<SandboxMiddlewareConfig, KoiError> {
+  if (!isRecord(config)) {
+    return validationError("Config must be a non-null object");
+  }
+
+  if (typeof config.profileFor !== "function") {
+    return validationError(
+      "Config requires 'profileFor' as a function mapping TrustTier to SandboxProfile",
+    );
+  }
+
+  if (typeof config.tierFor !== "function") {
+    return validationError("Config requires 'tierFor' as a function resolving toolId to TrustTier");
+  }
+
+  if (config.outputLimitBytes !== undefined) {
+    if (
+      typeof config.outputLimitBytes !== "number" ||
+      !Number.isFinite(config.outputLimitBytes) ||
+      config.outputLimitBytes <= 0
+    ) {
+      return validationError("outputLimitBytes must be a finite positive number");
+    }
+  }
+
+  if (config.timeoutGraceMs !== undefined) {
+    if (
+      typeof config.timeoutGraceMs !== "number" ||
+      !Number.isFinite(config.timeoutGraceMs) ||
+      config.timeoutGraceMs < 0
+    ) {
+      return validationError("timeoutGraceMs must be a finite non-negative number");
+    }
+  }
+
+  if (config.skipTiers !== undefined) {
+    if (!Array.isArray(config.skipTiers)) {
+      return validationError("skipTiers must be an array of TrustTier strings");
+    }
+    const allValid = config.skipTiers.every(
+      (t: unknown) => typeof t === "string" && VALID_TRUST_TIERS.has(t),
+    );
+    if (!allValid) {
+      return validationError(
+        "skipTiers must contain only valid TrustTier values: sandbox, verified, promoted",
+      );
+    }
+  }
+
+  if (
+    config.failClosedOnLookupError !== undefined &&
+    typeof config.failClosedOnLookupError !== "boolean"
+  ) {
+    return validationError("failClosedOnLookupError must be a boolean");
+  }
+
+  if (config.onSandboxError !== undefined && typeof config.onSandboxError !== "function") {
+    return validationError("onSandboxError must be a function");
+  }
+
+  if (config.onSandboxMetrics !== undefined && typeof config.onSandboxMetrics !== "function") {
+    return validationError("onSandboxMetrics must be a function");
+  }
+
+  // All required + optional fields validated. The isRecord guard narrowed config to
+  // Record<string, unknown> which doesn't overlap with SandboxMiddlewareConfig in TS,
+  // so we go through unknown — this is the standard pattern for validation functions.
+  const validated: unknown = config;
+  return { ok: true, value: validated as SandboxMiddlewareConfig };
+}

--- a/packages/middleware-sandbox/src/index.ts
+++ b/packages/middleware-sandbox/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @koi/middleware-sandbox — Sandbox policy enforcement middleware (Layer 2)
+ *
+ * Defense-in-depth timeout, output truncation, error classification,
+ * and observability for sandboxed tool execution.
+ * Depends on @koi/core and @koi/errors only.
+ */
+
+export type { SandboxMiddlewareConfig } from "./config.js";
+export {
+  DEFAULT_OUTPUT_LIMIT_BYTES,
+  DEFAULT_SKIP_TIERS,
+  DEFAULT_TIMEOUT_GRACE_MS,
+  validateConfig,
+} from "./config.js";
+export { createSandboxMiddleware } from "./sandbox-middleware.js";

--- a/packages/middleware-sandbox/src/sandbox-middleware.test.ts
+++ b/packages/middleware-sandbox/src/sandbox-middleware.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for createSandboxMiddleware — 15 cases covering all behavior.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import type { TrustTier } from "@koi/core/ecs";
+import type { ToolHandler, ToolRequest, ToolResponse } from "@koi/core/middleware";
+import type { SandboxProfile } from "@koi/core/sandbox-profile";
+import { KoiRuntimeError } from "@koi/errors";
+import { createMockTurnContext, createSpyToolHandler } from "@koi/test-utils";
+import type { SandboxMiddlewareConfig } from "./config.js";
+import { createSandboxMiddleware } from "./sandbox-middleware.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProfile(tier: TrustTier, timeoutMs: number): SandboxProfile {
+  return {
+    tier,
+    filesystem: {},
+    network: { allow: false },
+    resources: { timeoutMs },
+  };
+}
+
+const SANDBOX_PROFILE = makeProfile("sandbox", 50);
+const VERIFIED_PROFILE = makeProfile("verified", 200);
+const PROMOTED_PROFILE = makeProfile("promoted", 1000);
+
+function profileFor(tier: TrustTier): SandboxProfile {
+  switch (tier) {
+    case "sandbox":
+      return SANDBOX_PROFILE;
+    case "verified":
+      return VERIFIED_PROFILE;
+    case "promoted":
+      return PROMOTED_PROFILE;
+  }
+}
+
+function makeRequest(toolId: string): ToolRequest {
+  return { toolId, input: { arg: "value" } };
+}
+
+function makeConfig(
+  tierMap: Record<string, TrustTier | undefined>,
+  overrides?: Partial<SandboxMiddlewareConfig>,
+): SandboxMiddlewareConfig {
+  return {
+    profileFor,
+    tierFor: (toolId: string) => tierMap[toolId],
+    ...overrides,
+  };
+}
+
+const ctx = createMockTurnContext();
+
+/** Creates a handler that delays for the given milliseconds. */
+function createDelayHandler(delayMs: number, response?: Partial<ToolResponse>): ToolHandler {
+  return async (_request: ToolRequest): Promise<ToolResponse> => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return { output: { result: "delayed" }, ...response };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createSandboxMiddleware", () => {
+  describe("tier resolution", () => {
+    it("passes through promoted tools without wrapping", async () => {
+      const mw = createSandboxMiddleware(makeConfig({ "my-tool": "promoted" }));
+      const spy = createSpyToolHandler({ output: { ok: true } });
+      const request = makeRequest("my-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ ok: true });
+      expect(spy.calls).toHaveLength(1);
+    });
+
+    it("wraps sandbox-tier tools with timeout enforcement", async () => {
+      const mw = createSandboxMiddleware(
+        makeConfig({ "code-exec": "sandbox" }, { timeoutGraceMs: 100 }),
+      );
+      const spy = createSpyToolHandler({ output: { ran: true } });
+      const request = makeRequest("code-exec");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ ran: true });
+      expect(spy.calls).toHaveLength(1);
+    });
+
+    it("wraps verified-tier tools with permissive profile", async () => {
+      const mw = createSandboxMiddleware(
+        makeConfig({ "trusted-tool": "verified" }, { timeoutGraceMs: 100 }),
+      );
+      const spy = createSpyToolHandler({ output: { verified: true } });
+      const request = makeRequest("trusted-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ verified: true });
+      expect(spy.calls).toHaveLength(1);
+    });
+
+    it("treats unknown tools as sandbox when failClosed=true", async () => {
+      const onMetrics = mock(
+        (_toolId: string, _tier: TrustTier, _d: number, _b: number, _t: boolean) => {},
+      );
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          {}, // empty — all tools unknown
+          { failClosedOnLookupError: true, timeoutGraceMs: 100, onSandboxMetrics: onMetrics },
+        ),
+      );
+      const spy = createSpyToolHandler({ output: { fallback: true } });
+      const request = makeRequest("unknown-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ fallback: true });
+      // Metrics should fire with "sandbox" tier (fail-closed fallback)
+      expect(onMetrics).toHaveBeenCalledTimes(1);
+      const call = onMetrics.mock.calls.at(0);
+      expect(call?.at(1)).toBe("sandbox");
+    });
+
+    it("passes through unknown tools when failClosed=false", async () => {
+      const onMetrics = mock(
+        (_toolId: string, _tier: TrustTier, _d: number, _b: number, _t: boolean) => {},
+      );
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          {}, // empty — all tools unknown
+          { failClosedOnLookupError: false, onSandboxMetrics: onMetrics },
+        ),
+      );
+      const spy = createSpyToolHandler({ output: { passThrough: true } });
+      const request = makeRequest("unknown-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ passThrough: true });
+      // No metrics — tool was passed through without wrapping
+      expect(onMetrics).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("timeout enforcement", () => {
+    it("throws TIMEOUT when tool exceeds total timeout", async () => {
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          { "slow-tool": "sandbox" },
+          { timeoutGraceMs: 10 }, // total = 50 + 10 = 60ms
+        ),
+      );
+      // Handler takes 500ms — well beyond 60ms timeout
+      const handler = createDelayHandler(500);
+      const request = makeRequest("slow-tool");
+
+      try {
+        await mw.wrapToolCall?.(ctx, request, handler);
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(KoiRuntimeError);
+        const kErr = error as KoiRuntimeError;
+        expect(kErr.code).toBe("TIMEOUT");
+        expect(kErr.message).toContain("slow-tool");
+        expect(kErr.message).toContain("60ms");
+        expect(kErr.context).toMatchObject({ toolId: "slow-tool", tier: "sandbox" });
+      }
+    });
+
+    it("re-throws non-timeout errors unchanged", async () => {
+      const mw = createSandboxMiddleware(
+        makeConfig({ "fail-tool": "sandbox" }, { timeoutGraceMs: 100 }),
+      );
+      const customError = new Error("something broke");
+      const handler: ToolHandler = async () => {
+        throw customError;
+      };
+      const request = makeRequest("fail-tool");
+
+      try {
+        await mw.wrapToolCall?.(ctx, request, handler);
+        expect(true).toBe(false);
+      } catch (error: unknown) {
+        expect(error).toBe(customError);
+      }
+    });
+
+    it("uses grace period: middleware fires after profile timeout + grace", async () => {
+      // Profile timeout = 50ms, grace = 30ms → total = 80ms
+      // Handler takes 40ms — within 80ms, so should succeed
+      const mw = createSandboxMiddleware(
+        makeConfig({ "borderline-tool": "sandbox" }, { timeoutGraceMs: 30 }),
+      );
+      const handler = createDelayHandler(40);
+      const request = makeRequest("borderline-tool");
+
+      // Should succeed because 40ms < 80ms (50 + 30)
+      const response = await mw.wrapToolCall?.(ctx, request, handler);
+      expect(response?.output).toEqual({ result: "delayed" });
+    });
+  });
+
+  describe("output truncation", () => {
+    it("does not truncate output within limit", async () => {
+      const mw = createSandboxMiddleware(
+        makeConfig({ "small-tool": "sandbox" }, { outputLimitBytes: 1024, timeoutGraceMs: 100 }),
+      );
+      const spy = createSpyToolHandler({ output: { data: "small" } });
+      const request = makeRequest("small-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ data: "small" });
+      expect(response?.metadata?.truncated).toBeUndefined();
+    });
+
+    it("truncates output exceeding limit with metadata", async () => {
+      // Set a very small limit to trigger truncation
+      const mw = createSandboxMiddleware(
+        makeConfig({ "big-tool": "sandbox" }, { outputLimitBytes: 10, timeoutGraceMs: 100 }),
+      );
+      const largeOutput = { data: "this is a string that is definitely longer than 10 bytes" };
+      const spy = createSpyToolHandler({ output: largeOutput });
+      const request = makeRequest("big-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      // Output should be a truncated string
+      expect(typeof response?.output).toBe("string");
+      expect((response?.output as string).endsWith("...[truncated]")).toBe(true);
+      expect(response?.metadata?.truncated).toBe(true);
+      expect(typeof response?.metadata?.originalBytes).toBe("number");
+    });
+  });
+
+  describe("configuration", () => {
+    it("applies perToolOverrides to resource limits", async () => {
+      // Profile timeout = 50ms, but override gives 200ms. Grace = 10ms.
+      // Handler takes 100ms — would timeout with profile (50+10=60) but not with override (200+10=210)
+      const overrides = new Map([["slow-but-ok", { timeoutMs: 200 }]]);
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          { "slow-but-ok": "sandbox" },
+          { perToolOverrides: overrides, timeoutGraceMs: 10 },
+        ),
+      );
+      const handler = createDelayHandler(100);
+      const request = makeRequest("slow-but-ok");
+
+      const response = await mw.wrapToolCall?.(ctx, request, handler);
+      expect(response?.output).toEqual({ result: "delayed" });
+    });
+
+    it("respects skipTiers config", async () => {
+      const onMetrics = mock(
+        (_toolId: string, _tier: TrustTier, _d: number, _b: number, _t: boolean) => {},
+      );
+      // Skip verified tier (not just promoted)
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          { "ver-tool": "verified" },
+          { skipTiers: ["promoted", "verified"], onSandboxMetrics: onMetrics },
+        ),
+      );
+      const spy = createSpyToolHandler({ output: { skipped: true } });
+      const request = makeRequest("ver-tool");
+
+      const response = await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(response?.output).toEqual({ skipped: true });
+      // No metrics — skipped tier
+      expect(onMetrics).toHaveBeenCalledTimes(0);
+    });
+
+    it("has name 'sandbox' and priority 200", () => {
+      const mw = createSandboxMiddleware(makeConfig({}, { failClosedOnLookupError: false }));
+      expect(mw.name).toBe("sandbox");
+      expect(mw.priority).toBe(200);
+    });
+  });
+
+  describe("observability", () => {
+    it("calls onSandboxError on timeout", async () => {
+      const onError = mock((_toolId: string, _tier: TrustTier, _code: string, _msg: string) => {});
+      const mw = createSandboxMiddleware(
+        makeConfig({ "timeout-tool": "sandbox" }, { timeoutGraceMs: 10, onSandboxError: onError }),
+      );
+      const handler = createDelayHandler(500);
+      const request = makeRequest("timeout-tool");
+
+      try {
+        await mw.wrapToolCall?.(ctx, request, handler);
+      } catch {
+        // expected
+      }
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      const call = onError.mock.calls.at(0);
+      expect(call?.at(0)).toBe("timeout-tool");
+      expect(call?.at(1)).toBe("sandbox");
+      expect(call?.at(2)).toBe("TIMEOUT");
+    });
+
+    it("calls onSandboxMetrics for every sandboxed call", async () => {
+      const onMetrics = mock(
+        (_toolId: string, _tier: TrustTier, _d: number, _b: number, _t: boolean) => {},
+      );
+      const mw = createSandboxMiddleware(
+        makeConfig(
+          { "metric-tool": "sandbox" },
+          { timeoutGraceMs: 100, onSandboxMetrics: onMetrics },
+        ),
+      );
+      const spy = createSpyToolHandler({ output: { ok: true } });
+      const request = makeRequest("metric-tool");
+
+      await mw.wrapToolCall?.(ctx, request, spy.handler);
+
+      expect(onMetrics).toHaveBeenCalledTimes(1);
+      const call = onMetrics.mock.calls.at(0);
+      expect(call?.at(0)).toBe("metric-tool");
+      expect(call?.at(1)).toBe("sandbox");
+      expect(typeof call?.at(2)).toBe("number");
+      expect(typeof call?.at(3)).toBe("number");
+      expect(call?.at(4)).toBe(false);
+    });
+  });
+});

--- a/packages/middleware-sandbox/src/sandbox-middleware.ts
+++ b/packages/middleware-sandbox/src/sandbox-middleware.ts
@@ -1,0 +1,141 @@
+/**
+ * Sandbox policy middleware — defense-in-depth timeout, output truncation,
+ * error classification, and observability for sandboxed tool execution.
+ */
+
+import type { TrustTier } from "@koi/core/ecs";
+import type {
+  KoiMiddleware,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import type { SandboxMiddlewareConfig } from "./config.js";
+import {
+  DEFAULT_OUTPUT_LIMIT_BYTES,
+  DEFAULT_SKIP_TIERS,
+  DEFAULT_TIMEOUT_GRACE_MS,
+} from "./config.js";
+
+/** Default timeout when profile does not specify one (30 s). */
+const FALLBACK_TIMEOUT_MS = 30_000;
+
+const TRUNCATION_MARKER = "...[truncated]";
+
+export function createSandboxMiddleware(config: SandboxMiddlewareConfig): KoiMiddleware {
+  const {
+    profileFor,
+    tierFor,
+    outputLimitBytes = DEFAULT_OUTPUT_LIMIT_BYTES,
+    timeoutGraceMs = DEFAULT_TIMEOUT_GRACE_MS,
+    skipTiers = DEFAULT_SKIP_TIERS,
+    perToolOverrides,
+    failClosedOnLookupError = true,
+    onSandboxError,
+    onSandboxMetrics,
+  } = config;
+
+  const skipSet = new Set(skipTiers);
+
+  return {
+    name: "sandbox",
+    priority: 200,
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      // 1. Resolve trust tier
+      const resolvedTier = tierFor(request.toolId);
+      const tier: TrustTier | undefined =
+        resolvedTier ?? (failClosedOnLookupError ? "sandbox" : undefined);
+
+      // Unknown tool + fail-open → pass through
+      if (tier === undefined) {
+        return next(request);
+      }
+
+      // 2. Fast path for skip tiers (promoted by default)
+      if (skipSet.has(tier)) {
+        return next(request);
+      }
+
+      // 3. Resolve effective timeout
+      const profile = profileFor(tier);
+      const overrides = perToolOverrides?.get(request.toolId);
+      const effectiveTimeoutMs =
+        overrides?.timeoutMs ?? profile.resources.timeoutMs ?? FALLBACK_TIMEOUT_MS;
+      const totalTimeoutMs = effectiveTimeoutMs + timeoutGraceMs;
+
+      // 4. Execute with timeout wrapping
+      // let justified: mutable flag tracking async timeout state
+      let timedOut = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const start = performance.now();
+
+      try {
+        const timeoutPromise = new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(() => {
+            timedOut = true;
+            reject(new Error(`middleware-sandbox-timeout:${request.toolId}`));
+          }, totalTimeoutMs);
+        });
+
+        const response = await Promise.race([next(request), timeoutPromise]);
+
+        const durationMs = Math.round(performance.now() - start);
+
+        // 5. Output truncation (byte-accurate)
+        const encoder = new TextEncoder();
+        const encoded = encoder.encode(JSON.stringify(response.output));
+        const bytes = encoded.byteLength;
+        const truncated = bytes > outputLimitBytes;
+
+        onSandboxMetrics?.(request.toolId, tier, durationMs, bytes, truncated);
+
+        if (truncated) {
+          const decoder = new TextDecoder("utf-8", { fatal: false });
+          const truncatedJson =
+            decoder.decode(encoded.slice(0, outputLimitBytes)) + TRUNCATION_MARKER;
+          return {
+            output: truncatedJson,
+            metadata: {
+              ...response.metadata,
+              truncated: true,
+              originalBytes: bytes,
+            },
+          };
+        }
+
+        return response;
+      } catch (error: unknown) {
+        const durationMs = Math.round(performance.now() - start);
+
+        if (timedOut) {
+          const message = `Tool "${request.toolId}" exceeded sandbox timeout (${String(totalTimeoutMs)}ms)`;
+          onSandboxError?.(request.toolId, tier, "TIMEOUT", message);
+          throw KoiRuntimeError.from("TIMEOUT", message, {
+            cause: error,
+            context: {
+              toolId: request.toolId,
+              tier,
+              durationMs,
+              timeoutMs: totalTimeoutMs,
+            },
+          });
+        }
+
+        // Not our timeout — re-throw unchanged
+        throw error;
+      } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+      }
+    },
+  };
+}

--- a/packages/middleware-sandbox/tsconfig.json
+++ b/packages/middleware-sandbox/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-sandbox/tsup.config.ts
+++ b/packages/middleware-sandbox/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/e2e-middleware-sandbox.ts
+++ b/scripts/e2e-middleware-sandbox.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env bun
+
+/**
+ * E2E test script for @koi/middleware-sandbox — validates that sandbox policy
+ * enforcement (timeout, output truncation, tier resolution, observability)
+ * works end-to-end through the full middleware composition chain with a real
+ * Anthropic LLM call + Pi agent.
+ *
+ * Tests:
+ *   1. Sandbox middleware wraps tool calls — onSandboxMetrics fires
+ *   2. Promoted tool skips sandbox wrapping entirely
+ *   3. Output truncation triggers on oversized output
+ *   4. Full Pi agent run: real LLM triggers tool → sandbox middleware wraps it
+ *   5. Timeout enforcement fires on slow tool
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-middleware-sandbox.ts
+ *
+ *   Or if .env has ANTHROPIC_API_KEY:
+ *   bun scripts/e2e-middleware-sandbox.ts
+ *
+ * Cost: ~$0.01-0.03 per run (haiku model, minimal prompts).
+ */
+
+import type { TrustTier } from "../packages/core/src/ecs.js";
+import { toolToken } from "../packages/core/src/ecs.js";
+import type {
+  ComponentProvider,
+  EngineEvent,
+  Tool,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+} from "../packages/core/src/index.js";
+import type { SandboxProfile } from "../packages/core/src/sandbox-profile.js";
+import { composeToolChain } from "../packages/engine/src/compose.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { KoiRuntimeError } from "../packages/errors/src/index.js";
+import { createSandboxMiddleware } from "../packages/middleware-sandbox/src/index.js";
+import { createMockTurnContext } from "../packages/test-utils/src/index.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping E2E tests.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting middleware-sandbox E2E tests...\n");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = []; // let justified: test accumulator
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+  if (detail && !condition) console.log(`         ${detail}`);
+}
+
+function makeProfile(tier: TrustTier, timeoutMs: number): SandboxProfile {
+  return {
+    tier,
+    filesystem: {},
+    network: { allow: false },
+    resources: { timeoutMs },
+  };
+}
+
+function profileFor(tier: TrustTier): SandboxProfile {
+  switch (tier) {
+    case "sandbox":
+      return makeProfile("sandbox", 5_000);
+    case "verified":
+      return makeProfile("verified", 10_000);
+    case "promoted":
+      return makeProfile("promoted", 30_000);
+  }
+}
+
+const ctx = createMockTurnContext();
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — Sandbox middleware wraps tool calls, onSandboxMetrics fires
+// ---------------------------------------------------------------------------
+
+console.log("[test 1] Sandbox middleware wraps tool calls — metrics callback fires");
+
+const metricsLog1: Array<{
+  readonly toolId: string;
+  readonly tier: TrustTier;
+  readonly durationMs: number;
+  readonly outputBytes: number;
+  readonly truncated: boolean;
+}> = []; // let justified: test accumulator
+
+const tierMap1: Record<string, TrustTier> = { get_weather: "sandbox" };
+
+const sandboxMw1 = createSandboxMiddleware({
+  profileFor,
+  tierFor: (toolId: string) => tierMap1[toolId],
+  timeoutGraceMs: 5_000,
+  onSandboxMetrics: (toolId, tier, durationMs, outputBytes, truncated) => {
+    metricsLog1.push({ toolId, tier, durationMs, outputBytes, truncated });
+  },
+});
+
+const weatherTerminal: ToolHandler = async (_request: ToolRequest): Promise<ToolResponse> => {
+  return { output: { temperature: "22C", condition: "sunny", city: "Tokyo" } };
+};
+
+const toolChain1 = composeToolChain([sandboxMw1], weatherTerminal);
+const response1 = await toolChain1(ctx, { toolId: "get_weather", input: { city: "Tokyo" } });
+
+assert(
+  "tool returned expected output",
+  (response1.output as { temperature: string }).temperature === "22C",
+);
+assert("onSandboxMetrics fired once", metricsLog1.length === 1, `Got ${metricsLog1.length}`);
+
+const metric1 = metricsLog1[0];
+if (metric1) {
+  assert("metric toolId is get_weather", metric1.toolId === "get_weather");
+  assert("metric tier is sandbox", metric1.tier === "sandbox");
+  assert("metric durationMs >= 0", metric1.durationMs >= 0, `Got ${metric1.durationMs}`);
+  assert("metric outputBytes > 0", metric1.outputBytes > 0, `Got ${metric1.outputBytes}`);
+  assert("metric truncated is false", metric1.truncated === false);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — Promoted tool skips sandbox wrapping entirely
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 2] Promoted tool skips sandbox wrapping — no metrics");
+
+const metricsLog2: unknown[] = []; // let justified: test accumulator
+const tierMap2: Record<string, TrustTier> = { trusted_tool: "promoted" };
+
+const sandboxMw2 = createSandboxMiddleware({
+  profileFor,
+  tierFor: (toolId: string) => tierMap2[toolId],
+  onSandboxMetrics: () => {
+    metricsLog2.push(true);
+  },
+});
+
+const trustedTerminal: ToolHandler = async (): Promise<ToolResponse> => {
+  return { output: { status: "ok" } };
+};
+
+const toolChain2 = composeToolChain([sandboxMw2], trustedTerminal);
+const response2 = await toolChain2(ctx, { toolId: "trusted_tool", input: {} });
+
+assert("promoted tool returned output", (response2.output as { status: string }).status === "ok");
+assert("no metrics fired for promoted tier", metricsLog2.length === 0, `Got ${metricsLog2.length}`);
+
+// ---------------------------------------------------------------------------
+// Test 3 — Output truncation triggers on oversized output
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 3] Output truncation on oversized tool output");
+
+const metricsLog3: Array<{ readonly truncated: boolean; readonly outputBytes: number }> = [];
+
+const sandboxMw3 = createSandboxMiddleware({
+  profileFor,
+  tierFor: () => "sandbox",
+  outputLimitBytes: 50, // very small limit
+  timeoutGraceMs: 5_000,
+  onSandboxMetrics: (_toolId, _tier, _d, outputBytes, truncated) => {
+    metricsLog3.push({ outputBytes, truncated });
+  },
+});
+
+const bigOutputTerminal: ToolHandler = async (): Promise<ToolResponse> => {
+  return { output: { data: "A".repeat(200), extra: "B".repeat(200) } };
+};
+
+const toolChain3 = composeToolChain([sandboxMw3], bigOutputTerminal);
+const response3 = await toolChain3(ctx, { toolId: "big_tool", input: {} });
+
+assert("output is a truncated string", typeof response3.output === "string");
+assert(
+  "output ends with truncation marker",
+  (response3.output as string).endsWith("...[truncated]"),
+  `Got: "${(response3.output as string).slice(-30)}"`,
+);
+assert("metadata.truncated is true", response3.metadata?.truncated === true);
+assert("metadata.originalBytes is a number", typeof response3.metadata?.originalBytes === "number");
+assert(
+  "metrics show truncated=true",
+  metricsLog3[0]?.truncated === true,
+  `Got: ${JSON.stringify(metricsLog3[0])}`,
+);
+
+// ---------------------------------------------------------------------------
+// Test 4 — Full Pi agent (createPiAdapter): real LLM triggers tool → sandbox wraps it
+// ---------------------------------------------------------------------------
+
+console.log(
+  "\n[test 4] Full Pi agent (createPiAdapter) — real LLM + tool call through sandbox middleware",
+);
+
+const PI_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const TIMEOUT_MS = 60_000;
+
+const metricsLog4: Array<{
+  readonly toolId: string;
+  readonly tier: TrustTier;
+  readonly durationMs: number;
+}> = [];
+
+let toolExecuted4 = false; // let justified: toggled in tool execute
+
+const weatherTool4: Tool = {
+  descriptor: {
+    name: "get_weather",
+    description: "Get the current weather for a city. Returns JSON with temperature and condition.",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string", description: "City name" } },
+      required: ["city"],
+    },
+  },
+  trustTier: "sandbox",
+  execute: async () => {
+    toolExecuted4 = true;
+    return { temperature: "22C", condition: "sunny" };
+  },
+};
+
+const toolProvider4: ComponentProvider = {
+  name: "e2e-sandbox-tool-provider",
+  attach: async () => {
+    const components = new Map<string, unknown>();
+    components.set(toolToken("get_weather"), weatherTool4);
+    return components;
+  },
+};
+
+const sandboxMw4 = createSandboxMiddleware({
+  profileFor,
+  tierFor: (toolId: string) => {
+    if (toolId === "get_weather") return "sandbox";
+    return undefined;
+  },
+  timeoutGraceMs: 5_000,
+  failClosedOnLookupError: true,
+  onSandboxMetrics: (toolId, tier, durationMs) => {
+    metricsLog4.push({ toolId, tier, durationMs });
+  },
+  onSandboxError: (toolId, tier, code, message) => {
+    console.log(`  [sandbox-error] ${toolId} (${tier}): ${code} — ${message}`);
+  },
+});
+
+// Real Pi adapter — full Anthropic LLM calls, no deterministic shortcuts
+const piAdapter4 = createPiAdapter({
+  model: PI_MODEL,
+  systemPrompt: [
+    'You have ONE task: call the get_weather tool with city "Tokyo".',
+    "After getting the result, report the temperature.",
+    "Do NOT say anything before calling the tool. Just call it immediately.",
+  ].join("\n"),
+  getApiKey: async () => API_KEY,
+});
+
+const runtime4 = await createKoi({
+  manifest: { name: "e2e-sandbox-pi", version: "0.0.1", model: { name: PI_MODEL } },
+  adapter: piAdapter4,
+  middleware: [sandboxMw4],
+  providers: [toolProvider4],
+  limits: { maxTurns: 10, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+});
+
+try {
+  const events4 = await Promise.race([
+    collectEvents(runtime4.run({ kind: "text", text: "What is the weather in Tokyo?" })),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Test 4 timed out after 60s")), TIMEOUT_MS),
+    ),
+  ]);
+
+  const doneEvent = events4.find((e) => e.kind === "done");
+  assert("pi agent completed", doneEvent !== undefined);
+  if (doneEvent?.kind === "done") {
+    assert("stop reason is completed", doneEvent.output.stopReason === "completed");
+  }
+
+  assert("tool was executed via pi agent", toolExecuted4 === true);
+  assert(
+    "sandbox metrics fired for get_weather",
+    metricsLog4.some((m) => m.toolId === "get_weather"),
+    `Metrics: ${JSON.stringify(metricsLog4)}`,
+  );
+
+  const weatherMetric = metricsLog4.find((m) => m.toolId === "get_weather");
+  if (weatherMetric) {
+    assert("metric tier is sandbox", weatherMetric.tier === "sandbox");
+    assert("metric durationMs >= 0", weatherMetric.durationMs >= 0);
+  }
+
+  // Verify Pi adapter emitted tool call events through the sandbox middleware
+  const toolCallEvents = events4.filter(
+    (e) => e.kind === "tool_call_start" || e.kind === "tool_call_end",
+  );
+  assert(
+    "pi agent produced tool_call events",
+    toolCallEvents.length >= 2,
+    `Got ${toolCallEvents.length} tool_call events`,
+  );
+
+  console.log(`  Pi agent completed with ${events4.length} events`);
+} finally {
+  await runtime4.dispose?.();
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — Timeout enforcement on slow tool
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 5] Timeout enforcement fires on slow tool");
+
+const errorsLog5: Array<{ readonly toolId: string; readonly code: string }> = [];
+
+const sandboxMw5 = createSandboxMiddleware({
+  profileFor: (tier: TrustTier) => makeProfile(tier, 100), // 100ms timeout
+  tierFor: () => "sandbox",
+  timeoutGraceMs: 50, // total = 150ms
+  onSandboxError: (toolId, _tier, code) => {
+    errorsLog5.push({ toolId, code });
+  },
+});
+
+const slowTerminal: ToolHandler = async (): Promise<ToolResponse> => {
+  await new Promise((resolve) => setTimeout(resolve, 1_000)); // 1s >> 150ms
+  return { output: { data: "should not reach" } };
+};
+
+const toolChain5 = composeToolChain([sandboxMw5], slowTerminal);
+
+let timeoutErrorCaught = false; // let justified: toggled in catch
+try {
+  await toolChain5(ctx, { toolId: "slow_tool", input: {} });
+} catch (error: unknown) {
+  // instanceof may fail across source/dist module boundaries, so also check duck-typed code
+  const isKoiTimeout =
+    (error instanceof KoiRuntimeError && error.code === "TIMEOUT") ||
+    (error instanceof Error &&
+      "code" in error &&
+      (error as { readonly code: string }).code === "TIMEOUT");
+  if (isKoiTimeout) {
+    timeoutErrorCaught = true;
+  }
+}
+
+assert("TIMEOUT error thrown for slow tool", timeoutErrorCaught === true);
+assert(
+  "onSandboxError fired",
+  errorsLog5.length === 1,
+  `Got ${errorsLog5.length} errors: ${JSON.stringify(errorsLog5)}`,
+);
+assert("error code is TIMEOUT", errorsLog5[0]?.code === "TIMEOUT", `Got: ${errorsLog5[0]?.code}`);
+assert(
+  "error toolId is slow_tool",
+  errorsLog5[0]?.toolId === "slow_tool",
+  `Got: ${errorsLog5[0]?.toolId}`,
+);
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n${"─".repeat(60)}`);
+console.log(`[e2e] Results: ${passed}/${total} passed`);
+console.log("─".repeat(60));
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}`);
+      if (r.detail) console.error(`        ${r.detail}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e] ALL MIDDLEWARE-SANDBOX E2E TESTS PASSED!");


### PR DESCRIPTION
## Summary

- Adds `@koi/middleware-sandbox` — defense-in-depth policy middleware for sandboxed tool execution (L2 package, depends only on `@koi/core` + `@koi/errors`)
- Enforces timeout (profile timeout + configurable grace period), output truncation (byte-accurate via TextEncoder/TextDecoder), error classification (`KoiRuntimeError`), and observability (`onSandboxMetrics`, `onSandboxError` callbacks)
- Trust tier resolution via `tierFor(toolId)` with fail-closed default (unknown tools → sandbox tier), fast-path skip for promoted tools
- Includes E2E validation script using `createPiAdapter` + real Anthropic API through the full `createKoi` runtime assembly path

## Files

| File | Purpose |
|------|---------|
| `packages/middleware-sandbox/src/config.ts` | `SandboxMiddlewareConfig` type + `validateConfig` |
| `packages/middleware-sandbox/src/sandbox-middleware.ts` | `createSandboxMiddleware` factory |
| `packages/middleware-sandbox/src/index.ts` | Public API re-exports |
| `packages/middleware-sandbox/src/config.test.ts` | 20 validation tests |
| `packages/middleware-sandbox/src/sandbox-middleware.test.ts` | 15 behavior tests |
| `packages/middleware-sandbox/src/__tests__/api-surface.test.ts` | API surface snapshot |
| `scripts/e2e-middleware-sandbox.ts` | 5-test E2E script (real LLM + Pi agent) |

## Verification

- 37/37 unit tests, 100% coverage
- 25/25 E2E tests (including real `createPiAdapter` + Anthropic API)
- Build, typecheck, lint all clean
- Layer compliance: L0 + L0u only, zero peer L2 imports
- API surface snapshot in place

## Test plan

- [x] `bun test packages/middleware-sandbox` — 37/37 pass
- [x] `bun run build --filter=@koi/middleware-sandbox` — clean
- [x] `bun run typecheck --filter=@koi/middleware-sandbox` — clean
- [x] `bun run lint --filter=@koi/middleware-sandbox` — clean
- [x] `bun scripts/e2e-middleware-sandbox.ts` — 25/25 pass (requires `ANTHROPIC_API_KEY`)

Closes #145