### PR TITLE
feat(tool-browser): browser_console tool + retryAfterMs + INTERNAL error guidance

### DIFF
--- a/packages/browser-playwright/src/error-translator.test.ts
+++ b/packages/browser-playwright/src/error-translator.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { translatePlaywrightError } from "./error-translator.js";
+
+// ---------------------------------------------------------------------------
+// Helper: construct a Playwright-style Error with a given name + message
+// ---------------------------------------------------------------------------
+
+function playwrightError(message: string, name = "Error"): Error {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+describe("translatePlaywrightError", () => {
+  // Pattern 1: TimeoutError
+  test("maps TimeoutError (by name) to TIMEOUT code", () => {
+    const err = playwrightError(
+      "Timeout 3000ms exceeded while waiting for element",
+      "TimeoutError",
+    );
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("TIMEOUT");
+    expect(result.message).toContain("browser_click");
+    expect(result.message).toContain("browser_snapshot");
+    expect(result.retryable).toBe(true);
+  });
+
+  test("maps message containing 'Timeout ' to TIMEOUT code", () => {
+    const err = playwrightError("Timeout 5000ms exceeded");
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("TIMEOUT");
+  });
+
+  // Pattern 2: Element detached from DOM
+  test("maps 'element is detached' to STALE_REF code", () => {
+    const err = playwrightError("locator.click: element is detached from document");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+    expect(result.message).toContain("browser_snapshot");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps 'element is not stable' to STALE_REF code", () => {
+    const err = playwrightError("locator.click: element is not stable");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+  });
+
+  test("maps 'not attached to a Document' to STALE_REF code", () => {
+    const err = playwrightError("locator.fill: element is not attached to a Document");
+    const result = translatePlaywrightError("browser_type", err);
+    expect(result.code).toBe("STALE_REF");
+  });
+
+  // Pattern 3: Execution context destroyed
+  test("maps 'Execution context was destroyed' to STALE_REF code", () => {
+    const err = playwrightError(
+      "Execution context was destroyed, most likely because of a navigation.",
+    );
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+    expect(result.message).toContain("navigated");
+    expect(result.message).toContain("browser_snapshot");
+  });
+
+  // Pattern 4: Network navigation failures
+  test("maps net::ERR_NAME_NOT_RESOLVED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_NAME_NOT_RESOLVED at https://nonexistent.example");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("reachable");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps net::ERR_CONNECTION_REFUSED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_CONNECTION_REFUSED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  test("maps net::ERR_ABORTED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_ABORTED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  // Pattern 5: Page/target closed
+  test("maps 'Target closed' to INTERNAL code", () => {
+    const err = playwrightError("Target closed.");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("closed unexpectedly");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps 'page has been closed' to INTERNAL code", () => {
+    const err = playwrightError("locator.click: page has been closed");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+  });
+
+  // Pattern 6: WebSocket / connection lost
+  test("maps 'WebSocket error' to INTERNAL code", () => {
+    const err = playwrightError("WebSocket error: connection refused");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("connection was lost");
+  });
+
+  // Pattern 7: JavaScript eval error
+  test("maps 'Evaluation failed:' to EXTERNAL code", () => {
+    const err = playwrightError("Evaluation failed: ReferenceError: window.myFn is not defined");
+    const result = translatePlaywrightError("browser_evaluate", err);
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("JavaScript");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps 'is not a function' to EXTERNAL code", () => {
+    const err = playwrightError("document.querySelectorAll is not a function");
+    const result = translatePlaywrightError("browser_evaluate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  // Pattern 8: Invalid CSS selector
+  test("maps 'is not a valid selector' to VALIDATION code", () => {
+    const err = playwrightError(".foo[[bar] is not a valid selector");
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("VALIDATION");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps 'Failed to execute querySelector' to VALIDATION code", () => {
+    const err = playwrightError(
+      "Failed to execute 'querySelector' on 'Document': '#bad>>' is not a valid selector.",
+    );
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("VALIDATION");
+  });
+
+  // Pattern 9: CORS / security policy
+  test("maps CORS error to PERMISSION code", () => {
+    const err = playwrightError("Blocked by CORS policy: No 'Access-Control-Allow-Origin' header");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("PERMISSION");
+    expect(result.message).toContain("security policy");
+  });
+
+  test("maps ERR_BLOCKED_BY_CLIENT to PERMISSION code", () => {
+    const err = playwrightError("net::ERR_BLOCKED_BY_CLIENT");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("PERMISSION");
+  });
+
+  // Default fallback
+  test("defaults unknown errors to INTERNAL with cause preserved", () => {
+    const err = playwrightError("Something completely unexpected happened");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("browser_click");
+    expect(result.cause).toBe(err);
+  });
+
+  test("handles non-Error thrown values", () => {
+    const result = translatePlaywrightError("browser_click", "raw string error");
+    expect(result.code).toBe("INTERNAL");
+  });
+
+  // Operation name appears in error messages for traceability
+  test("includes operation name in TIMEOUT messages", () => {
+    const err = playwrightError("Timeout 3000ms exceeded", "TimeoutError");
+    const result = translatePlaywrightError("browser_fill_form", err);
+    expect(result.message).toContain("browser_fill_form");
+  });
+
+  test("includes operation name in EXTERNAL messages", () => {
+    const err = playwrightError("net::ERR_CONNECTION_REFUSED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.message).toContain("browser_navigate");
+  });
+});

--- a/packages/browser-playwright/src/error-translator.ts
+++ b/packages/browser-playwright/src/error-translator.ts
@@ -1,0 +1,183 @@
+/**
+ * Playwright → KoiError translator.
+ *
+ * Maps raw Playwright exceptions to typed KoiError objects with
+ * actionable guidance for LLM agents. Uses name/message checks
+ * since Playwright's TypeScript types don't export error classes.
+ *
+ * ## 9-pattern taxonomy
+ *
+ * | Pattern                        | Code        | Guidance                                    |
+ * |-------------------------------|-------------|---------------------------------------------|
+ * | TimeoutError (name check)     | TIMEOUT     | Try browser_wait or re-snapshot first        |
+ * | Element detached from DOM     | STALE_REF   | Call browser_snapshot to refresh refs        |
+ * | Execution context destroyed   | STALE_REF   | Page navigated — call browser_snapshot       |
+ * | Blocked by policy (CORS etc.) | PERMISSION  | Blocked by browser security policy           |
+ * | net::ERR_* navigation failure | EXTERNAL    | Check the URL is reachable                  |
+ * | Page/target closed            | INTERNAL    | Browser page closed unexpectedly             |
+ * | WebSocket disconnected        | INTERNAL    | Browser connection lost                      |
+ * | JavaScript eval error         | EXTERNAL    | Page JS threw an error                       |
+ * | Invalid CSS selector syntax   | VALIDATION  | Fix the CSS selector string                  |
+ */
+
+import type { KoiError } from "@koi/core";
+import { external, internal, permission, staleRef, timeout, validation } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Extract a message string safely from an unknown caught value. */
+function extractMsg(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** True when the error's `.name` property equals the given value. */
+function hasName(err: unknown, name: string): boolean {
+  return err instanceof Error && err.name === name;
+}
+
+/** True when the message includes any of the given fragments. */
+function msgIncludes(msg: string, ...fragments: readonly string[]): boolean {
+  return fragments.some((f) => msg.includes(f));
+}
+
+// ---------------------------------------------------------------------------
+// Main translator
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a caught Playwright exception to a typed KoiError with actionable
+ * guidance for LLM agents.
+ *
+ * @param operation - The browser operation that failed (e.g., "browser_click").
+ *                    Used in fallback INTERNAL messages for traceability.
+ * @param err       - The caught value from a catch block (`e: unknown`).
+ */
+export function translatePlaywrightError(operation: string, err: unknown): KoiError {
+  const msg = extractMsg(err);
+
+  // Pattern 1: TimeoutError — check .name since Playwright doesn't export the class
+  if (hasName(err, "TimeoutError") || msgIncludes(msg, "Timeout ", "timeout exceeded")) {
+    return timeout(
+      `${operation} timed out — try browser_wait first, increase the timeout, ` +
+        "or call browser_snapshot to verify the element is visible",
+      2_000,
+    );
+  }
+
+  // Pattern 2 & 3: Stale element / execution context destroyed
+  // These both indicate the DOM or page changed after the last snapshot.
+  if (
+    msgIncludes(
+      msg,
+      "element is detached",
+      "Element is detached",
+      "element was detached",
+      "is detached from document",
+      "not attached to a Document",
+      "element is not stable",
+      "not stable",
+    )
+  ) {
+    return staleRef(
+      "element",
+      "call browser_snapshot to get fresh refs — the DOM changed since your last snapshot",
+    );
+  }
+
+  if (msgIncludes(msg, "Execution context was destroyed", "execution context was destroyed")) {
+    return staleRef(
+      "page",
+      "the page navigated and all refs are now stale — call browser_snapshot to continue",
+    );
+  }
+
+  // Pattern 4: CORS / policy / security blocks
+  // Checked BEFORE generic net::ERR_* to avoid ERR_BLOCKED_BY_CLIENT being misclassified.
+  if (
+    msgIncludes(
+      msg,
+      "Access-Control-Allow-Origin",
+      "CORS",
+      "Cross-Origin",
+      "Blocked by CORS policy",
+      "ERR_BLOCKED_BY_CLIENT",
+      "ERR_BLOCKED_BY_RESPONSE",
+    )
+  ) {
+    return permission(
+      `${operation} blocked by browser security policy (CORS or content policy) — ${msg}`,
+    );
+  }
+
+  // Pattern 5: Network navigation failures
+  if (
+    msgIncludes(
+      msg,
+      "net::ERR_NAME_NOT_RESOLVED",
+      "net::ERR_CONNECTION_REFUSED",
+      "net::ERR_CONNECTION_TIMED_OUT",
+      "net::ERR_ABORTED",
+      "net::ERR_CERT_",
+      "net::ERR_",
+      "ERR_NAME_NOT_RESOLVED",
+      "ERR_CONNECTION",
+    )
+  ) {
+    return external(
+      `${operation} failed: navigation error — check the URL is reachable (${msg})`,
+      err,
+    );
+  }
+
+  // Pattern 6: Page or browser target closed unexpectedly
+  if (
+    msgIncludes(
+      msg,
+      "Target closed",
+      "Target page, context or browser has been closed",
+      "Page closed",
+      "page has been closed",
+      "browser has disconnected",
+    )
+  ) {
+    return internal(`${operation} failed: browser page was closed unexpectedly`, err);
+  }
+
+  // Pattern 7: WebSocket / CDP connection lost
+  if (msgIncludes(msg, "WebSocket error", "socket hang up", "Connection closed")) {
+    return internal(`${operation} failed: browser connection was lost`, err);
+  }
+
+  // Pattern 8: JavaScript evaluation errors (thrown inside the page)
+  if (
+    msgIncludes(
+      msg,
+      "Evaluation failed:",
+      "evaluation failed",
+      "Cannot read properties of",
+      "is not defined",
+      "is not a function",
+    )
+  ) {
+    return external(`${operation} failed: JavaScript in the page threw an error — ${msg}`, err);
+  }
+
+  // Pattern 9: Invalid CSS selector syntax
+  if (
+    msgIncludes(
+      msg,
+      "is not a valid selector",
+      "Failed to execute 'querySelector'",
+      "Invalid selector",
+      "SyntaxError: ",
+    )
+  ) {
+    return validation(`${operation} failed: invalid CSS selector syntax — ${msg}`);
+  }
+
+  // Default: unexpected error, preserve cause for debugging
+  return internal(`${operation} failed`, err);
+}

--- a/packages/browser-playwright/src/index.ts
+++ b/packages/browser-playwright/src/index.ts
@@ -9,6 +9,7 @@ export type { A11yNode, SerializeResult } from "./a11y-serializer.js";
 export { isAriaRole, parseAriaYaml, serializeA11yTree, VALID_ROLES } from "./a11y-serializer.js";
 export type { DetectedBrowser } from "./browser-detection.js";
 export { detectInstalledBrowsers } from "./browser-detection.js";
+export { translatePlaywrightError } from "./error-translator.js";
 
 export type { PlaywrightDriverConfig } from "./playwright-browser-driver.js";
 export { createPlaywrightBrowserDriver, STEALTH_INIT_SCRIPT } from "./playwright-browser-driver.js";

--- a/packages/browser-playwright/src/playwright-browser-driver.test.ts
+++ b/packages/browser-playwright/src/playwright-browser-driver.test.ts
@@ -42,8 +42,10 @@ interface MockPage {
   readonly evaluate: MockFn;
   readonly bringToFront: MockFn;
   readonly close: MockFn;
-  // Test helper — exposed by makeMockPage
+  readonly on: MockFn;
+  // Test helpers — exposed by makeMockPage
   readonly _locator: MockLocator;
+  readonly _triggerConsole: (msg: MockConsoleMessage) => void;
 }
 
 interface MockBrowserContext {
@@ -56,6 +58,26 @@ interface MockBrowser {
   readonly newContext: MockFn;
   readonly close: MockFn;
   readonly contexts: MockFn;
+}
+
+/** Minimal Playwright ConsoleMessage shape used by the driver's console listener. */
+interface MockConsoleMessage {
+  type(): string;
+  text(): string;
+  location(): { url: string; lineNumber: number; columnNumber: number };
+}
+
+function makeConsoleMsg(
+  type: string,
+  text: string,
+  url?: string,
+  lineNumber?: number,
+): MockConsoleMessage {
+  return {
+    type: () => type,
+    text: () => text,
+    location: () => ({ url: url ?? "", lineNumber: lineNumber ?? 0, columnNumber: 0 }),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -98,6 +120,9 @@ function makeMockPage(opts?: {
     })),
     elementHandle: mock(() => Promise.resolve(null)),
   };
+  // let: required to capture the handler registered by the driver's attachConsoleListener
+  // biome-ignore lint/suspicious/noExplicitAny: captures Playwright ConsoleMessage handler
+  let _consoleHandler: ((msg: any) => void) | undefined;
   return {
     url: mock(() => opts?.urlValue ?? "https://example.com"),
     title: mock(() => Promise.resolve(opts?.titleValue ?? "Test Page")),
@@ -131,7 +156,16 @@ function makeMockPage(opts?: {
     evaluate: mock((_script: string) => Promise.resolve("eval-result")),
     bringToFront: mock(() => Promise.resolve()),
     close: mock(() => Promise.resolve()),
+    on: mock((event: string, handler: (msg: unknown) => void) => {
+      if (event === "console") {
+        // biome-ignore lint/suspicious/noExplicitAny: test injection boundary
+        _consoleHandler = handler as (msg: any) => void;
+      }
+    }),
     _locator: locator,
+    _triggerConsole: (msg: MockConsoleMessage) => {
+      if (_consoleHandler !== undefined) _consoleHandler(msg);
+    },
   };
 }
 
@@ -220,7 +254,7 @@ describe("createPlaywrightBrowserDriver", () => {
       const result = await driver.click("e1", { snapshotId: "snap-999" });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
       expect(result.error.message).toContain("stale");
     });
 
@@ -260,7 +294,7 @@ describe("createPlaywrightBrowserDriver", () => {
       const click = await driver.click("e1", { snapshotId });
       expect(click.ok).toBe(false);
       if (click.ok) return;
-      expect(click.error.code).toBe("NOT_FOUND");
+      expect(click.error.code).toBe("STALE_REF");
     });
 
     it("returns VALIDATION error when timeout exceeds cap", async () => {
@@ -351,13 +385,13 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(result.ok).toBe(true);
     });
 
-    it("returns NOT_FOUND for unknown ref", async () => {
+    it("returns STALE_REF for unknown ref", async () => {
       const { driver } = buildDriver();
       await driver.snapshot();
       const result = await driver.type("e99", "hello");
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("returns VALIDATION when timeout exceeds cap", async () => {
@@ -375,7 +409,7 @@ describe("createPlaywrightBrowserDriver", () => {
       const result = await driver.type("e1", "hello", { snapshotId: "snap-999" });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("clears before filling when clear=true", async () => {
@@ -395,13 +429,13 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(result.ok).toBe(true);
     });
 
-    it("returns NOT_FOUND for unknown ref", async () => {
+    it("returns STALE_REF for unknown ref", async () => {
       const { driver } = buildDriver();
       await driver.snapshot();
       const result = await driver.select("e99", "opt-value");
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("rejects stale snapshotId", async () => {
@@ -410,7 +444,7 @@ describe("createPlaywrightBrowserDriver", () => {
       const result = await driver.select("e1", "v", { snapshotId: "stale-id" });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
   });
 
@@ -425,7 +459,7 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(result.ok).toBe(true);
     });
 
-    it("returns NOT_FOUND when any field ref is missing", async () => {
+    it("returns STALE_REF when any field ref is missing", async () => {
       const { driver } = buildDriver();
       await driver.snapshot();
       const result = await driver.fillForm([
@@ -434,7 +468,7 @@ describe("createPlaywrightBrowserDriver", () => {
       ]);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("returns VALIDATION when timeout exceeds cap", async () => {
@@ -463,13 +497,13 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(result.ok).toBe(true);
     });
 
-    it("element scroll returns NOT_FOUND for unknown ref", async () => {
+    it("element scroll returns STALE_REF for unknown ref", async () => {
       const { driver } = buildDriver();
       await driver.snapshot();
       const result = await driver.scroll({ kind: "element", ref: "e99" });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("scroll up direction inverts Y axis", async () => {
@@ -629,13 +663,13 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(result.ok).toBe(true);
     });
 
-    it("returns NOT_FOUND for unknown ref", async () => {
+    it("returns STALE_REF for unknown ref", async () => {
       const { driver } = buildDriver();
       await driver.snapshot();
       const result = await driver.hover("e99");
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("rejects stale snapshotId", async () => {
@@ -644,7 +678,7 @@ describe("createPlaywrightBrowserDriver", () => {
       const result = await driver.hover("e1", { snapshotId: "snap-999" });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
     });
 
     it("returns VALIDATION when timeout exceeds cap", async () => {
@@ -786,7 +820,7 @@ describe("createPlaywrightBrowserDriver", () => {
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.code).toBe("STALE_REF");
 
       // Regression: fill() must NOT have been called at all
       expect(page._locator.fill.mock.calls.length).toBe(0);
@@ -823,8 +857,8 @@ describe("createPlaywrightBrowserDriver", () => {
       const contextHolder = { current: context };
       browserMock.contexts.mockImplementation(() => [contextHolder.current]);
 
-      // biome-ignore lint/suspicious/noExplicitAny: test injection boundary
       const driver = createPlaywrightBrowserDriver({
+        // biome-ignore lint/suspicious/noExplicitAny: test injection boundary
         browser: browserMock as any,
         cdpEndpoint: "ws://localhost:9222",
       });
@@ -1042,6 +1076,95 @@ describe("createPlaywrightBrowserDriver", () => {
       expect(
         (page.frameLocator.mock.calls as string[][]).some((args) => args[0] === "#form-frame"),
       ).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // console() — per-tab console buffer
+  // ---------------------------------------------------------------------------
+
+  describe("console()", () => {
+    it("returns empty entries for new tab", async () => {
+      const { driver } = buildDriver();
+      await driver.snapshot(); // creates tab-1 with empty buffer
+      const result = await driver.console();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.entries.length).toBe(0);
+      expect(result.value.total).toBe(0);
+    });
+
+    it("captures log, warning, and error entries", async () => {
+      const { driver, page } = buildDriver();
+      await driver.snapshot();
+      page._triggerConsole(makeConsoleMsg("log", "hello world", "https://example.com/app.js", 10));
+      page._triggerConsole(makeConsoleMsg("warning", "deprecated api"));
+      page._triggerConsole(makeConsoleMsg("error", "something broke"));
+      const result = await driver.console();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.total).toBe(3);
+      expect(result.value.entries.map((e) => e.level)).toEqual(["log", "warning", "error"]);
+    });
+
+    it("filters by level", async () => {
+      const { driver, page } = buildDriver();
+      await driver.snapshot();
+      page._triggerConsole(makeConsoleMsg("log", "info message"));
+      page._triggerConsole(makeConsoleMsg("error", "error message"));
+      page._triggerConsole(makeConsoleMsg("warning", "warning message"));
+      const result = await driver.console({ levels: ["error"] });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.total).toBe(1);
+      expect(result.value.entries[0]?.level).toBe("error");
+      expect(result.value.entries[0]?.text).toBe("error message");
+    });
+
+    it("respects limit returning most recent N", async () => {
+      const { driver, page } = buildDriver();
+      await driver.snapshot();
+      for (let i = 0; i < 10; i++) {
+        page._triggerConsole(makeConsoleMsg("log", `message ${i}`));
+      }
+      const result = await driver.console({ limit: 3 });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // total reflects all 10 entries; entries is the last 3
+      expect(result.value.total).toBe(10);
+      expect(result.value.entries.length).toBe(3);
+      expect(result.value.entries[2]?.text).toBe("message 9");
+    });
+
+    it("clears buffer when clear: true", async () => {
+      const { driver, page } = buildDriver();
+      await driver.snapshot();
+      page._triggerConsole(makeConsoleMsg("log", "before clear"));
+      await driver.console({ clear: true });
+      // Second call should return empty buffer
+      const result = await driver.console();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.entries.length).toBe(0);
+    });
+
+    it("buffers up to 1000 entries with FIFO eviction", async () => {
+      const { driver, page } = buildDriver();
+      await driver.snapshot();
+      // Push 1001 messages — cap is 1000, first message should be evicted
+      for (let i = 0; i < 1001; i++) {
+        page._triggerConsole(makeConsoleMsg("log", `msg-${i}`));
+      }
+      const result = await driver.console({ limit: 200 });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Buffer holds exactly 1000 after eviction (msg-0 evicted, buf contains msg-1..msg-1000)
+      // total = all 1000 matching entries before the limit is applied
+      expect(result.value.total).toBe(1000);
+      // entries = last 200 of 1000-entry buffer = msg-801 through msg-1000 (0-indexed: buf[800..999])
+      expect(result.value.entries.length).toBe(200);
+      expect(result.value.entries[0]?.text).toBe("msg-801");
+      expect(result.value.entries[199]?.text).toBe("msg-1000");
     });
   });
 });

--- a/packages/browser-playwright/src/playwright-browser-driver.ts
+++ b/packages/browser-playwright/src/playwright-browser-driver.ts
@@ -17,6 +17,10 @@
 
 import type {
   BrowserActionOptions,
+  BrowserConsoleEntry,
+  BrowserConsoleLevel,
+  BrowserConsoleOptions,
+  BrowserConsoleResult,
   BrowserDriver,
   BrowserEvaluateOptions,
   BrowserEvaluateResult,
@@ -38,10 +42,11 @@ import type {
   KoiError,
   Result,
 } from "@koi/core";
-import { internal, notFound, validation } from "@koi/core";
+import { internal, notFound, staleRef, validation } from "@koi/core";
 import type { Browser, BrowserContext, FrameLocator, Locator, Page } from "playwright";
 import { chromium } from "playwright";
 import { parseAriaYaml, VALID_ROLES } from "./a11y-serializer.js";
+import { translatePlaywrightError } from "./error-translator.js";
 
 /** Playwright-typed role guard — same validation as isAriaRole, returns Playwright's AriaRole. */
 type AriaRole = Parameters<Page["getByRole"]>[0];
@@ -94,6 +99,54 @@ const WAIT_MAX_MS = 30_000;
 const EVALUATE_DEFAULT_MS = 5_000;
 const EVALUATE_MAX_MS = 10_000;
 const LAUNCH_DEFAULT_MS = 30_000;
+
+/** Maximum entries per tab before FIFO eviction kicks in. */
+const CONSOLE_BUFFER_CAP = 1_000;
+
+// ---------------------------------------------------------------------------
+// Console helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a Playwright ConsoleMessage type string to a BrowserConsoleLevel.
+ * Returns null for structural/grouping types that carry no signal for agents.
+ */
+function normalizeConsoleType(type: string): BrowserConsoleLevel | null {
+  switch (type) {
+    case "log":
+    case "trace":
+      return "log";
+    case "warning":
+      return "warning";
+    case "error":
+      return "error";
+    case "debug":
+      return "debug";
+    case "info":
+      return "info";
+    case "assert":
+      // assert fires when assertion fails — map to error for agent visibility
+      return "error";
+    case "dir":
+    case "dirxml":
+    case "table":
+    case "group":
+    case "groupCollapsed":
+    case "groupEnd":
+    case "count":
+    case "countReset":
+    case "time":
+    case "timeLog":
+    case "timeEnd":
+    case "clear":
+    case "startGroup":
+    case "startGroupCollapsed":
+    case "endGroup":
+      return null;
+    default:
+      return "log";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Stealth init script — injected at BrowserContext level
@@ -180,6 +233,9 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
   // Per-tab snapshot state — replaces the old single global currentSnapshotId / currentRefs
   const tabSnapshots = new Map<string, TabSnapshot>();
 
+  // Per-tab console log buffer (FIFO, capped at CONSOLE_BUFFER_CAP entries per tab)
+  const tabConsoleLogs = new Map<string, BrowserConsoleEntry[]>();
+
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
@@ -190,6 +246,25 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
 
   function invalidateTabSnapshot(tabId: string): void {
     tabSnapshots.delete(tabId);
+  }
+
+  function attachConsoleListener(page: Page, tabId: string): void {
+    tabConsoleLogs.set(tabId, []);
+    page.on("console", (msg) => {
+      const level = normalizeConsoleType(msg.type());
+      if (level === null) return;
+      const loc = msg.location();
+      const entry: BrowserConsoleEntry = {
+        level,
+        text: msg.text(),
+        ...(loc.url ? { url: loc.url } : {}),
+        ...(loc.lineNumber ? { line: loc.lineNumber } : {}),
+      };
+      const buf = tabConsoleLogs.get(tabId);
+      if (buf === undefined) return;
+      buf.push(entry);
+      if (buf.length > CONSOLE_BUFFER_CAP) buf.shift(); // FIFO eviction
+    });
   }
 
   async function ensureBrowser(): Promise<Browser> {
@@ -260,6 +335,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
       const tabId = newTabId();
       tabs.set(tabId, page);
       currentTabId = tabId;
+      attachConsoleListener(page, tabId);
     }
     const page = tabs.get(currentTabId);
     if (!page) {
@@ -272,7 +348,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
     return currentTabId;
   }
 
-  /** Returns a stale-snapshot error if snapshotId is provided but doesn't match the active tab's. */
+  /** Returns a STALE_REF error if snapshotId is provided but doesn't match the active tab's. */
   function checkSnapshotId(snapshotId: string | undefined): Result<void, KoiError> | null {
     if (snapshotId === undefined) return null;
     const tabId = getActiveTabId();
@@ -281,7 +357,10 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
     if (!snap || snapshotId !== snap.snapshotId) {
       return {
         ok: false,
-        error: notFound("Snapshot is stale — call browser_snapshot to refresh refs"),
+        error: staleRef(
+          snapshotId,
+          "call browser_snapshot to get fresh refs — the page changed since this snapshot was taken",
+        ),
       };
     }
     return null;
@@ -322,7 +401,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
     return root.getByRole(role).nth(nthIndex);
   }
 
-  /** Get a Locator or return a NOT_FOUND error Result. */
+  /** Get a Locator or return a STALE_REF/NOT_FOUND error Result. */
   function requireLocator(
     page: Page,
     ref: string,
@@ -333,8 +412,9 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
       return {
         error: {
           ok: false,
-          error: notFound(
-            `ref "${ref}" not found in current snapshot — call browser_snapshot to refresh refs`,
+          error: staleRef(
+            ref,
+            "call browser_snapshot to refresh refs — this ref is not in the current snapshot",
           ),
         },
       };
@@ -396,7 +476,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
           },
         };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_snapshot failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_snapshot", e) };
       }
     },
 
@@ -432,7 +512,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
           },
         };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_navigate failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_navigate", e) };
       }
     },
 
@@ -451,7 +531,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await found.locator.click({ timeout: t.value });
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_click failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_click", e) };
       }
     },
 
@@ -470,7 +550,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await found.locator.hover({ timeout: t.value });
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_hover failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_hover", e) };
       }
     },
 
@@ -483,7 +563,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await page.keyboard.press(key);
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_press failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_press", e) };
       }
     },
 
@@ -509,7 +589,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await found.locator.fill(value, { timeout: t.value });
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_type failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_type", e) };
       }
     },
 
@@ -532,7 +612,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await found.locator.selectOption(value, { timeout: t.value });
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_select failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_select", e) };
       }
     },
 
@@ -573,7 +653,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
 
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_fill_form failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_fill_form", e) };
       }
     },
 
@@ -606,7 +686,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
 
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_scroll failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_scroll", e) };
       }
     },
 
@@ -643,7 +723,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
           },
         };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_screenshot failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_screenshot", e) };
       }
     },
 
@@ -673,7 +753,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
 
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_wait failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_wait", e) };
       }
     },
 
@@ -683,6 +763,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         const page = await ctx.newPage();
         const tabId = newTabId();
         tabs.set(tabId, page);
+        attachConsoleListener(page, tabId);
         // New tab becomes the active tab (matches real browser behaviour).
         currentTabId = tabId;
 
@@ -710,7 +791,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
           },
         };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_tab_new failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_tab_new", e) };
       }
     },
 
@@ -730,6 +811,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         await page.close();
         tabs.delete(targetId);
         invalidateTabSnapshot(targetId);
+        tabConsoleLogs.delete(targetId);
 
         if (currentTabId === targetId) {
           // Single-pass iterator — avoids allocating a full array just to get the last key.
@@ -740,7 +822,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
 
         return { ok: true, value: undefined };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_tab_close failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_tab_close", e) };
       }
     },
 
@@ -780,7 +862,7 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
           },
         };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_tab_focus failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_tab_focus", e) };
       }
     },
 
@@ -797,8 +879,24 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         );
         return { ok: true, value };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_tab_list failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_tab_list", e) };
       }
+    },
+
+    async console(
+      options?: BrowserConsoleOptions,
+    ): Promise<Result<BrowserConsoleResult, KoiError>> {
+      const buf = currentTabId !== null ? (tabConsoleLogs.get(currentTabId) ?? []) : [];
+      const MAX_LIMIT = 200;
+      const limit = Math.min(options?.limit ?? 50, MAX_LIMIT);
+      const levels = options?.levels;
+      const filtered = levels ? buf.filter((e) => levels.includes(e.level)) : buf;
+      const total = filtered.length;
+      const entries = filtered.slice(-limit);
+      if (options?.clear === true && currentTabId !== null) {
+        tabConsoleLogs.set(currentTabId, []);
+      }
+      return { ok: true, value: { entries, total } };
     },
 
     async evaluate(
@@ -818,13 +916,14 @@ export function createPlaywrightBrowserDriver(config: PlaywrightDriverConfig = {
         const value: unknown = await page.evaluate(script);
         return { ok: true, value: { value } };
       } catch (e: unknown) {
-        return { ok: false, error: internal("browser_evaluate failed", e) };
+        return { ok: false, error: translatePlaywrightError("browser_evaluate", e) };
       }
     },
 
     async dispose(): Promise<void> {
-      // Invalidate all tab snapshots
+      // Invalidate all tab snapshots and console buffers
       tabSnapshots.clear();
+      tabConsoleLogs.clear();
 
       for (const page of tabs.values()) {
         await page.close().catch(() => undefined);

--- a/packages/channel-base/src/format-error.ts
+++ b/packages/channel-base/src/format-error.ts
@@ -20,6 +20,7 @@ const USER_MESSAGES: Readonly<Record<KoiErrorCode, string>> = {
   TIMEOUT: "The operation timed out. Please try again.",
   EXTERNAL: "An external service is temporarily unavailable.",
   INTERNAL: "Something went wrong. Please try again later.",
+  STALE_REF: "The referenced element is no longer valid. Please try again.",
 } as const;
 
 /**

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { BrickRef } from './brick-snapshot.js';
 export { BrickId, BrickSnapshot, BrickSource, SnapshotEvent, SnapshotId, SnapshotQuery, SnapshotStore, brickId, snapshotId } from './brick-snapshot.js';
-import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-B8ezO44s.js';
-export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserDriver, d as BrowserEvaluateOptions, e as BrowserEvaluateResult, f as BrowserFormField, g as BrowserNavigateOptions, h as BrowserNavigateResult, i as BrowserRefInfo, j as BrowserScreenshotOptions, k as BrowserScreenshotResult, l as BrowserScrollOptions, m as BrowserSnapshotOptions, n as BrowserSnapshotResult, o as BrowserTabCloseOptions, p as BrowserTabFocusOptions, q as BrowserTabInfo, r as BrowserTabNewOptions, s as BrowserTypeOptions, t as BrowserWaitOptions, u as BrowserWaitUntil, C as CREDENTIALS, v as ChildHandle, w as ChildLifecycleEvent, x as ComponentProvider, y as CredentialComponent, D as DELEGATION, E as EVENTS, z as EventComponent, F as FILESYSTEM, G as GOVERNANCE, H as GovernanceComponent, I as GovernanceUsage, M as MEMORY, J as MemoryComponent, K as MemoryResult, L as ProcessAccounter, N as ProcessId, R as RunId, O as SkillMetadata, Q as SpawnCheck, U as SpawnLedger, V as SubsystemToken, W as Tool, X as ToolDescriptor, Y as TrustTier, Z as TurnId, _ as agentId, $ as channelToken, a0 as runId, a1 as sessionId, a2 as skillToken, a3 as token, a4 as toolCallId, a5 as toolToken, a6 as turnId } from './ecs-B8ezO44s.js';
-import { E as EngineState, a as EngineInput } from './engine-DND0bmV7.js';
-export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-DND0bmV7.js';
+import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-piGm96or.js';
+export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentProvider, F as CredentialComponent, G as DELEGATION, H as EVENTS, I as EventComponent, J as FILESYSTEM, K as GOVERNANCE, L as GovernanceComponent, M as GovernanceUsage, N as MEMORY, O as MemoryComponent, Q as MemoryResult, R as ProcessAccounter, U as ProcessId, V as RunId, W as SkillMetadata, X as SpawnCheck, Y as SpawnLedger, Z as SubsystemToken, _ as Tool, $ as ToolDescriptor, a0 as TrustTier, a1 as TurnId, a2 as agentId, a3 as channelToken, a4 as runId, a5 as sessionId, a6 as skillToken, a7 as token, a8 as toolCallId, a9 as toolToken, aa as turnId } from './ecs-piGm96or.js';
+import { E as EngineState, a as EngineInput } from './engine-jr9uuAwQ.js';
+export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-jr9uuAwQ.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { A as AgentManifest } from './assembly-DuMs8y-i.js';
@@ -227,11 +227,19 @@ declare function internal(message: string, cause?: unknown): KoiError;
 /** Rate limit exceeded. Retryable (with backoff). */
 declare function rateLimit(message: string, context?: JsonObject): KoiError;
 /** Operation timed out. Retryable (with backoff). */
-declare function timeout(message: string): KoiError;
+declare function timeout(message: string, retryAfterMs?: number): KoiError;
 /** Third-party service failure. Not retryable by default. */
 declare function external(message: string, cause?: unknown): KoiError;
 /** Unauthorized action. Non-retryable. */
 declare function permission(message: string): KoiError;
+/**
+ * A cached reference has become invalid because the underlying resource changed.
+ * Non-retryable as-is — the caller must re-acquire a fresh reference first.
+ *
+ * @param refId - The stale reference identifier (e.g., "e1", "cursor-42").
+ * @param hint - Optional actionable hint for the caller (e.g., "call browser_snapshot").
+ */
+declare function staleRef(refId: string, hint?: string): KoiError;
 
 /**
  * Scheduler contract — pluggable task scheduling, priority queue, cron,
@@ -646,7 +654,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { AgentId, AgentManifest, type AgentSnapshot, type AgentSnapshotStore, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickRef, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_SCHEDULER_CONFIG, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, JsonObject, KoiError, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type RecoveryPlan, type RedactionRule, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskFilter, type TaskId, type TaskOptions, type TaskScheduler, type TaskStatus, type TaskStore, ToolCallId, type TraceEvent, type TraceEventKind, type TurnTrace, chainId, conflict, external, internal, isProcessState, nodeId, notFound, permission, rateLimit, scheduleId, taskId, timeout, validateNonEmpty, validation };
+export { AgentId, AgentManifest, type AgentSnapshot, type AgentSnapshotStore, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickRef, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_SCHEDULER_CONFIG, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, JsonObject, KoiError, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type RecoveryPlan, type RedactionRule, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskFilter, type TaskId, type TaskOptions, type TaskScheduler, type TaskStatus, type TaskStore, ToolCallId, type TraceEvent, type TraceEventKind, type TurnTrace, chainId, conflict, external, internal, isProcessState, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, timeout, validateNonEmpty, validation };
 "
 `;
 
@@ -854,7 +862,7 @@ import './common.js';
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
 "import './assembly-DuMs8y-i.js';
-export { a as Agent, A as AgentId, B as BROWSER, C as CREDENTIALS, v as ChildHandle, w as ChildLifecycleEvent, x as ComponentProvider, y as CredentialComponent, D as DELEGATION, E as EVENTS, z as EventComponent, F as FILESYSTEM, G as GOVERNANCE, H as GovernanceComponent, I as GovernanceUsage, M as MEMORY, J as MemoryComponent, K as MemoryResult, L as ProcessAccounter, N as ProcessId, P as ProcessState, R as RunId, S as SessionId, O as SkillMetadata, Q as SpawnCheck, U as SpawnLedger, V as SubsystemToken, W as Tool, T as ToolCallId, X as ToolDescriptor, Y as TrustTier, Z as TurnId, _ as agentId, $ as channelToken, a0 as runId, a1 as sessionId, a2 as skillToken, a3 as token, a4 as toolCallId, a5 as toolToken, a6 as turnId } from './ecs-B8ezO44s.js';
+export { a as Agent, A as AgentId, B as BROWSER, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentProvider, F as CredentialComponent, G as DELEGATION, H as EVENTS, I as EventComponent, J as FILESYSTEM, K as GOVERNANCE, L as GovernanceComponent, M as GovernanceUsage, N as MEMORY, O as MemoryComponent, Q as MemoryResult, R as ProcessAccounter, U as ProcessId, P as ProcessState, V as RunId, S as SessionId, W as SkillMetadata, X as SpawnCheck, Y as SpawnLedger, Z as SubsystemToken, _ as Tool, T as ToolCallId, $ as ToolDescriptor, a0 as TrustTier, a1 as TurnId, a2 as agentId, a3 as channelToken, a4 as runId, a5 as sessionId, a6 as skillToken, a7 as token, a8 as toolCallId, a9 as toolToken, aa as turnId } from './ecs-piGm96or.js';
 import './channel.js';
 import './common.js';
 import './filesystem-backend.js';
@@ -865,8 +873,8 @@ import './message.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-DND0bmV7.js';
-import './ecs-B8ezO44s.js';
+export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-jr9uuAwQ.js';
+import './ecs-piGm96or.js';
 import './message.js';
 import './middleware.js';
 import './assembly-DuMs8y-i.js';
@@ -1033,7 +1041,7 @@ exports[`@koi/core API surface ./errors has stable type surface 1`] = `
  *   switch (code) {
  *     case "VALIDATION": return "bad input";
  *     case "NOT_FOUND":  return "missing";
- *     // ... all 8 codes ...
+ *     // ... all 9 codes ...
  *     default: {
  *       const _exhaustive: never = code;
  *       throw new Error(\`Unhandled code: \${String(_exhaustive)}\`);
@@ -1043,7 +1051,20 @@ exports[`@koi/core API surface ./errors has stable type surface 1`] = `
  * \`\`\`
  */
 
-type KoiErrorCode = "VALIDATION" | "NOT_FOUND" | "PERMISSION" | "CONFLICT" | "RATE_LIMIT" | "TIMEOUT" | "EXTERNAL" | "INTERNAL";
+type KoiErrorCode = "VALIDATION" | "NOT_FOUND" | "PERMISSION" | "CONFLICT" | "RATE_LIMIT" | "TIMEOUT" | "EXTERNAL" | "INTERNAL"
+/**
+ * A cached reference (browser element ref, DB cursor, WebSocket token, etc.)
+ * has become invalid because the underlying resource changed or was replaced.
+ * The caller must re-acquire a fresh reference before retrying the operation.
+ *
+ * Distinct from NOT_FOUND (which means the resource never existed or was
+ * permanently deleted). STALE_REF means the resource likely still exists
+ * but the handle pointing to it is no longer valid.
+ *
+ * Common browser automation pattern: call browser_snapshot to obtain fresh
+ * [ref=eN] markers, then retry the action with the new ref.
+ */
+ | "STALE_REF";
 interface KoiError {
     readonly code: KoiErrorCode;
     readonly message: string;
@@ -1131,7 +1152,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import { ChannelStatus } from './channel.js';
 import { JsonObject } from './common.js';
-import { T as ToolCallId, S as SessionId, R as RunId, Z as TurnId } from './ecs-B8ezO44s.js';
+import { T as ToolCallId, S as SessionId, V as RunId, a1 as TurnId } from './ecs-piGm96or.js';
 import { InboundMessage } from './message.js';
 import './assembly-DuMs8y-i.js';
 import './errors.js';
@@ -1254,7 +1275,7 @@ export type { ApprovalDecision, ApprovalHandler, ApprovalRequest, KoiMiddleware,
 `;
 
 exports[`@koi/core API surface ./eviction has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-B8ezO44s.js';
+"import { A as AgentId, P as ProcessState } from './ecs-piGm96or.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
 import './errors.js';
@@ -1307,7 +1328,7 @@ export type { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult 
 `;
 
 exports[`@koi/core API surface ./health has stable type surface 1`] = `
-"import { A as AgentId } from './ecs-B8ezO44s.js';
+"import { A as AgentId } from './ecs-piGm96or.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
 import './errors.js';
@@ -1378,7 +1399,7 @@ export { DEFAULT_HEALTH_MONITOR_CONFIG, type HealthMonitor, type HealthMonitorCo
 `;
 
 exports[`@koi/core API surface ./lifecycle has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-B8ezO44s.js';
+"import { A as AgentId, P as ProcessState } from './ecs-piGm96or.js';
 import { Result, KoiError } from './errors.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
@@ -1718,7 +1739,7 @@ export { type BrickId, type BrickRef, type BrickSnapshot, type BrickSource, type
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"import { Y as TrustTier } from './ecs-B8ezO44s.js';
+"import { a0 as TrustTier } from './ecs-piGm96or.js';
 import { Result, KoiError } from './errors.js';
 import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-4-HydRtT.js';
 import './assembly-DuMs8y-i.js';
@@ -1863,7 +1884,7 @@ export type { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, Bri
 
 exports[`@koi/core API surface ./sandbox-adapter has stable type surface 1`] = `
 "import { SandboxProfile } from './sandbox-profile.js';
-import './ecs-B8ezO44s.js';
+import './ecs-piGm96or.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
 import './errors.js';
@@ -1934,7 +1955,7 @@ export type { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxI
 `;
 
 exports[`@koi/core API surface ./sandbox-executor has stable type surface 1`] = `
-"import { Y as TrustTier } from './ecs-B8ezO44s.js';
+"import { a0 as TrustTier } from './ecs-piGm96or.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
 import './errors.js';
@@ -1997,7 +2018,7 @@ export type { SandboxError, SandboxErrorCode, SandboxExecutor, SandboxResult, Ti
 `;
 
 exports[`@koi/core API surface ./sandbox-profile has stable type surface 1`] = `
-"import { Y as TrustTier } from './ecs-B8ezO44s.js';
+"import { a0 as TrustTier } from './ecs-piGm96or.js';
 import './assembly-DuMs8y-i.js';
 import './common.js';
 import './errors.js';

--- a/packages/core/src/__tests__/backward-compat.test.ts
+++ b/packages/core/src/__tests__/backward-compat.test.ts
@@ -36,6 +36,7 @@ import {
   scheduleId,
   sessionId,
   snapshotId,
+  staleRef,
   taskId,
   timeout,
   toolCallId,
@@ -58,16 +59,17 @@ describe("RETRYABLE_DEFAULTS backward compatibility", () => {
     ["TIMEOUT", true],
     ["EXTERNAL", false],
     ["INTERNAL", false],
+    ["STALE_REF", false],
   ] as const;
 
-  test("all 8 error codes exist with expected retryability", () => {
+  test("all 9 error codes exist with expected retryability", () => {
     for (const [code, retryable] of expectedEntries) {
       expect(RETRYABLE_DEFAULTS).toHaveProperty(code, retryable);
     }
   });
 
-  test("has exactly 8 codes (no unexpected additions)", () => {
-    expect(Object.keys(RETRYABLE_DEFAULTS)).toHaveLength(8);
+  test("has exactly 9 codes (no unexpected additions)", () => {
+    expect(Object.keys(RETRYABLE_DEFAULTS)).toHaveLength(9);
   });
 });
 
@@ -182,6 +184,13 @@ describe("error factory backward compatibility", () => {
     expect(err.retryable).toBe(true);
   });
 
+  test("timeout with retryAfterMs surfaces wait time", () => {
+    const err = timeout("timed out", 2_000);
+    expect(err.code).toBe("TIMEOUT");
+    expect(err.retryable).toBe(true);
+    expect(err.retryAfterMs).toBe(2_000);
+  });
+
   test("external produces EXTERNAL code", () => {
     const err = external("third-party down");
     expect(err.code).toBe("EXTERNAL");
@@ -192,6 +201,13 @@ describe("error factory backward compatibility", () => {
     const err = permission("denied");
     expect(err.code).toBe("PERMISSION");
     expect(err.retryable).toBe(false);
+  });
+
+  test("staleRef produces STALE_REF code", () => {
+    const err = staleRef("e42");
+    expect(err.code).toBe("STALE_REF");
+    expect(err.retryable).toBe(false);
+    expect(err.message).toContain("e42");
   });
 });
 

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -3,8 +3,8 @@ import type { KoiErrorCode } from "../index.js";
 import { RETRYABLE_DEFAULTS } from "../index.js";
 
 describe("RETRYABLE_DEFAULTS", () => {
-  test("contains exactly 8 entries (one per KoiErrorCode)", () => {
-    expect(Object.keys(RETRYABLE_DEFAULTS)).toHaveLength(8);
+  test("contains exactly 9 entries (one per KoiErrorCode)", () => {
+    expect(Object.keys(RETRYABLE_DEFAULTS)).toHaveLength(9);
   });
 
   test("VALIDATION is not retryable", () => {
@@ -45,6 +45,10 @@ describe("RETRYABLE_DEFAULTS", () => {
     }
   });
 
+  test("STALE_REF is not retryable", () => {
+    expect(RETRYABLE_DEFAULTS.STALE_REF).toBe(false);
+  });
+
   test("keys match every KoiErrorCode", () => {
     // Runtime: verify keys match the expected set
     const expectedCodes: readonly KoiErrorCode[] = [
@@ -56,6 +60,7 @@ describe("RETRYABLE_DEFAULTS", () => {
       "TIMEOUT",
       "EXTERNAL",
       "INTERNAL",
+      "STALE_REF",
     ];
     const actualKeys = Object.keys(RETRYABLE_DEFAULTS).sort();
     const expectedKeys = [...expectedCodes].sort();

--- a/packages/core/src/browser-driver.ts
+++ b/packages/core/src/browser-driver.ts
@@ -218,6 +218,36 @@ export interface BrowserEvaluateResult {
 }
 
 // ---------------------------------------------------------------------------
+// Console
+// ---------------------------------------------------------------------------
+
+export type BrowserConsoleLevel = "log" | "warning" | "error" | "debug" | "info";
+
+export interface BrowserConsoleEntry {
+  readonly level: BrowserConsoleLevel;
+  readonly text: string;
+  /** Source URL (from ConsoleMessage.location()). */
+  readonly url?: string;
+  /** Source line number. */
+  readonly line?: number;
+}
+
+export interface BrowserConsoleOptions {
+  /** Filter by level(s). Default: all levels. */
+  readonly levels?: readonly BrowserConsoleLevel[];
+  /** Max entries to return, from most recent (default: 50, max: 200). */
+  readonly limit?: number;
+  /** Clear the console buffer after reading (default: false). */
+  readonly clear?: boolean;
+}
+
+export interface BrowserConsoleResult {
+  readonly entries: readonly BrowserConsoleEntry[];
+  /** Total buffered entries before limit/filter was applied. */
+  readonly total: number;
+}
+
+// ---------------------------------------------------------------------------
 // Backend contract
 // ---------------------------------------------------------------------------
 
@@ -331,6 +361,11 @@ export interface BrowserDriver {
   readonly tabList: () =>
     | Result<readonly BrowserTabInfo[], KoiError>
     | Promise<Result<readonly BrowserTabInfo[], KoiError>>;
+
+  /** Read buffered console messages from the current page. */
+  readonly console: (
+    options?: BrowserConsoleOptions,
+  ) => Result<BrowserConsoleResult, KoiError> | Promise<Result<BrowserConsoleResult, KoiError>>;
 
   readonly dispose?: () => void | Promise<void>;
 }

--- a/packages/core/src/error-factories.ts
+++ b/packages/core/src/error-factories.ts
@@ -63,12 +63,13 @@ export function rateLimit(message: string, context?: JsonObject): KoiError {
 }
 
 /** Operation timed out. Retryable (with backoff). */
-export function timeout(message: string): KoiError {
-  return {
+export function timeout(message: string, retryAfterMs?: number): KoiError {
+  const base: KoiError = {
     code: "TIMEOUT",
     message,
     retryable: RETRYABLE_DEFAULTS.TIMEOUT,
   };
+  return retryAfterMs !== undefined ? { ...base, retryAfterMs } : base;
 }
 
 /** Third-party service failure. Not retryable by default. */
@@ -87,5 +88,22 @@ export function permission(message: string): KoiError {
     code: "PERMISSION",
     message,
     retryable: RETRYABLE_DEFAULTS.PERMISSION,
+  };
+}
+
+/**
+ * A cached reference has become invalid because the underlying resource changed.
+ * Non-retryable as-is — the caller must re-acquire a fresh reference first.
+ *
+ * @param refId - The stale reference identifier (e.g., "e1", "cursor-42").
+ * @param hint - Optional actionable hint for the caller (e.g., "call browser_snapshot").
+ */
+export function staleRef(refId: string, hint?: string): KoiError {
+  const base = hint ?? "re-acquire a fresh reference before retrying";
+  return {
+    code: "STALE_REF",
+    message: `Ref "${refId}" is stale — ${base}`,
+    retryable: RETRYABLE_DEFAULTS.STALE_REF,
+    context: { refId },
   };
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -10,7 +10,7 @@
  *   switch (code) {
  *     case "VALIDATION": return "bad input";
  *     case "NOT_FOUND":  return "missing";
- *     // ... all 8 codes ...
+ *     // ... all 9 codes ...
  *     default: {
  *       const _exhaustive: never = code;
  *       throw new Error(`Unhandled code: ${String(_exhaustive)}`);
@@ -30,7 +30,20 @@ export type KoiErrorCode =
   | "RATE_LIMIT"
   | "TIMEOUT"
   | "EXTERNAL"
-  | "INTERNAL";
+  | "INTERNAL"
+  /**
+   * A cached reference (browser element ref, DB cursor, WebSocket token, etc.)
+   * has become invalid because the underlying resource changed or was replaced.
+   * The caller must re-acquire a fresh reference before retrying the operation.
+   *
+   * Distinct from NOT_FOUND (which means the resource never existed or was
+   * permanently deleted). STALE_REF means the resource likely still exists
+   * but the handle pointing to it is no longer valid.
+   *
+   * Common browser automation pattern: call browser_snapshot to obtain fresh
+   * [ref=eN] markers, then retry the action with the new ref.
+   */
+  | "STALE_REF";
 
 export interface KoiError {
   readonly code: KoiErrorCode;
@@ -57,6 +70,7 @@ export const RETRYABLE_DEFAULTS: Readonly<Record<KoiErrorCode, boolean>> = Objec
   TIMEOUT: true,
   EXTERNAL: false,
   INTERNAL: false,
+  STALE_REF: false,
 });
 
 export type Result<T, E = KoiError> =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,10 @@ export type {
 // browser driver — cross-engine abstraction for browser automation
 export type {
   BrowserActionOptions,
+  BrowserConsoleEntry,
+  BrowserConsoleLevel,
+  BrowserConsoleOptions,
+  BrowserConsoleResult,
   BrowserDriver,
   BrowserEvaluateOptions,
   BrowserEvaluateResult,
@@ -185,6 +189,7 @@ export {
   notFound,
   permission,
   rateLimit,
+  staleRef,
   timeout,
   validation,
 } from "./error-factories.js";

--- a/packages/tool-browser/src/browser-component-provider.ts
+++ b/packages/tool-browser/src/browser-component-provider.ts
@@ -15,6 +15,7 @@ import {
   OPERATIONS,
 } from "./constants.js";
 import { createBrowserClickTool } from "./tools/click.js";
+import { createBrowserConsoleTool } from "./tools/console.js";
 import { createBrowserEvaluateTool } from "./tools/evaluate.js";
 import { createBrowserFillFormTool } from "./tools/fill-form.js";
 import { createBrowserHoverTool } from "./tools/hover.js";
@@ -86,6 +87,7 @@ const TOOL_FACTORIES: Readonly<
   wait: createBrowserWaitTool,
   tab_close: createBrowserTabCloseTool,
   tab_focus: createBrowserTabFocusTool,
+  console: createBrowserConsoleTool,
   evaluate: createBrowserEvaluateTool,
 };
 

--- a/packages/tool-browser/src/constants.test.ts
+++ b/packages/tool-browser/src/constants.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { BROWSER_SYSTEM_PROMPT } from "./constants.js";
+
+describe("BROWSER_SYSTEM_PROMPT", () => {
+  test("is a non-empty string", () => {
+    expect(typeof BROWSER_SYSTEM_PROMPT).toBe("string");
+    expect(BROWSER_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+  });
+
+  test("contains browser_snapshot instruction", () => {
+    expect(BROWSER_SYSTEM_PROMPT).toContain("browser_snapshot");
+  });
+
+  test("contains snapshotId guidance", () => {
+    expect(BROWSER_SYSTEM_PROMPT).toContain("snapshotId");
+  });
+
+  test("contains STALE_REF error code", () => {
+    expect(BROWSER_SYSTEM_PROMPT).toContain("STALE_REF");
+  });
+
+  test("contains INTERNAL error code for page crash scenario", () => {
+    expect(BROWSER_SYSTEM_PROMPT).toContain("INTERNAL");
+  });
+
+  test("contains snapshot-act-snapshot loop guidance", () => {
+    expect(BROWSER_SYSTEM_PROMPT).toContain("Re-snapshot");
+  });
+});

--- a/packages/tool-browser/src/constants.ts
+++ b/packages/tool-browser/src/constants.ts
@@ -6,6 +6,71 @@
 export const DEFAULT_PREFIX = "browser" as const;
 
 /**
+ * System prompt guidance for agents using browser tools.
+ *
+ * Include this in your agent's system prompt or koi.yaml `instructions` field
+ * to prime the agent with the snapshot-act-snapshot pattern and error-handling
+ * strategy that minimises hallucinated refs and unnecessary retries.
+ *
+ * Usage:
+ * ```ts
+ * import { BROWSER_SYSTEM_PROMPT } from "@koi/tool-browser";
+ * // Add to your agent manifest's system prompt:
+ * // system: BROWSER_SYSTEM_PROMPT
+ * ```
+ */
+export const BROWSER_SYSTEM_PROMPT: string = `
+## Browser automation — snapshot-act-snapshot loop
+
+Always follow this loop when operating the browser:
+
+1. **Snapshot first** — call \`browser_snapshot\` before every action.
+   The snapshot returns \`snapshotId\` and a list of interactive elements
+   with [ref=eN] markers (e.g., [button] Submit [ref=e3]).
+
+2. **Pass snapshotId to every action** — include the \`snapshotId\` field
+   from the latest snapshot in every interaction call (browser_click,
+   browser_type, browser_fill_form, etc.). This lets the browser detect
+   stale refs immediately instead of acting on wrong elements.
+
+3. **Re-snapshot after DOM changes** — after clicking a button, submitting
+   a form, or navigating, the page DOM may change. Always call
+   browser_snapshot again before performing further interactions.
+
+4. **Ref format** — refs are strings like "e1", "e42". Only use refs that
+   appeared in the most recent browser_snapshot output.
+
+## Error code meanings
+
+| Code       | Meaning                                | What to do                             |
+|------------|----------------------------------------|----------------------------------------|
+| STALE_REF  | Ref or snapshot is outdated            | Call browser_snapshot, retry action    |
+| TIMEOUT    | Element/navigation timed out           | Call browser_wait or browser_snapshot  |
+| NOT_FOUND  | Element was never in the snapshot      | Call browser_snapshot to see the page  |
+| EXTERNAL   | Network/JS error on the page           | Check the URL, retry or investigate    |
+| INTERNAL   | Page closed/crashed unexpectedly       | Report error; re-navigate if needed    |
+| PERMISSION | Blocked by CORS or browser policy      | Check allowed domains in config        |
+| VALIDATION | Bad argument (wrong ref format, etc.)  | Fix the argument and retry             |
+
+## Snapshot-act-snapshot example
+
+\`\`\`
+browser_snapshot()
+  → { snapshotId: "snap-tab-1-3", snapshot: "...[button] Log in [ref=e2]..." }
+
+browser_click({ ref: "e2", snapshotId: "snap-tab-1-3" })
+  → { success: true }
+
+// Page may have changed after click — re-snapshot before next action
+browser_snapshot()
+  → { snapshotId: "snap-tab-1-4", snapshot: "...[input] Email [ref=e5]..." }
+
+browser_type({ ref: "e5", snapshotId: "snap-tab-1-4", value: "user@example.com" })
+  → { success: true }
+\`\`\`
+`.trim();
+
+/**
  * All browser operation names in default order.
  * NOTE: "evaluate" is intentionally excluded from the default set.
  * It uses `promoted` trust tier and must be explicitly opted in.
@@ -25,6 +90,7 @@ export const OPERATIONS = [
   "tab_new",
   "tab_close",
   "tab_focus",
+  "console",
 ] as const;
 
 /** All operations including the promoted-tier evaluate. */
@@ -43,6 +109,7 @@ export const ALL_OPERATIONS = [
   "tab_new",
   "tab_close",
   "tab_focus",
+  "console",
   "evaluate",
 ] as const;
 

--- a/packages/tool-browser/src/index.ts
+++ b/packages/tool-browser/src/index.ts
@@ -26,6 +26,10 @@
 // types — re-exported from @koi/core for convenience
 export type {
   BrowserActionOptions,
+  BrowserConsoleEntry,
+  BrowserConsoleLevel,
+  BrowserConsoleOptions,
+  BrowserConsoleResult,
   BrowserDriver,
   BrowserEvaluateOptions,
   BrowserEvaluateResult,
@@ -57,6 +61,7 @@ export { createBrowserProvider } from "./browser-component-provider.js";
 export type { BrowserOperation } from "./constants.js";
 export {
   ALL_OPERATIONS,
+  BROWSER_SYSTEM_PROMPT,
   DEFAULT_PREFIX,
   EVALUATE_OPERATION,
   EVALUATE_TRUST_TIER,
@@ -66,6 +71,7 @@ export {
 export { createMockAgent, createMockDriver } from "./test-helpers.js";
 // tool factories — for advanced usage (custom tool composition)
 export { createBrowserClickTool } from "./tools/click.js";
+export { createBrowserConsoleTool } from "./tools/console.js";
 export { createBrowserEvaluateTool } from "./tools/evaluate.js";
 export { createBrowserFillFormTool } from "./tools/fill-form.js";
 export { createBrowserHoverTool } from "./tools/hover.js";

--- a/packages/tool-browser/src/parse-args.ts
+++ b/packages/tool-browser/src/parse-args.ts
@@ -5,7 +5,7 @@
  * on raw JsonObject args from the LLM.
  */
 
-import type { JsonObject } from "@koi/core";
+import type { BrowserConsoleLevel, JsonObject } from "@koi/core";
 
 interface ValidationError {
   readonly error: string;
@@ -293,4 +293,32 @@ export function parseOptionalWaitUntil(
     };
   }
   return { ok: true, value };
+}
+
+const CONSOLE_LEVELS: readonly BrowserConsoleLevel[] = ["log", "warning", "error", "debug", "info"];
+
+/** Parse an optional array of BrowserConsoleLevel values. */
+export function parseOptionalConsoleLevels(
+  args: JsonObject,
+  key: string,
+): ParseResult<readonly BrowserConsoleLevel[] | undefined> {
+  const raw = args[key];
+  if (raw === undefined || raw === null) return { ok: true, value: undefined };
+  if (!Array.isArray(raw)) {
+    return { ok: false, err: { error: `${key} must be an array`, code: "VALIDATION" } };
+  }
+  const result: BrowserConsoleLevel[] = [];
+  for (const item of raw) {
+    if (!memberOf<BrowserConsoleLevel>(CONSOLE_LEVELS, item)) {
+      return {
+        ok: false,
+        err: {
+          error: `${key} contains unknown level "${String(item)}". Valid: ${CONSOLE_LEVELS.join(", ")}`,
+          code: "VALIDATION",
+        },
+      };
+    }
+    result.push(item);
+  }
+  return { ok: true, value: result };
 }

--- a/packages/tool-browser/src/test-helpers.ts
+++ b/packages/tool-browser/src/test-helpers.ts
@@ -11,6 +11,8 @@
 import type {
   Agent,
   BrowserActionOptions,
+  BrowserConsoleOptions,
+  BrowserConsoleResult,
   BrowserDriver,
   BrowserEvaluateOptions,
   BrowserEvaluateResult,
@@ -54,7 +56,7 @@ function makeError(code: KoiErrorCode): KoiError {
 
 function makeStaleError(): KoiError {
   return {
-    code: "NOT_FOUND",
+    code: "STALE_REF",
     message:
       "Snapshot is stale — the page has changed since this snapshot was taken. " +
       "Call browser_snapshot to get fresh refs.",
@@ -218,6 +220,13 @@ export function createMockDriver(options: MockDriverOptions = {}): BrowserDriver
         ok: true,
         value: [{ tabId: "tab-1", url: "https://example.com", title: "Example Page" }],
       };
+    },
+
+    console: async (
+      _options?: BrowserConsoleOptions,
+    ): Promise<Result<BrowserConsoleResult, KoiError>> => {
+      if (failWith) return fail();
+      return { ok: true, value: { entries: [], total: 0 } };
     },
   };
 }

--- a/packages/tool-browser/src/tools/click.test.ts
+++ b/packages/tool-browser/src/tools/click.test.ts
@@ -35,8 +35,10 @@ describe("browser_click", () => {
     const driver = createMockDriver({ staleSnapshotId: "snap-old" });
     const tool = createBrowserClickTool(driver, "browser", "verified");
     const result = await tool.execute({ ref: "e1", snapshotId: "snap-old" });
-    expect(result).toMatchObject({ code: "NOT_FOUND" });
-    expect((result as { error: string }).error).toContain("stale");
+    expect(result).toMatchObject({
+      code: "STALE_REF",
+      error: expect.stringContaining("stale"),
+    });
   });
 
   test("rejects timeout above maximum", async () => {

--- a/packages/tool-browser/src/tools/click.ts
+++ b/packages/tool-browser/src/tools/click.ts
@@ -18,7 +18,10 @@ export function createBrowserClickTool(
       name: `${prefix}_click`,
       description:
         "Click an element identified by its snapshot ref. " +
-        "Pass snapshotId from the last browser_snapshot call to detect stale refs.",
+        "Always pass snapshotId from the last browser_snapshot call — if the ref " +
+        "is stale you receive STALE_REF, meaning you must call browser_snapshot " +
+        "again before retrying. Clicking may change the DOM: re-snapshot if you " +
+        "need to interact with elements that appear or move after the click.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/console.test.ts
+++ b/packages/tool-browser/src/tools/console.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { createMockDriver } from "../test-helpers.js";
+import { createBrowserConsoleTool } from "./console.js";
+
+describe("browser_console", () => {
+  test("returns console entries on success", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ success: true, entries: [], total: 0 });
+  });
+
+  test("returns empty entries when buffer is empty", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ success: true, entries: [] });
+  });
+
+  test("filters by levels", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({ levels: ["error", "warning"] });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  test("rejects invalid level", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({ levels: ["verbose"] });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects limit above 200", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({ limit: 201 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects limit below 1", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({ limit: 0 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("passes clear flag to driver", async () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({ clear: true });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  test("uses custom prefix in tool name", () => {
+    const driver = createMockDriver();
+    const tool = createBrowserConsoleTool(driver, "web", "verified");
+    expect(tool.descriptor.name).toBe("web_console");
+  });
+
+  test("returns INTERNAL error on driver failure", async () => {
+    const driver = createMockDriver({ failWith: "INTERNAL" });
+    const tool = createBrowserConsoleTool(driver, "browser", "verified");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ code: "INTERNAL" });
+  });
+});

--- a/packages/tool-browser/src/tools/console.ts
+++ b/packages/tool-browser/src/tools/console.ts
@@ -1,0 +1,80 @@
+/**
+ * Tool factory for `browser_console` — reads buffered console messages from the current page.
+ */
+
+import type { BrowserDriver, JsonObject, Tool, TrustTier } from "@koi/core";
+import {
+  parseOptionalBoolean,
+  parseOptionalConsoleLevels,
+  parseOptionalNumber,
+} from "../parse-args.js";
+
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 200;
+
+export function createBrowserConsoleTool(
+  driver: BrowserDriver,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_console`,
+      description:
+        "Read buffered console messages from the current browser page. " +
+        "Captures log, warning, error, debug, and info level messages from the " +
+        "page's JavaScript console. Useful for diagnosing JavaScript errors and " +
+        "page-side issues without needing browser_evaluate.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          levels: {
+            type: "array",
+            items: { type: "string", enum: ["log", "warning", "error", "debug", "info"] },
+            description: "Filter by level(s). Default: all levels.",
+          },
+          limit: {
+            type: "number",
+            description: `Max entries to return from most recent (default: 50, min: ${MIN_LIMIT}, max: ${MAX_LIMIT}).`,
+          },
+          clear: {
+            type: "boolean",
+            description: "Clear the console buffer after reading (default: false).",
+          },
+        },
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const levelsResult = parseOptionalConsoleLevels(args, "levels");
+      if (!levelsResult.ok) return levelsResult.err;
+
+      const limitResult = parseOptionalNumber(args, "limit");
+      if (!limitResult.ok) return limitResult.err;
+
+      if (limitResult.value !== undefined) {
+        if (limitResult.value < MIN_LIMIT || limitResult.value > MAX_LIMIT) {
+          return {
+            error: `limit must be between ${MIN_LIMIT} and ${MAX_LIMIT}`,
+            code: "VALIDATION",
+          };
+        }
+      }
+
+      const clearResult = parseOptionalBoolean(args, "clear");
+      if (!clearResult.ok) return clearResult.err;
+
+      const result = await driver.console({
+        ...(levelsResult.value !== undefined && { levels: levelsResult.value }),
+        ...(limitResult.value !== undefined && { limit: limitResult.value }),
+        ...(clearResult.value !== undefined && { clear: clearResult.value }),
+      });
+
+      if (!result.ok) {
+        return { error: result.error.message, code: result.error.code };
+      }
+
+      return { success: true, entries: result.value.entries, total: result.value.total };
+    },
+  };
+}

--- a/packages/tool-browser/src/tools/fill-form.ts
+++ b/packages/tool-browser/src/tools/fill-form.ts
@@ -18,7 +18,10 @@ export function createBrowserFillFormTool(
       name: `${prefix}_fill_form`,
       description:
         "Fill multiple form fields in one call. More efficient than calling " +
-        "browser_type/browser_select per field for multi-field forms.",
+        "browser_type/browser_select per field for multi-field forms. " +
+        "Always pass snapshotId from the last browser_snapshot call — " +
+        "a STALE_REF error on any field means the snapshot is outdated: " +
+        "re-snapshot and retry with fresh refs.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/hover.test.ts
+++ b/packages/tool-browser/src/tools/hover.test.ts
@@ -28,8 +28,10 @@ describe("browser_hover", () => {
     const driver = createMockDriver({ staleSnapshotId: "snap-old" });
     const tool = createBrowserHoverTool(driver, "browser", "verified");
     const result = await tool.execute({ ref: "e1", snapshotId: "snap-old" });
-    expect(result).toMatchObject({ code: "NOT_FOUND" });
-    expect((result as { error: string }).error).toContain("stale");
+    expect(result).toMatchObject({
+      code: "STALE_REF",
+      error: expect.stringContaining("stale"),
+    });
   });
 
   test("rejects timeout above maximum", async () => {

--- a/packages/tool-browser/src/tools/hover.ts
+++ b/packages/tool-browser/src/tools/hover.ts
@@ -18,8 +18,9 @@ export function createBrowserHoverTool(
       name: `${prefix}_hover`,
       description:
         "Hover over an element to trigger hover effects such as dropdowns, tooltips, and " +
-        "context menus. Use browser_snapshot first to get ref values, then call " +
-        "browser_snapshot again after hovering if new elements appear.",
+        "context menus. Always pass snapshotId from the last browser_snapshot call — " +
+        "a STALE_REF error means the ref is outdated and you must re-snapshot. " +
+        "Call browser_snapshot again after hovering if new elements appear.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/press.ts
+++ b/packages/tool-browser/src/tools/press.ts
@@ -22,7 +22,8 @@ export function createBrowserPressTool(
         "ArrowDown/ArrowUp (navigate dropdowns and lists), " +
         "Control+a (select all), Control+c/v (copy/paste), Shift+Tab (reverse focus). " +
         "Key names follow Playwright conventions — single keys or combinations with " +
-        'Control, Shift, Alt, Meta separated by "+".',
+        'Control, Shift, Alt, Meta separated by "+". ' +
+        "Key presses may trigger DOM changes: re-snapshot if the page content changes.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/scroll.ts
+++ b/packages/tool-browser/src/tools/scroll.ts
@@ -24,7 +24,9 @@ export function createBrowserScrollTool(
       name: `${prefix}_scroll`,
       description:
         "Scroll the page in a direction, or scroll to bring an element into view. " +
-        "Provide ref to scroll to an element; provide direction to scroll the page.",
+        "Provide ref to scroll to an element; provide direction to scroll the page. " +
+        "When using ref, always pass snapshotId — a STALE_REF error means " +
+        "the ref is outdated and you must call browser_snapshot first.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/select.ts
+++ b/packages/tool-browser/src/tools/select.ts
@@ -21,7 +21,11 @@ export function createBrowserSelectTool(
   return {
     descriptor: {
       name: `${prefix}_select`,
-      description: "Select an option in a combobox or listbox identified by its snapshot ref.",
+      description:
+        "Select an option in a combobox or listbox identified by its snapshot ref. " +
+        "Always pass snapshotId from the last browser_snapshot call — " +
+        "a STALE_REF error means the ref is outdated and you must re-snapshot. " +
+        "Selecting an option may trigger DOM changes: re-snapshot if needed.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/snapshot.ts
+++ b/packages/tool-browser/src/tools/snapshot.ts
@@ -15,8 +15,11 @@ export function createBrowserSnapshotTool(
       name: `${prefix}_snapshot`,
       description:
         "Capture the current page as an accessibility-tree text snapshot. " +
-        "Interactive elements get [ref=eN] markers. Pass snapshotId back to " +
-        "interaction tools to guard against stale refs.",
+        "Interactive elements get [ref=eN] markers (e.g., [button] Submit [ref=e3]). " +
+        "Always call this before interacting with the page. Pass the returned " +
+        "snapshotId to every interaction tool — if the page changes and a ref " +
+        "becomes stale, you will receive a STALE_REF error telling you to " +
+        "re-snapshot. Loop: snapshot → act → snapshot (after DOM-changing actions).",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/tools/type.ts
+++ b/packages/tool-browser/src/tools/type.ts
@@ -22,7 +22,11 @@ export function createBrowserTypeTool(
   return {
     descriptor: {
       name: `${prefix}_type`,
-      description: "Type text into an element identified by its snapshot ref.",
+      description:
+        "Type text into an element identified by its snapshot ref. " +
+        "Always pass snapshotId from the last browser_snapshot call — " +
+        "a STALE_REF error means the ref is outdated and you must re-snapshot. " +
+        "Typing may trigger DOM changes (e.g., autocomplete): re-snapshot if needed.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/tool-browser/src/url-security.ts
+++ b/packages/tool-browser/src/url-security.ts
@@ -6,7 +6,9 @@
  *   - Private IP blocking: RFC 1918, loopback, link-local, cloud metadata
  *   - IPv6 private range blocking: loopback (::1), link-local (fe80::/10),
  *     unique-local (fc00::/7), IPv4-mapped (::ffff:0:0/96), 6to4 (2002::/16)
- *   - Encoded IP bypass detection: decimal, hex, octal representations
+ *   - Encoded IP bypass (decimal, hex, octal) — handled automatically by the
+ *     WHATWG URL parser (`new URL()`), which normalises these to dotted-quad
+ *     before the checks below run.
  *   - Domain allowlist with exact and wildcard (*.example.com) matching
  *
  * NOTE: This is static URL analysis only. DNS rebinding attacks — where a
@@ -97,36 +99,6 @@ function isPrivateRfc1918(host: string): boolean {
     if (n >= 16 && n <= 31) return true;
   }
   return /^192\.168\./.test(host);
-}
-
-// ---------------------------------------------------------------------------
-// Encoded IP bypass detection (decimal, hex, octal representations)
-// ---------------------------------------------------------------------------
-
-function decimalToIp(host: string): string | undefined {
-  if (!/^\d+$/.test(host)) return undefined;
-  const n = Number(host);
-  if (!Number.isFinite(n) || n < 0 || n > 0xffffffff) return undefined;
-  return `${(n >>> 24) & 0xff}.${(n >>> 16) & 0xff}.${(n >>> 8) & 0xff}.${n & 0xff}`;
-}
-
-function hexToIp(host: string): string | undefined {
-  if (!/^0x[0-9a-f]+$/i.test(host)) return undefined;
-  const n = Number(host);
-  if (!Number.isFinite(n) || n < 0 || n > 0xffffffff) return undefined;
-  return `${(n >>> 24) & 0xff}.${(n >>> 16) & 0xff}.${(n >>> 8) & 0xff}.${n & 0xff}`;
-}
-
-function octalToIp(host: string): string | undefined {
-  const parts = host.split(".");
-  if (parts.length !== 4) return undefined;
-  const hasOctal = parts.some((p) => p.length > 1 && p.startsWith("0") && /^0[0-7]+$/.test(p));
-  if (!hasOctal) return undefined;
-  const octets = parts.map((p) =>
-    p.length > 1 && p.startsWith("0") ? Number.parseInt(p, 8) : Number.parseInt(p, 10),
-  );
-  if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) return undefined;
-  return octets.join(".");
 }
 
 // ---------------------------------------------------------------------------
@@ -300,23 +272,11 @@ function classifyHost(host: string): BlockedReason | undefined {
     return undefined; // Global unicast IPv6 — allowed
   }
 
-  // IPv4 dotted-quad or plain hostname
-  const directResult = classifyIpv4(lower);
-  if (directResult !== undefined) return directResult;
-
-  // Encoded IP bypass detection (decimal, hex, octal representations)
-  const decoded = decimalToIp(lower) ?? hexToIp(lower) ?? octalToIp(lower);
-  if (decoded !== undefined) {
-    const decodedResult = classifyIpv4(decoded);
-    if (decodedResult !== undefined) {
-      return {
-        category: `encoded ${decodedResult.category} — "${lower}" decodes to ${decoded}`,
-        guidance: decodedResult.guidance,
-      };
-    }
-  }
-
-  return undefined;
+  // IPv4 dotted-quad or plain hostname.
+  // Note: decimal (2130706433), hex (0x7f000001), and octal (0177.0.0.1)
+  // representations are normalised to dotted-quad by `new URL()` before
+  // reaching this function, so no additional decode step is needed.
+  return classifyIpv4(lower);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/e2e-browser-270.ts
+++ b/scripts/e2e-browser-270.ts
@@ -1,0 +1,571 @@
+#!/usr/bin/env bun
+
+/**
+ * Manual E2E — Issue #270 follow-on: browser_console + retryAfterMs + INTERNAL prompt
+ *
+ * Three features validated end-to-end:
+ *   1. browser_console tool — per-tab buffering, level filtering, limit, clear
+ *   2. retryAfterMs on timeout() — error translator produces retryAfterMs: 2_000 on TimeoutError
+ *   3. INTERNAL + STALE_REF rows in BROWSER_SYSTEM_PROMPT
+ *
+ * Section A — direct driver/module tests (no LLM required, no API key needed):
+ *   A1. console() returns empty entries on a fresh page
+ *   A2. console() captures log/warn/error injected via evaluate()
+ *   A3. console() filters by level (error-only)
+ *   A4. console() respects limit (most recent N entries)
+ *   A5. console() clears buffer when clear: true
+ *   A6. per-tab isolation — tab-1 and tab-2 have separate console buffers
+ *   A7. translatePlaywrightError produces TIMEOUT + retryAfterMs: 2_000 on TimeoutError
+ *   A8. BROWSER_SYSTEM_PROMPT contains INTERNAL and STALE_REF error-code rows
+ *
+ * Section B — LLM-driven tests (Pi adapter + real Anthropic API call):
+ *   B1. agent injects JS console messages, reads them via browser_console
+ *   B2. agent uses level=error filtering to isolate errors from log/warn
+ *   B3. agent reads console, then verifies buffer is empty after clear: true
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-browser-270.ts
+ *   ANTHROPIC_API_KEY=sk-... HEADLESS=false bun scripts/e2e-browser-270.ts  # headed
+ *   SECTION=A bun scripts/e2e-browser-270.ts                                 # no API key needed
+ */
+
+import { translatePlaywrightError } from "../packages/browser-playwright/src/error-translator.js";
+import { createPlaywrightBrowserDriver } from "../packages/browser-playwright/src/playwright-browser-driver.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { createBrowserProvider } from "../packages/tool-browser/src/browser-component-provider.js";
+import { ALL_OPERATIONS, BROWSER_SYSTEM_PROMPT } from "../packages/tool-browser/src/constants.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HEADLESS = process.env.HEADLESS !== "false";
+const SECTION = (process.env.SECTION ?? "AB").toUpperCase();
+const RUN_LLM = SECTION.includes("B");
+const MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+if (RUN_LLM && !API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Run with SECTION=A to skip LLM tests.");
+  process.exit(1);
+}
+
+console.log(`\n${"═".repeat(64)}`);
+console.log("  E2E: Issue #270 — browser_console + retryAfterMs + INTERNAL");
+console.log(`${"═".repeat(64)}`);
+console.log(`  Model:    ${MODEL}`);
+console.log(`  Headless: ${HEADLESS}`);
+console.log(`  Sections: ${SECTION}`);
+console.log(`${"═".repeat(64)}\n`);
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+let currentSection = "";
+
+function section(name: string): void {
+  currentSection = name;
+  console.log(`\n── ${name} ${"─".repeat(Math.max(0, 56 - name.length))}`);
+}
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  const label = `${currentSection} > ${name}`;
+  results.push({ name: label, passed: condition, detail });
+  const tag = condition ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m";
+  const suffix = detail ? `  (${detail})` : "";
+  console.log(`  ${tag}  ${name}${suffix}`);
+}
+
+function printReport(): void {
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  console.log(`\n${"═".repeat(64)}`);
+  console.log(
+    `  Results: ${passed}/${results.length} passed${failed > 0 ? `, ${failed} FAILED` : ""}`,
+  );
+  console.log(`${"═".repeat(64)}`);
+  if (failed > 0) {
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  ✗  ${r.name}${r.detail ? `  — ${r.detail}` : ""}`);
+    }
+  }
+  console.log();
+}
+
+async function runAgent(
+  runtime: Awaited<ReturnType<typeof createKoi>>,
+  task: string,
+): Promise<{
+  readonly text: string;
+  readonly toolNames: readonly string[];
+  readonly stopReason: string;
+}> {
+  const toolNames: string[] = [];
+  const textParts: string[] = [];
+  let stopReason = "unknown";
+
+  process.stdout.write(`  [task] ${task.slice(0, 120)}${task.length > 120 ? "…" : ""}\n  [llm]  `);
+
+  for await (const event of runtime.run({ kind: "text", text: task })) {
+    if (event.kind === "text_delta") {
+      process.stdout.write(event.delta);
+      textParts.push(event.delta);
+    } else if (event.kind === "tool_call_start") {
+      process.stdout.write(`\n  [tool] ${event.toolName}`);
+      toolNames.push(event.toolName);
+    } else if (event.kind === "tool_call_end") {
+      const r = JSON.stringify(event.result);
+      process.stdout.write(` → ${r.length > 100 ? `${r.slice(0, 100)}…` : r}`);
+    } else if (event.kind === "done") {
+      stopReason = event.output.stopReason;
+      process.stdout.write(
+        `\n  [done] stopReason=${stopReason} tokens=${event.output.metrics.totalTokens ?? 0}\n`,
+      );
+    }
+  }
+
+  return { text: textParts.join(""), toolNames, stopReason };
+}
+
+// ---------------------------------------------------------------------------
+// Section A — direct driver + module tests (no LLM required)
+// ---------------------------------------------------------------------------
+
+async function runSectionA(): Promise<void> {
+  const driver = createPlaywrightBrowserDriver({ headless: HEADLESS });
+
+  // ── A1: console() returns empty entries on a fresh page ─────────────────
+
+  section("A1: console() empty on fresh page");
+  {
+    const nav = await driver.navigate("https://example.com");
+    assert(
+      "navigate succeeds",
+      nav.ok,
+      nav.ok ? undefined : JSON.stringify((nav as { error: unknown }).error),
+    );
+
+    const result = await driver.console();
+    assert("console() succeeds", result.ok);
+    if (result.ok) {
+      // example.com may produce a small number of messages; what matters is
+      // the call succeeds and returns the expected shape.
+      assert("entries is an array", Array.isArray(result.value.entries));
+      assert("total is a number", typeof result.value.total === "number");
+      assert(
+        "total >= entries.length",
+        result.value.total >= result.value.entries.length,
+        `total=${result.value.total} entries=${result.value.entries.length}`,
+      );
+    }
+  }
+
+  // ── A2: console() captures messages injected via evaluate() ─────────────
+
+  section("A2: console() captures injected messages");
+  {
+    // Clear any existing buffer first, then inject known messages.
+    await driver.console({ clear: true });
+
+    const inject = await driver.evaluate(
+      `console.log("log-msg"); console.warn("warn-msg"); console.error("error-msg"); "done"`,
+    );
+    assert(
+      "evaluate inject succeeds",
+      inject.ok,
+      inject.ok ? undefined : JSON.stringify((inject as { error: unknown }).error),
+    );
+
+    const result = await driver.console();
+    assert("console() succeeds", result.ok);
+    if (result.ok) {
+      const texts = result.value.entries.map((e) => e.text);
+      assert("captured 3 entries", result.value.entries.length >= 3, String(result.value.total));
+      assert(
+        "log-msg present",
+        texts.some((t) => t.includes("log-msg")),
+      );
+      assert(
+        "warn-msg present",
+        texts.some((t) => t.includes("warn-msg")),
+      );
+      assert(
+        "error-msg present",
+        texts.some((t) => t.includes("error-msg")),
+      );
+      // Verify levels are correct
+      const logEntry = result.value.entries.find((e) => e.text.includes("log-msg"));
+      const errEntry = result.value.entries.find((e) => e.text.includes("error-msg"));
+      assert("log-msg has level=log", logEntry?.level === "log", logEntry?.level);
+      assert("error-msg has level=error", errEntry?.level === "error", errEntry?.level);
+    }
+  }
+
+  // ── A3: console() filters by level ──────────────────────────────────────
+
+  section("A3: console() level filtering");
+  {
+    // Buffer has log-msg, warn-msg, error-msg from A2 (not cleared).
+    const errorOnly = await driver.console({ levels: ["error"] });
+    assert("error-only filter succeeds", errorOnly.ok);
+    if (errorOnly.ok) {
+      const levels = errorOnly.value.entries.map((e) => e.level);
+      assert(
+        "all returned entries are 'error'",
+        levels.every((l) => l === "error"),
+        levels.join(),
+      );
+      assert(
+        "error-msg is included",
+        errorOnly.value.entries.some((e) => e.text.includes("error-msg")),
+      );
+      assert(
+        "log-msg is excluded",
+        !errorOnly.value.entries.some((e) => e.text.includes("log-msg")),
+      );
+    }
+  }
+
+  // ── A4: console() respects limit (most recent N entries) ─────────────────
+
+  section("A4: console() limit");
+  {
+    // Inject 10 numbered messages then ask for the last 3.
+    await driver.console({ clear: true });
+    await driver.evaluate(`for (let i = 1; i <= 10; i++) console.log("msg-" + i); "done"`);
+
+    const limited = await driver.console({ limit: 3 });
+    assert("limit request succeeds", limited.ok);
+    if (limited.ok) {
+      assert(
+        "total reflects full buffer (10)",
+        limited.value.total === 10,
+        String(limited.value.total),
+      );
+      assert(
+        "entries returned is at most 3",
+        limited.value.entries.length <= 3,
+        String(limited.value.entries.length),
+      );
+      // Should be the LAST 3 (most recent): msg-8, msg-9, msg-10
+      const texts = limited.value.entries.map((e) => e.text);
+      assert(
+        "msg-10 is present (most recent)",
+        texts.some((t) => t.includes("msg-10")),
+      );
+      // Use exact match — "msg-1" is a substring of "msg-10", so .includes() would false-positive
+      assert("msg-1 is absent (oldest, outside limit)", !texts.some((t) => t === "msg-1"));
+    }
+  }
+
+  // ── A5: console() clears buffer when clear: true ─────────────────────────
+
+  section("A5: console() clear");
+  {
+    // Buffer has 10 messages from A4.
+    const before = await driver.console();
+    assert(
+      "buffer is non-empty before clear",
+      before.ok && before.value.total > 0,
+      String(before.ok ? before.value.total : "error"),
+    );
+
+    // Read with clear: true
+    const cleared = await driver.console({ clear: true });
+    assert("clear request succeeds", cleared.ok);
+
+    // Next read should be empty
+    const after = await driver.console();
+    assert(
+      "buffer is empty after clear",
+      after.ok && after.value.total === 0,
+      String(after.ok ? after.value.total : "error"),
+    );
+  }
+
+  // ── A6: per-tab console isolation ─────────────────────────────────────────
+
+  section("A6: per-tab console isolation");
+  {
+    // tab-1 is already open on example.com
+    // Inject a message into tab-1
+    await driver.console({ clear: true });
+    await driver.evaluate(`console.log("tab1-only-message"); "done"`);
+
+    // Open tab-2 and inject a different message there
+    const tab2 = await driver.tabNew({ url: "about:blank" });
+    assert("tab-2 opens", tab2.ok);
+    await driver.evaluate(`console.log("tab2-only-message"); "done"`);
+
+    // Read console on tab-2 — should see tab2 message only
+    const tab2Console = await driver.console();
+    assert("tab-2 console succeeds", tab2Console.ok);
+    if (tab2Console.ok) {
+      assert(
+        "tab2-only-message present in tab-2",
+        tab2Console.value.entries.some((e) => e.text.includes("tab2-only-message")),
+      );
+      assert(
+        "tab1-only-message absent from tab-2",
+        !tab2Console.value.entries.some((e) => e.text.includes("tab1-only-message")),
+      );
+    }
+
+    // Switch back to tab-1 — should see its own message, not tab-2's
+    await driver.tabFocus("tab-1");
+    const tab1Console = await driver.console();
+    assert("tab-1 console succeeds after switch", tab1Console.ok);
+    if (tab1Console.ok) {
+      assert(
+        "tab1-only-message present in tab-1",
+        tab1Console.value.entries.some((e) => e.text.includes("tab1-only-message")),
+      );
+      assert(
+        "tab2-only-message absent from tab-1",
+        !tab1Console.value.entries.some((e) => e.text.includes("tab2-only-message")),
+      );
+    }
+
+    // Cleanup
+    if (tab2.ok) await driver.tabClose(tab2.value.tabId);
+  }
+
+  // ── A7: translatePlaywrightError produces retryAfterMs: 2_000 ───────────
+
+  section("A7: retryAfterMs on TimeoutError");
+  {
+    // Simulate a Playwright TimeoutError (name-based detection)
+    const fakeTimeout = new Error(
+      "locator.click: Timeout 30000ms exceeded waiting for element to be visible",
+    );
+    fakeTimeout.name = "TimeoutError";
+
+    const err = translatePlaywrightError("browser_click", fakeTimeout);
+    assert("code is TIMEOUT", err.code === "TIMEOUT", err.code);
+    assert("retryable is true", err.retryable === true, String(err.retryable));
+    assert(
+      "retryAfterMs is 2000",
+      err.retryAfterMs === 2_000,
+      `retryAfterMs=${String(err.retryAfterMs)}`,
+    );
+    assert("message mentions the operation", err.message.includes("browser_click"), err.message);
+
+    // Also verify message-based detection (for environments where name isn't set)
+    const msgBasedErr = translatePlaywrightError(
+      "browser_navigate",
+      new Error("Navigation timeout exceeded — try again"),
+    );
+    assert("message-based timeout detected", msgBasedErr.code === "TIMEOUT", msgBasedErr.code);
+    assert("message-based also gets retryAfterMs", msgBasedErr.retryAfterMs === 2_000);
+
+    // Non-timeout errors must NOT have retryAfterMs
+    const netErr = translatePlaywrightError(
+      "browser_navigate",
+      new Error("net::ERR_NAME_NOT_RESOLVED"),
+    );
+    assert(
+      "non-timeout has no retryAfterMs",
+      netErr.retryAfterMs === undefined,
+      String(netErr.retryAfterMs),
+    );
+  }
+
+  // ── A8: BROWSER_SYSTEM_PROMPT contains INTERNAL and STALE_REF rows ───────
+
+  section("A8: BROWSER_SYSTEM_PROMPT error table");
+  assert(
+    "is a non-empty string",
+    typeof BROWSER_SYSTEM_PROMPT === "string" && BROWSER_SYSTEM_PROMPT.length > 0,
+  );
+  assert("contains STALE_REF", BROWSER_SYSTEM_PROMPT.includes("STALE_REF"));
+  assert("contains INTERNAL", BROWSER_SYSTEM_PROMPT.includes("INTERNAL"));
+  assert("contains TIMEOUT", BROWSER_SYSTEM_PROMPT.includes("TIMEOUT"));
+  assert("contains PERMISSION", BROWSER_SYSTEM_PROMPT.includes("PERMISSION"));
+  assert("contains EXTERNAL", BROWSER_SYSTEM_PROMPT.includes("EXTERNAL"));
+  assert(
+    "INTERNAL row mentions page crash/closed",
+    BROWSER_SYSTEM_PROMPT.toLowerCase().includes("crash") ||
+      BROWSER_SYSTEM_PROMPT.toLowerCase().includes("closed") ||
+      BROWSER_SYSTEM_PROMPT.toLowerCase().includes("page"),
+  );
+  assert(
+    "STALE_REF row mentions snapshot",
+    BROWSER_SYSTEM_PROMPT.toLowerCase().includes("snapshot"),
+  );
+  assert("snapshotId guidance present", BROWSER_SYSTEM_PROMPT.includes("snapshotId"));
+
+  await driver.dispose?.();
+}
+
+// ---------------------------------------------------------------------------
+// Section B — LLM-driven tests (Pi adapter + real Anthropic API call)
+// ---------------------------------------------------------------------------
+
+function makeAdapter(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: MODEL,
+    getApiKey: () => API_KEY,
+    thinkingLevel: "off",
+    systemPrompt: [
+      "You are a browser automation agent.",
+      "Use the provided browser tools to complete each task exactly as instructed.",
+      "Always call browser_snapshot before clicking or interacting with elements.",
+      "Be concise — complete the task and report results briefly.",
+    ].join(" "),
+  });
+}
+
+async function makeRuntime(name: string): Promise<Awaited<ReturnType<typeof createKoi>>> {
+  const backend = createPlaywrightBrowserDriver({ headless: HEADLESS });
+  const provider = createBrowserProvider({
+    backend,
+    trustTier: "verified",
+    operations: ALL_OPERATIONS,
+  });
+  return createKoi({
+    manifest: { name, version: "0.1.0", model: { name: MODEL } },
+    adapter: makeAdapter(),
+    providers: [provider],
+    loopDetection: false,
+    limits: { maxTurns: 15 },
+  });
+}
+
+async function runSectionB(): Promise<void> {
+  console.log("[setup] Creating per-test runtimes (fresh driver per test).\n");
+
+  // ── B1: agent injects JS messages and reads them via browser_console ──────
+
+  section("B1: agent reads browser_console (LLM)");
+  {
+    const rt = await makeRuntime("e2e-270-b1");
+    try {
+      const { text, toolNames, stopReason } = await runAgent(
+        rt,
+        [
+          "Navigate to https://example.com.",
+          "Then use browser_evaluate to run this JavaScript:",
+          '  console.log("hello from log"); console.warn("hello from warn"); console.error("critical-failure-xyz"); "done"',
+          "After that, use browser_console to read all buffered console messages.",
+          "Tell me: how many messages are there, what levels are they, and what do they say?",
+        ].join(" "),
+      );
+      assert("agent completed", stopReason === "completed", stopReason);
+      assert("browser_navigate called", toolNames.includes("browser_navigate"));
+      assert("browser_evaluate called", toolNames.includes("browser_evaluate"));
+      assert("browser_console called", toolNames.includes("browser_console"));
+      const lower = text.toLowerCase();
+      assert(
+        "agent sees the injected messages",
+        lower.includes("critical-failure-xyz") ||
+          lower.includes("hello from log") ||
+          lower.includes("hello from warn"),
+        text.slice(0, 200),
+      );
+    } finally {
+      await rt.dispose();
+    }
+  }
+
+  // ── B2: agent filters by error level only ────────────────────────────────
+
+  section("B2: agent uses level=error filter (LLM)");
+  {
+    const rt = await makeRuntime("e2e-270-b2");
+    try {
+      const { text, toolNames, stopReason } = await runAgent(
+        rt,
+        [
+          "Navigate to https://example.com.",
+          "Use browser_evaluate to run:",
+          '  console.log("info one"); console.log("info two"); console.error("only-error-abc"); "done"',
+          'Now call browser_console with levels set to ["error"] to get only error messages.',
+          "Tell me how many error messages you see and quote their text.",
+        ].join(" "),
+      );
+      assert("agent completed", stopReason === "completed", stopReason);
+      assert("browser_console called", toolNames.includes("browser_console"));
+      const lower = text.toLowerCase();
+      assert("agent reports only-error-abc", lower.includes("only-error-abc"), text.slice(0, 200));
+      // Agent should mention filtering / errors (not info messages)
+      assert(
+        "response mentions error level",
+        lower.includes("error") || lower.includes("1 message") || lower.includes("one message"),
+        text.slice(0, 200),
+      );
+    } finally {
+      await rt.dispose();
+    }
+  }
+
+  // ── B3: agent verifies clear empties the buffer ───────────────────────────
+
+  section("B3: agent verifies clear: true empties buffer (LLM)");
+  {
+    const rt = await makeRuntime("e2e-270-b3");
+    try {
+      const { text, toolNames, stopReason } = await runAgent(
+        rt,
+        [
+          "Navigate to https://example.com.",
+          "Use browser_evaluate to run: console.log('msg-alpha'); console.log('msg-beta'); \"done\"",
+          "Call browser_console (no options) and confirm you see at least 2 messages.",
+          "Then call browser_console with clear set to true.",
+          "Finally call browser_console one more time (no options) and confirm the buffer is now empty (0 messages).",
+          "Report what you found at each step.",
+        ].join(" "),
+      );
+      assert("agent completed", stopReason === "completed", stopReason);
+      assert(
+        "browser_console called (at least twice)",
+        toolNames.filter((t) => t === "browser_console").length >= 2,
+      );
+      const lower = text.toLowerCase();
+      assert(
+        "agent confirms buffer is empty after clear",
+        lower.includes("empty") ||
+          lower.includes("0 message") ||
+          lower.includes("no message") ||
+          lower.includes("cleared"),
+        text.slice(0, 300),
+      );
+    } finally {
+      await rt.dispose();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  if (SECTION.includes("A")) {
+    console.log("Running Section A (direct driver + module tests)...");
+    await runSectionA();
+  }
+
+  if (RUN_LLM) {
+    console.log("\nRunning Section B (LLM-driven tests)...");
+    await runSectionB();
+  }
+
+  printReport();
+
+  const failed = results.filter((r) => !r.passed).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error: unknown) => {
+  console.error("\n[e2e] FATAL:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements three follow-on improvements from issue #270 (AI-friendly browser error translation):

- **`browser_console` tool** — per-tab FIFO ring buffer (1,000 entries, cap: 200 returned) capturing Playwright console events at log/warning/error/debug/info levels. Agents can filter by level, limit to N most-recent, and optionally clear the buffer. Removes the need for the promoted-tier `evaluate` tool to diagnose JS errors.
- **`retryAfterMs` on `timeout()`** — `error-factories.ts` now accepts an optional `retryAfterMs` parameter; the Playwright error translator passes `2_000` ms for navigation and element timeouts so LLMs know how long to wait before retrying.
- **`INTERNAL` row in `BROWSER_SYSTEM_PROMPT`** — the page-crash/closed scenario was absent from the error guidance table; added so agents know to re-navigate instead of retrying.

**Bonus:** removed dead IP-decode helpers (`decimalToIp` / `hexToIp` / `octalToIp`) from `url-security.ts` — Bun's WHATWG URL parser normalises all alternate representations before the checks run, so those branches were unreachable. `url-security.ts` coverage: 91.67 % → 100 %.

**E2E validation:** `scripts/e2e-browser-270.ts` — 48 Section A assertions (driver-level, no LLM) + 12 Section B assertions (real Pi agent via Anthropic API, Haiku-4.5) all pass.

## Changed packages

| Package | Change |
|---------|--------|
| `@koi/core` | New types: `BrowserConsoleLevel`, `BrowserConsoleEntry`, `BrowserConsoleOptions`, `BrowserConsoleResult`; `timeout()` factory gains optional `retryAfterMs` |
| `@koi/browser-playwright` | `console()` driver method, per-tab console buffer with FIFO eviction, `retryAfterMs: 2_000` in error translator, new `error-translator.ts` |
| `@koi/tool-browser` | `browser_console` tool, `console` in OPERATIONS, INTERNAL row in BROWSER_SYSTEM_PROMPT, `parseOptionalConsoleLevels` parser, mock driver updated |

## Test plan

- [x] `packages/core` — `errors.test.ts` (retryAfterMs), `backward-compat.test.ts`, API surface snapshot
- [x] `packages/browser-playwright` — `playwright-browser-driver.test.ts` (console tests), `error-translator.test.ts`
- [x] `packages/tool-browser` — `console.test.ts` (9 new tests), `constants.test.ts` (INTERNAL in prompt), `click.test.ts`/`hover.test.ts` (STALE_REF)
- [x] E2E: `SECTION=A bun scripts/e2e-browser-270.ts` — all 48 assertions pass
- [x] E2E: `bun scripts/e2e-browser-270.ts` — all 60 assertions pass (real Anthropic API)

Closes #270