### PR TITLE
feat(forge): make implementation bricks discoverable as ECS components

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -3,23 +3,23 @@
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { BrickRef } from './brick-snapshot.js';
 export { BrickId, BrickSnapshot, BrickSource, SnapshotEvent, SnapshotId, SnapshotQuery, SnapshotStore, brickId, snapshotId } from './brick-snapshot.js';
-import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-BV2EgL97.js';
-export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, X as RunId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as runId, a7 as sessionId, a8 as skillToken, a9 as token, aa as toolCallId, ab as toolToken, ac as turnId } from './ecs-BV2EgL97.js';
-import { E as EngineState, a as EngineInput } from './engine-BCN59tjf.js';
-export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-BCN59tjf.js';
+import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-DMen1Yu6.js';
+export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, X as RunId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as engineToken, a7 as middlewareToken, a8 as providerToken, a9 as resolverToken, aa as runId, ab as sessionId, ac as skillToken, ad as token, ae as toolCallId, af as toolToken, ag as turnId } from './ecs-DMen1Yu6.js';
+import { E as EngineState, a as EngineInput } from './engine-DTI80mYJ.js';
+export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-DTI80mYJ.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { A as AgentManifest } from './assembly-BeWjVbbb.js';
 export { C as ChannelConfig, D as DelegationComponent, a as DelegationConfig, b as DelegationDenyReason, c as DelegationGrant, d as DelegationId, e as DelegationScope, f as DelegationVerifyResult, M as MiddlewareConfig, g as ModelConfig, P as PermissionConfig, R as RevocationRegistry, S as ScopeChecker, T as ToolConfig } from './assembly-BeWjVbbb.js';
 import { JsonObject } from './common.js';
-export { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, CompositeArtifact, ForgeQuery, ForgeStore, LockHandle, LockMode, LockRequest, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, ToolArtifact } from './brick-store.js';
+export { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, CompositeArtifact, ForgeQuery, ForgeStore, ImplementationArtifact, LockHandle, LockMode, LockRequest, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, ToolArtifact } from './brick-store.js';
 export { ChannelAdapter, ChannelCapabilities, ChannelStatus, ChannelStatusKind, MessageHandler } from './channel.js';
 export { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, FeatureFlags, ForgeConfigSection, KoiConfig, LimitsConfig, LogLevel, LoopDetectionConfigSection, ModelRouterConfigSection, ModelTargetConfigEntry, SpawnConfig, TelemetryConfig } from './config.js';
 export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js';
 export { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfig, EventEnvelope, EventInput, ReadOptions, ReadResult, SubscribeOptions, SubscriptionHandle } from './event-backend.js';
 export { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult } from './eviction.js';
 export { FileEdit, FileEditOptions, FileEditResult, FileEntryKind, FileListEntry, FileListOptions, FileListResult, FileReadOptions, FileReadResult, FileSearchMatch, FileSearchOptions, FileSearchResult, FileSystemBackend, FileWriteOptions, FileWriteResult } from './filesystem-backend.js';
-export { B as BrickKind, a as BrickLifecycle, F as ForgeScope, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-4-HydRtT.js';
+export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-iu7PvGR6.js';
 export { DEFAULT_HEALTH_MONITOR_CONFIG, HealthMonitor, HealthMonitorConfig, HealthMonitorStats, HealthSnapshot, HealthStatus } from './health.js';
 export { AgentCondition, AgentRegistry, AgentStatus, RegistryEntry, RegistryEvent, RegistryFilter, TransitionReason, VALID_TRANSITIONS } from './lifecycle.js';
 export { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, InboundMessage, OutboundMessage, TextBlock } from './message.js';
@@ -865,7 +865,7 @@ import './webhook.js';
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
 "import './assembly-BeWjVbbb.js';
-export { a as Agent, A as AgentId, B as BROWSER, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, P as ProcessState, X as RunId, S as SessionId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, T as ToolCallId, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as runId, a7 as sessionId, a8 as skillToken, a9 as token, aa as toolCallId, ab as toolToken, ac as turnId } from './ecs-BV2EgL97.js';
+export { a as Agent, A as AgentId, B as BROWSER, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, P as ProcessState, X as RunId, S as SessionId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, T as ToolCallId, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as engineToken, a7 as middlewareToken, a8 as providerToken, a9 as resolverToken, aa as runId, ab as sessionId, ac as skillToken, ad as token, ae as toolCallId, af as toolToken, ag as turnId } from './ecs-DMen1Yu6.js';
 import './channel.js';
 import './common.js';
 import './filesystem-backend.js';
@@ -877,8 +877,8 @@ import './message.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-BCN59tjf.js';
-import './ecs-BV2EgL97.js';
+export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-DTI80mYJ.js';
+import './ecs-DMen1Yu6.js';
 import './message.js';
 import './middleware.js';
 import './assembly-BeWjVbbb.js';
@@ -1157,7 +1157,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import { ChannelStatus } from './channel.js';
 import { JsonObject } from './common.js';
-import { T as ToolCallId, S as SessionId, X as RunId, a3 as TurnId } from './ecs-BV2EgL97.js';
+import { T as ToolCallId, S as SessionId, X as RunId, a3 as TurnId } from './ecs-DMen1Yu6.js';
 import { InboundMessage } from './message.js';
 import './assembly-BeWjVbbb.js';
 import './webhook.js';
@@ -1281,7 +1281,7 @@ export type { ApprovalDecision, ApprovalHandler, ApprovalRequest, KoiMiddleware,
 `;
 
 exports[`@koi/core API surface ./eviction has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-BV2EgL97.js';
+"import { A as AgentId, P as ProcessState } from './ecs-DMen1Yu6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1335,7 +1335,7 @@ export type { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult 
 `;
 
 exports[`@koi/core API surface ./health has stable type surface 1`] = `
-"import { A as AgentId } from './ecs-BV2EgL97.js';
+"import { A as AgentId } from './ecs-DMen1Yu6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1407,7 +1407,7 @@ export { DEFAULT_HEALTH_MONITOR_CONFIG, type HealthMonitor, type HealthMonitorCo
 `;
 
 exports[`@koi/core API surface ./lifecycle has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-BV2EgL97.js';
+"import { A as AgentId, P as ProcessState } from './ecs-DMen1Yu6.js';
 import { Result, KoiError } from './errors.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
@@ -1635,8 +1635,14 @@ export type { Resolver, SourceBundle, SourceLanguage };
 
 exports[`@koi/core API surface ./brick-snapshot has stable type surface 1`] = `
 "import { Result, KoiError } from './errors.js';
-import { B as BrickKind } from './forge-types-4-HydRtT.js';
+import { B as BrickKind } from './forge-types-iu7PvGR6.js';
 import './common.js';
+import './ecs-DMen1Yu6.js';
+import './assembly-BeWjVbbb.js';
+import './webhook.js';
+import './channel.js';
+import './message.js';
+import './filesystem-backend.js';
 
 /**
  * Brick snapshot types — version history, provenance tracking, and diff.
@@ -1748,9 +1754,9 @@ export { type BrickId, type BrickRef, type BrickSnapshot, type BrickSource, type
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-BV2EgL97.js';
+"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
 import { Result, KoiError } from './errors.js';
-import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-4-HydRtT.js';
+import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-iu7PvGR6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1818,7 +1824,11 @@ interface CompositeArtifact extends BrickArtifactBase {
     readonly kind: "composite";
     readonly brickIds: readonly string[];
 }
-type BrickArtifact = ToolArtifact | SkillArtifact | AgentArtifact | CompositeArtifact;
+interface ImplementationArtifact extends BrickArtifactBase {
+    readonly kind: "engine" | "resolver" | "provider" | "middleware" | "channel";
+    readonly implementation: string;
+}
+type BrickArtifact = ToolArtifact | SkillArtifact | AgentArtifact | CompositeArtifact | ImplementationArtifact;
 interface ForgeQuery {
     readonly kind?: BrickKind;
     readonly scope?: ForgeScope;
@@ -1892,13 +1902,13 @@ interface AdvisoryLock {
     readonly release: (handle: LockHandle) => Promise<Result<void, KoiError>>;
 }
 
-export type { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, CompositeArtifact, ForgeQuery, ForgeStore, LockHandle, LockMode, LockRequest, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, ToolArtifact };
+export type { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, CompositeArtifact, ForgeQuery, ForgeStore, ImplementationArtifact, LockHandle, LockMode, LockRequest, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, ToolArtifact };
 "
 `;
 
 exports[`@koi/core API surface ./sandbox-adapter has stable type surface 1`] = `
 "import { SandboxProfile } from './sandbox-profile.js';
-import './ecs-BV2EgL97.js';
+import './ecs-DMen1Yu6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1970,7 +1980,7 @@ export type { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxI
 `;
 
 exports[`@koi/core API surface ./sandbox-executor has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-BV2EgL97.js';
+"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -2034,7 +2044,7 @@ export type { SandboxError, SandboxErrorCode, SandboxExecutor, SandboxResult, Ti
 `;
 
 exports[`@koi/core API surface ./sandbox-profile has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-BV2EgL97.js';
+"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';

--- a/packages/core/src/__tests__/build.test.ts
+++ b/packages/core/src/__tests__/build.test.ts
@@ -35,9 +35,9 @@ describe.skipIf(!distExists)("build output", () => {
     }
   });
 
-  test("index bundle is under 4KB", async () => {
+  test("index bundle is under 5KB", async () => {
     const file = Bun.file(resolve(DIST_DIR, "index.js"));
     const size = file.size;
-    expect(size).toBeLessThan(4096);
+    expect(size).toBeLessThan(5120);
   });
 });

--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -47,6 +47,7 @@ import type {
   HealthSnapshot,
   HealthStatus,
   ImageBlock,
+  ImplementationArtifact,
   InboundMessage,
   // common
   JsonObject,
@@ -96,16 +97,21 @@ import type {
   TrustTier,
   TurnContext,
 } from "../index.js";
-
 import {
+  ALL_BRICK_KINDS,
   agentId,
   CREDENTIALS,
   channelToken,
   DEFAULT_HEALTH_MONITOR_CONFIG,
   EVENTS,
+  engineToken,
   GOVERNANCE,
   MEMORY,
+  MIN_TRUST_BY_KIND,
+  middlewareToken,
+  providerToken,
   RETRYABLE_DEFAULTS,
+  resolverToken,
   skillToken,
   token,
   toolToken,
@@ -196,7 +202,8 @@ type _TypeGuard =
   | AssertDefined<EvictionPolicy>
   // resolver source types
   | AssertDefined<SourceBundle>
-  | AssertDefined<SourceLanguage>;
+  | AssertDefined<SourceLanguage>
+  | AssertDefined<ImplementationArtifact>;
 
 describe("export inventory", () => {
   test("all runtime values are defined", () => {
@@ -204,6 +211,10 @@ describe("export inventory", () => {
     expect(toolToken).toBeDefined();
     expect(channelToken).toBeDefined();
     expect(skillToken).toBeDefined();
+    expect(engineToken).toBeDefined();
+    expect(resolverToken).toBeDefined();
+    expect(providerToken).toBeDefined();
+    expect(middlewareToken).toBeDefined();
     expect(agentId).toBeDefined();
     expect(MEMORY).toBeDefined();
     expect(GOVERNANCE).toBeDefined();
@@ -212,6 +223,8 @@ describe("export inventory", () => {
     expect(RETRYABLE_DEFAULTS).toBeDefined();
     expect(VALID_TRANSITIONS).toBeDefined();
     expect(DEFAULT_HEALTH_MONITOR_CONFIG).toBeDefined();
+    expect(ALL_BRICK_KINDS).toBeDefined();
+    expect(MIN_TRUST_BY_KIND).toBeDefined();
   });
 
   test("runtime values are functions, strings, or objects", () => {
@@ -219,6 +232,10 @@ describe("export inventory", () => {
     expect(typeof toolToken).toBe("function");
     expect(typeof channelToken).toBe("function");
     expect(typeof skillToken).toBe("function");
+    expect(typeof engineToken).toBe("function");
+    expect(typeof resolverToken).toBe("function");
+    expect(typeof providerToken).toBe("function");
+    expect(typeof middlewareToken).toBe("function");
     expect(typeof agentId).toBe("function");
     expect(typeof MEMORY).toBe("string");
     expect(typeof GOVERNANCE).toBe("string");

--- a/packages/core/src/__tests__/forge-types.test.ts
+++ b/packages/core/src/__tests__/forge-types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickKind, TrustTier } from "../index.js";
+import { ALL_BRICK_KINDS, MIN_TRUST_BY_KIND } from "../index.js";
+
+describe("ALL_BRICK_KINDS", () => {
+  test("contains exactly 9 values", () => {
+    expect(ALL_BRICK_KINDS).toHaveLength(9);
+  });
+
+  test("includes all expected kinds", () => {
+    const expected: readonly BrickKind[] = [
+      "tool",
+      "skill",
+      "agent",
+      "composite",
+      "middleware",
+      "channel",
+      "engine",
+      "resolver",
+      "provider",
+    ];
+    for (const kind of expected) {
+      expect(ALL_BRICK_KINDS).toContain(kind);
+    }
+  });
+
+  test("has no duplicates", () => {
+    const unique = new Set(ALL_BRICK_KINDS);
+    expect(unique.size).toBe(ALL_BRICK_KINDS.length);
+  });
+});
+
+describe("MIN_TRUST_BY_KIND", () => {
+  test("has an entry for every kind in ALL_BRICK_KINDS", () => {
+    for (const kind of ALL_BRICK_KINDS) {
+      expect(MIN_TRUST_BY_KIND).toHaveProperty(kind);
+    }
+  });
+
+  test("sandbox kinds require sandbox trust", () => {
+    const sandboxKinds: readonly BrickKind[] = ["tool", "skill", "agent", "composite"];
+    for (const kind of sandboxKinds) {
+      expect(MIN_TRUST_BY_KIND[kind]).toBe("sandbox" satisfies TrustTier);
+    }
+  });
+
+  test("engine/resolver/provider require verified trust", () => {
+    const verifiedKinds: readonly BrickKind[] = ["engine", "resolver", "provider"];
+    for (const kind of verifiedKinds) {
+      expect(MIN_TRUST_BY_KIND[kind]).toBe("verified" satisfies TrustTier);
+    }
+  });
+
+  test("middleware/channel require promoted trust", () => {
+    const promotedKinds: readonly BrickKind[] = ["middleware", "channel"];
+    for (const kind of promotedKinds) {
+      expect(MIN_TRUST_BY_KIND[kind]).toBe("promoted" satisfies TrustTier);
+    }
+  });
+});

--- a/packages/core/src/__tests__/tokens.test.ts
+++ b/packages/core/src/__tests__/tokens.test.ts
@@ -3,8 +3,12 @@ import {
   CREDENTIALS,
   channelToken,
   EVENTS,
+  engineToken,
   GOVERNANCE,
   MEMORY,
+  middlewareToken,
+  providerToken,
+  resolverToken,
   skillToken,
   token,
   toolToken,
@@ -81,6 +85,78 @@ describe("skillToken()", () => {
 
   test("empty name produces skill: prefix only", () => {
     expect(str(skillToken(""))).toBe("skill:");
+  });
+});
+
+describe("engineToken()", () => {
+  test("prefixes with engine:", () => {
+    expect(str(engineToken("langGraph"))).toBe("engine:langGraph");
+  });
+
+  test("contains namespace separator", () => {
+    expect(str(engineToken("openai"))).toContain(":");
+  });
+
+  test("empty name produces engine: prefix only", () => {
+    expect(str(engineToken(""))).toBe("engine:");
+  });
+
+  test("name with colon produces double colon", () => {
+    expect(str(engineToken("v2:beta"))).toBe("engine:v2:beta");
+  });
+});
+
+describe("resolverToken()", () => {
+  test("prefixes with resolver:", () => {
+    expect(str(resolverToken("npm"))).toBe("resolver:npm");
+  });
+
+  test("contains namespace separator", () => {
+    expect(str(resolverToken("local"))).toContain(":");
+  });
+
+  test("empty name produces resolver: prefix only", () => {
+    expect(str(resolverToken(""))).toBe("resolver:");
+  });
+
+  test("name with colon produces double colon", () => {
+    expect(str(resolverToken("v2:beta"))).toBe("resolver:v2:beta");
+  });
+});
+
+describe("providerToken()", () => {
+  test("prefixes with provider:", () => {
+    expect(str(providerToken("openai"))).toBe("provider:openai");
+  });
+
+  test("contains namespace separator", () => {
+    expect(str(providerToken("anthropic"))).toContain(":");
+  });
+
+  test("empty name produces provider: prefix only", () => {
+    expect(str(providerToken(""))).toBe("provider:");
+  });
+
+  test("name with colon produces double colon", () => {
+    expect(str(providerToken("v2:beta"))).toBe("provider:v2:beta");
+  });
+});
+
+describe("middlewareToken()", () => {
+  test("prefixes with middleware:", () => {
+    expect(str(middlewareToken("audit"))).toBe("middleware:audit");
+  });
+
+  test("contains namespace separator", () => {
+    expect(str(middlewareToken("rateLimit"))).toContain(":");
+  });
+
+  test("empty name produces middleware: prefix only", () => {
+    expect(str(middlewareToken(""))).toBe("middleware:");
+  });
+
+  test("name with colon produces double colon", () => {
+    expect(str(middlewareToken("v2:beta"))).toBe("middleware:v2:beta");
   });
 });
 

--- a/packages/core/src/brick-store.ts
+++ b/packages/core/src/brick-store.ts
@@ -81,7 +81,17 @@ export interface CompositeArtifact extends BrickArtifactBase {
   readonly brickIds: readonly string[];
 }
 
-export type BrickArtifact = ToolArtifact | SkillArtifact | AgentArtifact | CompositeArtifact;
+export interface ImplementationArtifact extends BrickArtifactBase {
+  readonly kind: "engine" | "resolver" | "provider" | "middleware" | "channel";
+  readonly implementation: string;
+}
+
+export type BrickArtifact =
+  | ToolArtifact
+  | SkillArtifact
+  | AgentArtifact
+  | CompositeArtifact
+  | ImplementationArtifact;
 
 // ---------------------------------------------------------------------------
 // Forge query (structured search)

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -72,6 +72,22 @@ export function skillToken(name: string): SubsystemToken<SkillMetadata> {
   return `skill:${name}` as SubsystemToken<SkillMetadata>;
 }
 
+export function engineToken(name: string): SubsystemToken<unknown> {
+  return `engine:${name}` as SubsystemToken<unknown>;
+}
+
+export function resolverToken(name: string): SubsystemToken<unknown> {
+  return `resolver:${name}` as SubsystemToken<unknown>;
+}
+
+export function providerToken(name: string): SubsystemToken<unknown> {
+  return `provider:${name}` as SubsystemToken<unknown>;
+}
+
+export function middlewareToken(name: string): SubsystemToken<unknown> {
+  return `middleware:${name}` as SubsystemToken<unknown>;
+}
+
 /** Create a branded AgentId from a plain string. */
 export function agentId(id: string): AgentId {
   return id as AgentId;

--- a/packages/core/src/forge-types.ts
+++ b/packages/core/src/forge-types.ts
@@ -48,5 +48,50 @@ export const VALID_LIFECYCLE_TRANSITIONS: Readonly<
   quarantined: ["draft"] as const,
 });
 
-/** Kind of forged brick (tool, skill, agent, composite, middleware, channel). */
-export type BrickKind = "tool" | "skill" | "agent" | "composite" | "middleware" | "channel";
+/** Kind of forged brick. */
+export type BrickKind =
+  | "tool"
+  | "skill"
+  | "agent"
+  | "composite"
+  | "engine"
+  | "resolver"
+  | "provider"
+  | "middleware"
+  | "channel";
+
+// ---------------------------------------------------------------------------
+// Brick-kind constants (architecture-doc invariants)
+// ---------------------------------------------------------------------------
+
+/** All valid brick kinds as a readonly tuple. */
+export const ALL_BRICK_KINDS: readonly BrickKind[] = [
+  "tool",
+  "skill",
+  "agent",
+  "composite",
+  "engine",
+  "resolver",
+  "provider",
+  "middleware",
+  "channel",
+] as const;
+
+/**
+ * Minimum trust tier required per brick kind.
+ *
+ * - sandbox: tool, skill, agent, composite (sandboxed execution)
+ * - verified: engine, resolver, provider (elevated access)
+ * - promoted: middleware, channel (full interposition)
+ */
+export const MIN_TRUST_BY_KIND: Readonly<Record<BrickKind, import("./ecs.js").TrustTier>> = {
+  tool: "sandbox",
+  skill: "sandbox",
+  agent: "sandbox",
+  composite: "sandbox",
+  engine: "verified",
+  resolver: "verified",
+  provider: "verified",
+  middleware: "promoted",
+  channel: "promoted",
+} as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   CompositeArtifact,
   ForgeQuery,
   ForgeStore,
+  ImplementationArtifact,
   LockHandle,
   LockMode,
   LockRequest,
@@ -159,9 +160,13 @@ export {
   channelToken,
   DELEGATION,
   EVENTS,
+  engineToken,
   FILESYSTEM,
   GOVERNANCE,
   MEMORY,
+  middlewareToken,
+  providerToken,
+  resolverToken,
   runId,
   sessionId,
   skillToken,
@@ -239,7 +244,7 @@ export type {
 } from "./filesystem-backend.js";
 // forge types
 export type { BrickKind, BrickLifecycle, ForgeScope } from "./forge-types.js";
-export { VALID_LIFECYCLE_TRANSITIONS } from "./forge-types.js";
+export { ALL_BRICK_KINDS, MIN_TRUST_BY_KIND, VALID_LIFECYCLE_TRANSITIONS } from "./forge-types.js";
 // health
 export type {
   HealthMonitor,

--- a/packages/forge/src/forge-component-provider.test.ts
+++ b/packages/forge/src/forge-component-provider.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import type { Agent, SubsystemToken, TieredSandboxExecutor } from "@koi/core";
-import { agentId, toolToken } from "@koi/core";
+import {
+  agentId,
+  channelToken,
+  engineToken,
+  middlewareToken,
+  providerToken,
+  resolverToken,
+  toolToken,
+} from "@koi/core";
 import { brickToTool, createForgeComponentProvider } from "./forge-component-provider.js";
 import { createInMemoryForgeStore } from "./memory-store.js";
 import { createMemoryStoreChangeNotifier } from "./store-notifier.js";
-import type { SandboxExecutor, SkillArtifact, ToolArtifact } from "./types.js";
+import type {
+  ImplementationArtifact,
+  SandboxExecutor,
+  SkillArtifact,
+  ToolArtifact,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -914,5 +927,219 @@ describe("createForgeComponentProvider — notifier integration", () => {
     });
 
     provider.dispose(); // Should not throw
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Implementation kinds (engine, resolver, provider, middleware, channel)
+// ---------------------------------------------------------------------------
+
+function createImplementationBrick(
+  kind: ImplementationArtifact["kind"],
+  overrides?: Partial<ImplementationArtifact>,
+): ImplementationArtifact {
+  return {
+    id: `brick_${crypto.randomUUID()}`,
+    kind,
+    name: `my-${kind}`,
+    description: `A ${kind} implementation`,
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    createdBy: "agent-1",
+    createdAt: Date.now(),
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    contentHash: "test-hash",
+    implementation: `// ${kind} code`,
+    ...overrides,
+  } as ImplementationArtifact;
+}
+
+describe("createForgeComponentProvider — implementation kinds", () => {
+  test("attaches engine brick as ImplementationArtifact", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createImplementationBrick("engine", { name: "myEngine" }));
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    const components = await provider.attach(createMockAgent());
+    expect(components.has(engineToken("myEngine") as string)).toBe(true);
+
+    const artifact = components.get(engineToken("myEngine") as string) as ImplementationArtifact;
+    expect(artifact.kind).toBe("engine");
+    expect(artifact.name).toBe("myEngine");
+  });
+
+  test("attaches all 5 implementation kinds", async () => {
+    const store = createInMemoryForgeStore();
+    const kinds: readonly ImplementationArtifact["kind"][] = [
+      "engine",
+      "resolver",
+      "provider",
+      "middleware",
+      "channel",
+    ];
+    for (const kind of kinds) {
+      await store.save(createImplementationBrick(kind));
+    }
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    const components = await provider.attach(createMockAgent());
+    expect(components.size).toBe(5);
+    expect(components.has(engineToken("my-engine") as string)).toBe(true);
+    expect(components.has(resolverToken("my-resolver") as string)).toBe(true);
+    expect(components.has(providerToken("my-provider") as string)).toBe(true);
+    expect(components.has(middlewareToken("my-middleware") as string)).toBe(true);
+    expect(components.has(channelToken("my-channel") as string)).toBe(true);
+  });
+
+  test("tools and implementations coexist", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "calc" }));
+    await store.save(createImplementationBrick("engine", { name: "myEngine" }));
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    const components = await provider.attach(createMockAgent());
+    expect(components.size).toBe(2);
+    expect(components.has(toolToken("calc") as string)).toBe(true);
+    expect(components.has(engineToken("myEngine") as string)).toBe(true);
+  });
+
+  test("skips skill/agent/composite bricks", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ name: "myTool" }));
+    await store.save(createImplementationBrick("engine", { name: "myEngine" }));
+    const skillBrick: SkillArtifact = {
+      id: `brick_${crypto.randomUUID()}`,
+      kind: "skill",
+      name: "mySkill",
+      description: "A skill",
+      scope: "agent",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      createdBy: "agent-1",
+      createdAt: Date.now(),
+      version: "0.0.1",
+      tags: [],
+      usageCount: 0,
+      contentHash: "test-hash",
+      content: "# Skill",
+    };
+    await store.save(skillBrick);
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    const components = await provider.attach(createMockAgent());
+    // tool + engine = 2, skill is skipped
+    expect(components.size).toBe(2);
+    expect(components.has(toolToken("myTool") as string)).toBe(true);
+    expect(components.has(engineToken("myEngine") as string)).toBe(true);
+  });
+
+  test("scope filtering works for implementations", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createImplementationBrick("engine", { name: "agentEngine", scope: "agent" }));
+    await store.save(
+      createImplementationBrick("engine", { name: "globalEngine", scope: "global" }),
+    );
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+      scope: "global",
+    });
+
+    const components = await provider.attach(createMockAgent());
+    // Global scope sees only global bricks
+    expect(components.size).toBe(1);
+    expect(components.has(engineToken("globalEngine") as string)).toBe(true);
+    expect(components.has(engineToken("agentEngine") as string)).toBe(false);
+  });
+
+  test("lookupBrickId works for implementation names", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createImplementationBrick("middleware", { id: "brick_mw1", name: "audit" }));
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    await provider.attach(createMockAgent());
+    expect(provider.lookupBrickId("audit")).toBe("brick_mw1");
+  });
+
+  test("inactive implementations are skipped", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createImplementationBrick("engine", { name: "activeEngine", lifecycle: "active" }),
+    );
+    await store.save(
+      createImplementationBrick("engine", {
+        name: "deprecatedEngine",
+        lifecycle: "deprecated",
+      }),
+    );
+
+    const provider = createForgeComponentProvider({
+      store,
+      executor: mockTiered(echoExecutor()),
+    });
+
+    const components = await provider.attach(createMockAgent());
+    expect(components.size).toBe(1);
+    expect(components.has(engineToken("activeEngine") as string)).toBe(true);
+  });
+
+  test("cache invalidation works for implementation bricks", async () => {
+    let searchCount = 0;
+    const realStore = createInMemoryForgeStore();
+    await realStore.save(createImplementationBrick("engine", { name: "myEngine" }));
+
+    const countingStore = {
+      ...realStore,
+      search: async (...args: readonly unknown[]) => {
+        searchCount++;
+        return realStore.search(...(args as Parameters<typeof realStore.search>));
+      },
+    };
+
+    const notifier = createMemoryStoreChangeNotifier();
+    const provider = createForgeComponentProvider({
+      store: countingStore,
+      executor: mockTiered(echoExecutor()),
+      notifier,
+    });
+
+    const first = await provider.attach(createMockAgent());
+    expect(first.size).toBe(1);
+    expect(searchCount).toBe(1);
+
+    // Add a new engine brick to the store
+    await realStore.save(createImplementationBrick("resolver", { name: "myResolver" }));
+
+    // Simulate notifier event
+    notifier.notify({ kind: "saved", brickId: "b2", scope: "agent" });
+
+    // Cache should be invalidated — next attach re-queries
+    const second = await provider.attach(createMockAgent());
+    expect(second.size).toBe(2);
+    expect(searchCount).toBe(2);
   });
 });

--- a/packages/forge/src/forge-component-provider.ts
+++ b/packages/forge/src/forge-component-provider.ts
@@ -1,24 +1,35 @@
 /**
- * ForgeComponentProvider — attaches forged tools as components to agents.
+ * ForgeComponentProvider — attaches forged bricks as components to agents.
  *
  * Implements the L0 ComponentProvider interface. On first attach(), it discovers
- * all active tool bricks from the ForgeStore and wraps each as an executable
- * Tool that runs in the sandbox. Results are cached for subsequent attach() calls.
+ * all active bricks from the ForgeStore: tool bricks are wrapped as executable
+ * Tools; implementation bricks (engine, resolver, provider, middleware, channel)
+ * are registered as raw ImplementationArtifact values under kind-specific tokens.
+ * Results are cached for subsequent attach() calls.
  *
- * Lazy loading (decision 13A): tools are loaded on first attach(), not at creation.
+ * Lazy loading (decision 13A): bricks are loaded on first attach(), not at creation.
  * Scope + zoneId filtering (Issue 8A): only agent-scoped + zone-scoped bricks visible.
  * Delta-based invalidation (Issue 15A): invalidate by scope or brick ID.
  */
 
 import type {
   Agent,
+  BrickKind,
   ComponentProvider,
   ForgeScope,
   ForgeStore,
+  ImplementationArtifact,
   StoreChangeNotifier,
   TieredSandboxExecutor,
 } from "@koi/core";
-import { toolToken } from "@koi/core";
+import {
+  channelToken,
+  engineToken,
+  middlewareToken,
+  providerToken,
+  resolverToken,
+  toolToken,
+} from "@koi/core";
 import { brickToTool } from "./brick-conversion.js";
 
 // ---------------------------------------------------------------------------
@@ -26,6 +37,31 @@ import { brickToTool } from "./brick-conversion.js";
 // ---------------------------------------------------------------------------
 
 const DEFAULT_SANDBOX_TIMEOUT_MS = 5_000;
+
+/** Brick kinds that represent implementation artifacts (discoverable as ECS components). */
+const IMPLEMENTATION_KINDS: ReadonlySet<BrickKind> = new Set([
+  "engine",
+  "resolver",
+  "provider",
+  "middleware",
+  "channel",
+]);
+
+/** Maps an implementation brick kind + name to the correct namespaced token string. */
+function implementationToken(kind: ImplementationArtifact["kind"], name: string): string {
+  switch (kind) {
+    case "engine":
+      return engineToken(name) as string;
+    case "resolver":
+      return resolverToken(name) as string;
+    case "provider":
+      return providerToken(name) as string;
+    case "middleware":
+      return middlewareToken(name) as string;
+    case "channel":
+      return channelToken(name) as string;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -60,8 +96,8 @@ export interface ForgeComponentProviderInstance extends ComponentProvider {
   readonly invalidateByScope: (scope: ForgeScope) => void;
   /** Invalidate cache if the specific brick ID is cached. */
   readonly invalidateByBrickId: (brickId: string) => void;
-  /** Resolves a tool name to its brick ID. Returns `undefined` for non-forged tools or before first `attach()`. */
-  readonly lookupBrickId: (toolName: string) => string | undefined;
+  /** Resolves a brick name to its brick ID. Returns `undefined` for non-forged bricks or before first `attach()`. */
+  readonly lookupBrickId: (brickName: string) => string | undefined;
   /** Unsubscribes from the notifier (if one was provided). */
   readonly dispose: () => void;
 }
@@ -98,7 +134,7 @@ export function createForgeComponentProvider(
   let cached: ReadonlyMap<string, unknown> | undefined;
   // Track cached brick metadata for delta invalidation
   let cachedBrickScopes: ReadonlyMap<string, ForgeScope> | undefined;
-  // Reverse map: tool name → brick ID (populated during loadTools)
+  // Reverse map: brick name → brick ID (populated during loadComponents)
   let nameToBrickId: ReadonlyMap<string, string> | undefined;
 
   const invalidate = (): void => {
@@ -124,7 +160,7 @@ export function createForgeComponentProvider(
     }
   };
 
-  const loadTools = async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
+  const loadComponents = async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
     if (cached !== undefined) {
       return cached;
     }
@@ -132,26 +168,24 @@ export function createForgeComponentProvider(
     // Optimize store query when possible (Issue M1).
     // ForgeQuery.scope is exact-match, but the provider needs "at scope or broader".
     // Only "global" callers can use exact-match (they only see global-scoped bricks).
+    // No kind filter — we load tools AND implementation bricks in one pass.
     const searchResult = await config.store.search({
-      kind: "tool",
       lifecycle: "active",
       ...(config.scope === "global" ? { scope: "global" } : {}),
     });
 
     if (!searchResult.ok) {
       throw new Error(
-        `ForgeComponentProvider: failed to load tools: ${searchResult.error.message}`,
+        `ForgeComponentProvider: failed to load bricks: ${searchResult.error.message}`,
         { cause: searchResult.error },
       );
     }
 
-    const tools: Map<string, unknown> = new Map();
+    const components: Map<string, unknown> = new Map();
     const scopeTracker: Map<string, ForgeScope> = new Map();
     const nameTracker: Map<string, string> = new Map();
 
     for (const brick of searchResult.value) {
-      if (brick.kind !== "tool") continue;
-
       // Scope filtering (Issue 8A)
       if (!isScopeVisible(brick.scope, config.scope)) continue;
 
@@ -161,15 +195,26 @@ export function createForgeComponentProvider(
         if (!brick.tags.includes(zoneTag)) continue;
       }
 
-      const token = toolToken(brick.name);
-      const { executor: tierExecutor } = config.executor.forTier(brick.trustTier);
-      const tool = brickToTool(brick, tierExecutor, timeoutMs);
-      tools.set(token as string, tool);
+      if (brick.kind === "tool") {
+        // Tool path: wrap as executable Tool under toolToken(name)
+        const tok = toolToken(brick.name);
+        const { executor: tierExecutor } = config.executor.forTier(brick.trustTier);
+        const tool = brickToTool(brick, tierExecutor, timeoutMs);
+        components.set(tok as string, tool);
+      } else if (IMPLEMENTATION_KINDS.has(brick.kind)) {
+        // Implementation path: register raw artifact under kind-specific token
+        const tok = implementationToken(brick.kind as ImplementationArtifact["kind"], brick.name);
+        components.set(tok, brick);
+      } else {
+        // skill, agent, composite — skip (different attachment semantics)
+        continue;
+      }
+
       scopeTracker.set(brick.id, brick.scope);
       nameTracker.set(brick.name, brick.id);
     }
 
-    cached = tools;
+    cached = components;
     cachedBrickScopes = scopeTracker;
     nameToBrickId = nameTracker;
     return cached;
@@ -194,7 +239,7 @@ export function createForgeComponentProvider(
 
   return {
     name: "forge",
-    attach: loadTools,
+    attach: loadComponents,
     invalidate,
     invalidateByScope,
     invalidateByBrickId,

--- a/packages/forge/src/forge-resolver.ts
+++ b/packages/forge/src/forge-resolver.ts
@@ -21,6 +21,11 @@ export function extractSource(brick: BrickArtifact): SourceBundle {
   const files = brick.files !== undefined ? { files: brick.files } : {};
   switch (brick.kind) {
     case "tool":
+    case "engine":
+    case "resolver":
+    case "provider":
+    case "middleware":
+    case "channel":
       return { content: brick.implementation, language: "typescript", ...files };
     case "skill":
       return { content: brick.content, language: "markdown", ...files };

--- a/packages/forge/src/integrity.ts
+++ b/packages/forge/src/integrity.ts
@@ -34,6 +34,11 @@ export type IntegrityResult = IntegrityOk | IntegrityMismatch;
 function extractContentForHash(brick: BrickArtifact): string {
   switch (brick.kind) {
     case "tool":
+    case "engine":
+    case "resolver":
+    case "provider":
+    case "middleware":
+    case "channel":
       return brick.implementation;
     case "skill":
       return brick.content;

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -175,6 +175,7 @@ export type {
   BrickArtifact,
   BrickArtifactBase,
   CompositeArtifact,
+  ImplementationArtifact,
   SkillArtifact,
   ToolArtifact,
 } from "@koi/core";


### PR DESCRIPTION
## Summary

Closes the discoverability gap left after BrickKind was expanded (Issue #208): forged implementation bricks (engine, resolver, provider, middleware, channel) are now loadable and discoverable as ECS components via `agent.query()`.

- **L0 (`@koi/core`)**: Expand `BrickKind` to 9 values, add `ImplementationArtifact` type, add `ALL_BRICK_KINDS` + `MIN_TRUST_BY_KIND` constants, add 4 token factories (`engineToken`, `resolverToken`, `providerToken`, `middlewareToken`)
- **L2 (`@koi/forge`)**: `ForgeComponentProvider` now loads all active bricks in one pass — tools wrapped as `Tool`, implementations registered as raw `ImplementationArtifact` under kind-specific tokens (`engine:name`, `resolver:name`, etc.)
- Scope/zone filtering, delta-based cache invalidation, and `lookupBrickId` all work for implementation bricks

**Out of scope**: Activation (evaluating implementation code to produce live `EngineAdapter` / `KoiMiddleware` / etc.) — follow-up task.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/forge-types.ts` | Expand `BrickKind` to 9 values, add `ALL_BRICK_KINDS`, `MIN_TRUST_BY_KIND` |
| `packages/core/src/brick-store.ts` | Add `ImplementationArtifact` interface |
| `packages/core/src/ecs.ts` | 4 token factories |
| `packages/core/src/index.ts` | Export new types and factories |
| `packages/forge/src/forge-component-provider.ts` | Remove `kind:"tool"` filter, add `IMPLEMENTATION_KINDS`, `implementationToken`, three-way brick loop |
| Tests | 8 new forge-component-provider tests, 16 token tests, forge-types constant tests |

## Test plan

- [x] `bun test packages/core` — 298/298 pass (100% coverage)
- [x] `bun test packages/forge` — 549/549 pass (100% coverage on forge-component-provider.ts)
- [x] `bun run lint --filter='@koi/core' --filter='@koi/forge'` — clean
- [x] Anti-leak: `@koi/core` has zero imports from other packages
- [ ] CI passes