### PR TITLE
feat: add @koi/self-test (L2) — agent pre-deployment self-verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -581,6 +581,19 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/self-test": {
+      "name": "@koi/self-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+      },
+    },
     "packages/session-store": {
       "name": "@koi/session-store",
       "version": "0.0.0",
@@ -1028,6 +1041,8 @@
     "@koi/scheduler": ["@koi/scheduler@workspace:packages/scheduler"],
 
     "@koi/search": ["@koi/search@workspace:packages/search"],
+
+    "@koi/self-test": ["@koi/self-test@workspace:packages/self-test"],
 
     "@koi/session-store": ["@koi/session-store@workspace:packages/session-store"],
 

--- a/packages/self-test/package.json
+++ b/packages/self-test/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/self-test",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts",
+    "test:e2e": "bun test src/__tests__/e2e.test.ts"
+  }
+}

--- a/packages/self-test/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/self-test/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,99 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/self-test API surface . has stable type surface 1`] = `
+"import { KoiError, JsonObject, AgentManifest, EngineAdapter, KoiMiddleware, ToolDescriptor, ToolResponse, EngineInput, EngineEvent } from '@koi/core';
+
+/**
+ * @koi/self-test — Public types for agent self-verification.
+ */
+
+/** Status of a single check. */
+type CheckStatus = "pass" | "fail" | "skip";
+/** Built-in check categories plus user-defined custom. */
+type CheckCategory = "manifest" | "middleware" | "tools" | "engine" | "scenarios" | "custom";
+/** Result of a single check. */
+interface CheckResult {
+    readonly name: string;
+    readonly category: CheckCategory;
+    readonly status: CheckStatus;
+    readonly durationMs: number;
+    readonly error?: KoiError;
+    /** Human-readable detail (e.g., "manifest.name is empty string"). */
+    readonly message?: string;
+    /** Machine-readable context for CI tools (e.g., { field: "name" }). */
+    readonly metadata?: JsonObject;
+}
+/** Aggregated self-test report. */
+interface SelfTestReport {
+    readonly passed: number;
+    readonly failed: number;
+    readonly skipped: number;
+    readonly totalDurationMs: number;
+    readonly checks: readonly CheckResult[];
+    /** True when failed === 0. */
+    readonly healthy: boolean;
+}
+/** A tool descriptor + optional mock handler for self-test verification. */
+interface SelfTestTool {
+    readonly descriptor: ToolDescriptor;
+    /** If provided, handler is invoked with empty input to verify it returns valid ToolResponse. */
+    readonly handler?: (args: JsonObject) => Promise<ToolResponse>;
+}
+/** An E2E smoke-test scenario. */
+interface SelfTestScenario {
+    readonly name: string;
+    readonly input: EngineInput;
+    /** Expected text pattern (regex or string) in streamed text_delta output. */
+    readonly expectedPattern?: string | RegExp;
+    /** Custom assertion function run against the collected events. */
+    readonly assert?: (events: readonly EngineEvent[]) => void | Promise<void>;
+}
+/** A user-defined custom check. */
+interface SelfTestCustomCheck {
+    readonly name: string;
+    readonly fn: () => void | Promise<void>;
+}
+/** Configuration for createSelfTest. */
+interface SelfTestConfig {
+    readonly manifest: AgentManifest;
+    /**
+     * Engine adapter instance or factory function.
+     * - Function: self-test owns lifecycle (creates, uses, disposes).
+     * - Object: caller owns lifecycle (dispose check is skipped).
+     */
+    readonly adapter?: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>);
+    readonly middleware?: readonly KoiMiddleware[];
+    readonly tools?: readonly SelfTestTool[];
+    readonly scenarios?: readonly SelfTestScenario[];
+    readonly customChecks?: readonly SelfTestCustomCheck[];
+    /** Whitelist of categories to run. undefined = all categories. */
+    readonly categories?: readonly CheckCategory[];
+    /** Per-check timeout in ms. Default: 5000. */
+    readonly checkTimeoutMs?: number;
+    /** Global run timeout in ms. Default: 30000. */
+    readonly timeoutMs?: number;
+    /** Stop on first category failure. Default: false. */
+    readonly failFast?: boolean;
+}
+/** The self-test runner returned by createSelfTest. */
+interface SelfTest {
+    readonly run: () => Promise<SelfTestReport>;
+}
+
+/**
+ * createSelfTest — factory for the self-test runner.
+ *
+ * Orchestrates check categories sequentially, aggregates results,
+ * and returns a machine-readable SelfTestReport.
+ */
+
+/**
+ * Create a self-test runner from the given config.
+ *
+ * @throws KoiRuntimeError with code VALIDATION if config is structurally invalid.
+ */
+declare function createSelfTest(config: SelfTestConfig): SelfTest;
+
+export { type CheckCategory, type CheckResult, type CheckStatus, type SelfTest, type SelfTestConfig, type SelfTestCustomCheck, type SelfTestReport, type SelfTestScenario, type SelfTestTool, createSelfTest };
+"
+`;

--- a/packages/self-test/src/__tests__/api-surface.test.ts
+++ b/packages/self-test/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/self-test/src/__tests__/e2e.test.ts
+++ b/packages/self-test/src/__tests__/e2e.test.ts
@@ -1,0 +1,246 @@
+/**
+ * End-to-end tests for @koi/self-test with real LLM calls.
+ *
+ * Validates the full self-test pipeline through createKoi (L1) + createPiAdapter:
+ *   - Manifest checks pass for a real agent config
+ *   - Middleware hooks are structurally valid
+ *   - Engine adapter resolves, streams, yields done event through L1 runtime
+ *   - E2E scenario completes with pattern matching against real LLM output
+ *   - Full report is healthy
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest, EngineAdapter, EngineInput, KoiMiddleware } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createSelfTest } from "../self-test.js";
+import type { SelfTestScenario } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const CHECK_TIMEOUT_MS = 30_000;
+
+// Use haiku for speed + cost
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Shared config
+// ---------------------------------------------------------------------------
+
+const E2E_MANIFEST: AgentManifest = {
+  name: "self-test-e2e-agent",
+  version: "1.0.0",
+  model: { name: "claude-haiku" },
+};
+
+/**
+ * Factory that creates a KoiRuntime-backed EngineAdapter.
+ *
+ * Each call assembles a fresh createKoi runtime with the Pi adapter,
+ * wrapping runtime.run() as adapter.stream(). This exercises the full
+ * L1 path: assembly → guards → middleware composition → Pi adapter → real LLM.
+ */
+async function createKoiAdapter(middleware?: readonly KoiMiddleware[]): Promise<EngineAdapter> {
+  const piAdapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: "You are a concise test assistant. Reply briefly and exactly as instructed.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: E2E_MANIFEST,
+    adapter: piAdapter,
+    middleware: middleware ?? [],
+    loopDetection: false,
+    limits: { maxTurns: 5, maxDurationMs: 55_000, maxTokens: 10_000 },
+  });
+
+  return {
+    engineId: "koi-pi-e2e",
+    stream: (input: EngineInput) => runtime.run(input),
+    dispose: () => runtime.dispose(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: self-test with real Anthropic API via createKoi + createPiAdapter", () => {
+  test(
+    "full self-test report is healthy with real LLM adapter",
+    async () => {
+      const observerMw: KoiMiddleware = {
+        name: "e2e-observer",
+        async onSessionStart() {
+          // no-op — validates structural check passes
+        },
+        async onSessionEnd() {
+          // no-op
+        },
+      };
+
+      const scenario: SelfTestScenario = {
+        name: "ping-pong",
+        input: { kind: "text", text: "Reply with exactly one word: pong" },
+        expectedPattern: /pong/i,
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter([observerMw]),
+        middleware: [observerMw],
+        scenarios: [scenario],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      // Log report for manual inspection
+      for (const check of report.checks) {
+        const icon = check.status === "pass" ? "+" : check.status === "fail" ? "x" : "-";
+        const suffix = check.message !== undefined ? ` — ${check.message}` : "";
+        console.log(`  [${icon}] ${check.name}${suffix}`);
+      }
+      console.log(
+        `\n  Result: ${String(report.passed)} pass, ${String(report.failed)} fail, ${String(report.skipped)} skip`,
+      );
+
+      expect(report.healthy).toBe(true);
+      expect(report.failed).toBe(0);
+      expect(report.passed).toBeGreaterThan(0);
+
+      // Engine checks should have run (not skipped)
+      const engineChecks = report.checks.filter((c) => c.category === "engine");
+      const passingEngineChecks = engineChecks.filter((c) => c.status === "pass");
+      expect(passingEngineChecks.length).toBeGreaterThan(0);
+
+      // Scenario check should have run and passed
+      const scenarioChecks = report.checks.filter((c) => c.category === "scenarios");
+      expect(scenarioChecks.length).toBeGreaterThan(0);
+      const scenarioPass = scenarioChecks.find((c) => c.status === "pass");
+      expect(scenarioPass).toBeDefined();
+
+      // Middleware structural checks should pass
+      const mwChecks = report.checks.filter((c) => c.category === "middleware");
+      expect(mwChecks.length).toBeGreaterThan(0);
+      for (const check of mwChecks) {
+        expect(check.status).toBe("pass");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "scenario with regex pattern matching against real LLM output",
+    async () => {
+      const scenario: SelfTestScenario = {
+        name: "math-answer",
+        input: { kind: "text", text: "What is 2 + 2? Reply with just the number." },
+        expectedPattern: /4/,
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        scenarios: [scenario],
+        categories: ["scenarios"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      const scenarioCheck = report.checks.find(
+        (c) => c.category === "scenarios" && c.name.includes("math-answer"),
+      );
+      expect(scenarioCheck?.status).toBe("pass");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "scenario custom assertion receives real events",
+    async () => {
+      // let justified: mutated in closure to verify assertion ran
+      let assertionCalled = false;
+      // let justified: capture token count for verification
+      let tokenCount = 0;
+
+      const scenario: SelfTestScenario = {
+        name: "custom-assert",
+        input: { kind: "text", text: "Say hello" },
+        assert: (events) => {
+          assertionCalled = true;
+          const doneEvent = events.find((e) => e.kind === "done");
+          if (doneEvent === undefined || doneEvent.kind !== "done") {
+            throw new Error("No done event");
+          }
+          tokenCount = doneEvent.output.metrics.totalTokens;
+          // Real LLM call should consume tokens
+          if (doneEvent.output.metrics.totalTokens === 0) {
+            throw new Error("Expected non-zero token count from real LLM");
+          }
+        },
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        scenarios: [scenario],
+        categories: ["scenarios"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      expect(assertionCalled).toBe(true);
+      expect(tokenCount).toBeGreaterThan(0);
+
+      const check = report.checks.find((c) => c.name.includes("custom-assert"));
+      expect(check?.status).toBe("pass");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "engine checks pass through full L1 pipeline (dispose included for factory)",
+    async () => {
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        categories: ["engine"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      const engineChecks = report.checks.filter((c) => c.category === "engine");
+      // Factory mode: resolve + engineId + stream callable + stream yields done + output valid + dispose = 6
+      expect(engineChecks).toHaveLength(6);
+
+      for (const check of engineChecks) {
+        if (check.status === "fail") {
+          console.log(`  FAIL: ${check.name} — ${check.error?.message ?? "no error"}`);
+        }
+        expect(check.status).toBe("pass");
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/self-test/src/check-runner.test.ts
+++ b/packages/self-test/src/check-runner.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput } from "@koi/core";
+import { collectEvents, extractText, runCheck, skipCheck } from "./check-runner.js";
+
+describe("runCheck", () => {
+  test("returns pass for a check that succeeds", async () => {
+    const result = await runCheck("test-pass", "manifest", () => {}, 5_000);
+    expect(result.status).toBe("pass");
+    expect(result.name).toBe("test-pass");
+    expect(result.category).toBe("manifest");
+    expect(typeof result.durationMs).toBe("number");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns pass for an async check that resolves", async () => {
+    const result = await runCheck(
+      "async-pass",
+      "tools",
+      async () => {
+        await Promise.resolve();
+      },
+      5_000,
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  test("returns fail for a check that throws synchronously", async () => {
+    const result = await runCheck(
+      "sync-throw",
+      "middleware",
+      () => {
+        throw new Error("deliberate failure");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe("INTERNAL");
+    expect(result.error?.message).toBe("deliberate failure");
+    expect(result.message).toBe("deliberate failure");
+  });
+
+  test("returns fail for a check that rejects", async () => {
+    const result = await runCheck(
+      "async-reject",
+      "engine",
+      async () => {
+        throw new Error("async failure");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.code).toBe("INTERNAL");
+    expect(result.error?.message).toBe("async failure");
+  });
+
+  test("returns fail with TIMEOUT for a check that exceeds timeout", async () => {
+    const result = await runCheck(
+      "timeout-check",
+      "engine",
+      () => new Promise(() => {}), // never resolves
+      10,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.code).toBe("TIMEOUT");
+    expect(result.error?.retryable).toBe(true);
+    expect(result.error?.message).toContain("timed out");
+  });
+
+  test("tracks duration for successful checks", async () => {
+    const result = await runCheck(
+      "timed-check",
+      "manifest",
+      async () => {
+        await Bun.sleep(10);
+      },
+      5_000,
+    );
+    expect(result.durationMs).toBeGreaterThanOrEqual(5);
+  });
+
+  test("tracks duration for failed checks", async () => {
+    const result = await runCheck(
+      "failed-timed",
+      "manifest",
+      async () => {
+        await Bun.sleep(10);
+        throw new Error("fail after delay");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.durationMs).toBeGreaterThanOrEqual(5);
+  });
+
+  test("handles non-Error throws gracefully", async () => {
+    const result = await runCheck(
+      "string-throw",
+      "tools",
+      () => {
+        throw "plain string error";
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.message).toBe("plain string error");
+  });
+});
+
+describe("collectEvents", () => {
+  test("collects events from async iterable", async () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    async function* gen(): AsyncIterable<EngineEvent> {
+      yield { kind: "text_delta", delta: "hello" };
+      yield { kind: "done", output };
+    }
+
+    const events = await collectEvents(gen());
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("text_delta");
+    expect(events[1]?.kind).toBe("done");
+  });
+
+  test("returns empty array for empty iterable", async () => {
+    async function* gen(): AsyncIterable<EngineEvent> {
+      // yields nothing
+    }
+    const events = await collectEvents(gen());
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe("extractText", () => {
+  test("concatenates text_delta events", () => {
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "hello " },
+      { kind: "text_delta", delta: "world" },
+    ];
+    expect(extractText(events)).toBe("hello world");
+  });
+
+  test("ignores non-text_delta events", () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output },
+    ];
+    expect(extractText(events)).toBe("hello");
+  });
+
+  test("returns empty string for no text events", () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    const events: readonly EngineEvent[] = [{ kind: "done", output }];
+    expect(extractText(events)).toBe("");
+  });
+});
+
+describe("skipCheck", () => {
+  test("creates a skip result with correct fields", () => {
+    const result = skipCheck("skipped-check", "engine", "no adapter");
+    expect(result.status).toBe("skip");
+    expect(result.name).toBe("skipped-check");
+    expect(result.category).toBe("engine");
+    expect(result.message).toBe("no adapter");
+    expect(result.durationMs).toBe(0);
+  });
+});

--- a/packages/self-test/src/check-runner.ts
+++ b/packages/self-test/src/check-runner.ts
@@ -1,0 +1,91 @@
+/**
+ * Check execution helper — wraps individual checks with timeout and error containment.
+ */
+
+import type { EngineAdapter, EngineEvent, KoiError } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CheckCategory, CheckResult } from "./types.js";
+
+/** Type guard: adapter config is a factory function (vs an instance). */
+export function isAdapterFactory(
+  value: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+): value is () => EngineAdapter | Promise<EngineAdapter> {
+  return typeof value === "function";
+}
+
+/**
+ * Run a single check with timeout and error containment.
+ *
+ * The check function receives an AbortSignal that fires on timeout.
+ * Checks that complete normally produce a "pass" result.
+ * Checks that throw (or time out) produce a "fail" result.
+ * Never throws — all errors are captured into CheckResult.
+ */
+export async function runCheck(
+  name: string,
+  category: CheckCategory,
+  fn: (signal: AbortSignal) => void | Promise<void>,
+  timeoutMs: number,
+): Promise<CheckResult> {
+  const start = Date.now();
+  try {
+    const signal = AbortSignal.timeout(timeoutMs);
+    // Race the check against the timeout — if fn ignores the signal and never
+    // resolves, the timeout promise rejects and Promise.race propagates it.
+    const timeoutRejection = new Promise<never>((_, reject) => {
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    });
+    await Promise.race([fn(signal), timeoutRejection]);
+    return {
+      name,
+      category,
+      status: "pass",
+      durationMs: Date.now() - start,
+    };
+  } catch (e: unknown) {
+    const isTimeout = e instanceof DOMException && e.name === "TimeoutError";
+    const error: KoiError = {
+      code: isTimeout ? "TIMEOUT" : "INTERNAL",
+      message: isTimeout
+        ? `Check "${name}" timed out after ${String(timeoutMs)}ms`
+        : e instanceof Error
+          ? e.message
+          : String(e),
+      retryable: isTimeout ? RETRYABLE_DEFAULTS.TIMEOUT : RETRYABLE_DEFAULTS.INTERNAL,
+      ...(e instanceof Error && e.cause !== undefined ? { cause: e.cause } : {}),
+    };
+    return {
+      name,
+      category,
+      status: "fail",
+      durationMs: Date.now() - start,
+      error,
+      message: error.message,
+    };
+  }
+}
+
+/** Collect all events from an async iterable into an array. */
+export async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  // Local mutable array for accumulation — not shared state
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Extract concatenated text from text_delta events. */
+export function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+/** Create a skip check result. */
+export function skipCheck(name: string, category: CheckCategory, message: string): CheckResult {
+  return { name, category, status: "skip", durationMs: 0, message };
+}

--- a/packages/self-test/src/checks/engine-checks.test.ts
+++ b/packages/self-test/src/checks/engine-checks.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent } from "@koi/core";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import { runEngineChecks } from "./engine-checks.js";
+
+const TIMEOUT = 5_000;
+
+describe("runEngineChecks", () => {
+  test("all checks pass for a valid mock adapter (instance)", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    // resolve + engineId + stream callable + stream done + output valid = 5
+    // No dispose check (instance mode)
+    expect(results).toHaveLength(5);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("engine");
+    }
+  });
+
+  test("all checks pass for a valid mock adapter (factory)", async () => {
+    const factory = () => createMockEngineAdapter();
+    const results = await runEngineChecks(factory, TIMEOUT);
+    // resolve + engineId + stream callable + stream done + output valid + dispose = 6
+    expect(results).toHaveLength(6);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+    }
+  });
+
+  test("skips all checks when factory throws", async () => {
+    const factory = () => {
+      throw new Error("factory boom");
+    };
+    const results = await runEngineChecks(factory, TIMEOUT);
+    // resolve (fail) + 4 skips + dispose skip = 6
+    expect(results).toHaveLength(6);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toBe("factory boom");
+    for (const r of results.slice(1)) {
+      expect(r.status).toBe("skip");
+    }
+  });
+
+  test("fails when adapter has empty engineId", async () => {
+    const adapter = createMockEngineAdapter({ engineId: "" });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const idCheck = results.find((r) => r.name.includes("engineId"));
+    expect(idCheck?.status).toBe("fail");
+  });
+
+  test("fails when stream yields no done event", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "hello" }];
+    const adapter = createMockEngineAdapter({ events });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const streamCheck = results.find((r) => r.name.includes("stream yields done"));
+    expect(streamCheck?.status).toBe("fail");
+    expect(streamCheck?.error?.message).toContain("done event");
+  });
+
+  test("skips output validation when stream check fails", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "no done" }];
+    const adapter = createMockEngineAdapter({ events });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const outputCheck = results.find((r) => r.name.includes("done output is valid"));
+    expect(outputCheck?.status).toBe("skip");
+  });
+
+  test("dispose check runs for factory adapter", async () => {
+    const adapter = createMockEngineAdapter();
+    const factory = () => adapter;
+    const results = await runEngineChecks(factory, TIMEOUT);
+    const disposeCheck = results.find((r) => r.name.includes("dispose completes"));
+    expect(disposeCheck?.status).toBe("pass");
+    expect(adapter.disposeCalls.length).toBe(1);
+  });
+
+  test("no dispose check for instance adapter", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const disposeCheck = results.find((r) => r.name.includes("dispose"));
+    expect(disposeCheck).toBeUndefined();
+  });
+});

--- a/packages/self-test/src/checks/engine-checks.ts
+++ b/packages/self-test/src/checks/engine-checks.ts
@@ -1,0 +1,146 @@
+/**
+ * Engine adapter contract checks.
+ *
+ * Verifies that the adapter has a valid engineId, stream() is callable,
+ * stream yields a done event with valid output, and dispose completes cleanly.
+ */
+
+import type { EngineAdapter, EngineEvent, EngineInput } from "@koi/core";
+import { collectEvents, isAdapterFactory, runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+export async function runEngineChecks(
+  adapterOrFactory: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+  const isFactory = isAdapterFactory(adapterOrFactory);
+
+  // let: assigned inside runCheck closure, read after for subsequent checks
+  let adapter: EngineAdapter | undefined;
+  const resolveResult = await runCheck(
+    "engine: adapter resolves",
+    "engine",
+    async () => {
+      adapter = isFactory ? await adapterOrFactory() : adapterOrFactory;
+    },
+    checkTimeoutMs,
+  );
+  results.push(resolveResult);
+
+  if (resolveResult.status !== "pass" || adapter === undefined) {
+    results.push(skipCheck("engine: engineId is valid", "engine", "Adapter resolution failed"));
+    results.push(skipCheck("engine: stream is callable", "engine", "Adapter resolution failed"));
+    results.push(
+      skipCheck("engine: stream yields done event", "engine", "Adapter resolution failed"),
+    );
+    results.push(skipCheck("engine: done output is valid", "engine", "Adapter resolution failed"));
+    if (isFactory) {
+      results.push(skipCheck("engine: dispose completes", "engine", "Adapter resolution failed"));
+    }
+    return results;
+  }
+
+  // Capture adapter in a const for closure safety
+  const resolvedAdapter = adapter;
+
+  // engineId is a non-empty string
+  results.push(
+    await runCheck(
+      "engine: engineId is valid",
+      "engine",
+      () => {
+        if (typeof resolvedAdapter.engineId !== "string" || resolvedAdapter.engineId.length === 0) {
+          throw new Error("engineId must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  // stream is a function
+  results.push(
+    await runCheck(
+      "engine: stream is callable",
+      "engine",
+      () => {
+        if (typeof resolvedAdapter.stream !== "function") {
+          throw new Error("stream must be a function");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  // let: populated inside stream check closure, read in output validation check
+  let events: readonly EngineEvent[] = [];
+  const streamResult = await runCheck(
+    "engine: stream yields done event",
+    "engine",
+    async (signal) => {
+      const input: EngineInput = { ...PING_INPUT, signal };
+      events = await collectEvents(resolvedAdapter.stream(input));
+      const doneEvent = events.find((e) => e.kind === "done");
+      if (doneEvent === undefined) {
+        throw new Error("Stream did not yield a done event");
+      }
+    },
+    checkTimeoutMs,
+  );
+  results.push(streamResult);
+
+  // done output structure is valid
+  if (streamResult.status === "pass") {
+    results.push(
+      await runCheck(
+        "engine: done output is valid",
+        "engine",
+        () => {
+          const doneEvent = events.find(
+            (e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done",
+          );
+          if (doneEvent === undefined) {
+            throw new Error("No done event found");
+          }
+          const { output } = doneEvent;
+          if (!Array.isArray(output.content)) {
+            throw new Error("output.content must be an array");
+          }
+          const validReasons = new Set(["completed", "max_turns", "interrupted", "error"]);
+          if (!validReasons.has(output.stopReason)) {
+            throw new Error(`Invalid stopReason: ${output.stopReason}`);
+          }
+          if (typeof output.metrics.totalTokens !== "number") {
+            throw new Error("output.metrics.totalTokens must be a number");
+          }
+          if (typeof output.metrics.durationMs !== "number") {
+            throw new Error("output.metrics.durationMs must be a number");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  } else {
+    results.push(skipCheck("engine: done output is valid", "engine", "Stream check failed"));
+  }
+
+  // dispose completes (only if factory — self-test owns lifecycle)
+  if (isFactory) {
+    results.push(
+      await runCheck(
+        "engine: dispose completes",
+        "engine",
+        async () => {
+          if (resolvedAdapter.dispose !== undefined) {
+            await resolvedAdapter.dispose();
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/manifest-checks.test.ts
+++ b/packages/self-test/src/checks/manifest-checks.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest } from "@koi/core";
+import { runManifestChecks } from "./manifest-checks.js";
+
+const VALID_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "1.0.0",
+  model: { name: "test-model" },
+};
+
+const TIMEOUT = 5_000;
+
+describe("runManifestChecks", () => {
+  test("all checks pass for a valid manifest", async () => {
+    const results = await runManifestChecks(VALID_MANIFEST, TIMEOUT);
+    expect(results.length).toBe(5);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("manifest");
+    }
+  });
+
+  test("fails when name is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, name: "" };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("name is non-empty"));
+    expect(nameCheck?.status).toBe("fail");
+    expect(nameCheck?.error?.message).toContain("non-empty");
+  });
+
+  test("fails when name is whitespace only", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, name: "   " };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("name is non-empty"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("fails when version is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, version: "" };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const versionCheck = results.find((r) => r.name.includes("version is non-empty"));
+    expect(versionCheck?.status).toBe("fail");
+  });
+
+  test("fails when model.name is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, model: { name: "" } };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const modelCheck = results.find((r) => r.name.includes("model config"));
+    expect(modelCheck?.status).toBe("fail");
+    expect(modelCheck?.error?.message).toContain("model.name");
+  });
+
+  test("passes with valid tool configs", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      tools: [{ name: "tool-a" }, { name: "tool-b" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("pass");
+  });
+
+  test("fails when tool config has empty name", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      tools: [{ name: "" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("fail");
+  });
+
+  test("passes when tools is undefined", async () => {
+    const results = await runManifestChecks(VALID_MANIFEST, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("pass");
+  });
+
+  test("fails when middleware config has empty name", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      middleware: [{ name: "" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const mwCheck = results.find((r) => r.name.includes("middleware configs"));
+    expect(mwCheck?.status).toBe("fail");
+  });
+
+  test("passes with valid middleware configs", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      middleware: [{ name: "audit" }, { name: "memory" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const mwCheck = results.find((r) => r.name.includes("middleware configs"));
+    expect(mwCheck?.status).toBe("pass");
+  });
+});

--- a/packages/self-test/src/checks/manifest-checks.ts
+++ b/packages/self-test/src/checks/manifest-checks.ts
@@ -1,0 +1,98 @@
+/**
+ * Manifest structural validation checks.
+ *
+ * Verifies that the AgentManifest has valid name, version, model config,
+ * and that tool/middleware config entries have non-empty names.
+ */
+
+import type { AgentManifest } from "@koi/core";
+import { runCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+export async function runManifestChecks(
+  manifest: AgentManifest,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  // Local mutable array for sequential accumulation
+  const results: CheckResult[] = [];
+
+  results.push(
+    await runCheck(
+      "manifest: name is non-empty string",
+      "manifest",
+      () => {
+        if (typeof manifest.name !== "string" || manifest.name.trim().length === 0) {
+          throw new Error("manifest.name must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: version is non-empty string",
+      "manifest",
+      () => {
+        if (typeof manifest.version !== "string" || manifest.version.trim().length === 0) {
+          throw new Error("manifest.version must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: model config is present and valid",
+      "manifest",
+      () => {
+        if (manifest.model === undefined || manifest.model === null) {
+          throw new Error("manifest.model must be defined");
+        }
+        if (typeof manifest.model.name !== "string" || manifest.model.name.trim().length === 0) {
+          throw new Error("manifest.model.name must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: tool configs have valid names",
+      "manifest",
+      () => {
+        if (manifest.tools === undefined) return;
+        for (const tool of manifest.tools) {
+          if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
+            throw new Error(
+              `manifest.tools contains entry with invalid name: ${JSON.stringify(tool.name)}`,
+            );
+          }
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: middleware configs have valid names",
+      "manifest",
+      () => {
+        if (manifest.middleware === undefined) return;
+        for (const mw of manifest.middleware) {
+          if (typeof mw.name !== "string" || mw.name.trim().length === 0) {
+            throw new Error(
+              `manifest.middleware contains entry with invalid name: ${JSON.stringify(mw.name)}`,
+            );
+          }
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  return results;
+}

--- a/packages/self-test/src/checks/middleware-checks.test.ts
+++ b/packages/self-test/src/checks/middleware-checks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiMiddleware } from "@koi/core";
+import { createMockSessionContext } from "@koi/test-utils";
+import { runMiddlewareChecks } from "./middleware-checks.js";
+
+const TIMEOUT = 5_000;
+
+function createSessionCtx() {
+  return createMockSessionContext();
+}
+
+describe("runMiddlewareChecks", () => {
+  test("returns skip when no middleware provided", async () => {
+    const results = await runMiddlewareChecks([], createSessionCtx, TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("passes for middleware with valid name and no hooks", async () => {
+    const mw: KoiMiddleware = { name: "noop" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    const hookCheck = results.find((r) => r.name.includes("hooks are functions"));
+    expect(nameCheck?.status).toBe("pass");
+    expect(hookCheck?.status).toBe("pass");
+  });
+
+  test("fails for middleware with empty name", async () => {
+    const mw: KoiMiddleware = { name: "" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("passes when onSessionStart executes without error", async () => {
+    const mw: KoiMiddleware = {
+      name: "good-lifecycle",
+      async onSessionStart() {},
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const startCheck = results.find((r) => r.name.includes("onSessionStart"));
+    expect(startCheck?.status).toBe("pass");
+  });
+
+  test("fails when onSessionStart throws", async () => {
+    const mw: KoiMiddleware = {
+      name: "bad-lifecycle",
+      async onSessionStart() {
+        throw new Error("session start failed");
+      },
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const startCheck = results.find((r) => r.name.includes("onSessionStart"));
+    expect(startCheck?.status).toBe("fail");
+    expect(startCheck?.error?.message).toContain("session start failed");
+  });
+
+  test("passes when onSessionEnd executes without error", async () => {
+    const mw: KoiMiddleware = {
+      name: "good-end",
+      async onSessionEnd() {},
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const endCheck = results.find((r) => r.name.includes("onSessionEnd"));
+    expect(endCheck?.status).toBe("pass");
+  });
+
+  test("fails when onSessionEnd throws", async () => {
+    const mw: KoiMiddleware = {
+      name: "bad-end",
+      async onSessionEnd() {
+        throw new Error("session end failed");
+      },
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const endCheck = results.find((r) => r.name.includes("onSessionEnd"));
+    expect(endCheck?.status).toBe("fail");
+  });
+
+  test("handles multiple middleware sequentially", async () => {
+    const mw1: KoiMiddleware = { name: "mw-a", async onSessionStart() {} };
+    const mw2: KoiMiddleware = { name: "mw-b" };
+    const results = await runMiddlewareChecks([mw1, mw2], createSessionCtx, TIMEOUT);
+    // mw-a: name + hooks + onSessionStart = 3 checks
+    // mw-b: name + hooks = 2 checks
+    expect(results).toHaveLength(5);
+  });
+
+  test("does not test onSessionStart/End when not provided", async () => {
+    const mw: KoiMiddleware = { name: "minimal" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    // Only structural checks: name + hooks
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+});

--- a/packages/self-test/src/checks/middleware-checks.ts
+++ b/packages/self-test/src/checks/middleware-checks.ts
@@ -1,0 +1,102 @@
+/**
+ * Middleware structural and lifecycle checks.
+ *
+ * Verifies that each middleware has a valid name, hooks are functions,
+ * and lifecycle hooks (onSessionStart, onSessionEnd) execute without error.
+ */
+
+import type { KoiMiddleware, SessionContext } from "@koi/core";
+import { runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+const HOOK_NAMES = [
+  "onSessionStart",
+  "onSessionEnd",
+  "onBeforeTurn",
+  "onAfterTurn",
+  "wrapModelCall",
+  "wrapModelStream",
+  "wrapToolCall",
+] as const;
+
+export async function runMiddlewareChecks(
+  middleware: readonly KoiMiddleware[],
+  createSessionCtx: () => SessionContext,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (middleware.length === 0) {
+    results.push(
+      skipCheck("middleware: no middleware to check", "middleware", "No middleware provided"),
+    );
+    return results;
+  }
+
+  for (const mw of middleware) {
+    // Structural: name is valid
+    results.push(
+      await runCheck(
+        `middleware[${mw.name}]: has valid name`,
+        "middleware",
+        () => {
+          if (typeof mw.name !== "string" || mw.name.trim().length === 0) {
+            throw new Error("Middleware name must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Structural: all hooks are functions (or undefined)
+    results.push(
+      await runCheck(
+        `middleware[${mw.name}]: hooks are functions`,
+        "middleware",
+        () => {
+          for (const hookName of HOOK_NAMES) {
+            const hook = mw[hookName];
+            if (hook !== undefined && typeof hook !== "function") {
+              throw new Error(`middleware.${hookName} must be a function, got ${typeof hook}`);
+            }
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Lifecycle: onSessionStart executes without error
+    const sessionStart = mw.onSessionStart;
+    if (sessionStart !== undefined) {
+      results.push(
+        await runCheck(
+          `middleware[${mw.name}]: onSessionStart executes`,
+          "middleware",
+          async () => {
+            const ctx = createSessionCtx();
+            await sessionStart(ctx);
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+
+    // Lifecycle: onSessionEnd executes without error
+    const sessionEnd = mw.onSessionEnd;
+    if (sessionEnd !== undefined) {
+      results.push(
+        await runCheck(
+          `middleware[${mw.name}]: onSessionEnd executes`,
+          "middleware",
+          async () => {
+            const ctx = createSessionCtx();
+            await sessionEnd(ctx);
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/scenario-checks.test.ts
+++ b/packages/self-test/src/checks/scenario-checks.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineInput, EngineOutput } from "@koi/core";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import type { SelfTestScenario } from "../types.js";
+import { runScenarioChecks } from "./scenario-checks.js";
+
+const TIMEOUT = 5_000;
+
+const DEFAULT_OUTPUT: EngineOutput = {
+  content: [{ kind: "text", text: "pong" }],
+  stopReason: "completed",
+  metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+};
+
+const DEFAULT_EVENTS: readonly EngineEvent[] = [
+  { kind: "text_delta", delta: "pong" },
+  { kind: "done", output: DEFAULT_OUTPUT },
+];
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+describe("runScenarioChecks", () => {
+  test("returns skip when no scenarios provided", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runScenarioChecks(adapter, [], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("passes for a scenario that completes with done event", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = { name: "ping-pong", input: PING_INPUT };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when expected pattern matches", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "pattern-match",
+      input: PING_INPUT,
+      expectedPattern: "pong",
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when expected pattern does not match", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "pattern-miss",
+      input: PING_INPUT,
+      expectedPattern: "notfound",
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toContain("did not match");
+  });
+
+  test("passes when regex pattern matches", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "regex-match",
+      input: PING_INPUT,
+      expectedPattern: /p.ng/,
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when custom assertion succeeds", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "custom-assert",
+      input: PING_INPUT,
+      assert(events) {
+        if (events.length < 2) throw new Error("too few events");
+      },
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when custom assertion throws", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "custom-assert-fail",
+      input: PING_INPUT,
+      assert() {
+        throw new Error("assertion failed");
+      },
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toBe("assertion failed");
+  });
+
+  test("fails when stream yields no done event", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "no done" }];
+    const adapter = createMockEngineAdapter({ events: [...events] });
+    const scenario: SelfTestScenario = { name: "no-done", input: PING_INPUT };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toContain("done event");
+  });
+
+  test("disposes factory-created adapters", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const factory = () => adapter;
+    const scenario: SelfTestScenario = { name: "dispose-test", input: PING_INPUT };
+    const results = await runScenarioChecks(factory, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+    expect(adapter.disposeCalls.length).toBe(1);
+  });
+
+  test("handles multiple scenarios", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenarios: readonly SelfTestScenario[] = [
+      { name: "scenario-a", input: PING_INPUT },
+      { name: "scenario-b", input: PING_INPUT },
+    ];
+    const results = await runScenarioChecks(adapter, scenarios, TIMEOUT);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+});

--- a/packages/self-test/src/checks/scenario-checks.ts
+++ b/packages/self-test/src/checks/scenario-checks.ts
@@ -1,0 +1,84 @@
+/**
+ * E2E scenario checks.
+ *
+ * Streams scenario input through the adapter, verifies the stream completes
+ * with a done event, matches expected patterns, and runs custom assertions.
+ */
+
+import type { EngineAdapter, EngineInput } from "@koi/core";
+import {
+  collectEvents,
+  extractText,
+  isAdapterFactory,
+  runCheck,
+  skipCheck,
+} from "../check-runner.js";
+import type { CheckResult, SelfTestScenario } from "../types.js";
+
+export async function runScenarioChecks(
+  adapterOrFactory: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+  scenarios: readonly SelfTestScenario[],
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (scenarios.length === 0) {
+    results.push(
+      skipCheck("scenarios: no scenarios to check", "scenarios", "No scenarios provided"),
+    );
+    return results;
+  }
+
+  const isFactory = isAdapterFactory(adapterOrFactory);
+
+  for (const scenario of scenarios) {
+    results.push(
+      await runCheck(
+        `scenario[${scenario.name}]: completes`,
+        "scenarios",
+        async (signal) => {
+          // Resolve adapter: factory = fresh per scenario, instance = shared
+          const adapter = isFactory ? await adapterOrFactory() : adapterOrFactory;
+
+          try {
+            const input: EngineInput = { ...scenario.input, signal };
+            const events = await collectEvents(adapter.stream(input));
+
+            // Verify done event exists
+            const doneEvent = events.find((e) => e.kind === "done");
+            if (doneEvent === undefined) {
+              throw new Error("Stream did not yield a done event");
+            }
+
+            // Check expected pattern against text_delta output
+            if (scenario.expectedPattern !== undefined) {
+              const text = extractText(events);
+              const pattern =
+                scenario.expectedPattern instanceof RegExp
+                  ? scenario.expectedPattern
+                  : new RegExp(scenario.expectedPattern);
+              if (!pattern.test(text)) {
+                throw new Error(
+                  `Output text did not match pattern ${String(scenario.expectedPattern)}. Got: "${text}"`,
+                );
+              }
+            }
+
+            // Run custom assertion
+            if (scenario.assert !== undefined) {
+              await scenario.assert(events);
+            }
+          } finally {
+            // Dispose factory-created adapters
+            if (isFactory && adapter.dispose !== undefined) {
+              await adapter.dispose();
+            }
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/tool-checks.test.ts
+++ b/packages/self-test/src/checks/tool-checks.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { JsonObject, ToolDescriptor, ToolResponse } from "@koi/core";
+import type { SelfTestTool } from "../types.js";
+import { runToolChecks } from "./tool-checks.js";
+
+const TIMEOUT = 5_000;
+
+const VALID_DESCRIPTOR: ToolDescriptor = {
+  name: "search",
+  description: "Search the web",
+  inputSchema: { type: "object", properties: { query: { type: "string" } } },
+};
+
+describe("runToolChecks", () => {
+  test("returns skip when no tools provided", async () => {
+    const results = await runToolChecks([], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("all checks pass for a valid tool descriptor", async () => {
+    const tool: SelfTestTool = { descriptor: VALID_DESCRIPTOR };
+    const results = await runToolChecks([tool], TIMEOUT);
+    // name + description + inputSchema = 3 checks
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("tools");
+    }
+  });
+
+  test("fails when descriptor name is empty", async () => {
+    const tool: SelfTestTool = {
+      descriptor: { ...VALID_DESCRIPTOR, name: "" },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("fails when descriptor description is empty", async () => {
+    const tool: SelfTestTool = {
+      descriptor: { ...VALID_DESCRIPTOR, description: "" },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const descCheck = results.find((r) => r.name.includes("has description"));
+    expect(descCheck?.status).toBe("fail");
+  });
+
+  test("passes when handler returns valid ToolResponse", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(_args: JsonObject): Promise<ToolResponse> {
+        return { output: { result: "ok" } };
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("pass");
+  });
+
+  test("fails when handler returns null", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(): Promise<ToolResponse> {
+        return null as unknown as ToolResponse;
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("fail");
+    expect(handlerCheck?.error?.message).toContain("undefined/null");
+  });
+
+  test("fails when handler throws", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(): Promise<ToolResponse> {
+        throw new Error("handler boom");
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("fail");
+    expect(handlerCheck?.error?.message).toBe("handler boom");
+  });
+
+  test("does not run handler check when handler is not provided", async () => {
+    const tool: SelfTestTool = { descriptor: VALID_DESCRIPTOR };
+    const results = await runToolChecks([tool], TIMEOUT);
+    // Only 3 descriptor checks, no handler check
+    expect(results).toHaveLength(3);
+  });
+
+  test("handles multiple tools", async () => {
+    const tools: readonly SelfTestTool[] = [
+      { descriptor: VALID_DESCRIPTOR },
+      { descriptor: { ...VALID_DESCRIPTOR, name: "calculator" } },
+    ];
+    const results = await runToolChecks(tools, TIMEOUT);
+    // 3 checks per tool = 6 total
+    expect(results).toHaveLength(6);
+  });
+});

--- a/packages/self-test/src/checks/tool-checks.ts
+++ b/packages/self-test/src/checks/tool-checks.ts
@@ -1,0 +1,101 @@
+/**
+ * Tool descriptor validation and optional handler invocation checks.
+ *
+ * Verifies that each tool has a valid descriptor (name, description, inputSchema)
+ * and that mock handlers (when provided) return a valid ToolResponse.
+ */
+
+import type { JsonObject } from "@koi/core";
+import { runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult, SelfTestTool } from "../types.js";
+
+const EMPTY_INPUT: JsonObject = {};
+
+export async function runToolChecks(
+  tools: readonly SelfTestTool[],
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (tools.length === 0) {
+    results.push(skipCheck("tools: no tools to check", "tools", "No tools provided"));
+    return results;
+  }
+
+  for (const tool of tools) {
+    const { descriptor } = tool;
+
+    // Descriptor: name is valid
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has valid name`,
+        "tools",
+        () => {
+          if (typeof descriptor.name !== "string" || descriptor.name.trim().length === 0) {
+            throw new Error("Tool descriptor name must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Descriptor: description is present
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has description`,
+        "tools",
+        () => {
+          if (
+            typeof descriptor.description !== "string" ||
+            descriptor.description.trim().length === 0
+          ) {
+            throw new Error("Tool descriptor description must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Descriptor: inputSchema is an object
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has inputSchema`,
+        "tools",
+        () => {
+          if (descriptor.inputSchema === undefined || descriptor.inputSchema === null) {
+            throw new Error("Tool descriptor must have an inputSchema");
+          }
+          if (typeof descriptor.inputSchema !== "object") {
+            throw new Error(
+              `Tool descriptor inputSchema must be an object, got ${typeof descriptor.inputSchema}`,
+            );
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Handler: returns valid ToolResponse (if provided)
+    const { handler } = tool;
+    if (handler !== undefined) {
+      results.push(
+        await runCheck(
+          `tool[${descriptor.name}]: handler returns valid response`,
+          "tools",
+          async () => {
+            const response = await handler(EMPTY_INPUT);
+            if (response === undefined || response === null) {
+              throw new Error("Tool handler returned undefined/null instead of ToolResponse");
+            }
+            if (!("output" in response)) {
+              throw new Error("Tool handler response is missing 'output' field");
+            }
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/self-test/src/index.ts
+++ b/packages/self-test/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @koi/self-test — Agent E2E self-verification framework.
+ *
+ * Provides a composable, pre-deployment smoke test runner for Koi agents.
+ * Validates manifests, middleware, tools, engine adapters, and E2E scenarios,
+ * returning a machine-readable SelfTestReport.
+ */
+
+export { createSelfTest } from "./self-test.js";
+export type {
+  CheckCategory,
+  CheckResult,
+  CheckStatus,
+  SelfTest,
+  SelfTestConfig,
+  SelfTestCustomCheck,
+  SelfTestReport,
+  SelfTestScenario,
+  SelfTestTool,
+} from "./types.js";

--- a/packages/self-test/src/self-test.test.ts
+++ b/packages/self-test/src/self-test.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  EngineEvent,
+  EngineInput,
+  EngineOutput,
+  KoiMiddleware,
+} from "@koi/core";
+import { KoiRuntimeError } from "@koi/errors";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import { createSelfTest } from "./self-test.js";
+import type { SelfTestScenario, SelfTestTool } from "./types.js";
+
+const VALID_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "1.0.0",
+  model: { name: "test-model" },
+};
+
+const DEFAULT_OUTPUT: EngineOutput = {
+  content: [{ kind: "text", text: "pong" }],
+  stopReason: "completed",
+  metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+};
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+describe("createSelfTest", () => {
+  test("throws VALIDATION error when manifest is null", () => {
+    expect(() => createSelfTest({ manifest: null as unknown as AgentManifest })).toThrow(
+      KoiRuntimeError,
+    );
+  });
+
+  test("returns a SelfTest with a run method", () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+    expect(typeof st.run).toBe("function");
+  });
+});
+
+describe("SelfTest.run", () => {
+  test("full healthy run with all categories", async () => {
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "pong" },
+      { kind: "done", output: DEFAULT_OUTPUT },
+    ];
+
+    const adapter = createMockEngineAdapter({ events: [...events] });
+    const mw: KoiMiddleware = { name: "test-mw", async onSessionStart() {} };
+    const tool: SelfTestTool = {
+      descriptor: {
+        name: "search",
+        description: "Search the web",
+        inputSchema: { type: "object" },
+      },
+      async handler() {
+        return { output: "ok" };
+      },
+    };
+    const scenario: SelfTestScenario = {
+      name: "ping-pong",
+      input: PING_INPUT,
+    };
+
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      adapter,
+      middleware: [mw],
+      tools: [tool],
+      scenarios: [scenario],
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(true);
+    expect(report.failed).toBe(0);
+    expect(report.passed).toBeGreaterThan(0);
+    expect(report.passed + report.failed + report.skipped).toBe(report.checks.length);
+    expect(typeof report.totalDurationMs).toBe("number");
+  });
+
+  test("full failing run when manifest is invalid", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+    expect(report.failed).toBeGreaterThan(0);
+    const failedCheck = report.checks.find((c) => c.status === "fail" && c.category === "manifest");
+    expect(failedCheck).toBeDefined();
+  });
+
+  test("failFast stops after first category failure", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+      middleware: [{ name: "should-be-skipped", async onSessionStart() {} }],
+      failFast: true,
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+
+    // Middleware category should be skipped
+    const mwChecks = report.checks.filter((c) => c.category === "middleware");
+    expect(mwChecks.length).toBe(1);
+    expect(mwChecks[0]?.status).toBe("skip");
+    expect(mwChecks[0]?.message).toContain("failFast");
+  });
+
+  test("category filtering only runs specified categories", async () => {
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      categories: ["manifest"],
+    });
+
+    const report = await st.run();
+    const categories = new Set(report.checks.map((c) => c.category));
+    expect(categories.has("manifest")).toBe(true);
+    expect(categories.has("middleware")).toBe(false);
+    expect(categories.has("tools")).toBe(false);
+    expect(categories.has("engine")).toBe(false);
+    expect(categories.has("scenarios")).toBe(false);
+  });
+
+  test("custom checks are executed", async () => {
+    let called = false;
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      customChecks: [
+        {
+          name: "custom: db connectivity",
+          fn() {
+            called = true;
+          },
+        },
+      ],
+    });
+
+    const report = await st.run();
+    expect(called).toBe(true);
+    const customCheck = report.checks.find((c) => c.category === "custom");
+    expect(customCheck?.status).toBe("pass");
+    expect(customCheck?.name).toBe("custom: db connectivity");
+  });
+
+  test("custom checks that throw produce fail results", async () => {
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      customChecks: [
+        {
+          name: "custom: failing check",
+          fn() {
+            throw new Error("db unreachable");
+          },
+        },
+      ],
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+    const customCheck = report.checks.find((c) => c.category === "custom");
+    expect(customCheck?.status).toBe("fail");
+    expect(customCheck?.error?.message).toBe("db unreachable");
+  });
+
+  test("report aggregates are correct", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+      categories: ["manifest"],
+    });
+
+    const report = await st.run();
+    const passed = report.checks.filter((c) => c.status === "pass").length;
+    const failed = report.checks.filter((c) => c.status === "fail").length;
+    const skipped = report.checks.filter((c) => c.status === "skip").length;
+
+    expect(report.passed).toBe(passed);
+    expect(report.failed).toBe(failed);
+    expect(report.skipped).toBe(skipped);
+    expect(report.passed + report.failed + report.skipped).toBe(report.checks.length);
+  });
+
+  test("skips engine and scenarios when no adapter provided", async () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+
+    const report = await st.run();
+    const engineChecks = report.checks.filter((c) => c.category === "engine");
+    const scenarioChecks = report.checks.filter((c) => c.category === "scenarios");
+
+    // Engine and scenarios should have skip results
+    for (const check of [...engineChecks, ...scenarioChecks]) {
+      expect(check.status).toBe("skip");
+    }
+  });
+
+  test("empty middleware and tools produce skip results", async () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+
+    const report = await st.run();
+    const mwChecks = report.checks.filter((c) => c.category === "middleware");
+    const toolChecks = report.checks.filter((c) => c.category === "tools");
+
+    expect(mwChecks.length).toBe(1);
+    expect(mwChecks[0]?.status).toBe("skip");
+    expect(toolChecks.length).toBe(1);
+    expect(toolChecks[0]?.status).toBe("skip");
+  });
+
+  test("global timeout skips remaining categories", async () => {
+    // Use categories filter so manifest runs first (fast), then engine (skipped by timeout)
+    // We set global timeout to 0 so it's already expired when the second category starts
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      categories: ["manifest", "engine"],
+      adapter: createMockEngineAdapter(),
+      timeoutMs: 0, // Already expired — second category should be skipped
+    });
+
+    const report = await st.run();
+    const skippedByTimeout = report.checks.filter(
+      (c) => c.status === "skip" && c.message?.includes("Global timeout"),
+    );
+    expect(skippedByTimeout.length).toBeGreaterThan(0);
+    // Manifest checks should have run (before timeout check)
+    const manifestChecks = report.checks.filter((c) => c.category === "manifest");
+    expect(manifestChecks.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/self-test/src/self-test.ts
+++ b/packages/self-test/src/self-test.ts
@@ -1,0 +1,167 @@
+/**
+ * createSelfTest — factory for the self-test runner.
+ *
+ * Orchestrates check categories sequentially, aggregates results,
+ * and returns a machine-readable SelfTestReport.
+ */
+
+import { KoiRuntimeError } from "@koi/errors";
+import { createMockSessionContext } from "@koi/test-utils";
+import { runCheck, skipCheck } from "./check-runner.js";
+import { runEngineChecks } from "./checks/engine-checks.js";
+import { runManifestChecks } from "./checks/manifest-checks.js";
+import { runMiddlewareChecks } from "./checks/middleware-checks.js";
+import { runScenarioChecks } from "./checks/scenario-checks.js";
+import { runToolChecks } from "./checks/tool-checks.js";
+import type {
+  CheckCategory,
+  CheckResult,
+  SelfTest,
+  SelfTestConfig,
+  SelfTestReport,
+} from "./types.js";
+
+const DEFAULT_CHECK_TIMEOUT_MS = 5_000;
+const DEFAULT_GLOBAL_TIMEOUT_MS = 30_000;
+
+const CATEGORY_ORDER: readonly CheckCategory[] = [
+  "manifest",
+  "middleware",
+  "tools",
+  "engine",
+  "scenarios",
+  "custom",
+];
+
+/**
+ * Create a self-test runner from the given config.
+ *
+ * @throws KoiRuntimeError with code VALIDATION if config is structurally invalid.
+ */
+export function createSelfTest(config: SelfTestConfig): SelfTest {
+  if (config.manifest === undefined || config.manifest === null) {
+    throw KoiRuntimeError.from("VALIDATION", "SelfTestConfig.manifest is required");
+  }
+
+  const checkTimeoutMs = config.checkTimeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS;
+  const globalTimeoutMs = config.timeoutMs ?? DEFAULT_GLOBAL_TIMEOUT_MS;
+  const failFast = config.failFast ?? false;
+  const categorySet = new Set(config.categories ?? CATEGORY_ORDER);
+
+  return {
+    async run(): Promise<SelfTestReport> {
+      const globalStart = Date.now();
+      // Local mutable array for sequential accumulation
+      const allChecks: CheckResult[] = [];
+
+      for (const category of CATEGORY_ORDER) {
+        if (!categorySet.has(category)) continue;
+
+        // Global timeout: skip remaining categories
+        if (Date.now() - globalStart >= globalTimeoutMs) {
+          allChecks.push(
+            skipCheck(
+              `${category}: skipped (global timeout)`,
+              category,
+              `Global timeout of ${String(globalTimeoutMs)}ms exceeded`,
+            ),
+          );
+          continue;
+        }
+
+        // Fail-fast: skip if any previous check failed
+        if (failFast && allChecks.some((c) => c.status === "fail")) {
+          allChecks.push(
+            skipCheck(
+              `${category}: skipped (failFast)`,
+              category,
+              "Previous category had failures and failFast is enabled",
+            ),
+          );
+          continue;
+        }
+
+        const categoryResults = await runCategory(category, config, checkTimeoutMs);
+        for (const result of categoryResults) {
+          allChecks.push(result);
+        }
+      }
+
+      const passed = allChecks.filter((c) => c.status === "pass").length;
+      const failed = allChecks.filter((c) => c.status === "fail").length;
+      const skipped = allChecks.filter((c) => c.status === "skip").length;
+
+      return {
+        passed,
+        failed,
+        skipped,
+        totalDurationMs: Date.now() - globalStart,
+        checks: allChecks,
+        healthy: failed === 0,
+      };
+    },
+  };
+}
+
+async function runCategory(
+  category: CheckCategory,
+  config: SelfTestConfig,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  switch (category) {
+    case "manifest":
+      return runManifestChecks(config.manifest, checkTimeoutMs);
+
+    case "middleware":
+      return runMiddlewareChecks(
+        config.middleware ?? [],
+        () => createMockSessionContext(),
+        checkTimeoutMs,
+      );
+
+    case "tools":
+      return runToolChecks(config.tools ?? [], checkTimeoutMs);
+
+    case "engine": {
+      if (config.adapter === undefined) {
+        return [skipCheck("engine: skipped", "engine", "No adapter provided")];
+      }
+      return runEngineChecks(config.adapter, checkTimeoutMs);
+    }
+
+    case "scenarios": {
+      if (config.scenarios === undefined || config.scenarios.length === 0) {
+        return [skipCheck("scenarios: skipped", "scenarios", "No scenarios provided")];
+      }
+      if (config.adapter === undefined) {
+        return [skipCheck("scenarios: skipped", "scenarios", "No adapter provided for scenarios")];
+      }
+      return runScenarioChecks(config.adapter, config.scenarios, checkTimeoutMs);
+    }
+
+    case "custom": {
+      if (config.customChecks === undefined || config.customChecks.length === 0) {
+        return [];
+      }
+      const results: CheckResult[] = [];
+      for (const check of config.customChecks) {
+        results.push(
+          await runCheck(
+            check.name,
+            "custom",
+            async () => {
+              await check.fn();
+            },
+            checkTimeoutMs,
+          ),
+        );
+      }
+      return results;
+    }
+
+    default: {
+      const _exhaustive: never = category;
+      throw new Error(`Unknown category: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/self-test/src/types.ts
+++ b/packages/self-test/src/types.ts
@@ -1,0 +1,116 @@
+/**
+ * @koi/self-test — Public types for agent self-verification.
+ */
+
+import type {
+  AgentManifest,
+  EngineAdapter,
+  EngineEvent,
+  EngineInput,
+  JsonObject,
+  KoiError,
+  KoiMiddleware,
+  ToolDescriptor,
+  ToolResponse,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Check primitives
+// ---------------------------------------------------------------------------
+
+/** Status of a single check. */
+export type CheckStatus = "pass" | "fail" | "skip";
+
+/** Built-in check categories plus user-defined custom. */
+export type CheckCategory = "manifest" | "middleware" | "tools" | "engine" | "scenarios" | "custom";
+
+/** Result of a single check. */
+export interface CheckResult {
+  readonly name: string;
+  readonly category: CheckCategory;
+  readonly status: CheckStatus;
+  readonly durationMs: number;
+  readonly error?: KoiError;
+  /** Human-readable detail (e.g., "manifest.name is empty string"). */
+  readonly message?: string;
+  /** Machine-readable context for CI tools (e.g., { field: "name" }). */
+  readonly metadata?: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+/** Aggregated self-test report. */
+export interface SelfTestReport {
+  readonly passed: number;
+  readonly failed: number;
+  readonly skipped: number;
+  readonly totalDurationMs: number;
+  readonly checks: readonly CheckResult[];
+  /** True when failed === 0. */
+  readonly healthy: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Config building blocks
+// ---------------------------------------------------------------------------
+
+/** A tool descriptor + optional mock handler for self-test verification. */
+export interface SelfTestTool {
+  readonly descriptor: ToolDescriptor;
+  /** If provided, handler is invoked with empty input to verify it returns valid ToolResponse. */
+  readonly handler?: (args: JsonObject) => Promise<ToolResponse>;
+}
+
+/** An E2E smoke-test scenario. */
+export interface SelfTestScenario {
+  readonly name: string;
+  readonly input: EngineInput;
+  /** Expected text pattern (regex or string) in streamed text_delta output. */
+  readonly expectedPattern?: string | RegExp;
+  /** Custom assertion function run against the collected events. */
+  readonly assert?: (events: readonly EngineEvent[]) => void | Promise<void>;
+}
+
+/** A user-defined custom check. */
+export interface SelfTestCustomCheck {
+  readonly name: string;
+  readonly fn: () => void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Configuration for createSelfTest. */
+export interface SelfTestConfig {
+  readonly manifest: AgentManifest;
+  /**
+   * Engine adapter instance or factory function.
+   * - Function: self-test owns lifecycle (creates, uses, disposes).
+   * - Object: caller owns lifecycle (dispose check is skipped).
+   */
+  readonly adapter?: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>);
+  readonly middleware?: readonly KoiMiddleware[];
+  readonly tools?: readonly SelfTestTool[];
+  readonly scenarios?: readonly SelfTestScenario[];
+  readonly customChecks?: readonly SelfTestCustomCheck[];
+  /** Whitelist of categories to run. undefined = all categories. */
+  readonly categories?: readonly CheckCategory[];
+  /** Per-check timeout in ms. Default: 5000. */
+  readonly checkTimeoutMs?: number;
+  /** Global run timeout in ms. Default: 30000. */
+  readonly timeoutMs?: number;
+  /** Stop on first category failure. Default: false. */
+  readonly failFast?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/** The self-test runner returned by createSelfTest. */
+export interface SelfTest {
+  readonly run: () => Promise<SelfTestReport>;
+}

--- a/packages/self-test/tsconfig.json
+++ b/packages/self-test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../errors" },
+    { "path": "../test-utils" },
+    { "path": "../engine" },
+    { "path": "../engine-pi" }
+  ]
+}

--- a/packages/self-test/tsup.config.ts
+++ b/packages/self-test/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Adds `@koi/self-test`, a composable L2 package for agent pre-deployment smoke testing
- Validates 5 categories: **manifest** (5 checks), **middleware** (structural + lifecycle hooks), **tools** (descriptor + handler), **engine** (adapter contract ping), **scenarios** (E2E with pattern matching + custom assertions)
- Returns machine-readable `SelfTestReport` with per-check results, durations, and error details for CI/CD gating
- Supports adapter factory vs instance ownership, configurable `failFast`, per-check + global timeouts, category filtering, and custom checks

## Architecture

- **Layer**: L2 — imports only from `@koi/core` (L0) and L0u utilities (`@koi/errors`, `@koi/test-utils`)
- **No L1 dependency** in production code — `@koi/engine` and `@koi/engine-pi` are devDependencies for E2E tests only
- **Immutability**: all interface properties `readonly`, all array params `readonly T[]`, no shared state mutation
- **Timeout**: dual-layer — `AbortSignal.timeout()` + `Promise.race` per check, elapsed-time global timeout

## Test coverage

- 74 unit tests across 8 files (177 assertions)
- 4 E2E tests with real Anthropic API via `createKoi` + `createPiAdapter` (gated on `ANTHROPIC_API_KEY`)
- API surface `.d.ts` snapshot test

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run build` — ESM + .d.ts emitted
- [x] `bun test` — 74 pass, 0 fail
- [x] `bun run test:api` — API surface snapshot matches
- [x] `bun run test:e2e` — 4 pass with real LLM (createKoi + Pi adapter + Haiku)
- [x] `bunx biome check` — 18 files, 0 issues
- [x] Anti-leak checklist verified (L2 layer compliance, readonly, no vendor types)
- [ ] CI passes (note: `@koi/middleware-sanitize` has a pre-existing build failure on main unrelated to this PR)

Closes #32