### PR TITLE
feat: add @koi/task-spawn (L2) — lightweight task tool for subagent spawning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -653,6 +653,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/task-spawn": {
+      "name": "@koi/task-spawn",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-loop": "workspace:*",
+        "@koi/model-router": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/test-utils": {
       "name": "@koi/test-utils",
       "version": "0.0.0",
@@ -1055,6 +1068,8 @@
     "@koi/store-fs": ["@koi/store-fs@workspace:packages/store-fs"],
 
     "@koi/store-sqlite": ["@koi/store-sqlite@workspace:packages/store-sqlite"],
+
+    "@koi/task-spawn": ["@koi/task-spawn@workspace:packages/task-spawn"],
 
     "@koi/test-utils": ["@koi/test-utils@workspace:packages/test-utils"],
 

--- a/packages/task-spawn/package.json
+++ b/packages/task-spawn/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/task-spawn",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-loop": "workspace:*",
+    "@koi/model-router": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/task-spawn/src/__tests__/e2e.test.ts
+++ b/packages/task-spawn/src/__tests__/e2e.test.ts
@@ -1,0 +1,328 @@
+/**
+ * E2E test for @koi/task-spawn through the full L1 runtime (createKoi).
+ *
+ * Validates the complete path:
+ *   Parent agent (createKoi + task tool provider)
+ *     → LLM decides to call `task` tool
+ *     → SpawnFn creates child agent (createKoi + createLoopAdapter)
+ *     → Child runs with real LLM call
+ *     → Output flows back as tool result
+ *     → Parent incorporates result
+ *
+ * Gated on OPENROUTER_API_KEY — skipped when the key is not set.
+ *
+ * Run:
+ *   OPENROUTER_API_KEY=... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput, ModelRequest, ModelResponse, Tool } from "@koi/core";
+import type { AgentManifest } from "@koi/core/assembly";
+import { createInMemorySpawnLedger, createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import {
+  createAnthropicAdapter,
+  createOpenAIAdapter,
+  createOpenRouterAdapter,
+} from "@koi/model-router";
+import { createTaskSpawnProvider } from "../provider.js";
+import type { TaskSpawnConfig, TaskSpawnRequest, TaskSpawnResult } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate — supports OPENROUTER_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY
+// ---------------------------------------------------------------------------
+
+const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY ?? "";
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = OPENROUTER_KEY.length > 0 || OPENAI_KEY.length > 0 || ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+
+function resolveModel(): string {
+  if (OPENROUTER_KEY.length > 0) return "openai/gpt-4o-mini";
+  if (OPENAI_KEY.length > 0) return "gpt-4o-mini";
+  return "claude-haiku-4-5-20251001";
+}
+
+const MODEL = resolveModel();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+// ---------------------------------------------------------------------------
+// E2E Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("@koi/task-spawn E2E with real LLM", () => {
+  // Priority: OpenRouter > OpenAI > Anthropic
+  const llmAdapter =
+    OPENROUTER_KEY.length > 0
+      ? createOpenRouterAdapter({ apiKey: OPENROUTER_KEY, appName: "koi-task-spawn-e2e" })
+      : OPENAI_KEY.length > 0
+        ? createOpenAIAdapter({ apiKey: OPENAI_KEY })
+        : createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+
+  const modelCall = (request: ModelRequest): Promise<ModelResponse> =>
+    llmAdapter.complete({ ...request, model: MODEL });
+
+  // -------------------------------------------------------------------------
+  // Test 1: Direct task tool invocation through createKoi runtime
+  // -------------------------------------------------------------------------
+  test(
+    "task tool executes child agent through full L1 runtime",
+    async () => {
+      // Child spawn callback: creates a child runtime with a real LLM call
+      const spawn = async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+        const childAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+        try {
+          const events = await collectEvents(
+            childAdapter.stream({ kind: "text", text: request.description }),
+          );
+          const output = findDoneOutput(events);
+
+          if (output === undefined) {
+            return { ok: false, error: "No done event received from child engine" };
+          }
+
+          const textBlocks = output.content.filter(
+            (b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text",
+          );
+          const text = textBlocks.map((b) => b.text).join("\n");
+          return { ok: true, output: text.length > 0 ? text : "(empty)" };
+        } finally {
+          await childAdapter.dispose?.();
+        }
+      };
+
+      const workerManifest: AgentManifest = {
+        name: "research-worker",
+        version: "0.0.1",
+        description: "A research worker",
+        model: { name: MODEL },
+      };
+
+      const config: TaskSpawnConfig = {
+        agents: new Map([
+          [
+            "researcher",
+            { name: "research-worker", description: "Researches topics", manifest: workerManifest },
+          ],
+        ]),
+        spawn,
+        defaultAgent: "researcher",
+        maxDurationMs: 60_000,
+      };
+
+      const provider = createTaskSpawnProvider(config);
+
+      // Create parent runtime through full createKoi path
+      const parentAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+      const parentRuntime = await createKoi({
+        manifest: {
+          name: "parent-agent",
+          version: "0.0.1",
+          description: "Parent agent with task tool",
+          model: { name: MODEL },
+        },
+        adapter: parentAdapter,
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 60_000, maxTokens: 50_000 },
+      });
+
+      // Verify the task tool was attached to the assembled agent
+      const taskTool = parentRuntime.agent.component<Tool>(
+        "tool:task" as import("@koi/core").SubsystemToken<Tool>,
+      );
+      expect(taskTool).toBeDefined();
+      expect(taskTool?.descriptor.name).toBe("task");
+
+      // Directly invoke the task tool (bypasses the model deciding to call it)
+      if (taskTool === undefined) {
+        throw new Error("taskTool was not attached");
+      }
+      const result = await taskTool.execute({
+        description: "Reply with exactly: PONG",
+      });
+
+      expect(typeof result).toBe("string");
+      const output = result as string;
+      expect(output.toLowerCase()).toContain("pong");
+
+      await parentRuntime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 2: Full round-trip with spawnChildAgent through L1 ledger
+  // -------------------------------------------------------------------------
+  test(
+    "task tool with spawnChildAgent uses L1 ledger correctly",
+    async () => {
+      const ledger = createInMemorySpawnLedger(10);
+      expect(ledger.activeCount()).toBe(0);
+
+      // Spawn callback using the real L1 spawnChildAgent path
+      const spawn = async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+        const childAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+        // Use createKoi directly (spawnChildAgent needs a parent Agent entity,
+        // which is complex to set up in E2E. This still validates ledger + runtime.)
+        const childRuntime = await createKoi({
+          manifest: request.manifest,
+          adapter: childAdapter,
+          agentType: "worker",
+          spawnLedger: ledger,
+          loopDetection: false,
+          limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 20_000 },
+        });
+
+        try {
+          const events = await collectEvents(
+            childRuntime.run({ kind: "text", text: request.description }),
+          );
+          const output = findDoneOutput(events);
+
+          if (output === undefined) {
+            return { ok: false, error: "No done event from child" };
+          }
+
+          if (output.stopReason === "error") {
+            return { ok: false, error: "Child terminated with error" };
+          }
+
+          const textBlocks = output.content.filter(
+            (b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text",
+          );
+          const text = textBlocks.map((b) => b.text).join("\n");
+          return { ok: true, output: text.length > 0 ? text : "(empty)" };
+        } finally {
+          await childRuntime.dispose();
+        }
+      };
+
+      const workerManifest: AgentManifest = {
+        name: "math-worker",
+        version: "0.0.1",
+        model: { name: MODEL },
+      };
+
+      const config: TaskSpawnConfig = {
+        agents: new Map([
+          ["math", { name: "math-worker", description: "Does math", manifest: workerManifest }],
+        ]),
+        spawn,
+        defaultAgent: "math",
+        maxDurationMs: 60_000,
+      };
+
+      const provider = createTaskSpawnProvider(config);
+
+      const parentAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+      const parentRuntime = await createKoi({
+        manifest: {
+          name: "parent",
+          version: "0.0.1",
+          model: { name: MODEL },
+        },
+        adapter: parentAdapter,
+        providers: [provider],
+        spawnLedger: ledger,
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 60_000, maxTokens: 50_000 },
+      });
+
+      const taskTool = parentRuntime.agent.component<Tool>(
+        "tool:task" as import("@koi/core").SubsystemToken<Tool>,
+      );
+      expect(taskTool).toBeDefined();
+
+      if (taskTool === undefined) {
+        throw new Error("taskTool was not attached");
+      }
+      const result = await taskTool.execute({
+        description: "What is 2 + 2? Reply with just the number.",
+      });
+
+      expect(typeof result).toBe("string");
+      const output = result as string;
+      expect(output).toContain("4");
+
+      await parentRuntime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 3: Error propagation — child failure returns as tool result
+  // -------------------------------------------------------------------------
+  test(
+    "child failure propagates as tool result string (not thrown)",
+    async () => {
+      const spawn = async (_request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+        return { ok: false, error: "simulated child failure" };
+      };
+
+      const config: TaskSpawnConfig = {
+        agents: new Map([
+          [
+            "worker",
+            {
+              name: "worker",
+              description: "A worker",
+              manifest: { name: "w", version: "0.0.1", model: { name: MODEL } },
+            },
+          ],
+        ]),
+        spawn,
+        defaultAgent: "worker",
+      };
+
+      const provider = createTaskSpawnProvider(config);
+      const parentAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+      const parentRuntime = await createKoi({
+        manifest: { name: "parent", version: "0.0.1", model: { name: MODEL } },
+        adapter: parentAdapter,
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 20_000 },
+      });
+
+      const taskTool = parentRuntime.agent.component<Tool>(
+        "tool:task" as import("@koi/core").SubsystemToken<Tool>,
+      );
+
+      if (taskTool === undefined) {
+        throw new Error("taskTool was not attached");
+      }
+      const result = await taskTool.execute({
+        description: "This will fail",
+      });
+
+      expect(result).toBe("Task failed: simulated child failure");
+      await parentRuntime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/task-spawn/src/__tests__/spawn-flow.integration.test.ts
+++ b/packages/task-spawn/src/__tests__/spawn-flow.integration.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration test for @koi/task-spawn.
+ *
+ * Exercises the full flow: task tool → spawn callback → engine adapter → output.
+ * Uses @koi/engine-loop's createLoopAdapter with a mock model call to simulate
+ * a real subagent execution without requiring the full L1 spawn infrastructure.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { EngineEvent, EngineOutput, ModelRequest, ModelResponse } from "@koi/core";
+import type { AgentManifest } from "@koi/core/assembly";
+import type { Tool } from "@koi/core/ecs";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { createMockAgent } from "@koi/test-utils";
+import { createTaskSpawnProvider } from "../provider.js";
+import type { TaskSpawnConfig, TaskSpawnRequest, TaskSpawnResult } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const EXPECTED_OUTPUT = "The answer to your research question is 42.";
+
+const WORKER_MANIFEST: AgentManifest = {
+  name: "research-worker",
+  version: "0.0.1",
+  description: "A research worker for integration testing",
+  model: { name: "mock-model" },
+};
+
+function createMockModelCall(): (request: ModelRequest) => Promise<ModelResponse> {
+  return async (_request: ModelRequest): Promise<ModelResponse> => ({
+    content: EXPECTED_OUTPUT,
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 20 },
+  });
+}
+
+/**
+ * Simulates what an L3 consumer would provide as the spawn callback:
+ * creates a loop adapter, runs it, and extracts output from the done event.
+ */
+function createTestSpawnFn(): {
+  readonly spawn: (request: TaskSpawnRequest) => Promise<TaskSpawnResult>;
+  readonly spawnCalls: readonly TaskSpawnRequest[];
+} {
+  const spawnCalls: TaskSpawnRequest[] = [];
+
+  const spawn = async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+    spawnCalls.push(request);
+
+    const adapter = createLoopAdapter({
+      modelCall: createMockModelCall(),
+      maxTurns: 3,
+    });
+
+    try {
+      const events = await collectEvents(
+        adapter.stream({ kind: "text", text: request.description }),
+      );
+      const output = findDoneOutput(events);
+
+      if (output === undefined) {
+        return { ok: false, error: "No done event received from engine" };
+      }
+
+      const textBlocks = output.content.filter(
+        (b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text",
+      );
+      const text = textBlocks.map((b) => b.text).join("\n");
+
+      return { ok: true, output: text };
+    } finally {
+      await adapter.dispose?.();
+    }
+  };
+
+  return { spawn, spawnCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("@koi/task-spawn integration", () => {
+  it("full spawn flow: provider → task tool → engine → output", async () => {
+    const { spawn, spawnCalls } = createTestSpawnFn();
+
+    const config: TaskSpawnConfig = {
+      agents: new Map([
+        [
+          "researcher",
+          {
+            name: "research-worker",
+            description: "Researches topics",
+            manifest: WORKER_MANIFEST,
+          },
+        ],
+      ]),
+      spawn,
+      defaultAgent: "researcher",
+    };
+
+    const provider = createTaskSpawnProvider(config);
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+    const tool = components.get("tool:task") as Tool;
+
+    expect(tool).toBeDefined();
+    expect(tool.descriptor.name).toBe("task");
+
+    const result = await tool.execute({
+      description: "What is the meaning of life?",
+    });
+
+    expect(result).toBe(EXPECTED_OUTPUT);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.description).toBe("What is the meaning of life?");
+    expect(spawnCalls[0]?.agentName).toBe("research-worker");
+    expect(spawnCalls[0]?.manifest).toBe(WORKER_MANIFEST);
+  });
+
+  it("handles engine failure gracefully", async () => {
+    const spawn = async (_request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+      return { ok: false, error: "engine adapter failed to initialize" };
+    };
+
+    const config: TaskSpawnConfig = {
+      agents: new Map([
+        [
+          "worker",
+          {
+            name: "worker",
+            description: "A worker",
+            manifest: WORKER_MANIFEST,
+          },
+        ],
+      ]),
+      spawn,
+      defaultAgent: "worker",
+    };
+
+    const provider = createTaskSpawnProvider(config);
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+    const tool = components.get("tool:task") as Tool;
+
+    const result = await tool.execute({
+      description: "This will fail",
+    });
+
+    expect(result).toBe("Task failed: engine adapter failed to initialize");
+  });
+
+  it("specific agent_type routes to correct manifest", async () => {
+    const secondManifest: AgentManifest = {
+      name: "coder",
+      version: "0.0.1",
+      model: { name: "code-model" },
+    };
+
+    // let justified: track which manifest was used
+    let usedManifest: AgentManifest | undefined;
+
+    const spawn = async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+      usedManifest = request.manifest;
+      return { ok: true, output: "coded" };
+    };
+
+    const config: TaskSpawnConfig = {
+      agents: new Map([
+        [
+          "researcher",
+          {
+            name: "research-worker",
+            description: "Researches",
+            manifest: WORKER_MANIFEST,
+          },
+        ],
+        [
+          "coder",
+          {
+            name: "coder",
+            description: "Writes code",
+            manifest: secondManifest,
+          },
+        ],
+      ]),
+      spawn,
+      defaultAgent: "researcher",
+    };
+
+    const provider = createTaskSpawnProvider(config);
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+    const tool = components.get("tool:task") as Tool;
+
+    const result = await tool.execute({
+      description: "Write a function",
+      agent_type: "coder",
+    });
+
+    expect(result).toBe("coded");
+    expect(usedManifest).toBe(secondManifest);
+  });
+});

--- a/packages/task-spawn/src/config.test.ts
+++ b/packages/task-spawn/src/config.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentManifest } from "@koi/core/assembly";
+import { validateTaskSpawnConfig } from "./config.js";
+import type { TaskableAgent, TaskSpawnResult } from "./types.js";
+
+const MOCK_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "0.0.1",
+  model: { name: "test-model" },
+};
+
+const MOCK_AGENT: TaskableAgent = {
+  name: "test-agent",
+  description: "A test agent",
+  manifest: MOCK_MANIFEST,
+};
+
+const MOCK_SPAWN = async (): Promise<TaskSpawnResult> => ({
+  ok: true,
+  output: "done",
+});
+
+function validConfig(): Record<string, unknown> {
+  return {
+    agents: new Map([["test", MOCK_AGENT]]),
+    spawn: MOCK_SPAWN,
+  };
+}
+
+describe("validateTaskSpawnConfig", () => {
+  it("accepts a valid config", () => {
+    const result = validateTaskSpawnConfig(validConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.agents.size).toBe(1);
+    }
+  });
+
+  it("accepts valid config with all optional fields", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      defaultAgent: "test",
+      maxDurationMs: 60_000,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects null", () => {
+    const result = validateTaskSpawnConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  it("rejects missing spawn function", () => {
+    const result = validateTaskSpawnConfig({ agents: new Map([["test", MOCK_AGENT]]) });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("spawn");
+    }
+  });
+
+  it("rejects non-Map agents", () => {
+    const result = validateTaskSpawnConfig({
+      spawn: MOCK_SPAWN,
+      agents: { test: MOCK_AGENT },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Map");
+    }
+  });
+
+  it("rejects empty agents map", () => {
+    const result = validateTaskSpawnConfig({
+      spawn: MOCK_SPAWN,
+      agents: new Map(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("at least one agent");
+    }
+  });
+
+  it("rejects agent map with non-string key", () => {
+    const agents = new Map<unknown, unknown>();
+    agents.set(42, { name: "bad", description: "desc", manifest: MOCK_MANIFEST });
+    const result = validateTaskSpawnConfig({ spawn: MOCK_SPAWN, agents });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("key must be a string");
+    }
+  });
+
+  it("rejects agent map with non-object value", () => {
+    const agents = new Map<unknown, unknown>();
+    agents.set("bad", "not-an-object");
+    const result = validateTaskSpawnConfig({ spawn: MOCK_SPAWN, agents });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  it("rejects agent with missing name", () => {
+    const result = validateTaskSpawnConfig({
+      spawn: MOCK_SPAWN,
+      agents: new Map([["bad", { name: "", description: "desc", manifest: MOCK_MANIFEST }]]),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("non-empty 'name'");
+    }
+  });
+
+  it("rejects agent with missing description", () => {
+    const result = validateTaskSpawnConfig({
+      spawn: MOCK_SPAWN,
+      agents: new Map([["bad", { name: "bad", description: "", manifest: MOCK_MANIFEST }]]),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("non-empty 'description'");
+    }
+  });
+
+  it("rejects agent with non-object manifest", () => {
+    const result = validateTaskSpawnConfig({
+      spawn: MOCK_SPAWN,
+      agents: new Map([["bad", { name: "bad", description: "desc", manifest: "nope" }]]),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("manifest");
+    }
+  });
+
+  it("rejects defaultAgent not in agents map", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      defaultAgent: "nonexistent",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("nonexistent");
+    }
+  });
+
+  it("rejects non-string defaultAgent", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      defaultAgent: 42,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("defaultAgent");
+    }
+  });
+
+  it("rejects maxDurationMs <= 0", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      maxDurationMs: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxDurationMs");
+    }
+  });
+
+  it("rejects non-integer maxDurationMs", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      maxDurationMs: 1.5,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxDurationMs");
+    }
+  });
+
+  it("rejects negative maxDurationMs", () => {
+    const result = validateTaskSpawnConfig({
+      ...validConfig(),
+      maxDurationMs: -100,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxDurationMs");
+    }
+  });
+
+  it("validation errors are not retryable", () => {
+    const result = validateTaskSpawnConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+});

--- a/packages/task-spawn/src/config.ts
+++ b/packages/task-spawn/src/config.ts
@@ -1,0 +1,99 @@
+/**
+ * Task spawn configuration validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { TaskSpawnConfig } from "./types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function validationError(message: string): {
+  readonly ok: false;
+  readonly error: KoiError;
+} {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+/**
+ * Validates a TaskSpawnConfig from an unknown input.
+ *
+ * Checks:
+ * - `agents` is a Map with at least one entry (each with name, description, manifest)
+ * - `spawn` is a function
+ * - `defaultAgent` (if provided) references a key in `agents`
+ * - `maxDurationMs` (if provided) is a finite positive integer
+ */
+export function validateTaskSpawnConfig(config: unknown): Result<TaskSpawnConfig, KoiError> {
+  if (!isRecord(config)) {
+    return validationError("Config must be a non-null object");
+  }
+
+  if (typeof config.spawn !== "function") {
+    return validationError(
+      "Config requires 'spawn' as a function (request: TaskSpawnRequest) => Promise<TaskSpawnResult>",
+    );
+  }
+
+  if (!(config.agents instanceof Map)) {
+    return validationError("Config requires 'agents' as a Map<string, TaskableAgent>");
+  }
+
+  if (config.agents.size === 0) {
+    return validationError("Config requires at least one agent in the 'agents' map");
+  }
+
+  for (const [key, value] of config.agents as Map<unknown, unknown>) {
+    if (typeof key !== "string") {
+      return validationError(`Agent map key must be a string, got ${typeof key}`);
+    }
+    if (!isRecord(value)) {
+      return validationError(
+        `Agent '${key}' must be a non-null object with name, description, and manifest`,
+      );
+    }
+    if (typeof value.name !== "string" || value.name.length === 0) {
+      return validationError(`Agent '${key}' requires a non-empty 'name' string`);
+    }
+    if (typeof value.description !== "string" || value.description.length === 0) {
+      return validationError(`Agent '${key}' requires a non-empty 'description' string`);
+    }
+    if (!isRecord(value.manifest)) {
+      return validationError(`Agent '${key}' requires a 'manifest' object (AgentManifest)`);
+    }
+  }
+
+  if (config.defaultAgent !== undefined) {
+    if (typeof config.defaultAgent !== "string") {
+      return validationError("'defaultAgent' must be a string");
+    }
+    if (!(config.agents as Map<string, unknown>).has(config.defaultAgent)) {
+      return validationError(
+        `'defaultAgent' value '${config.defaultAgent}' must reference a key in 'agents'`,
+      );
+    }
+  }
+
+  if (config.maxDurationMs !== undefined) {
+    if (
+      typeof config.maxDurationMs !== "number" ||
+      !Number.isFinite(config.maxDurationMs) ||
+      config.maxDurationMs <= 0 ||
+      !Number.isInteger(config.maxDurationMs)
+    ) {
+      return validationError("'maxDurationMs' must be a finite positive integer");
+    }
+  }
+
+  const validated: unknown = config;
+  return { ok: true, value: validated as TaskSpawnConfig };
+}

--- a/packages/task-spawn/src/index.ts
+++ b/packages/task-spawn/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @koi/task-spawn — Lightweight task tool for zero-friction subagent spawning (Layer 2)
+ *
+ * Injects a `task` tool via ComponentProvider that delegates work to
+ * pre-registered subagent types. The spawn callback is provided by the
+ * consumer (L3/app) to keep this package free of L1 imports.
+ *
+ * Depends on @koi/core only.
+ */
+
+export { validateTaskSpawnConfig } from "./config.js";
+export { extractOutput } from "./output.js";
+export { createTaskSpawnProvider } from "./provider.js";
+export { createTaskTool } from "./task-tool.js";
+export type {
+  SpawnFn,
+  TaskableAgent,
+  TaskSpawnConfig,
+  TaskSpawnRequest,
+  TaskSpawnResult,
+} from "./types.js";
+export {
+  DEFAULT_MAX_DURATION_MS,
+  isTaskSpawnFailure,
+  isTaskSpawnSuccess,
+  TASK_TOOL_DESCRIPTOR,
+} from "./types.js";

--- a/packages/task-spawn/src/output.test.ts
+++ b/packages/task-spawn/src/output.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { extractOutput } from "./output.js";
+import type { TaskSpawnResult } from "./types.js";
+
+describe("extractOutput", () => {
+  it("returns output text on success", () => {
+    const result: TaskSpawnResult = { ok: true, output: "Hello world" };
+    expect(extractOutput(result)).toBe("Hello world");
+  });
+
+  it("returns default message for empty success output", () => {
+    const result: TaskSpawnResult = { ok: true, output: "" };
+    expect(extractOutput(result)).toBe("(task completed with no output)");
+  });
+
+  it("returns failure message on error", () => {
+    const result: TaskSpawnResult = { ok: false, error: "connection lost" };
+    expect(extractOutput(result)).toBe("Task failed: connection lost");
+  });
+
+  it("preserves multiline output", () => {
+    const result: TaskSpawnResult = { ok: true, output: "line1\nline2\nline3" };
+    expect(extractOutput(result)).toBe("line1\nline2\nline3");
+  });
+
+  it("preserves empty-looking error messages", () => {
+    const result: TaskSpawnResult = { ok: false, error: "" };
+    expect(extractOutput(result)).toBe("Task failed: ");
+  });
+});

--- a/packages/task-spawn/src/output.ts
+++ b/packages/task-spawn/src/output.ts
@@ -1,0 +1,22 @@
+/**
+ * Output extraction helper for task spawn results.
+ */
+
+import type { TaskSpawnResult } from "./types.js";
+
+/** Default message when a task completes with no output. */
+const EMPTY_OUTPUT_MESSAGE = "(task completed with no output)";
+
+/**
+ * Extracts a human-readable string from a TaskSpawnResult.
+ *
+ * - Success with text → returns the text
+ * - Success with empty string → returns default message
+ * - Failure → returns "Task failed: ..." message
+ */
+export function extractOutput(result: TaskSpawnResult): string {
+  if (result.ok) {
+    return result.output.length > 0 ? result.output : EMPTY_OUTPUT_MESSAGE;
+  }
+  return `Task failed: ${result.error}`;
+}

--- a/packages/task-spawn/src/provider.test.ts
+++ b/packages/task-spawn/src/provider.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentManifest } from "@koi/core/assembly";
+import type { Tool } from "@koi/core/ecs";
+import { createMockAgent } from "@koi/test-utils";
+import { createTaskSpawnProvider } from "./provider.js";
+import type { TaskSpawnConfig, TaskSpawnResult } from "./types.js";
+
+const MOCK_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "0.0.1",
+  model: { name: "test-model" },
+};
+
+function createConfig(): TaskSpawnConfig {
+  return {
+    agents: new Map([
+      [
+        "test",
+        {
+          name: "test-agent",
+          description: "A test agent",
+          manifest: MOCK_MANIFEST,
+        },
+      ],
+    ]),
+    spawn: async (): Promise<TaskSpawnResult> => ({
+      ok: true,
+      output: "done",
+    }),
+    defaultAgent: "test",
+  };
+}
+
+describe("createTaskSpawnProvider", () => {
+  it("has name 'task-spawn'", () => {
+    const provider = createTaskSpawnProvider(createConfig());
+    expect(provider.name).toBe("task-spawn");
+  });
+
+  it("attaches tool:task component", async () => {
+    const provider = createTaskSpawnProvider(createConfig());
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    expect(components.has("tool:task")).toBe(true);
+    expect(components.size).toBe(1);
+  });
+
+  it("attached tool has correct descriptor name", async () => {
+    const provider = createTaskSpawnProvider(createConfig());
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+    const tool = components.get("tool:task") as Tool;
+
+    expect(tool.descriptor.name).toBe("task");
+    expect(tool.descriptor.description).toBeDefined();
+    expect(tool.descriptor.inputSchema).toBeDefined();
+  });
+
+  it("attached tool is callable", async () => {
+    const provider = createTaskSpawnProvider(createConfig());
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+    const tool = components.get("tool:task") as Tool;
+
+    const result = await tool.execute({ description: "test task" });
+    expect(result).toBe("done");
+  });
+
+  it("caches components across multiple attach() calls", async () => {
+    const provider = createTaskSpawnProvider(createConfig());
+    const agent = createMockAgent();
+
+    const first = await provider.attach(agent);
+    const second = await provider.attach(agent);
+
+    expect(first).toBe(second);
+  });
+});

--- a/packages/task-spawn/src/provider.ts
+++ b/packages/task-spawn/src/provider.ts
@@ -1,0 +1,32 @@
+/**
+ * ComponentProvider that attaches the task tool to an agent.
+ */
+
+import type { ComponentProvider } from "@koi/core/ecs";
+import { createTaskTool } from "./task-tool.js";
+import type { TaskSpawnConfig } from "./types.js";
+
+/**
+ * Creates a ComponentProvider that attaches a single `tool:task` component.
+ *
+ * The tool is created once and cached — subsequent attach() calls return
+ * the same tool instance.
+ */
+export function createTaskSpawnProvider(config: TaskSpawnConfig): ComponentProvider {
+  // let justified: mutable cache (set once on first attach)
+  let cached: ReadonlyMap<string, unknown> | undefined;
+
+  return {
+    name: "task-spawn",
+
+    async attach(): Promise<ReadonlyMap<string, unknown>> {
+      if (cached !== undefined) return cached;
+
+      const tool = createTaskTool(config);
+      const components = new Map<string, unknown>();
+      components.set("tool:task", tool);
+      cached = components;
+      return cached;
+    },
+  };
+}

--- a/packages/task-spawn/src/task-tool.test.ts
+++ b/packages/task-spawn/src/task-tool.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { AgentManifest } from "@koi/core/assembly";
+import { createTaskTool } from "./task-tool.js";
+import type { SpawnFn, TaskSpawnConfig, TaskSpawnRequest, TaskSpawnResult } from "./types.js";
+
+const MOCK_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "0.0.1",
+  model: { name: "test-model" },
+};
+
+const RESEARCH_MANIFEST: AgentManifest = {
+  name: "researcher",
+  version: "0.0.1",
+  model: { name: "research-model" },
+};
+
+function createConfig(
+  overrides?: Partial<TaskSpawnConfig> & { readonly spawnFn?: SpawnFn },
+): TaskSpawnConfig {
+  const agents = new Map([
+    [
+      "test",
+      {
+        name: "test-agent",
+        description: "A test agent",
+        manifest: MOCK_MANIFEST,
+      },
+    ],
+    [
+      "researcher",
+      {
+        name: "researcher",
+        description: "A research agent",
+        manifest: RESEARCH_MANIFEST,
+      },
+    ],
+  ]);
+
+  const spawn: SpawnFn =
+    overrides?.spawnFn ?? (async () => ({ ok: true, output: "mock output" }) as TaskSpawnResult);
+
+  return {
+    agents: overrides?.agents ?? agents,
+    spawn: overrides?.spawn ?? spawn,
+    defaultAgent: overrides?.defaultAgent,
+    maxDurationMs: overrides?.maxDurationMs,
+  };
+}
+
+describe("createTaskTool", () => {
+  it("returns output on successful spawn (happy path)", async () => {
+    const spawnFn = mock(
+      async (): Promise<TaskSpawnResult> => ({ ok: true, output: "result text" }),
+    );
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    const result = await tool.execute({
+      description: "do something",
+      agent_type: "test",
+    });
+
+    expect(result).toBe("result text");
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const call = spawnFn.mock.calls[0] as unknown as [TaskSpawnRequest];
+    expect(call[0].description).toBe("do something");
+    expect(call[0].agentName).toBe("test-agent");
+    expect(call[0].manifest).toBe(MOCK_MANIFEST);
+    expect(call[0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns error string for unknown agent type", async () => {
+    const tool = createTaskTool(createConfig());
+
+    const result = await tool.execute({
+      description: "do something",
+      agent_type: "nonexistent",
+    });
+
+    expect(typeof result).toBe("string");
+    expect(result as string).toContain("unknown agent type");
+    expect(result as string).toContain("nonexistent");
+    expect(result as string).toContain("test");
+  });
+
+  it("re-throws when spawn callback throws (infra failure)", async () => {
+    const spawnFn = mock(async (): Promise<TaskSpawnResult> => {
+      throw new Error("adapter factory exploded");
+    });
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    await expect(tool.execute({ description: "do something", agent_type: "test" })).rejects.toThrow(
+      "adapter factory exploded",
+    );
+  });
+
+  it("re-throws when spawn rejects (ledger full)", async () => {
+    const spawnFn = mock(async (): Promise<TaskSpawnResult> => {
+      throw new Error("spawn ledger at capacity");
+    });
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    await expect(tool.execute({ description: "do something", agent_type: "test" })).rejects.toThrow(
+      "spawn ledger at capacity",
+    );
+  });
+
+  it("returns error string on timeout via abort signal", async () => {
+    const spawnFn = mock(async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+      // Simulate the spawn checking the signal
+      if (request.signal.aborted) {
+        return { ok: false, error: "task timed out" };
+      }
+      // Wait until aborted
+      return new Promise((resolve) => {
+        request.signal.addEventListener("abort", () => {
+          resolve({ ok: false, error: "task timed out" });
+        });
+      });
+    });
+    const tool = createTaskTool(createConfig({ spawn: spawnFn, maxDurationMs: 50 }));
+
+    const result = await tool.execute({
+      description: "slow task",
+      agent_type: "test",
+    });
+
+    expect(result).toBe("Task failed: task timed out");
+  });
+
+  it("returns error string when child run fails", async () => {
+    const spawnFn = mock(
+      async (): Promise<TaskSpawnResult> => ({
+        ok: false,
+        error: "child execution failed: model returned error",
+      }),
+    );
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    const result = await tool.execute({
+      description: "do something",
+      agent_type: "test",
+    });
+
+    expect(result).toBe("Task failed: child execution failed: model returned error");
+  });
+
+  it("returns error string when child terminates with error stop reason", async () => {
+    const spawnFn = mock(
+      async (): Promise<TaskSpawnResult> => ({
+        ok: false,
+        error: "agent terminated with stop reason: error",
+      }),
+    );
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    const result = await tool.execute({
+      description: "do something",
+      agent_type: "test",
+    });
+
+    expect(result).toBe("Task failed: agent terminated with stop reason: error");
+  });
+
+  it("returns default message when child produces empty output", async () => {
+    const spawnFn = mock(async (): Promise<TaskSpawnResult> => ({ ok: true, output: "" }));
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    const result = await tool.execute({
+      description: "do something",
+      agent_type: "test",
+    });
+
+    expect(result).toBe("(task completed with no output)");
+  });
+
+  it("uses default agent when agent_type is omitted", async () => {
+    const spawnFn = mock(
+      async (): Promise<TaskSpawnResult> => ({ ok: true, output: "researched" }),
+    );
+    const tool = createTaskTool(createConfig({ spawn: spawnFn, defaultAgent: "researcher" }));
+
+    const result = await tool.execute({ description: "research topic" });
+
+    expect(result).toBe("researched");
+    const call = spawnFn.mock.calls[0] as unknown as [TaskSpawnRequest];
+    expect(call[0].agentName).toBe("researcher");
+    expect(call[0].manifest).toBe(RESEARCH_MANIFEST);
+  });
+
+  it("clears timeout on spawn failure (no leaked timers)", async () => {
+    // let justified: track whether spawn was called
+    let spawnCalled = false;
+    const spawnFn = mock(async (): Promise<TaskSpawnResult> => {
+      spawnCalled = true;
+      throw new Error("infra failure");
+    });
+
+    const tool = createTaskTool(createConfig({ spawn: spawnFn, maxDurationMs: 60_000 }));
+
+    await expect(tool.execute({ description: "do something", agent_type: "test" })).rejects.toThrow(
+      "infra failure",
+    );
+    expect(spawnCalled).toBe(true);
+    // Timer cleared in finally — no timeout leak
+  });
+
+  it("returns error when agent_type omitted and no default configured", async () => {
+    const tool = createTaskTool(createConfig());
+
+    const result = await tool.execute({ description: "do something" });
+
+    expect(typeof result).toBe("string");
+    expect(result as string).toContain("agent_type");
+    expect(result as string).toContain("required");
+  });
+
+  it("returns error for empty description", async () => {
+    const tool = createTaskTool(createConfig({ defaultAgent: "test" }));
+
+    const result = await tool.execute({
+      description: "",
+      agent_type: "test",
+    });
+
+    expect(typeof result).toBe("string");
+    expect(result as string).toContain("description");
+  });
+
+  it("has descriptor with name 'task'", () => {
+    const tool = createTaskTool(createConfig());
+    expect(tool.descriptor.name).toBe("task");
+  });
+
+  it("has trustTier 'verified'", () => {
+    const tool = createTaskTool(createConfig());
+    expect(tool.trustTier).toBe("verified");
+  });
+
+  it("passes abort signal to spawn callback", async () => {
+    // let justified: capture the signal for assertion
+    let capturedSignal: AbortSignal | undefined;
+    const spawnFn = mock(async (request: TaskSpawnRequest): Promise<TaskSpawnResult> => {
+      capturedSignal = request.signal;
+      return { ok: true, output: "done" };
+    });
+    const tool = createTaskTool(createConfig({ spawn: spawnFn }));
+
+    await tool.execute({ description: "do something", agent_type: "test" });
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+});

--- a/packages/task-spawn/src/task-tool.ts
+++ b/packages/task-spawn/src/task-tool.ts
@@ -1,0 +1,72 @@
+/**
+ * Task tool factory — creates a Tool that delegates work to subagents.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { Tool } from "@koi/core/ecs";
+import { extractOutput } from "./output.js";
+import { DEFAULT_MAX_DURATION_MS, TASK_TOOL_DESCRIPTOR, type TaskSpawnConfig } from "./types.js";
+
+/**
+ * Creates the `task` tool for subagent delegation.
+ *
+ * Flow:
+ * 1. Parse input → extract `description` and `agent_type`
+ * 2. Resolve agent from config.agents (fall back to config.defaultAgent)
+ * 3. Create AbortController with timeout
+ * 4. Call config.spawn() with the resolved manifest + signal
+ * 5. Return extracted output as tool result
+ *
+ * Error boundary:
+ * - config.spawn throws → re-throw (governance/infra failure)
+ * - config.spawn returns { ok: false } → return error as tool result string
+ * - config.spawn returns { ok: true } → return output as tool result
+ */
+export function createTaskTool(config: TaskSpawnConfig): Tool {
+  const maxDurationMs = config.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
+
+  return {
+    descriptor: TASK_TOOL_DESCRIPTOR,
+    trustTier: "verified",
+
+    async execute(args: JsonObject): Promise<unknown> {
+      const description = args.description;
+      if (typeof description !== "string" || description.length === 0) {
+        return "Error: 'description' is required and must be a non-empty string";
+      }
+
+      const agentType =
+        typeof args.agent_type === "string" && args.agent_type.length > 0
+          ? args.agent_type
+          : config.defaultAgent;
+
+      if (agentType === undefined) {
+        return "Error: 'agent_type' is required when no default agent is configured";
+      }
+
+      const agent = config.agents.get(agentType);
+      if (agent === undefined) {
+        const available = [...config.agents.keys()].join(", ");
+        return `Error: unknown agent type '${agentType}'. Available: ${available}`;
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort("timeout");
+      }, maxDurationMs);
+
+      try {
+        const result = await config.spawn({
+          description,
+          agentName: agent.name,
+          manifest: agent.manifest,
+          signal: controller.signal,
+        });
+
+        return extractOutput(result);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/task-spawn/src/types.test.ts
+++ b/packages/task-spawn/src/types.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isTaskSpawnFailure,
+  isTaskSpawnSuccess,
+  TASK_TOOL_DESCRIPTOR,
+  type TaskSpawnResult,
+} from "./types.js";
+
+describe("isTaskSpawnSuccess", () => {
+  it("returns true for ok result", () => {
+    const result: TaskSpawnResult = { ok: true, output: "done" };
+    expect(isTaskSpawnSuccess(result)).toBe(true);
+  });
+
+  it("returns false for error result", () => {
+    const result: TaskSpawnResult = { ok: false, error: "failed" };
+    expect(isTaskSpawnSuccess(result)).toBe(false);
+  });
+});
+
+describe("isTaskSpawnFailure", () => {
+  it("returns true for error result", () => {
+    const result: TaskSpawnResult = { ok: false, error: "failed" };
+    expect(isTaskSpawnFailure(result)).toBe(true);
+  });
+
+  it("returns false for ok result", () => {
+    const result: TaskSpawnResult = { ok: true, output: "done" };
+    expect(isTaskSpawnFailure(result)).toBe(false);
+  });
+});
+
+describe("TASK_TOOL_DESCRIPTOR", () => {
+  it("has name 'task'", () => {
+    expect(TASK_TOOL_DESCRIPTOR.name).toBe("task");
+  });
+
+  it("requires description in input schema", () => {
+    const schema = TASK_TOOL_DESCRIPTOR.inputSchema;
+    expect(schema.required).toEqual(["description"]);
+  });
+
+  it("defines description and agent_type properties", () => {
+    const props = TASK_TOOL_DESCRIPTOR.inputSchema.properties as Record<string, unknown>;
+    expect(props.description).toBeDefined();
+    expect(props.agent_type).toBeDefined();
+  });
+});

--- a/packages/task-spawn/src/types.ts
+++ b/packages/task-spawn/src/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Types for the task spawn system.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+import type { AgentManifest } from "@koi/core/assembly";
+import type { ToolDescriptor } from "@koi/core/ecs";
+
+/** A pre-registered agent type available for task delegation. */
+export interface TaskableAgent {
+  readonly name: string;
+  readonly description: string;
+  readonly manifest: AgentManifest;
+}
+
+/** Options passed to the spawn callback by the task tool. */
+export interface TaskSpawnRequest {
+  readonly description: string;
+  readonly agentName: string;
+  readonly manifest: AgentManifest;
+  readonly signal: AbortSignal;
+}
+
+/** Result returned by the spawn callback. */
+export type TaskSpawnResult =
+  | { readonly ok: true; readonly output: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Spawn callback — the consumer (L3/app) provides this to wire
+ * L2 task-spawn to L1 spawnChildAgent() + runtime.run().
+ * This keeps @koi/task-spawn free of L1 imports.
+ */
+export type SpawnFn = (request: TaskSpawnRequest) => Promise<TaskSpawnResult>;
+
+/** Default maximum duration per task in ms (5 minutes). */
+export const DEFAULT_MAX_DURATION_MS = 300_000;
+
+/** Configuration for the task spawn provider. */
+export interface TaskSpawnConfig {
+  /** Pre-registered agent types available for task delegation. */
+  readonly agents: ReadonlyMap<string, TaskableAgent>;
+  /** Spawn callback — consumer wires to spawnChildAgent() + runtime.run(). */
+  readonly spawn: SpawnFn;
+  /** Optional default agent type used when agent_type is omitted. */
+  readonly defaultAgent?: string | undefined;
+  /** Maximum duration per task in ms. Default: 300_000 (5 min). */
+  readonly maxDurationMs?: number | undefined;
+}
+
+/** Tool descriptor exposed to the model for the task tool. */
+export const TASK_TOOL_DESCRIPTOR: ToolDescriptor = {
+  name: "task",
+  description: "Delegate a task to a specialized subagent. Returns the agent's final response.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      description: {
+        type: "string",
+        description: "What the subagent should do — clear, self-contained instruction",
+      },
+      agent_type: {
+        type: "string",
+        description: "Which agent type to use (optional, defaults to general-purpose)",
+      },
+    },
+    required: ["description"],
+  },
+};
+
+/** Type guard for TaskSpawnResult. */
+export function isTaskSpawnSuccess(
+  result: TaskSpawnResult,
+): result is { readonly ok: true; readonly output: string } {
+  return result.ok === true;
+}
+
+/** Type guard for TaskSpawnResult failure. */
+export function isTaskSpawnFailure(
+  result: TaskSpawnResult,
+): result is { readonly ok: false; readonly error: string } {
+  return result.ok === false;
+}

--- a/packages/task-spawn/tsconfig.json
+++ b/packages/task-spawn/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/task-spawn/tsup.config.ts
+++ b/packages/task-spawn/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Adds `@koi/task-spawn` (L2) — a lightweight `task` tool for zero-friction subagent spawning via ComponentProvider
- SpawnFn callback is DI'd by the consumer (L3/app), keeping this package free of L1 imports
- Includes AbortController-based timeout, tool instance caching in provider, and full validation

## What's included

| File | Purpose |
|------|---------|
| `types.ts` | `TaskableAgent`, `TaskSpawnRequest`, `TaskSpawnResult`, `SpawnFn`, `TaskSpawnConfig` |
| `config.ts` | `validateTaskSpawnConfig()` with full input validation |
| `task-tool.ts` | `createTaskTool()` — core factory with timeout + error boundary |
| `provider.ts` | `createTaskSpawnProvider()` — ComponentProvider with cached tool |
| `output.ts` | `extractOutput()` helper |
| `index.ts` | Public API barrel |

## Test coverage

- **52 unit/integration tests** — 100% function + line coverage on all production code
- **3 E2E tests** through full `createKoi + createLoopAdapter` L1 runtime path with real LLM calls (gated on API key)

## Layer integrity

- Production code imports only from `@koi/core` (L0) — zero L1 or peer L2 imports
- `@koi/engine`, `@koi/engine-loop`, `@koi/model-router` are devDependencies only (tests)

## Test plan

- [x] `bun test packages/task-spawn/src/` — 52 unit/integration tests pass
- [x] `bun run --cwd packages/task-spawn typecheck` — zero errors
- [x] `bunx biome check packages/task-spawn/` — zero issues
- [x] `bunx turbo run build --filter=@koi/task-spawn` — clean ESM 5.23 KB + types 4.31 KB
- [x] E2E tests pass with real Anthropic API calls through full L1 runtime

Closes #312