### PR TITLE
feat: priority-based ComponentProvider resolution semantics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -581,6 +581,19 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/self-test": {
+      "name": "@koi/self-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+      },
+    },
     "packages/session-store": {
       "name": "@koi/session-store",
       "version": "0.0.0",
@@ -1028,6 +1041,8 @@
     "@koi/scheduler": ["@koi/scheduler@workspace:packages/scheduler"],
 
     "@koi/search": ["@koi/search@workspace:packages/search"],
+
+    "@koi/self-test": ["@koi/self-test@workspace:packages/self-test"],
 
     "@koi/session-store": ["@koi/session-store@workspace:packages/session-store"],
 

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { BrickRef } from './brick-snapshot.js';
 export { BrickId, BrickSnapshot, BrickSource, SnapshotEvent, SnapshotId, SnapshotQuery, SnapshotStore, brickId, snapshotId } from './brick-snapshot.js';
-import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-DMen1Yu6.js';
-export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, X as RunId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as engineToken, a7 as middlewareToken, a8 as providerToken, a9 as resolverToken, aa as runId, ab as sessionId, ac as skillToken, ad as token, ae as toolCallId, af as toolToken, ag as turnId } from './ecs-DMen1Yu6.js';
-import { E as EngineState, a as EngineInput } from './engine-DTI80mYJ.js';
-export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-DTI80mYJ.js';
+import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-C8V-GENO.js';
+export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as COMPONENT_PRIORITY, z as CREDENTIALS, D as ChildHandle, E as ChildLifecycleEvent, F as ComponentEvent, G as ComponentEventKind, H as ComponentProvider, I as CredentialComponent, J as DELEGATION, K as EVENTS, L as EventComponent, M as FILESYSTEM, N as GOVERNANCE, O as GovernanceComponent, Q as GovernanceUsage, R as MEMORY, U as MemoryComponent, V as MemoryResult, W as ProcessAccounter, X as ProcessId, Y as RunId, Z as SkillMetadata, _ as SpawnCheck, $ as SpawnLedger, a0 as SubsystemToken, a1 as Tool, a2 as ToolDescriptor, a3 as TrustTier, a4 as TurnId, a5 as agentId, a6 as channelToken, a7 as engineToken, a8 as middlewareToken, a9 as providerToken, aa as resolverToken, ab as runId, ac as sessionId, ad as skillToken, ae as token, af as toolCallId, ag as toolToken, ah as turnId } from './ecs-C8V-GENO.js';
+import { E as EngineState, a as EngineInput } from './engine-BGQns2cv.js';
+export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-BGQns2cv.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { A as AgentManifest } from './assembly-BeWjVbbb.js';
@@ -19,7 +19,7 @@ export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js
 export { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfig, EventEnvelope, EventInput, ReadOptions, ReadResult, SubscribeOptions, SubscriptionHandle } from './event-backend.js';
 export { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult } from './eviction.js';
 export { FileEdit, FileEditOptions, FileEditResult, FileEntryKind, FileListEntry, FileListOptions, FileListResult, FileReadOptions, FileReadResult, FileSearchMatch, FileSearchOptions, FileSearchResult, FileSystemBackend, FileWriteOptions, FileWriteResult } from './filesystem-backend.js';
-export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-iu7PvGR6.js';
+export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-BnCO13Xh.js';
 export { DEFAULT_HEALTH_MONITOR_CONFIG, HealthMonitor, HealthMonitorConfig, HealthMonitorStats, HealthSnapshot, HealthStatus } from './health.js';
 export { AgentCondition, AgentRegistry, AgentStatus, RegistryEntry, RegistryEvent, RegistryFilter, TransitionReason, VALID_TRANSITIONS } from './lifecycle.js';
 export { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, InboundMessage, OutboundMessage, TextBlock } from './message.js';
@@ -865,7 +865,7 @@ import './webhook.js';
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
 "import './assembly-BeWjVbbb.js';
-export { a as Agent, A as AgentId, B as BROWSER, C as CREDENTIALS, z as ChildHandle, D as ChildLifecycleEvent, E as ComponentEvent, F as ComponentEventKind, G as ComponentProvider, H as CredentialComponent, I as DELEGATION, J as EVENTS, K as EventComponent, L as FILESYSTEM, M as GOVERNANCE, N as GovernanceComponent, O as GovernanceUsage, Q as MEMORY, R as MemoryComponent, U as MemoryResult, V as ProcessAccounter, W as ProcessId, P as ProcessState, X as RunId, S as SessionId, Y as SkillMetadata, Z as SpawnCheck, _ as SpawnLedger, $ as SubsystemToken, a0 as Tool, T as ToolCallId, a1 as ToolDescriptor, a2 as TrustTier, a3 as TurnId, a4 as agentId, a5 as channelToken, a6 as engineToken, a7 as middlewareToken, a8 as providerToken, a9 as resolverToken, aa as runId, ab as sessionId, ac as skillToken, ad as token, ae as toolCallId, af as toolToken, ag as turnId } from './ecs-DMen1Yu6.js';
+export { a as Agent, A as AgentId, B as BROWSER, C as COMPONENT_PRIORITY, z as CREDENTIALS, D as ChildHandle, E as ChildLifecycleEvent, F as ComponentEvent, G as ComponentEventKind, H as ComponentProvider, I as CredentialComponent, J as DELEGATION, K as EVENTS, L as EventComponent, M as FILESYSTEM, N as GOVERNANCE, O as GovernanceComponent, Q as GovernanceUsage, R as MEMORY, U as MemoryComponent, V as MemoryResult, W as ProcessAccounter, X as ProcessId, P as ProcessState, Y as RunId, S as SessionId, Z as SkillMetadata, _ as SpawnCheck, $ as SpawnLedger, a0 as SubsystemToken, a1 as Tool, T as ToolCallId, a2 as ToolDescriptor, a3 as TrustTier, a4 as TurnId, a5 as agentId, a6 as channelToken, a7 as engineToken, a8 as middlewareToken, a9 as providerToken, aa as resolverToken, ab as runId, ac as sessionId, ad as skillToken, ae as token, af as toolCallId, ag as toolToken, ah as turnId } from './ecs-C8V-GENO.js';
 import './channel.js';
 import './common.js';
 import './filesystem-backend.js';
@@ -877,8 +877,8 @@ import './message.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-DTI80mYJ.js';
-import './ecs-DMen1Yu6.js';
+export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-BGQns2cv.js';
+import './ecs-C8V-GENO.js';
 import './message.js';
 import './middleware.js';
 import './assembly-BeWjVbbb.js';
@@ -1157,7 +1157,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import { ChannelStatus } from './channel.js';
 import { JsonObject } from './common.js';
-import { T as ToolCallId, S as SessionId, X as RunId, a3 as TurnId } from './ecs-DMen1Yu6.js';
+import { T as ToolCallId, S as SessionId, Y as RunId, a4 as TurnId } from './ecs-C8V-GENO.js';
 import { InboundMessage } from './message.js';
 import './assembly-BeWjVbbb.js';
 import './webhook.js';
@@ -1281,7 +1281,7 @@ export type { ApprovalDecision, ApprovalHandler, ApprovalRequest, KoiMiddleware,
 `;
 
 exports[`@koi/core API surface ./eviction has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-DMen1Yu6.js';
+"import { A as AgentId, P as ProcessState } from './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1335,7 +1335,7 @@ export type { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult 
 `;
 
 exports[`@koi/core API surface ./health has stable type surface 1`] = `
-"import { A as AgentId } from './ecs-DMen1Yu6.js';
+"import { A as AgentId } from './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1407,7 +1407,7 @@ export { DEFAULT_HEALTH_MONITOR_CONFIG, type HealthMonitor, type HealthMonitorCo
 `;
 
 exports[`@koi/core API surface ./lifecycle has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-DMen1Yu6.js';
+"import { A as AgentId, P as ProcessState } from './ecs-C8V-GENO.js';
 import { Result, KoiError } from './errors.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
@@ -1635,9 +1635,9 @@ export type { Resolver, SourceBundle, SourceLanguage };
 
 exports[`@koi/core API surface ./brick-snapshot has stable type surface 1`] = `
 "import { Result, KoiError } from './errors.js';
-import { B as BrickKind } from './forge-types-iu7PvGR6.js';
+import { B as BrickKind } from './forge-types-BnCO13Xh.js';
 import './common.js';
-import './ecs-DMen1Yu6.js';
+import './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './webhook.js';
 import './channel.js';
@@ -1754,9 +1754,9 @@ export { type BrickId, type BrickRef, type BrickSnapshot, type BrickSource, type
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
+"import { a3 as TrustTier } from './ecs-C8V-GENO.js';
 import { Result, KoiError } from './errors.js';
-import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-iu7PvGR6.js';
+import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-BnCO13Xh.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1908,7 +1908,7 @@ export type { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, Bri
 
 exports[`@koi/core API surface ./sandbox-adapter has stable type surface 1`] = `
 "import { SandboxProfile } from './sandbox-profile.js';
-import './ecs-DMen1Yu6.js';
+import './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -1980,7 +1980,7 @@ export type { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxI
 `;
 
 exports[`@koi/core API surface ./sandbox-executor has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
+"import { a3 as TrustTier } from './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';
@@ -2044,7 +2044,7 @@ export type { SandboxError, SandboxErrorCode, SandboxExecutor, SandboxResult, Ti
 `;
 
 exports[`@koi/core API surface ./sandbox-profile has stable type surface 1`] = `
-"import { a2 as TrustTier } from './ecs-DMen1Yu6.js';
+"import { a3 as TrustTier } from './ecs-C8V-GENO.js';
 import './assembly-BeWjVbbb.js';
 import './common.js';
 import './webhook.js';

--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -100,6 +100,7 @@ import type {
 import {
   ALL_BRICK_KINDS,
   agentId,
+  COMPONENT_PRIORITY,
   CREDENTIALS,
   channelToken,
   DEFAULT_HEALTH_MONITOR_CONFIG,
@@ -225,6 +226,7 @@ describe("export inventory", () => {
     expect(DEFAULT_HEALTH_MONITOR_CONFIG).toBeDefined();
     expect(ALL_BRICK_KINDS).toBeDefined();
     expect(MIN_TRUST_BY_KIND).toBeDefined();
+    expect(COMPONENT_PRIORITY).toBeDefined();
   });
 
   test("runtime values are functions, strings, or objects", () => {
@@ -244,5 +246,6 @@ describe("export inventory", () => {
     expect(typeof RETRYABLE_DEFAULTS).toBe("object");
     expect(typeof VALID_TRANSITIONS).toBe("object");
     expect(typeof DEFAULT_HEALTH_MONITOR_CONFIG).toBe("object");
+    expect(typeof COMPONENT_PRIORITY).toBe("object");
   });
 });

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -182,10 +182,38 @@ export interface SkillMetadata {
 
 export interface ComponentProvider {
   readonly name: string;
+  /**
+   * Assembly priority. Lower = higher precedence.
+   * When multiple providers supply the same component key,
+   * the provider with the lowest priority wins (first-write-wins after sort).
+   * Defaults to COMPONENT_PRIORITY.BUNDLED (100) if omitted.
+   */
+  readonly priority?: number;
   readonly attach: (agent: Agent) => Promise<ReadonlyMap<string, unknown>>;
   readonly detach?: (agent: Agent) => Promise<void>;
   readonly watch?: (listener: (event: ComponentEvent) => void) => () => void;
 }
+
+// ---------------------------------------------------------------------------
+// Component priority constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Priority tiers for ComponentProvider resolution.
+ * Lower number = higher precedence.
+ * Order: Agent-forged > Zone-forged > Global-forged > Bundled.
+ */
+export const COMPONENT_PRIORITY: Readonly<{
+  readonly AGENT_FORGED: 0;
+  readonly ZONE_FORGED: 10;
+  readonly GLOBAL_FORGED: 50;
+  readonly BUNDLED: 100;
+}> = Object.freeze({
+  AGENT_FORGED: 0,
+  ZONE_FORGED: 10,
+  GLOBAL_FORGED: 50,
+  BUNDLED: 100,
+} as const);
 
 // ---------------------------------------------------------------------------
 // Component events

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,6 +156,7 @@ export type {
 export {
   agentId,
   BROWSER,
+  COMPONENT_PRIORITY,
   CREDENTIALS,
   channelToken,
   DELEGATION,

--- a/packages/engine/src/agent-entity.test.ts
+++ b/packages/engine/src/agent-entity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentManifest, ComponentProvider, ProcessId, Tool } from "@koi/core";
-import { agentId, MEMORY, token, toolToken } from "@koi/core";
+import { agentId, COMPONENT_PRIORITY, MEMORY, token, toolToken } from "@koi/core";
 import { AgentEntity } from "./agent-entity.js";
 
 // ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ describe("AgentEntity.assemble", () => {
       },
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
 
     expect(agent.has(toolToken("calc"))).toBe(true);
     expect(agent.has(toolToken("search"))).toBe(true);
@@ -123,33 +123,153 @@ describe("AgentEntity.assemble", () => {
       attach: async () => new Map([["memory", { recall: async () => [], store: async () => {} }]]),
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
 
     expect(agent.has(toolToken("calc"))).toBe(true);
     expect(agent.has(MEMORY)).toBe(true);
     expect(agent.components().size).toBe(2);
   });
 
-  test("later provider overwrites earlier for same key", async () => {
+  test("higher-priority provider wins (first-write-wins after sort)", async () => {
     const tool1 = testTool("v1");
     const tool2 = testTool("v2");
     const provider1: ComponentProvider = {
-      name: "first",
+      name: "bundled",
+      priority: COMPONENT_PRIORITY.BUNDLED,
       attach: async () => new Map([["tool:calc", tool1]]),
     };
     const provider2: ComponentProvider = {
-      name: "second",
+      name: "forge",
+      priority: COMPONENT_PRIORITY.AGENT_FORGED,
       attach: async () => new Map([["tool:calc", tool2]]),
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
+    // provider1 registered first, but provider2 has higher priority (lower number)
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
 
     const result = agent.component<Tool>(toolToken("calc"));
     expect(result?.descriptor.name).toBe("v2");
   });
 
+  test("same-priority ties broken by registration order (stable sort)", async () => {
+    const tool1 = testTool("first");
+    const tool2 = testTool("second");
+    const provider1: ComponentProvider = {
+      name: "first",
+      priority: 50,
+      attach: async () => new Map([["tool:calc", tool1]]),
+    };
+    const provider2: ComponentProvider = {
+      name: "second",
+      priority: 50,
+      attach: async () => new Map([["tool:calc", tool2]]),
+    };
+
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
+
+    // first-write-wins: provider1 comes first at same priority
+    const result = agent.component<Tool>(toolToken("calc"));
+    expect(result?.descriptor.name).toBe("first");
+  });
+
+  test("default priority is BUNDLED (100)", async () => {
+    const tool1 = testTool("no-priority");
+    const tool2 = testTool("forged");
+    const provider1: ComponentProvider = {
+      name: "no-priority",
+      // no priority set — defaults to BUNDLED (100)
+      attach: async () => new Map([["tool:calc", tool1]]),
+    };
+    const provider2: ComponentProvider = {
+      name: "forged",
+      priority: COMPONENT_PRIORITY.AGENT_FORGED,
+      attach: async () => new Map([["tool:calc", tool2]]),
+    };
+
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider1, provider2]);
+
+    // forged (priority 0) beats unset (defaults to 100)
+    const result = agent.component<Tool>(toolToken("calc"));
+    expect(result?.descriptor.name).toBe("forged");
+  });
+
+  test("returns empty conflicts when no key collisions", async () => {
+    const provider1: ComponentProvider = {
+      name: "tools",
+      attach: async () => new Map([["tool:calc", testTool("calc")]]),
+    };
+    const provider2: ComponentProvider = {
+      name: "memory",
+      attach: async () => new Map([["memory", { recall: async () => [], store: async () => {} }]]),
+    };
+
+    const { conflicts } = await AgentEntity.assemble(testPid(), testManifest(), [
+      provider1,
+      provider2,
+    ]);
+
+    expect(conflicts).toEqual([]);
+  });
+
+  test("records conflict when forge shadows bundled", async () => {
+    const provider1: ComponentProvider = {
+      name: "bundled",
+      priority: COMPONENT_PRIORITY.BUNDLED,
+      attach: async () => new Map([["tool:calc", testTool("v1")]]),
+    };
+    const provider2: ComponentProvider = {
+      name: "forge",
+      priority: COMPONENT_PRIORITY.AGENT_FORGED,
+      attach: async () => new Map([["tool:calc", testTool("v2")]]),
+    };
+
+    const { conflicts } = await AgentEntity.assemble(testPid(), testManifest(), [
+      provider1,
+      provider2,
+    ]);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.key).toBe("tool:calc");
+    expect(conflicts[0]?.winner).toBe("forge");
+    expect(conflicts[0]?.shadowed).toEqual(["bundled"]);
+  });
+
+  test("records multiple conflicts for multiple shadowed keys", async () => {
+    const provider1: ComponentProvider = {
+      name: "bundled",
+      priority: COMPONENT_PRIORITY.BUNDLED,
+      attach: async () =>
+        new Map([
+          ["tool:calc", testTool("calc-b")],
+          ["tool:search", testTool("search-b")],
+        ]),
+    };
+    const provider2: ComponentProvider = {
+      name: "forge",
+      priority: COMPONENT_PRIORITY.AGENT_FORGED,
+      attach: async () =>
+        new Map([
+          ["tool:calc", testTool("calc-f")],
+          ["tool:search", testTool("search-f")],
+        ]),
+    };
+
+    const { conflicts } = await AgentEntity.assemble(testPid(), testManifest(), [
+      provider1,
+      provider2,
+    ]);
+
+    expect(conflicts).toHaveLength(2);
+    const keys = conflicts.map((c) => c.key).sort();
+    expect(keys).toEqual(["tool:calc", "tool:search"]);
+    for (const conflict of conflicts) {
+      expect(conflict.winner).toBe("forge");
+      expect(conflict.shadowed).toEqual(["bundled"]);
+    }
+  });
+
   test("empty providers results in empty components", async () => {
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), []);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), []);
     expect(agent.components().size).toBe(0);
   });
 
@@ -160,7 +280,7 @@ describe("AgentEntity.assemble", () => {
       attach: async () => new Map([["tool:calc", calc]]),
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
     const retrieved = agent.component<Tool>(toolToken("calc"));
     expect(retrieved).toBe(calc);
   });
@@ -183,7 +303,7 @@ describe("query", () => {
         ]),
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
 
     const tools = agent.query<Tool>("tool:");
     expect(tools.size).toBe(2);
@@ -206,7 +326,7 @@ describe("query", () => {
         ]),
     };
 
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
     const first = agent.query<Tool>("tool:");
     const second = agent.query<Tool>("tool:");
     expect(first).toBe(second); // Same reference = cache hit
@@ -228,7 +348,7 @@ describe("hasAll with assembled components", () => {
           ["memory", {}],
         ]),
     };
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
     expect(agent.hasAll(toolToken("calc"), MEMORY)).toBe(true);
   });
 
@@ -237,7 +357,7 @@ describe("hasAll with assembled components", () => {
       name: "provider",
       attach: async () => new Map([["tool:calc", testTool("calc")]]),
     };
-    const agent = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
+    const { agent } = await AgentEntity.assemble(testPid(), testManifest(), [provider]);
     expect(agent.hasAll(toolToken("calc"), MEMORY)).toBe(false);
   });
 });

--- a/packages/engine/src/agent-entity.ts
+++ b/packages/engine/src/agent-entity.ts
@@ -13,8 +13,24 @@ import type {
   ProcessState,
   SubsystemToken,
 } from "@koi/core";
+import { COMPONENT_PRIORITY } from "@koi/core";
 import type { AgentLifecycle, LifecycleEvent } from "./lifecycle.js";
 import { createLifecycle, transition } from "./lifecycle.js";
+
+// ---------------------------------------------------------------------------
+// Assembly result types
+// ---------------------------------------------------------------------------
+
+export interface AssemblyConflict {
+  readonly key: string;
+  readonly winner: string;
+  readonly shadowed: readonly string[];
+}
+
+export interface AssemblyResult {
+  readonly agent: AgentEntity;
+  readonly conflicts: readonly AssemblyConflict[];
+}
 
 export class AgentEntity implements Agent {
   readonly pid: ProcessId;
@@ -96,19 +112,51 @@ export class AgentEntity implements Agent {
     pid: ProcessId,
     manifest: AgentManifest,
     providers: readonly ComponentProvider[],
-  ): Promise<AgentEntity> {
+  ): Promise<AssemblyResult> {
     const agent = new AgentEntity(pid, manifest);
     const merged = new Map<string, unknown>();
 
-    for (const provider of providers) {
+    // Sort providers by priority ascending (lower = higher precedence).
+    // Stable sort preserves registration order for same-priority providers.
+    const sorted = [...providers].sort(
+      (a, b) =>
+        (a.priority ?? COMPONENT_PRIORITY.BUNDLED) - (b.priority ?? COMPONENT_PRIORITY.BUNDLED),
+    );
+
+    // Track which provider won each key and which were shadowed
+    const winnerByKey = new Map<string, string>();
+    const shadowedByKey = new Map<string, string[]>();
+
+    for (const provider of sorted) {
       const components = await provider.attach(agent);
       for (const [key, value] of components) {
-        merged.set(key, value);
+        if (!merged.has(key)) {
+          // First-write-wins: highest-priority provider claims the key
+          merged.set(key, value);
+          winnerByKey.set(key, provider.name);
+        } else {
+          // Record conflict: this provider was shadowed
+          const existing = shadowedByKey.get(key);
+          if (existing !== undefined) {
+            existing.push(provider.name);
+          } else {
+            shadowedByKey.set(key, [provider.name]);
+          }
+        }
       }
     }
 
+    // Build conflict list
+    const conflicts: readonly AssemblyConflict[] = [...shadowedByKey.entries()].map(
+      ([key, shadowed]) => ({
+        key,
+        winner: winnerByKey.get(key) ?? "unknown",
+        shadowed,
+      }),
+    );
+
     agent._components = merged;
     agent._queryCache.clear();
-    return agent;
+    return { agent, conflicts };
   }
 }

--- a/packages/engine/src/compose.test.ts
+++ b/packages/engine/src/compose.test.ts
@@ -466,7 +466,7 @@ const testManifest: AgentManifest = {
 
 async function createStartedAgent(): Promise<AgentEntity> {
   const pid = { id: agentId("a1"), name: "Test", type: "copilot" as const, depth: 0 };
-  const agent = await AgentEntity.assemble(pid, testManifest, []);
+  const { agent } = await AgentEntity.assemble(pid, testManifest, []);
   agent.transition({ kind: "start" });
   return agent;
 }
@@ -640,7 +640,7 @@ describe("createComposedCallHandlers", () => {
       },
     };
     const pid = { id: agentId("a1"), name: "Test", type: "copilot" as const, depth: 0 };
-    const agent = await AgentEntity.assemble(pid, testManifest, [toolProvider]);
+    const { agent } = await AgentEntity.assemble(pid, testManifest, [toolProvider]);
     agent.transition({ kind: "start" });
 
     const rawModel = mock(() => Promise.resolve(mockModelResponse()));

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,6 +9,7 @@
 // errors
 export { KoiRuntimeError } from "@koi/errors";
 // agent entity
+export type { AssemblyConflict, AssemblyResult } from "./agent-entity.js";
 export { AgentEntity } from "./agent-entity.js";
 // swarm
 export type { CascadingTermination } from "./cascading-termination.js";

--- a/packages/engine/src/inherited-component-provider.test.ts
+++ b/packages/engine/src/inherited-component-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { Agent, AgentManifest, ForgeScope, ProcessId, SubsystemToken, Tool } from "@koi/core";
-import { agentId } from "@koi/core";
+import { agentId, COMPONENT_PRIORITY } from "@koi/core";
 import { createInheritedComponentProvider } from "./inherited-component-provider.js";
 
 // ---------------------------------------------------------------------------
@@ -218,6 +218,12 @@ describe("createInheritedComponentProvider", () => {
     expect(first).toBe(second);
     // query() called only once (on first attach)
     expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("priority defaults to BUNDLED (100)", () => {
+    const parent = mockParentAgent(new Map());
+    const provider = createInheritedComponentProvider({ parent });
+    expect(provider.priority).toBe(COMPONENT_PRIORITY.BUNDLED);
   });
 
   test("tool trust tier is preserved in inherited tools", async () => {

--- a/packages/engine/src/inherited-component-provider.ts
+++ b/packages/engine/src/inherited-component-provider.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Agent, ComponentProvider, ForgeScope, Tool } from "@koi/core";
+import { COMPONENT_PRIORITY } from "@koi/core";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -42,6 +43,7 @@ export function createInheritedComponentProvider(
 
   return {
     name: "inherited",
+    priority: COMPONENT_PRIORITY.BUNDLED,
 
     attach: async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
       if (cached !== undefined) return cached;

--- a/packages/engine/src/koi.test.ts
+++ b/packages/engine/src/koi.test.ts
@@ -1023,7 +1023,7 @@ describe("createKoi live forge resolution", () => {
     expect(toolResult).toBe(42);
   });
 
-  test("entity tool takes precedence over forged tool with same name", async () => {
+  test("forged tool takes precedence over entity tool with same name", async () => {
     const entityExecute = mock(() => Promise.resolve("entity-result"));
     const forgedTool = mockTool("calculator", async () => "forged-result");
     const forge = mockForgeRuntime({
@@ -1069,10 +1069,10 @@ describe("createKoi live forge resolution", () => {
 
     await collectEvents(runtime.run({ kind: "text", text: "test" }));
 
-    // Entity tool should win; forge.resolveTool should NOT be called
-    expect(entityExecute).toHaveBeenCalledTimes(1);
-    expect(toolResult).toBe("entity-result");
-    expect(forgedTool.execute).not.toHaveBeenCalled();
+    // Forged tool should win (forge-first resolution)
+    expect(forgedTool.execute).toHaveBeenCalledTimes(1);
+    expect(toolResult).toBe("forged-result");
+    expect(entityExecute).not.toHaveBeenCalled();
   });
 
   test("NOT_FOUND when neither entity nor forge has the tool", async () => {
@@ -1137,7 +1137,7 @@ describe("createKoi live forge resolution", () => {
     expect(names).toContain("forged-search");
   });
 
-  test("callHandlers.tools merges entity and forged descriptors", async () => {
+  test("callHandlers.tools merges entity and forged descriptors (forged first)", async () => {
     const forgedDescriptor: ToolDescriptor = {
       name: "forged-tool",
       description: "Forged",
@@ -1182,6 +1182,61 @@ describe("createKoi live forge resolution", () => {
     const names = capturedTools?.map((t) => t.name);
     expect(names).toContain("entity-tool");
     expect(names).toContain("forged-tool");
+    // Forged descriptors come first
+    expect(names?.[0]).toBe("forged-tool");
+  });
+
+  test("callHandlers.tools deduplicates by name (forged wins)", async () => {
+    const forgedDescriptor: ToolDescriptor = {
+      name: "shared-tool",
+      description: "Forged version",
+      inputSchema: {},
+    };
+    const forge = mockForgeRuntime({
+      toolDescriptors: mock(async () => [forgedDescriptor]),
+    });
+
+    let capturedTools: readonly ToolDescriptor[] | undefined;
+    const adapter = forgeTestAdapter(async function* (input) {
+      capturedTools = input.callHandlers?.tools;
+      yield { kind: "done" as const, output: doneOutput() };
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      forge,
+      loopDetection: false,
+      providers: [
+        {
+          name: "tool-provider",
+          attach: async () =>
+            new Map([
+              [
+                toolToken("shared-tool") as string,
+                {
+                  descriptor: {
+                    name: "shared-tool",
+                    description: "Entity version",
+                    inputSchema: {},
+                  },
+                  trustTier: "verified" as const,
+                  execute: async () => "ok",
+                },
+              ],
+            ]),
+        },
+      ],
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    expect(capturedTools).toBeDefined();
+    // Only one entry with name "shared-tool" (deduped)
+    const matching = capturedTools?.filter((t) => t.name === "shared-tool");
+    expect(matching).toHaveLength(1);
+    // The forged description wins
+    expect(matching?.[0]?.description).toBe("Forged version");
   });
 
   test("forged descriptors returns entity-only when forge has no descriptors", async () => {
@@ -1425,13 +1480,15 @@ describe("createKoi live forge resolution", () => {
     });
   });
 
-  test("forge.resolveTool is NOT called when entity has the tool", async () => {
+  test("forge.resolveTool IS called first, falls back to entity when forge returns undefined", async () => {
     const resolveTool = mock(async () => undefined);
     const forge = mockForgeRuntime({ resolveTool });
 
+    let toolResult: unknown;
     const adapter = forgeTestAdapter(async function* (input) {
       if (input.callHandlers) {
-        await input.callHandlers.toolCall({ toolId: "entity-calc", input: {} });
+        const res = await input.callHandlers.toolCall({ toolId: "entity-calc", input: {} });
+        toolResult = res.output;
       }
       yield { kind: "done" as const, output: doneOutput() };
     });
@@ -1461,8 +1518,9 @@ describe("createKoi live forge resolution", () => {
 
     await collectEvents(runtime.run({ kind: "text", text: "test" }));
 
-    // Due to ?? short-circuit, resolveTool should never be called
-    expect(resolveTool).not.toHaveBeenCalled();
+    // Forge-first: resolveTool is called first (returns undefined), entity fallback used
+    expect(resolveTool).toHaveBeenCalledTimes(1);
+    expect(toolResult).toBe("ok");
   });
 
   test("forge.resolveTool error propagates to caller", async () => {
@@ -1722,6 +1780,77 @@ describe("createKoi live forge resolution", () => {
     // Tool was callable
     expect(forgedTool.execute).toHaveBeenCalledTimes(1);
     await runtime.dispose();
+  });
+
+  test("forge shadows entity tool end-to-end (shadow pattern)", async () => {
+    // Entity provides "calculator" with entity-result
+    const entityExecute = mock(() => Promise.resolve("entity-result"));
+    // Forge provides "calculator" with forged-result
+    const forgedTool = mockTool("calculator", async () => "forged-result");
+    const forgedDescriptor: ToolDescriptor = {
+      name: "calculator",
+      description: "Forged calculator",
+      inputSchema: {},
+    };
+    const forge = mockForgeRuntime({
+      resolveTool: mock(async (toolId: string) =>
+        toolId === "calculator" ? forgedTool : undefined,
+      ),
+      toolDescriptors: mock(async () => [forgedDescriptor]),
+    });
+
+    let toolResult: unknown;
+    let capturedTools: readonly ToolDescriptor[] | undefined;
+    const adapter = forgeTestAdapter(async function* (input) {
+      capturedTools = input.callHandlers?.tools;
+      if (input.callHandlers) {
+        const res = await input.callHandlers.toolCall({
+          toolId: "calculator",
+          input: {},
+        });
+        toolResult = res.output;
+      }
+      yield { kind: "done" as const, output: doneOutput() };
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      forge,
+      loopDetection: false,
+      providers: [
+        {
+          name: "tool-provider",
+          attach: async () =>
+            new Map([
+              [
+                toolToken("calculator") as string,
+                {
+                  descriptor: {
+                    name: "calculator",
+                    description: "Entity calculator",
+                    inputSchema: {},
+                  },
+                  trustTier: "verified" as const,
+                  execute: entityExecute,
+                },
+              ],
+            ]),
+        },
+      ],
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    // Forge wins tool call resolution
+    expect(forgedTool.execute).toHaveBeenCalledTimes(1);
+    expect(toolResult).toBe("forged-result");
+    expect(entityExecute).not.toHaveBeenCalled();
+
+    // Descriptors deduplicated — only one "calculator", forged version
+    const calcDescriptors = capturedTools?.filter((t) => t.name === "calculator");
+    expect(calcDescriptors).toHaveLength(1);
+    expect(calcDescriptors?.[0]?.description).toBe("Forged calculator");
   });
 });
 

--- a/packages/engine/src/koi.ts
+++ b/packages/engine/src/koi.ts
@@ -110,7 +110,7 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
     ...(options.parentPid !== undefined ? { parent: options.parentPid } : {}),
     ...(options.agentType !== undefined ? { agentType: options.agentType } : {}),
   });
-  const agent = await AgentEntity.assemble(pid, manifest, providers);
+  const { agent, conflicts } = await AgentEntity.assemble(pid, manifest, providers);
 
   // --- 2. Create L1 guards (declarative, no mutation) ---
   const spawnPolicy = { ...options.spawn };
@@ -133,11 +133,11 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
   // --- 3. Compose middleware chain: guards + user middleware, sorted by priority ---
   const allMiddleware: readonly KoiMiddleware[] = sortByPriority([...guards, ...middleware]);
 
-  // --- 4. Default tool terminal (entity first, then forge fallback) ---
+  // --- 4. Default tool terminal (forge first, then entity fallback) ---
   const defaultToolTerminal = async (request: ToolRequest): Promise<ToolResponse> => {
-    // O(1) entity lookup (manifest-defined + previously assembled forged tools)
+    // Forge-first: forged tools shadow entity tools (Agent-forged > Bundled)
     const tool: Tool | undefined =
-      agent.component(toolToken(request.toolId)) ?? (await forge?.resolveTool(request.toolId));
+      (await forge?.resolveTool(request.toolId)) ?? agent.component(toolToken(request.toolId));
 
     if (tool === undefined) {
       throw KoiRuntimeError.from("NOT_FOUND", `Tool not found: "${request.toolId}"`, {
@@ -157,6 +157,7 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
   // --- 6. Build runtime ---
   const runtime: KoiRuntime = {
     agent,
+    conflicts,
 
     run(input: EngineInput): AsyncIterable<EngineEvent> {
       // Guard concurrent run() calls
@@ -195,6 +196,9 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
 
           // let justified: mutable forged descriptor cache, refreshed at turn boundaries
           let forgedDescriptorsCache: readonly ToolDescriptor[] = [];
+          // let justified: mutable memo for deduped tools getter — avoids O(n) alloc per access
+          let dedupedToolsMemo: readonly ToolDescriptor[] = [];
+          let dedupedForgeRef: readonly ToolDescriptor[] = forgedDescriptorsCache;
 
           // let justified: mutable flag to defer forge refresh until next iteration,
           // giving the consumer a chance to inject tools/middleware between turns
@@ -382,7 +386,18 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
                             if (forgedDescriptorsCache.length === 0) {
                               return entityDescriptors;
                             }
-                            return [...entityDescriptors, ...forgedDescriptorsCache];
+                            // Memoized: recompute only when forgedDescriptorsCache ref changes
+                            if (dedupedForgeRef !== forgedDescriptorsCache) {
+                              dedupedForgeRef = forgedDescriptorsCache;
+                              const forgedNames = new Set(
+                                forgedDescriptorsCache.map((d) => d.name),
+                              );
+                              dedupedToolsMemo = [
+                                ...forgedDescriptorsCache,
+                                ...entityDescriptors.filter((d) => !forgedNames.has(d.name)),
+                              ];
+                            }
+                            return dedupedToolsMemo;
                           },
                           enumerable: true,
                           configurable: false,

--- a/packages/engine/src/types.test.ts
+++ b/packages/engine/src/types.test.ts
@@ -132,9 +132,10 @@ describe("CreateKoiOptions", () => {
 // ---------------------------------------------------------------------------
 
 describe("KoiRuntime", () => {
-  test("has agent, run, and dispose", () => {
+  test("has agent, conflicts, run, and dispose", () => {
     // Type-level check that KoiRuntime has the expected shape
     type _AssertAgent = KoiRuntime["agent"];
+    type _AssertConflicts = KoiRuntime["conflicts"];
     type _AssertRun = KoiRuntime["run"];
     type _AssertDispose = KoiRuntime["dispose"];
     expect(true).toBe(true);

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -22,6 +22,7 @@ import type {
   Tool,
   ToolDescriptor,
 } from "@koi/core";
+import type { AssemblyConflict } from "./agent-entity.js";
 
 // ---------------------------------------------------------------------------
 // Guard configuration
@@ -234,6 +235,8 @@ export interface CreateKoiOptions {
 export interface KoiRuntime {
   /** The assembled agent entity. */
   readonly agent: Agent;
+  /** Component key conflicts detected during assembly. Empty when no keys collide. */
+  readonly conflicts: readonly AssemblyConflict[];
   /** Run the agent with the given input. Returns an async iterable of engine events. */
   readonly run: (input: EngineInput) => AsyncIterable<EngineEvent>;
   /** Dispose the runtime and release resources. */

--- a/packages/forge/src/forge-component-provider.test.ts
+++ b/packages/forge/src/forge-component-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { Agent, SubsystemToken, TieredSandboxExecutor } from "@koi/core";
 import {
   agentId,
+  COMPONENT_PRIORITY,
   channelToken,
   engineToken,
   middlewareToken,
@@ -1141,5 +1142,46 @@ describe("createForgeComponentProvider — implementation kinds", () => {
     const second = await provider.attach(createMockAgent());
     expect(second.size).toBe(2);
     expect(searchCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Priority by scope
+// ---------------------------------------------------------------------------
+
+describe("createForgeComponentProvider — priority by scope", () => {
+  test("agent scope sets AGENT_FORGED priority", () => {
+    const provider = createForgeComponentProvider({
+      store: createInMemoryForgeStore(),
+      executor: mockTiered(echoExecutor()),
+      scope: "agent",
+    });
+    expect(provider.priority).toBe(COMPONENT_PRIORITY.AGENT_FORGED);
+  });
+
+  test("zone scope sets ZONE_FORGED priority", () => {
+    const provider = createForgeComponentProvider({
+      store: createInMemoryForgeStore(),
+      executor: mockTiered(echoExecutor()),
+      scope: "zone",
+    });
+    expect(provider.priority).toBe(COMPONENT_PRIORITY.ZONE_FORGED);
+  });
+
+  test("global scope sets GLOBAL_FORGED priority", () => {
+    const provider = createForgeComponentProvider({
+      store: createInMemoryForgeStore(),
+      executor: mockTiered(echoExecutor()),
+      scope: "global",
+    });
+    expect(provider.priority).toBe(COMPONENT_PRIORITY.GLOBAL_FORGED);
+  });
+
+  test("undefined scope defaults to AGENT_FORGED priority", () => {
+    const provider = createForgeComponentProvider({
+      store: createInMemoryForgeStore(),
+      executor: mockTiered(echoExecutor()),
+    });
+    expect(provider.priority).toBe(COMPONENT_PRIORITY.AGENT_FORGED);
   });
 });

--- a/packages/forge/src/forge-component-provider.ts
+++ b/packages/forge/src/forge-component-provider.ts
@@ -23,6 +23,7 @@ import type {
   TieredSandboxExecutor,
 } from "@koi/core";
 import {
+  COMPONENT_PRIORITY,
   channelToken,
   engineToken,
   middlewareToken,
@@ -117,6 +118,13 @@ function isScopeVisible(brickScope: ForgeScope, callerScope: ForgeScope | undefi
   if (callerScope === undefined) return true;
   return SCOPE_LEVEL[brickScope] >= SCOPE_LEVEL[callerScope];
 }
+
+/** Map forge scope to component priority for assembly ordering. */
+const SCOPE_PRIORITY: Readonly<Record<ForgeScope, number>> = {
+  agent: COMPONENT_PRIORITY.AGENT_FORGED,
+  zone: COMPONENT_PRIORITY.ZONE_FORGED,
+  global: COMPONENT_PRIORITY.GLOBAL_FORGED,
+} as const;
 
 /**
  * Creates a ComponentProvider that lazily loads forged tools on first attach().
@@ -239,6 +247,7 @@ export function createForgeComponentProvider(
 
   return {
     name: "forge",
+    priority: SCOPE_PRIORITY[config.scope ?? "agent"],
     attach: loadComponents,
     invalidate,
     invalidateByScope,

--- a/packages/self-test/package.json
+++ b/packages/self-test/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/self-test",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts",
+    "test:e2e": "bun test src/__tests__/e2e.test.ts"
+  }
+}

--- a/packages/self-test/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/self-test/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,99 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/self-test API surface . has stable type surface 1`] = `
+"import { KoiError, JsonObject, AgentManifest, EngineAdapter, KoiMiddleware, ToolDescriptor, ToolResponse, EngineInput, EngineEvent } from '@koi/core';
+
+/**
+ * @koi/self-test — Public types for agent self-verification.
+ */
+
+/** Status of a single check. */
+type CheckStatus = "pass" | "fail" | "skip";
+/** Built-in check categories plus user-defined custom. */
+type CheckCategory = "manifest" | "middleware" | "tools" | "engine" | "scenarios" | "custom";
+/** Result of a single check. */
+interface CheckResult {
+    readonly name: string;
+    readonly category: CheckCategory;
+    readonly status: CheckStatus;
+    readonly durationMs: number;
+    readonly error?: KoiError;
+    /** Human-readable detail (e.g., "manifest.name is empty string"). */
+    readonly message?: string;
+    /** Machine-readable context for CI tools (e.g., { field: "name" }). */
+    readonly metadata?: JsonObject;
+}
+/** Aggregated self-test report. */
+interface SelfTestReport {
+    readonly passed: number;
+    readonly failed: number;
+    readonly skipped: number;
+    readonly totalDurationMs: number;
+    readonly checks: readonly CheckResult[];
+    /** True when failed === 0. */
+    readonly healthy: boolean;
+}
+/** A tool descriptor + optional mock handler for self-test verification. */
+interface SelfTestTool {
+    readonly descriptor: ToolDescriptor;
+    /** If provided, handler is invoked with empty input to verify it returns valid ToolResponse. */
+    readonly handler?: (args: JsonObject) => Promise<ToolResponse>;
+}
+/** An E2E smoke-test scenario. */
+interface SelfTestScenario {
+    readonly name: string;
+    readonly input: EngineInput;
+    /** Expected text pattern (regex or string) in streamed text_delta output. */
+    readonly expectedPattern?: string | RegExp;
+    /** Custom assertion function run against the collected events. */
+    readonly assert?: (events: readonly EngineEvent[]) => void | Promise<void>;
+}
+/** A user-defined custom check. */
+interface SelfTestCustomCheck {
+    readonly name: string;
+    readonly fn: () => void | Promise<void>;
+}
+/** Configuration for createSelfTest. */
+interface SelfTestConfig {
+    readonly manifest: AgentManifest;
+    /**
+     * Engine adapter instance or factory function.
+     * - Function: self-test owns lifecycle (creates, uses, disposes).
+     * - Object: caller owns lifecycle (dispose check is skipped).
+     */
+    readonly adapter?: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>);
+    readonly middleware?: readonly KoiMiddleware[];
+    readonly tools?: readonly SelfTestTool[];
+    readonly scenarios?: readonly SelfTestScenario[];
+    readonly customChecks?: readonly SelfTestCustomCheck[];
+    /** Whitelist of categories to run. undefined = all categories. */
+    readonly categories?: readonly CheckCategory[];
+    /** Per-check timeout in ms. Default: 5000. */
+    readonly checkTimeoutMs?: number;
+    /** Global run timeout in ms. Default: 30000. */
+    readonly timeoutMs?: number;
+    /** Stop on first category failure. Default: false. */
+    readonly failFast?: boolean;
+}
+/** The self-test runner returned by createSelfTest. */
+interface SelfTest {
+    readonly run: () => Promise<SelfTestReport>;
+}
+
+/**
+ * createSelfTest — factory for the self-test runner.
+ *
+ * Orchestrates check categories sequentially, aggregates results,
+ * and returns a machine-readable SelfTestReport.
+ */
+
+/**
+ * Create a self-test runner from the given config.
+ *
+ * @throws KoiRuntimeError with code VALIDATION if config is structurally invalid.
+ */
+declare function createSelfTest(config: SelfTestConfig): SelfTest;
+
+export { type CheckCategory, type CheckResult, type CheckStatus, type SelfTest, type SelfTestConfig, type SelfTestCustomCheck, type SelfTestReport, type SelfTestScenario, type SelfTestTool, createSelfTest };
+"
+`;

--- a/packages/self-test/src/__tests__/api-surface.test.ts
+++ b/packages/self-test/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/self-test/src/__tests__/e2e.test.ts
+++ b/packages/self-test/src/__tests__/e2e.test.ts
@@ -1,0 +1,246 @@
+/**
+ * End-to-end tests for @koi/self-test with real LLM calls.
+ *
+ * Validates the full self-test pipeline through createKoi (L1) + createPiAdapter:
+ *   - Manifest checks pass for a real agent config
+ *   - Middleware hooks are structurally valid
+ *   - Engine adapter resolves, streams, yields done event through L1 runtime
+ *   - E2E scenario completes with pattern matching against real LLM output
+ *   - Full report is healthy
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest, EngineAdapter, EngineInput, KoiMiddleware } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createSelfTest } from "../self-test.js";
+import type { SelfTestScenario } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const CHECK_TIMEOUT_MS = 30_000;
+
+// Use haiku for speed + cost
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Shared config
+// ---------------------------------------------------------------------------
+
+const E2E_MANIFEST: AgentManifest = {
+  name: "self-test-e2e-agent",
+  version: "1.0.0",
+  model: { name: "claude-haiku" },
+};
+
+/**
+ * Factory that creates a KoiRuntime-backed EngineAdapter.
+ *
+ * Each call assembles a fresh createKoi runtime with the Pi adapter,
+ * wrapping runtime.run() as adapter.stream(). This exercises the full
+ * L1 path: assembly → guards → middleware composition → Pi adapter → real LLM.
+ */
+async function createKoiAdapter(middleware?: readonly KoiMiddleware[]): Promise<EngineAdapter> {
+  const piAdapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: "You are a concise test assistant. Reply briefly and exactly as instructed.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: E2E_MANIFEST,
+    adapter: piAdapter,
+    middleware: middleware ?? [],
+    loopDetection: false,
+    limits: { maxTurns: 5, maxDurationMs: 55_000, maxTokens: 10_000 },
+  });
+
+  return {
+    engineId: "koi-pi-e2e",
+    stream: (input: EngineInput) => runtime.run(input),
+    dispose: () => runtime.dispose(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: self-test with real Anthropic API via createKoi + createPiAdapter", () => {
+  test(
+    "full self-test report is healthy with real LLM adapter",
+    async () => {
+      const observerMw: KoiMiddleware = {
+        name: "e2e-observer",
+        async onSessionStart() {
+          // no-op — validates structural check passes
+        },
+        async onSessionEnd() {
+          // no-op
+        },
+      };
+
+      const scenario: SelfTestScenario = {
+        name: "ping-pong",
+        input: { kind: "text", text: "Reply with exactly one word: pong" },
+        expectedPattern: /pong/i,
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter([observerMw]),
+        middleware: [observerMw],
+        scenarios: [scenario],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      // Log report for manual inspection
+      for (const check of report.checks) {
+        const icon = check.status === "pass" ? "+" : check.status === "fail" ? "x" : "-";
+        const suffix = check.message !== undefined ? ` — ${check.message}` : "";
+        console.log(`  [${icon}] ${check.name}${suffix}`);
+      }
+      console.log(
+        `\n  Result: ${String(report.passed)} pass, ${String(report.failed)} fail, ${String(report.skipped)} skip`,
+      );
+
+      expect(report.healthy).toBe(true);
+      expect(report.failed).toBe(0);
+      expect(report.passed).toBeGreaterThan(0);
+
+      // Engine checks should have run (not skipped)
+      const engineChecks = report.checks.filter((c) => c.category === "engine");
+      const passingEngineChecks = engineChecks.filter((c) => c.status === "pass");
+      expect(passingEngineChecks.length).toBeGreaterThan(0);
+
+      // Scenario check should have run and passed
+      const scenarioChecks = report.checks.filter((c) => c.category === "scenarios");
+      expect(scenarioChecks.length).toBeGreaterThan(0);
+      const scenarioPass = scenarioChecks.find((c) => c.status === "pass");
+      expect(scenarioPass).toBeDefined();
+
+      // Middleware structural checks should pass
+      const mwChecks = report.checks.filter((c) => c.category === "middleware");
+      expect(mwChecks.length).toBeGreaterThan(0);
+      for (const check of mwChecks) {
+        expect(check.status).toBe("pass");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "scenario with regex pattern matching against real LLM output",
+    async () => {
+      const scenario: SelfTestScenario = {
+        name: "math-answer",
+        input: { kind: "text", text: "What is 2 + 2? Reply with just the number." },
+        expectedPattern: /4/,
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        scenarios: [scenario],
+        categories: ["scenarios"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      const scenarioCheck = report.checks.find(
+        (c) => c.category === "scenarios" && c.name.includes("math-answer"),
+      );
+      expect(scenarioCheck?.status).toBe("pass");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "scenario custom assertion receives real events",
+    async () => {
+      // let justified: mutated in closure to verify assertion ran
+      let assertionCalled = false;
+      // let justified: capture token count for verification
+      let tokenCount = 0;
+
+      const scenario: SelfTestScenario = {
+        name: "custom-assert",
+        input: { kind: "text", text: "Say hello" },
+        assert: (events) => {
+          assertionCalled = true;
+          const doneEvent = events.find((e) => e.kind === "done");
+          if (doneEvent === undefined || doneEvent.kind !== "done") {
+            throw new Error("No done event");
+          }
+          tokenCount = doneEvent.output.metrics.totalTokens;
+          // Real LLM call should consume tokens
+          if (doneEvent.output.metrics.totalTokens === 0) {
+            throw new Error("Expected non-zero token count from real LLM");
+          }
+        },
+      };
+
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        scenarios: [scenario],
+        categories: ["scenarios"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      expect(assertionCalled).toBe(true);
+      expect(tokenCount).toBeGreaterThan(0);
+
+      const check = report.checks.find((c) => c.name.includes("custom-assert"));
+      expect(check?.status).toBe("pass");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "engine checks pass through full L1 pipeline (dispose included for factory)",
+    async () => {
+      const st = createSelfTest({
+        manifest: E2E_MANIFEST,
+        adapter: () => createKoiAdapter(),
+        categories: ["engine"],
+        checkTimeoutMs: CHECK_TIMEOUT_MS,
+        timeoutMs: TIMEOUT_MS,
+      });
+
+      const report = await st.run();
+
+      const engineChecks = report.checks.filter((c) => c.category === "engine");
+      // Factory mode: resolve + engineId + stream callable + stream yields done + output valid + dispose = 6
+      expect(engineChecks).toHaveLength(6);
+
+      for (const check of engineChecks) {
+        if (check.status === "fail") {
+          console.log(`  FAIL: ${check.name} — ${check.error?.message ?? "no error"}`);
+        }
+        expect(check.status).toBe("pass");
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/self-test/src/check-runner.test.ts
+++ b/packages/self-test/src/check-runner.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput } from "@koi/core";
+import { collectEvents, extractText, runCheck, skipCheck } from "./check-runner.js";
+
+describe("runCheck", () => {
+  test("returns pass for a check that succeeds", async () => {
+    const result = await runCheck("test-pass", "manifest", () => {}, 5_000);
+    expect(result.status).toBe("pass");
+    expect(result.name).toBe("test-pass");
+    expect(result.category).toBe("manifest");
+    expect(typeof result.durationMs).toBe("number");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns pass for an async check that resolves", async () => {
+    const result = await runCheck(
+      "async-pass",
+      "tools",
+      async () => {
+        await Promise.resolve();
+      },
+      5_000,
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  test("returns fail for a check that throws synchronously", async () => {
+    const result = await runCheck(
+      "sync-throw",
+      "middleware",
+      () => {
+        throw new Error("deliberate failure");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe("INTERNAL");
+    expect(result.error?.message).toBe("deliberate failure");
+    expect(result.message).toBe("deliberate failure");
+  });
+
+  test("returns fail for a check that rejects", async () => {
+    const result = await runCheck(
+      "async-reject",
+      "engine",
+      async () => {
+        throw new Error("async failure");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.code).toBe("INTERNAL");
+    expect(result.error?.message).toBe("async failure");
+  });
+
+  test("returns fail with TIMEOUT for a check that exceeds timeout", async () => {
+    const result = await runCheck(
+      "timeout-check",
+      "engine",
+      () => new Promise(() => {}), // never resolves
+      10,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.code).toBe("TIMEOUT");
+    expect(result.error?.retryable).toBe(true);
+    expect(result.error?.message).toContain("timed out");
+  });
+
+  test("tracks duration for successful checks", async () => {
+    const result = await runCheck(
+      "timed-check",
+      "manifest",
+      async () => {
+        await Bun.sleep(10);
+      },
+      5_000,
+    );
+    expect(result.durationMs).toBeGreaterThanOrEqual(5);
+  });
+
+  test("tracks duration for failed checks", async () => {
+    const result = await runCheck(
+      "failed-timed",
+      "manifest",
+      async () => {
+        await Bun.sleep(10);
+        throw new Error("fail after delay");
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.durationMs).toBeGreaterThanOrEqual(5);
+  });
+
+  test("handles non-Error throws gracefully", async () => {
+    const result = await runCheck(
+      "string-throw",
+      "tools",
+      () => {
+        throw "plain string error";
+      },
+      5_000,
+    );
+    expect(result.status).toBe("fail");
+    expect(result.error?.message).toBe("plain string error");
+  });
+});
+
+describe("collectEvents", () => {
+  test("collects events from async iterable", async () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    async function* gen(): AsyncIterable<EngineEvent> {
+      yield { kind: "text_delta", delta: "hello" };
+      yield { kind: "done", output };
+    }
+
+    const events = await collectEvents(gen());
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("text_delta");
+    expect(events[1]?.kind).toBe("done");
+  });
+
+  test("returns empty array for empty iterable", async () => {
+    async function* gen(): AsyncIterable<EngineEvent> {
+      // yields nothing
+    }
+    const events = await collectEvents(gen());
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe("extractText", () => {
+  test("concatenates text_delta events", () => {
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "hello " },
+      { kind: "text_delta", delta: "world" },
+    ];
+    expect(extractText(events)).toBe("hello world");
+  });
+
+  test("ignores non-text_delta events", () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output },
+    ];
+    expect(extractText(events)).toBe("hello");
+  });
+
+  test("returns empty string for no text events", () => {
+    const output: EngineOutput = {
+      content: [],
+      stopReason: "completed",
+      metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+    };
+    const events: readonly EngineEvent[] = [{ kind: "done", output }];
+    expect(extractText(events)).toBe("");
+  });
+});
+
+describe("skipCheck", () => {
+  test("creates a skip result with correct fields", () => {
+    const result = skipCheck("skipped-check", "engine", "no adapter");
+    expect(result.status).toBe("skip");
+    expect(result.name).toBe("skipped-check");
+    expect(result.category).toBe("engine");
+    expect(result.message).toBe("no adapter");
+    expect(result.durationMs).toBe(0);
+  });
+});

--- a/packages/self-test/src/check-runner.ts
+++ b/packages/self-test/src/check-runner.ts
@@ -1,0 +1,91 @@
+/**
+ * Check execution helper — wraps individual checks with timeout and error containment.
+ */
+
+import type { EngineAdapter, EngineEvent, KoiError } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CheckCategory, CheckResult } from "./types.js";
+
+/** Type guard: adapter config is a factory function (vs an instance). */
+export function isAdapterFactory(
+  value: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+): value is () => EngineAdapter | Promise<EngineAdapter> {
+  return typeof value === "function";
+}
+
+/**
+ * Run a single check with timeout and error containment.
+ *
+ * The check function receives an AbortSignal that fires on timeout.
+ * Checks that complete normally produce a "pass" result.
+ * Checks that throw (or time out) produce a "fail" result.
+ * Never throws — all errors are captured into CheckResult.
+ */
+export async function runCheck(
+  name: string,
+  category: CheckCategory,
+  fn: (signal: AbortSignal) => void | Promise<void>,
+  timeoutMs: number,
+): Promise<CheckResult> {
+  const start = Date.now();
+  try {
+    const signal = AbortSignal.timeout(timeoutMs);
+    // Race the check against the timeout — if fn ignores the signal and never
+    // resolves, the timeout promise rejects and Promise.race propagates it.
+    const timeoutRejection = new Promise<never>((_, reject) => {
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    });
+    await Promise.race([fn(signal), timeoutRejection]);
+    return {
+      name,
+      category,
+      status: "pass",
+      durationMs: Date.now() - start,
+    };
+  } catch (e: unknown) {
+    const isTimeout = e instanceof DOMException && e.name === "TimeoutError";
+    const error: KoiError = {
+      code: isTimeout ? "TIMEOUT" : "INTERNAL",
+      message: isTimeout
+        ? `Check "${name}" timed out after ${String(timeoutMs)}ms`
+        : e instanceof Error
+          ? e.message
+          : String(e),
+      retryable: isTimeout ? RETRYABLE_DEFAULTS.TIMEOUT : RETRYABLE_DEFAULTS.INTERNAL,
+      ...(e instanceof Error && e.cause !== undefined ? { cause: e.cause } : {}),
+    };
+    return {
+      name,
+      category,
+      status: "fail",
+      durationMs: Date.now() - start,
+      error,
+      message: error.message,
+    };
+  }
+}
+
+/** Collect all events from an async iterable into an array. */
+export async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  // Local mutable array for accumulation — not shared state
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Extract concatenated text from text_delta events. */
+export function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+/** Create a skip check result. */
+export function skipCheck(name: string, category: CheckCategory, message: string): CheckResult {
+  return { name, category, status: "skip", durationMs: 0, message };
+}

--- a/packages/self-test/src/checks/engine-checks.test.ts
+++ b/packages/self-test/src/checks/engine-checks.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent } from "@koi/core";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import { runEngineChecks } from "./engine-checks.js";
+
+const TIMEOUT = 5_000;
+
+describe("runEngineChecks", () => {
+  test("all checks pass for a valid mock adapter (instance)", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    // resolve + engineId + stream callable + stream done + output valid = 5
+    // No dispose check (instance mode)
+    expect(results).toHaveLength(5);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("engine");
+    }
+  });
+
+  test("all checks pass for a valid mock adapter (factory)", async () => {
+    const factory = () => createMockEngineAdapter();
+    const results = await runEngineChecks(factory, TIMEOUT);
+    // resolve + engineId + stream callable + stream done + output valid + dispose = 6
+    expect(results).toHaveLength(6);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+    }
+  });
+
+  test("skips all checks when factory throws", async () => {
+    const factory = () => {
+      throw new Error("factory boom");
+    };
+    const results = await runEngineChecks(factory, TIMEOUT);
+    // resolve (fail) + 4 skips + dispose skip = 6
+    expect(results).toHaveLength(6);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toBe("factory boom");
+    for (const r of results.slice(1)) {
+      expect(r.status).toBe("skip");
+    }
+  });
+
+  test("fails when adapter has empty engineId", async () => {
+    const adapter = createMockEngineAdapter({ engineId: "" });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const idCheck = results.find((r) => r.name.includes("engineId"));
+    expect(idCheck?.status).toBe("fail");
+  });
+
+  test("fails when stream yields no done event", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "hello" }];
+    const adapter = createMockEngineAdapter({ events });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const streamCheck = results.find((r) => r.name.includes("stream yields done"));
+    expect(streamCheck?.status).toBe("fail");
+    expect(streamCheck?.error?.message).toContain("done event");
+  });
+
+  test("skips output validation when stream check fails", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "no done" }];
+    const adapter = createMockEngineAdapter({ events });
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const outputCheck = results.find((r) => r.name.includes("done output is valid"));
+    expect(outputCheck?.status).toBe("skip");
+  });
+
+  test("dispose check runs for factory adapter", async () => {
+    const adapter = createMockEngineAdapter();
+    const factory = () => adapter;
+    const results = await runEngineChecks(factory, TIMEOUT);
+    const disposeCheck = results.find((r) => r.name.includes("dispose completes"));
+    expect(disposeCheck?.status).toBe("pass");
+    expect(adapter.disposeCalls.length).toBe(1);
+  });
+
+  test("no dispose check for instance adapter", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runEngineChecks(adapter, TIMEOUT);
+    const disposeCheck = results.find((r) => r.name.includes("dispose"));
+    expect(disposeCheck).toBeUndefined();
+  });
+});

--- a/packages/self-test/src/checks/engine-checks.ts
+++ b/packages/self-test/src/checks/engine-checks.ts
@@ -1,0 +1,146 @@
+/**
+ * Engine adapter contract checks.
+ *
+ * Verifies that the adapter has a valid engineId, stream() is callable,
+ * stream yields a done event with valid output, and dispose completes cleanly.
+ */
+
+import type { EngineAdapter, EngineEvent, EngineInput } from "@koi/core";
+import { collectEvents, isAdapterFactory, runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+export async function runEngineChecks(
+  adapterOrFactory: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+  const isFactory = isAdapterFactory(adapterOrFactory);
+
+  // let: assigned inside runCheck closure, read after for subsequent checks
+  let adapter: EngineAdapter | undefined;
+  const resolveResult = await runCheck(
+    "engine: adapter resolves",
+    "engine",
+    async () => {
+      adapter = isFactory ? await adapterOrFactory() : adapterOrFactory;
+    },
+    checkTimeoutMs,
+  );
+  results.push(resolveResult);
+
+  if (resolveResult.status !== "pass" || adapter === undefined) {
+    results.push(skipCheck("engine: engineId is valid", "engine", "Adapter resolution failed"));
+    results.push(skipCheck("engine: stream is callable", "engine", "Adapter resolution failed"));
+    results.push(
+      skipCheck("engine: stream yields done event", "engine", "Adapter resolution failed"),
+    );
+    results.push(skipCheck("engine: done output is valid", "engine", "Adapter resolution failed"));
+    if (isFactory) {
+      results.push(skipCheck("engine: dispose completes", "engine", "Adapter resolution failed"));
+    }
+    return results;
+  }
+
+  // Capture adapter in a const for closure safety
+  const resolvedAdapter = adapter;
+
+  // engineId is a non-empty string
+  results.push(
+    await runCheck(
+      "engine: engineId is valid",
+      "engine",
+      () => {
+        if (typeof resolvedAdapter.engineId !== "string" || resolvedAdapter.engineId.length === 0) {
+          throw new Error("engineId must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  // stream is a function
+  results.push(
+    await runCheck(
+      "engine: stream is callable",
+      "engine",
+      () => {
+        if (typeof resolvedAdapter.stream !== "function") {
+          throw new Error("stream must be a function");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  // let: populated inside stream check closure, read in output validation check
+  let events: readonly EngineEvent[] = [];
+  const streamResult = await runCheck(
+    "engine: stream yields done event",
+    "engine",
+    async (signal) => {
+      const input: EngineInput = { ...PING_INPUT, signal };
+      events = await collectEvents(resolvedAdapter.stream(input));
+      const doneEvent = events.find((e) => e.kind === "done");
+      if (doneEvent === undefined) {
+        throw new Error("Stream did not yield a done event");
+      }
+    },
+    checkTimeoutMs,
+  );
+  results.push(streamResult);
+
+  // done output structure is valid
+  if (streamResult.status === "pass") {
+    results.push(
+      await runCheck(
+        "engine: done output is valid",
+        "engine",
+        () => {
+          const doneEvent = events.find(
+            (e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done",
+          );
+          if (doneEvent === undefined) {
+            throw new Error("No done event found");
+          }
+          const { output } = doneEvent;
+          if (!Array.isArray(output.content)) {
+            throw new Error("output.content must be an array");
+          }
+          const validReasons = new Set(["completed", "max_turns", "interrupted", "error"]);
+          if (!validReasons.has(output.stopReason)) {
+            throw new Error(`Invalid stopReason: ${output.stopReason}`);
+          }
+          if (typeof output.metrics.totalTokens !== "number") {
+            throw new Error("output.metrics.totalTokens must be a number");
+          }
+          if (typeof output.metrics.durationMs !== "number") {
+            throw new Error("output.metrics.durationMs must be a number");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  } else {
+    results.push(skipCheck("engine: done output is valid", "engine", "Stream check failed"));
+  }
+
+  // dispose completes (only if factory — self-test owns lifecycle)
+  if (isFactory) {
+    results.push(
+      await runCheck(
+        "engine: dispose completes",
+        "engine",
+        async () => {
+          if (resolvedAdapter.dispose !== undefined) {
+            await resolvedAdapter.dispose();
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/manifest-checks.test.ts
+++ b/packages/self-test/src/checks/manifest-checks.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest } from "@koi/core";
+import { runManifestChecks } from "./manifest-checks.js";
+
+const VALID_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "1.0.0",
+  model: { name: "test-model" },
+};
+
+const TIMEOUT = 5_000;
+
+describe("runManifestChecks", () => {
+  test("all checks pass for a valid manifest", async () => {
+    const results = await runManifestChecks(VALID_MANIFEST, TIMEOUT);
+    expect(results.length).toBe(5);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("manifest");
+    }
+  });
+
+  test("fails when name is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, name: "" };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("name is non-empty"));
+    expect(nameCheck?.status).toBe("fail");
+    expect(nameCheck?.error?.message).toContain("non-empty");
+  });
+
+  test("fails when name is whitespace only", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, name: "   " };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("name is non-empty"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("fails when version is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, version: "" };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const versionCheck = results.find((r) => r.name.includes("version is non-empty"));
+    expect(versionCheck?.status).toBe("fail");
+  });
+
+  test("fails when model.name is empty", async () => {
+    const manifest: AgentManifest = { ...VALID_MANIFEST, model: { name: "" } };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const modelCheck = results.find((r) => r.name.includes("model config"));
+    expect(modelCheck?.status).toBe("fail");
+    expect(modelCheck?.error?.message).toContain("model.name");
+  });
+
+  test("passes with valid tool configs", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      tools: [{ name: "tool-a" }, { name: "tool-b" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("pass");
+  });
+
+  test("fails when tool config has empty name", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      tools: [{ name: "" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("fail");
+  });
+
+  test("passes when tools is undefined", async () => {
+    const results = await runManifestChecks(VALID_MANIFEST, TIMEOUT);
+    const toolCheck = results.find((r) => r.name.includes("tool configs"));
+    expect(toolCheck?.status).toBe("pass");
+  });
+
+  test("fails when middleware config has empty name", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      middleware: [{ name: "" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const mwCheck = results.find((r) => r.name.includes("middleware configs"));
+    expect(mwCheck?.status).toBe("fail");
+  });
+
+  test("passes with valid middleware configs", async () => {
+    const manifest: AgentManifest = {
+      ...VALID_MANIFEST,
+      middleware: [{ name: "audit" }, { name: "memory" }],
+    };
+    const results = await runManifestChecks(manifest, TIMEOUT);
+    const mwCheck = results.find((r) => r.name.includes("middleware configs"));
+    expect(mwCheck?.status).toBe("pass");
+  });
+});

--- a/packages/self-test/src/checks/manifest-checks.ts
+++ b/packages/self-test/src/checks/manifest-checks.ts
@@ -1,0 +1,98 @@
+/**
+ * Manifest structural validation checks.
+ *
+ * Verifies that the AgentManifest has valid name, version, model config,
+ * and that tool/middleware config entries have non-empty names.
+ */
+
+import type { AgentManifest } from "@koi/core";
+import { runCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+export async function runManifestChecks(
+  manifest: AgentManifest,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  // Local mutable array for sequential accumulation
+  const results: CheckResult[] = [];
+
+  results.push(
+    await runCheck(
+      "manifest: name is non-empty string",
+      "manifest",
+      () => {
+        if (typeof manifest.name !== "string" || manifest.name.trim().length === 0) {
+          throw new Error("manifest.name must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: version is non-empty string",
+      "manifest",
+      () => {
+        if (typeof manifest.version !== "string" || manifest.version.trim().length === 0) {
+          throw new Error("manifest.version must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: model config is present and valid",
+      "manifest",
+      () => {
+        if (manifest.model === undefined || manifest.model === null) {
+          throw new Error("manifest.model must be defined");
+        }
+        if (typeof manifest.model.name !== "string" || manifest.model.name.trim().length === 0) {
+          throw new Error("manifest.model.name must be a non-empty string");
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: tool configs have valid names",
+      "manifest",
+      () => {
+        if (manifest.tools === undefined) return;
+        for (const tool of manifest.tools) {
+          if (typeof tool.name !== "string" || tool.name.trim().length === 0) {
+            throw new Error(
+              `manifest.tools contains entry with invalid name: ${JSON.stringify(tool.name)}`,
+            );
+          }
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  results.push(
+    await runCheck(
+      "manifest: middleware configs have valid names",
+      "manifest",
+      () => {
+        if (manifest.middleware === undefined) return;
+        for (const mw of manifest.middleware) {
+          if (typeof mw.name !== "string" || mw.name.trim().length === 0) {
+            throw new Error(
+              `manifest.middleware contains entry with invalid name: ${JSON.stringify(mw.name)}`,
+            );
+          }
+        }
+      },
+      checkTimeoutMs,
+    ),
+  );
+
+  return results;
+}

--- a/packages/self-test/src/checks/middleware-checks.test.ts
+++ b/packages/self-test/src/checks/middleware-checks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiMiddleware } from "@koi/core";
+import { createMockSessionContext } from "@koi/test-utils";
+import { runMiddlewareChecks } from "./middleware-checks.js";
+
+const TIMEOUT = 5_000;
+
+function createSessionCtx() {
+  return createMockSessionContext();
+}
+
+describe("runMiddlewareChecks", () => {
+  test("returns skip when no middleware provided", async () => {
+    const results = await runMiddlewareChecks([], createSessionCtx, TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("passes for middleware with valid name and no hooks", async () => {
+    const mw: KoiMiddleware = { name: "noop" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    const hookCheck = results.find((r) => r.name.includes("hooks are functions"));
+    expect(nameCheck?.status).toBe("pass");
+    expect(hookCheck?.status).toBe("pass");
+  });
+
+  test("fails for middleware with empty name", async () => {
+    const mw: KoiMiddleware = { name: "" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("passes when onSessionStart executes without error", async () => {
+    const mw: KoiMiddleware = {
+      name: "good-lifecycle",
+      async onSessionStart() {},
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const startCheck = results.find((r) => r.name.includes("onSessionStart"));
+    expect(startCheck?.status).toBe("pass");
+  });
+
+  test("fails when onSessionStart throws", async () => {
+    const mw: KoiMiddleware = {
+      name: "bad-lifecycle",
+      async onSessionStart() {
+        throw new Error("session start failed");
+      },
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const startCheck = results.find((r) => r.name.includes("onSessionStart"));
+    expect(startCheck?.status).toBe("fail");
+    expect(startCheck?.error?.message).toContain("session start failed");
+  });
+
+  test("passes when onSessionEnd executes without error", async () => {
+    const mw: KoiMiddleware = {
+      name: "good-end",
+      async onSessionEnd() {},
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const endCheck = results.find((r) => r.name.includes("onSessionEnd"));
+    expect(endCheck?.status).toBe("pass");
+  });
+
+  test("fails when onSessionEnd throws", async () => {
+    const mw: KoiMiddleware = {
+      name: "bad-end",
+      async onSessionEnd() {
+        throw new Error("session end failed");
+      },
+    };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    const endCheck = results.find((r) => r.name.includes("onSessionEnd"));
+    expect(endCheck?.status).toBe("fail");
+  });
+
+  test("handles multiple middleware sequentially", async () => {
+    const mw1: KoiMiddleware = { name: "mw-a", async onSessionStart() {} };
+    const mw2: KoiMiddleware = { name: "mw-b" };
+    const results = await runMiddlewareChecks([mw1, mw2], createSessionCtx, TIMEOUT);
+    // mw-a: name + hooks + onSessionStart = 3 checks
+    // mw-b: name + hooks = 2 checks
+    expect(results).toHaveLength(5);
+  });
+
+  test("does not test onSessionStart/End when not provided", async () => {
+    const mw: KoiMiddleware = { name: "minimal" };
+    const results = await runMiddlewareChecks([mw], createSessionCtx, TIMEOUT);
+    // Only structural checks: name + hooks
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+});

--- a/packages/self-test/src/checks/middleware-checks.ts
+++ b/packages/self-test/src/checks/middleware-checks.ts
@@ -1,0 +1,102 @@
+/**
+ * Middleware structural and lifecycle checks.
+ *
+ * Verifies that each middleware has a valid name, hooks are functions,
+ * and lifecycle hooks (onSessionStart, onSessionEnd) execute without error.
+ */
+
+import type { KoiMiddleware, SessionContext } from "@koi/core";
+import { runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult } from "../types.js";
+
+const HOOK_NAMES = [
+  "onSessionStart",
+  "onSessionEnd",
+  "onBeforeTurn",
+  "onAfterTurn",
+  "wrapModelCall",
+  "wrapModelStream",
+  "wrapToolCall",
+] as const;
+
+export async function runMiddlewareChecks(
+  middleware: readonly KoiMiddleware[],
+  createSessionCtx: () => SessionContext,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (middleware.length === 0) {
+    results.push(
+      skipCheck("middleware: no middleware to check", "middleware", "No middleware provided"),
+    );
+    return results;
+  }
+
+  for (const mw of middleware) {
+    // Structural: name is valid
+    results.push(
+      await runCheck(
+        `middleware[${mw.name}]: has valid name`,
+        "middleware",
+        () => {
+          if (typeof mw.name !== "string" || mw.name.trim().length === 0) {
+            throw new Error("Middleware name must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Structural: all hooks are functions (or undefined)
+    results.push(
+      await runCheck(
+        `middleware[${mw.name}]: hooks are functions`,
+        "middleware",
+        () => {
+          for (const hookName of HOOK_NAMES) {
+            const hook = mw[hookName];
+            if (hook !== undefined && typeof hook !== "function") {
+              throw new Error(`middleware.${hookName} must be a function, got ${typeof hook}`);
+            }
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Lifecycle: onSessionStart executes without error
+    const sessionStart = mw.onSessionStart;
+    if (sessionStart !== undefined) {
+      results.push(
+        await runCheck(
+          `middleware[${mw.name}]: onSessionStart executes`,
+          "middleware",
+          async () => {
+            const ctx = createSessionCtx();
+            await sessionStart(ctx);
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+
+    // Lifecycle: onSessionEnd executes without error
+    const sessionEnd = mw.onSessionEnd;
+    if (sessionEnd !== undefined) {
+      results.push(
+        await runCheck(
+          `middleware[${mw.name}]: onSessionEnd executes`,
+          "middleware",
+          async () => {
+            const ctx = createSessionCtx();
+            await sessionEnd(ctx);
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/scenario-checks.test.ts
+++ b/packages/self-test/src/checks/scenario-checks.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineInput, EngineOutput } from "@koi/core";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import type { SelfTestScenario } from "../types.js";
+import { runScenarioChecks } from "./scenario-checks.js";
+
+const TIMEOUT = 5_000;
+
+const DEFAULT_OUTPUT: EngineOutput = {
+  content: [{ kind: "text", text: "pong" }],
+  stopReason: "completed",
+  metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+};
+
+const DEFAULT_EVENTS: readonly EngineEvent[] = [
+  { kind: "text_delta", delta: "pong" },
+  { kind: "done", output: DEFAULT_OUTPUT },
+];
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+describe("runScenarioChecks", () => {
+  test("returns skip when no scenarios provided", async () => {
+    const adapter = createMockEngineAdapter();
+    const results = await runScenarioChecks(adapter, [], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("passes for a scenario that completes with done event", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = { name: "ping-pong", input: PING_INPUT };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when expected pattern matches", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "pattern-match",
+      input: PING_INPUT,
+      expectedPattern: "pong",
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when expected pattern does not match", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "pattern-miss",
+      input: PING_INPUT,
+      expectedPattern: "notfound",
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toContain("did not match");
+  });
+
+  test("passes when regex pattern matches", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "regex-match",
+      input: PING_INPUT,
+      expectedPattern: /p.ng/,
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when custom assertion succeeds", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "custom-assert",
+      input: PING_INPUT,
+      assert(events) {
+        if (events.length < 2) throw new Error("too few events");
+      },
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when custom assertion throws", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenario: SelfTestScenario = {
+      name: "custom-assert-fail",
+      input: PING_INPUT,
+      assert() {
+        throw new Error("assertion failed");
+      },
+    };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toBe("assertion failed");
+  });
+
+  test("fails when stream yields no done event", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "text_delta", delta: "no done" }];
+    const adapter = createMockEngineAdapter({ events: [...events] });
+    const scenario: SelfTestScenario = { name: "no-done", input: PING_INPUT };
+    const results = await runScenarioChecks(adapter, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("fail");
+    expect(results[0]?.error?.message).toContain("done event");
+  });
+
+  test("disposes factory-created adapters", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const factory = () => adapter;
+    const scenario: SelfTestScenario = { name: "dispose-test", input: PING_INPUT };
+    const results = await runScenarioChecks(factory, [scenario], TIMEOUT);
+    expect(results[0]?.status).toBe("pass");
+    expect(adapter.disposeCalls.length).toBe(1);
+  });
+
+  test("handles multiple scenarios", async () => {
+    const adapter = createMockEngineAdapter({ events: [...DEFAULT_EVENTS] });
+    const scenarios: readonly SelfTestScenario[] = [
+      { name: "scenario-a", input: PING_INPUT },
+      { name: "scenario-b", input: PING_INPUT },
+    ];
+    const results = await runScenarioChecks(adapter, scenarios, TIMEOUT);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+});

--- a/packages/self-test/src/checks/scenario-checks.ts
+++ b/packages/self-test/src/checks/scenario-checks.ts
@@ -1,0 +1,84 @@
+/**
+ * E2E scenario checks.
+ *
+ * Streams scenario input through the adapter, verifies the stream completes
+ * with a done event, matches expected patterns, and runs custom assertions.
+ */
+
+import type { EngineAdapter, EngineInput } from "@koi/core";
+import {
+  collectEvents,
+  extractText,
+  isAdapterFactory,
+  runCheck,
+  skipCheck,
+} from "../check-runner.js";
+import type { CheckResult, SelfTestScenario } from "../types.js";
+
+export async function runScenarioChecks(
+  adapterOrFactory: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>),
+  scenarios: readonly SelfTestScenario[],
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (scenarios.length === 0) {
+    results.push(
+      skipCheck("scenarios: no scenarios to check", "scenarios", "No scenarios provided"),
+    );
+    return results;
+  }
+
+  const isFactory = isAdapterFactory(adapterOrFactory);
+
+  for (const scenario of scenarios) {
+    results.push(
+      await runCheck(
+        `scenario[${scenario.name}]: completes`,
+        "scenarios",
+        async (signal) => {
+          // Resolve adapter: factory = fresh per scenario, instance = shared
+          const adapter = isFactory ? await adapterOrFactory() : adapterOrFactory;
+
+          try {
+            const input: EngineInput = { ...scenario.input, signal };
+            const events = await collectEvents(adapter.stream(input));
+
+            // Verify done event exists
+            const doneEvent = events.find((e) => e.kind === "done");
+            if (doneEvent === undefined) {
+              throw new Error("Stream did not yield a done event");
+            }
+
+            // Check expected pattern against text_delta output
+            if (scenario.expectedPattern !== undefined) {
+              const text = extractText(events);
+              const pattern =
+                scenario.expectedPattern instanceof RegExp
+                  ? scenario.expectedPattern
+                  : new RegExp(scenario.expectedPattern);
+              if (!pattern.test(text)) {
+                throw new Error(
+                  `Output text did not match pattern ${String(scenario.expectedPattern)}. Got: "${text}"`,
+                );
+              }
+            }
+
+            // Run custom assertion
+            if (scenario.assert !== undefined) {
+              await scenario.assert(events);
+            }
+          } finally {
+            // Dispose factory-created adapters
+            if (isFactory && adapter.dispose !== undefined) {
+              await adapter.dispose();
+            }
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+  }
+
+  return results;
+}

--- a/packages/self-test/src/checks/tool-checks.test.ts
+++ b/packages/self-test/src/checks/tool-checks.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { JsonObject, ToolDescriptor, ToolResponse } from "@koi/core";
+import type { SelfTestTool } from "../types.js";
+import { runToolChecks } from "./tool-checks.js";
+
+const TIMEOUT = 5_000;
+
+const VALID_DESCRIPTOR: ToolDescriptor = {
+  name: "search",
+  description: "Search the web",
+  inputSchema: { type: "object", properties: { query: { type: "string" } } },
+};
+
+describe("runToolChecks", () => {
+  test("returns skip when no tools provided", async () => {
+    const results = await runToolChecks([], TIMEOUT);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skip");
+  });
+
+  test("all checks pass for a valid tool descriptor", async () => {
+    const tool: SelfTestTool = { descriptor: VALID_DESCRIPTOR };
+    const results = await runToolChecks([tool], TIMEOUT);
+    // name + description + inputSchema = 3 checks
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      expect(r.status).toBe("pass");
+      expect(r.category).toBe("tools");
+    }
+  });
+
+  test("fails when descriptor name is empty", async () => {
+    const tool: SelfTestTool = {
+      descriptor: { ...VALID_DESCRIPTOR, name: "" },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const nameCheck = results.find((r) => r.name.includes("has valid name"));
+    expect(nameCheck?.status).toBe("fail");
+  });
+
+  test("fails when descriptor description is empty", async () => {
+    const tool: SelfTestTool = {
+      descriptor: { ...VALID_DESCRIPTOR, description: "" },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const descCheck = results.find((r) => r.name.includes("has description"));
+    expect(descCheck?.status).toBe("fail");
+  });
+
+  test("passes when handler returns valid ToolResponse", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(_args: JsonObject): Promise<ToolResponse> {
+        return { output: { result: "ok" } };
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("pass");
+  });
+
+  test("fails when handler returns null", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(): Promise<ToolResponse> {
+        return null as unknown as ToolResponse;
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("fail");
+    expect(handlerCheck?.error?.message).toContain("undefined/null");
+  });
+
+  test("fails when handler throws", async () => {
+    const tool: SelfTestTool = {
+      descriptor: VALID_DESCRIPTOR,
+      async handler(): Promise<ToolResponse> {
+        throw new Error("handler boom");
+      },
+    };
+    const results = await runToolChecks([tool], TIMEOUT);
+    const handlerCheck = results.find((r) => r.name.includes("handler returns"));
+    expect(handlerCheck?.status).toBe("fail");
+    expect(handlerCheck?.error?.message).toBe("handler boom");
+  });
+
+  test("does not run handler check when handler is not provided", async () => {
+    const tool: SelfTestTool = { descriptor: VALID_DESCRIPTOR };
+    const results = await runToolChecks([tool], TIMEOUT);
+    // Only 3 descriptor checks, no handler check
+    expect(results).toHaveLength(3);
+  });
+
+  test("handles multiple tools", async () => {
+    const tools: readonly SelfTestTool[] = [
+      { descriptor: VALID_DESCRIPTOR },
+      { descriptor: { ...VALID_DESCRIPTOR, name: "calculator" } },
+    ];
+    const results = await runToolChecks(tools, TIMEOUT);
+    // 3 checks per tool = 6 total
+    expect(results).toHaveLength(6);
+  });
+});

--- a/packages/self-test/src/checks/tool-checks.ts
+++ b/packages/self-test/src/checks/tool-checks.ts
@@ -1,0 +1,101 @@
+/**
+ * Tool descriptor validation and optional handler invocation checks.
+ *
+ * Verifies that each tool has a valid descriptor (name, description, inputSchema)
+ * and that mock handlers (when provided) return a valid ToolResponse.
+ */
+
+import type { JsonObject } from "@koi/core";
+import { runCheck, skipCheck } from "../check-runner.js";
+import type { CheckResult, SelfTestTool } from "../types.js";
+
+const EMPTY_INPUT: JsonObject = {};
+
+export async function runToolChecks(
+  tools: readonly SelfTestTool[],
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  const results: CheckResult[] = [];
+
+  if (tools.length === 0) {
+    results.push(skipCheck("tools: no tools to check", "tools", "No tools provided"));
+    return results;
+  }
+
+  for (const tool of tools) {
+    const { descriptor } = tool;
+
+    // Descriptor: name is valid
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has valid name`,
+        "tools",
+        () => {
+          if (typeof descriptor.name !== "string" || descriptor.name.trim().length === 0) {
+            throw new Error("Tool descriptor name must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Descriptor: description is present
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has description`,
+        "tools",
+        () => {
+          if (
+            typeof descriptor.description !== "string" ||
+            descriptor.description.trim().length === 0
+          ) {
+            throw new Error("Tool descriptor description must be a non-empty string");
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Descriptor: inputSchema is an object
+    results.push(
+      await runCheck(
+        `tool[${descriptor.name}]: has inputSchema`,
+        "tools",
+        () => {
+          if (descriptor.inputSchema === undefined || descriptor.inputSchema === null) {
+            throw new Error("Tool descriptor must have an inputSchema");
+          }
+          if (typeof descriptor.inputSchema !== "object") {
+            throw new Error(
+              `Tool descriptor inputSchema must be an object, got ${typeof descriptor.inputSchema}`,
+            );
+          }
+        },
+        checkTimeoutMs,
+      ),
+    );
+
+    // Handler: returns valid ToolResponse (if provided)
+    const { handler } = tool;
+    if (handler !== undefined) {
+      results.push(
+        await runCheck(
+          `tool[${descriptor.name}]: handler returns valid response`,
+          "tools",
+          async () => {
+            const response = await handler(EMPTY_INPUT);
+            if (response === undefined || response === null) {
+              throw new Error("Tool handler returned undefined/null instead of ToolResponse");
+            }
+            if (!("output" in response)) {
+              throw new Error("Tool handler response is missing 'output' field");
+            }
+          },
+          checkTimeoutMs,
+        ),
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/self-test/src/index.ts
+++ b/packages/self-test/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @koi/self-test — Agent E2E self-verification framework.
+ *
+ * Provides a composable, pre-deployment smoke test runner for Koi agents.
+ * Validates manifests, middleware, tools, engine adapters, and E2E scenarios,
+ * returning a machine-readable SelfTestReport.
+ */
+
+export { createSelfTest } from "./self-test.js";
+export type {
+  CheckCategory,
+  CheckResult,
+  CheckStatus,
+  SelfTest,
+  SelfTestConfig,
+  SelfTestCustomCheck,
+  SelfTestReport,
+  SelfTestScenario,
+  SelfTestTool,
+} from "./types.js";

--- a/packages/self-test/src/self-test.test.ts
+++ b/packages/self-test/src/self-test.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  EngineEvent,
+  EngineInput,
+  EngineOutput,
+  KoiMiddleware,
+} from "@koi/core";
+import { KoiRuntimeError } from "@koi/errors";
+import { createMockEngineAdapter } from "@koi/test-utils";
+import { createSelfTest } from "./self-test.js";
+import type { SelfTestScenario, SelfTestTool } from "./types.js";
+
+const VALID_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "1.0.0",
+  model: { name: "test-model" },
+};
+
+const DEFAULT_OUTPUT: EngineOutput = {
+  content: [{ kind: "text", text: "pong" }],
+  stopReason: "completed",
+  metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+};
+
+const PING_INPUT: EngineInput = { kind: "text", text: "ping" };
+
+describe("createSelfTest", () => {
+  test("throws VALIDATION error when manifest is null", () => {
+    expect(() => createSelfTest({ manifest: null as unknown as AgentManifest })).toThrow(
+      KoiRuntimeError,
+    );
+  });
+
+  test("returns a SelfTest with a run method", () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+    expect(typeof st.run).toBe("function");
+  });
+});
+
+describe("SelfTest.run", () => {
+  test("full healthy run with all categories", async () => {
+    const events: readonly EngineEvent[] = [
+      { kind: "text_delta", delta: "pong" },
+      { kind: "done", output: DEFAULT_OUTPUT },
+    ];
+
+    const adapter = createMockEngineAdapter({ events: [...events] });
+    const mw: KoiMiddleware = { name: "test-mw", async onSessionStart() {} };
+    const tool: SelfTestTool = {
+      descriptor: {
+        name: "search",
+        description: "Search the web",
+        inputSchema: { type: "object" },
+      },
+      async handler() {
+        return { output: "ok" };
+      },
+    };
+    const scenario: SelfTestScenario = {
+      name: "ping-pong",
+      input: PING_INPUT,
+    };
+
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      adapter,
+      middleware: [mw],
+      tools: [tool],
+      scenarios: [scenario],
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(true);
+    expect(report.failed).toBe(0);
+    expect(report.passed).toBeGreaterThan(0);
+    expect(report.passed + report.failed + report.skipped).toBe(report.checks.length);
+    expect(typeof report.totalDurationMs).toBe("number");
+  });
+
+  test("full failing run when manifest is invalid", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+    expect(report.failed).toBeGreaterThan(0);
+    const failedCheck = report.checks.find((c) => c.status === "fail" && c.category === "manifest");
+    expect(failedCheck).toBeDefined();
+  });
+
+  test("failFast stops after first category failure", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+      middleware: [{ name: "should-be-skipped", async onSessionStart() {} }],
+      failFast: true,
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+
+    // Middleware category should be skipped
+    const mwChecks = report.checks.filter((c) => c.category === "middleware");
+    expect(mwChecks.length).toBe(1);
+    expect(mwChecks[0]?.status).toBe("skip");
+    expect(mwChecks[0]?.message).toContain("failFast");
+  });
+
+  test("category filtering only runs specified categories", async () => {
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      categories: ["manifest"],
+    });
+
+    const report = await st.run();
+    const categories = new Set(report.checks.map((c) => c.category));
+    expect(categories.has("manifest")).toBe(true);
+    expect(categories.has("middleware")).toBe(false);
+    expect(categories.has("tools")).toBe(false);
+    expect(categories.has("engine")).toBe(false);
+    expect(categories.has("scenarios")).toBe(false);
+  });
+
+  test("custom checks are executed", async () => {
+    let called = false;
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      customChecks: [
+        {
+          name: "custom: db connectivity",
+          fn() {
+            called = true;
+          },
+        },
+      ],
+    });
+
+    const report = await st.run();
+    expect(called).toBe(true);
+    const customCheck = report.checks.find((c) => c.category === "custom");
+    expect(customCheck?.status).toBe("pass");
+    expect(customCheck?.name).toBe("custom: db connectivity");
+  });
+
+  test("custom checks that throw produce fail results", async () => {
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      customChecks: [
+        {
+          name: "custom: failing check",
+          fn() {
+            throw new Error("db unreachable");
+          },
+        },
+      ],
+    });
+
+    const report = await st.run();
+    expect(report.healthy).toBe(false);
+    const customCheck = report.checks.find((c) => c.category === "custom");
+    expect(customCheck?.status).toBe("fail");
+    expect(customCheck?.error?.message).toBe("db unreachable");
+  });
+
+  test("report aggregates are correct", async () => {
+    const st = createSelfTest({
+      manifest: { ...VALID_MANIFEST, name: "" },
+      categories: ["manifest"],
+    });
+
+    const report = await st.run();
+    const passed = report.checks.filter((c) => c.status === "pass").length;
+    const failed = report.checks.filter((c) => c.status === "fail").length;
+    const skipped = report.checks.filter((c) => c.status === "skip").length;
+
+    expect(report.passed).toBe(passed);
+    expect(report.failed).toBe(failed);
+    expect(report.skipped).toBe(skipped);
+    expect(report.passed + report.failed + report.skipped).toBe(report.checks.length);
+  });
+
+  test("skips engine and scenarios when no adapter provided", async () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+
+    const report = await st.run();
+    const engineChecks = report.checks.filter((c) => c.category === "engine");
+    const scenarioChecks = report.checks.filter((c) => c.category === "scenarios");
+
+    // Engine and scenarios should have skip results
+    for (const check of [...engineChecks, ...scenarioChecks]) {
+      expect(check.status).toBe("skip");
+    }
+  });
+
+  test("empty middleware and tools produce skip results", async () => {
+    const st = createSelfTest({ manifest: VALID_MANIFEST });
+
+    const report = await st.run();
+    const mwChecks = report.checks.filter((c) => c.category === "middleware");
+    const toolChecks = report.checks.filter((c) => c.category === "tools");
+
+    expect(mwChecks.length).toBe(1);
+    expect(mwChecks[0]?.status).toBe("skip");
+    expect(toolChecks.length).toBe(1);
+    expect(toolChecks[0]?.status).toBe("skip");
+  });
+
+  test("global timeout skips remaining categories", async () => {
+    // Use categories filter so manifest runs first (fast), then engine (skipped by timeout)
+    // We set global timeout to 0 so it's already expired when the second category starts
+    const st = createSelfTest({
+      manifest: VALID_MANIFEST,
+      categories: ["manifest", "engine"],
+      adapter: createMockEngineAdapter(),
+      timeoutMs: 0, // Already expired — second category should be skipped
+    });
+
+    const report = await st.run();
+    const skippedByTimeout = report.checks.filter(
+      (c) => c.status === "skip" && c.message?.includes("Global timeout"),
+    );
+    expect(skippedByTimeout.length).toBeGreaterThan(0);
+    // Manifest checks should have run (before timeout check)
+    const manifestChecks = report.checks.filter((c) => c.category === "manifest");
+    expect(manifestChecks.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/self-test/src/self-test.ts
+++ b/packages/self-test/src/self-test.ts
@@ -1,0 +1,167 @@
+/**
+ * createSelfTest — factory for the self-test runner.
+ *
+ * Orchestrates check categories sequentially, aggregates results,
+ * and returns a machine-readable SelfTestReport.
+ */
+
+import { KoiRuntimeError } from "@koi/errors";
+import { createMockSessionContext } from "@koi/test-utils";
+import { runCheck, skipCheck } from "./check-runner.js";
+import { runEngineChecks } from "./checks/engine-checks.js";
+import { runManifestChecks } from "./checks/manifest-checks.js";
+import { runMiddlewareChecks } from "./checks/middleware-checks.js";
+import { runScenarioChecks } from "./checks/scenario-checks.js";
+import { runToolChecks } from "./checks/tool-checks.js";
+import type {
+  CheckCategory,
+  CheckResult,
+  SelfTest,
+  SelfTestConfig,
+  SelfTestReport,
+} from "./types.js";
+
+const DEFAULT_CHECK_TIMEOUT_MS = 5_000;
+const DEFAULT_GLOBAL_TIMEOUT_MS = 30_000;
+
+const CATEGORY_ORDER: readonly CheckCategory[] = [
+  "manifest",
+  "middleware",
+  "tools",
+  "engine",
+  "scenarios",
+  "custom",
+];
+
+/**
+ * Create a self-test runner from the given config.
+ *
+ * @throws KoiRuntimeError with code VALIDATION if config is structurally invalid.
+ */
+export function createSelfTest(config: SelfTestConfig): SelfTest {
+  if (config.manifest === undefined || config.manifest === null) {
+    throw KoiRuntimeError.from("VALIDATION", "SelfTestConfig.manifest is required");
+  }
+
+  const checkTimeoutMs = config.checkTimeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS;
+  const globalTimeoutMs = config.timeoutMs ?? DEFAULT_GLOBAL_TIMEOUT_MS;
+  const failFast = config.failFast ?? false;
+  const categorySet = new Set(config.categories ?? CATEGORY_ORDER);
+
+  return {
+    async run(): Promise<SelfTestReport> {
+      const globalStart = Date.now();
+      // Local mutable array for sequential accumulation
+      const allChecks: CheckResult[] = [];
+
+      for (const category of CATEGORY_ORDER) {
+        if (!categorySet.has(category)) continue;
+
+        // Global timeout: skip remaining categories
+        if (Date.now() - globalStart >= globalTimeoutMs) {
+          allChecks.push(
+            skipCheck(
+              `${category}: skipped (global timeout)`,
+              category,
+              `Global timeout of ${String(globalTimeoutMs)}ms exceeded`,
+            ),
+          );
+          continue;
+        }
+
+        // Fail-fast: skip if any previous check failed
+        if (failFast && allChecks.some((c) => c.status === "fail")) {
+          allChecks.push(
+            skipCheck(
+              `${category}: skipped (failFast)`,
+              category,
+              "Previous category had failures and failFast is enabled",
+            ),
+          );
+          continue;
+        }
+
+        const categoryResults = await runCategory(category, config, checkTimeoutMs);
+        for (const result of categoryResults) {
+          allChecks.push(result);
+        }
+      }
+
+      const passed = allChecks.filter((c) => c.status === "pass").length;
+      const failed = allChecks.filter((c) => c.status === "fail").length;
+      const skipped = allChecks.filter((c) => c.status === "skip").length;
+
+      return {
+        passed,
+        failed,
+        skipped,
+        totalDurationMs: Date.now() - globalStart,
+        checks: allChecks,
+        healthy: failed === 0,
+      };
+    },
+  };
+}
+
+async function runCategory(
+  category: CheckCategory,
+  config: SelfTestConfig,
+  checkTimeoutMs: number,
+): Promise<readonly CheckResult[]> {
+  switch (category) {
+    case "manifest":
+      return runManifestChecks(config.manifest, checkTimeoutMs);
+
+    case "middleware":
+      return runMiddlewareChecks(
+        config.middleware ?? [],
+        () => createMockSessionContext(),
+        checkTimeoutMs,
+      );
+
+    case "tools":
+      return runToolChecks(config.tools ?? [], checkTimeoutMs);
+
+    case "engine": {
+      if (config.adapter === undefined) {
+        return [skipCheck("engine: skipped", "engine", "No adapter provided")];
+      }
+      return runEngineChecks(config.adapter, checkTimeoutMs);
+    }
+
+    case "scenarios": {
+      if (config.scenarios === undefined || config.scenarios.length === 0) {
+        return [skipCheck("scenarios: skipped", "scenarios", "No scenarios provided")];
+      }
+      if (config.adapter === undefined) {
+        return [skipCheck("scenarios: skipped", "scenarios", "No adapter provided for scenarios")];
+      }
+      return runScenarioChecks(config.adapter, config.scenarios, checkTimeoutMs);
+    }
+
+    case "custom": {
+      if (config.customChecks === undefined || config.customChecks.length === 0) {
+        return [];
+      }
+      const results: CheckResult[] = [];
+      for (const check of config.customChecks) {
+        results.push(
+          await runCheck(
+            check.name,
+            "custom",
+            async () => {
+              await check.fn();
+            },
+            checkTimeoutMs,
+          ),
+        );
+      }
+      return results;
+    }
+
+    default: {
+      const _exhaustive: never = category;
+      throw new Error(`Unknown category: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/self-test/src/types.ts
+++ b/packages/self-test/src/types.ts
@@ -1,0 +1,116 @@
+/**
+ * @koi/self-test — Public types for agent self-verification.
+ */
+
+import type {
+  AgentManifest,
+  EngineAdapter,
+  EngineEvent,
+  EngineInput,
+  JsonObject,
+  KoiError,
+  KoiMiddleware,
+  ToolDescriptor,
+  ToolResponse,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Check primitives
+// ---------------------------------------------------------------------------
+
+/** Status of a single check. */
+export type CheckStatus = "pass" | "fail" | "skip";
+
+/** Built-in check categories plus user-defined custom. */
+export type CheckCategory = "manifest" | "middleware" | "tools" | "engine" | "scenarios" | "custom";
+
+/** Result of a single check. */
+export interface CheckResult {
+  readonly name: string;
+  readonly category: CheckCategory;
+  readonly status: CheckStatus;
+  readonly durationMs: number;
+  readonly error?: KoiError;
+  /** Human-readable detail (e.g., "manifest.name is empty string"). */
+  readonly message?: string;
+  /** Machine-readable context for CI tools (e.g., { field: "name" }). */
+  readonly metadata?: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+/** Aggregated self-test report. */
+export interface SelfTestReport {
+  readonly passed: number;
+  readonly failed: number;
+  readonly skipped: number;
+  readonly totalDurationMs: number;
+  readonly checks: readonly CheckResult[];
+  /** True when failed === 0. */
+  readonly healthy: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Config building blocks
+// ---------------------------------------------------------------------------
+
+/** A tool descriptor + optional mock handler for self-test verification. */
+export interface SelfTestTool {
+  readonly descriptor: ToolDescriptor;
+  /** If provided, handler is invoked with empty input to verify it returns valid ToolResponse. */
+  readonly handler?: (args: JsonObject) => Promise<ToolResponse>;
+}
+
+/** An E2E smoke-test scenario. */
+export interface SelfTestScenario {
+  readonly name: string;
+  readonly input: EngineInput;
+  /** Expected text pattern (regex or string) in streamed text_delta output. */
+  readonly expectedPattern?: string | RegExp;
+  /** Custom assertion function run against the collected events. */
+  readonly assert?: (events: readonly EngineEvent[]) => void | Promise<void>;
+}
+
+/** A user-defined custom check. */
+export interface SelfTestCustomCheck {
+  readonly name: string;
+  readonly fn: () => void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Configuration for createSelfTest. */
+export interface SelfTestConfig {
+  readonly manifest: AgentManifest;
+  /**
+   * Engine adapter instance or factory function.
+   * - Function: self-test owns lifecycle (creates, uses, disposes).
+   * - Object: caller owns lifecycle (dispose check is skipped).
+   */
+  readonly adapter?: EngineAdapter | (() => EngineAdapter | Promise<EngineAdapter>);
+  readonly middleware?: readonly KoiMiddleware[];
+  readonly tools?: readonly SelfTestTool[];
+  readonly scenarios?: readonly SelfTestScenario[];
+  readonly customChecks?: readonly SelfTestCustomCheck[];
+  /** Whitelist of categories to run. undefined = all categories. */
+  readonly categories?: readonly CheckCategory[];
+  /** Per-check timeout in ms. Default: 5000. */
+  readonly checkTimeoutMs?: number;
+  /** Global run timeout in ms. Default: 30000. */
+  readonly timeoutMs?: number;
+  /** Stop on first category failure. Default: false. */
+  readonly failFast?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/** The self-test runner returned by createSelfTest. */
+export interface SelfTest {
+  readonly run: () => Promise<SelfTestReport>;
+}

--- a/packages/self-test/tsconfig.json
+++ b/packages/self-test/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../errors" },
+    { "path": "../test-utils" },
+    { "path": "../engine" },
+    { "path": "../engine-pi" }
+  ]
+}

--- a/packages/self-test/tsup.config.ts
+++ b/packages/self-test/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/e2e-component-resolution.ts
+++ b/scripts/e2e-component-resolution.ts
@@ -1,0 +1,529 @@
+#!/usr/bin/env bun
+/**
+ * E2E: Issue #246 — ComponentProvider Resolution Semantics.
+ *
+ * Validates the full createKoi → createLoopAdapter path with:
+ * 1. Priority-sorted assembly (lower number wins, first-write-wins)
+ * 2. AssemblyConflict[] reporting when providers supply the same key
+ * 3. Forge-first tool resolution (forged tool shadows entity tool at call-time)
+ * 4. Descriptor deduplication (forged descriptors shadow entity by name)
+ * 5. Real LLM call through middleware chain to prove wiring works end-to-end
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-component-resolution.ts
+ *
+ * Can also run without a key (scripted model mode):
+ *   bun scripts/e2e-component-resolution.ts
+ */
+
+import type {
+  ComponentProvider,
+  EngineAdapter,
+  EngineEvent,
+  EngineInput,
+  JsonObject,
+  ModelRequest,
+  ModelResponse,
+  Tool,
+  ToolDescriptor,
+} from "../packages/core/src/index.js";
+import { COMPONENT_PRIORITY, toolToken } from "../packages/core/src/index.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import type { ForgeRuntime } from "../packages/engine/src/types.js";
+import { createLoopAdapter } from "../packages/engine-loop/src/loop-adapter.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}${detail && !condition ? ` (${detail})` : ""}`);
+}
+
+function printReport(): void {
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed).length;
+  const total = results.length;
+
+  console.log(`\n${"\u2500".repeat(60)}`);
+  console.log(`Results: ${passed}/${total} passed, ${failed} failed`);
+  console.log("\u2500".repeat(60));
+
+  if (failed > 0) {
+    console.log("\nFailed tests:");
+    for (const r of results.filter((r) => !r.passed)) {
+      console.log(`  - ${r.name}${r.detail ? ` (${r.detail})` : ""}`);
+    }
+  }
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = [];
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Scripted model (deterministic — no API key needed)
+// ---------------------------------------------------------------------------
+
+function createScriptedModel(
+  script: readonly ((request: ModelRequest) => ModelResponse)[],
+): (request: ModelRequest) => Promise<ModelResponse> {
+  // let justified: mutable turn counter
+  let turn = 0;
+  return async (request: ModelRequest): Promise<ModelResponse> => {
+    const handler = script[turn];
+    if (handler === undefined) {
+      return { content: "Script exhausted", model: "scripted" };
+    }
+    turn++;
+    return handler(request);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool factories
+// ---------------------------------------------------------------------------
+
+function createTrackingTool(
+  name: string,
+  tag: string,
+): {
+  readonly tool: Tool;
+  readonly calls: Array<{ readonly input: unknown; readonly tag: string }>;
+} {
+  const calls: Array<{ readonly input: unknown; readonly tag: string }> = [];
+  const tool: Tool = {
+    descriptor: {
+      name,
+      description: `${tag} version of ${name}`,
+      inputSchema: { type: "object" },
+    },
+    trustTier: "sandbox",
+    execute: async (input: JsonObject): Promise<unknown> => {
+      calls.push({ input, tag });
+      return { result: `${tag}:${name}`, tag };
+    },
+  };
+  return { tool, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Priority-sorted assembly + conflict reporting
+// ---------------------------------------------------------------------------
+
+async function testAssemblyConflicts(): Promise<void> {
+  console.log("\n--- Test 1: Priority-sorted assembly + conflict reporting ---\n");
+
+  const { tool: bundledCalc } = createTrackingTool("calc", "bundled");
+  const { tool: forgedCalc } = createTrackingTool("calc", "forged");
+
+  // Bundled provider: priority 100 (default)
+  const bundledProvider: ComponentProvider = {
+    name: "bundled-tools",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    attach: async () => new Map<string, unknown>([[toolToken("calc") as string, bundledCalc]]),
+  };
+
+  // Agent-forged provider: priority 0 (highest precedence)
+  const forgedProvider: ComponentProvider = {
+    name: "agent-forged-tools",
+    priority: COMPONENT_PRIORITY.AGENT_FORGED,
+    attach: async () => new Map<string, unknown>([[toolToken("calc") as string, forgedCalc]]),
+  };
+
+  // Provide bundled FIRST in array — but agent-forged should win by priority
+  const modelCall = createScriptedModel([
+    () => ({ content: "No tools needed.", model: "scripted" }),
+  ]);
+  const adapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+  const runtime = await createKoi({
+    manifest: { name: "conflict-test", version: "0.1.0", model: { name: "scripted" } },
+    adapter,
+    providers: [bundledProvider, forgedProvider],
+    loopDetection: false,
+  });
+
+  // Check conflicts
+  assert(
+    "conflicts array has 1 entry (calc key collision)",
+    runtime.conflicts.length === 1,
+    `got ${runtime.conflicts.length}`,
+  );
+
+  if (runtime.conflicts.length > 0) {
+    const conflict = runtime.conflicts[0];
+    if (conflict === undefined) throw new Error("unreachable");
+    assert("conflict key is tool:calc", conflict.key === "tool:calc", `got ${conflict.key}`);
+    assert(
+      "conflict winner is agent-forged-tools (priority 0)",
+      conflict.winner === "agent-forged-tools",
+      `got ${conflict.winner}`,
+    );
+    assert(
+      "conflict shadowed includes bundled-tools",
+      conflict.shadowed.includes("bundled-tools"),
+      `got ${JSON.stringify(conflict.shadowed)}`,
+    );
+  }
+
+  // Verify the winning component is indeed the forged one
+  const resolvedCalc = runtime.agent.component(toolToken("calc"));
+  assert(
+    "agent.component() returns forged calc (priority 0 wins)",
+    resolvedCalc === forgedCalc,
+    resolvedCalc === bundledCalc ? "got bundled instead" : "got unknown",
+  );
+
+  await runtime.dispose();
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Forge-first tool resolution at call-time
+// ---------------------------------------------------------------------------
+
+async function testForgeFirstResolution(): Promise<void> {
+  console.log("\n--- Test 2: Forge-first tool resolution (shadow pattern) ---\n");
+
+  const { tool: entityGreet, calls: entityCalls } = createTrackingTool("greet", "entity");
+  const { tool: forgedGreet, calls: forgeCalls } = createTrackingTool("greet", "forged");
+
+  // Entity provider (bundled in assembly)
+  const entityProvider: ComponentProvider = {
+    name: "entity-tools",
+    attach: async () => new Map<string, unknown>([[toolToken("greet") as string, entityGreet]]),
+  };
+
+  // ForgeRuntime that shadows "greet" at call-time
+  const forge: ForgeRuntime = {
+    resolveTool: async (toolId: string): Promise<Tool | undefined> => {
+      if (toolId === "greet") return forgedGreet;
+      return undefined;
+    },
+    toolDescriptors: async (): Promise<readonly ToolDescriptor[]> => [forgedGreet.descriptor],
+  };
+
+  // Scripted model calls "greet" tool, then gives final text
+  const modelCall = createScriptedModel([
+    () => ({
+      content: "Let me greet.",
+      model: "scripted",
+      metadata: {
+        toolCalls: [{ toolName: "greet", callId: "call-0", input: { name: "World" } }],
+      } as JsonObject,
+    }),
+    () => ({ content: "Greeting done.", model: "scripted" }),
+  ]);
+
+  const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+
+  const runtime = await createKoi({
+    manifest: { name: "forge-first-test", version: "0.1.0", model: { name: "scripted" } },
+    adapter,
+    forge,
+    providers: [entityProvider],
+    loopDetection: false,
+  });
+
+  const events = await collectEvents(runtime.run({ kind: "text", text: "Say hello" }));
+
+  // Forged tool should have been called (forge-first resolution)
+  assert(
+    "forged greet was called (forge-first)",
+    forgeCalls.length === 1,
+    `forgeCalls=${forgeCalls.length}`,
+  );
+  assert(
+    "entity greet was NOT called (shadowed by forge)",
+    entityCalls.length === 0,
+    `entityCalls=${entityCalls.length}`,
+  );
+
+  // Verify tool_call_end event has forged result
+  const toolEnd = events.find((e) => e.kind === "tool_call_end");
+  if (toolEnd?.kind === "tool_call_end") {
+    const result = toolEnd.result as Record<string, unknown>;
+    assert("tool result tag is 'forged'", result.tag === "forged", `got tag=${String(result.tag)}`);
+  } else {
+    assert("tool_call_end event found", false, "missing");
+  }
+
+  // Verify done event
+  const doneEvent = events.find((e) => e.kind === "done");
+  assert(
+    "run completed successfully",
+    doneEvent?.kind === "done" && doneEvent.output.stopReason === "completed",
+  );
+
+  await runtime.dispose();
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Descriptor deduplication (forged shadows entity by name)
+// ---------------------------------------------------------------------------
+
+async function testDescriptorDedup(): Promise<void> {
+  console.log("\n--- Test 3: Descriptor deduplication (forged wins by name) ---\n");
+
+  const { tool: entityCalc } = createTrackingTool("calc", "entity");
+  const { tool: entitySearch } = createTrackingTool("search", "entity");
+
+  const entityProvider: ComponentProvider = {
+    name: "entity-tools",
+    attach: async () =>
+      new Map<string, unknown>([
+        [toolToken("calc") as string, entityCalc],
+        [toolToken("search") as string, entitySearch],
+      ]),
+  };
+
+  // Forge provides a "calc" descriptor (shadows entity) + "special" (additive)
+  const forgedCalcDescriptor: ToolDescriptor = {
+    name: "calc",
+    description: "Forged calculator",
+    inputSchema: { type: "object" },
+  };
+  const specialDescriptor: ToolDescriptor = {
+    name: "special",
+    description: "Forged-only tool",
+    inputSchema: { type: "object" },
+  };
+
+  const forge: ForgeRuntime = {
+    resolveTool: async () => undefined,
+    toolDescriptors: async () => [forgedCalcDescriptor, specialDescriptor],
+  };
+
+  // Intercepting adapter: wraps loop adapter to capture callHandlers.tools from EngineInput
+  // let justified: mutable capture of the tools list seen by the adapter
+  let capturedTools: readonly ToolDescriptor[] = [];
+
+  const innerAdapter = createLoopAdapter({
+    modelCall: createScriptedModel([() => ({ content: "Done.", model: "scripted" })]),
+    maxTurns: 1,
+  });
+
+  const interceptingAdapter: EngineAdapter = {
+    engineId: "intercepting-loop",
+    terminals: innerAdapter.terminals,
+    stream(input: EngineInput): AsyncIterable<EngineEvent> {
+      // Capture callHandlers.tools from the EngineInput that koi.ts passes
+      if (input.callHandlers !== undefined) {
+        capturedTools = input.callHandlers.tools;
+      }
+      return innerAdapter.stream(input);
+    },
+  };
+
+  const runtime = await createKoi({
+    manifest: { name: "dedup-test", version: "0.1.0", model: { name: "scripted" } },
+    adapter: interceptingAdapter,
+    forge,
+    providers: [entityProvider],
+    loopDetection: false,
+  });
+
+  await collectEvents(runtime.run({ kind: "text", text: "inspect tools" }));
+
+  // Verify dedup: forged "calc" + forged "special" + entity "search" = 3 total
+  // Entity "calc" should be deduped out (forged "calc" wins by name)
+  assert(
+    "total tool descriptors = 3 (forged calc + forged special + entity search)",
+    capturedTools.length === 3,
+    `got ${capturedTools.length}: [${capturedTools.map((d) => d.name).join(", ")}]`,
+  );
+
+  const calcDesc = capturedTools.find((d) => d.name === "calc");
+  assert(
+    "calc descriptor is forged version (description check)",
+    calcDesc?.description === "Forged calculator",
+    `got description="${calcDesc?.description}"`,
+  );
+
+  const hasSearch = capturedTools.some((d) => d.name === "search");
+  assert("entity-only 'search' still present", hasSearch);
+
+  const hasSpecial = capturedTools.some((d) => d.name === "special");
+  assert("forged-only 'special' present", hasSpecial);
+
+  await runtime.dispose();
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Real LLM call (optional, requires ANTHROPIC_API_KEY)
+// ---------------------------------------------------------------------------
+
+async function testRealLlm(): Promise<void> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.log("\n--- Test 4: Real LLM call (SKIPPED — no ANTHROPIC_API_KEY) ---\n");
+    return;
+  }
+
+  console.log("\n--- Test 4: Real LLM call through assembled runtime with forge ---\n");
+
+  const { createAnthropicAdapter } = await import(
+    "../packages/model-router/src/adapters/anthropic.js"
+  );
+
+  const SECRET = `MAGIC_${Date.now()}`;
+
+  const anthropic = createAnthropicAdapter({ apiKey });
+  const modelCall = (request: ModelRequest) =>
+    anthropic.complete({ ...request, model: "claude-haiku-4-5-20251001", maxTokens: 100 });
+
+  // Entity tools: bundled calc + search
+  const { tool: entityCalc } = createTrackingTool("calc", "entity");
+  const { tool: entitySearch } = createTrackingTool("search", "entity");
+
+  const entityProvider: ComponentProvider = {
+    name: "entity-tools",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    attach: async () =>
+      new Map<string, unknown>([
+        [toolToken("calc") as string, entityCalc],
+        [toolToken("search") as string, entitySearch],
+      ]),
+  };
+
+  // Forge: shadows "calc" descriptor (different description) + adds "special"
+  const forgedCalcDescriptor: ToolDescriptor = {
+    name: "calc",
+    description: "Forged calculator (shadowed)",
+    inputSchema: { type: "object" },
+  };
+  const specialDescriptor: ToolDescriptor = {
+    name: "special",
+    description: "Forged-only tool",
+    inputSchema: { type: "object" },
+  };
+
+  const forge: ForgeRuntime = {
+    resolveTool: async () => undefined,
+    toolDescriptors: async () => [forgedCalcDescriptor, specialDescriptor],
+  };
+
+  // Intercepting adapter: captures callHandlers.tools, then delegates to real loop adapter
+  // let justified: mutable capture
+  let capturedTools: readonly ToolDescriptor[] = [];
+
+  const innerAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+  const interceptingAdapter: EngineAdapter = {
+    engineId: "intercepting-loop",
+    terminals: innerAdapter.terminals,
+    stream(input: EngineInput): AsyncIterable<EngineEvent> {
+      if (input.callHandlers !== undefined) {
+        capturedTools = input.callHandlers.tools;
+      }
+      return innerAdapter.stream(input);
+    },
+  };
+
+  const runtime = await createKoi({
+    manifest: { name: "real-llm-e2e", version: "0.1.0", model: { name: "claude-haiku-4-5" } },
+    adapter: interceptingAdapter,
+    forge,
+    providers: [entityProvider],
+    loopDetection: false,
+  });
+
+  console.log(`  Conflicts: ${runtime.conflicts.length}`);
+  console.log(`  Sending: "Reply with exactly: ${SECRET}"\n`);
+
+  let fullResponse = "";
+
+  for await (const event of runtime.run({
+    kind: "text",
+    text: `Reply with exactly this text and nothing else: ${SECRET}`,
+  })) {
+    if (event.kind === "text_delta") {
+      fullResponse += event.delta;
+      process.stdout.write(event.delta);
+    } else if (event.kind === "done") {
+      console.log(
+        `\n\n  [done] stopReason=${event.output.stopReason} turns=${event.output.metrics.turns}`,
+      );
+      console.log(
+        `  [done] tokens: ${event.output.metrics.inputTokens} in / ${event.output.metrics.outputTokens} out`,
+      );
+    }
+  }
+
+  console.log();
+
+  // Verify real LLM response came through
+  assert(
+    `LLM response contains secret (${SECRET})`,
+    fullResponse.includes(SECRET),
+    `response="${fullResponse.substring(0, 100)}"`,
+  );
+
+  // Verify descriptor dedup worked with real adapter (same as Test 3 but with real LLM)
+  assert(
+    "callHandlers.tools has 3 descriptors (forged calc + forged special + entity search)",
+    capturedTools.length === 3,
+    `got ${capturedTools.length}: [${capturedTools.map((d) => d.name).join(", ")}]`,
+  );
+
+  const calcDesc = capturedTools.find((d) => d.name === "calc");
+  assert(
+    "calc descriptor is forged version in real LLM path",
+    calcDesc?.description === "Forged calculator (shadowed)",
+    `got "${calcDesc?.description}"`,
+  );
+
+  // Verify conflicts were tracked
+  assert(
+    "no assembly conflicts (forge doesn't go through providers)",
+    runtime.conflicts.length === 0,
+    `got ${runtime.conflicts.length}`,
+  );
+
+  await runtime.dispose();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log(
+    "\n\u2550\u2550\u2550 E2E: Issue #246 — ComponentProvider Resolution Semantics \u2550\u2550\u2550\n",
+  );
+
+  await testAssemblyConflicts();
+  await testForgeFirstResolution();
+  await testDescriptorDedup();
+  await testRealLlm();
+
+  printReport();
+
+  const failed = results.filter((r) => !r.passed).length;
+  if (failed > 0) {
+    process.exit(1);
+  }
+
+  console.log("\n[e2e] COMPONENT RESOLUTION E2E VALIDATION PASSED");
+}
+
+main().catch((error: unknown) => {
+  console.error("\nE2E FAILED:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #246

Aligns ComponentProvider resolution with the architecture doc's precedence rule: **Agent-forged > Zone-forged > Global-forged > Bundled** (lower priority number wins).

- **L0 (`@koi/core`)**: Added `priority` field to `ComponentProvider` interface and `COMPONENT_PRIORITY` constants (`AGENT_FORGED=0`, `ZONE_FORGED=10`, `GLOBAL_FORGED=50`, `BUNDLED=100`)
- **L1 (`@koi/engine`)**: Changed `AgentEntity.assemble()` to sort providers by priority ascending with first-write-wins semantics, returning structured `AssemblyConflict[]` for shadow tracking
- **L1 (`@koi/engine`)**: Flipped `defaultToolTerminal` to forge-first resolution (`forge ?? entity`) and deduped `callHandlers.tools` getter with reference-equality memoization
- **L2 (`@koi/forge`)**: `ForgeComponentProvider` now maps scope to priority (`agent→0`, `zone→10`, `global→50`)
- **L1**: `InheritedComponentProvider` explicitly sets `priority: BUNDLED (100)`
- **E2E**: Added `scripts/e2e-component-resolution.ts` validating assembly, forge-first resolution, descriptor dedup, and real LLM call

## Anti-leak checklist

- [x] `@koi/core` has zero `import` statements from other packages
- [x] No `function` bodies or `class` in `@koi/core` (types/interfaces only, except branded casts and pure data constants)
- [x] L2 packages only import from `@koi/core` (L0) and L0u utilities
- [x] All interface properties are `readonly`
- [x] No vendor types in L0 or L1

## Test plan

- [x] `bun test packages/core` — 26/26 pass (snapshot updated for new exports)
- [x] `bun test packages/engine` — 180/180 pass (assembly, koi runtime, types, inherited provider)
- [x] `bun test packages/forge` — 50/50 pass (scope→priority mapping)
- [x] E2E script: 17/17 pass including real Anthropic API call
- [ ] CI green