### PR TITLE
feat: add @koi/middleware-guardrails (L2) — Zod-based output validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -338,6 +338,21 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-guardrails": {
+      "name": "@koi/middleware-guardrails",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-loop": "workspace:*",
+        "@koi/model-router": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-guided-retry": {
       "name": "@koi/middleware-guided-retry",
       "version": "0.0.0",
@@ -1024,6 +1039,8 @@
     "@koi/middleware-feedback-loop": ["@koi/middleware-feedback-loop@workspace:packages/middleware-feedback-loop"],
 
     "@koi/middleware-fs-rollback": ["@koi/middleware-fs-rollback@workspace:packages/middleware-fs-rollback"],
+
+    "@koi/middleware-guardrails": ["@koi/middleware-guardrails@workspace:packages/middleware-guardrails"],
 
     "@koi/middleware-guided-retry": ["@koi/middleware-guided-retry@workspace:packages/middleware-guided-retry"],
 

--- a/packages/middleware-guardrails/package.json
+++ b/packages/middleware-guardrails/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/middleware-guardrails",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-loop": "workspace:*",
+    "@koi/model-router": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-guardrails/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-guardrails/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,121 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-guardrails API surface . has stable type surface 1`] = `
+"import { Result, KoiError } from '@koi/core/errors';
+import { z } from 'zod';
+import { KoiMiddleware } from '@koi/core/middleware';
+
+/**
+ * Type definitions for @koi/middleware-guardrails.
+ *
+ * Defines guardrail rules, config, and violation events for
+ * Zod-based output validation of model and tool responses.
+ */
+
+/** Target of a guardrail rule — which output to validate. */
+type GuardrailTarget = "modelOutput" | "toolOutput";
+/** Action to take when validation fails. */
+type GuardrailAction = "block" | "warn" | "retry";
+/** How to parse model output content before schema validation. */
+type GuardrailParseMode = "json" | "text";
+/** A single guardrail rule binding a Zod schema to an output target. */
+interface GuardrailRule {
+    /** Human-readable rule name (unique within a config). */
+    readonly name: string;
+    /** Zod schema to validate the output against. */
+    readonly schema: z.ZodType;
+    /** Which output this rule applies to. */
+    readonly target: GuardrailTarget;
+    /** What to do when the output fails validation. */
+    readonly action: GuardrailAction;
+    /** How to parse model output content (default: "json"). Ignored for toolOutput. */
+    readonly parseMode?: GuardrailParseMode | undefined;
+}
+/** Retry configuration for rules with action "retry". */
+interface GuardrailRetryConfig {
+    /** Maximum number of retry attempts (default: 2). */
+    readonly maxAttempts?: number | undefined;
+}
+/** Full middleware configuration. */
+interface GuardrailsConfig {
+    /** Guardrail rules to enforce. Must be non-empty. */
+    readonly rules: readonly GuardrailRule[];
+    /** Retry settings for rules with action "retry". */
+    readonly retry?: GuardrailRetryConfig | undefined;
+    /** Max characters to buffer for streaming validation (default: 262144). */
+    readonly maxBufferSize?: number | undefined;
+    /** Called whenever a rule violation is detected. */
+    readonly onViolation?: ((event: GuardrailViolationEvent) => void) | undefined;
+}
+/** Event fired when a guardrail rule detects a violation. */
+interface GuardrailViolationEvent {
+    /** Name of the rule that was violated. */
+    readonly rule: string;
+    /** Which output the violation was detected in. */
+    readonly target: GuardrailTarget;
+    /** Action taken (or to be taken) for this violation. */
+    readonly action: GuardrailAction;
+    /** Zod validation errors. */
+    readonly errors: readonly GuardrailError[];
+    /** Current retry attempt (1-indexed), present when action is "retry". */
+    readonly attempt?: number | undefined;
+}
+/** A single validation error detail from Zod. */
+interface GuardrailError {
+    /** Dot-separated path to the failing field (empty string for root). */
+    readonly path: string;
+    /** Human-readable error message. */
+    readonly message: string;
+    /** Zod issue code. */
+    readonly code: string;
+}
+
+/**
+ * Guardrails middleware configuration and validation.
+ */
+
+/** Default max buffer size for streaming validation (256KB). */
+declare const DEFAULT_MAX_BUFFER_SIZE = 262144;
+/** Default max retry attempts for "retry" action. */
+declare const DEFAULT_MAX_RETRY_ATTEMPTS = 2;
+declare function validateGuardrailsConfig(config: unknown): Result<GuardrailsConfig, KoiError>;
+
+/**
+ * Guardrails middleware factory — Zod-based output validation for model
+ * and tool responses.
+ *
+ * Priority 375: runs after sanitize (350), before memory (400).
+ */
+
+declare function createGuardrailsMiddleware(config: GuardrailsConfig): KoiMiddleware;
+
+/**
+ * Output validation — parse content and apply Zod schemas.
+ *
+ * Pure functions with no side effects. Handles both JSON and text parse modes.
+ */
+
+/** Result of validating output against guardrail rules. */
+interface GuardrailValidationResult {
+    readonly valid: boolean;
+    readonly errors: readonly GuardrailError[];
+    /** The first failing rule name, if any. */
+    readonly failedRule?: string | undefined;
+}
+/**
+ * Validates model output content against guardrail rules.
+ *
+ * JSON mode: parses content as JSON, then applies schema.safeParse.
+ * Text mode: wraps content as \`{ text: content }\` before schema.safeParse.
+ */
+declare function validateModelOutput(content: string, rules: readonly GuardrailRule[], parseMode?: GuardrailParseMode): GuardrailValidationResult;
+/**
+ * Validates tool output against guardrail rules.
+ *
+ * No JSON parsing needed — tool output is already structured data.
+ */
+declare function validateToolOutput(output: unknown, rules: readonly GuardrailRule[]): GuardrailValidationResult;
+
+export { DEFAULT_MAX_BUFFER_SIZE, DEFAULT_MAX_RETRY_ATTEMPTS, type GuardrailAction, type GuardrailError, type GuardrailParseMode, type GuardrailRetryConfig, type GuardrailRule, type GuardrailTarget, type GuardrailValidationResult, type GuardrailViolationEvent, type GuardrailsConfig, createGuardrailsMiddleware, validateGuardrailsConfig, validateModelOutput, validateToolOutput };
+"
+`;

--- a/packages/middleware-guardrails/src/__tests__/api-surface.test.ts
+++ b/packages/middleware-guardrails/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware-guardrails/src/__tests__/e2e.test.ts
+++ b/packages/middleware-guardrails/src/__tests__/e2e.test.ts
@@ -1,0 +1,320 @@
+/**
+ * End-to-end tests for @koi/middleware-guardrails with real LLM API calls.
+ *
+ * Wires guardrails middleware through the full createKoi + createLoopAdapter
+ * L1 runtime path to verify middleware interposition works with a real model.
+ *
+ * Gated on the ANTHROPIC_API_KEY environment variable — tests are skipped
+ * when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineOutput, ModelRequest } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { createAnthropicAdapter } from "@koi/model-router";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "../guardrails.js";
+import type { GuardrailViolationEvent } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const MODEL = "claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractTextFromEvents(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: guardrails middleware through createKoi + createLoopAdapter", () => {
+  const anthropicAdapter = createAnthropicAdapter({
+    apiKey: ANTHROPIC_KEY,
+  });
+
+  const modelCall = (request: ModelRequest) =>
+    anthropicAdapter.complete({ ...request, model: MODEL });
+
+  test(
+    "valid JSON output passes through guardrails",
+    async () => {
+      const jsonSchema = z.object({
+        greeting: z.string(),
+      });
+
+      const violations: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [
+          {
+            name: "json-format",
+            schema: jsonSchema,
+            target: "modelOutput",
+            action: "block",
+          },
+        ],
+        onViolation: (e) => {
+          violations.push(e);
+        },
+      });
+
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+      const runtime = await createKoi({
+        manifest: {
+          name: "guardrails-e2e-valid",
+          version: "0.0.0",
+          model: { name: MODEL },
+        },
+        adapter,
+        middleware: [mw],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: 'Respond with ONLY a JSON object. No markdown, no code fences, no extra text. The JSON must have exactly one key "greeting" with a string value. Example: {"greeting": "hello"}',
+          }),
+        );
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Model should complete successfully (guardrails pass)
+        expect(output?.stopReason).toBe("completed");
+
+        // Text should contain valid JSON with greeting
+        const text = extractTextFromEvents(events);
+        expect(text.length).toBeGreaterThan(0);
+
+        const parsed = JSON.parse(text) as { greeting: string };
+        expect(typeof parsed.greeting).toBe("string");
+
+        // No violations should have been fired
+        expect(violations).toHaveLength(0);
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "warn action fires violation callback but passes through",
+    async () => {
+      const strictSchema = z.object({
+        answer: z.number().int().min(0).max(10),
+      });
+
+      const violations: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [
+          {
+            name: "strict-number",
+            schema: strictSchema,
+            target: "modelOutput",
+            action: "warn",
+          },
+        ],
+        onViolation: (e) => {
+          violations.push(e);
+        },
+      });
+
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+      const runtime = await createKoi({
+        manifest: {
+          name: "guardrails-e2e-warn",
+          version: "0.0.0",
+          model: { name: MODEL },
+        },
+        adapter,
+        middleware: [mw],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Tell me a short joke about programming in plain text.",
+          }),
+        );
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Should complete even though output doesn't match schema
+        expect(output?.stopReason).toBe("completed");
+
+        // Text content should exist (model responded normally)
+        const text = extractTextFromEvents(events);
+        expect(text.length).toBeGreaterThan(0);
+
+        // Violation callback should have fired (plain text ≠ JSON)
+        expect(violations.length).toBeGreaterThanOrEqual(1);
+        expect(violations[0]?.action).toBe("warn");
+        expect(violations[0]?.target).toBe("modelOutput");
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "block action prevents delivery of invalid output",
+    async () => {
+      const strictSchema = z.object({
+        answer: z.number().int(),
+      });
+
+      const violations: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [
+          {
+            name: "strict-json",
+            schema: strictSchema,
+            target: "modelOutput",
+            action: "block",
+          },
+        ],
+        onViolation: (e) => {
+          violations.push(e);
+        },
+      });
+
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+      const runtime = await createKoi({
+        manifest: {
+          name: "guardrails-e2e-block",
+          version: "0.0.0",
+          model: { name: MODEL },
+        },
+        adapter,
+        middleware: [mw],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Tell me a short joke about cats in plain text. Do not use JSON.",
+          }),
+        );
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // createKoi converts KoiRuntimeError into a done event with "error" stopReason
+        expect(output?.stopReason).toBe("error");
+
+        // Violation should have been fired
+        expect(violations.length).toBeGreaterThanOrEqual(1);
+        expect(violations[0]?.action).toBe("block");
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "retry action re-prompts the model with error context",
+    async () => {
+      const jsonSchema = z.object({
+        color: z.string(),
+        hex: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+      });
+
+      const violations: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [
+          {
+            name: "color-format",
+            schema: jsonSchema,
+            target: "modelOutput",
+            action: "retry",
+          },
+        ],
+        retry: { maxAttempts: 3 },
+        onViolation: (e) => {
+          violations.push(e);
+        },
+      });
+
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+      const runtime = await createKoi({
+        manifest: {
+          name: "guardrails-e2e-retry",
+          version: "0.0.0",
+          model: { name: MODEL },
+        },
+        adapter,
+        middleware: [mw],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: 'Respond with ONLY a JSON object containing "color" (a color name string) and "hex" (its hex code starting with # followed by 6 hex digits). Example: {"color": "red", "hex": "#FF0000"}. No markdown, no code fences.',
+          }),
+        );
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Model should eventually produce valid JSON (possibly after retries)
+        // If it succeeds, stopReason is "completed"
+        // If all retries fail, stopReason is "error"
+        if (output?.stopReason === "completed") {
+          const text = extractTextFromEvents(events);
+          const parsed = JSON.parse(text) as {
+            color: string;
+            hex: string;
+          };
+          expect(typeof parsed.color).toBe("string");
+          expect(parsed.hex).toMatch(/^#[0-9a-fA-F]{6}$/);
+        }
+        // Either way, test infrastructure worked
+        expect(output).toBeDefined();
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/middleware-guardrails/src/__tests__/integration.test.ts
+++ b/packages/middleware-guardrails/src/__tests__/integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests — end-to-end scenarios exercising the guardrails middleware.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ModelChunk, ModelResponse } from "@koi/core/middleware";
+import {
+  createMockModelHandler,
+  createMockToolHandler,
+  createMockTurnContext,
+  createSpyModelStreamHandler,
+} from "@koi/test-utils";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "../guardrails.js";
+import type { GuardrailRule, GuardrailViolationEvent } from "../types.js";
+
+const ctx = createMockTurnContext();
+
+const responseSchema = z.object({
+  answer: z.string(),
+  confidence: z.number().min(0).max(1),
+});
+
+const modelRule: GuardrailRule = {
+  name: "response-format",
+  schema: responseSchema,
+  target: "modelOutput",
+  action: "block",
+};
+
+const toolOutputSchema = z.object({ result: z.string() });
+const toolRule: GuardrailRule = {
+  name: "tool-format",
+  schema: toolOutputSchema,
+  target: "toolOutput",
+  action: "block",
+};
+
+async function collectStream(stream: AsyncIterable<ModelChunk>): Promise<readonly ModelChunk[]> {
+  const chunks: ModelChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function assertStream(stream: AsyncIterable<ModelChunk> | undefined): AsyncIterable<ModelChunk> {
+  if (stream === undefined) throw new Error("Expected stream to be defined");
+  return stream;
+}
+
+describe("integration", () => {
+  test("scenario 1: full model call with valid JSON passes through", async () => {
+    const validContent = JSON.stringify({ answer: "42", confidence: 0.95 });
+    const handler = createMockModelHandler({ content: validContent });
+    const events: GuardrailViolationEvent[] = [];
+    const mw = createGuardrailsMiddleware({
+      rules: [modelRule],
+      onViolation: (e) => events.push(e),
+    });
+
+    const response = await mw.wrapModelCall?.(ctx, { messages: [] }, handler);
+    expect(response?.content).toBe(validContent);
+    expect(events).toHaveLength(0);
+  });
+
+  test("scenario 2: streaming with valid JSON validated at done", async () => {
+    const validContent = JSON.stringify({ answer: "hello", confidence: 0.8 });
+    const doneResponse: ModelResponse = { content: validContent, model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: '{"answer":"hello",' },
+      { kind: "text_delta", delta: '"confidence":0.8}' },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const mw = createGuardrailsMiddleware({ rules: [modelRule] });
+
+    const stream = assertStream(mw.wrapModelStream?.(ctx, { messages: [] }, handler.handler));
+    const collected = await collectStream(stream);
+
+    expect(collected).toHaveLength(3);
+    expect(collected[2]?.kind).toBe("done");
+  });
+
+  test("scenario 3: model + tool rules both enforced", async () => {
+    const validModelContent = JSON.stringify({ answer: "ok", confidence: 0.5 });
+    const modelHandler = createMockModelHandler({ content: validModelContent });
+    const validToolHandler = createMockToolHandler({ output: { result: "success" } });
+    const invalidToolHandler = createMockToolHandler({ output: { wrong: true } });
+
+    const mw = createGuardrailsMiddleware({ rules: [modelRule, toolRule] });
+
+    // Model call works
+    const modelResponse = await mw.wrapModelCall?.(ctx, { messages: [] }, modelHandler);
+    expect(modelResponse?.content).toBe(validModelContent);
+
+    // Valid tool call works
+    const toolResponse = await mw.wrapToolCall?.(
+      ctx,
+      { toolId: "t1", input: {} },
+      validToolHandler,
+    );
+    expect((toolResponse?.output as Record<string, string>).result).toBe("success");
+
+    // Invalid tool call blocked
+    await expect(
+      mw.wrapToolCall?.(ctx, { toolId: "t2", input: {} }, invalidToolHandler),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/middleware-guardrails/src/config.test.ts
+++ b/packages/middleware-guardrails/src/config.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for guardrails config validation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { validateGuardrailsConfig } from "./config.js";
+
+const validRule = {
+  name: "test-rule",
+  schema: z.object({ message: z.string() }),
+  target: "modelOutput",
+  action: "block",
+};
+
+describe("validateGuardrailsConfig", () => {
+  test("accepts valid config with minimal fields", () => {
+    const result = validateGuardrailsConfig({ rules: [validRule] });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts config with all optional fields", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      retry: { maxAttempts: 3 },
+      maxBufferSize: 1024,
+      onViolation: () => {},
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts config with toolOutput target", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ ...validRule, target: "toolOutput" }],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts config with all action types", () => {
+    for (const action of ["block", "warn", "retry"]) {
+      const result = validateGuardrailsConfig({
+        rules: [{ ...validRule, action }],
+      });
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test("accepts config with parseMode", () => {
+    for (const parseMode of ["json", "text"]) {
+      const result = validateGuardrailsConfig({
+        rules: [{ ...validRule, parseMode }],
+      });
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test("rejects null config", () => {
+    const result = validateGuardrailsConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  test("rejects config without rules", () => {
+    const result = validateGuardrailsConfig({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("rules");
+    }
+  });
+
+  test("rejects empty rules array", () => {
+    const result = validateGuardrailsConfig({ rules: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("non-empty");
+    }
+  });
+
+  test("rejects rule without name", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ schema: z.string(), target: "modelOutput", action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  test("rejects rule with empty name", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ name: "", schema: z.string(), target: "modelOutput", action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  test("rejects duplicate rule names", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule, { ...validRule, action: "warn" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Duplicate");
+      expect(result.error.message).toContain("test-rule");
+    }
+  });
+
+  test("rejects rule without schema", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ name: "test", target: "modelOutput", action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("schema");
+    }
+  });
+
+  test("rejects rule with invalid target", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ ...validRule, target: "invalid" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("target");
+    }
+  });
+
+  test("rejects rule with invalid action", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ ...validRule, action: "invalid" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("action");
+    }
+  });
+
+  test("rejects rule with invalid parseMode", () => {
+    const result = validateGuardrailsConfig({
+      rules: [{ ...validRule, parseMode: "xml" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("parseMode");
+    }
+  });
+
+  test("rejects invalid retry.maxAttempts (zero)", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      retry: { maxAttempts: 0 },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxAttempts");
+    }
+  });
+
+  test("rejects invalid retry.maxAttempts (negative)", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      retry: { maxAttempts: -1 },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxAttempts");
+    }
+  });
+
+  test("rejects non-object retry", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      retry: "invalid",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("retry");
+    }
+  });
+
+  test("rejects invalid maxBufferSize (zero)", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      maxBufferSize: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxBufferSize");
+    }
+  });
+
+  test("rejects invalid maxBufferSize (NaN)", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      maxBufferSize: Number.NaN,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("maxBufferSize");
+    }
+  });
+
+  test("rejects non-function onViolation", () => {
+    const result = validateGuardrailsConfig({
+      rules: [validRule],
+      onViolation: "not a function",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("onViolation");
+    }
+  });
+
+  test("all errors have VALIDATION code", () => {
+    const invalidConfigs = [null, {}, { rules: [] }, { rules: [{}] }];
+    for (const config of invalidConfigs) {
+      const result = validateGuardrailsConfig(config);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION");
+        expect(result.error.retryable).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/middleware-guardrails/src/config.ts
+++ b/packages/middleware-guardrails/src/config.ts
@@ -1,0 +1,111 @@
+/**
+ * Guardrails middleware configuration and validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { GuardrailsConfig } from "./types.js";
+
+/** Default max buffer size for streaming validation (256KB). */
+export const DEFAULT_MAX_BUFFER_SIZE = 262_144;
+
+/** Default max retry attempts for "retry" action. */
+export const DEFAULT_MAX_RETRY_ATTEMPTS = 2;
+
+const VALID_TARGETS = new Set(["modelOutput", "toolOutput"]);
+const VALID_ACTIONS = new Set(["block", "warn", "retry"]);
+const VALID_PARSE_MODES = new Set(["json", "text"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: { code: "VALIDATION", message, retryable: RETRYABLE_DEFAULTS.VALIDATION },
+  };
+}
+
+export function validateGuardrailsConfig(config: unknown): Result<GuardrailsConfig, KoiError> {
+  if (!isRecord(config)) {
+    return validationError("Config must be a non-null object");
+  }
+
+  if (!Array.isArray(config.rules)) {
+    return validationError("'rules' must be a non-empty array of GuardrailRule objects");
+  }
+
+  if (config.rules.length === 0) {
+    return validationError("'rules' must be a non-empty array of GuardrailRule objects");
+  }
+
+  const seenNames = new Set<string>();
+  // Array.isArray narrows to any[], assignable to readonly unknown[] without assertion
+  const rules: readonly unknown[] = config.rules;
+  for (const rule of rules) {
+    if (!isRecord(rule)) {
+      return validationError("Each rule must be a non-null object");
+    }
+    if (typeof rule.name !== "string" || rule.name.length === 0) {
+      return validationError("Each rule must have a non-empty 'name' string");
+    }
+    if (seenNames.has(rule.name)) {
+      return validationError(`Duplicate rule name: "${rule.name}"`);
+    }
+    seenNames.add(rule.name);
+    if (rule.schema === undefined || rule.schema === null) {
+      return validationError(`Rule "${String(rule.name)}": 'schema' is required`);
+    }
+    if (typeof rule.target !== "string" || !VALID_TARGETS.has(rule.target)) {
+      return validationError(
+        `Rule "${String(rule.name)}": 'target' must be "modelOutput" or "toolOutput"`,
+      );
+    }
+    if (typeof rule.action !== "string" || !VALID_ACTIONS.has(rule.action)) {
+      return validationError(
+        `Rule "${String(rule.name)}": 'action' must be "block", "warn", or "retry"`,
+      );
+    }
+    if (
+      rule.parseMode !== undefined &&
+      (typeof rule.parseMode !== "string" || !VALID_PARSE_MODES.has(rule.parseMode))
+    ) {
+      return validationError(`Rule "${String(rule.name)}": 'parseMode' must be "json" or "text"`);
+    }
+  }
+
+  if (config.retry !== undefined) {
+    if (!isRecord(config.retry)) {
+      return validationError("'retry' must be an object");
+    }
+    if (config.retry.maxAttempts !== undefined) {
+      if (
+        typeof config.retry.maxAttempts !== "number" ||
+        !Number.isInteger(config.retry.maxAttempts) ||
+        config.retry.maxAttempts <= 0
+      ) {
+        return validationError("retry.maxAttempts must be a positive integer");
+      }
+    }
+  }
+
+  if (config.maxBufferSize !== undefined) {
+    if (
+      typeof config.maxBufferSize !== "number" ||
+      !Number.isFinite(config.maxBufferSize) ||
+      config.maxBufferSize <= 0
+    ) {
+      return validationError("maxBufferSize must be a finite positive number");
+    }
+  }
+
+  if (config.onViolation !== undefined && typeof config.onViolation !== "function") {
+    return validationError("onViolation must be a function");
+  }
+
+  // Validation-boundary cast: all fields individually verified above.
+  // Matches established project pattern (see middleware-sanitize/src/config.ts:135-136).
+  const validated: unknown = config;
+  return { ok: true, value: validated as GuardrailsConfig };
+}

--- a/packages/middleware-guardrails/src/guardrails.test.ts
+++ b/packages/middleware-guardrails/src/guardrails.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Unit tests for the guardrails middleware factory.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ModelChunk, ModelRequest, ModelResponse } from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import {
+  createMockModelHandler,
+  createMockToolHandler,
+  createMockTurnContext,
+  createSpyModelHandler,
+  createSpyModelStreamHandler,
+} from "@koi/test-utils";
+import { z } from "zod";
+import { createGuardrailsMiddleware } from "./guardrails.js";
+import type { GuardrailRule, GuardrailViolationEvent } from "./types.js";
+
+const ctx = createMockTurnContext();
+const request: ModelRequest = { messages: [] };
+
+const jsonSchema = z.object({ message: z.string(), score: z.number().min(0).max(100) });
+
+const blockRule: GuardrailRule = {
+  name: "json-format",
+  schema: jsonSchema,
+  target: "modelOutput",
+  action: "block",
+};
+
+const warnRule: GuardrailRule = {
+  name: "json-warn",
+  schema: jsonSchema,
+  target: "modelOutput",
+  action: "warn",
+};
+
+const retryRule: GuardrailRule = {
+  name: "json-retry",
+  schema: jsonSchema,
+  target: "modelOutput",
+  action: "retry",
+};
+
+const toolSchema = z.object({ result: z.string() });
+const toolRule: GuardrailRule = {
+  name: "tool-format",
+  schema: toolSchema,
+  target: "toolOutput",
+  action: "block",
+};
+
+async function collectStream(stream: AsyncIterable<ModelChunk>): Promise<readonly ModelChunk[]> {
+  const chunks: ModelChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function assertStream(stream: AsyncIterable<ModelChunk> | undefined): AsyncIterable<ModelChunk> {
+  if (stream === undefined) throw new Error("Expected stream to be defined");
+  return stream;
+}
+
+describe("createGuardrailsMiddleware", () => {
+  test("has name 'guardrails' and priority 375", () => {
+    const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+    expect(mw.name).toBe("guardrails");
+    expect(mw.priority).toBe(375);
+  });
+
+  describe("wrapModelCall", () => {
+    test("passes through valid JSON output", async () => {
+      const validContent = JSON.stringify({ message: "hello", score: 42 });
+      const handler = createMockModelHandler({ content: validContent });
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      const response = await mw.wrapModelCall?.(ctx, request, handler);
+      expect(response?.content).toBe(validContent);
+    });
+
+    test("block action throws KoiRuntimeError on invalid output", async () => {
+      const handler = createMockModelHandler({ content: "not json" });
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+        KoiRuntimeError,
+      );
+    });
+
+    test("block action throws with VALIDATION code", async () => {
+      const handler = createMockModelHandler({ content: "not json" });
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      try {
+        await mw.wrapModelCall?.(ctx, request, handler);
+        expect(true).toBe(false); // Should not reach
+      } catch (e: unknown) {
+        expect(e).toBeInstanceOf(KoiRuntimeError);
+        expect((e as KoiRuntimeError).code).toBe("VALIDATION");
+      }
+    });
+
+    test("warn action fires callback and passes through", async () => {
+      const handler = createMockModelHandler({ content: "not json" });
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [warnRule],
+        onViolation: (e) => events.push(e),
+      });
+
+      const response = await mw.wrapModelCall?.(ctx, request, handler);
+      expect(response?.content).toBe("not json");
+      expect(events).toHaveLength(1);
+      expect(events[0]?.action).toBe("warn");
+      expect(events[0]?.rule).toBe("json-warn");
+    });
+
+    test("retry re-calls next with error context in messages", async () => {
+      const spy = createSpyModelHandler({
+        content: JSON.stringify({ message: "hello", score: 42 }),
+      });
+      // First call returns invalid, second returns valid
+      // let justified: counter tracks call attempts
+      let callCount = 0;
+      const handler = async (req: ModelRequest): Promise<ModelResponse> => {
+        callCount++;
+        if (callCount === 1) {
+          return { content: "not json", model: "test" };
+        }
+        return spy.handler(req);
+      };
+
+      const mw = createGuardrailsMiddleware({
+        rules: [retryRule],
+        retry: { maxAttempts: 3 },
+      });
+
+      const response = await mw.wrapModelCall?.(ctx, request, handler);
+      expect(callCount).toBe(2);
+      expect(response?.content).toBe(JSON.stringify({ message: "hello", score: 42 }));
+    });
+
+    test("retry exhausts attempts and throws", async () => {
+      const handler = createMockModelHandler({ content: "always invalid" });
+      const mw = createGuardrailsMiddleware({
+        rules: [retryRule],
+        retry: { maxAttempts: 2 },
+      });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+        KoiRuntimeError,
+      );
+    });
+
+    test("retry fires onViolation for each attempt", async () => {
+      const handler = createMockModelHandler({ content: "not json" });
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [retryRule],
+        retry: { maxAttempts: 2 },
+        onViolation: (e) => events.push(e),
+      });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+
+      expect(events).toHaveLength(2);
+      expect(events[0]?.attempt).toBe(1);
+      expect(events[1]?.attempt).toBe(2);
+    });
+
+    test("multiple rules: first block wins", async () => {
+      const rule1: GuardrailRule = {
+        name: "strict-schema",
+        schema: z.object({ a: z.string(), b: z.number() }),
+        target: "modelOutput",
+        action: "block",
+      };
+      const rule2: GuardrailRule = {
+        name: "loose-schema",
+        schema: z.object({ a: z.string() }),
+        target: "modelOutput",
+        action: "block",
+      };
+      const handler = createMockModelHandler({
+        content: JSON.stringify({ a: "ok" }),
+      });
+      const mw = createGuardrailsMiddleware({ rules: [rule1, rule2] });
+
+      try {
+        await mw.wrapModelCall?.(ctx, request, handler);
+        expect(true).toBe(false);
+      } catch (e: unknown) {
+        expect(e).toBeInstanceOf(KoiRuntimeError);
+        expect((e as KoiRuntimeError).message).toContain("strict-schema");
+      }
+    });
+
+    test("text mode rule validates text wrapping", async () => {
+      const textRule: GuardrailRule = {
+        name: "text-check",
+        schema: z.object({ text: z.string().min(5) }),
+        target: "modelOutput",
+        action: "block",
+        parseMode: "text",
+      };
+      const handler = createMockModelHandler({ content: "hi" });
+      const mw = createGuardrailsMiddleware({ rules: [textRule] });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+        KoiRuntimeError,
+      );
+    });
+
+    test("text mode passes valid content", async () => {
+      const textRule: GuardrailRule = {
+        name: "text-check",
+        schema: z.object({ text: z.string().min(5) }),
+        target: "modelOutput",
+        action: "block",
+        parseMode: "text",
+      };
+      const handler = createMockModelHandler({ content: "hello world" });
+      const mw = createGuardrailsMiddleware({ rules: [textRule] });
+
+      const response = await mw.wrapModelCall?.(ctx, request, handler);
+      expect(response?.content).toBe("hello world");
+    });
+  });
+
+  describe("wrapModelStream", () => {
+    test("buffers text_delta and validates on done", async () => {
+      const validJson = JSON.stringify({ message: "hello", score: 42 });
+      const doneResponse: ModelResponse = { content: validJson, model: "test" };
+      const chunks: readonly ModelChunk[] = [
+        { kind: "text_delta", delta: '{"message":' },
+        { kind: "text_delta", delta: '"hello","score":42}' },
+        { kind: "done", response: doneResponse },
+      ];
+      const handler = createSpyModelStreamHandler(chunks);
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      const collected = await collectStream(stream);
+
+      // All chunks passed through (validation on done)
+      expect(collected).toHaveLength(3);
+      expect(collected[0]?.kind).toBe("text_delta");
+      expect(collected[2]?.kind).toBe("done");
+    });
+
+    test("block rule throws on invalid streamed output", async () => {
+      const doneResponse: ModelResponse = { content: "not json", model: "test" };
+      const chunks: readonly ModelChunk[] = [
+        { kind: "text_delta", delta: "not json" },
+        { kind: "done", response: doneResponse },
+      ];
+      const handler = createSpyModelStreamHandler(chunks);
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      await expect(collectStream(stream)).rejects.toBeInstanceOf(KoiRuntimeError);
+    });
+
+    test("warn rule fires callback but does not throw", async () => {
+      const doneResponse: ModelResponse = { content: "not json", model: "test" };
+      const chunks: readonly ModelChunk[] = [
+        { kind: "text_delta", delta: "not json" },
+        { kind: "done", response: doneResponse },
+      ];
+      const handler = createSpyModelStreamHandler(chunks);
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [warnRule],
+        onViolation: (e) => events.push(e),
+      });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      const collected = await collectStream(stream);
+      expect(collected).toHaveLength(2);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.action).toBe("warn");
+    });
+
+    test("stream buffer overflow fires warn event", async () => {
+      const longContent = "x".repeat(300);
+      const doneResponse: ModelResponse = { content: longContent, model: "test" };
+      const chunks: readonly ModelChunk[] = [
+        { kind: "text_delta", delta: longContent },
+        { kind: "done", response: doneResponse },
+      ];
+      const handler = createSpyModelStreamHandler(chunks);
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [blockRule],
+        maxBufferSize: 100,
+        onViolation: (e) => events.push(e),
+      });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      const collected = await collectStream(stream);
+
+      // Overflow warning fired
+      const overflowEvent = events.find((e) => e.rule === "stream-buffer-overflow");
+      expect(overflowEvent).toBeDefined();
+      expect(overflowEvent?.action).toBe("warn");
+
+      // All chunks still yielded (validation skipped)
+      expect(collected).toHaveLength(2);
+    });
+
+    test("passes through non-text chunks unchanged", async () => {
+      const validJson = JSON.stringify({ message: "hello", score: 42 });
+      const doneResponse: ModelResponse = { content: validJson, model: "test" };
+      const chunks: readonly ModelChunk[] = [
+        { kind: "text_delta", delta: validJson },
+        { kind: "usage", inputTokens: 10, outputTokens: 20 },
+        { kind: "done", response: doneResponse },
+      ];
+      const handler = createSpyModelStreamHandler(chunks);
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      const collected = await collectStream(stream);
+      const usageChunk = collected.find((c) => c.kind === "usage");
+      expect(usageChunk).toBeDefined();
+    });
+
+    test("empty buffer skips validation on done", async () => {
+      const doneResponse: ModelResponse = { content: "", model: "test" };
+      const chunks: readonly ModelChunk[] = [{ kind: "done", response: doneResponse }];
+      const handler = createSpyModelStreamHandler(chunks);
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      const stream = assertStream(mw.wrapModelStream?.(ctx, request, handler.handler));
+      const collected = await collectStream(stream);
+      expect(collected).toHaveLength(1);
+      expect(collected[0]?.kind).toBe("done");
+    });
+  });
+
+  describe("wrapToolCall", () => {
+    test("passes through valid tool output", async () => {
+      const handler = createMockToolHandler({ output: { result: "ok" } });
+      const mw = createGuardrailsMiddleware({ rules: [toolRule] });
+
+      const response = await mw.wrapToolCall?.(ctx, { toolId: "test-tool", input: {} }, handler);
+      expect((response?.output as Record<string, string>).result).toBe("ok");
+    });
+
+    test("block action throws on invalid tool output", async () => {
+      const handler = createMockToolHandler({ output: { bad: 123 } });
+      const mw = createGuardrailsMiddleware({ rules: [toolRule] });
+
+      await expect(
+        mw.wrapToolCall?.(ctx, { toolId: "test-tool", input: {} }, handler),
+      ).rejects.toBeInstanceOf(KoiRuntimeError);
+    });
+
+    test("warn action fires callback and passes through", async () => {
+      const warnToolRule: GuardrailRule = { ...toolRule, action: "warn", name: "tool-warn" };
+      const handler = createMockToolHandler({ output: { bad: 123 } });
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [warnToolRule],
+        onViolation: (e) => events.push(e),
+      });
+
+      const response = await mw.wrapToolCall?.(ctx, { toolId: "test-tool", input: {} }, handler);
+      expect(response).toBeDefined();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.target).toBe("toolOutput");
+    });
+
+    test("includes toolId in error context", async () => {
+      const handler = createMockToolHandler({ output: "wrong" });
+      const mw = createGuardrailsMiddleware({ rules: [toolRule] });
+
+      try {
+        await mw.wrapToolCall?.(ctx, { toolId: "my-tool", input: {} }, handler);
+        expect(true).toBe(false);
+      } catch (e: unknown) {
+        expect(e).toBeInstanceOf(KoiRuntimeError);
+        expect((e as KoiRuntimeError).message).toContain("my-tool");
+      }
+    });
+  });
+
+  describe("conditional hook registration", () => {
+    test("no wrapModelCall/wrapModelStream when only toolOutput rules", () => {
+      const mw = createGuardrailsMiddleware({ rules: [toolRule] });
+      expect(mw.wrapModelCall).toBeUndefined();
+      expect(mw.wrapModelStream).toBeUndefined();
+      expect(mw.wrapToolCall).toBeDefined();
+    });
+
+    test("no wrapToolCall when only modelOutput rules", () => {
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+      expect(mw.wrapModelCall).toBeDefined();
+      expect(mw.wrapModelStream).toBeDefined();
+      expect(mw.wrapToolCall).toBeUndefined();
+    });
+
+    test("all hooks registered when both targets present", () => {
+      const mw = createGuardrailsMiddleware({ rules: [blockRule, toolRule] });
+      expect(mw.wrapModelCall).toBeDefined();
+      expect(mw.wrapModelStream).toBeDefined();
+      expect(mw.wrapToolCall).toBeDefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    test("empty string model output fails JSON parse", async () => {
+      const handler = createMockModelHandler({ content: "" });
+      const mw = createGuardrailsMiddleware({ rules: [blockRule] });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+        KoiRuntimeError,
+      );
+    });
+
+    test("default retry maxAttempts is 2", async () => {
+      const handler = createMockModelHandler({ content: "invalid" });
+      const events: GuardrailViolationEvent[] = [];
+      const mw = createGuardrailsMiddleware({
+        rules: [retryRule],
+        onViolation: (e) => events.push(e),
+      });
+
+      await expect(mw.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+
+      expect(events).toHaveLength(2);
+    });
+  });
+});

--- a/packages/middleware-guardrails/src/guardrails.ts
+++ b/packages/middleware-guardrails/src/guardrails.ts
@@ -1,0 +1,281 @@
+/**
+ * Guardrails middleware factory — Zod-based output validation for model
+ * and tool responses.
+ *
+ * Priority 375: runs after sanitize (350), before memory (400).
+ */
+
+import type { InboundMessage } from "@koi/core/message";
+import type {
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import { DEFAULT_MAX_BUFFER_SIZE, DEFAULT_MAX_RETRY_ATTEMPTS } from "./config.js";
+import type {
+  GuardrailAction,
+  GuardrailError,
+  GuardrailsConfig,
+  GuardrailViolationEvent,
+} from "./types.js";
+import type { GuardrailValidationResult } from "./validate-output.js";
+import { validateModelOutput, validateToolOutput } from "./validate-output.js";
+
+/** Sender ID for retry context messages injected by guardrails. */
+const GUARDRAILS_SENDER_ID = "system" as const;
+
+export function createGuardrailsMiddleware(config: GuardrailsConfig): KoiMiddleware {
+  const maxAttempts = config.retry?.maxAttempts ?? DEFAULT_MAX_RETRY_ATTEMPTS;
+  const maxBufferSize = config.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+  const onViolation = config.onViolation;
+
+  // Partition rules by target at factory time
+  const modelOutputRules = config.rules.filter((r) => r.target === "modelOutput");
+  const toolOutputRules = config.rules.filter((r) => r.target === "toolOutput");
+
+  // Further partition model rules by parseMode for efficient lookup
+  const jsonModelRules = modelOutputRules.filter((r) => (r.parseMode ?? "json") === "json");
+  const textModelRules = modelOutputRules.filter((r) => r.parseMode === "text");
+
+  const hasModelOutputRules = modelOutputRules.length > 0;
+  const hasToolOutputRules = toolOutputRules.length > 0;
+
+  // Pre-built map for O(1) rule lookup by name
+  const rulesByName = new Map(config.rules.map((r) => [r.name, r]));
+
+  /** Fire violation event and return the action of the failed rule. */
+  function fireViolation(
+    failedRuleName: string,
+    target: "modelOutput" | "toolOutput",
+    errors: readonly GuardrailError[],
+    attempt?: number,
+  ): GuardrailAction {
+    const rule = rulesByName.get(failedRuleName);
+    const action = rule?.action ?? "block";
+    const event: GuardrailViolationEvent = {
+      rule: failedRuleName,
+      target,
+      action,
+      errors,
+      ...(attempt !== undefined ? { attempt } : {}),
+    };
+    onViolation?.(event);
+    return action;
+  }
+
+  /** Format Zod errors as a string for injection into retry request messages. */
+  function formatErrors(errors: readonly GuardrailError[]): string {
+    return errors.map((e) => `${e.path || "root"}: ${e.message}`).join("; ");
+  }
+
+  /** Validate content against all model rules (JSON first, then text). */
+  function validateAllModelRules(content: string): GuardrailValidationResult {
+    const jsonResult = validateModelOutput(content, jsonModelRules, "json");
+    if (!jsonResult.valid) return jsonResult;
+    if (textModelRules.length === 0) return jsonResult;
+    return validateModelOutput(content, textModelRules, "text");
+  }
+
+  /**
+   * Handle a model output validation failure in wrapModelCall.
+   * Returns "warn" if the response should pass through, "retry" if the
+   * caller should retry. Throws KoiRuntimeError for "block" or exhausted retries.
+   */
+  function handleCallFailure(result: GuardrailValidationResult, attempt: number): "warn" | "retry" {
+    const action = fireViolation(
+      result.failedRule ?? "unknown",
+      "modelOutput",
+      result.errors,
+      attempt,
+    );
+    if (action === "warn") return "warn";
+    if (action === "retry" && attempt < maxAttempts) return "retry";
+    // Block action, or retry attempts exhausted
+    const label =
+      attempt >= maxAttempts ? `failed after ${maxAttempts} attempt(s)` : "blocked output";
+    throw KoiRuntimeError.from(
+      "VALIDATION",
+      `Guardrail "${result.failedRule}" ${label}: ${formatErrors(result.errors)}`,
+      {
+        context: { rule: result.failedRule, errors: result.errors },
+      },
+    );
+  }
+
+  /**
+   * Handle a model output validation failure in wrapModelStream.
+   * Streaming cannot retry (content already yielded), so "retry" degrades to "warn".
+   * Only "block" action throws; "warn" and "retry" both pass through silently.
+   */
+  function handleStreamFailure(result: GuardrailValidationResult): void {
+    fireViolation(result.failedRule ?? "unknown", "modelOutput", result.errors);
+    const rule = rulesByName.get(result.failedRule ?? "");
+    if (rule?.action === "block") {
+      throw KoiRuntimeError.from(
+        "VALIDATION",
+        `Guardrail "${result.failedRule}" blocked streamed output: ${formatErrors(result.errors)}`,
+        { context: { rule: result.failedRule } },
+      );
+    }
+  }
+
+  /** Inject validation errors into the request for a retry attempt. */
+  function injectRetryContext(
+    request: ModelRequest,
+    previousContent: string,
+    errors: readonly GuardrailError[],
+  ): ModelRequest {
+    const errorMessage = formatErrors(errors);
+    const retryMessage: InboundMessage = {
+      content: [
+        {
+          kind: "text",
+          text: `Your previous response failed validation: ${errorMessage}. Previous response: ${previousContent.slice(0, 500)}. Please fix the errors and respond with valid output.`,
+        },
+      ],
+      senderId: GUARDRAILS_SENDER_ID,
+      timestamp: Date.now(),
+    };
+    return { ...request, messages: [...request.messages, retryMessage] };
+  }
+
+  // Build middleware with conditional hook registration
+  const middleware: KoiMiddleware = {
+    name: "guardrails",
+    priority: 375,
+
+    // Only register wrapModelCall/wrapModelStream if model output rules exist
+    ...(hasModelOutputRules
+      ? {
+          async wrapModelCall(
+            _ctx: TurnContext,
+            request: ModelRequest,
+            next: ModelHandler,
+          ): Promise<ModelResponse> {
+            // let justified: request changes across retry attempts
+            let currentRequest = request;
+
+            for (
+              // let justified: attempt counter increments across retries
+              let attempt = 1;
+              attempt <= maxAttempts;
+              attempt++
+            ) {
+              const response = await next(currentRequest);
+              const result = validateAllModelRules(response.content);
+              if (result.valid) return response;
+
+              const disposition = handleCallFailure(result, attempt);
+              if (disposition === "warn") return response;
+              // disposition === "retry"
+              currentRequest = injectRetryContext(request, response.content, result.errors);
+            }
+
+            // Should not reach here, but satisfy TypeScript
+            throw KoiRuntimeError.from("INTERNAL", "Guardrails retry loop exhausted unexpectedly");
+          },
+
+          async *wrapModelStream(
+            _ctx: TurnContext,
+            request: ModelRequest,
+            next: ModelStreamHandler,
+          ): AsyncIterable<ModelChunk> {
+            // let justified: buffer grows across stream chunks
+            let buffer = "";
+            // let justified: track buffer overflow state
+            let overflowed = false;
+
+            for await (const chunk of next(request)) {
+              switch (chunk.kind) {
+                case "text_delta": {
+                  if (!overflowed) {
+                    if (buffer.length + chunk.delta.length > maxBufferSize) {
+                      overflowed = true;
+                      onViolation?.({
+                        rule: "stream-buffer-overflow",
+                        target: "modelOutput",
+                        action: "warn",
+                        errors: [
+                          {
+                            path: "",
+                            message: `Stream buffer exceeded ${maxBufferSize} characters, skipping validation`,
+                            code: "buffer_overflow",
+                          },
+                        ],
+                      });
+                    } else {
+                      buffer += chunk.delta;
+                    }
+                  }
+                  yield chunk;
+                  break;
+                }
+                case "done": {
+                  if (!overflowed && buffer.length > 0) {
+                    const result = validateAllModelRules(buffer);
+                    buffer = ""; // Release memory before potential throw
+                    if (!result.valid) handleStreamFailure(result);
+                  }
+                  buffer = ""; // Release memory
+                  yield chunk;
+                  break;
+                }
+                default: {
+                  yield chunk;
+                }
+              }
+            }
+          },
+        }
+      : {}),
+
+    // Only register wrapToolCall if tool output rules exist
+    ...(hasToolOutputRules
+      ? {
+          async wrapToolCall(
+            _ctx: TurnContext,
+            request: ToolRequest,
+            next: ToolHandler,
+          ): Promise<ToolResponse> {
+            const response = await next(request);
+
+            const result = validateToolOutput(response.output, toolOutputRules);
+            if (!result.valid) {
+              const action = fireViolation(
+                result.failedRule ?? "unknown",
+                "toolOutput",
+                result.errors,
+              );
+
+              if (action === "warn") return response;
+
+              // block or retry (retry not supported for tool calls — treat as block)
+              throw KoiRuntimeError.from(
+                "VALIDATION",
+                `Guardrail "${result.failedRule}" blocked tool "${request.toolId}" output: ${formatErrors(result.errors)}`,
+                {
+                  context: {
+                    rule: result.failedRule,
+                    toolId: request.toolId,
+                    errors: result.errors,
+                  },
+                },
+              );
+            }
+
+            return response;
+          },
+        }
+      : {}),
+  };
+
+  return middleware;
+}

--- a/packages/middleware-guardrails/src/index.ts
+++ b/packages/middleware-guardrails/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @koi/middleware-guardrails — Output validation middleware (Layer 2)
+ *
+ * Validates agent outputs against Zod schemas before delivery.
+ * Prevents malformed responses, sensitive data leaks, and format violations.
+ * Defense for OWASP LLM02 (Insecure Output Handling).
+ *
+ * Depends on @koi/core, @koi/errors, and zod only.
+ */
+
+export {
+  DEFAULT_MAX_BUFFER_SIZE,
+  DEFAULT_MAX_RETRY_ATTEMPTS,
+  validateGuardrailsConfig,
+} from "./config.js";
+export { createGuardrailsMiddleware } from "./guardrails.js";
+export type {
+  GuardrailAction,
+  GuardrailError,
+  GuardrailParseMode,
+  GuardrailRetryConfig,
+  GuardrailRule,
+  GuardrailsConfig,
+  GuardrailTarget,
+  GuardrailViolationEvent,
+} from "./types.js";
+export type { GuardrailValidationResult } from "./validate-output.js";
+export { validateModelOutput, validateToolOutput } from "./validate-output.js";

--- a/packages/middleware-guardrails/src/types.ts
+++ b/packages/middleware-guardrails/src/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Type definitions for @koi/middleware-guardrails.
+ *
+ * Defines guardrail rules, config, and violation events for
+ * Zod-based output validation of model and tool responses.
+ */
+
+import type { z } from "zod";
+
+/** Target of a guardrail rule — which output to validate. */
+export type GuardrailTarget = "modelOutput" | "toolOutput";
+
+/** Action to take when validation fails. */
+export type GuardrailAction = "block" | "warn" | "retry";
+
+/** How to parse model output content before schema validation. */
+export type GuardrailParseMode = "json" | "text";
+
+/** A single guardrail rule binding a Zod schema to an output target. */
+export interface GuardrailRule {
+  /** Human-readable rule name (unique within a config). */
+  readonly name: string;
+  /** Zod schema to validate the output against. */
+  readonly schema: z.ZodType;
+  /** Which output this rule applies to. */
+  readonly target: GuardrailTarget;
+  /** What to do when the output fails validation. */
+  readonly action: GuardrailAction;
+  /** How to parse model output content (default: "json"). Ignored for toolOutput. */
+  readonly parseMode?: GuardrailParseMode | undefined;
+}
+
+/** Retry configuration for rules with action "retry". */
+export interface GuardrailRetryConfig {
+  /** Maximum number of retry attempts (default: 2). */
+  readonly maxAttempts?: number | undefined;
+}
+
+/** Full middleware configuration. */
+export interface GuardrailsConfig {
+  /** Guardrail rules to enforce. Must be non-empty. */
+  readonly rules: readonly GuardrailRule[];
+  /** Retry settings for rules with action "retry". */
+  readonly retry?: GuardrailRetryConfig | undefined;
+  /** Max characters to buffer for streaming validation (default: 262144). */
+  readonly maxBufferSize?: number | undefined;
+  /** Called whenever a rule violation is detected. */
+  readonly onViolation?: ((event: GuardrailViolationEvent) => void) | undefined;
+}
+
+/** Event fired when a guardrail rule detects a violation. */
+export interface GuardrailViolationEvent {
+  /** Name of the rule that was violated. */
+  readonly rule: string;
+  /** Which output the violation was detected in. */
+  readonly target: GuardrailTarget;
+  /** Action taken (or to be taken) for this violation. */
+  readonly action: GuardrailAction;
+  /** Zod validation errors. */
+  readonly errors: readonly GuardrailError[];
+  /** Current retry attempt (1-indexed), present when action is "retry". */
+  readonly attempt?: number | undefined;
+}
+
+/** A single validation error detail from Zod. */
+export interface GuardrailError {
+  /** Dot-separated path to the failing field (empty string for root). */
+  readonly path: string;
+  /** Human-readable error message. */
+  readonly message: string;
+  /** Zod issue code. */
+  readonly code: string;
+}

--- a/packages/middleware-guardrails/src/validate-output.test.ts
+++ b/packages/middleware-guardrails/src/validate-output.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for output validation logic (JSON/text parsing + Zod schemas).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { GuardrailRule } from "./types.js";
+import { validateModelOutput, validateToolOutput } from "./validate-output.js";
+
+const jsonSchema = z.object({
+  message: z.string(),
+  score: z.number().min(0).max(100),
+});
+
+const textSchema = z.object({
+  text: z.string().min(1),
+});
+
+function makeRule(overrides: Partial<GuardrailRule> & { readonly name: string }): GuardrailRule {
+  return {
+    schema: jsonSchema,
+    target: "modelOutput",
+    action: "block",
+    ...overrides,
+  };
+}
+
+describe("validateModelOutput", () => {
+  describe("JSON mode", () => {
+    const rules = [makeRule({ name: "json-rule" })];
+
+    test("returns valid for conforming JSON", () => {
+      const result = validateModelOutput(
+        JSON.stringify({ message: "hello", score: 42 }),
+        rules,
+        "json",
+      );
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test("returns invalid for non-conforming JSON", () => {
+      const result = validateModelOutput(
+        JSON.stringify({ message: "hello", score: 200 }),
+        rules,
+        "json",
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.failedRule).toBe("json-rule");
+    });
+
+    test("returns invalid for unparseable JSON", () => {
+      const result = validateModelOutput("not json{", rules, "json");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]?.code).toBe("invalid_json");
+      expect(result.failedRule).toBe("json-rule");
+    });
+
+    test("returns invalid for partial JSON", () => {
+      const result = validateModelOutput('{"message": "hello"', rules, "json");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]?.code).toBe("invalid_json");
+    });
+
+    test("truncates long content in JSON parse error message", () => {
+      const longContent = "x".repeat(200);
+      const result = validateModelOutput(longContent, rules, "json");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]?.message.length).toBeLessThan(200);
+    });
+  });
+
+  describe("text mode", () => {
+    const rules = [makeRule({ name: "text-rule", schema: textSchema })];
+
+    test("returns valid for non-empty text", () => {
+      const result = validateModelOutput("hello world", rules, "text");
+      expect(result.valid).toBe(true);
+    });
+
+    test("returns invalid for empty text (schema min 1)", () => {
+      const result = validateModelOutput("", rules, "text");
+      expect(result.valid).toBe(false);
+      expect(result.failedRule).toBe("text-rule");
+    });
+
+    test("wraps text in { text: content } before validation", () => {
+      const schema = z.object({ text: z.string().includes("expected") });
+      const rules = [makeRule({ name: "wrapper-test", schema })];
+      const result = validateModelOutput("expected content", rules, "text");
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("returns valid for empty rules", () => {
+      const result = validateModelOutput("anything", [], "json");
+      expect(result.valid).toBe(true);
+    });
+
+    test("fails fast on first failing rule", () => {
+      const rules = [
+        makeRule({ name: "first", schema: z.object({ a: z.string() }) }),
+        makeRule({ name: "second", schema: z.object({ b: z.string() }) }),
+      ];
+      const result = validateModelOutput(JSON.stringify({ b: "ok" }), rules, "json");
+      expect(result.valid).toBe(false);
+      expect(result.failedRule).toBe("first");
+    });
+
+    test("validates against all rules when earlier pass", () => {
+      const rules = [
+        makeRule({ name: "first", schema: z.object({ a: z.string() }) }),
+        makeRule({ name: "second", schema: z.object({ b: z.number() }) }),
+      ];
+      const result = validateModelOutput(
+        JSON.stringify({ a: "ok", b: "not-a-number" }),
+        rules,
+        "json",
+      );
+      expect(result.valid).toBe(false);
+      expect(result.failedRule).toBe("second");
+    });
+
+    test("defaults parseMode to json", () => {
+      const rules = [makeRule({ name: "default-mode" })];
+      const result = validateModelOutput(JSON.stringify({ message: "hello", score: 50 }), rules);
+      expect(result.valid).toBe(true);
+    });
+  });
+});
+
+describe("validateToolOutput", () => {
+  const schema = z.object({ result: z.string(), count: z.number() });
+  const rules = [makeRule({ name: "tool-rule", schema, target: "toolOutput" })];
+
+  test("returns valid for conforming output", () => {
+    const result = validateToolOutput({ result: "ok", count: 5 }, rules);
+    expect(result.valid).toBe(true);
+  });
+
+  test("returns invalid for non-conforming output", () => {
+    const result = validateToolOutput({ result: 123 }, rules);
+    expect(result.valid).toBe(false);
+    expect(result.failedRule).toBe("tool-rule");
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("returns valid for empty rules", () => {
+    const result = validateToolOutput("anything", []);
+    expect(result.valid).toBe(true);
+  });
+
+  test("validates directly without JSON parsing", () => {
+    const stringSchema = z.string();
+    const rules = [makeRule({ name: "string-rule", schema: stringSchema, target: "toolOutput" })];
+    const result = validateToolOutput("hello", rules);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/middleware-guardrails/src/validate-output.ts
+++ b/packages/middleware-guardrails/src/validate-output.ts
@@ -1,0 +1,88 @@
+/**
+ * Output validation — parse content and apply Zod schemas.
+ *
+ * Pure functions with no side effects. Handles both JSON and text parse modes.
+ */
+
+import type { GuardrailError, GuardrailParseMode, GuardrailRule } from "./types.js";
+
+/** Result of validating output against guardrail rules. */
+export interface GuardrailValidationResult {
+  readonly valid: boolean;
+  readonly errors: readonly GuardrailError[];
+  /** The first failing rule name, if any. */
+  readonly failedRule?: string | undefined;
+}
+
+const EMPTY_RESULT: GuardrailValidationResult = { valid: true, errors: [] } as const;
+
+/**
+ * Validates model output content against guardrail rules.
+ *
+ * JSON mode: parses content as JSON, then applies schema.safeParse.
+ * Text mode: wraps content as `{ text: content }` before schema.safeParse.
+ */
+export function validateModelOutput(
+  content: string,
+  rules: readonly GuardrailRule[],
+  parseMode: GuardrailParseMode = "json",
+): GuardrailValidationResult {
+  if (rules.length === 0) return EMPTY_RESULT;
+
+  // Parse content based on mode
+  // let justified: parsed may be JSON object or text wrapper
+  let parsed: unknown;
+  if (parseMode === "json") {
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return {
+        valid: false,
+        errors: [
+          {
+            path: "",
+            message: `Failed to parse model output as JSON: ${content.slice(0, 100)}`,
+            code: "invalid_json",
+          },
+        ],
+        failedRule: rules[0]?.name,
+      };
+    }
+  } else {
+    parsed = { text: content };
+  }
+
+  return applySchemas(parsed, rules);
+}
+
+/**
+ * Validates tool output against guardrail rules.
+ *
+ * No JSON parsing needed — tool output is already structured data.
+ */
+export function validateToolOutput(
+  output: unknown,
+  rules: readonly GuardrailRule[],
+): GuardrailValidationResult {
+  if (rules.length === 0) return EMPTY_RESULT;
+  return applySchemas(output, rules);
+}
+
+/**
+ * Applies each rule's Zod schema to the parsed value.
+ * Returns on first failure (fail-fast).
+ */
+function applySchemas(value: unknown, rules: readonly GuardrailRule[]): GuardrailValidationResult {
+  for (const rule of rules) {
+    const result = rule.schema.safeParse(value);
+    if (!result.success) {
+      const errors: readonly GuardrailError[] = result.error.issues.map((issue) => ({
+        path: issue.path.map(String).join("."),
+        message: issue.message,
+        code: issue.code,
+      }));
+      return { valid: false, errors, failedRule: rule.name };
+    }
+  }
+  return EMPTY_RESULT;
+}

--- a/packages/middleware-guardrails/tsconfig.json
+++ b/packages/middleware-guardrails/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-guardrails/tsup.config.ts
+++ b/packages/middleware-guardrails/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary
- Add `@koi/middleware-guardrails` — Zod-based output validation middleware for model and tool responses
- Rule-based config with block/warn/retry failure actions, streaming support with bounded buffer, conditional hook registration
- 73 tests, 100% function coverage, 99.43% line coverage, E2E tested through full createKoi + createLoopAdapter runtime with real Anthropic API

## Details
Implements **OWASP LLM02** (Insecure Output Handling) defense:
- **Block**: throws `KoiRuntimeError` with `VALIDATION` code, preventing delivery
- **Warn**: fires `onViolation` callback, passes response through
- **Retry**: re-prompts model with Zod error context, up to configurable max attempts
- Streaming: buffers `text_delta` chunks (bounded, default 256KB), validates on `done`
- Tool output: validates structured data directly with `schema.safeParse()`
- Conditional hook registration: only attaches `wrapModelCall`/`wrapModelStream`/`wrapToolCall` when matching rules exist
- Priority 375: runs after sanitize (350), before memory (400)

## Test plan
- [x] Unit tests: config validation (8), output validation (14), middleware behavior (20+)
- [x] Integration tests: 3 full middleware chain tests with mock handlers
- [x] E2E tests: 4 tests through createKoi + createLoopAdapter + real Anthropic API
- [x] API surface snapshot locked
- [x] Build, typecheck, lint all clean
- [x] 80%+ coverage threshold met (99.43% lines, 100% functions)

Closes #22