### PR TITLE
feat: pluggable KernelExtension for L1 guard/lifecycle/assembly slots

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,6 +138,9 @@
         "@koi/errors": "workspace:*",
         "@koi/hash": "workspace:*",
       },
+      "devDependencies": {
+        "@koi/engine-pi": "workspace:*",
+      },
     },
     "packages/engine-claude": {
       "name": "@koi/engine-claude",

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { BrickRef } from './brick-snapshot.js';
 export { BrickId, BrickSnapshot, BrickSource, SnapshotEvent, SnapshotId, SnapshotQuery, SnapshotStore, brickId, snapshotId } from './brick-snapshot.js';
-import { A as AgentId, P as ProcessState, S as SessionId, T as ToolCallId } from './ecs-d084so0Y.js';
-export { a as Agent, B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as COMPONENT_PRIORITY, z as CREDENTIALS, D as ChildHandle, E as ChildLifecycleEvent, F as ComponentEvent, G as ComponentEventKind, H as ComponentProvider, I as CredentialComponent, J as DELEGATION, K as EVENTS, L as EventComponent, M as FILESYSTEM, N as GOVERNANCE, O as GovernanceComponent, Q as GovernanceUsage, R as MEMORY, U as MemoryComponent, V as MemoryResult, W as ProcessAccounter, X as ProcessId, Y as RunId, Z as SkillMetadata, _ as SpawnCheck, $ as SpawnLedger, a0 as SubsystemToken, a1 as Tool, a2 as ToolDescriptor, a3 as TrustTier, a4 as TurnId, a5 as agentId, a6 as channelToken, a7 as engineToken, a8 as middlewareToken, a9 as providerToken, aa as resolverToken, ab as runId, ac as sessionId, ad as skillToken, ae as token, af as toolCallId, ag as toolToken, ah as turnId } from './ecs-d084so0Y.js';
+import { A as AgentId, P as ProcessState, a as Agent, S as SessionId, T as ToolCallId } from './ecs-d084so0Y.js';
+export { B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTypeOptions, x as BrowserWaitOptions, y as BrowserWaitUntil, C as COMPONENT_PRIORITY, z as CREDENTIALS, D as ChildHandle, E as ChildLifecycleEvent, F as ComponentEvent, G as ComponentEventKind, H as ComponentProvider, I as CredentialComponent, J as DELEGATION, K as EVENTS, L as EventComponent, M as FILESYSTEM, N as GOVERNANCE, O as GovernanceComponent, Q as GovernanceUsage, R as MEMORY, U as MemoryComponent, V as MemoryResult, W as ProcessAccounter, X as ProcessId, Y as RunId, Z as SkillMetadata, _ as SpawnCheck, $ as SpawnLedger, a0 as SubsystemToken, a1 as Tool, a2 as ToolDescriptor, a3 as TrustTier, a4 as TurnId, a5 as agentId, a6 as channelToken, a7 as engineToken, a8 as middlewareToken, a9 as providerToken, aa as resolverToken, ab as runId, ac as sessionId, ad as skillToken, ae as token, af as toolCallId, ag as toolToken, ah as turnId } from './ecs-d084so0Y.js';
 import { E as EngineState, a as EngineInput } from './engine-DoGrEOa4.js';
 export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-DoGrEOa4.js';
 import { Result, KoiError } from './errors.js';
@@ -21,9 +21,10 @@ export { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult } fro
 export { FileEdit, FileEditOptions, FileEditResult, FileEntryKind, FileListEntry, FileListOptions, FileListResult, FileReadOptions, FileReadResult, FileSearchMatch, FileSearchOptions, FileSearchResult, FileSystemBackend, FileWriteOptions, FileWriteResult } from './filesystem-backend.js';
 export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-CDaWduep.js';
 export { DEFAULT_HEALTH_MONITOR_CONFIG, HealthMonitor, HealthMonitorConfig, HealthMonitorStats, HealthSnapshot, HealthStatus } from './health.js';
+import { KoiMiddleware } from './middleware.js';
+export { ApprovalDecision, ApprovalHandler, ApprovalRequest, ModelChunk, ModelHandler, ModelRequest, ModelResponse, ModelStreamHandler, SessionContext, ToolHandler, ToolRequest, ToolResponse, TurnContext } from './middleware.js';
 export { AgentCondition, AgentRegistry, AgentStatus, RegistryEntry, RegistryEvent, RegistryFilter, TransitionReason, VALID_TRANSITIONS } from './lifecycle.js';
 export { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, InboundMessage, OutboundMessage, TextBlock } from './message.js';
-export { ApprovalDecision, ApprovalHandler, ApprovalRequest, KoiMiddleware, ModelChunk, ModelHandler, ModelRequest, ModelResponse, ModelStreamHandler, SessionContext, ToolHandler, ToolRequest, ToolResponse, TurnContext } from './middleware.js';
 export { ModelCapabilities, ModelProvider, ModelTarget } from './model-provider.js';
 export { Resolver, SourceBundle, SourceLanguage } from './resolver.js';
 export { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxInstance } from './sandbox-adapter.js';
@@ -241,6 +242,104 @@ declare function permission(message: string): KoiError;
  * @param hint - Optional actionable hint for the caller (e.g., "call browser_snapshot").
  */
 declare function staleRef(refId: string, hint?: string): KoiError;
+
+/**
+ * Kernel extension contract — pluggable L1 guard/lifecycle/assembly slots.
+ *
+ * Extensions allow composable, replaceable kernel behaviors without forking
+ * createKoi(). Guard slots produce KoiMiddleware (sole interposition layer),
+ * lifecycle validators gate state transitions, and assembly validators
+ * verify component correctness before an agent starts.
+ *
+ * Exception: EXTENSION_PRIORITY constant is permitted in L0 as a pure
+ * readonly data constant derived from L0 type definitions with zero logic.
+ */
+
+/**
+ * Priority tiers for KernelExtension ordering.
+ * Lower number = higher precedence (runs first / takes priority).
+ * Order: Core > Platform > User > Addon.
+ */
+declare const EXTENSION_PRIORITY: Readonly<{
+    readonly CORE: 0;
+    readonly PLATFORM: 10;
+    readonly USER: 50;
+    readonly ADDON: 100;
+}>;
+/**
+ * Context provided to a KernelExtension's guard slot at assembly time.
+ * Guards use this to produce middleware tailored to the current agent.
+ */
+interface GuardContext {
+    /** Depth of the agent in the process tree (0 = root). */
+    readonly agentDepth: number;
+    /** The agent's manifest. */
+    readonly manifest: AgentManifest;
+    /** All attached components as a readonly map. */
+    readonly components: ReadonlyMap<string, unknown>;
+    /** The assembled agent entity (for GovernanceComponent lookup, etc.). */
+    readonly agent?: Agent;
+}
+/**
+ * Context for lifecycle transition validation.
+ * Validators receive the current and target states.
+ */
+interface TransitionContext {
+    /** Current process state before the transition. */
+    readonly from: ProcessState;
+    /** Target process state after the transition. */
+    readonly to: ProcessState;
+}
+/** A single diagnostic produced by assembly validation. */
+interface ValidationDiagnostic {
+    /** Name of the extension or validator that produced this diagnostic. */
+    readonly source: string;
+    /** Human-readable description of the issue. */
+    readonly message: string;
+    /** Severity: "error" blocks agent creation, "warning" is advisory. */
+    readonly severity: "error" | "warning";
+}
+/** Result of assembly validation — discriminated union. */
+type ValidationResult = {
+    readonly ok: true;
+} | {
+    readonly ok: false;
+    readonly diagnostics: readonly ValidationDiagnostic[];
+};
+/**
+ * A composable kernel extension that plugs into L1 guard, lifecycle,
+ * and assembly validation slots.
+ *
+ * All slots are optional — an extension can provide any combination.
+ * Extensions are sorted by priority (ascending) before composition.
+ */
+interface KernelExtension {
+    /** Unique name for this extension (e.g., "koi:default-guards"). */
+    readonly name: string;
+    /**
+     * Extension priority. Lower = higher precedence.
+     * Defaults to EXTENSION_PRIORITY.USER (50) if omitted.
+     */
+    readonly priority?: number;
+    /**
+     * Guard slot — produces KoiMiddleware for the agent session.
+     * Called once at assembly time. The returned middleware array is
+     * composed into the agent's middleware chain.
+     */
+    readonly guards?: (ctx: GuardContext) => readonly KoiMiddleware[] | Promise<readonly KoiMiddleware[]>;
+    /**
+     * Lifecycle transition validator — sync only for hot-path performance.
+     * Returns true to allow the transition, false to block it.
+     * Only called for significant transitions (not wait/resume hot path).
+     */
+    readonly validateTransition?: (ctx: TransitionContext) => boolean;
+    /**
+     * Assembly validator — checks component/manifest correctness before
+     * the agent starts running. Can be async for I/O-backed validation.
+     * Return { ok: true } to pass, or { ok: false, diagnostics } to report issues.
+     */
+    readonly validateAssembly?: (components: ReadonlyMap<string, unknown>, manifest: AgentManifest) => ValidationResult | Promise<ValidationResult>;
+}
 
 /**
  * Scheduler contract — pluggable task scheduling, priority queue, cron,
@@ -655,7 +754,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { AgentId, AgentManifest, type AgentSnapshot, type AgentSnapshotStore, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickRef, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_SCHEDULER_CONFIG, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, JsonObject, KoiError, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type RecoveryPlan, type RedactionRule, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskFilter, type TaskId, type TaskOptions, type TaskScheduler, type TaskStatus, type TaskStore, ToolCallId, type TraceEvent, type TraceEventKind, type TurnTrace, chainId, conflict, external, internal, isProcessState, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, timeout, validateNonEmpty, validation };
+export { Agent, AgentId, AgentManifest, type AgentSnapshot, type AgentSnapshotStore, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickRef, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_SCHEDULER_CONFIG, EXTENSION_PRIORITY, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GuardContext, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type RecoveryPlan, type RedactionRule, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskFilter, type TaskId, type TaskOptions, type TaskScheduler, type TaskStatus, type TaskStore, ToolCallId, type TraceEvent, type TraceEventKind, type TransitionContext, type TurnTrace, type ValidationDiagnostic, type ValidationResult, chainId, conflict, external, internal, isProcessState, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, timeout, validateNonEmpty, validation };
 "
 `;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -261,6 +261,15 @@ export type {
 } from "./health.js";
 // health — runtime values
 export { DEFAULT_HEALTH_MONITOR_CONFIG } from "./health.js";
+// kernel extension — pluggable L1 guard/lifecycle/assembly slots
+export type {
+  GuardContext,
+  KernelExtension,
+  TransitionContext,
+  ValidationDiagnostic,
+  ValidationResult,
+} from "./kernel-extension.js";
+export { EXTENSION_PRIORITY } from "./kernel-extension.js";
 // lifecycle
 export type {
   AgentCondition,

--- a/packages/core/src/kernel-extension.test.ts
+++ b/packages/core/src/kernel-extension.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { EXTENSION_PRIORITY } from "./kernel-extension.js";
+
+describe("EXTENSION_PRIORITY", () => {
+  test("has correct values", () => {
+    expect(EXTENSION_PRIORITY.CORE).toBe(0);
+    expect(EXTENSION_PRIORITY.PLATFORM).toBe(10);
+    expect(EXTENSION_PRIORITY.USER).toBe(50);
+    expect(EXTENSION_PRIORITY.ADDON).toBe(100);
+  });
+
+  test("is frozen", () => {
+    expect(Object.isFrozen(EXTENSION_PRIORITY)).toBe(true);
+  });
+});

--- a/packages/core/src/kernel-extension.ts
+++ b/packages/core/src/kernel-extension.ts
@@ -1,0 +1,137 @@
+/**
+ * Kernel extension contract — pluggable L1 guard/lifecycle/assembly slots.
+ *
+ * Extensions allow composable, replaceable kernel behaviors without forking
+ * createKoi(). Guard slots produce KoiMiddleware (sole interposition layer),
+ * lifecycle validators gate state transitions, and assembly validators
+ * verify component correctness before an agent starts.
+ *
+ * Exception: EXTENSION_PRIORITY constant is permitted in L0 as a pure
+ * readonly data constant derived from L0 type definitions with zero logic.
+ */
+
+import type { AgentManifest } from "./assembly.js";
+import type { Agent, ProcessState } from "./ecs.js";
+import type { KoiMiddleware } from "./middleware.js";
+
+// ---------------------------------------------------------------------------
+// Extension priority tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Priority tiers for KernelExtension ordering.
+ * Lower number = higher precedence (runs first / takes priority).
+ * Order: Core > Platform > User > Addon.
+ */
+export const EXTENSION_PRIORITY: Readonly<{
+  readonly CORE: 0;
+  readonly PLATFORM: 10;
+  readonly USER: 50;
+  readonly ADDON: 100;
+}> = Object.freeze({
+  CORE: 0,
+  PLATFORM: 10,
+  USER: 50,
+  ADDON: 100,
+} as const);
+
+// ---------------------------------------------------------------------------
+// Guard context
+// ---------------------------------------------------------------------------
+
+/**
+ * Context provided to a KernelExtension's guard slot at assembly time.
+ * Guards use this to produce middleware tailored to the current agent.
+ */
+export interface GuardContext {
+  /** Depth of the agent in the process tree (0 = root). */
+  readonly agentDepth: number;
+  /** The agent's manifest. */
+  readonly manifest: AgentManifest;
+  /** All attached components as a readonly map. */
+  readonly components: ReadonlyMap<string, unknown>;
+  /** The assembled agent entity (for GovernanceComponent lookup, etc.). */
+  readonly agent?: Agent;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle transition context
+// ---------------------------------------------------------------------------
+
+/**
+ * Context for lifecycle transition validation.
+ * Validators receive the current and target states.
+ */
+export interface TransitionContext {
+  /** Current process state before the transition. */
+  readonly from: ProcessState;
+  /** Target process state after the transition. */
+  readonly to: ProcessState;
+}
+
+// ---------------------------------------------------------------------------
+// Assembly validation
+// ---------------------------------------------------------------------------
+
+/** A single diagnostic produced by assembly validation. */
+export interface ValidationDiagnostic {
+  /** Name of the extension or validator that produced this diagnostic. */
+  readonly source: string;
+  /** Human-readable description of the issue. */
+  readonly message: string;
+  /** Severity: "error" blocks agent creation, "warning" is advisory. */
+  readonly severity: "error" | "warning";
+}
+
+/** Result of assembly validation — discriminated union. */
+export type ValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly diagnostics: readonly ValidationDiagnostic[] };
+
+// ---------------------------------------------------------------------------
+// KernelExtension interface
+// ---------------------------------------------------------------------------
+
+/**
+ * A composable kernel extension that plugs into L1 guard, lifecycle,
+ * and assembly validation slots.
+ *
+ * All slots are optional — an extension can provide any combination.
+ * Extensions are sorted by priority (ascending) before composition.
+ */
+export interface KernelExtension {
+  /** Unique name for this extension (e.g., "koi:default-guards"). */
+  readonly name: string;
+
+  /**
+   * Extension priority. Lower = higher precedence.
+   * Defaults to EXTENSION_PRIORITY.USER (50) if omitted.
+   */
+  readonly priority?: number;
+
+  /**
+   * Guard slot — produces KoiMiddleware for the agent session.
+   * Called once at assembly time. The returned middleware array is
+   * composed into the agent's middleware chain.
+   */
+  readonly guards?: (
+    ctx: GuardContext,
+  ) => readonly KoiMiddleware[] | Promise<readonly KoiMiddleware[]>;
+
+  /**
+   * Lifecycle transition validator — sync only for hot-path performance.
+   * Returns true to allow the transition, false to block it.
+   * Only called for significant transitions (not wait/resume hot path).
+   */
+  readonly validateTransition?: (ctx: TransitionContext) => boolean;
+
+  /**
+   * Assembly validator — checks component/manifest correctness before
+   * the agent starts running. Can be async for I/O-backed validation.
+   * Return { ok: true } to pass, or { ok: false, diagnostics } to report issues.
+   */
+  readonly validateAssembly?: (
+    components: ReadonlyMap<string, unknown>,
+    manifest: AgentManifest,
+  ) => ValidationResult | Promise<ValidationResult>;
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -14,6 +14,9 @@
     "@koi/errors": "workspace:*",
     "@koi/hash": "workspace:*"
   },
+  "devDependencies": {
+    "@koi/engine-pi": "workspace:*"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/packages/engine/src/__tests__/extension.e2e.test.ts
+++ b/packages/engine/src/__tests__/extension.e2e.test.ts
@@ -1,0 +1,349 @@
+/**
+ * E2E tests for KernelExtension through the full createKoi() + Pi adapter path.
+ *
+ * Validates that the extension pipeline works end-to-end with real LLM calls:
+ *   - Custom KernelExtension guards fire during a real agent run
+ *   - Extension priority ordering is honored
+ *   - Assembly validators run before the agent starts
+ *   - Lifecycle validators gate state transitions
+ *   - Default guards (iteration, spawn) compose with custom extensions
+ *   - Middleware chain executes in correct order
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/extension.e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  EngineEvent,
+  EngineOutput,
+  KernelExtension,
+  KoiMiddleware,
+} from "@koi/core";
+import { EXTENSION_PRIORITY } from "@koi/core";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createKoi } from "../koi.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+
+// Use haiku for speed + cost
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const E2E_MANIFEST: AgentManifest = {
+  name: "extension-e2e-agent",
+  version: "1.0.0",
+  model: { name: "claude-haiku" },
+};
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: KernelExtension through createKoi + Pi adapter", () => {
+  test(
+    "custom extension guard fires during real LLM call",
+    async () => {
+      const guardLog: string[] = [];
+
+      const loggingExtension: KernelExtension = {
+        name: "e2e:logging-guard",
+        priority: EXTENSION_PRIORITY.USER,
+        guards: () => [
+          {
+            name: "e2e:before-turn-logger",
+            priority: 900,
+            onBeforeTurn: async () => {
+              guardLog.push("before-turn");
+            },
+            onAfterTurn: async () => {
+              guardLog.push("after-turn");
+            },
+          },
+        ],
+      };
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant. Reply briefly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: piAdapter,
+        extensions: [loggingExtension],
+        loopDetection: false,
+        limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly one word: pong" }),
+      );
+
+      // Verify real LLM output
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+      expect(output?.metrics.totalTokens).toBeGreaterThan(0);
+
+      const text = extractText(events);
+      expect(text.toLowerCase()).toContain("pong");
+
+      // Verify custom guard fired
+      expect(guardLog).toContain("before-turn");
+      expect(guardLog).toContain("after-turn");
+
+      // Verify lifecycle reached terminated
+      expect(runtime.agent.state).toBe("terminated");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "multiple extensions compose correctly with real LLM",
+    async () => {
+      const order: string[] = [];
+
+      const platformExtension: KernelExtension = {
+        name: "e2e:platform-ext",
+        priority: EXTENSION_PRIORITY.PLATFORM,
+        guards: () => [
+          {
+            name: "e2e:platform-logger",
+            priority: 5,
+            onBeforeTurn: async () => {
+              order.push("platform");
+            },
+          },
+        ],
+      };
+
+      const userExtension: KernelExtension = {
+        name: "e2e:user-ext",
+        priority: EXTENSION_PRIORITY.USER,
+        guards: () => [
+          {
+            name: "e2e:user-logger",
+            priority: 6,
+            onBeforeTurn: async () => {
+              order.push("user");
+            },
+          },
+        ],
+      };
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: piAdapter,
+        extensions: [userExtension, platformExtension],
+        loopDetection: false,
+        limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+      });
+
+      await collectEvents(runtime.run({ kind: "text", text: "Reply with exactly: ok" }));
+
+      // Both guards should have fired
+      expect(order).toContain("platform");
+      expect(order).toContain("user");
+
+      // Platform (priority 5) runs before user (priority 6)
+      expect(order.indexOf("platform")).toBeLessThan(order.indexOf("user"));
+
+      expect(runtime.agent.state).toBe("terminated");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "assembly validator runs before real LLM call",
+    async () => {
+      // let justified: tracks whether assembly validator was called
+      let assemblyCalled = false;
+
+      const validatingExtension: KernelExtension = {
+        name: "e2e:assembly-validator",
+        priority: EXTENSION_PRIORITY.ADDON,
+        validateAssembly: () => {
+          assemblyCalled = true;
+          return { ok: true };
+        },
+      };
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: piAdapter,
+        extensions: [validatingExtension],
+        loopDetection: false,
+        limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+      });
+
+      // Assembly validator runs during createKoi, before any LLM call
+      expect(assemblyCalled).toBe(true);
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Reply: validated" }));
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(runtime.agent.state).toBe("terminated");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "default guards compose with custom extensions through real LLM",
+    async () => {
+      // let justified: tracks session hooks from custom middleware
+      let sessionStarted = false;
+      // let justified: tracks session hooks from custom middleware
+      let sessionEnded = false;
+
+      const customMiddleware: KoiMiddleware = {
+        name: "e2e:session-tracker",
+        priority: 500,
+        onSessionStart: async () => {
+          sessionStarted = true;
+        },
+        onSessionEnd: async () => {
+          sessionEnded = true;
+        },
+      };
+
+      // Extension that adds an additional guard alongside the default guards
+      const extraGuardExtension: KernelExtension = {
+        name: "e2e:extra-guard",
+        priority: EXTENSION_PRIORITY.USER,
+        guards: () => [
+          {
+            name: "e2e:noop-guard",
+            priority: 999,
+            onBeforeTurn: async () => {
+              // no-op — just verifies it participates in the chain
+            },
+          },
+        ],
+      };
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: piAdapter,
+        middleware: [customMiddleware],
+        extensions: [extraGuardExtension],
+        loopDetection: false,
+        limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with: composed" }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.metrics.totalTokens).toBeGreaterThan(0);
+
+      // Session hooks from user middleware should have fired
+      expect(sessionStarted).toBe(true);
+      expect(sessionEnded).toBe(true);
+
+      expect(runtime.agent.state).toBe("terminated");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "lifecycle validator allows normal transitions with real LLM",
+    async () => {
+      const transitions: string[] = [];
+
+      const lifecycleExtension: KernelExtension = {
+        name: "e2e:lifecycle-observer",
+        priority: EXTENSION_PRIORITY.USER,
+        validateTransition: (ctx) => {
+          transitions.push(`${ctx.from}→${ctx.to}`);
+          return true; // Allow all transitions
+        },
+      };
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: piAdapter,
+        extensions: [lifecycleExtension],
+        loopDetection: false,
+        limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+      });
+
+      await collectEvents(runtime.run({ kind: "text", text: "Reply with: lifecycle" }));
+
+      // Significant transitions should have been observed
+      // At minimum: created→running and running→terminated
+      expect(transitions).toContain("created→running");
+
+      // running→waiting and waiting→running are hot-path, should NOT appear
+      expect(transitions).not.toContain("running→waiting");
+      expect(transitions).not.toContain("waiting→running");
+
+      expect(runtime.agent.state).toBe("terminated");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/engine/src/__tests__/extension.integration.test.ts
+++ b/packages/engine/src/__tests__/extension.integration.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Integration tests for the KernelExtension pipeline.
+ *
+ * These tests verify the full extension lifecycle through createKoi(),
+ * including guard composition, assembly validation, lifecycle validation,
+ * and backward compatibility with sugar config fields.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  EngineAdapter,
+  EngineEvent,
+  EngineOutput,
+  KernelExtension,
+  KoiMiddleware,
+  ValidationResult,
+} from "@koi/core";
+import { EXTENSION_PRIORITY } from "@koi/core";
+import { KoiRuntimeError } from "@koi/errors";
+import { createKoi } from "../koi.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function testManifest(): AgentManifest {
+  return {
+    name: "Extension Test Agent",
+    version: "0.1.0",
+    model: { name: "test-model" },
+  };
+}
+
+function doneOutput(overrides?: Partial<EngineOutput>): EngineOutput {
+  return {
+    content: [{ kind: "text", text: "done" }],
+    stopReason: "completed",
+    metrics: {
+      totalTokens: 100,
+      inputTokens: 60,
+      outputTokens: 40,
+      turns: 1,
+      durationMs: 100,
+    },
+    ...overrides,
+  };
+}
+
+function mockAdapter(events: readonly EngineEvent[]): EngineAdapter {
+  return {
+    engineId: "mock-adapter",
+    stream: () => {
+      // let justified: mutable index for iterator position
+      let index = 0;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<EngineEvent>> {
+              const event = events[index];
+              if (event === undefined) {
+                return { done: true, value: undefined };
+              }
+              index++;
+              return { done: false, value: event };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+async function collectEvents(iter: AsyncIterable<EngineEvent>): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iter) {
+    events.push(event);
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Default guards via extension
+// ---------------------------------------------------------------------------
+
+describe("default guards via extension", () => {
+  test("createKoi with no extensions still creates guards", async () => {
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({ manifest: testManifest(), adapter });
+    const events = await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+
+    // Should complete normally (guards active but not triggered)
+    const doneEvent = events.find((e) => e.kind === "done");
+    expect(doneEvent).toBeDefined();
+    expect(runtime.agent.state).toBe("terminated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Custom extension with guard
+// ---------------------------------------------------------------------------
+
+describe("custom extension with guard", () => {
+  test("extension adds extra middleware", async () => {
+    const callLog: string[] = [];
+
+    const customExtension: KernelExtension = {
+      name: "test:custom-guard",
+      priority: EXTENSION_PRIORITY.USER,
+      guards: () => {
+        const mw: KoiMiddleware = {
+          name: "test:logger",
+          priority: 999,
+          onBeforeTurn: async () => {
+            callLog.push("custom-before-turn");
+          },
+        };
+        return [mw];
+      },
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [customExtension],
+    });
+
+    await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+
+    expect(callLog).toContain("custom-before-turn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Extension priority ordering
+// ---------------------------------------------------------------------------
+
+describe("extension priority ordering", () => {
+  test("lower priority extension guard runs outer", async () => {
+    const order: string[] = [];
+
+    const lowPriority: KernelExtension = {
+      name: "test:low",
+      priority: EXTENSION_PRIORITY.PLATFORM,
+      guards: () => [
+        {
+          name: "low-mw",
+          priority: 5,
+          onBeforeTurn: async () => {
+            order.push("low");
+          },
+        },
+      ],
+    };
+
+    const highPriority: KernelExtension = {
+      name: "test:high",
+      priority: EXTENSION_PRIORITY.ADDON,
+      guards: () => [
+        {
+          name: "high-mw",
+          priority: 6,
+          onBeforeTurn: async () => {
+            order.push("high");
+          },
+        },
+      ],
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [highPriority, lowPriority],
+    });
+
+    await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+
+    // Both should have been called (onBeforeTurn runs for all middleware)
+    expect(order).toContain("low");
+    expect(order).toContain("high");
+    // Low priority middleware (priority 5) runs before high (priority 6)
+    expect(order.indexOf("low")).toBeLessThan(order.indexOf("high"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Assembly validator blocks creation
+// ---------------------------------------------------------------------------
+
+describe("assembly validator blocks creation", () => {
+  test("validator returns error → createKoi throws", async () => {
+    const blockingExtension: KernelExtension = {
+      name: "test:blocker",
+      validateAssembly: (): ValidationResult => ({
+        ok: false,
+        diagnostics: [
+          { source: "test:blocker", message: "Missing required tool", severity: "error" },
+        ],
+      }),
+    };
+
+    const adapter = mockAdapter([]);
+
+    try {
+      await createKoi({
+        manifest: testManifest(),
+        adapter,
+        extensions: [blockingExtension],
+      });
+      // Should not reach here
+      expect(true).toBe(false);
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiRuntimeError);
+      if (e instanceof KoiRuntimeError) {
+        expect(e.code).toBe("VALIDATION");
+        expect(e.message).toContain("Assembly validation failed");
+        expect(e.message).toContain("Missing required tool");
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Assembly validator warning passes
+// ---------------------------------------------------------------------------
+
+describe("assembly validator warning passes", () => {
+  test("warning-only diagnostics do not block creation", async () => {
+    const warningExtension: KernelExtension = {
+      name: "test:warner",
+      validateAssembly: (): ValidationResult => ({
+        ok: false,
+        diagnostics: [{ source: "test:warner", message: "Deprecated config", severity: "warning" }],
+      }),
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    // Should succeed — warnings don't block
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [warningExtension],
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+    const doneEvent = events.find((e) => e.kind === "done");
+    expect(doneEvent).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Lifecycle validator blocks transition
+// ---------------------------------------------------------------------------
+
+describe("lifecycle validator blocks transition", () => {
+  test("validator rejects created→running → state stays created", async () => {
+    const blockTransitions: KernelExtension = {
+      name: "test:lifecycle-blocker",
+      validateTransition: (ctx) => {
+        // Block created→running
+        if (ctx.from === "created" && ctx.to === "running") {
+          return false;
+        }
+        return true;
+      },
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [blockTransitions],
+    });
+
+    // The agent will try to start running but the validator blocks it
+    // State should stay "created" since the transition was rejected
+    await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+    expect(runtime.agent.state).toBe("created");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Hot path skip
+// ---------------------------------------------------------------------------
+
+describe("hot path skip", () => {
+  test("running→waiting does not call validator", async () => {
+    let validatorCallCount = 0;
+    const trackingExtension: KernelExtension = {
+      name: "test:tracker",
+      validateTransition: (ctx) => {
+        validatorCallCount++;
+        // Throw if called with hot-path transition — should never happen
+        if (
+          (ctx.from === "running" && ctx.to === "waiting") ||
+          (ctx.from === "waiting" && ctx.to === "running")
+        ) {
+          throw new Error("Should not be called for hot-path transitions");
+        }
+        return true;
+      },
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [trackingExtension],
+    });
+
+    // Should run without the throw being triggered
+    await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+
+    // Validator was called for significant transitions only
+    // (created→running, running→terminated)
+    expect(validatorCallCount).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Multiple extensions compose
+// ---------------------------------------------------------------------------
+
+describe("multiple extensions compose", () => {
+  test("three extensions with different slots compose correctly", async () => {
+    const guardCalled: string[] = [];
+
+    const guardExtension: KernelExtension = {
+      name: "test:guard-ext",
+      priority: EXTENSION_PRIORITY.PLATFORM,
+      guards: () => [
+        {
+          name: "test:extra-guard",
+          priority: 998,
+          onBeforeTurn: async () => {
+            guardCalled.push("guard-ext");
+          },
+        },
+      ],
+    };
+
+    const lifecycleExtension: KernelExtension = {
+      name: "test:lifecycle-ext",
+      priority: EXTENSION_PRIORITY.USER,
+      validateTransition: () => true, // Allow all
+    };
+
+    const assemblyExtension: KernelExtension = {
+      name: "test:assembly-ext",
+      priority: EXTENSION_PRIORITY.ADDON,
+      validateAssembly: () => ({ ok: true }),
+    };
+
+    const adapter = mockAdapter([
+      { kind: "text_delta", delta: "hello" },
+      { kind: "done", output: doneOutput() },
+    ]);
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      extensions: [guardExtension, lifecycleExtension, assemblyExtension],
+    });
+
+    await collectEvents(runtime.run({ kind: "messages", messages: [] }));
+
+    expect(guardCalled).toContain("guard-ext");
+    expect(runtime.agent.state).toBe("terminated");
+  });
+});

--- a/packages/engine/src/agent-entity.test.ts
+++ b/packages/engine/src/agent-entity.test.ts
@@ -388,4 +388,40 @@ describe("lifecycle transitions", () => {
     agent.transition({ kind: "start" });
     expect(agent.lifecycle.state).toBe("running");
   });
+
+  test("validator blocks transition — state unchanged", () => {
+    const agent = new AgentEntity(testPid(), testManifest());
+    agent.setTransitionValidator(() => false);
+    agent.transition({ kind: "start" });
+    expect(agent.state).toBe("created"); // Blocked
+  });
+
+  test("validator allows transition — state changes normally", () => {
+    const agent = new AgentEntity(testPid(), testManifest());
+    agent.setTransitionValidator(() => true);
+    agent.transition({ kind: "start" });
+    expect(agent.state).toBe("running");
+  });
+
+  test("no state change (no-op event) — validator not called", () => {
+    const agent = new AgentEntity(testPid(), testManifest());
+    let called = false;
+    agent.setTransitionValidator(() => {
+      called = true;
+      return false;
+    });
+    // "resume" from "created" is a no-op (state doesn't change)
+    agent.transition({ kind: "resume" });
+    expect(called).toBe(false);
+    expect(agent.state).toBe("created");
+  });
+
+  test("no validator set — transitions work as before", () => {
+    const agent = new AgentEntity(testPid(), testManifest());
+    // No setTransitionValidator called
+    agent.transition({ kind: "start" });
+    expect(agent.state).toBe("running");
+    agent.transition({ kind: "complete", stopReason: "completed" });
+    expect(agent.state).toBe("terminated");
+  });
 });

--- a/packages/engine/src/agent-entity.ts
+++ b/packages/engine/src/agent-entity.ts
@@ -14,6 +14,7 @@ import type {
   SubsystemToken,
 } from "@koi/core";
 import { COMPONENT_PRIORITY } from "@koi/core";
+import type { TransitionValidator } from "./extension-composer.js";
 import type { AgentLifecycle, LifecycleEvent } from "./lifecycle.js";
 import { createLifecycle, transition } from "./lifecycle.js";
 
@@ -38,6 +39,7 @@ export class AgentEntity implements Agent {
 
   private _lifecycle: AgentLifecycle;
   private _components: ReadonlyMap<string, unknown> = new Map();
+  private _transitionValidator: TransitionValidator | undefined;
   /**
    * Prefix query cache. Safe because components are immutable after assembly.
    * If runtime component modification is added (e.g., Forge), this cache
@@ -99,9 +101,25 @@ export class AgentEntity implements Agent {
     return this._lifecycle;
   }
 
+  /** @internal — Set a validator that gates lifecycle transitions. */
+  setTransitionValidator(validator: TransitionValidator): void {
+    this._transitionValidator = validator;
+  }
+
   /** @internal */
   transition(event: LifecycleEvent): void {
-    this._lifecycle = transition(this._lifecycle, event);
+    const next = transition(this._lifecycle, event);
+
+    // If state actually changed and a validator is set, check permission
+    if (
+      next.state !== this._lifecycle.state &&
+      this._transitionValidator !== undefined &&
+      !this._transitionValidator(this._lifecycle.state, next.state)
+    ) {
+      return; // Validator blocked the transition — state unchanged
+    }
+
+    this._lifecycle = next;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/engine/src/extension-composer.test.ts
+++ b/packages/engine/src/extension-composer.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  GuardContext,
+  KernelExtension,
+  KoiMiddleware,
+  ValidationDiagnostic,
+} from "@koi/core";
+import { EXTENSION_PRIORITY } from "@koi/core";
+import {
+  composeExtensions,
+  createDefaultGuardExtension,
+  isSignificantTransition,
+} from "./extension-composer.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function testGuardCtx(overrides?: Partial<GuardContext>): GuardContext {
+  return {
+    agentDepth: 0,
+    manifest: { name: "test", version: "0.1.0", model: { name: "test-model" } },
+    components: new Map(),
+    ...overrides,
+  };
+}
+
+function testManifest(overrides?: Partial<AgentManifest>): AgentManifest {
+  return {
+    name: "Test Agent",
+    version: "0.1.0",
+    model: { name: "test-model" },
+    ...overrides,
+  };
+}
+
+function stubMiddleware(name: string, priority?: number): KoiMiddleware {
+  return { name, ...(priority !== undefined ? { priority } : {}) };
+}
+
+// ---------------------------------------------------------------------------
+// isSignificantTransition
+// ---------------------------------------------------------------------------
+
+describe("isSignificantTransition", () => {
+  test("significant transitions return true", () => {
+    expect(isSignificantTransition("created", "running")).toBe(true);
+    expect(isSignificantTransition("created", "terminated")).toBe(true);
+    expect(isSignificantTransition("running", "suspended")).toBe(true);
+    expect(isSignificantTransition("running", "terminated")).toBe(true);
+    expect(isSignificantTransition("waiting", "suspended")).toBe(true);
+    expect(isSignificantTransition("waiting", "terminated")).toBe(true);
+    expect(isSignificantTransition("suspended", "running")).toBe(true);
+    expect(isSignificantTransition("suspended", "terminated")).toBe(true);
+  });
+
+  test("hot-path transitions return false", () => {
+    expect(isSignificantTransition("running", "waiting")).toBe(false);
+    expect(isSignificantTransition("waiting", "running")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeExtensions — sorting
+// ---------------------------------------------------------------------------
+
+describe("composeExtensions sorting", () => {
+  test("sorts extensions by priority ascending", async () => {
+    const order: string[] = [];
+    const ext1: KernelExtension = {
+      name: "addon",
+      priority: EXTENSION_PRIORITY.ADDON,
+      guards: () => {
+        order.push("addon");
+        return [stubMiddleware("addon-mw")];
+      },
+    };
+    const ext2: KernelExtension = {
+      name: "core",
+      priority: EXTENSION_PRIORITY.CORE,
+      guards: () => {
+        order.push("core");
+        return [stubMiddleware("core-mw")];
+      },
+    };
+
+    await composeExtensions([ext1, ext2], testGuardCtx());
+
+    expect(order).toEqual(["core", "addon"]);
+  });
+
+  test("uses default USER priority when omitted", async () => {
+    const order: string[] = [];
+    const ext1: KernelExtension = {
+      name: "no-priority",
+      guards: () => {
+        order.push("no-priority");
+        return [stubMiddleware("np-mw")];
+      },
+    };
+    const ext2: KernelExtension = {
+      name: "platform",
+      priority: EXTENSION_PRIORITY.PLATFORM,
+      guards: () => {
+        order.push("platform");
+        return [stubMiddleware("plat-mw")];
+      },
+    };
+
+    await composeExtensions([ext1, ext2], testGuardCtx());
+
+    // Platform (10) < default USER (50)
+    expect(order).toEqual(["platform", "no-priority"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeExtensions — guard slot
+// ---------------------------------------------------------------------------
+
+describe("composeExtensions guard slot", () => {
+  test("collects middleware from guard slots", async () => {
+    const ext: KernelExtension = {
+      name: "test",
+      guards: () => [stubMiddleware("mw-a"), stubMiddleware("mw-b")],
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+
+    expect(composed.guardMiddleware).toHaveLength(2);
+    expect(composed.guardMiddleware[0]?.name).toBe("mw-a");
+    expect(composed.guardMiddleware[1]?.name).toBe("mw-b");
+  });
+
+  test("handles async guard slot", async () => {
+    const ext: KernelExtension = {
+      name: "async-guards",
+      guards: async () => [stubMiddleware("async-mw")],
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+
+    expect(composed.guardMiddleware).toHaveLength(1);
+    expect(composed.guardMiddleware[0]?.name).toBe("async-mw");
+  });
+
+  test("concatenates middleware from multiple extensions in priority order", async () => {
+    const ext1: KernelExtension = {
+      name: "high",
+      priority: 100,
+      guards: () => [stubMiddleware("high-mw")],
+    };
+    const ext2: KernelExtension = {
+      name: "low",
+      priority: 0,
+      guards: () => [stubMiddleware("low-mw")],
+    };
+
+    const composed = await composeExtensions([ext1, ext2], testGuardCtx());
+
+    expect(composed.guardMiddleware).toHaveLength(2);
+    expect(composed.guardMiddleware[0]?.name).toBe("low-mw");
+    expect(composed.guardMiddleware[1]?.name).toBe("high-mw");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeExtensions — transition validator
+// ---------------------------------------------------------------------------
+
+describe("composeExtensions transition validator", () => {
+  test("skips non-significant transitions", async () => {
+    let called = false;
+    const ext: KernelExtension = {
+      name: "blocker",
+      validateTransition: () => {
+        called = true;
+        return false;
+      },
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+
+    // running→waiting is hot path, should NOT call validator
+    const allowed = composed.validateTransition("running", "waiting");
+    expect(allowed).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test("calls validator for significant transitions", async () => {
+    let called = false;
+    const ext: KernelExtension = {
+      name: "observer",
+      validateTransition: () => {
+        called = true;
+        return true;
+      },
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+    composed.validateTransition("created", "running");
+    expect(called).toBe(true);
+  });
+
+  test("short-circuits on first false", async () => {
+    const order: string[] = [];
+    const ext1: KernelExtension = {
+      name: "blocker",
+      priority: 0,
+      validateTransition: () => {
+        order.push("blocker");
+        return false;
+      },
+    };
+    const ext2: KernelExtension = {
+      name: "observer",
+      priority: 10,
+      validateTransition: () => {
+        order.push("observer");
+        return true;
+      },
+    };
+
+    const composed = await composeExtensions([ext1, ext2], testGuardCtx());
+    const allowed = composed.validateTransition("created", "running");
+
+    expect(allowed).toBe(false);
+    expect(order).toEqual(["blocker"]);
+  });
+
+  test("returns true when no validators", async () => {
+    const ext: KernelExtension = { name: "no-validator" };
+    const composed = await composeExtensions([ext], testGuardCtx());
+    expect(composed.validateTransition("created", "running")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeExtensions — assembly validator
+// ---------------------------------------------------------------------------
+
+describe("composeExtensions assembly validator", () => {
+  test("returns ok when no validators", async () => {
+    const ext: KernelExtension = { name: "no-validator" };
+    const composed = await composeExtensions([ext], testGuardCtx());
+    const result = await composed.validateAssembly(new Map(), testManifest());
+    expect(result.ok).toBe(true);
+  });
+
+  test("merges diagnostics from multiple validators", async () => {
+    const ext1: KernelExtension = {
+      name: "v1",
+      validateAssembly: () => ({
+        ok: false,
+        diagnostics: [{ source: "v1", message: "missing tool", severity: "error" }],
+      }),
+    };
+    const ext2: KernelExtension = {
+      name: "v2",
+      validateAssembly: () => ({
+        ok: false,
+        diagnostics: [{ source: "v2", message: "deprecated config", severity: "warning" }],
+      }),
+    };
+
+    const composed = await composeExtensions([ext1, ext2], testGuardCtx());
+    const result = await composed.validateAssembly(new Map(), testManifest());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.diagnostics).toHaveLength(2);
+      expect(result.diagnostics[0]?.source).toBe("v1");
+      expect(result.diagnostics[1]?.source).toBe("v2");
+    }
+  });
+
+  test("runs validators in parallel", async () => {
+    const startTimes: number[] = [];
+    const ext1: KernelExtension = {
+      name: "slow1",
+      validateAssembly: async () => {
+        startTimes.push(Date.now());
+        await new Promise((r) => setTimeout(r, 50));
+        return { ok: true };
+      },
+    };
+    const ext2: KernelExtension = {
+      name: "slow2",
+      validateAssembly: async () => {
+        startTimes.push(Date.now());
+        await new Promise((r) => setTimeout(r, 50));
+        return { ok: true };
+      },
+    };
+
+    const composed = await composeExtensions([ext1, ext2], testGuardCtx());
+    await composed.validateAssembly(new Map(), testManifest());
+
+    // Both should start within a tight window (parallel, not sequential)
+    expect(startTimes).toHaveLength(2);
+    const timeDiff = Math.abs((startTimes[0] ?? 0) - (startTimes[1] ?? 0));
+    expect(timeDiff).toBeLessThan(30);
+  });
+
+  test("warning-only diagnostics still pass", async () => {
+    const ext: KernelExtension = {
+      name: "warner",
+      validateAssembly: () => ({
+        ok: false,
+        diagnostics: [{ source: "warner", message: "advisory", severity: "warning" }],
+      }),
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+    const result = await composed.validateAssembly(new Map(), testManifest());
+    expect(result.ok).toBe(true);
+  });
+
+  test("errors cause failure even when mixed with warnings", async () => {
+    const ext: KernelExtension = {
+      name: "mixed",
+      validateAssembly: (): {
+        readonly ok: false;
+        readonly diagnostics: readonly ValidationDiagnostic[];
+      } => ({
+        ok: false,
+        diagnostics: [
+          { source: "mixed", message: "warning", severity: "warning" },
+          { source: "mixed", message: "error", severity: "error" },
+        ],
+      }),
+    };
+
+    const composed = await composeExtensions([ext], testGuardCtx());
+    const result = await composed.validateAssembly(new Map(), testManifest());
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDefaultGuardExtension
+// ---------------------------------------------------------------------------
+
+describe("createDefaultGuardExtension", () => {
+  test("has CORE priority", () => {
+    const ext = createDefaultGuardExtension();
+    expect(ext.priority).toBe(EXTENSION_PRIORITY.CORE);
+  });
+
+  test("has correct name", () => {
+    const ext = createDefaultGuardExtension();
+    expect(ext.name).toBe("koi:default-guards");
+  });
+
+  test("produces 3 guards by default", () => {
+    const ext = createDefaultGuardExtension();
+    const guards = ext.guards?.(testGuardCtx());
+    // Sync path — should return array directly
+    expect(Array.isArray(guards)).toBe(true);
+    if (Array.isArray(guards)) {
+      expect(guards).toHaveLength(3);
+      expect(guards[0]?.name).toBe("koi:iteration-guard");
+      expect(guards[1]?.name).toBe("koi:loop-detector");
+      expect(guards[2]?.name).toBe("koi:spawn-guard");
+    }
+  });
+
+  test("produces 2 guards when loopDetection is false", () => {
+    const ext = createDefaultGuardExtension({ loopDetection: false });
+    const guards = ext.guards?.(testGuardCtx());
+    expect(Array.isArray(guards)).toBe(true);
+    if (Array.isArray(guards)) {
+      expect(guards).toHaveLength(2);
+      expect(guards[0]?.name).toBe("koi:iteration-guard");
+      expect(guards[1]?.name).toBe("koi:spawn-guard");
+    }
+  });
+
+  test("passes agentDepth from guard context to spawn guard", async () => {
+    const ext = createDefaultGuardExtension();
+    const ctx = testGuardCtx({ agentDepth: 2 });
+    const composed = await composeExtensions([ext], ctx);
+    // Spawn guard should be created with depth 2 — verified by composition succeeding
+    expect(composed.guardMiddleware).toHaveLength(3);
+  });
+});

--- a/packages/engine/src/extension-composer.ts
+++ b/packages/engine/src/extension-composer.ts
@@ -1,0 +1,228 @@
+/**
+ * Extension composer — sorts, merges, and composes KernelExtension slots
+ * into a single ComposedExtensions value for use by createKoi().
+ *
+ * Also provides createDefaultGuardExtension() which wraps the existing
+ * 3 L1 guards (iteration, loop, spawn) as a KernelExtension for dogfooding.
+ */
+
+import type {
+  AgentManifest,
+  GuardContext,
+  KernelExtension,
+  KoiMiddleware,
+  ProcessState,
+  TransitionContext,
+  ValidationDiagnostic,
+  ValidationResult,
+} from "@koi/core";
+import { EXTENSION_PRIORITY } from "@koi/core";
+import { createIterationGuard, createLoopDetector, createSpawnGuard } from "./guards.js";
+import type { IterationLimits, LoopDetectionConfig, SpawnPolicy } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Significant transitions (validator is called)
+// ---------------------------------------------------------------------------
+
+/**
+ * Significant transitions — lifecycle validator is only invoked for these.
+ * Running↔waiting is the hot path (model calls, tool calls) and is skipped.
+ */
+const SIGNIFICANT_TRANSITIONS: ReadonlySet<string> = new Set([
+  "created→running",
+  "created→terminated",
+  "running→suspended",
+  "running→terminated",
+  "waiting→suspended",
+  "waiting→terminated",
+  "suspended→running",
+  "suspended→terminated",
+]);
+
+/** Check if a transition is significant (should invoke validators). O(1) set lookup. */
+export function isSignificantTransition(from: ProcessState, to: ProcessState): boolean {
+  return SIGNIFICANT_TRANSITIONS.has(`${from}→${to}`);
+}
+
+// ---------------------------------------------------------------------------
+// ComposedExtensions
+// ---------------------------------------------------------------------------
+
+/** Sync validator for lifecycle transitions. Used by AgentEntity. */
+export type TransitionValidator = (from: ProcessState, to: ProcessState) => boolean;
+
+/** The composed result of all KernelExtension slots, ready for use by createKoi(). */
+export interface ComposedExtensions {
+  /** All guard middleware produced by extensions, sorted by extension priority. */
+  readonly guardMiddleware: readonly KoiMiddleware[];
+  /** Composed lifecycle transition validator (AND-logic, sync). */
+  readonly validateTransition: (from: ProcessState, to: ProcessState) => boolean;
+  /** Composed assembly validator (parallel execution, merged diagnostics). */
+  readonly validateAssembly: (
+    components: ReadonlyMap<string, unknown>,
+    manifest: AgentManifest,
+  ) => Promise<ValidationResult>;
+}
+
+// ---------------------------------------------------------------------------
+// composeExtensions
+// ---------------------------------------------------------------------------
+
+/**
+ * Sort, merge, and compose all KernelExtension slots into a single
+ * ComposedExtensions value.
+ *
+ * - Extensions are sorted by priority ascending (lower = runs first).
+ * - Guard slots produce middleware arrays that are concatenated in priority order.
+ * - Transition validators are composed with AND logic (short-circuit on false).
+ * - Assembly validators run in parallel via Promise.all, diagnostics merged.
+ */
+export async function composeExtensions(
+  extensions: readonly KernelExtension[],
+  guardCtx: GuardContext,
+): Promise<ComposedExtensions> {
+  // 1. Sort by priority ascending (stable sort, default USER=50)
+  const sorted = [...extensions].sort(
+    (a, b) => (a.priority ?? EXTENSION_PRIORITY.USER) - (b.priority ?? EXTENSION_PRIORITY.USER),
+  );
+
+  // 2. Collect guard middleware from each extension (in priority order)
+  const allGuardMiddleware: KoiMiddleware[] = [];
+  for (const ext of sorted) {
+    if (ext.guards !== undefined) {
+      const produced = await ext.guards(guardCtx);
+      for (const mw of produced) {
+        allGuardMiddleware.push(mw);
+      }
+    }
+  }
+
+  // 3. Collect transition validators → compose into AND-logic
+  const transitionValidators: readonly ((ctx: TransitionContext) => boolean)[] = sorted
+    .filter(
+      (
+        ext,
+      ): ext is KernelExtension & {
+        readonly validateTransition: (ctx: TransitionContext) => boolean;
+      } => ext.validateTransition !== undefined,
+    )
+    .map((ext) => ext.validateTransition);
+
+  const composedTransitionValidator = (from: ProcessState, to: ProcessState): boolean => {
+    // Skip non-significant transitions (wait/resume hot path)
+    if (!isSignificantTransition(from, to)) {
+      return true;
+    }
+    const ctx: TransitionContext = { from, to };
+    // AND-logic: short-circuit on first false
+    for (const validator of transitionValidators) {
+      if (!validator(ctx)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // 4. Collect assembly validators → compose into parallel execution
+  const assemblyValidators = sorted.filter(
+    (
+      ext,
+    ): ext is KernelExtension & {
+      readonly validateAssembly: (
+        components: ReadonlyMap<string, unknown>,
+        manifest: AgentManifest,
+      ) => ValidationResult | Promise<ValidationResult>;
+    } => ext.validateAssembly !== undefined,
+  );
+
+  const composedAssemblyValidator = async (
+    components: ReadonlyMap<string, unknown>,
+    manifest: AgentManifest,
+  ): Promise<ValidationResult> => {
+    if (assemblyValidators.length === 0) {
+      return { ok: true };
+    }
+
+    const results = await Promise.all(
+      assemblyValidators.map((ext) => ext.validateAssembly(components, manifest)),
+    );
+
+    const allDiagnostics: ValidationDiagnostic[] = [];
+    for (const result of results) {
+      if (!result.ok) {
+        for (const diag of result.diagnostics) {
+          allDiagnostics.push(diag);
+        }
+      }
+    }
+
+    if (allDiagnostics.some((d) => d.severity === "error")) {
+      return { ok: false, diagnostics: allDiagnostics };
+    }
+
+    if (allDiagnostics.length > 0) {
+      // Warnings only — still ok but carry diagnostics
+      // Return ok: true since no errors, warnings are advisory
+      return { ok: true };
+    }
+
+    return { ok: true };
+  };
+
+  return {
+    guardMiddleware: allGuardMiddleware,
+    validateTransition: composedTransitionValidator,
+    validateAssembly: composedAssemblyValidator,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default guard extension config
+// ---------------------------------------------------------------------------
+
+/** Configuration for the default guard extension (wraps existing L1 guards). */
+export interface DefaultGuardExtensionConfig {
+  /** Iteration limits. Defaults to DEFAULT_ITERATION_LIMITS. */
+  readonly limits?: Partial<IterationLimits>;
+  /** Loop detection config. Set to false to disable. */
+  readonly loopDetection?: Partial<LoopDetectionConfig> | false;
+  /** Spawn policy. Defaults to DEFAULT_SPAWN_POLICY. */
+  readonly spawn?: Partial<SpawnPolicy>;
+}
+
+// ---------------------------------------------------------------------------
+// createDefaultGuardExtension
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps the existing 3 L1 guards (iteration, loop, spawn) as a
+ * KernelExtension at CORE priority (0) for dogfooding.
+ *
+ * This is the default extension created by createKoi() when sugar fields
+ * (limits, loopDetection, spawn) are used.
+ */
+export function createDefaultGuardExtension(config?: DefaultGuardExtensionConfig): KernelExtension {
+  return {
+    name: "koi:default-guards",
+    priority: EXTENSION_PRIORITY.CORE,
+
+    guards: (ctx: GuardContext): readonly KoiMiddleware[] => {
+      const guards: KoiMiddleware[] = [createIterationGuard(config?.limits ?? undefined)];
+
+      if (config?.loopDetection !== false) {
+        const loopConfig = config?.loopDetection;
+        guards.push(createLoopDetector(loopConfig === undefined ? undefined : loopConfig));
+      }
+
+      guards.push(
+        createSpawnGuard({
+          ...(config?.spawn !== undefined ? { policy: config.spawn } : {}),
+          agentDepth: ctx.agentDepth,
+          ...(ctx.agent !== undefined ? { agent: ctx.agent } : {}),
+        }),
+      );
+
+      return guards;
+    },
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -30,6 +30,17 @@ export {
 export { disposeAll } from "./dispose.js";
 // eviction policies
 export { lruPolicy, qosPolicy } from "./eviction-policies.js";
+// extension composer
+export type {
+  ComposedExtensions,
+  DefaultGuardExtensionConfig,
+  TransitionValidator,
+} from "./extension-composer.js";
+export {
+  composeExtensions,
+  createDefaultGuardExtension,
+  isSignificantTransition,
+} from "./extension-composer.js";
 // guards
 export type { CreateSpawnGuardOptions } from "./guards.js";
 export {

--- a/packages/engine/src/koi.ts
+++ b/packages/engine/src/koi.ts
@@ -44,7 +44,7 @@ import {
   runSessionHooks,
   runTurnHooks,
 } from "./compose.js";
-import { createIterationGuard, createLoopDetector, createSpawnGuard } from "./guards.js";
+import { composeExtensions, createDefaultGuardExtension } from "./extension-composer.js";
 import type { CreateKoiOptions, KoiRuntime } from "./types.js";
 
 /** Generate a unique process ID for a new agent. */
@@ -112,26 +112,41 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
   });
   const { agent, conflicts } = await AgentEntity.assemble(pid, manifest, providers);
 
-  // --- 2. Create L1 guards (declarative, no mutation) ---
-  const spawnPolicy = { ...options.spawn };
-  const guards: readonly KoiMiddleware[] = [
-    createIterationGuard(options.limits),
-    ...(options.loopDetection !== false
-      ? [
-          createLoopDetector(
-            options.loopDetection === undefined ? undefined : options.loopDetection,
-          ),
-        ]
-      : []),
-    createSpawnGuard({
-      policy: spawnPolicy,
-      agentDepth: pid.depth,
-      agent,
-    }),
-  ];
+  // --- 2. Compose kernel extensions ---
+  const defaultGuardExt = createDefaultGuardExtension({
+    ...(options.limits !== undefined ? { limits: options.limits } : {}),
+    ...(options.loopDetection !== undefined ? { loopDetection: options.loopDetection } : {}),
+    ...(options.spawn !== undefined ? { spawn: options.spawn } : {}),
+  });
+  const allExtensions = [defaultGuardExt, ...(options.extensions ?? [])];
 
-  // --- 3. Compose middleware chain: guards + user middleware, sorted by priority ---
-  const allMiddleware: readonly KoiMiddleware[] = sortByPriority([...guards, ...middleware]);
+  const guardCtx = {
+    agentDepth: pid.depth,
+    manifest,
+    components: agent.components(),
+    agent,
+  };
+  const composed = await composeExtensions(allExtensions, guardCtx);
+
+  // --- 2b. Run assembly validators ---
+  const assemblyResult = await composed.validateAssembly(agent.components(), manifest);
+  if (!assemblyResult.ok) {
+    const messages = assemblyResult.diagnostics
+      .filter((d) => d.severity === "error")
+      .map((d) => `[${d.source}] ${d.message}`);
+    throw KoiRuntimeError.from("VALIDATION", `Assembly validation failed: ${messages.join("; ")}`, {
+      context: { diagnostics: assemblyResult.diagnostics },
+    });
+  }
+
+  // --- 2c. Wire transition validator into agent entity ---
+  agent.setTransitionValidator(composed.validateTransition);
+
+  // --- 3. Compose middleware chain: guard middleware + user middleware, sorted by priority ---
+  const allMiddleware: readonly KoiMiddleware[] = sortByPriority([
+    ...composed.guardMiddleware,
+    ...middleware,
+  ]);
 
   // --- 4. Default tool terminal (forge first, then entity fallback) ---
   const defaultToolTerminal = async (request: ToolRequest): Promise<ToolResponse> => {

--- a/packages/engine/src/spawn-child.ts
+++ b/packages/engine/src/spawn-child.ts
@@ -74,6 +74,7 @@ export async function spawnChildAgent(options: SpawnChildOptions): Promise<Spawn
       ...(options.registry !== undefined ? { registry: options.registry } : {}),
       ...(options.limits !== undefined ? { limits: options.limits } : {}),
       ...(options.loopDetection !== undefined ? { loopDetection: options.loopDetection } : {}),
+      ...(options.extensions !== undefined ? { extensions: options.extensions } : {}),
     });
   } catch (e: unknown) {
     // Release ledger slot on assembly failure — no leak

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -14,6 +14,7 @@ import type {
   EngineEvent,
   EngineInput,
   ForgeScope,
+  KernelExtension,
   KoiMiddleware,
   ProcessAccounter,
   ProcessId,
@@ -210,6 +211,11 @@ export interface CreateKoiOptions {
   /** Spawn governance policy. Defaults to DEFAULT_SPAWN_POLICY. */
   readonly spawn?: Partial<SpawnPolicy>;
   /**
+   * Kernel extensions for pluggable guards, lifecycle validation, and assembly validation.
+   * Extensions are composed with the default guard extension (created from limits/loopDetection/spawn).
+   */
+  readonly extensions?: readonly KernelExtension[];
+  /**
    * Shared spawn ledger for tree-wide concurrency tracking.
    * The root agent creates a ledger; children share the same instance.
    * Defaults to an in-memory counter (single-Node scope).
@@ -278,6 +284,8 @@ export interface SpawnChildOptions {
   readonly limits?: Partial<IterationLimits>;
   /** Loop detection config for the child. Set to false to disable. */
   readonly loopDetection?: Partial<LoopDetectionConfig> | false;
+  /** Kernel extensions for the child. */
+  readonly extensions?: readonly KernelExtension[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #219

- Add `KernelExtension` interface to `@koi/core` (L0) with 3 optional slots: `guards`, `validateTransition`, `validateAssembly`
- Refactor existing 3 hardcoded guards (iteration, loop, spawn) into a default `KernelExtension` at CORE priority (dogfooding via `createDefaultGuardExtension()`)
- Wire extension composition pipeline into `createKoi()` with full backward compatibility — existing `limits`/`loopDetection`/`spawn` sugar fields work unchanged
- `EXTENSION_PRIORITY` constant: CORE=0, PLATFORM=10, USER=50, ADDON=100

### Performance

- **Hot-path optimized**: `running↔waiting` transitions skip validators entirely via O(1) `Set.has()`
- **Sync lifecycle validators**: zero async overhead on transitions
- **Assembly-time composition**: `composeExtensions()` called once in `createKoi()`, not per-turn
- **Zero allocation on hot path**: closure captures pre-built arrays

### Files changed

| File | Action |
|------|--------|
| `packages/core/src/kernel-extension.ts` | **New** — L0 types (KernelExtension, EXTENSION_PRIORITY, GuardContext, etc.) |
| `packages/engine/src/extension-composer.ts` | **New** — composeExtensions(), createDefaultGuardExtension() |
| `packages/engine/src/agent-entity.ts` | Modified — transition validator integration |
| `packages/engine/src/koi.ts` | Modified — extension pipeline replaces direct guard creation |
| `packages/engine/src/types.ts` | Modified — `extensions` field on CreateKoiOptions |
| `packages/engine/src/spawn-child.ts` | Modified — pass extensions through |

## Test plan

- [x] L0 unit tests: EXTENSION_PRIORITY values and freeze (2 tests)
- [x] Extension composer unit tests: sorting, guard collection, transition validators, assembly validators (21 tests)
- [x] AgentEntity validator tests: blocks/allows transitions, backward compat (4 tests)
- [x] Integration tests with mock adapter through full createKoi() (8 tests)
- [x] E2E tests with real Anthropic API through createKoi() + Pi adapter (5 tests)
- [x] Full engine suite regression: 555 pass, 0 fail
- [x] Full core suite: 302 pass, 0 fail
- [x] Anti-leak checklist verified: zero L2 imports in L0/L1, all readonly, types-only in L0
- [x] API surface snapshot updated