### PR TITLE
fix(forge): add max-listener safety guards to prevent unbounded listener growth

### DIFF
--- a/packages/forge/src/__tests__/e2e.test.ts
+++ b/packages/forge/src/__tests__/e2e.test.ts
@@ -30,7 +30,9 @@ import { createLoopAdapter } from "@koi/engine-loop";
 import { createAnthropicAdapter } from "@koi/model-router";
 import { createDefaultForgeConfig } from "../config.js";
 import { createForgeComponentProvider } from "../forge-component-provider.js";
+import { createForgeRuntime } from "../forge-runtime.js";
 import { createInMemoryForgeStore } from "../memory-store.js";
+import { createMemoryStoreChangeNotifier } from "../store-notifier.js";
 import { createForgeEngineTool } from "../tools/forge-engine.js";
 import { createForgeMiddlewareTool } from "../tools/forge-middleware.js";
 import { createForgeToolTool } from "../tools/forge-tool.js";
@@ -429,6 +431,124 @@ describeE2E("e2e: forge through createKoi + createLoopAdapter with Anthropic", (
         expect(loadResult.value.kind).toBe("middleware");
         expect(loadResult.value.name).toBe("retry-mw");
       }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "listener guard: StoreChangeNotifier rejects subscribers beyond limit",
+    async () => {
+      const notifier = createMemoryStoreChangeNotifier();
+
+      // Fill to the limit (64 subscribers)
+      const unsubs: (() => void)[] = [];
+      for (let i = 0; i < 64; i++) {
+        unsubs.push(notifier.subscribe(() => {}));
+      }
+
+      // 65th must throw
+      expect(() => notifier.subscribe(() => {})).toThrow(/subscriber limit.*64.*reached/);
+
+      // After unsubscribing one, a new subscriber should succeed
+      unsubs[0]?.();
+      expect(() => notifier.subscribe(() => {})).not.toThrow();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "listener guard: ForgeRuntime.watch rejects listeners beyond limit",
+    async () => {
+      const store = createInMemoryForgeStore();
+      const executor = mockExecutor();
+
+      const runtime = createForgeRuntime({
+        store,
+        executor: mockTiered(executor),
+      });
+
+      expect(runtime.watch).toBeDefined();
+
+      // Fill to the limit (64 external listeners)
+      const unsubs: (() => void)[] = [];
+      for (let i = 0; i < 64; i++) {
+        const unsub = runtime.watch?.(() => {});
+        if (unsub !== undefined) {
+          unsubs.push(unsub);
+        }
+      }
+
+      // 65th must throw
+      expect(() => runtime.watch?.(() => {})).toThrow(/external listener limit.*64.*reached/);
+
+      // After unsubscribing one, a new listener should succeed
+      unsubs[0]?.();
+      expect(() => runtime.watch?.(() => {})).not.toThrow();
+
+      // Clean up
+      runtime.dispose?.();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "listener guard: notifier + ForgeComponentProvider within full createKoi assembly",
+    async () => {
+      const store = createInMemoryForgeStore();
+      const executor = adderExecutor();
+      const deps = defaultDeps(store, executor);
+      const notifier = createMemoryStoreChangeNotifier();
+
+      // Forge an adder tool so the runtime has something to work with
+      const forgeTool = createForgeToolTool(deps);
+      await forgeTool.execute({
+        name: "guard-adder",
+        description: "Adds two numbers.",
+        inputSchema: {
+          type: "object",
+          properties: { a: { type: "number" }, b: { type: "number" } },
+          required: ["a", "b"],
+        },
+        implementation: "return { sum: input.a + input.b };",
+      });
+
+      // Create provider wired to the notifier — this subscribes 1 listener
+      const forgeProvider = createForgeComponentProvider({
+        store,
+        executor: mockTiered(executor),
+        notifier,
+      });
+
+      // Full L1 assembly with real LLM
+      const modelCall = createModelCall();
+      const loopAdapter = createLoopAdapter({ modelCall, maxTurns: 1 });
+
+      const koiRuntime = await createKoi({
+        manifest: testManifest(),
+        adapter: loopAdapter,
+        providers: [forgeProvider],
+        loopDetection: false,
+      });
+
+      // Run one turn to prove the assembly works
+      const events = await collectEvents(koiRuntime.run({ kind: "text", text: "Say hello." }));
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+
+      // The notifier already has 1 subscriber (from forgeProvider).
+      // Fill remaining capacity: subscribe 63 more to reach 64.
+      const unsubs: (() => void)[] = [];
+      for (let i = 0; i < 63; i++) {
+        unsubs.push(notifier.subscribe(() => {}));
+      }
+
+      // 65th total subscriber (provider + 63 + 1) must throw
+      expect(() => notifier.subscribe(() => {})).toThrow(/subscriber limit.*64.*reached/);
+
+      // Clean up
+      for (const u of unsubs) u();
+      forgeProvider.dispose();
+      await koiRuntime.dispose();
     },
     TIMEOUT_MS,
   );

--- a/packages/forge/src/forge-runtime.test.ts
+++ b/packages/forge/src/forge-runtime.test.ts
@@ -154,6 +154,21 @@ describe("createForgeRuntime", () => {
     unsub?.();
   });
 
+  test("throws when external listener limit is exceeded", () => {
+    const store = createInMemoryForgeStore();
+    const runtime = createForgeRuntime({ store, executor: mockTiered() });
+
+    expect(runtime.watch).toBeDefined();
+
+    // Register up to the limit (64)
+    for (let i = 0; i < 64; i++) {
+      runtime.watch?.(() => {});
+    }
+
+    // The 65th listener should throw
+    expect(() => runtime.watch?.(() => {})).toThrow(/external listener limit.*64.*reached/);
+  });
+
   test("dispose calls store.dispose when available", () => {
     const store = createInMemoryForgeStore();
     const disposeSpy = mock(() => {});

--- a/packages/forge/src/forge-runtime.ts
+++ b/packages/forge/src/forge-runtime.ts
@@ -16,6 +16,9 @@ import type { TieredSandboxExecutor } from "./types.js";
 
 const DEFAULT_SANDBOX_TIMEOUT_MS = 5_000;
 
+/** Safety cap — catches leaked listeners before they accumulate unboundedly. */
+const MAX_EXTERNAL_LISTENERS = 64;
+
 export interface CreateForgeRuntimeOptions {
   readonly store: ForgeStore;
   readonly executor: TieredSandboxExecutor;
@@ -104,8 +107,14 @@ export function createForgeRuntime(options: CreateForgeRuntimeOptions): ForgeRun
   if (store.watch !== undefined) {
     unsubStore = store.watch((event) => {
       invalidateCache();
-      for (const listener of externalListeners) {
-        listener(event);
+      // Snapshot to avoid issues if a listener unsubscribes during iteration
+      const snapshot = [...externalListeners];
+      for (const listener of snapshot) {
+        try {
+          listener(event);
+        } catch (_: unknown) {
+          // Never let one listener break others — silently continue
+        }
       }
     });
   }
@@ -113,6 +122,12 @@ export function createForgeRuntime(options: CreateForgeRuntimeOptions): ForgeRun
   const watch =
     store.watch !== undefined
       ? (listener: (event: StoreChangeEvent) => void): (() => void) => {
+          if (externalListeners.size >= MAX_EXTERNAL_LISTENERS) {
+            throw new Error(
+              `ForgeRuntime: external listener limit (${String(MAX_EXTERNAL_LISTENERS)}) reached — likely a listener leak. ` +
+                `Ensure returned unsubscribe functions are called.`,
+            );
+          }
           externalListeners.add(listener);
           return () => {
             externalListeners.delete(listener);

--- a/packages/forge/src/store-notifier.test.ts
+++ b/packages/forge/src/store-notifier.test.ts
@@ -86,6 +86,18 @@ describe("createMemoryStoreChangeNotifier", () => {
     unsubscribe(); // Should not throw
   });
 
+  test("throws when subscriber limit is exceeded", () => {
+    const notifier = createMemoryStoreChangeNotifier();
+
+    // Subscribe up to the limit (64)
+    for (let i = 0; i < 64; i++) {
+      notifier.subscribe(() => {});
+    }
+
+    // The 65th subscriber should throw
+    expect(() => notifier.subscribe(() => {})).toThrow(/subscriber limit.*64.*reached/);
+  });
+
   test("events without scope are delivered correctly", () => {
     const notifier = createMemoryStoreChangeNotifier();
     const received: StoreChangeEvent[] = [];

--- a/packages/forge/src/store-notifier.ts
+++ b/packages/forge/src/store-notifier.ts
@@ -6,11 +6,15 @@
 
 import type { StoreChangeEvent, StoreChangeNotifier } from "@koi/core";
 
+/** Safety cap — catches leaked listeners before they accumulate unboundedly. */
+const MAX_SUBSCRIBERS = 64;
+
 /**
  * Creates an in-memory `StoreChangeNotifier` backed by a simple listener map.
  *
  * - `notify()` snapshots the listener array and calls each synchronously.
  * - `subscribe()` returns an unsubscribe function.
+ * - Throws if subscriber count reaches `MAX_SUBSCRIBERS` (likely a leak).
  */
 export function createMemoryStoreChangeNotifier(): StoreChangeNotifier {
   let nextId = 0;
@@ -29,6 +33,12 @@ export function createMemoryStoreChangeNotifier(): StoreChangeNotifier {
   };
 
   const subscribe = (listener: (event: StoreChangeEvent) => void): (() => void) => {
+    if (listeners.size >= MAX_SUBSCRIBERS) {
+      throw new Error(
+        `StoreChangeNotifier: subscriber limit (${String(MAX_SUBSCRIBERS)}) reached — likely a listener leak. ` +
+          `Ensure dispose()/unsubscribe() is called when providers are torn down.`,
+      );
+    }
     const id = nextId++;
     listeners.set(id, listener);
     return (): void => {


### PR DESCRIPTION
## Summary

- **StoreChangeNotifier**: `subscribe()` now throws when subscriber count reaches 64 — catches leaked listeners early instead of silently accumulating
- **ForgeRuntime**: `watch()` now throws when external listener count reaches 64 — same safety pattern
- **ForgeRuntime store.watch callback**: Fixed to snapshot listeners and wrap in try/catch before iterating (matching the existing `store-notifier` pattern) — a throwing listener no longer breaks notification delivery to subsequent listeners

Why 64: forge uses ~1 listener per component-provider and ~1 per forge-runtime. Even a busy system with many providers won't approach 64. Hitting it genuinely means a leak.

## Test plan

- [x] Unit test: `store-notifier.test.ts` — "throws when subscriber limit is exceeded"
- [x] Unit test: `forge-runtime.test.ts` — "throws when external listener limit is exceeded"
- [x] E2E test: StoreChangeNotifier rejects subscribers beyond limit (with unsubscribe recovery)
- [x] E2E test: ForgeRuntime.watch rejects listeners beyond limit (with unsubscribe recovery)
- [x] E2E test: notifier + ForgeComponentProvider within full `createKoi` + `createLoopAdapter` assembly (real Anthropic LLM call, validates guard fires at capacity with 1 provider subscriber + 63 manual)
- [x] Pre-push: build (99/99), test, typecheck all pass