### PR TITLE
feat: add @koi/eval (L2) — agent evaluation framework

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,6 +183,19 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/eval": {
+      "name": "@koi/eval",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/events-memory": {
       "name": "@koi/events-memory",
       "version": "0.0.0",
@@ -1009,6 +1022,8 @@
     "@koi/engine-pi": ["@koi/engine-pi@workspace:packages/engine-pi"],
 
     "@koi/errors": ["@koi/errors@workspace:packages/errors"],
+
+    "@koi/eval": ["@koi/eval@workspace:packages/eval"],
 
     "@koi/events-memory": ["@koi/events-memory@workspace:packages/events-memory"],
 

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/eval",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*",
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts",
+    "test:e2e": "bun test src/__tests__/e2e.test.ts"
+  }
+}

--- a/packages/eval/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/eval/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,325 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/eval API surface . has stable type surface 1`] = `
+"import { EngineInput, EngineEvent, EngineMetrics, JsonObject, Result, KoiError } from '@koi/core';
+
+/**
+ * @koi/eval — type definitions for the agent evaluation framework.
+ *
+ * Follows Anthropic's task/trial/run hierarchy.
+ * All properties readonly, no class, no enum.
+ */
+
+interface EvalGrader {
+    readonly id: string;
+    readonly name: string;
+    readonly grade: (transcript: readonly EngineEvent[], expected: EvalExpectation | undefined, metrics: EngineMetrics) => EvalScore | Promise<EvalScore>;
+}
+type EvalExpectation = {
+    readonly kind: "text";
+    readonly pattern: string | RegExp;
+} | {
+    readonly kind: "tool_calls";
+    readonly calls: readonly ExpectedToolCall[];
+} | {
+    readonly kind: "composite";
+    readonly expectations: readonly EvalExpectation[];
+} | {
+    readonly kind: "custom";
+    readonly assert: (events: readonly EngineEvent[]) => void | Promise<void>;
+};
+interface ExpectedToolCall {
+    readonly toolName: string;
+    readonly args?: Readonly<Record<string, unknown>>;
+    /** Whether tool call order must match. Default: "any". */
+    readonly order?: "strict" | "any";
+}
+interface EvalTask {
+    readonly id: string;
+    readonly name: string;
+    readonly input: EngineInput;
+    readonly expected?: EvalExpectation;
+    readonly graders: readonly EvalGrader[];
+    /** Number of trials per task. Default: 1. */
+    readonly trialCount?: number;
+    /** Per-trial timeout in ms. Default: 60_000. */
+    readonly timeoutMs?: number;
+    readonly tags?: readonly string[];
+    readonly metadata?: JsonObject;
+}
+interface EvalTrial {
+    readonly taskId: string;
+    readonly trialIndex: number;
+    readonly transcript: readonly EngineEvent[];
+    readonly scores: readonly EvalScore[];
+    readonly metrics: EngineMetrics;
+    readonly status: "pass" | "fail" | "error";
+    readonly error?: string;
+}
+interface EvalScore {
+    readonly graderId: string;
+    readonly score: number;
+    readonly pass: boolean;
+    readonly reasoning?: string;
+    readonly metadata?: JsonObject;
+}
+interface EvalRun {
+    readonly id: string;
+    readonly name: string;
+    readonly timestamp: string;
+    readonly config: EvalRunConfigSnapshot;
+    readonly trials: readonly EvalTrial[];
+    readonly summary: EvalSummary;
+}
+/**
+ * Serializable subset of EvalRunConfig preserved for reproducibility.
+ * Excludes functions (agentFactory, onTrialComplete) that cannot be serialized.
+ */
+interface EvalRunConfigSnapshot {
+    readonly name: string;
+    readonly concurrency: number;
+    readonly timeoutMs: number;
+    readonly passThreshold: number;
+    readonly taskCount: number;
+}
+interface EvalSummary {
+    readonly taskCount: number;
+    readonly trialCount: number;
+    readonly passRate: number;
+    readonly passAtK: number;
+    readonly passToTheK: number;
+    readonly meanScore: number;
+    readonly latencyP50Ms: number;
+    readonly latencyP95Ms: number;
+    readonly totalCostUsd: number;
+    readonly byTask: readonly TaskSummary[];
+}
+interface TaskSummary {
+    readonly taskId: string;
+    readonly taskName: string;
+    readonly passRate: number;
+    readonly passAtK: number;
+    readonly passToTheK: number;
+    readonly meanScore: number;
+    readonly trials: number;
+}
+interface EvalRunConfig {
+    readonly name: string;
+    readonly tasks: readonly EvalTask[];
+    readonly agentFactory: () => Promise<AgentHandle>;
+    /** Max concurrent trials. Default: 5. */
+    readonly concurrency?: number;
+    /** Per-trial timeout fallback in ms. Default: 60_000. */
+    readonly timeoutMs?: number;
+    /** Score >= this = pass. Default: 0.5. */
+    readonly passThreshold?: number;
+    readonly onTrialComplete?: (trial: EvalTrial) => void;
+}
+interface AgentHandle {
+    readonly stream: (input: EngineInput) => AsyncIterable<EngineEvent>;
+    readonly dispose?: () => Promise<void>;
+}
+interface EvalStore {
+    readonly save: (run: EvalRun) => Promise<void>;
+    readonly load: (runId: string) => Promise<EvalRun | undefined>;
+    readonly latest: (evalName: string) => Promise<EvalRun | undefined>;
+    readonly list: (evalName: string) => Promise<readonly EvalRunMeta[]>;
+}
+interface EvalRunMeta {
+    readonly id: string;
+    readonly name: string;
+    readonly timestamp: string;
+    readonly passRate: number;
+    readonly taskCount: number;
+}
+type RegressionResult = {
+    readonly kind: "pass";
+    readonly baseline: EvalSummary;
+    readonly current: EvalSummary;
+} | {
+    readonly kind: "fail";
+    readonly regressions: readonly RegressionDetail[];
+    readonly baseline: EvalSummary;
+    readonly current: EvalSummary;
+} | {
+    readonly kind: "no_baseline";
+};
+interface RegressionDetail {
+    readonly taskId: string;
+    readonly metric: string;
+    readonly baseline: number;
+    readonly current: number;
+    readonly delta: number;
+}
+interface RegressionThresholds {
+    /** Max acceptable pass rate drop. Default: 0.05 (5%). */
+    readonly passRateDelta?: number;
+    /** Max acceptable score drop. Default: 0.1. */
+    readonly scoreDelta?: number;
+    /** Max acceptable latency multiplier. Default: 2.0. */
+    readonly latencyMultiplier?: number;
+}
+type TranscriptMode = "full" | "summary" | "last-n";
+interface LlmJudgeConfig {
+    readonly modelCall: (prompt: string) => Promise<string>;
+    readonly rubric: string;
+    readonly transcriptMode?: TranscriptMode;
+    /** For "last-n" mode. Default: 5. */
+    readonly lastN?: number;
+    readonly parseScore?: (response: string) => number;
+}
+interface CiReport {
+    readonly exitCode: 0 | 1;
+    readonly json: string;
+    readonly summary: string;
+}
+interface ToolCallSummary {
+    readonly toolName: string;
+    readonly callId: string;
+    readonly args?: JsonObject;
+}
+interface EvalRunner {
+    readonly run: () => Promise<EvalRun>;
+}
+
+/**
+ * Eval config validation and defaults.
+ */
+
+declare const DEFAULT_CONCURRENCY = 5;
+declare const DEFAULT_TIMEOUT_MS = 60000;
+declare const DEFAULT_PASS_THRESHOLD = 0.5;
+declare function validateEvalConfig(config: unknown): Result<EvalRunConfig, KoiError>;
+
+/**
+ * Exact match grader — scores against text expectations.
+ */
+
+interface ExactMatchConfig {
+    readonly caseSensitive?: boolean;
+}
+declare function createExactMatchGrader(config?: ExactMatchConfig): EvalGrader;
+
+/**
+ * JSON schema grader — validates agent output against a schema.
+ *
+ * Simple recursive validation without external dependencies.
+ */
+
+interface JsonSchemaGraderConfig {
+    readonly schema: JsonObject;
+}
+declare function createJsonSchemaGrader(config: JsonSchemaGraderConfig): EvalGrader;
+
+/**
+ * LLM-as-judge grader — uses a model call to evaluate agent output.
+ */
+
+declare function createLlmJudgeGrader(config: LlmJudgeConfig): EvalGrader;
+
+/**
+ * Tool call grader — scores based on expected vs actual tool usage.
+ */
+
+interface ToolCallGraderConfig {
+    /** Whether tool calls must appear in expected order. Default: false. */
+    readonly orderStrict?: boolean;
+}
+declare function createToolCallGrader(config?: ToolCallGraderConfig): EvalGrader;
+
+/**
+ * Regression detection — compares current eval run against a baseline.
+ */
+
+/**
+ * Compares current summary against baseline, returning regression details.
+ */
+declare function detectRegression(baseline: EvalSummary, current: EvalSummary, thresholds?: RegressionThresholds): RegressionResult;
+
+/**
+ * Reporter — CI-friendly output formatting.
+ */
+
+/**
+ * Formats a summary as an ASCII table for human reading.
+ */
+declare function formatSummaryTable(summary: EvalSummary): string;
+/**
+ * Formats a CI report with exit code, JSON output, and human summary.
+ */
+declare function formatCiReport(run: EvalRun, regression?: RegressionResult): CiReport;
+
+/**
+ * Eval runner — orchestrates task execution, grading, and summary computation.
+ */
+
+/**
+ * Creates an eval runner from a validated config.
+ */
+declare function createEvalRunner(config: EvalRunConfig): EvalRunner;
+
+/**
+ * Scoring aggregation — pass@k, pass^k, percentiles, summary computation.
+ */
+
+/**
+ * Computes a full EvalSummary from trial results and task definitions.
+ */
+declare function computeSummary(trials: readonly EvalTrial[], tasks: readonly EvalTask[]): EvalSummary;
+/**
+ * pass@k — probability of at least one pass in k samples.
+ * Formula: 1 - C(n-c, k) / C(n, k) where n = total, c = passing.
+ */
+declare function computePassAtK(trialResults: readonly boolean[], k: number): number;
+/**
+ * pass^k — probability of all k trials passing. Measures consistency.
+ * Formula: (c/n)^k
+ */
+declare function computePassToTheK(trialResults: readonly boolean[], k: number): number;
+/**
+ * Computes a percentile value from a sorted array of numbers.
+ */
+declare function computePercentile(values: readonly number[], percentile: number): number;
+
+/**
+ * Filesystem-based eval store — saves/loads eval runs as JSON files.
+ */
+
+interface FsEvalStoreConfig {
+    readonly baseDir: string;
+}
+declare function createFsEvalStore(config: FsEvalStoreConfig): EvalStore;
+
+/**
+ * Transcript collection and extraction helpers.
+ */
+
+/**
+ * Collects all events from an async iterable into an array.
+ */
+declare function collectTranscript(stream: AsyncIterable<EngineEvent>): Promise<readonly EngineEvent[]>;
+/**
+ * Extracts concatenated text from text_delta events.
+ */
+declare function extractText(events: readonly EngineEvent[]): string;
+/**
+ * Extracts tool call summaries from tool_call_start events.
+ */
+declare function extractToolCalls(events: readonly EngineEvent[]): readonly ToolCallSummary[];
+/**
+ * Extracts metrics from events and measured duration.
+ */
+declare function extractMetrics(events: readonly EngineEvent[], durationMs: number): EngineMetrics;
+/**
+ * Creates a brief text summary of a transcript.
+ * Shows first message, tool call names, and last message.
+ */
+declare function summarizeTranscript(events: readonly EngineEvent[]): string;
+/**
+ * Returns the last N turn-bounded event groups.
+ */
+declare function lastNTurns(events: readonly EngineEvent[], n: number): readonly EngineEvent[];
+
+export { type AgentHandle, type CiReport, DEFAULT_CONCURRENCY, DEFAULT_PASS_THRESHOLD, DEFAULT_TIMEOUT_MS, type EvalExpectation, type EvalGrader, type EvalRun, type EvalRunConfig, type EvalRunConfigSnapshot, type EvalRunMeta, type EvalRunner, type EvalScore, type EvalStore, type EvalSummary, type EvalTask, type EvalTrial, type ExpectedToolCall, type LlmJudgeConfig, type RegressionDetail, type RegressionResult, type RegressionThresholds, type TaskSummary, type ToolCallSummary, type TranscriptMode, collectTranscript, computePassAtK, computePassToTheK, computePercentile, computeSummary, createEvalRunner, createExactMatchGrader, createFsEvalStore, createJsonSchemaGrader, createLlmJudgeGrader, createToolCallGrader, detectRegression, extractMetrics, extractText, extractToolCalls, formatCiReport, formatSummaryTable, lastNTurns, summarizeTranscript, validateEvalConfig };
+"
+`;

--- a/packages/eval/src/__tests__/api-surface.test.ts
+++ b/packages/eval/src/__tests__/api-surface.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/eval/src/__tests__/e2e.test.ts
+++ b/packages/eval/src/__tests__/e2e.test.ts
@@ -1,0 +1,145 @@
+/**
+ * End-to-end tests for @koi/eval with real LLM calls.
+ *
+ * Validates the full eval pipeline: run → grade → store → regress.
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineInput } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createExactMatchGrader } from "../graders/exact-match.js";
+import { detectRegression } from "../regression.js";
+import { createEvalRunner } from "../runner.js";
+import type { AgentHandle, EvalRunConfig, EvalTask } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Agent factory
+// ---------------------------------------------------------------------------
+
+async function createAgent(): Promise<AgentHandle> {
+  const piAdapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: "You are a concise test assistant. Reply briefly and exactly as instructed.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: {
+      name: "eval-e2e-agent",
+      version: "1.0.0",
+      model: { name: "claude-haiku" },
+    },
+    adapter: piAdapter,
+    middleware: [],
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 55_000, maxTokens: 5_000 },
+  });
+
+  return {
+    stream: (input: EngineInput) => runtime.run(input),
+    dispose: () => runtime.dispose(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: eval with real Anthropic API", () => {
+  test(
+    "runs a simple evaluation with exact match grader",
+    async () => {
+      const tasks: readonly EvalTask[] = [
+        {
+          id: "ping",
+          name: "Ping-Pong",
+          input: { kind: "text", text: "Reply with exactly one word: pong" },
+          expected: { kind: "text", pattern: /pong/i },
+          graders: [createExactMatchGrader()],
+          timeoutMs: 30_000,
+        },
+        {
+          id: "math",
+          name: "Simple Math",
+          input: { kind: "text", text: "What is 2 + 2? Reply with just the number." },
+          expected: { kind: "text", pattern: "4" },
+          graders: [createExactMatchGrader()],
+          timeoutMs: 30_000,
+        },
+      ];
+
+      const config: EvalRunConfig = {
+        name: "e2e-test",
+        tasks,
+        agentFactory: createAgent,
+        concurrency: 2,
+        passThreshold: 0.5,
+      };
+
+      const runner = createEvalRunner(config);
+      const run = await runner.run();
+
+      console.log(`\n  Eval run: ${run.id}`);
+      console.log(`  Pass rate: ${String(run.summary.passRate * 100)}%`);
+      for (const trial of run.trials) {
+        const icon = trial.status === "pass" ? "+" : trial.status === "fail" ? "x" : "!";
+        console.log(`  [${icon}] ${trial.taskId} #${String(trial.trialIndex)}: ${trial.status}`);
+      }
+
+      expect(run.trials).toHaveLength(2);
+      expect(run.summary.taskCount).toBe(2);
+      // At least one trial should pass with a real LLM
+      expect(run.summary.passRate).toBeGreaterThan(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "regression detection works with real eval runs",
+    async () => {
+      const tasks: readonly EvalTask[] = [
+        {
+          id: "greet",
+          name: "Greeting",
+          input: { kind: "text", text: "Say hello in one word" },
+          expected: { kind: "text", pattern: /hello/i },
+          graders: [createExactMatchGrader()],
+          trialCount: 2,
+          timeoutMs: 30_000,
+        },
+      ];
+
+      const config: EvalRunConfig = {
+        name: "regression-test",
+        tasks,
+        agentFactory: createAgent,
+        concurrency: 2,
+      };
+
+      const runner = createEvalRunner(config);
+      const run = await runner.run();
+
+      // Compare run against itself (no regression expected)
+      const result = detectRegression(run.summary, run.summary);
+      expect(result.kind).toBe("pass");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/eval/src/config.test.ts
+++ b/packages/eval/src/config.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_PASS_THRESHOLD,
+  DEFAULT_TIMEOUT_MS,
+  validateEvalConfig,
+} from "./config.js";
+
+const VALID_TASK = {
+  id: "t1",
+  name: "test task",
+  input: { kind: "text" as const, text: "hello" },
+  graders: [
+    { id: "g1", name: "test grader", grade: () => ({ graderId: "g1", score: 1, pass: true }) },
+  ],
+};
+
+const VALID_CONFIG = {
+  name: "test-eval",
+  tasks: [VALID_TASK],
+  agentFactory: async () => ({
+    stream: async function* () {
+      yield {
+        kind: "done" as const,
+        output: {
+          content: [],
+          stopReason: "completed" as const,
+          metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs: 0 },
+        },
+      };
+    },
+  }),
+};
+
+describe("validateEvalConfig", () => {
+  test("accepts valid config", () => {
+    const result = validateEvalConfig(VALID_CONFIG);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object config", () => {
+    const result = validateEvalConfig("not an object");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  test("rejects null config", () => {
+    const result = validateEvalConfig(null);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects empty name", () => {
+    const result = validateEvalConfig({ ...VALID_CONFIG, name: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  test("rejects missing tasks", () => {
+    const result = validateEvalConfig({ ...VALID_CONFIG, tasks: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("tasks");
+    }
+  });
+
+  test("rejects task without id", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, id: "" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("id");
+    }
+  });
+
+  test("rejects task without name", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, name: "" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  test("rejects task without valid input", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, input: "not an object" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("input");
+    }
+  });
+
+  test("rejects task with empty graders", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, graders: [] }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("graders");
+    }
+  });
+
+  test("rejects task with invalid trialCount", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, trialCount: 0 }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("trialCount");
+    }
+  });
+
+  test("rejects task with invalid timeoutMs", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      tasks: [{ ...VALID_TASK, timeoutMs: -1 }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("timeoutMs");
+    }
+  });
+
+  test("rejects missing agentFactory", () => {
+    const { agentFactory: _, ...noFactory } = VALID_CONFIG;
+    const result = validateEvalConfig(noFactory);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("agentFactory");
+    }
+  });
+
+  test("rejects invalid concurrency", () => {
+    const result = validateEvalConfig({ ...VALID_CONFIG, concurrency: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("concurrency");
+    }
+  });
+
+  test("rejects invalid passThreshold", () => {
+    const result = validateEvalConfig({ ...VALID_CONFIG, passThreshold: 1.5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("passThreshold");
+    }
+  });
+
+  test("rejects non-function onTrialComplete", () => {
+    const result = validateEvalConfig({
+      ...VALID_CONFIG,
+      onTrialComplete: "not a function",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("onTrialComplete");
+    }
+  });
+});
+
+describe("defaults", () => {
+  test("DEFAULT_CONCURRENCY is 5", () => {
+    expect(DEFAULT_CONCURRENCY).toBe(5);
+  });
+
+  test("DEFAULT_TIMEOUT_MS is 60_000", () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(60_000);
+  });
+
+  test("DEFAULT_PASS_THRESHOLD is 0.5", () => {
+    expect(DEFAULT_PASS_THRESHOLD).toBe(0.5);
+  });
+});

--- a/packages/eval/src/config.ts
+++ b/packages/eval/src/config.ts
@@ -1,0 +1,123 @@
+/**
+ * Eval config validation and defaults.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core";
+import type { EvalRunConfig } from "./types.js";
+
+export const DEFAULT_CONCURRENCY = 5;
+export const DEFAULT_TIMEOUT_MS = 60_000;
+export const DEFAULT_PASS_THRESHOLD = 0.5;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function validationError(message: string): {
+  readonly ok: false;
+  readonly error: KoiError;
+} {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function validateTask(task: unknown): string | undefined {
+  if (!isRecord(task)) return "Each task must be a non-null object";
+  if (typeof task.id !== "string" || task.id.length === 0) {
+    return "Each task must have a non-empty 'id' string";
+  }
+  if (typeof task.name !== "string" || task.name.length === 0) {
+    return "Each task must have a non-empty 'name' string";
+  }
+  if (!isRecord(task.input) || typeof task.input.kind !== "string") {
+    return `Task "${String(task.id)}": 'input' must have a 'kind' field`;
+  }
+  if (!Array.isArray(task.graders) || task.graders.length === 0) {
+    return `Task "${String(task.id)}": 'graders' must be a non-empty array`;
+  }
+  if (task.trialCount !== undefined) {
+    if (
+      typeof task.trialCount !== "number" ||
+      !Number.isInteger(task.trialCount) ||
+      task.trialCount < 1
+    ) {
+      return `Task "${String(task.id)}": 'trialCount' must be a positive integer`;
+    }
+  }
+  if (task.timeoutMs !== undefined) {
+    if (
+      typeof task.timeoutMs !== "number" ||
+      !Number.isFinite(task.timeoutMs) ||
+      task.timeoutMs <= 0
+    ) {
+      return `Task "${String(task.id)}": 'timeoutMs' must be a finite positive number`;
+    }
+  }
+  return undefined;
+}
+
+function validateOptionalFields(config: Record<string, unknown>): string | undefined {
+  if (config.concurrency !== undefined) {
+    if (
+      typeof config.concurrency !== "number" ||
+      !Number.isInteger(config.concurrency) ||
+      config.concurrency < 1
+    ) {
+      return "'concurrency' must be a positive integer";
+    }
+  }
+  if (config.timeoutMs !== undefined) {
+    if (
+      typeof config.timeoutMs !== "number" ||
+      !Number.isFinite(config.timeoutMs) ||
+      config.timeoutMs <= 0
+    ) {
+      return "'timeoutMs' must be a finite positive number";
+    }
+  }
+  if (config.passThreshold !== undefined) {
+    if (
+      typeof config.passThreshold !== "number" ||
+      config.passThreshold < 0 ||
+      config.passThreshold > 1
+    ) {
+      return "'passThreshold' must be a number between 0 and 1";
+    }
+  }
+  if (config.onTrialComplete !== undefined && typeof config.onTrialComplete !== "function") {
+    return "'onTrialComplete' must be a function";
+  }
+  return undefined;
+}
+
+export function validateEvalConfig(config: unknown): Result<EvalRunConfig, KoiError> {
+  if (!isRecord(config)) return validationError("Config must be a non-null object");
+  if (typeof config.name !== "string" || config.name.length === 0) {
+    return validationError("'name' must be a non-empty string");
+  }
+  if (!Array.isArray(config.tasks) || config.tasks.length === 0) {
+    return validationError("'tasks' must be a non-empty array");
+  }
+
+  for (const task of config.tasks as unknown[]) {
+    const taskError = validateTask(task);
+    if (taskError !== undefined) return validationError(taskError);
+  }
+
+  if (typeof config.agentFactory !== "function") {
+    return validationError("'agentFactory' must be a function");
+  }
+
+  const optionalError = validateOptionalFields(config);
+  if (optionalError !== undefined) return validationError(optionalError);
+
+  const validated: unknown = config;
+  return { ok: true, value: validated as EvalRunConfig };
+}

--- a/packages/eval/src/graders/exact-match.test.ts
+++ b/packages/eval/src/graders/exact-match.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import type { EvalExpectation } from "../types.js";
+import { createExactMatchGrader } from "./exact-match.js";
+
+const ZERO_METRICS: EngineMetrics = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 0,
+};
+
+function textEvents(text: string): readonly EngineEvent[] {
+  return [{ kind: "text_delta", delta: text }];
+}
+
+describe("createExactMatchGrader", () => {
+  const grader = createExactMatchGrader();
+
+  test("passes on exact string match", () => {
+    const events = textEvents("hello world");
+    const expected: EvalExpectation = { kind: "text", pattern: "hello world" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 1, pass: true }));
+  });
+
+  test("passes on substring match", () => {
+    const events = textEvents("the answer is 42");
+    const expected: EvalExpectation = { kind: "text", pattern: "42" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 1, pass: true }));
+  });
+
+  test("fails on mismatch", () => {
+    const events = textEvents("hello world");
+    const expected: EvalExpectation = { kind: "text", pattern: "goodbye" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("is case sensitive by default", () => {
+    const events = textEvents("Hello World");
+    const expected: EvalExpectation = { kind: "text", pattern: "hello world" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("supports case insensitive mode", () => {
+    const caseInsensitive = createExactMatchGrader({ caseSensitive: false });
+    const events = textEvents("Hello World");
+    const expected: EvalExpectation = { kind: "text", pattern: "hello world" };
+    const score = caseInsensitive.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 1, pass: true }));
+  });
+
+  test("supports regex patterns", () => {
+    const events = textEvents("The answer is 42.");
+    const expected: EvalExpectation = {
+      kind: "text",
+      pattern: /answer is \d+/,
+    };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 1, pass: true }));
+  });
+
+  test("handles regex mismatch", () => {
+    const events = textEvents("no numbers here");
+    const expected: EvalExpectation = { kind: "text", pattern: /\d+/ };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("returns 0 when no expectation provided", () => {
+    const events = textEvents("hello");
+    const score = grader.grade(events, undefined, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("returns 0 for non-text expectation", () => {
+    const events = textEvents("hello");
+    const expected: EvalExpectation = { kind: "tool_calls", calls: [] };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("handles empty output", () => {
+    const events: readonly EngineEvent[] = [];
+    const expected: EvalExpectation = { kind: "text", pattern: "something" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 0, pass: false }));
+  });
+
+  test("handles unicode text", () => {
+    const events = textEvents("cafe\u0301");
+    const expected: EvalExpectation = { kind: "text", pattern: "cafe\u0301" };
+    const score = grader.grade(events, expected, ZERO_METRICS);
+    expect(score).toEqual(expect.objectContaining({ score: 1, pass: true }));
+  });
+});

--- a/packages/eval/src/graders/exact-match.ts
+++ b/packages/eval/src/graders/exact-match.ts
@@ -1,0 +1,53 @@
+/**
+ * Exact match grader — scores against text expectations.
+ */
+
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { extractText } from "../transcript.js";
+import type { EvalExpectation, EvalGrader, EvalScore } from "../types.js";
+
+export interface ExactMatchConfig {
+  readonly caseSensitive?: boolean;
+}
+
+export function createExactMatchGrader(config?: ExactMatchConfig): EvalGrader {
+  const caseSensitive = config?.caseSensitive ?? true;
+
+  return {
+    id: "exact-match",
+    name: "Exact Match",
+    grade(
+      transcript: readonly EngineEvent[],
+      expected: EvalExpectation | undefined,
+      _metrics: EngineMetrics,
+    ): EvalScore {
+      if (expected === undefined || expected.kind !== "text") {
+        return {
+          graderId: "exact-match",
+          score: 0,
+          pass: false,
+          reasoning: "No text expectation provided",
+        };
+      }
+
+      const output = extractText(transcript);
+      const { pattern } = expected;
+
+      const matches =
+        pattern instanceof RegExp
+          ? pattern.test(output)
+          : caseSensitive
+            ? output.includes(pattern)
+            : output.toLowerCase().includes(pattern.toLowerCase());
+
+      return {
+        graderId: "exact-match",
+        score: matches ? 1 : 0,
+        pass: matches,
+        reasoning: matches
+          ? "Output matches expected pattern"
+          : `Output did not match expected pattern`,
+      };
+    },
+  };
+}

--- a/packages/eval/src/graders/json-schema.test.ts
+++ b/packages/eval/src/graders/json-schema.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { createJsonSchemaGrader } from "./json-schema.js";
+
+const ZERO_METRICS: EngineMetrics = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 0,
+};
+
+function textEvents(text: string): readonly EngineEvent[] {
+  return [{ kind: "text_delta", delta: text }];
+}
+
+describe("createJsonSchemaGrader", () => {
+  const grader = createJsonSchemaGrader({
+    schema: {
+      type: "object",
+      required: ["name", "age"],
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+      },
+    },
+  });
+
+  test("passes for valid JSON matching schema", async () => {
+    const events = textEvents('{"name": "Alice", "age": 30}');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+    expect(score.pass).toBe(true);
+  });
+
+  test("fails for missing required field", async () => {
+    const events = textEvents('{"name": "Alice"}');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.pass).toBe(false);
+    expect(score.reasoning).toContain("age");
+  });
+
+  test("fails for wrong type", async () => {
+    const events = textEvents('{"name": 123, "age": 30}');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("expected string");
+  });
+
+  test("fails for non-JSON output", async () => {
+    const events = textEvents("this is not json");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("parse JSON");
+  });
+
+  test("handles JSON in markdown code block", async () => {
+    const events = textEvents('```json\n{"name": "Bob", "age": 25}\n```');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+    expect(score.pass).toBe(true);
+  });
+
+  test("handles empty output", async () => {
+    const events: readonly EngineEvent[] = [];
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.pass).toBe(false);
+  });
+});
+
+describe("nested object validation", () => {
+  const grader = createJsonSchemaGrader({
+    schema: {
+      type: "object",
+      required: ["user"],
+      properties: {
+        user: {
+          type: "object",
+          required: ["id"],
+          properties: {
+            id: { type: "number" },
+          },
+        },
+      },
+    },
+  });
+
+  test("validates nested objects", async () => {
+    const events = textEvents('{"user": {"id": 1}}');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("fails for missing nested required", async () => {
+    const events = textEvents('{"user": {}}');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("id");
+  });
+});
+
+describe("array validation", () => {
+  const grader = createJsonSchemaGrader({
+    schema: {
+      type: "array",
+      items: { type: "number" },
+    },
+  });
+
+  test("validates array items", async () => {
+    const events = textEvents("[1, 2, 3]");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("fails for wrong item type", async () => {
+    const events = textEvents('[1, "two", 3]');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("expected number");
+  });
+});
+
+describe("numeric constraints", () => {
+  const grader = createJsonSchemaGrader({
+    schema: {
+      type: "number",
+      minimum: 0,
+      maximum: 100,
+    },
+  });
+
+  test("passes for value in range", async () => {
+    const events = textEvents("50");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("fails for value below minimum", async () => {
+    const events = textEvents("-1");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("minimum");
+  });
+});
+
+describe("string constraints", () => {
+  const grader = createJsonSchemaGrader({
+    schema: {
+      type: "string",
+      minLength: 2,
+      maxLength: 5,
+    },
+  });
+
+  test("passes for valid length", async () => {
+    const events = textEvents('"abc"');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("fails for string too short", async () => {
+    const events = textEvents('"a"');
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.reasoning).toContain("minLength");
+  });
+});

--- a/packages/eval/src/graders/json-schema.ts
+++ b/packages/eval/src/graders/json-schema.ts
@@ -1,0 +1,180 @@
+/**
+ * JSON schema grader — validates agent output against a schema.
+ *
+ * Simple recursive validation without external dependencies.
+ */
+
+import type { EngineEvent, EngineMetrics, JsonObject } from "@koi/core";
+import { extractText } from "../transcript.js";
+import type { EvalExpectation, EvalGrader, EvalScore } from "../types.js";
+
+export interface JsonSchemaGraderConfig {
+  readonly schema: JsonObject;
+}
+
+export function createJsonSchemaGrader(config: JsonSchemaGraderConfig): EvalGrader {
+  return {
+    id: "json-schema",
+    name: "JSON Schema",
+    grade(
+      transcript: readonly EngineEvent[],
+      _expected: EvalExpectation | undefined,
+      _metrics: EngineMetrics,
+    ): EvalScore {
+      const text = extractText(transcript).trim();
+
+      // Try to extract JSON from the output (may be wrapped in markdown code blocks)
+      const jsonStr = extractJson(text);
+      if (jsonStr === undefined) {
+        return {
+          graderId: "json-schema",
+          score: 0,
+          pass: false,
+          reasoning: "Output is not valid JSON",
+        };
+      }
+
+      // let justified: parse may throw
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(jsonStr);
+      } catch {
+        return {
+          graderId: "json-schema",
+          score: 0,
+          pass: false,
+          reasoning: "Failed to parse JSON from output",
+        };
+      }
+
+      const errors = validateSchema(parsed, config.schema, "root");
+      if (errors.length === 0) {
+        return {
+          graderId: "json-schema",
+          score: 1,
+          pass: true,
+          reasoning: "Output matches JSON schema",
+        };
+      }
+
+      return {
+        graderId: "json-schema",
+        score: 0,
+        pass: false,
+        reasoning: `Schema validation failed: ${errors.join("; ")}`,
+      };
+    },
+  };
+}
+
+/**
+ * Extracts a JSON string from text, handling markdown code blocks.
+ */
+function extractJson(text: string): string | undefined {
+  const codeBlockMatch = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(text);
+  if (codeBlockMatch?.[1] !== undefined) {
+    return codeBlockMatch[1].trim();
+  }
+
+  // Try the raw text as-is — could be any valid JSON value
+  const trimmed = text.trim();
+  if (trimmed.length > 0) {
+    return trimmed;
+  }
+
+  return undefined;
+}
+
+/**
+ * Simple recursive JSON schema validator.
+ * Supports: type, properties, required, items, minimum, maximum, minLength, maxLength.
+ */
+function validateSchema(
+  value: unknown,
+  schema: Readonly<Record<string, unknown>>,
+  path: string,
+): readonly string[] {
+  const errors: string[] = [];
+
+  if (schema.type !== undefined) {
+    const expected = schema.type;
+    const actual = getJsonType(value);
+    if (expected === "integer") {
+      if (typeof value !== "number" || !Number.isInteger(value)) {
+        errors.push(`${path}: expected integer, got ${actual}`);
+        return errors;
+      }
+    } else if (actual !== expected) {
+      errors.push(`${path}: expected ${String(expected)}, got ${actual}`);
+      return errors;
+    }
+  }
+
+  if (schema.type === "object" && typeof value === "object" && value !== null) {
+    const obj = value as Readonly<Record<string, unknown>>;
+    const required = schema.required;
+    if (Array.isArray(required)) {
+      for (const key of required as readonly string[]) {
+        if (!(key in obj)) {
+          errors.push(`${path}.${key}: required property missing`);
+        }
+      }
+    }
+
+    const properties = schema.properties;
+    if (typeof properties === "object" && properties !== null) {
+      const props = properties as Readonly<Record<string, unknown>>;
+      for (const [key, propSchema] of Object.entries(props)) {
+        if (key in obj && typeof propSchema === "object" && propSchema !== null) {
+          const subErrors = validateSchema(
+            obj[key],
+            propSchema as Readonly<Record<string, unknown>>,
+            `${path}.${key}`,
+          );
+          for (const e of subErrors) errors.push(e);
+        }
+      }
+    }
+  }
+
+  if (schema.type === "array" && Array.isArray(value)) {
+    const items = schema.items;
+    if (typeof items === "object" && items !== null) {
+      const itemSchema = items as Readonly<Record<string, unknown>>;
+      for (const [i, item] of value.entries()) {
+        const subErrors = validateSchema(item, itemSchema, `${path}[${String(i)}]`);
+        for (const e of subErrors) errors.push(e);
+      }
+    }
+  }
+
+  if (typeof value === "number") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push(`${path}: ${String(value)} < minimum ${String(schema.minimum)}`);
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push(`${path}: ${String(value)} > maximum ${String(schema.maximum)}`);
+    }
+  }
+
+  if (typeof value === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push(
+        `${path}: string length ${String(value.length)} < minLength ${String(schema.minLength)}`,
+      );
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push(
+        `${path}: string length ${String(value.length)} > maxLength ${String(schema.maxLength)}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function getJsonType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/packages/eval/src/graders/llm-judge.test.ts
+++ b/packages/eval/src/graders/llm-judge.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import type { EvalExpectation } from "../types.js";
+import { createLlmJudgeGrader } from "./llm-judge.js";
+
+const ZERO_METRICS: EngineMetrics = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 0,
+};
+
+function textEvents(text: string): readonly EngineEvent[] {
+  return [{ kind: "text_delta", delta: text }];
+}
+
+describe("createLlmJudgeGrader", () => {
+  test("parses valid JSON response from model", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => '{"score": 0.8, "reasoning": "Good output"}',
+      rubric: "Is the output helpful?",
+    });
+
+    const events = textEvents("hello world");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0.8);
+    expect(score.pass).toBe(true);
+    expect(score.reasoning).toBe("Good output");
+  });
+
+  test("handles score below pass threshold", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => '{"score": 0.3, "reasoning": "Poor output"}',
+      rubric: "Is the output helpful?",
+    });
+
+    const events = textEvents("bad");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0.3);
+    expect(score.pass).toBe(false);
+  });
+
+  test("handles malformed JSON response", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => "this is not json at all",
+      rubric: "Is the output helpful?",
+    });
+
+    const events = textEvents("hello");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.pass).toBe(false);
+    expect(score.reasoning).toContain("Failed to parse");
+  });
+
+  test("handles model call error", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => {
+        throw new Error("API timeout");
+      },
+      rubric: "Is the output helpful?",
+    });
+
+    const events = textEvents("hello");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.pass).toBe(false);
+    expect(score.reasoning).toContain("API timeout");
+  });
+
+  test("uses custom parseScore function", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => "Score: 9/10",
+      rubric: "Rate the output",
+      parseScore: (response) => {
+        const match = /(\d+)\/10/.exec(response);
+        return match?.[1] !== undefined ? Number(match[1]) / 10 : 0;
+      },
+    });
+
+    const events = textEvents("great answer");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0.9);
+    expect(score.pass).toBe(true);
+  });
+
+  test("clamps score to [0, 1] range", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () => '{"score": 1.5, "reasoning": "over the top"}',
+      rubric: "Rate",
+    });
+
+    const events = textEvents("hello");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("includes expected text in prompt when provided", async () => {
+    // let justified: capturing prompt for assertion
+    let capturedPrompt = "";
+
+    const grader = createLlmJudgeGrader({
+      modelCall: async (prompt) => {
+        capturedPrompt = prompt;
+        return '{"score": 0.8, "reasoning": "ok"}';
+      },
+      rubric: "Check accuracy",
+    });
+
+    const events = textEvents("answer is 42");
+    const expected: EvalExpectation = { kind: "text", pattern: "42" };
+    await grader.grade(events, expected, ZERO_METRICS);
+
+    expect(capturedPrompt).toContain("42");
+    expect(capturedPrompt).toContain("Expected Output");
+  });
+
+  test("uses summary transcript mode", async () => {
+    // let justified: capturing prompt for assertion
+    let capturedPrompt = "";
+
+    const grader = createLlmJudgeGrader({
+      modelCall: async (prompt) => {
+        capturedPrompt = prompt;
+        return '{"score": 1, "reasoning": "good"}';
+      },
+      rubric: "Rate",
+      transcriptMode: "summary",
+    });
+
+    const events: readonly EngineEvent[] = [
+      { kind: "turn_start", turnIndex: 0 },
+      { kind: "text_delta", delta: "hello" },
+      { kind: "tool_call_start", toolName: "search", callId: "c1" } as EngineEvent,
+      { kind: "turn_end", turnIndex: 0 },
+    ];
+    await grader.grade(events, undefined, ZERO_METRICS);
+
+    expect(capturedPrompt).toContain("Tools: search");
+  });
+
+  test("extracts JSON from markdown code block in response", async () => {
+    const grader = createLlmJudgeGrader({
+      modelCall: async () =>
+        'Here is my assessment:\n```json\n{"score": 0.75, "reasoning": "decent"}\n```',
+      rubric: "Rate",
+    });
+
+    const events = textEvents("hello");
+    const score = await grader.grade(events, undefined, ZERO_METRICS);
+    expect(score.score).toBe(0.75);
+  });
+});

--- a/packages/eval/src/graders/llm-judge.ts
+++ b/packages/eval/src/graders/llm-judge.ts
@@ -1,0 +1,123 @@
+/**
+ * LLM-as-judge grader — uses a model call to evaluate agent output.
+ */
+
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { extractText, lastNTurns, summarizeTranscript } from "../transcript.js";
+import type { EvalExpectation, EvalGrader, EvalScore, LlmJudgeConfig } from "../types.js";
+
+const DEFAULT_LAST_N = 5;
+
+export function createLlmJudgeGrader(config: LlmJudgeConfig): EvalGrader {
+  const transcriptMode = config.transcriptMode ?? "full";
+  const lastN = config.lastN ?? DEFAULT_LAST_N;
+
+  return {
+    id: "llm-judge",
+    name: "LLM Judge",
+    async grade(
+      transcript: readonly EngineEvent[],
+      expected: EvalExpectation | undefined,
+      _metrics: EngineMetrics,
+    ): Promise<EvalScore> {
+      const transcriptText = formatTranscript(transcript, transcriptMode, lastN);
+      const expectedText =
+        expected !== undefined && expected.kind === "text" ? String(expected.pattern) : undefined;
+
+      const prompt = buildPrompt(config.rubric, transcriptText, expectedText);
+
+      try {
+        const response = await config.modelCall(prompt);
+        return parseJudgeResponse(response, config.parseScore);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : "Unknown model call error";
+        return {
+          graderId: "llm-judge",
+          score: 0,
+          pass: false,
+          reasoning: `LLM judge error: ${message}`,
+        };
+      }
+    },
+  };
+}
+
+function formatTranscript(events: readonly EngineEvent[], mode: string, lastN: number): string {
+  switch (mode) {
+    case "summary":
+      return summarizeTranscript(events);
+    case "last-n":
+      return extractText(lastNTurns(events, lastN));
+    default:
+      return extractText(events);
+  }
+}
+
+function buildPrompt(rubric: string, transcript: string, expected: string | undefined): string {
+  const parts = [
+    "You are an evaluation judge. Score the following agent output.",
+    "",
+    "## Rubric",
+    rubric,
+    "",
+    "## Agent Output",
+    transcript,
+  ];
+
+  if (expected !== undefined) {
+    parts.push("", "## Expected Output", expected);
+  }
+
+  parts.push(
+    "",
+    "## Instructions",
+    'Respond with ONLY a JSON object: {"score": <0.0-1.0>, "reasoning": "<explanation>"}',
+    "The score must be between 0.0 (worst) and 1.0 (best).",
+  );
+
+  return parts.join("\n");
+}
+
+function parseJudgeResponse(
+  response: string,
+  customParser?: (response: string) => number,
+): EvalScore {
+  if (customParser !== undefined) {
+    const score = customParser(response);
+    return {
+      graderId: "llm-judge",
+      score: clampScore(score),
+      pass: score >= 0.5,
+      reasoning: response,
+    };
+  }
+
+  // Try JSON parse
+  const jsonMatch = /\{[\s\S]*\}/.exec(response);
+  if (jsonMatch?.[0] !== undefined) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]) as Readonly<Record<string, unknown>>;
+      const score = typeof parsed.score === "number" ? parsed.score : 0;
+      const reasoning = typeof parsed.reasoning === "string" ? parsed.reasoning : response;
+      return {
+        graderId: "llm-judge",
+        score: clampScore(score),
+        pass: score >= 0.5,
+        reasoning,
+      };
+    } catch {
+      // Fall through to fallback
+    }
+  }
+
+  return {
+    graderId: "llm-judge",
+    score: 0,
+    pass: false,
+    reasoning: `Failed to parse judge response: ${response.slice(0, 200)}`,
+  };
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(1, score));
+}

--- a/packages/eval/src/graders/tool-call.test.ts
+++ b/packages/eval/src/graders/tool-call.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { toolCallId } from "@koi/core";
+import type { EvalExpectation } from "../types.js";
+import { createToolCallGrader } from "./tool-call.js";
+
+const ZERO_METRICS: EngineMetrics = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 0,
+};
+
+function toolCallEvents(names: readonly string[]): readonly EngineEvent[] {
+  return names.map((name, i) => ({
+    kind: "tool_call_start" as const,
+    toolName: name,
+    callId: toolCallId(`c${String(i)}`),
+  })) as readonly EngineEvent[];
+}
+
+describe("createToolCallGrader", () => {
+  const grader = createToolCallGrader();
+
+  test("passes when expected tools match actual", async () => {
+    const events = toolCallEvents(["search", "calculate"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }, { toolName: "calculate" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    expect(score.score).toBe(1);
+    expect(score.pass).toBe(true);
+  });
+
+  test("scores partial match with Jaccard", async () => {
+    const events = toolCallEvents(["search", "extra"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }, { toolName: "calculate" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    // Jaccard: intersection=1(search), union=3(search,extra,calculate) → 1/3
+    expect(score.score).toBeCloseTo(1 / 3, 2);
+    expect(score.pass).toBe(false);
+  });
+
+  test("scores 0 when no expected tools are found", async () => {
+    const events = toolCallEvents(["unrelated"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    expect(score.score).toBe(0);
+    expect(score.pass).toBe(false);
+  });
+
+  test("returns score 1 when both empty", async () => {
+    const expected: EvalExpectation = { kind: "tool_calls", calls: [] };
+    const score = await grader.grade([], expected, ZERO_METRICS);
+    expect(score.score).toBe(1);
+    expect(score.pass).toBe(true);
+  });
+
+  test("returns 0 for non-tool_calls expectation", async () => {
+    const score = await grader.grade([], undefined, ZERO_METRICS);
+    expect(score.pass).toBe(false);
+  });
+
+  test("handles extra actual calls", async () => {
+    const events = toolCallEvents(["search", "extra1", "extra2"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    // Jaccard: 1/3
+    expect(score.score).toBeCloseTo(1 / 3, 2);
+  });
+});
+
+describe("createToolCallGrader with strict order", () => {
+  const grader = createToolCallGrader({ orderStrict: true });
+
+  test("passes when tools in correct order", async () => {
+    const events = toolCallEvents(["search", "calculate"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }, { toolName: "calculate" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    expect(score.score).toBe(1);
+    expect(score.pass).toBe(true);
+  });
+
+  test("fails when tools in wrong order", async () => {
+    const events = toolCallEvents(["calculate", "search"]);
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search" }, { toolName: "calculate" }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    // Only "calculate" matches (search comes before it in expected but after in actual)
+    expect(score.score).toBeLessThan(1);
+  });
+});
+
+describe("tool call arg matching", () => {
+  const grader = createToolCallGrader();
+
+  test("matches when args match", async () => {
+    const events: readonly EngineEvent[] = [
+      {
+        kind: "tool_call_start",
+        toolName: "search",
+        callId: toolCallId("c0"),
+        args: { query: "test" },
+      },
+    ];
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search", args: { query: "test" } }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    expect(score.score).toBe(1);
+  });
+
+  test("penalizes arg mismatches", async () => {
+    const events: readonly EngineEvent[] = [
+      {
+        kind: "tool_call_start",
+        toolName: "search",
+        callId: toolCallId("c0"),
+        args: { query: "wrong" },
+      },
+    ];
+    const expected: EvalExpectation = {
+      kind: "tool_calls",
+      calls: [{ toolName: "search", args: { query: "test" } }],
+    };
+    const score = await grader.grade(events, expected, ZERO_METRICS);
+    expect(score.score).toBeLessThan(1);
+  });
+});

--- a/packages/eval/src/graders/tool-call.ts
+++ b/packages/eval/src/graders/tool-call.ts
@@ -1,0 +1,173 @@
+/**
+ * Tool call grader — scores based on expected vs actual tool usage.
+ */
+
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { extractToolCalls } from "../transcript.js";
+import type { EvalExpectation, EvalGrader, EvalScore } from "../types.js";
+
+export interface ToolCallGraderConfig {
+  /** Whether tool calls must appear in expected order. Default: false. */
+  readonly orderStrict?: boolean;
+}
+
+export function createToolCallGrader(config?: ToolCallGraderConfig): EvalGrader {
+  const orderStrict = config?.orderStrict ?? false;
+
+  return {
+    id: "tool-call",
+    name: "Tool Call",
+    grade(
+      transcript: readonly EngineEvent[],
+      expected: EvalExpectation | undefined,
+      _metrics: EngineMetrics,
+    ): EvalScore {
+      if (expected === undefined || expected.kind !== "tool_calls") {
+        return {
+          graderId: "tool-call",
+          score: 0,
+          pass: false,
+          reasoning: "No tool_calls expectation provided",
+        };
+      }
+
+      const actualCalls = extractToolCalls(transcript);
+      const expectedCalls = expected.calls;
+
+      if (expectedCalls.length === 0 && actualCalls.length === 0) {
+        return {
+          graderId: "tool-call",
+          score: 1,
+          pass: true,
+          reasoning: "No tool calls expected or observed",
+        };
+      }
+
+      if (expectedCalls.length === 0) {
+        return {
+          graderId: "tool-call",
+          score: 0,
+          pass: false,
+          reasoning: `Expected no tool calls but got ${String(actualCalls.length)}`,
+        };
+      }
+
+      const actualNames = actualCalls.map((c) => c.toolName);
+      const expectedNames = expectedCalls.map((c) => c.toolName);
+
+      if (orderStrict || expectedCalls.some((c) => c.order === "strict")) {
+        return gradeStrictOrder(expectedNames, actualNames, expectedCalls, actualCalls);
+      }
+
+      return gradeAnyOrder(expectedNames, actualNames, expectedCalls, actualCalls);
+    },
+  };
+}
+
+function gradeStrictOrder(
+  expectedNames: readonly string[],
+  actualNames: readonly string[],
+  expectedCalls: readonly {
+    readonly toolName: string;
+    readonly args?: Readonly<Record<string, unknown>>;
+  }[],
+  actualCalls: readonly {
+    readonly toolName: string;
+    readonly args?: Readonly<Record<string, unknown>>;
+  }[],
+): EvalScore {
+  // let justified: tracking matched count for score calculation
+  let matched = 0;
+  // let justified: tracking position in actual calls for sequential matching
+  let actualIdx = 0;
+
+  for (const exp of expectedCalls) {
+    while (actualIdx < actualCalls.length) {
+      const actual = actualCalls[actualIdx];
+      actualIdx += 1;
+      if (actual !== undefined && actual.toolName === exp.toolName) {
+        if (exp.args === undefined || argsMatch(exp.args, actual.args)) {
+          matched += 1;
+        }
+        break;
+      }
+    }
+  }
+
+  const total = Math.max(expectedNames.length, actualNames.length);
+  const score = total > 0 ? matched / total : 1;
+
+  return {
+    graderId: "tool-call",
+    score,
+    pass: score >= 0.5,
+    reasoning: `Strict order: ${String(matched)}/${String(expectedCalls.length)} expected calls matched`,
+  };
+}
+
+function gradeAnyOrder(
+  expectedNames: readonly string[],
+  actualNames: readonly string[],
+  expectedCalls: readonly {
+    readonly toolName: string;
+    readonly args?: Readonly<Record<string, unknown>>;
+  }[],
+  actualCalls: readonly {
+    readonly toolName: string;
+    readonly args?: Readonly<Record<string, unknown>>;
+  }[],
+): EvalScore {
+  const expectedSet = new Set(expectedNames);
+  const actualSet = new Set(actualNames);
+
+  const intersection = [...expectedSet].filter((n) => actualSet.has(n)).length;
+  const union = new Set([...expectedNames, ...actualNames]).size;
+  const jaccardScore = union > 0 ? intersection / union : 1;
+
+  // Also check args for matched tools
+  // let justified: tracking arg-matching failures
+  let argMismatches = 0;
+  for (const exp of expectedCalls) {
+    if (exp.args !== undefined) {
+      const matching = actualCalls.find((a) => a.toolName === exp.toolName);
+      if (matching !== undefined && !argsMatch(exp.args, matching.args)) {
+        argMismatches += 1;
+      }
+    }
+  }
+
+  const argPenalty = expectedCalls.length > 0 ? argMismatches / expectedCalls.length : 0;
+  const score = Math.max(0, jaccardScore - argPenalty * 0.5);
+
+  return {
+    graderId: "tool-call",
+    score,
+    pass: score >= 0.5,
+    reasoning: `Any order: Jaccard=${jaccardScore.toFixed(2)}, arg mismatches=${String(argMismatches)}`,
+  };
+}
+
+function argsMatch(
+  expected: Readonly<Record<string, unknown>>,
+  actual: Readonly<Record<string, unknown>> | undefined,
+): boolean {
+  if (actual === undefined) return false;
+
+  for (const [key, value] of Object.entries(expected)) {
+    if (actual[key] !== value) {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        typeof actual[key] === "object" &&
+        actual[key] !== null
+      ) {
+        if (JSON.stringify(value) !== JSON.stringify(actual[key])) {
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * @koi/eval — Agent evaluation framework (Layer 2)
+ *
+ * Define eval scenarios, run against live or mock agents,
+ * score accuracy/tool usage/latency/cost, and detect regressions.
+ */
+
+// Config
+export {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_PASS_THRESHOLD,
+  DEFAULT_TIMEOUT_MS,
+  validateEvalConfig,
+} from "./config.js";
+// Graders
+export { createExactMatchGrader } from "./graders/exact-match.js";
+export { createJsonSchemaGrader } from "./graders/json-schema.js";
+export { createLlmJudgeGrader } from "./graders/llm-judge.js";
+export { createToolCallGrader } from "./graders/tool-call.js";
+// Regression
+export { detectRegression } from "./regression.js";
+// Reporter
+export { formatCiReport, formatSummaryTable } from "./reporter.js";
+// Runner factory
+export { createEvalRunner } from "./runner.js";
+// Scorer (for advanced use)
+export {
+  computePassAtK,
+  computePassToTheK,
+  computePercentile,
+  computeSummary,
+} from "./scorer.js";
+// Store
+export { createFsEvalStore } from "./store/fs-store.js";
+// Transcript helpers
+export {
+  collectTranscript,
+  extractMetrics,
+  extractText,
+  extractToolCalls,
+  lastNTurns,
+  summarizeTranscript,
+} from "./transcript.js";
+// Types
+export type {
+  AgentHandle,
+  CiReport,
+  EvalExpectation,
+  EvalGrader,
+  EvalRun,
+  EvalRunConfig,
+  EvalRunConfigSnapshot,
+  EvalRunMeta,
+  EvalRunner,
+  EvalScore,
+  EvalStore,
+  EvalSummary,
+  EvalTask,
+  EvalTrial,
+  ExpectedToolCall,
+  LlmJudgeConfig,
+  RegressionDetail,
+  RegressionResult,
+  RegressionThresholds,
+  TaskSummary,
+  ToolCallSummary,
+  TranscriptMode,
+} from "./types.js";

--- a/packages/eval/src/pool.test.ts
+++ b/packages/eval/src/pool.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { runPool } from "./pool.js";
+
+describe("runPool", () => {
+  test("returns results in order", async () => {
+    const tasks = [
+      () => Promise.resolve("a"),
+      () => Promise.resolve("b"),
+      () => Promise.resolve("c"),
+    ];
+    const results = await runPool(tasks, 3);
+    expect(results).toEqual(["a", "b", "c"]);
+  });
+
+  test("respects concurrency limit", async () => {
+    // let justified: tracking concurrent execution count
+    let concurrent = 0;
+    // let justified: tracking max observed concurrency
+    let maxConcurrent = 0;
+
+    const createTask = (value: string) => async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      concurrent -= 1;
+      return value;
+    };
+
+    const tasks = Array.from({ length: 10 }, (_, i) => createTask(String(i)));
+    await runPool(tasks, 3);
+
+    expect(maxConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  test("calls onComplete for each result", async () => {
+    const completed: string[] = [];
+    const tasks = [() => Promise.resolve("a"), () => Promise.resolve("b")];
+    await runPool(tasks, 2, (result) => completed.push(result));
+    expect(completed).toContain("a");
+    expect(completed).toContain("b");
+    expect(completed).toHaveLength(2);
+  });
+
+  test("propagates errors", async () => {
+    const tasks = [() => Promise.resolve("ok"), () => Promise.reject(new Error("fail"))];
+    await expect(runPool(tasks, 2)).rejects.toThrow("fail");
+  });
+
+  test("handles empty task list", async () => {
+    const results = await runPool([], 5);
+    expect(results).toEqual([]);
+  });
+
+  test("handles concurrency greater than task count", async () => {
+    const tasks = [() => Promise.resolve(1), () => Promise.resolve(2)];
+    const results = await runPool(tasks, 100);
+    expect(results).toEqual([1, 2]);
+  });
+});

--- a/packages/eval/src/pool.ts
+++ b/packages/eval/src/pool.ts
@@ -1,0 +1,30 @@
+/**
+ * Promise concurrency pool — runs tasks with a bounded number in-flight.
+ */
+
+export async function runPool<T>(
+  tasks: readonly (() => Promise<T>)[],
+  concurrency: number,
+  onComplete?: (result: T) => void,
+): Promise<readonly T[]> {
+  const results: T[] = new Array(tasks.length) as T[];
+  // let justified: mutable index for next task to dispatch
+  let nextIndex = 0;
+
+  async function runNext(): Promise<void> {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const task = tasks[index];
+      if (task === undefined) continue;
+      const result = await task();
+      results[index] = result;
+      onComplete?.(result);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, () => runNext());
+  await Promise.all(workers);
+
+  return results;
+}

--- a/packages/eval/src/regression.test.ts
+++ b/packages/eval/src/regression.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { detectRegression } from "./regression.js";
+import type { EvalSummary } from "./types.js";
+
+function makeSummary(overrides: Partial<EvalSummary> = {}): EvalSummary {
+  return {
+    taskCount: 1,
+    trialCount: 3,
+    passRate: 0.8,
+    passAtK: 1,
+    passToTheK: 0.512,
+    meanScore: 0.85,
+    latencyP50Ms: 100,
+    latencyP95Ms: 200,
+    totalCostUsd: 0,
+    byTask: [],
+    ...overrides,
+  };
+}
+
+describe("detectRegression", () => {
+  test("returns pass when no regression", () => {
+    const baseline = makeSummary();
+    const current = makeSummary({ passRate: 0.79 });
+    const result = detectRegression(baseline, current);
+    expect(result.kind).toBe("pass");
+  });
+
+  test("detects pass rate regression", () => {
+    const baseline = makeSummary({ passRate: 0.9 });
+    const current = makeSummary({ passRate: 0.8 });
+    const result = detectRegression(baseline, current);
+    expect(result.kind).toBe("fail");
+    if (result.kind === "fail") {
+      const passRateReg = result.regressions.find(
+        (r) => r.metric === "passRate" && r.taskId === "*",
+      );
+      expect(passRateReg).toBeDefined();
+      expect(passRateReg?.delta).toBeLessThan(0);
+    }
+  });
+
+  test("detects mean score regression", () => {
+    const baseline = makeSummary({ meanScore: 0.9 });
+    const current = makeSummary({ meanScore: 0.7 });
+    const result = detectRegression(baseline, current);
+    expect(result.kind).toBe("fail");
+    if (result.kind === "fail") {
+      expect(result.regressions.some((r) => r.metric === "meanScore")).toBe(true);
+    }
+  });
+
+  test("detects latency regression", () => {
+    const baseline = makeSummary({ latencyP95Ms: 100 });
+    const current = makeSummary({ latencyP95Ms: 250 });
+    const result = detectRegression(baseline, current);
+    expect(result.kind).toBe("fail");
+    if (result.kind === "fail") {
+      expect(result.regressions.some((r) => r.metric === "latencyP95Ms")).toBe(true);
+    }
+  });
+
+  test("detects per-task regression", () => {
+    const baseline = makeSummary({
+      byTask: [
+        {
+          taskId: "t1",
+          taskName: "Task 1",
+          passRate: 1.0,
+          passAtK: 1,
+          passToTheK: 1,
+          meanScore: 0.9,
+          trials: 3,
+        },
+      ],
+    });
+    const current = makeSummary({
+      byTask: [
+        {
+          taskId: "t1",
+          taskName: "Task 1",
+          passRate: 0.5,
+          passAtK: 1,
+          passToTheK: 0.125,
+          meanScore: 0.5,
+          trials: 3,
+        },
+      ],
+    });
+    const result = detectRegression(baseline, current);
+    expect(result.kind).toBe("fail");
+    if (result.kind === "fail") {
+      const taskReg = result.regressions.find((r) => r.taskId === "t1");
+      expect(taskReg).toBeDefined();
+    }
+  });
+
+  test("uses custom thresholds", () => {
+    const baseline = makeSummary({ passRate: 0.9 });
+    const current = makeSummary({ passRate: 0.8 });
+
+    // With default threshold (0.05), this is a regression
+    const strict = detectRegression(baseline, current);
+    expect(strict.kind).toBe("fail");
+
+    // With relaxed threshold (0.2), this is not a regression
+    const relaxed = detectRegression(baseline, current, {
+      passRateDelta: 0.2,
+    });
+    expect(relaxed.kind).toBe("pass");
+  });
+
+  test("ignores latency regression when baseline is 0", () => {
+    const baseline = makeSummary({ latencyP95Ms: 0 });
+    const current = makeSummary({ latencyP95Ms: 1000 });
+    const result = detectRegression(baseline, current);
+    // Should not flag latency when baseline is 0
+    if (result.kind === "fail") {
+      expect(result.regressions.some((r) => r.metric === "latencyP95Ms")).toBe(false);
+    }
+  });
+
+  test("ignores new tasks not in baseline", () => {
+    const baseline = makeSummary({ byTask: [] });
+    const current = makeSummary({
+      byTask: [
+        {
+          taskId: "new-task",
+          taskName: "New Task",
+          passRate: 0,
+          passAtK: 0,
+          passToTheK: 0,
+          meanScore: 0,
+          trials: 1,
+        },
+      ],
+    });
+    const result = detectRegression(baseline, current);
+    if (result.kind === "fail") {
+      expect(result.regressions.some((r) => r.taskId === "new-task")).toBe(false);
+    }
+  });
+});

--- a/packages/eval/src/regression.ts
+++ b/packages/eval/src/regression.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression detection — compares current eval run against a baseline.
+ */
+
+import type {
+  EvalSummary,
+  RegressionDetail,
+  RegressionResult,
+  RegressionThresholds,
+  TaskSummary,
+} from "./types.js";
+
+const DEFAULT_PASS_RATE_DELTA = 0.05;
+const DEFAULT_SCORE_DELTA = 0.1;
+const DEFAULT_LATENCY_MULTIPLIER = 2.0;
+
+/**
+ * Compares current summary against baseline, returning regression details.
+ */
+export function detectRegression(
+  baseline: EvalSummary,
+  current: EvalSummary,
+  thresholds?: RegressionThresholds,
+): RegressionResult {
+  const passRateDelta = thresholds?.passRateDelta ?? DEFAULT_PASS_RATE_DELTA;
+  const scoreDelta = thresholds?.scoreDelta ?? DEFAULT_SCORE_DELTA;
+  const latencyMultiplier = thresholds?.latencyMultiplier ?? DEFAULT_LATENCY_MULTIPLIER;
+
+  const regressions = [
+    ...checkGlobalRegressions(baseline, current, passRateDelta, scoreDelta, latencyMultiplier),
+    ...checkPerTaskRegressions(baseline, current, passRateDelta, scoreDelta),
+  ];
+
+  if (regressions.length === 0) {
+    return { kind: "pass", baseline, current };
+  }
+  return { kind: "fail", regressions, baseline, current };
+}
+
+function checkGlobalRegressions(
+  baseline: EvalSummary,
+  current: EvalSummary,
+  passRateDelta: number,
+  scoreDelta: number,
+  latencyMultiplier: number,
+): readonly RegressionDetail[] {
+  const regressions: RegressionDetail[] = [];
+
+  const passRateDrop = baseline.passRate - current.passRate;
+  if (passRateDrop > passRateDelta) {
+    regressions.push(
+      makeDetail("*", "passRate", baseline.passRate, current.passRate, -passRateDrop),
+    );
+  }
+
+  const scoreDrop = baseline.meanScore - current.meanScore;
+  if (scoreDrop > scoreDelta) {
+    regressions.push(
+      makeDetail("*", "meanScore", baseline.meanScore, current.meanScore, -scoreDrop),
+    );
+  }
+
+  if (
+    baseline.latencyP95Ms > 0 &&
+    current.latencyP95Ms > baseline.latencyP95Ms * latencyMultiplier
+  ) {
+    const delta = current.latencyP95Ms - baseline.latencyP95Ms;
+    regressions.push(
+      makeDetail("*", "latencyP95Ms", baseline.latencyP95Ms, current.latencyP95Ms, delta),
+    );
+  }
+
+  return regressions;
+}
+
+function checkPerTaskRegressions(
+  baseline: EvalSummary,
+  current: EvalSummary,
+  passRateDelta: number,
+  scoreDelta: number,
+): readonly RegressionDetail[] {
+  const baselineMap = new Map(baseline.byTask.map((t) => [t.taskId, t]));
+  const regressions: RegressionDetail[] = [];
+
+  for (const ct of current.byTask) {
+    const bt = baselineMap.get(ct.taskId);
+    if (bt === undefined) continue;
+
+    const taskRegs = checkTaskPair(bt, ct, passRateDelta, scoreDelta);
+    for (const r of taskRegs) regressions.push(r);
+  }
+  return regressions;
+}
+
+function checkTaskPair(
+  bt: TaskSummary,
+  ct: TaskSummary,
+  passRateDelta: number,
+  scoreDelta: number,
+): readonly RegressionDetail[] {
+  const regressions: RegressionDetail[] = [];
+  const passDrop = bt.passRate - ct.passRate;
+  if (passDrop > passRateDelta) {
+    regressions.push(makeDetail(ct.taskId, "passRate", bt.passRate, ct.passRate, -passDrop));
+  }
+  const scoreDrop = bt.meanScore - ct.meanScore;
+  if (scoreDrop > scoreDelta) {
+    regressions.push(makeDetail(ct.taskId, "meanScore", bt.meanScore, ct.meanScore, -scoreDrop));
+  }
+  return regressions;
+}
+
+function makeDetail(
+  taskId: string,
+  metric: string,
+  baseline: number,
+  current: number,
+  delta: number,
+): RegressionDetail {
+  return { taskId, metric, baseline, current, delta };
+}

--- a/packages/eval/src/reporter.test.ts
+++ b/packages/eval/src/reporter.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { formatCiReport, formatSummaryTable } from "./reporter.js";
+import type { EvalRun, EvalSummary, RegressionResult } from "./types.js";
+
+function makeSummary(overrides: Partial<EvalSummary> = {}): EvalSummary {
+  return {
+    taskCount: 2,
+    trialCount: 4,
+    passRate: 0.75,
+    passAtK: 0.9,
+    passToTheK: 0.5,
+    meanScore: 0.8,
+    latencyP50Ms: 100,
+    latencyP95Ms: 250,
+    totalCostUsd: 0.05,
+    byTask: [
+      {
+        taskId: "t1",
+        taskName: "Task One",
+        passRate: 1.0,
+        passAtK: 1.0,
+        passToTheK: 1.0,
+        meanScore: 0.9,
+        trials: 2,
+      },
+      {
+        taskId: "t2",
+        taskName: "Task Two",
+        passRate: 0.5,
+        passAtK: 0.75,
+        passToTheK: 0.25,
+        meanScore: 0.7,
+        trials: 2,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeRun(summary: EvalSummary): EvalRun {
+  return {
+    id: "run-001",
+    name: "test-eval",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    config: {
+      name: "test-eval",
+      concurrency: 5,
+      timeoutMs: 60_000,
+      passThreshold: 0.5,
+      taskCount: 2,
+    },
+    trials: [],
+    summary,
+  };
+}
+
+describe("formatSummaryTable", () => {
+  test("includes key metrics", () => {
+    const summary = makeSummary();
+    const table = formatSummaryTable(summary);
+
+    expect(table).toContain("Eval Summary");
+    expect(table).toContain("Tasks: 2");
+    expect(table).toContain("Trials: 4");
+    expect(table).toContain("75.0%");
+    expect(table).toContain("0.80");
+    expect(table).toContain("P50: 100ms");
+    expect(table).toContain("P95: 250ms");
+  });
+
+  test("includes per-task rows", () => {
+    const table = formatSummaryTable(makeSummary());
+    expect(table).toContain("Task One");
+    expect(table).toContain("Task Two");
+  });
+
+  test("handles empty byTask", () => {
+    const table = formatSummaryTable(makeSummary({ byTask: [] }));
+    expect(table).toContain("Tasks: 2");
+    expect(table).not.toContain("Task One");
+  });
+});
+
+describe("formatCiReport", () => {
+  test("returns exitCode 0 when no regression", () => {
+    const run = makeRun(makeSummary());
+    const report = formatCiReport(run);
+    expect(report.exitCode).toBe(0);
+  });
+
+  test("returns exitCode 1 when regression detected", () => {
+    const run = makeRun(makeSummary());
+    const regression: RegressionResult = {
+      kind: "fail",
+      regressions: [
+        {
+          taskId: "*",
+          metric: "passRate",
+          baseline: 0.9,
+          current: 0.75,
+          delta: -0.15,
+        },
+      ],
+      baseline: makeSummary({ passRate: 0.9 }),
+      current: makeSummary(),
+    };
+
+    const report = formatCiReport(run, regression);
+    expect(report.exitCode).toBe(1);
+    expect(report.summary).toContain("REGRESSIONS DETECTED");
+    expect(report.summary).toContain("passRate");
+  });
+
+  test("produces valid JSON", () => {
+    const run = makeRun(makeSummary());
+    const report = formatCiReport(run);
+    const parsed = JSON.parse(report.json);
+    expect(parsed.runId).toBe("run-001");
+    expect(parsed.summary.passRate).toBe(0.75);
+  });
+
+  test("includes regression details in JSON", () => {
+    const regression: RegressionResult = {
+      kind: "fail",
+      regressions: [
+        {
+          taskId: "t1",
+          metric: "passRate",
+          baseline: 1,
+          current: 0.5,
+          delta: -0.5,
+        },
+      ],
+      baseline: makeSummary(),
+      current: makeSummary(),
+    };
+    const report = formatCiReport(makeRun(makeSummary()), regression);
+    const parsed = JSON.parse(report.json);
+    expect(parsed.regression.kind).toBe("fail");
+    expect(parsed.regression.regressions).toHaveLength(1);
+  });
+
+  test("handles pass regression result", () => {
+    const regression: RegressionResult = {
+      kind: "pass",
+      baseline: makeSummary(),
+      current: makeSummary(),
+    };
+    const report = formatCiReport(makeRun(makeSummary()), regression);
+    expect(report.exitCode).toBe(0);
+    expect(report.summary).not.toContain("REGRESSIONS");
+  });
+});

--- a/packages/eval/src/reporter.ts
+++ b/packages/eval/src/reporter.ts
@@ -1,0 +1,97 @@
+/**
+ * Reporter — CI-friendly output formatting.
+ */
+
+import type { CiReport, EvalRun, EvalSummary, RegressionResult } from "./types.js";
+
+/**
+ * Formats a summary as an ASCII table for human reading.
+ */
+export function formatSummaryTable(summary: EvalSummary): string {
+  const lines: string[] = [];
+
+  lines.push("Eval Summary");
+  lines.push("=".repeat(60));
+  lines.push(`Tasks: ${String(summary.taskCount)}  Trials: ${String(summary.trialCount)}`);
+  lines.push(
+    `Pass Rate: ${formatPercent(summary.passRate)}  Mean Score: ${summary.meanScore.toFixed(2)}`,
+  );
+  lines.push(
+    `pass@k: ${formatPercent(summary.passAtK)}  pass^k: ${formatPercent(summary.passToTheK)}`,
+  );
+  lines.push(
+    `Latency P50: ${String(Math.round(summary.latencyP50Ms))}ms  P95: ${String(Math.round(summary.latencyP95Ms))}ms`,
+  );
+  lines.push(`Total Cost: $${summary.totalCostUsd.toFixed(4)}`);
+
+  if (summary.byTask.length > 0) {
+    lines.push("");
+    lines.push(`${padRight("Task", 30)}${padRight("Pass%", 10)}${padRight("Score", 10)}Trials`);
+    lines.push("-".repeat(60));
+
+    for (const task of summary.byTask) {
+      lines.push(
+        padRight(truncate(task.taskName, 28), 30) +
+          padRight(formatPercent(task.passRate), 10) +
+          padRight(task.meanScore.toFixed(2), 10) +
+          String(task.trials),
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Formats a CI report with exit code, JSON output, and human summary.
+ */
+export function formatCiReport(run: EvalRun, regression?: RegressionResult): CiReport {
+  const hasRegression = regression?.kind === "fail";
+  const exitCode = hasRegression ? 1 : 0;
+
+  const jsonData = {
+    runId: run.id,
+    name: run.name,
+    timestamp: run.timestamp,
+    summary: run.summary,
+    regression:
+      regression !== undefined
+        ? {
+            kind: regression.kind,
+            regressions: regression.kind === "fail" ? regression.regressions : [],
+          }
+        : undefined,
+  };
+
+  const summaryLines: string[] = [];
+  summaryLines.push(formatSummaryTable(run.summary));
+
+  if (hasRegression) {
+    summaryLines.push("");
+    summaryLines.push("REGRESSIONS DETECTED:");
+    for (const r of regression.regressions) {
+      const scope = r.taskId === "*" ? "Global" : `Task ${r.taskId}`;
+      summaryLines.push(
+        `  ${scope} ${r.metric}: ${r.baseline.toFixed(2)} -> ${r.current.toFixed(2)} (delta: ${r.delta.toFixed(2)})`,
+      );
+    }
+  }
+
+  return {
+    exitCode,
+    json: JSON.stringify(jsonData, null, 2),
+    summary: summaryLines.join("\n"),
+  };
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function padRight(str: string, length: number): string {
+  return str.length >= length ? str : str + " ".repeat(length - str.length);
+}
+
+function truncate(str: string, maxLength: number): string {
+  return str.length <= maxLength ? str : `${str.slice(0, maxLength - 1)}…`;
+}

--- a/packages/eval/src/runner.test.ts
+++ b/packages/eval/src/runner.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, EngineInput } from "@koi/core";
+import { createEvalRunner } from "./runner.js";
+import type { AgentHandle, EvalRunConfig, EvalTrial } from "./types.js";
+
+function createMockAgent(events: readonly EngineEvent[]): AgentHandle {
+  return {
+    stream(_input: EngineInput): AsyncIterable<EngineEvent> {
+      return {
+        [Symbol.asyncIterator]: async function* () {
+          for (const event of events) {
+            yield event;
+          }
+        },
+      };
+    },
+    async dispose(): Promise<void> {
+      // no-op
+    },
+  };
+}
+
+const DONE_EVENT: EngineEvent = {
+  kind: "done",
+  output: {
+    content: [],
+    stopReason: "completed",
+    metrics: {
+      totalTokens: 10,
+      inputTokens: 5,
+      outputTokens: 5,
+      turns: 1,
+      durationMs: 50,
+    },
+  },
+};
+
+const TEXT_EVENTS: readonly EngineEvent[] = [
+  { kind: "text_delta", delta: "hello world" },
+  DONE_EVENT,
+];
+
+const BASE_TASK = {
+  id: "t1",
+  name: "Test Task",
+  input: { kind: "text" as const, text: "say hello" },
+  expected: { kind: "text" as const, pattern: "hello" },
+  graders: [
+    {
+      id: "test-grader",
+      name: "Test Grader",
+      grade: (_transcript: readonly EngineEvent[], _expected: unknown, _metrics: unknown) => ({
+        graderId: "test-grader",
+        score: 1,
+        pass: true,
+      }),
+    },
+  ],
+};
+
+const baseConfig: EvalRunConfig = {
+  name: "test-eval",
+  tasks: [BASE_TASK],
+  agentFactory: async () => createMockAgent(TEXT_EVENTS),
+};
+
+describe("createEvalRunner", () => {
+  test("throws on invalid config", () => {
+    expect(() => createEvalRunner({ name: "" } as unknown as EvalRunConfig)).toThrow();
+  });
+
+  test("runs a simple evaluation", async () => {
+    const runner = createEvalRunner(baseConfig);
+    const run = await runner.run();
+
+    expect(run.name).toBe("test-eval");
+    expect(run.trials).toHaveLength(1);
+    expect(run.trials[0]?.status).toBe("pass");
+    expect(run.summary.taskCount).toBe(1);
+    expect(run.summary.passRate).toBe(1);
+  });
+
+  test("creates fresh agent per trial", async () => {
+    // let justified: tracking agent creation count
+    let agentCount = 0;
+
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      tasks: [{ ...BASE_TASK, trialCount: 3 }],
+      agentFactory: async () => {
+        agentCount += 1;
+        return createMockAgent(TEXT_EVENTS);
+      },
+    };
+
+    const runner = createEvalRunner(config);
+    await runner.run();
+
+    expect(agentCount).toBe(3);
+  });
+
+  test("handles agent errors gracefully", async () => {
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      agentFactory: async () => ({
+        stream: (): AsyncIterable<EngineEvent> => ({
+          [Symbol.asyncIterator]: () => ({
+            next: () => Promise.reject(new Error("Agent crashed")),
+          }),
+        }),
+      }),
+    };
+
+    const runner = createEvalRunner(config);
+    const run = await runner.run();
+
+    expect(run.trials[0]?.status).toBe("error");
+    expect(run.trials[0]?.error).toContain("Agent crashed");
+  });
+
+  test("handles trial timeout", async () => {
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      tasks: [{ ...BASE_TASK, timeoutMs: 50 }],
+      agentFactory: async () => ({
+        stream: () => ({
+          [Symbol.asyncIterator]: async function* () {
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+            yield DONE_EVENT;
+          },
+        }),
+      }),
+    };
+
+    const runner = createEvalRunner(config);
+    const run = await runner.run();
+
+    expect(run.trials[0]?.status).toBe("error");
+    expect(run.trials[0]?.error).toContain("timed out");
+  }, 10_000);
+
+  test("calls onTrialComplete callback", async () => {
+    const completed: EvalTrial[] = [];
+
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      onTrialComplete: (trial) => completed.push(trial),
+    };
+
+    const runner = createEvalRunner(config);
+    await runner.run();
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.taskId).toBe("t1");
+  });
+
+  test("handles grader errors gracefully", async () => {
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      tasks: [
+        {
+          ...BASE_TASK,
+          graders: [
+            {
+              id: "broken",
+              name: "Broken Grader",
+              grade: () => {
+                throw new Error("Grader exploded");
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const runner = createEvalRunner(config);
+    const run = await runner.run();
+
+    expect(run.trials[0]?.scores[0]?.score).toBe(0);
+    expect(run.trials[0]?.scores[0]?.reasoning).toContain("Grader error");
+  });
+
+  test("disposes agents after trials", async () => {
+    // let justified: tracking disposal count
+    let disposed = 0;
+
+    const config: EvalRunConfig = {
+      ...baseConfig,
+      agentFactory: async () => ({
+        ...createMockAgent(TEXT_EVENTS),
+        async dispose() {
+          disposed += 1;
+        },
+      }),
+    };
+
+    const runner = createEvalRunner(config);
+    await runner.run();
+
+    expect(disposed).toBe(1);
+  });
+
+  test("preserves run config snapshot", async () => {
+    const runner = createEvalRunner(baseConfig);
+    const run = await runner.run();
+
+    expect(run.config.name).toBe("test-eval");
+    expect(run.config.concurrency).toBe(5);
+    expect(run.config.timeoutMs).toBe(60_000);
+    expect(run.config.passThreshold).toBe(0.5);
+    expect(run.config.taskCount).toBe(1);
+  });
+});

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -1,0 +1,184 @@
+/**
+ * Eval runner — orchestrates task execution, grading, and summary computation.
+ */
+
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import { KoiRuntimeError } from "@koi/errors";
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_PASS_THRESHOLD,
+  DEFAULT_TIMEOUT_MS,
+  validateEvalConfig,
+} from "./config.js";
+import { runPool } from "./pool.js";
+import { computeSummary } from "./scorer.js";
+import { collectTranscript, extractMetrics } from "./transcript.js";
+import type {
+  AgentHandle,
+  EvalRun,
+  EvalRunConfig,
+  EvalRunner,
+  EvalScore,
+  EvalTask,
+  EvalTrial,
+} from "./types.js";
+
+/**
+ * Creates an eval runner from a validated config.
+ */
+export function createEvalRunner(config: EvalRunConfig): EvalRunner {
+  const validated = validateEvalConfig(config);
+  if (!validated.ok) {
+    throw KoiRuntimeError.from("VALIDATION", validated.error.message);
+  }
+
+  const concurrency = config.concurrency ?? DEFAULT_CONCURRENCY;
+  const globalTimeout = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const passThreshold = config.passThreshold ?? DEFAULT_PASS_THRESHOLD;
+
+  return {
+    async run(): Promise<EvalRun> {
+      const runId = generateRunId();
+      const timestamp = new Date().toISOString();
+
+      const trialDescriptors = config.tasks.flatMap((task) => {
+        const count = task.trialCount ?? 1;
+        return Array.from({ length: count }, (_, i) => ({ task, trialIndex: i }));
+      });
+
+      const trialTasks = trialDescriptors.map(
+        ({ task, trialIndex }) =>
+          () =>
+            executeTrial(task, trialIndex, globalTimeout, passThreshold, config),
+      );
+
+      const trials = await runPool(trialTasks, concurrency, config.onTrialComplete);
+      const summary = computeSummary(trials, [...config.tasks]);
+
+      return {
+        id: runId,
+        name: config.name,
+        timestamp,
+        config: {
+          name: config.name,
+          concurrency,
+          timeoutMs: globalTimeout,
+          passThreshold,
+          taskCount: config.tasks.length,
+        },
+        trials,
+        summary,
+      };
+    },
+  };
+}
+
+async function executeTrial(
+  task: EvalTask,
+  trialIndex: number,
+  globalTimeout: number,
+  passThreshold: number,
+  config: EvalRunConfig,
+): Promise<EvalTrial> {
+  const timeoutMs = task.timeoutMs ?? globalTimeout;
+  const start = Date.now();
+  // let justified: agent reference needed in finally for disposal
+  let agent: AgentHandle | undefined;
+
+  try {
+    agent = await config.agentFactory();
+    const transcript = await collectWithTimeout(agent, task, timeoutMs);
+    const metrics = extractMetrics(transcript, Date.now() - start);
+    const scores = await gradeAll(task, transcript, metrics, passThreshold);
+
+    return {
+      taskId: task.id,
+      trialIndex,
+      transcript,
+      scores,
+      metrics,
+      status: scores.every((s) => s.pass) ? "pass" : "fail",
+    };
+  } catch (e: unknown) {
+    return makeErrorTrial(task.id, trialIndex, Date.now() - start, e, timeoutMs);
+  } finally {
+    await disposeAgent(agent);
+  }
+}
+
+async function collectWithTimeout(
+  agent: AgentHandle,
+  task: EvalTask,
+  timeoutMs: number,
+): Promise<readonly EngineEvent[]> {
+  const signal = AbortSignal.timeout(timeoutMs);
+  const timeoutRejection = new Promise<never>((_, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+  return Promise.race([collectTranscript(agent.stream(task.input)), timeoutRejection]);
+}
+
+function makeErrorTrial(
+  taskId: string,
+  trialIndex: number,
+  durationMs: number,
+  e: unknown,
+  timeoutMs: number,
+): EvalTrial {
+  const isTimeout = e instanceof DOMException && e.name === "TimeoutError";
+  const message = isTimeout
+    ? `Trial timed out after ${String(timeoutMs)}ms`
+    : e instanceof Error
+      ? e.message
+      : String(e);
+
+  return {
+    taskId,
+    trialIndex,
+    transcript: [],
+    scores: [],
+    metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 0, durationMs },
+    status: "error",
+    error: message,
+  };
+}
+
+async function disposeAgent(agent: AgentHandle | undefined): Promise<void> {
+  if (agent?.dispose !== undefined) {
+    try {
+      await agent.dispose();
+    } catch {
+      // Dispose errors are not propagated — agent cleanup is best-effort
+    }
+  }
+}
+
+async function gradeAll(
+  task: EvalTask,
+  transcript: readonly EngineEvent[],
+  metrics: EngineMetrics,
+  passThreshold: number,
+): Promise<readonly EvalScore[]> {
+  return Promise.all(
+    task.graders.map(async (grader) => {
+      try {
+        const score = await grader.grade(transcript, task.expected, metrics);
+        return { ...score, pass: score.score >= passThreshold };
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : "Unknown grader error";
+        return {
+          graderId: grader.id,
+          score: 0,
+          pass: false,
+          reasoning: `Grader error: ${message}`,
+        };
+      }
+    }),
+  );
+}
+
+function generateRunId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `eval-${timestamp}-${random}`;
+}

--- a/packages/eval/src/scorer.test.ts
+++ b/packages/eval/src/scorer.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineMetrics } from "@koi/core";
+import { computePassAtK, computePassToTheK, computePercentile, computeSummary } from "./scorer.js";
+import type { EvalTask, EvalTrial } from "./types.js";
+
+const ZERO_METRICS: EngineMetrics = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 100,
+};
+
+function makeTrial(
+  taskId: string,
+  index: number,
+  status: "pass" | "fail" | "error",
+  score: number,
+): EvalTrial {
+  return {
+    taskId,
+    trialIndex: index,
+    transcript: [],
+    scores: [{ graderId: "test", score, pass: status === "pass" }],
+    metrics: ZERO_METRICS,
+    status,
+  };
+}
+
+describe("computePassAtK", () => {
+  test("returns 1 when all pass", () => {
+    expect(computePassAtK([true, true, true], 3)).toBe(1);
+  });
+
+  test("returns 0 when all fail", () => {
+    expect(computePassAtK([false, false, false], 3)).toBe(0);
+  });
+
+  test("returns 0 for empty results", () => {
+    expect(computePassAtK([], 1)).toBe(0);
+  });
+
+  test("is always in [0, 1]", () => {
+    const cases = [[true, false, true, false], [true], [false], [true, true, false]];
+    for (const results of cases) {
+      for (const k of [1, 2, 3, 5]) {
+        const value = computePassAtK(results, k);
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("pass@1 equals pass rate for single-sample", () => {
+    const results = [true, false, true, true];
+    const passRate = results.filter(Boolean).length / results.length;
+    expect(computePassAtK(results, 1)).toBeCloseTo(passRate, 5);
+  });
+
+  test("pass@k increases with k", () => {
+    const results = [true, false, true, false, false];
+    const at1 = computePassAtK(results, 1);
+    const at2 = computePassAtK(results, 2);
+    const at3 = computePassAtK(results, 3);
+    expect(at2).toBeGreaterThanOrEqual(at1);
+    expect(at3).toBeGreaterThanOrEqual(at2);
+  });
+});
+
+describe("computePassToTheK", () => {
+  test("returns 1 when all pass and k=1", () => {
+    expect(computePassToTheK([true, true, true], 1)).toBe(1);
+  });
+
+  test("returns 0 when all fail", () => {
+    expect(computePassToTheK([false, false], 1)).toBe(0);
+  });
+
+  test("returns 0 for empty results", () => {
+    expect(computePassToTheK([], 1)).toBe(0);
+  });
+
+  test("is always in [0, 1]", () => {
+    const results = [true, false, true];
+    for (const k of [1, 2, 3, 5]) {
+      const value = computePassToTheK(results, k);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("pass^k decreases with k for non-perfect results", () => {
+    const results = [true, true, false, true];
+    const k1 = computePassToTheK(results, 1);
+    const k2 = computePassToTheK(results, 2);
+    const k3 = computePassToTheK(results, 3);
+    expect(k2).toBeLessThanOrEqual(k1);
+    expect(k3).toBeLessThanOrEqual(k2);
+  });
+});
+
+describe("passAtK >= passToTheK", () => {
+  test("holds for various inputs", () => {
+    const testCases: readonly (readonly boolean[])[] = [
+      [true, false, true],
+      [true, true, true],
+      [false, false, false],
+      [true, false],
+      [true],
+    ];
+
+    for (const results of testCases) {
+      for (const k of [1, 2, 3]) {
+        const atK = computePassAtK(results, k);
+        const toTheK = computePassToTheK(results, k);
+        expect(atK).toBeGreaterThanOrEqual(toTheK - 0.001);
+      }
+    }
+  });
+});
+
+describe("computePercentile", () => {
+  test("returns median for p50", () => {
+    expect(computePercentile([1, 2, 3, 4, 5], 50)).toBe(3);
+  });
+
+  test("returns 0 for empty array", () => {
+    expect(computePercentile([], 50)).toBe(0);
+  });
+
+  test("returns min for p0", () => {
+    expect(computePercentile([10, 20, 30], 0)).toBe(10);
+  });
+
+  test("returns max for p100", () => {
+    expect(computePercentile([10, 20, 30], 100)).toBe(30);
+  });
+
+  test("interpolates between values", () => {
+    const p75 = computePercentile([1, 2, 3, 4], 75);
+    expect(p75).toBeCloseTo(3.25, 5);
+  });
+});
+
+describe("computeSummary", () => {
+  test("computes summary for multiple tasks", () => {
+    const tasks: readonly EvalTask[] = [
+      {
+        id: "t1",
+        name: "Task 1",
+        input: { kind: "text", text: "test" },
+        graders: [],
+      },
+      {
+        id: "t2",
+        name: "Task 2",
+        input: { kind: "text", text: "test" },
+        graders: [],
+      },
+    ];
+
+    const trials: readonly EvalTrial[] = [
+      makeTrial("t1", 0, "pass", 1),
+      makeTrial("t1", 1, "fail", 0),
+      makeTrial("t2", 0, "pass", 0.8),
+    ];
+
+    const summary = computeSummary(trials, tasks);
+    expect(summary.taskCount).toBe(2);
+    expect(summary.trialCount).toBe(3);
+    expect(summary.passRate).toBeCloseTo(2 / 3, 5);
+    expect(summary.byTask).toHaveLength(2);
+  });
+
+  test("handles empty trials", () => {
+    const summary = computeSummary([], []);
+    expect(summary.taskCount).toBe(0);
+    expect(summary.trialCount).toBe(0);
+    expect(summary.passRate).toBe(0);
+    expect(summary.meanScore).toBe(0);
+  });
+});

--- a/packages/eval/src/scorer.ts
+++ b/packages/eval/src/scorer.ts
@@ -1,0 +1,138 @@
+/**
+ * Scoring aggregation — pass@k, pass^k, percentiles, summary computation.
+ */
+
+import type { EvalSummary, EvalTask, EvalTrial, TaskSummary } from "./types.js";
+
+/**
+ * Computes a full EvalSummary from trial results and task definitions.
+ */
+export function computeSummary(
+  trials: readonly EvalTrial[],
+  tasks: readonly EvalTask[],
+): EvalSummary {
+  const taskMap = new Map(tasks.map((t) => [t.id, t]));
+  const trialsByTask = groupBy(trials, (t) => t.taskId);
+  const byTask = computeTaskSummaries(trialsByTask, taskMap);
+
+  const allPassResults = trials.map((t) => t.status === "pass");
+  const allScores = trials.flatMap((t) => t.scores.map((s) => s.score));
+  const allLatencies = trials.map((t) => t.metrics.durationMs);
+  const maxK = Math.max(...tasks.map((t) => t.trialCount ?? 1), 1);
+
+  return {
+    taskCount: tasks.length,
+    trialCount: trials.length,
+    passRate: mean(allPassResults.map((p) => (p ? 1 : 0))),
+    passAtK: computePassAtK(allPassResults, maxK),
+    passToTheK: computePassToTheK(allPassResults, maxK),
+    meanScore: mean(allScores),
+    latencyP50Ms: computePercentile(allLatencies, 50),
+    latencyP95Ms: computePercentile(allLatencies, 95),
+    totalCostUsd: 0,
+    byTask,
+  };
+}
+
+function computeTaskSummaries(
+  trialsByTask: Map<string, EvalTrial[]>,
+  taskMap: Map<string, EvalTask>,
+): readonly TaskSummary[] {
+  const result: TaskSummary[] = [];
+  for (const [taskId, taskTrials] of trialsByTask.entries()) {
+    const task = taskMap.get(taskId);
+    const k = task?.trialCount ?? 1;
+    const passResults = taskTrials.map((t) => t.status === "pass");
+    const scores = taskTrials.flatMap((t) => t.scores.map((s) => s.score));
+
+    result.push({
+      taskId,
+      taskName: task?.name ?? taskId,
+      passRate: passResults.filter(Boolean).length / passResults.length,
+      passAtK: computePassAtK(passResults, k),
+      passToTheK: computePassToTheK(passResults, k),
+      meanScore: mean(scores),
+      trials: taskTrials.length,
+    });
+  }
+  return result;
+}
+
+/**
+ * pass@k — probability of at least one pass in k samples.
+ * Formula: 1 - C(n-c, k) / C(n, k) where n = total, c = passing.
+ */
+export function computePassAtK(trialResults: readonly boolean[], k: number): number {
+  const n = trialResults.length;
+  const c = trialResults.filter(Boolean).length;
+
+  if (n === 0 || k <= 0) return 0;
+  if (c === n) return 1;
+  if (c === 0) return 0;
+  if (k > n) return c > 0 ? 1 : 0;
+
+  const logNumerator = logCombination(n - c, k);
+  const logDenominator = logCombination(n, k);
+
+  if (logNumerator === -Infinity) return 1;
+  if (logDenominator === -Infinity) return 0;
+
+  return 1 - Math.exp(logNumerator - logDenominator);
+}
+
+/**
+ * pass^k — probability of all k trials passing. Measures consistency.
+ * Formula: (c/n)^k
+ */
+export function computePassToTheK(trialResults: readonly boolean[], k: number): number {
+  const n = trialResults.length;
+  const c = trialResults.filter(Boolean).length;
+  if (n === 0 || k <= 0) return 0;
+  return (c / n) ** k;
+}
+
+/**
+ * Computes a percentile value from a sorted array of numbers.
+ */
+export function computePercentile(values: readonly number[], percentile: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (percentile / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const fraction = index - lower;
+  const lowerVal = sorted[lower] ?? 0;
+  const upperVal = sorted[upper] ?? lowerVal;
+  return lowerVal + fraction * (upperVal - lowerVal);
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function logCombination(n: number, k: number): number {
+  if (k > n) return -Infinity;
+  if (k === 0 || k === n) return 0;
+  // let justified: accumulating log sum
+  let logResult = 0;
+  const effectiveK = Math.min(k, n - k);
+  for (const i of Array.from({ length: effectiveK }, (_, idx) => idx)) {
+    logResult += Math.log(n - i) - Math.log(i + 1);
+  }
+  return logResult;
+}
+
+function groupBy<T>(items: readonly T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const existing = map.get(key);
+    if (existing !== undefined) {
+      existing.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  }
+  return map;
+}

--- a/packages/eval/src/store/fs-store.test.ts
+++ b/packages/eval/src/store/fs-store.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EvalRun, EvalSummary } from "../types.js";
+import { createFsEvalStore } from "./fs-store.js";
+
+function makeSummary(): EvalSummary {
+  return {
+    taskCount: 1,
+    trialCount: 2,
+    passRate: 0.5,
+    passAtK: 1,
+    passToTheK: 0.25,
+    meanScore: 0.75,
+    latencyP50Ms: 100,
+    latencyP95Ms: 200,
+    totalCostUsd: 0.01,
+    byTask: [
+      {
+        taskId: "t1",
+        taskName: "Test",
+        passRate: 0.5,
+        passAtK: 1,
+        passToTheK: 0.25,
+        meanScore: 0.75,
+        trials: 2,
+      },
+    ],
+  };
+}
+
+function makeRun(id: string, name: string): EvalRun {
+  return {
+    id,
+    name,
+    timestamp: new Date().toISOString(),
+    config: {
+      name,
+      concurrency: 5,
+      timeoutMs: 60_000,
+      passThreshold: 0.5,
+      taskCount: 1,
+    },
+    trials: [],
+    summary: makeSummary(),
+  };
+}
+
+// let justified: tracks temp dir for cleanup
+let tempDir: string;
+
+afterEach(async () => {
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("createFsEvalStore", () => {
+  test("save and load cycle", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+    const run = makeRun("run-001", "my-eval");
+
+    await store.save(run);
+    const loaded = await store.load("run-001");
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.id).toBe("run-001");
+    expect(loaded?.name).toBe("my-eval");
+    expect(loaded?.summary.passRate).toBe(0.5);
+  });
+
+  test("returns undefined for non-existent run", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+
+    const loaded = await store.load("non-existent");
+    expect(loaded).toBeUndefined();
+  });
+
+  test("latest returns most recent run", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+
+    const run1 = makeRun("run-001", "my-eval");
+    const run2 = makeRun("run-002", "my-eval");
+
+    await store.save(run1);
+    await store.save(run2);
+
+    const latest = await store.latest("my-eval");
+    expect(latest?.id).toBe("run-002");
+  });
+
+  test("latest returns undefined when no runs exist", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+
+    const latest = await store.latest("non-existent");
+    expect(latest).toBeUndefined();
+  });
+
+  test("list returns all run summaries", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+
+    await store.save(makeRun("run-001", "my-eval"));
+    await store.save(makeRun("run-002", "my-eval"));
+
+    const list = await store.list("my-eval");
+    expect(list).toHaveLength(2);
+    expect(list.map((m) => m.id).sort()).toEqual(["run-001", "run-002"]);
+  });
+
+  test("list returns empty array for non-existent eval", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const store = createFsEvalStore({ baseDir: tempDir });
+
+    const list = await store.list("non-existent");
+    expect(list).toEqual([]);
+  });
+
+  test("save creates directories recursively", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-eval-test-"));
+    const deepDir = join(tempDir, "deep", "nested");
+    const store = createFsEvalStore({ baseDir: deepDir });
+
+    const run = makeRun("run-001", "my-eval");
+    await store.save(run);
+
+    const loaded = await store.load("run-001");
+    expect(loaded?.id).toBe("run-001");
+  });
+});

--- a/packages/eval/src/store/fs-store.ts
+++ b/packages/eval/src/store/fs-store.ts
@@ -1,0 +1,109 @@
+/**
+ * Filesystem-based eval store — saves/loads eval runs as JSON files.
+ */
+
+import { mkdir, readdir, rename } from "node:fs/promises";
+import { join } from "node:path";
+import type { EvalRun, EvalRunMeta, EvalStore, EvalSummary } from "../types.js";
+
+export interface FsEvalStoreConfig {
+  readonly baseDir: string;
+}
+
+export function createFsEvalStore(config: FsEvalStoreConfig): EvalStore {
+  const { baseDir } = config;
+
+  return {
+    async save(run: EvalRun): Promise<void> {
+      const dir = join(baseDir, run.name, "runs");
+      await mkdir(dir, { recursive: true });
+
+      const fullPath = join(dir, `${run.id}.json`);
+      const summaryPath = join(dir, `${run.id}.summary.json`);
+      const latestPath = join(baseDir, run.name, "latest.json");
+
+      await atomicWrite(fullPath, JSON.stringify(run, null, 2));
+      await atomicWrite(summaryPath, JSON.stringify(run.summary, null, 2));
+      await atomicWrite(latestPath, JSON.stringify({ runId: run.id, ...run.summary }, null, 2));
+    },
+
+    async load(runId: string): Promise<EvalRun | undefined> {
+      return loadRunById(baseDir, runId);
+    },
+
+    async latest(evalName: string): Promise<EvalRun | undefined> {
+      const latestPath = join(baseDir, evalName, "latest.json");
+      const file = Bun.file(latestPath);
+      if (!(await file.exists())) return undefined;
+
+      try {
+        const content = await file.text();
+        const parsed: unknown = JSON.parse(content);
+        if (typeof parsed === "object" && parsed !== null && "runId" in parsed) {
+          const meta = parsed as Readonly<Record<string, unknown>>;
+          if (typeof meta.runId === "string") {
+            return loadRunById(baseDir, meta.runId);
+          }
+        }
+        return undefined;
+      } catch {
+        return undefined;
+      }
+    },
+
+    async list(evalName: string): Promise<readonly EvalRunMeta[]> {
+      return listRunMetas(baseDir, evalName);
+    },
+  };
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  const tmpPath = `${filePath}.tmp`;
+  await Bun.write(tmpPath, content);
+  await rename(tmpPath, filePath);
+}
+
+async function loadRunById(baseDir: string, runId: string): Promise<EvalRun | undefined> {
+  try {
+    const evalDirs = await readdir(baseDir);
+    for (const evalName of evalDirs) {
+      const filePath = join(baseDir, evalName, "runs", `${runId}.json`);
+      const file = Bun.file(filePath);
+      if (await file.exists()) {
+        const content = await file.text();
+        return JSON.parse(content) as EvalRun;
+      }
+    }
+  } catch {
+    // Directory doesn't exist or read error
+  }
+  return undefined;
+}
+
+async function listRunMetas(baseDir: string, evalName: string): Promise<readonly EvalRunMeta[]> {
+  const dir = join(baseDir, evalName, "runs");
+  try {
+    const files = await readdir(dir);
+    const summaryFiles = files.filter((f) => f.endsWith(".summary.json"));
+    const metas: EvalRunMeta[] = [];
+
+    for (const file of summaryFiles) {
+      try {
+        const content = await Bun.file(join(dir, file)).text();
+        const summary = JSON.parse(content) as EvalSummary;
+        metas.push({
+          id: file.replace(".summary.json", ""),
+          name: evalName,
+          timestamp: "",
+          passRate: summary.passRate,
+          taskCount: summary.taskCount,
+        });
+      } catch {
+        // Skip corrupted summary files
+      }
+    }
+    return metas;
+  } catch {
+    return [];
+  }
+}

--- a/packages/eval/src/transcript.test.ts
+++ b/packages/eval/src/transcript.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent } from "@koi/core";
+import {
+  collectTranscript,
+  extractMetrics,
+  extractText,
+  extractToolCalls,
+  lastNTurns,
+  summarizeTranscript,
+} from "./transcript.js";
+
+function textDelta(delta: string): EngineEvent {
+  return { kind: "text_delta", delta };
+}
+
+function toolCallStart(toolName: string, callId: string): EngineEvent {
+  return { kind: "tool_call_start", toolName, callId } as EngineEvent;
+}
+
+function turnStart(index: number): EngineEvent {
+  return { kind: "turn_start", turnIndex: index };
+}
+
+function turnEnd(index: number): EngineEvent {
+  return { kind: "turn_end", turnIndex: index };
+}
+
+function doneEvent(tokens: number): EngineEvent {
+  return {
+    kind: "done",
+    output: {
+      content: [],
+      stopReason: "completed" as const,
+      metrics: {
+        totalTokens: tokens,
+        inputTokens: tokens / 2,
+        outputTokens: tokens / 2,
+        turns: 1,
+        durationMs: 100,
+      },
+    },
+  };
+}
+
+describe("collectTranscript", () => {
+  test("collects all events from async iterable", async () => {
+    async function* gen(): AsyncIterable<EngineEvent> {
+      yield textDelta("hello");
+      yield textDelta(" world");
+    }
+    const events = await collectTranscript(gen());
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("text_delta");
+  });
+
+  test("handles empty stream", async () => {
+    async function* gen(): AsyncIterable<EngineEvent> {
+      // empty
+    }
+    const events = await collectTranscript(gen());
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe("extractText", () => {
+  test("concatenates text deltas", () => {
+    const events: readonly EngineEvent[] = [textDelta("hello"), textDelta(" world")];
+    expect(extractText(events)).toBe("hello world");
+  });
+
+  test("ignores non-text events", () => {
+    const events: readonly EngineEvent[] = [
+      textDelta("hello"),
+      toolCallStart("tool1", "c1"),
+      textDelta(" world"),
+    ];
+    expect(extractText(events)).toBe("hello world");
+  });
+
+  test("returns empty string for no text events", () => {
+    const events: readonly EngineEvent[] = [toolCallStart("tool1", "c1")];
+    expect(extractText(events)).toBe("");
+  });
+});
+
+describe("extractToolCalls", () => {
+  test("extracts tool call summaries", () => {
+    const events: readonly EngineEvent[] = [
+      toolCallStart("tool1", "c1"),
+      toolCallStart("tool2", "c2"),
+    ];
+    const calls = extractToolCalls(events);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.toolName).toBe("tool1");
+    expect(calls[1]?.toolName).toBe("tool2");
+  });
+
+  test("returns empty for no tool calls", () => {
+    const events: readonly EngineEvent[] = [textDelta("hello")];
+    expect(extractToolCalls(events)).toHaveLength(0);
+  });
+});
+
+describe("extractMetrics", () => {
+  test("uses done event metrics when available", () => {
+    const events: readonly EngineEvent[] = [textDelta("hello"), doneEvent(100)];
+    const metrics = extractMetrics(events, 500);
+    expect(metrics.totalTokens).toBe(100);
+    expect(metrics.durationMs).toBe(500);
+  });
+
+  test("returns fallback metrics when no done event", () => {
+    const events: readonly EngineEvent[] = [turnStart(0), textDelta("hello"), turnEnd(0)];
+    const metrics = extractMetrics(events, 200);
+    expect(metrics.totalTokens).toBe(0);
+    expect(metrics.turns).toBe(1);
+    expect(metrics.durationMs).toBe(200);
+  });
+});
+
+describe("summarizeTranscript", () => {
+  test("includes input, tools, and output", () => {
+    const events: readonly EngineEvent[] = [
+      turnStart(0),
+      textDelta("hello "),
+      textDelta("world"),
+      toolCallStart("search", "c1"),
+      turnEnd(0),
+      turnStart(1),
+      textDelta("result"),
+      turnEnd(1),
+    ];
+    const summary = summarizeTranscript(events);
+    expect(summary).toContain("Input:");
+    expect(summary).toContain("Tools: search");
+    expect(summary).toContain("Output:");
+  });
+
+  test("handles empty events", () => {
+    const summary = summarizeTranscript([]);
+    expect(summary).toBe("");
+  });
+});
+
+describe("lastNTurns", () => {
+  test("returns last N turn groups", () => {
+    const events: readonly EngineEvent[] = [
+      turnStart(0),
+      textDelta("turn0"),
+      turnEnd(0),
+      turnStart(1),
+      textDelta("turn1"),
+      turnEnd(1),
+      turnStart(2),
+      textDelta("turn2"),
+      turnEnd(2),
+    ];
+    const last2 = lastNTurns(events, 2);
+    const text = extractText(last2);
+    expect(text).toContain("turn1");
+    expect(text).toContain("turn2");
+    expect(text).not.toContain("turn0");
+  });
+
+  test("returns all events when fewer turns than N", () => {
+    const events: readonly EngineEvent[] = [turnStart(0), textDelta("only"), turnEnd(0)];
+    const result = lastNTurns(events, 5);
+    expect(result).toHaveLength(3);
+  });
+
+  test("falls back to slice for events with no turn markers", () => {
+    const events: readonly EngineEvent[] = [textDelta("a"), textDelta("b"), textDelta("c")];
+    const result = lastNTurns(events, 2);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/packages/eval/src/transcript.ts
+++ b/packages/eval/src/transcript.ts
@@ -1,0 +1,151 @@
+/**
+ * Transcript collection and extraction helpers.
+ */
+
+import type { EngineEvent, EngineMetrics } from "@koi/core";
+import type { ToolCallSummary } from "./types.js";
+
+/**
+ * Collects all events from an async iterable into an array.
+ */
+export async function collectTranscript(
+  stream: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  // Local mutable array for accumulation — not shared state
+  const events: EngineEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+/**
+ * Extracts concatenated text from text_delta events.
+ */
+export function extractText(events: readonly EngineEvent[]): string {
+  const parts: string[] = [];
+  for (const event of events) {
+    if (event.kind === "text_delta") {
+      parts.push(event.delta);
+    }
+  }
+  return parts.join("");
+}
+
+/**
+ * Extracts tool call summaries from tool_call_start events.
+ */
+export function extractToolCalls(events: readonly EngineEvent[]): readonly ToolCallSummary[] {
+  const calls: ToolCallSummary[] = [];
+  for (const event of events) {
+    if (event.kind === "tool_call_start") {
+      const base: ToolCallSummary = {
+        toolName: event.toolName,
+        callId: event.callId,
+      };
+      calls.push(event.args !== undefined ? { ...base, args: event.args } : base);
+    }
+  }
+  return calls;
+}
+
+/**
+ * Extracts metrics from events and measured duration.
+ */
+export function extractMetrics(events: readonly EngineEvent[], durationMs: number): EngineMetrics {
+  const doneEvent = events.find((e) => e.kind === "done");
+  if (doneEvent !== undefined && doneEvent.kind === "done") {
+    return {
+      ...doneEvent.output.metrics,
+      durationMs,
+    };
+  }
+
+  const turnCount = events.filter((e) => e.kind === "turn_end").length;
+
+  return {
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    turns: turnCount,
+    durationMs,
+  };
+}
+
+/**
+ * Creates a brief text summary of a transcript.
+ * Shows first message, tool call names, and last message.
+ */
+export function summarizeTranscript(events: readonly EngineEvent[]): string {
+  const parts: string[] = [];
+
+  const firstText = extractFirstText(events);
+  if (firstText.length > 0) {
+    parts.push(`Input: ${firstText.slice(0, 200)}`);
+  }
+
+  const toolCalls = extractToolCalls(events);
+  if (toolCalls.length > 0) {
+    const names = toolCalls.map((tc) => tc.toolName).join(", ");
+    parts.push(`Tools: ${names}`);
+  }
+
+  const lastText = extractLastText(events);
+  if (lastText.length > 0) {
+    parts.push(`Output: ${lastText.slice(0, 200)}`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Returns the last N turn-bounded event groups.
+ */
+export function lastNTurns(events: readonly EngineEvent[], n: number): readonly EngineEvent[] {
+  const turnStarts: number[] = [];
+  for (const [i, event] of events.entries()) {
+    if (event.kind === "turn_start") {
+      turnStarts.push(i);
+    }
+  }
+
+  if (turnStarts.length === 0) {
+    return events.slice(-n);
+  }
+
+  const startFrom = turnStarts.length <= n ? 0 : turnStarts.length - n;
+  const startIndex = turnStarts[startFrom];
+  return startIndex !== undefined ? events.slice(startIndex) : events;
+}
+
+function extractFirstText(events: readonly EngineEvent[]): string {
+  const parts: string[] = [];
+  for (const event of events) {
+    if (event.kind === "text_delta") {
+      parts.push(event.delta);
+    }
+    if (event.kind === "tool_call_start" || event.kind === "turn_end") {
+      break;
+    }
+  }
+  return parts.join("");
+}
+
+function extractLastText(events: readonly EngineEvent[]): string {
+  const parts: string[] = [];
+  // let justified: scanning backwards for the last text block
+  let lastTurnStart = -1;
+  for (const [i, event] of events.entries()) {
+    if (event.kind === "turn_start") {
+      lastTurnStart = i;
+    }
+  }
+
+  const startIdx = lastTurnStart >= 0 ? lastTurnStart : 0;
+  for (const event of events.slice(startIdx)) {
+    if (event.kind === "text_delta") {
+      parts.push(event.delta);
+    }
+  }
+  return parts.join("");
+}

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -1,0 +1,264 @@
+/**
+ * @koi/eval — type definitions for the agent evaluation framework.
+ *
+ * Follows Anthropic's task/trial/run hierarchy.
+ * All properties readonly, no class, no enum.
+ */
+
+import type { EngineEvent, EngineInput, EngineMetrics, JsonObject } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Grader contract
+// ---------------------------------------------------------------------------
+
+export interface EvalGrader {
+  readonly id: string;
+  readonly name: string;
+  readonly grade: (
+    transcript: readonly EngineEvent[],
+    expected: EvalExpectation | undefined,
+    metrics: EngineMetrics,
+  ) => EvalScore | Promise<EvalScore>;
+}
+
+// ---------------------------------------------------------------------------
+// Expectation (what we expect from the agent)
+// ---------------------------------------------------------------------------
+
+export type EvalExpectation =
+  | { readonly kind: "text"; readonly pattern: string | RegExp }
+  | { readonly kind: "tool_calls"; readonly calls: readonly ExpectedToolCall[] }
+  | {
+      readonly kind: "composite";
+      readonly expectations: readonly EvalExpectation[];
+    }
+  | {
+      readonly kind: "custom";
+      readonly assert: (events: readonly EngineEvent[]) => void | Promise<void>;
+    };
+
+export interface ExpectedToolCall {
+  readonly toolName: string;
+  readonly args?: Readonly<Record<string, unknown>>;
+  /** Whether tool call order must match. Default: "any". */
+  readonly order?: "strict" | "any";
+}
+
+// ---------------------------------------------------------------------------
+// Task (the evaluation template)
+// ---------------------------------------------------------------------------
+
+export interface EvalTask {
+  readonly id: string;
+  readonly name: string;
+  readonly input: EngineInput;
+  readonly expected?: EvalExpectation;
+  readonly graders: readonly EvalGrader[];
+  /** Number of trials per task. Default: 1. */
+  readonly trialCount?: number;
+  /** Per-trial timeout in ms. Default: 60_000. */
+  readonly timeoutMs?: number;
+  readonly tags?: readonly string[];
+  readonly metadata?: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Trial (one execution of a task)
+// ---------------------------------------------------------------------------
+
+export interface EvalTrial {
+  readonly taskId: string;
+  readonly trialIndex: number;
+  readonly transcript: readonly EngineEvent[];
+  readonly scores: readonly EvalScore[];
+  readonly metrics: EngineMetrics;
+  readonly status: "pass" | "fail" | "error";
+  readonly error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Score (one grader's assessment)
+// ---------------------------------------------------------------------------
+
+export interface EvalScore {
+  readonly graderId: string;
+  readonly score: number;
+  readonly pass: boolean;
+  readonly reasoning?: string;
+  readonly metadata?: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Run (the full evaluation session)
+// ---------------------------------------------------------------------------
+
+export interface EvalRun {
+  readonly id: string;
+  readonly name: string;
+  readonly timestamp: string;
+  readonly config: EvalRunConfigSnapshot;
+  readonly trials: readonly EvalTrial[];
+  readonly summary: EvalSummary;
+}
+
+/**
+ * Serializable subset of EvalRunConfig preserved for reproducibility.
+ * Excludes functions (agentFactory, onTrialComplete) that cannot be serialized.
+ */
+export interface EvalRunConfigSnapshot {
+  readonly name: string;
+  readonly concurrency: number;
+  readonly timeoutMs: number;
+  readonly passThreshold: number;
+  readonly taskCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Summary (aggregated scores)
+// ---------------------------------------------------------------------------
+
+export interface EvalSummary {
+  readonly taskCount: number;
+  readonly trialCount: number;
+  readonly passRate: number;
+  readonly passAtK: number;
+  readonly passToTheK: number;
+  readonly meanScore: number;
+  readonly latencyP50Ms: number;
+  readonly latencyP95Ms: number;
+  readonly totalCostUsd: number;
+  readonly byTask: readonly TaskSummary[];
+}
+
+export interface TaskSummary {
+  readonly taskId: string;
+  readonly taskName: string;
+  readonly passRate: number;
+  readonly passAtK: number;
+  readonly passToTheK: number;
+  readonly meanScore: number;
+  readonly trials: number;
+}
+
+// ---------------------------------------------------------------------------
+// Runner config
+// ---------------------------------------------------------------------------
+
+export interface EvalRunConfig {
+  readonly name: string;
+  readonly tasks: readonly EvalTask[];
+  readonly agentFactory: () => Promise<AgentHandle>;
+  /** Max concurrent trials. Default: 5. */
+  readonly concurrency?: number;
+  /** Per-trial timeout fallback in ms. Default: 60_000. */
+  readonly timeoutMs?: number;
+  /** Score >= this = pass. Default: 0.5. */
+  readonly passThreshold?: number;
+  readonly onTrialComplete?: (trial: EvalTrial) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Agent handle (what the factory returns)
+// ---------------------------------------------------------------------------
+
+export interface AgentHandle {
+  readonly stream: (input: EngineInput) => AsyncIterable<EngineEvent>;
+  readonly dispose?: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Store contract
+// ---------------------------------------------------------------------------
+
+export interface EvalStore {
+  readonly save: (run: EvalRun) => Promise<void>;
+  readonly load: (runId: string) => Promise<EvalRun | undefined>;
+  readonly latest: (evalName: string) => Promise<EvalRun | undefined>;
+  readonly list: (evalName: string) => Promise<readonly EvalRunMeta[]>;
+}
+
+export interface EvalRunMeta {
+  readonly id: string;
+  readonly name: string;
+  readonly timestamp: string;
+  readonly passRate: number;
+  readonly taskCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Regression detection
+// ---------------------------------------------------------------------------
+
+export type RegressionResult =
+  | {
+      readonly kind: "pass";
+      readonly baseline: EvalSummary;
+      readonly current: EvalSummary;
+    }
+  | {
+      readonly kind: "fail";
+      readonly regressions: readonly RegressionDetail[];
+      readonly baseline: EvalSummary;
+      readonly current: EvalSummary;
+    }
+  | { readonly kind: "no_baseline" };
+
+export interface RegressionDetail {
+  readonly taskId: string;
+  readonly metric: string;
+  readonly baseline: number;
+  readonly current: number;
+  readonly delta: number;
+}
+
+export interface RegressionThresholds {
+  /** Max acceptable pass rate drop. Default: 0.05 (5%). */
+  readonly passRateDelta?: number;
+  /** Max acceptable score drop. Default: 0.1. */
+  readonly scoreDelta?: number;
+  /** Max acceptable latency multiplier. Default: 2.0. */
+  readonly latencyMultiplier?: number;
+}
+
+// ---------------------------------------------------------------------------
+// LLM judge config
+// ---------------------------------------------------------------------------
+
+export type TranscriptMode = "full" | "summary" | "last-n";
+
+export interface LlmJudgeConfig {
+  readonly modelCall: (prompt: string) => Promise<string>;
+  readonly rubric: string;
+  readonly transcriptMode?: TranscriptMode;
+  /** For "last-n" mode. Default: 5. */
+  readonly lastN?: number;
+  readonly parseScore?: (response: string) => number;
+}
+
+// ---------------------------------------------------------------------------
+// Reporter types
+// ---------------------------------------------------------------------------
+
+export interface CiReport {
+  readonly exitCode: 0 | 1;
+  readonly json: string;
+  readonly summary: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool call summary (used by transcript helpers)
+// ---------------------------------------------------------------------------
+
+export interface ToolCallSummary {
+  readonly toolName: string;
+  readonly callId: string;
+  readonly args?: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Runner interface
+// ---------------------------------------------------------------------------
+
+export interface EvalRunner {
+  readonly run: () => Promise<EvalRun>;
+}

--- a/packages/eval/tsconfig.json
+++ b/packages/eval/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../errors" },
+    { "path": "../test-utils" },
+    { "path": "../engine" },
+    { "path": "../engine-pi" }
+  ]
+}

--- a/packages/eval/tsup.config.ts
+++ b/packages/eval/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Implements `@koi/eval`, a structured agent evaluation framework (L2 package)
- Anthropic-aligned Task → Trial → Run hierarchy with pluggable graders
- 4 built-in graders: exact-match, tool-call, json-schema, LLM-as-judge
- Statistical scoring: pass@k, pass^k, mean score, latency P50/P95
- Regression detection with configurable thresholds (pass rate, score, latency)
- Filesystem-based `EvalStore` with atomic writes and run history
- CI reporter with JSON artifacts and exit code 0/1
- Configurable concurrency pool (default 5), trial isolation, timeouts

## Test plan

- [x] 135 unit tests pass across 14 test files (2 E2E skipped without API key)
- [x] TypeScript strict mode typecheck passes (zero errors)
- [x] Biome lint passes (zero warnings)
- [x] Build produces clean ESM + .d.ts (32.97 KB + 10.59 KB)
- [x] API surface snapshot generated
- [x] Full monorepo build passes (68/68 packages)
- [x] No layer violations from @koi/eval

Closes #53
Depends on #32