### PR TITLE
feat: add @koi/middleware-pii and @koi/middleware-planning (L2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -399,6 +399,28 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-pii": {
+      "name": "@koi/middleware-pii",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
+    "packages/middleware-planning": {
+      "name": "@koi/middleware-planning",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-sandbox": {
       "name": "@koi/middleware-sandbox",
       "version": "0.0.0",
@@ -728,6 +750,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@koi/core": "workspace:*",
+        "@koi/delegation": "workspace:*",
         "@koi/engine": "workspace:*",
         "@koi/engine-loop": "workspace:*",
         "@koi/engine-pi": "workspace:*",
@@ -1031,6 +1054,10 @@
     "@koi/middleware-pay": ["@koi/middleware-pay@workspace:packages/middleware-pay"],
 
     "@koi/middleware-permissions": ["@koi/middleware-permissions@workspace:packages/middleware-permissions"],
+
+    "@koi/middleware-pii": ["@koi/middleware-pii@workspace:packages/middleware-pii"],
+
+    "@koi/middleware-planning": ["@koi/middleware-planning@workspace:packages/middleware-planning"],
 
     "@koi/middleware-sandbox": ["@koi/middleware-sandbox@workspace:packages/middleware-sandbox"],
 

--- a/packages/middleware-pii/package.json
+++ b/packages/middleware-pii/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/middleware-pii",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-pii/src/apply-matches.test.ts
+++ b/packages/middleware-pii/src/apply-matches.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { applyMatches } from "./apply-matches.js";
+import type { PIIMatch } from "./types.js";
+
+function makeMatch(text: string, start: number, end: number, kind: string): PIIMatch {
+  return { text, start, end, kind };
+}
+
+describe("applyMatches", () => {
+  test("returns identity for empty matches", () => {
+    const result = applyMatches("hello world", [], "redact");
+    expect(result.text).toBe("hello world");
+    expect(result.matches).toHaveLength(0);
+  });
+
+  test("redacts a single match", () => {
+    const matches = [makeMatch("user@example.com", 9, 25, "email")];
+    const result = applyMatches("Contact: user@example.com today", matches, "redact");
+    expect(result.text).toBe("Contact: [REDACTED_EMAIL] today");
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("applies multiple non-overlapping matches in correct order", () => {
+    const text = "Email: a@b.com IP: 1.2.3.4";
+    const matches = [makeMatch("a@b.com", 7, 14, "email"), makeMatch("1.2.3.4", 19, 26, "ip")];
+    const result = applyMatches(text, matches, "redact");
+    expect(result.text).toBe("Email: [REDACTED_EMAIL] IP: [REDACTED_IP]");
+  });
+
+  test("resolves overlapping matches: longest wins", () => {
+    const text = "See https://user@example.com/page";
+    const urlStart = text.indexOf("https://user@example.com/page");
+    const urlEnd = urlStart + "https://user@example.com/page".length;
+    const emailStart = text.indexOf("user@example.com");
+    const emailEnd = emailStart + "user@example.com".length;
+    const matches = [
+      makeMatch("https://user@example.com/page", urlStart, urlEnd, "url"),
+      makeMatch("user@example.com", emailStart, emailEnd, "email"),
+    ];
+    const result = applyMatches(text, matches, "redact");
+    expect(result.text).toBe("See [REDACTED_URL]");
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.kind).toBe("url");
+  });
+
+  test("uses mask strategy correctly", () => {
+    const matches = [makeMatch("john@example.com", 0, 16, "email")];
+    const result = applyMatches("john@example.com", matches, "mask");
+    expect(result.text).toBe("j***@example.com");
+  });
+
+  test("uses hash strategy correctly", () => {
+    const matches = [makeMatch("user@test.com", 0, 13, "email")];
+    const createHasher = () => new Bun.CryptoHasher("sha256", "secret");
+    const result = applyMatches("user@test.com", matches, "hash", createHasher);
+    expect(result.text).toMatch(/^<email:[0-9a-f]{16}>$/);
+  });
+
+  test("preserves text indices with reverse-order application", () => {
+    const text = "A a@b.com B c@d.com C";
+    const matches = [makeMatch("a@b.com", 2, 9, "email"), makeMatch("c@d.com", 12, 19, "email")];
+    const result = applyMatches(text, matches, "redact");
+    expect(result.text).toBe("A [REDACTED_EMAIL] B [REDACTED_EMAIL] C");
+  });
+});

--- a/packages/middleware-pii/src/apply-matches.ts
+++ b/packages/middleware-pii/src/apply-matches.ts
@@ -1,0 +1,108 @@
+/**
+ * Match application — reverse-index processing + longest-match-wins overlap resolution.
+ */
+
+import type { PIIHasherFactory } from "./strategies.js";
+import { applyHash, applyMask, applyRedact } from "./strategies.js";
+import type { PIIMatch, PIIStrategy } from "./types.js";
+
+/** Result of applying PII replacements to a string. */
+export interface ApplyResult {
+  readonly text: string;
+  readonly matches: readonly PIIMatch[];
+}
+
+/** Pre-allocated result for the no-match case. */
+const IDENTITY_MATCHES: readonly PIIMatch[] = [];
+
+/**
+ * Resolve overlapping matches: keep the longer one. Ties: earlier start wins.
+ * Input must be sorted by start ascending.
+ */
+function resolveOverlaps(sorted: readonly PIIMatch[]): readonly PIIMatch[] {
+  if (sorted.length <= 1) return sorted;
+
+  const resolved: PIIMatch[] = [sorted[0]!];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i]!;
+    const prev = resolved[resolved.length - 1]!;
+
+    // No overlap — keep both
+    if (current.start >= prev.end) {
+      resolved.push(current);
+      continue;
+    }
+
+    // Overlap — keep the longer match
+    const prevLen = prev.end - prev.start;
+    const currLen = current.end - current.start;
+    if (currLen > prevLen) {
+      resolved[resolved.length - 1] = current;
+    }
+    // else: keep prev (earlier or equal length wins)
+  }
+
+  return resolved;
+}
+
+/**
+ * Apply a PII strategy to all non-overlapping matches in a string.
+ *
+ * 1. Collect all matches from all detectors
+ * 2. Sort by start ascending
+ * 3. Resolve overlaps (longest wins)
+ * 4. Apply replacements in reverse index order (right-to-left) to preserve indices
+ */
+export function applyMatches(
+  text: string,
+  allMatches: readonly PIIMatch[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+): ApplyResult {
+  if (allMatches.length === 0) {
+    return { text, matches: IDENTITY_MATCHES };
+  }
+
+  // Sort by start ascending, then by length descending for stability
+  const sorted = [...allMatches].sort((a, b) => {
+    const startDiff = a.start - b.start;
+    if (startDiff !== 0) return startDiff;
+    return b.end - b.start - (a.end - a.start);
+  });
+
+  const resolved = resolveOverlaps(sorted);
+
+  // Apply in reverse order to preserve string indices
+  // let justified: accumulates the modified text through replacements
+  let result = text;
+  for (let i = resolved.length - 1; i >= 0; i--) {
+    const match = resolved[i]!;
+    // let justified: holds the replacement string for current match
+    let replacement: string;
+
+    switch (strategy) {
+      case "redact":
+        replacement = applyRedact(match);
+        break;
+      case "mask":
+        replacement = applyMask(match);
+        break;
+      case "hash": {
+        if (createHasher === undefined) {
+          throw new Error("Hash strategy requires a hasher factory");
+        }
+        replacement = applyHash(match, createHasher);
+        break;
+      }
+      case "block":
+        // Block strategy is handled at the middleware level, not here
+        replacement = applyRedact(match);
+        break;
+    }
+
+    result = result.slice(0, match.start) + replacement + result.slice(match.end);
+  }
+
+  return { text: result, matches: resolved };
+}

--- a/packages/middleware-pii/src/config.ts
+++ b/packages/middleware-pii/src/config.ts
@@ -1,0 +1,54 @@
+/**
+ * PII middleware configuration validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { PIIConfig, PIIStrategy } from "./types.js";
+
+const VALID_STRATEGIES = new Set<string>(["block", "redact", "mask", "hash"]);
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: { code: "VALIDATION", message, retryable: RETRYABLE_DEFAULTS.VALIDATION },
+  };
+}
+
+export function validatePIIConfig(config: unknown): Result<PIIConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (typeof c.strategy !== "string" || !VALID_STRATEGIES.has(c.strategy)) {
+    return validationError(`strategy must be one of: ${[...VALID_STRATEGIES].join(", ")}`);
+  }
+
+  const strategy = c.strategy as PIIStrategy;
+
+  if (strategy === "hash" && (typeof c.hashSecret !== "string" || c.hashSecret.length === 0)) {
+    return validationError("hashSecret is required when strategy is 'hash'");
+  }
+
+  if (c.detectors !== undefined && !Array.isArray(c.detectors)) {
+    return validationError("detectors must be an array");
+  }
+
+  if (c.customDetectors !== undefined && !Array.isArray(c.customDetectors)) {
+    return validationError("customDetectors must be an array");
+  }
+
+  if (c.scope !== undefined) {
+    if (typeof c.scope !== "object" || c.scope === null) {
+      return validationError("scope must be a non-null object");
+    }
+  }
+
+  if (c.onDetection !== undefined && typeof c.onDetection !== "function") {
+    return validationError("onDetection must be a function");
+  }
+
+  return { ok: true, value: config as PIIConfig };
+}

--- a/packages/middleware-pii/src/detectors.test.ts
+++ b/packages/middleware-pii/src/detectors.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAllDetectors,
+  createCreditCardDetector,
+  createEmailDetector,
+  createIPDetector,
+  createMACDetector,
+  createPhoneDetector,
+  createSSNDetector,
+  createURLDetector,
+} from "./detectors.js";
+
+describe("createEmailDetector", () => {
+  const detector = createEmailDetector();
+
+  test("detects simple email addresses", () => {
+    const matches = detector.detect("Contact us at user@example.com for info");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("user@example.com");
+    expect(matches[0]?.kind).toBe("email");
+  });
+
+  test("detects multiple emails", () => {
+    const matches = detector.detect("a@b.com and c@d.org");
+    expect(matches).toHaveLength(2);
+  });
+
+  test("detects emails with dots and plus signs", () => {
+    const matches = detector.detect("first.last+tag@sub.example.co.uk");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("first.last+tag@sub.example.co.uk");
+  });
+
+  test("returns empty for text without @", () => {
+    const matches = detector.detect("no email here");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("returns empty for invalid email-like strings", () => {
+    const matches = detector.detect("@nousername.com");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createCreditCardDetector", () => {
+  const detector = createCreditCardDetector();
+
+  test("detects standard card numbers with spaces", () => {
+    const matches = detector.detect("Card: 4532 0151 2345 6789");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.kind).toBe("credit_card");
+  });
+
+  test("detects card numbers with dashes", () => {
+    const matches = detector.detect("Card: 4532-0151-2345-6789");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("detects card numbers without separators", () => {
+    const matches = detector.detect("Card: 4532015123456789");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("rejects numbers that fail Luhn check", () => {
+    const matches = detector.detect("Not a card: 1234 5678 9012 3456");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("returns empty for text without digit clusters", () => {
+    const matches = detector.detect("no cards here");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createIPDetector", () => {
+  const detector = createIPDetector();
+
+  test("detects standard IPv4 addresses", () => {
+    const matches = detector.detect("Server at 192.168.1.1");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("192.168.1.1");
+    expect(matches[0]?.kind).toBe("ip");
+  });
+
+  test("detects multiple IPs", () => {
+    const matches = detector.detect("10.0.0.1 and 172.16.0.1");
+    expect(matches).toHaveLength(2);
+  });
+
+  test("validates octet ranges", () => {
+    const matches = detector.detect("Invalid: 999.999.999.999");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("detects boundary values", () => {
+    const matches = detector.detect("Address: 0.0.0.0 and 255.255.255.255");
+    expect(matches).toHaveLength(2);
+  });
+
+  test("returns empty for text without dots", () => {
+    const matches = detector.detect("no ips here");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createMACDetector", () => {
+  const detector = createMACDetector();
+
+  test("detects colon-separated MAC addresses", () => {
+    const matches = detector.detect("MAC: aa:bb:cc:dd:ee:ff");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("aa:bb:cc:dd:ee:ff");
+    expect(matches[0]?.kind).toBe("mac");
+  });
+
+  test("detects dash-separated MAC addresses", () => {
+    const matches = detector.detect("MAC: AA-BB-CC-DD-EE-FF");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("detects mixed-case MAC addresses", () => {
+    const matches = detector.detect("MAC: aA:bB:cC:dD:eE:fF");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("returns empty for text without colons or dashes", () => {
+    const matches = detector.detect("no macs here");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createURLDetector", () => {
+  const detector = createURLDetector();
+
+  test("detects https URLs", () => {
+    const matches = detector.detect("Visit https://example.com/page");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("https://example.com/page");
+    expect(matches[0]?.kind).toBe("url");
+  });
+
+  test("detects http URLs", () => {
+    const matches = detector.detect("Visit http://example.com");
+    expect(matches).toHaveLength(1);
+  });
+
+  test("detects www URLs", () => {
+    const matches = detector.detect("Visit www.example.com");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("www.example.com");
+  });
+
+  test("strips trailing punctuation", () => {
+    const matches = detector.detect("See https://example.com/page.");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("https://example.com/page");
+  });
+
+  test("strips trailing comma and paren", () => {
+    const matches = detector.detect("(see https://example.com/page),");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("https://example.com/page");
+  });
+
+  test("returns empty for text without URL signals", () => {
+    const matches = detector.detect("no urls here");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createSSNDetector", () => {
+  const detector = createSSNDetector();
+
+  test("detects standard SSN format", () => {
+    const matches = detector.detect("SSN: 123-45-6789");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("123-45-6789");
+    expect(matches[0]?.kind).toBe("ssn");
+  });
+
+  test("detects multiple SSNs", () => {
+    const matches = detector.detect("SSN 123-45-6789 and 234-56-7890");
+    expect(matches).toHaveLength(2);
+  });
+
+  test("rejects area 000", () => {
+    const matches = detector.detect("Invalid: 000-12-3456");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("rejects area 666", () => {
+    const matches = detector.detect("Invalid: 666-12-3456");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("rejects area 900-999", () => {
+    const matches = detector.detect("Invalid: 900-12-3456");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("rejects group 00", () => {
+    const matches = detector.detect("Invalid: 123-00-4567");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("rejects serial 0000", () => {
+    const matches = detector.detect("Invalid: 123-45-0000");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("returns empty for text without dash-digit pattern", () => {
+    const matches = detector.detect("no ssn here");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createPhoneDetector", () => {
+  const detector = createPhoneDetector();
+
+  test("detects US phone with dashes", () => {
+    const matches = detector.detect("Call 555-123-4567");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("555-123-4567");
+    expect(matches[0]?.kind).toBe("phone");
+  });
+
+  test("detects US phone with dots", () => {
+    const matches = detector.detect("Call 555.123.4567");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("555.123.4567");
+  });
+
+  test("detects US phone with parenthesized area code", () => {
+    const matches = detector.detect("Call (555) 123-4567");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("(555) 123-4567");
+  });
+
+  test("detects phone with country code", () => {
+    const matches = detector.detect("Call +1-555-123-4567");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("+1-555-123-4567");
+  });
+
+  test("detects phone with country code and parens", () => {
+    const matches = detector.detect("Call +1 (555) 123-4567");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.text).toBe("+1 (555) 123-4567");
+  });
+
+  test("detects multiple phone numbers", () => {
+    const matches = detector.detect("555-123-4567 or 555-987-6543");
+    expect(matches).toHaveLength(2);
+  });
+
+  test("returns empty for text without phone patterns", () => {
+    const matches = detector.detect("no phones here");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("returns empty for too few digits", () => {
+    const matches = detector.detect("555-12-4567");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("createAllDetectors", () => {
+  test("returns 7 detectors", () => {
+    const detectors = createAllDetectors();
+    expect(detectors).toHaveLength(7);
+  });
+
+  test("each detector has name and kind", () => {
+    const detectors = createAllDetectors();
+    for (const d of detectors) {
+      expect(typeof d.name).toBe("string");
+      expect(typeof d.kind).toBe("string");
+      expect(typeof d.detect).toBe("function");
+    }
+  });
+});

--- a/packages/middleware-pii/src/detectors.ts
+++ b/packages/middleware-pii/src/detectors.ts
@@ -1,0 +1,196 @@
+/**
+ * Built-in PII detectors — 7 factory functions with signal-character short-circuit.
+ */
+
+import type { PIIDetector, PIIMatch } from "./types.js";
+
+// Pre-compiled patterns at module level
+const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+const CREDIT_CARD_PATTERN = /\b(?:\d{4}[-\s]?){3}\d{4}\b/g;
+const IP_PATTERN = /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g;
+const MAC_PATTERN = /\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b/gi;
+const URL_PATTERN = /(?:https?:\/\/|www\.)[^\s<>"{}|\\^`[\]]+/gi;
+const SSN_PATTERN = /\b\d{3}-\d{2}-\d{4}\b/g;
+const PHONE_PATTERN = /(?:\+\d{1,3}[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]\d{3}[-.\s]\d{4}\b/g;
+
+/** Trailing punctuation that should not be part of a URL. */
+const URL_TRAILING = /[.,)]+$/;
+
+/** Luhn checksum validation for credit card numbers. */
+function isValidLuhn(digits: string): boolean {
+  const nums = digits.replace(/\D/g, "");
+  const len = nums.length;
+  if (len < 13 || len > 19) return false;
+
+  // let justified: luhn algorithm accumulator
+  let sum = 0;
+  // let justified: alternating flag for luhn algorithm
+  let alternate = false;
+
+  for (let i = len - 1; i >= 0; i--) {
+    // let justified: current digit being processed in luhn step
+    let n = Number(nums[i]);
+    if (alternate) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alternate = !alternate;
+  }
+  return sum % 10 === 0;
+}
+
+function collectMatches(
+  text: string,
+  pattern: RegExp,
+  kind: string,
+  validate?: (match: string) => boolean,
+  postProcess?: (match: RegExpExecArray) => { readonly text: string; readonly end: number },
+): readonly PIIMatch[] {
+  const results: PIIMatch[] = [];
+  // Reset lastIndex for global regex reuse
+  pattern.lastIndex = 0;
+
+  // let justified: regex exec loop variable
+  let m: RegExpExecArray | null = pattern.exec(text);
+  while (m !== null) {
+    const processed = postProcess?.(m);
+    const matchText = processed?.text ?? m[0];
+    const end = processed?.end ?? m.index + m[0].length;
+
+    if (validate === undefined || validate(matchText)) {
+      results.push({
+        text: matchText,
+        start: m.index,
+        end,
+        kind,
+      });
+    }
+    m = pattern.exec(text);
+  }
+  return results;
+}
+
+/** Creates an email address detector. Signal character: `@`. */
+export function createEmailDetector(): PIIDetector {
+  return {
+    name: "email",
+    kind: "email",
+    detect(text: string): readonly PIIMatch[] {
+      if (!text.includes("@")) return [];
+      return collectMatches(text, EMAIL_PATTERN, "email");
+    },
+  };
+}
+
+/** Creates a credit card number detector with Luhn validation. Signal: digit density. */
+export function createCreditCardDetector(): PIIDetector {
+  return {
+    name: "credit_card",
+    kind: "credit_card",
+    detect(text: string): readonly PIIMatch[] {
+      // Signal check: must have at least 13 consecutive digits (with optional separators)
+      if (!/\d{4}/.test(text)) return [];
+      return collectMatches(text, CREDIT_CARD_PATTERN, "credit_card", isValidLuhn);
+    },
+  };
+}
+
+/** Creates an IPv4 address detector. Signal: `.` + digit. */
+export function createIPDetector(): PIIDetector {
+  return {
+    name: "ip",
+    kind: "ip",
+    detect(text: string): readonly PIIMatch[] {
+      if (!text.includes(".") || !/\d/.test(text)) return [];
+      return collectMatches(text, IP_PATTERN, "ip");
+    },
+  };
+}
+
+/** Creates a MAC address detector. Signal: `:` or `-` + hex. */
+export function createMACDetector(): PIIDetector {
+  return {
+    name: "mac",
+    kind: "mac",
+    detect(text: string): readonly PIIMatch[] {
+      if (!text.includes(":") && !text.includes("-")) return [];
+      if (!/[0-9A-Fa-f]{2}/.test(text)) return [];
+      return collectMatches(text, MAC_PATTERN, "mac");
+    },
+  };
+}
+
+/** Creates a URL detector. Signal: `://` or `www.`. */
+export function createURLDetector(): PIIDetector {
+  return {
+    name: "url",
+    kind: "url",
+    detect(text: string): readonly PIIMatch[] {
+      if (!text.includes("://") && !text.includes("www.")) return [];
+      return collectMatches(text, URL_PATTERN, "url", undefined, (m) => {
+        const stripped = m[0].replace(URL_TRAILING, "");
+        return { text: stripped, end: m.index + stripped.length };
+      });
+    },
+  };
+}
+
+/** Validate SSN area/group/serial per SSA rules. */
+function isValidSSN(text: string): boolean {
+  const parts = text.split("-");
+  if (parts.length !== 3) return false;
+  const area = Number(parts[0]);
+  const group = Number(parts[1]);
+  const serial = Number(parts[2]);
+  // Area cannot be 000, 666, or 900-999
+  if (area === 0 || area === 666 || area >= 900) return false;
+  // Group and serial cannot be 00 / 0000
+  if (group === 0 || serial === 0) return false;
+  return true;
+}
+
+/** Validate phone has 10-15 digits (E.164 range). */
+function isValidPhone(text: string): boolean {
+  const digits = text.replace(/\D/g, "");
+  return digits.length >= 10 && digits.length <= 15;
+}
+
+/** Creates a US Social Security Number detector. Signal: `-` + digit groups. */
+export function createSSNDetector(): PIIDetector {
+  return {
+    name: "ssn",
+    kind: "ssn",
+    detect(text: string): readonly PIIMatch[] {
+      if (!text.includes("-") || !/\d{3}-\d{2}/.test(text)) return [];
+      return collectMatches(text, SSN_PATTERN, "ssn", isValidSSN);
+    },
+  };
+}
+
+/** Creates a phone number detector. Signal: `(`, `+`, or digit-separator patterns. */
+export function createPhoneDetector(): PIIDetector {
+  return {
+    name: "phone",
+    kind: "phone",
+    detect(text: string): readonly PIIMatch[] {
+      // Need separators (-, ., or parens) adjacent to digits to avoid false positives
+      if (!/\d[-.(]/.test(text) && !/[-.)\d]\d/.test(text)) return [];
+      if (!/\+|\(|\d[-.]/.test(text)) return [];
+      return collectMatches(text, PHONE_PATTERN, "phone", isValidPhone);
+    },
+  };
+}
+
+/** All 7 built-in detectors in standard order. */
+export function createAllDetectors(): readonly PIIDetector[] {
+  return [
+    createEmailDetector(),
+    createCreditCardDetector(),
+    createIPDetector(),
+    createMACDetector(),
+    createURLDetector(),
+    createSSNDetector(),
+    createPhoneDetector(),
+  ];
+}

--- a/packages/middleware-pii/src/index.ts
+++ b/packages/middleware-pii/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @koi/middleware-pii — Detect and redact PII in agent I/O (Layer 2)
+ *
+ * Supports 7 built-in detectors (email, credit card, IP, MAC, URL, SSN, phone)
+ * and 4 strategies (redact, mask, hash, block). Custom detectors
+ * can be added via config.
+ */
+
+export { validatePIIConfig } from "./config.js";
+export {
+  createAllDetectors,
+  createCreditCardDetector,
+  createEmailDetector,
+  createIPDetector,
+  createMACDetector,
+  createPhoneDetector,
+  createSSNDetector,
+  createURLDetector,
+} from "./detectors.js";
+export { createPIIMiddleware } from "./pii-middleware.js";
+export type { PIIConfig, PIIDetector, PIIMatch, PIIScope, PIIStrategy } from "./types.js";

--- a/packages/middleware-pii/src/pii-middleware.test.ts
+++ b/packages/middleware-pii/src/pii-middleware.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { JsonObject } from "@koi/core/common";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelChunk, ModelRequest, ModelResponse, ToolResponse } from "@koi/core/middleware";
+import { createMockTurnContext, testMiddlewareContract } from "@koi/test-utils";
+import { createPIIMiddleware } from "./pii-middleware.js";
+
+function createRequest(text: string): ModelRequest {
+  return {
+    messages: [
+      {
+        senderId: "user",
+        timestamp: Date.now(),
+        content: [{ kind: "text" as const, text }],
+      },
+    ] satisfies readonly InboundMessage[],
+    model: "test-model",
+  };
+}
+
+function createResponse(content: string): ModelResponse {
+  return { content, model: "test-model" };
+}
+
+/** Extract text from the first text block of the first message. */
+function firstText(request: ModelRequest): string {
+  return (request.messages[0]?.content[0] as { text: string }).text;
+}
+
+describe("createPIIMiddleware", () => {
+  test("throws on invalid config", () => {
+    expect(() => createPIIMiddleware({ strategy: "invalid" as "redact" })).toThrow();
+  });
+
+  test("throws when hash strategy missing hashSecret", () => {
+    expect(() => createPIIMiddleware({ strategy: "hash" })).toThrow();
+  });
+
+  test("creates middleware with valid config", () => {
+    const mw = createPIIMiddleware({ strategy: "redact" });
+    expect(mw.name).toBe("pii");
+    expect(mw.priority).toBe(340);
+  });
+});
+
+describe("middleware contract", () => {
+  testMiddlewareContract({
+    createMiddleware: () => createPIIMiddleware({ strategy: "redact" }),
+  });
+});
+
+describe("wrapModelCall — input scanning", () => {
+  test("redacts PII in input messages (default scope)", async () => {
+    const mw = createPIIMiddleware({ strategy: "redact" });
+    const ctx = createMockTurnContext();
+    const request = createRequest("Contact user@example.com");
+
+    // let justified: captured inside callback for inspection
+    let capturedRequest: ModelRequest | undefined;
+    await mw.wrapModelCall?.(ctx, request, async (req) => {
+      capturedRequest = req;
+      return createResponse("ok");
+    });
+
+    expect(capturedRequest).toBeDefined();
+    expect(firstText(capturedRequest!)).toBe("Contact [REDACTED_EMAIL]");
+  });
+
+  test("calls onDetection callback on input PII", async () => {
+    // let justified: tracking callback args
+    let detectionLocation = "";
+    const onDetection = mock((_matches: readonly unknown[], location: string) => {
+      detectionLocation = location;
+    });
+    const mw = createPIIMiddleware({ strategy: "redact", onDetection });
+    const ctx = createMockTurnContext();
+
+    await mw.wrapModelCall?.(ctx, createRequest("user@test.com"), async () => createResponse("ok"));
+    expect(onDetection).toHaveBeenCalledTimes(1);
+    expect(detectionLocation).toBe("input");
+  });
+
+  test("passes through clean messages unchanged", async () => {
+    const mw = createPIIMiddleware({ strategy: "redact" });
+    const ctx = createMockTurnContext();
+    const request = createRequest("nothing special");
+
+    // let justified: captured inside callback for inspection
+    let capturedRequest: ModelRequest | undefined;
+    await mw.wrapModelCall?.(ctx, request, async (req) => {
+      capturedRequest = req;
+      return createResponse("ok");
+    });
+
+    expect(capturedRequest).toBe(request);
+  });
+});
+
+describe("wrapModelCall — output scanning", () => {
+  test("redacts PII in output when output scope enabled", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "redact",
+      scope: { input: false, output: true },
+    });
+    const ctx = createMockTurnContext();
+
+    const response = await mw.wrapModelCall?.(ctx, createRequest("hi"), async () =>
+      createResponse("Reply to user@test.com"),
+    );
+    expect(response?.content).toBe("Reply to [REDACTED_EMAIL]");
+  });
+
+  test("throws on block strategy with output PII", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "block",
+      scope: { input: false, output: true },
+    });
+    const ctx = createMockTurnContext();
+
+    expect(
+      mw.wrapModelCall?.(ctx, createRequest("hi"), async () =>
+        createResponse("Secret: user@test.com"),
+      ),
+    ).rejects.toThrow("Model output contains PII");
+  });
+});
+
+describe("wrapToolCall — tool results scanning", () => {
+  test("redacts PII in tool output when toolResults scope enabled", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "redact",
+      scope: { input: false, toolResults: true },
+    });
+    const ctx = createMockTurnContext();
+    const toolRequest = { toolId: "search", input: {} satisfies JsonObject };
+    const toolResponse: ToolResponse = {
+      output: { result: "Found user@test.com" },
+    };
+
+    const response = await mw.wrapToolCall?.(ctx, toolRequest, async () => toolResponse);
+    expect((response?.output as Record<string, unknown>).result).toBe("Found [REDACTED_EMAIL]");
+  });
+
+  test("passes through when toolResults scope disabled", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "redact",
+      scope: { input: false, toolResults: false },
+    });
+    const ctx = createMockTurnContext();
+    const toolRequest = { toolId: "search", input: {} satisfies JsonObject };
+    const toolResponse: ToolResponse = {
+      output: { result: "Found user@test.com" },
+    };
+
+    const response = await mw.wrapToolCall?.(ctx, toolRequest, async () => toolResponse);
+    expect(response).toBe(toolResponse);
+  });
+});
+
+describe("wrapModelStream — output scanning", () => {
+  test("scans streaming text deltas when output scope enabled", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "redact",
+      scope: { input: false, output: true },
+    });
+    const ctx = createMockTurnContext();
+
+    async function* mockStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "Email: user@" };
+      yield { kind: "text_delta", delta: "example.com here" };
+      yield { kind: "done", response: createResponse("Email: user@example.com here") };
+    }
+
+    const chunks: ModelChunk[] = [];
+    // biome-ignore lint/style/noNonNullAssertion: hook is guaranteed to exist on created middleware
+    for await (const chunk of mw.wrapModelStream!(ctx, createRequest("hi"), () => mockStream())) {
+      chunks.push(chunk);
+    }
+
+    // Should have yielded at least one text_delta and a done chunk
+    const textChunks = chunks.filter((c) => c.kind === "text_delta");
+    const combined = textChunks.map((c) => (c as { delta: string }).delta).join("");
+    expect(combined).toContain("[REDACTED_EMAIL]");
+    expect(combined).not.toContain("user@example.com");
+  });
+
+  test("passes through when output scope disabled", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "redact",
+      scope: { input: true, output: false },
+    });
+    const ctx = createMockTurnContext();
+
+    async function* mockStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "user@example.com" };
+      yield { kind: "done", response: createResponse("user@example.com") };
+    }
+
+    const chunks: ModelChunk[] = [];
+    // biome-ignore lint/style/noNonNullAssertion: hook is guaranteed to exist on created middleware
+    for await (const chunk of mw.wrapModelStream!(ctx, createRequest("hi"), () => mockStream())) {
+      chunks.push(chunk);
+    }
+
+    const textChunks = chunks.filter((c) => c.kind === "text_delta");
+    const combined = textChunks.map((c) => (c as { delta: string }).delta).join("");
+    expect(combined).toBe("user@example.com");
+  });
+});
+
+describe("hash strategy", () => {
+  test("hashes PII with HMAC-SHA256", async () => {
+    const mw = createPIIMiddleware({
+      strategy: "hash",
+      hashSecret: "my-secret-key",
+    });
+    const ctx = createMockTurnContext();
+    const request = createRequest("user@test.com");
+
+    // let justified: captured inside callback for inspection
+    let capturedRequest: ModelRequest | undefined;
+    await mw.wrapModelCall?.(ctx, request, async (req) => {
+      capturedRequest = req;
+      return createResponse("ok");
+    });
+
+    expect(capturedRequest).toBeDefined();
+    expect(firstText(capturedRequest!)).toMatch(/^<email:[0-9a-f]{16}>$/);
+  });
+});
+
+describe("mask strategy", () => {
+  test("masks PII preserving partial info", async () => {
+    const mw = createPIIMiddleware({ strategy: "mask" });
+    const ctx = createMockTurnContext();
+    const request = createRequest("john@example.com");
+
+    // let justified: captured inside callback for inspection
+    let capturedRequest: ModelRequest | undefined;
+    await mw.wrapModelCall?.(ctx, request, async (req) => {
+      capturedRequest = req;
+      return createResponse("ok");
+    });
+
+    expect(capturedRequest).toBeDefined();
+    expect(firstText(capturedRequest!)).toBe("j***@example.com");
+  });
+});

--- a/packages/middleware-pii/src/pii-middleware.ts
+++ b/packages/middleware-pii/src/pii-middleware.ts
@@ -1,0 +1,227 @@
+/**
+ * PII middleware factory — detect and redact PII in agent I/O.
+ *
+ * Priority 340: runs after audit (300), before sanitize (350).
+ * PII redacts first, then sanitize strips injection patterns.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type {
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import { validatePIIConfig } from "./config.js";
+import { createAllDetectors } from "./detectors.js";
+import { scanJson, scanMessage, scanString } from "./scan.js";
+import type { PIIHasherFactory } from "./strategies.js";
+import { createPIIStreamBuffer } from "./stream-buffer.js";
+import type { PIIConfig, PIIDetector, PIIMatch, PIIStrategy } from "./types.js";
+
+/**
+ * Creates a PII middleware that detects and handles PII in model/tool I/O.
+ * Requires `hashSecret` when strategy is `"hash"`.
+ */
+export function createPIIMiddleware(config: PIIConfig): KoiMiddleware {
+  const validResult = validatePIIConfig(config);
+  if (!validResult.ok) {
+    throw KoiRuntimeError.from(validResult.error.code, validResult.error.message);
+  }
+
+  const validated = validResult.value;
+  const strategy = validated.strategy;
+  const scanInput = validated.scope?.input ?? true;
+  const scanOutput = validated.scope?.output ?? false;
+  const scanToolResults = validated.scope?.toolResults ?? false;
+  const onDetection = validated.onDetection;
+
+  // Merge built-in + custom detectors
+  const builtIn = validated.detectors ?? createAllDetectors();
+  const custom = validated.customDetectors ?? [];
+  const detectors: readonly PIIDetector[] = [...builtIn, ...custom];
+
+  // Build hasher factory if using hash strategy
+  const createHasher: PIIHasherFactory | undefined =
+    strategy === "hash" && validated.hashSecret !== undefined
+      ? () => new Bun.CryptoHasher("sha256", validated.hashSecret!)
+      : undefined;
+
+  return {
+    name: "pii",
+    priority: 340,
+
+    async wrapModelCall(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      // INPUT: scan request messages if input scope enabled
+      const processedRequest = scanInput
+        ? scanRequestMessages(request, detectors, strategy, createHasher, onDetection)
+        : request;
+
+      const response = await next(processedRequest);
+
+      // OUTPUT: scan response content if output scope enabled
+      if (!scanOutput) return response;
+
+      const outputResult = scanString(response.content, detectors, strategy, createHasher);
+      if (!outputResult.changed) return response;
+
+      if (strategy === "block") {
+        throw KoiRuntimeError.from("VALIDATION", "Model output contains PII", {
+          context: { location: "output", matchCount: outputResult.matches.length },
+        });
+      }
+
+      onDetection?.(outputResult.matches, "output");
+
+      const metadata: JsonObject = {
+        ...response.metadata,
+        piiDetections: outputResult.matches.length,
+      };
+      return { ...response, content: outputResult.text, metadata };
+    },
+
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      // INPUT: scan request messages
+      const processedRequest = scanInput
+        ? scanRequestMessages(request, detectors, strategy, createHasher, onDetection)
+        : request;
+
+      if (!scanOutput) {
+        yield* next(processedRequest);
+        return;
+      }
+
+      // OUTPUT: buffer and scan streaming text
+      const textBuf = createPIIStreamBuffer(detectors, strategy, createHasher);
+      const thinkBuf = createPIIStreamBuffer(detectors, strategy, createHasher);
+
+      for await (const chunk of next(processedRequest)) {
+        switch (chunk.kind) {
+          case "text_delta": {
+            const result = textBuf.push(chunk.delta);
+            if (result.safe.length > 0) {
+              yield { kind: "text_delta", delta: result.safe };
+            }
+            if (result.matches.length > 0) {
+              onDetection?.(result.matches, "output");
+            }
+            break;
+          }
+          case "thinking_delta": {
+            const result = thinkBuf.push(chunk.delta);
+            if (result.safe.length > 0) {
+              yield { kind: "thinking_delta", delta: result.safe };
+            }
+            if (result.matches.length > 0) {
+              onDetection?.(result.matches, "output");
+            }
+            break;
+          }
+          case "done": {
+            const flushedText = textBuf.flush();
+            if (flushedText.safe.length > 0) {
+              yield { kind: "text_delta", delta: flushedText.safe };
+            }
+            if (flushedText.matches.length > 0) {
+              onDetection?.(flushedText.matches, "output");
+            }
+
+            const flushedThink = thinkBuf.flush();
+            if (flushedThink.safe.length > 0) {
+              yield { kind: "thinking_delta", delta: flushedThink.safe };
+            }
+            if (flushedThink.matches.length > 0) {
+              onDetection?.(flushedThink.matches, "output");
+            }
+
+            // Scan the final response content
+            const finalResult = scanString(
+              chunk.response.content,
+              detectors,
+              strategy === "block" ? "redact" : strategy,
+              createHasher,
+            );
+            const finalResponse: ModelResponse = finalResult.changed
+              ? { ...chunk.response, content: finalResult.text }
+              : chunk.response;
+
+            yield { kind: "done", response: finalResponse };
+            break;
+          }
+          default:
+            yield chunk;
+        }
+      }
+    },
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      const response = await next(request);
+
+      if (!scanToolResults) return response;
+
+      const outputResult = scanJson(response.output, detectors, strategy, createHasher);
+      if (!outputResult.changed) return response;
+
+      if (strategy === "block") {
+        throw KoiRuntimeError.from("VALIDATION", `Tool "${request.toolId}" output contains PII`, {
+          context: { toolId: request.toolId, location: "tool-output" },
+        });
+      }
+
+      onDetection?.(outputResult.matches, "tool-output");
+      return { ...response, output: outputResult.value };
+    },
+  };
+}
+
+/** Scan all messages in a ModelRequest for PII. Throws on block strategy. */
+function scanRequestMessages(
+  request: ModelRequest,
+  detectors: readonly PIIDetector[],
+  strategy: string,
+  createHasher: PIIHasherFactory | undefined,
+  onDetection: ((matches: readonly PIIMatch[], location: string) => void) | undefined,
+): ModelRequest {
+  // let justified: tracks whether any message was modified
+  let anyChanged = false;
+
+  const scannedMessages = request.messages.map((msg) => {
+    const result = scanMessage(msg, detectors, strategy as PIIStrategy, createHasher);
+
+    if (result.changed) {
+      anyChanged = true;
+
+      if (strategy === "block") {
+        throw KoiRuntimeError.from("VALIDATION", "Input message contains PII", {
+          context: { location: "input", matchCount: result.matches.length },
+        });
+      }
+
+      onDetection?.(result.matches, "input");
+    }
+
+    return result.message;
+  });
+
+  if (!anyChanged) return request;
+  return { ...request, messages: scannedMessages };
+}

--- a/packages/middleware-pii/src/scan.test.ts
+++ b/packages/middleware-pii/src/scan.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { ContentBlock, InboundMessage } from "@koi/core/message";
+import { createEmailDetector, createIPDetector } from "./detectors.js";
+import { scanBlock, scanJson, scanMessage, scanString } from "./scan.js";
+
+const detectors = [createEmailDetector(), createIPDetector()];
+
+describe("scanString", () => {
+  test("returns unchanged for clean text", () => {
+    const result = scanString("hello world", detectors, "redact");
+    expect(result.text).toBe("hello world");
+    expect(result.changed).toBe(false);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  test("redacts email in text", () => {
+    const result = scanString("Contact user@example.com", detectors, "redact");
+    expect(result.text).toBe("Contact [REDACTED_EMAIL]");
+    expect(result.changed).toBe(true);
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("redacts multiple PII types", () => {
+    const result = scanString("user@test.com at 10.0.0.1", detectors, "redact");
+    expect(result.text).toContain("[REDACTED_EMAIL]");
+    expect(result.text).toContain("[REDACTED_IP]");
+    expect(result.matches).toHaveLength(2);
+  });
+});
+
+describe("scanBlock", () => {
+  test("scans text blocks", () => {
+    const block: ContentBlock = { kind: "text", text: "Email: a@b.com" };
+    const result = scanBlock(block, detectors, "redact");
+    expect(result.changed).toBe(true);
+    expect(result.block).toEqual({ kind: "text", text: "Email: [REDACTED_EMAIL]" });
+  });
+
+  test("returns identity for non-text blocks", () => {
+    const block: ContentBlock = { kind: "image", url: "http://example.com/img.png" };
+    const result = scanBlock(block, detectors, "redact");
+    expect(result.changed).toBe(false);
+    expect(result.block).toBe(block);
+  });
+
+  test("returns identity for clean text blocks", () => {
+    const block: ContentBlock = { kind: "text", text: "no pii here" };
+    const result = scanBlock(block, detectors, "redact");
+    expect(result.changed).toBe(false);
+    expect(result.block).toBe(block);
+  });
+});
+
+describe("scanMessage", () => {
+  test("scans all text blocks in a message", () => {
+    const message: InboundMessage = {
+      senderId: "user",
+      timestamp: Date.now(),
+      content: [
+        { kind: "text", text: "Email: user@test.com" },
+        { kind: "text", text: "IP: 192.168.1.1" },
+      ],
+    };
+    const result = scanMessage(message, detectors, "redact");
+    expect(result.changed).toBe(true);
+    expect(result.matches).toHaveLength(2);
+  });
+
+  test("returns identity for clean messages", () => {
+    const message: InboundMessage = {
+      senderId: "user",
+      timestamp: Date.now(),
+      content: [{ kind: "text", text: "nothing to see" }],
+    };
+    const result = scanMessage(message, detectors, "redact");
+    expect(result.changed).toBe(false);
+    expect(result.message).toBe(message);
+  });
+});
+
+describe("scanJson", () => {
+  test("scans string values in objects", () => {
+    const value = { email: "user@test.com", name: "John" };
+    const result = scanJson(value, detectors, "redact");
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, unknown>).email).toBe("[REDACTED_EMAIL]");
+    expect((result.value as Record<string, unknown>).name).toBe("John");
+  });
+
+  test("scans nested arrays", () => {
+    const value = { data: ["user@test.com", "clean", "10.0.0.1"] };
+    const result = scanJson(value, detectors, "redact");
+    expect(result.changed).toBe(true);
+    const arr = (result.value as Record<string, unknown>).data as string[];
+    expect(arr[0]).toBe("[REDACTED_EMAIL]");
+    expect(arr[1]).toBe("clean");
+    expect(arr[2]).toBe("[REDACTED_IP]");
+  });
+
+  test("returns identity for non-string values", () => {
+    const value = { count: 42, flag: true, nothing: null };
+    const result = scanJson(value, detectors, "redact");
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(value);
+  });
+
+  test("respects max depth", () => {
+    const deep = { a: { b: { c: "user@test.com" } } };
+    const result = scanJson(deep, detectors, "redact", undefined, 1);
+    // At depth > 1, stops recursing — email should not be redacted
+    expect(result.changed).toBe(false);
+  });
+});

--- a/packages/middleware-pii/src/scan.ts
+++ b/packages/middleware-pii/src/scan.ts
@@ -1,0 +1,207 @@
+/**
+ * Content scanning — scan strings, content blocks, messages, and tool output for PII.
+ */
+
+import type { ContentBlock, InboundMessage } from "@koi/core/message";
+import { applyMatches } from "./apply-matches.js";
+import type { PIIHasherFactory } from "./strategies.js";
+import type { PIIDetector, PIIMatch, PIIStrategy } from "./types.js";
+
+/** Result of scanning a string for PII. */
+export interface ScanStringResult {
+  readonly text: string;
+  readonly matches: readonly PIIMatch[];
+  readonly changed: boolean;
+}
+
+/** Result of scanning a content block. */
+export interface ScanBlockResult {
+  readonly block: ContentBlock;
+  readonly matches: readonly PIIMatch[];
+  readonly changed: boolean;
+}
+
+/** Result of scanning a full message. */
+export interface ScanMessageResult {
+  readonly message: InboundMessage;
+  readonly matches: readonly PIIMatch[];
+  readonly changed: boolean;
+}
+
+/** Result of scanning a JSON value (tool output). */
+export interface ScanJsonResult {
+  readonly value: unknown;
+  readonly matches: readonly PIIMatch[];
+  readonly changed: boolean;
+}
+
+const EMPTY_MATCHES: readonly PIIMatch[] = [];
+
+/** Scan a single string for PII and apply the strategy. */
+export function scanString(
+  text: string,
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+): ScanStringResult {
+  // Collect matches from all detectors
+  const allMatches: PIIMatch[] = [];
+  for (const detector of detectors) {
+    const found = detector.detect(text);
+    for (const match of found) {
+      allMatches.push(match);
+    }
+  }
+
+  if (allMatches.length === 0) {
+    return { text, matches: EMPTY_MATCHES, changed: false };
+  }
+
+  const result = applyMatches(text, allMatches, strategy, createHasher);
+  return { text: result.text, matches: result.matches, changed: true };
+}
+
+/** Scan a single content block for PII. Only processes text blocks. */
+export function scanBlock(
+  block: ContentBlock,
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+): ScanBlockResult {
+  switch (block.kind) {
+    case "text": {
+      const result = scanString(block.text, detectors, strategy, createHasher);
+      if (!result.changed) {
+        return { block, matches: EMPTY_MATCHES, changed: false };
+      }
+      return {
+        block: { ...block, text: result.text },
+        matches: result.matches,
+        changed: true,
+      };
+    }
+    case "file":
+    case "image":
+    case "button":
+    case "custom":
+      return { block, matches: EMPTY_MATCHES, changed: false };
+  }
+}
+
+/** Scan all content blocks in an InboundMessage. */
+export function scanMessage(
+  message: InboundMessage,
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+): ScanMessageResult {
+  const allMatches: PIIMatch[] = [];
+  // let justified: tracks whether any block was modified
+  let anyChanged = false;
+
+  const scannedContent = message.content.map((block) => {
+    const result = scanBlock(block, detectors, strategy, createHasher);
+    if (result.changed) {
+      anyChanged = true;
+      for (const match of result.matches) {
+        allMatches.push(match);
+      }
+    }
+    return result.block;
+  });
+
+  if (!anyChanged) {
+    return { message, matches: EMPTY_MATCHES, changed: false };
+  }
+
+  return {
+    message: { ...message, content: scannedContent },
+    matches: allMatches,
+    changed: true,
+  };
+}
+
+/** Default maximum recursion depth for JSON walking. */
+const DEFAULT_MAX_DEPTH = 10;
+
+/** Recursively scan a JSON value for PII in all string leaves. */
+export function scanJson(
+  value: unknown,
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+  maxDepth: number = DEFAULT_MAX_DEPTH,
+): ScanJsonResult {
+  return walkJson(value, detectors, strategy, createHasher, maxDepth, 0);
+}
+
+function walkJson(
+  value: unknown,
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher: PIIHasherFactory | undefined,
+  maxDepth: number,
+  depth: number,
+): ScanJsonResult {
+  if (depth > maxDepth) {
+    return { value, matches: EMPTY_MATCHES, changed: false };
+  }
+
+  if (typeof value === "string") {
+    const result = scanString(value, detectors, strategy, createHasher);
+    return { value: result.text, matches: result.matches, changed: result.changed };
+  }
+
+  if (value === null || value === undefined || typeof value !== "object") {
+    return { value, matches: EMPTY_MATCHES, changed: false };
+  }
+
+  if (Array.isArray(value)) {
+    const allMatches: PIIMatch[] = [];
+    // let justified: tracks whether any element was modified
+    let anyChanged = false;
+
+    const newArr = value.map((item: unknown) => {
+      const result = walkJson(item, detectors, strategy, createHasher, maxDepth, depth + 1);
+      if (result.changed) {
+        anyChanged = true;
+        for (const match of result.matches) {
+          allMatches.push(match);
+        }
+      }
+      return result.value;
+    });
+
+    return { value: anyChanged ? newArr : value, matches: allMatches, changed: anyChanged };
+  }
+
+  // Object — recurse values
+  // Cast justified: value is non-null, non-array object after guards above.
+  const obj: Record<string, unknown> = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  const allMatches: PIIMatch[] = [];
+  // let justified: tracks whether any field was modified
+  let anyChanged = false;
+  const entries: Array<readonly [string, unknown]> = [];
+
+  for (const key of keys) {
+    const result = walkJson(obj[key], detectors, strategy, createHasher, maxDepth, depth + 1);
+    if (result.changed) {
+      anyChanged = true;
+      for (const match of result.matches) {
+        allMatches.push(match);
+      }
+    }
+    entries.push([key, result.value] as const);
+  }
+
+  if (!anyChanged) {
+    return { value, matches: allMatches, changed: false };
+  }
+
+  const newObj: Record<string, unknown> = {};
+  for (const [key, val] of entries) {
+    newObj[key] = val;
+  }
+  return { value: newObj, matches: allMatches, changed: true };
+}

--- a/packages/middleware-pii/src/strategies.test.ts
+++ b/packages/middleware-pii/src/strategies.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { applyHash, applyMask, applyRedact } from "./strategies.js";
+import type { PIIMatch } from "./types.js";
+
+function match(overrides: Partial<PIIMatch> & { readonly kind: string }): PIIMatch {
+  return { text: "test@example.com", start: 0, end: 16, ...overrides };
+}
+
+describe("applyRedact", () => {
+  test("replaces with [REDACTED_<KIND>]", () => {
+    expect(applyRedact(match({ kind: "email" }))).toBe("[REDACTED_EMAIL]");
+    expect(applyRedact(match({ kind: "credit_card" }))).toBe("[REDACTED_CREDIT_CARD]");
+    expect(applyRedact(match({ kind: "ip" }))).toBe("[REDACTED_IP]");
+    expect(applyRedact(match({ kind: "mac" }))).toBe("[REDACTED_MAC]");
+    expect(applyRedact(match({ kind: "url" }))).toBe("[REDACTED_URL]");
+    expect(applyRedact(match({ kind: "ssn" }))).toBe("[REDACTED_SSN]");
+    expect(applyRedact(match({ kind: "phone" }))).toBe("[REDACTED_PHONE]");
+  });
+});
+
+describe("applyMask", () => {
+  test("masks email preserving first char and domain", () => {
+    const result = applyMask(match({ kind: "email", text: "john@example.com" }));
+    expect(result).toBe("j***@example.com");
+  });
+
+  test("masks credit card preserving last 4 digits", () => {
+    const result = applyMask(match({ kind: "credit_card", text: "4532 0151 2345 6789" }));
+    expect(result).toBe("****-****-****-6789");
+  });
+
+  test("masks IP preserving last octet", () => {
+    const result = applyMask(match({ kind: "ip", text: "192.168.1.42" }));
+    expect(result).toBe("***.***.***.42");
+  });
+
+  test("masks MAC preserving OUI with colons", () => {
+    const result = applyMask(match({ kind: "mac", text: "aa:bb:cc:dd:ee:ff" }));
+    expect(result).toBe("aa:bb:cc:**:**:**");
+  });
+
+  test("masks MAC preserving OUI with dashes", () => {
+    const result = applyMask(match({ kind: "mac", text: "AA-BB-CC-DD-EE-FF" }));
+    expect(result).toBe("AA-BB-CC-**-**-**");
+  });
+
+  test("fully masks URL", () => {
+    const result = applyMask(match({ kind: "url", text: "https://example.com" }));
+    expect(result).toBe("[MASKED_URL]");
+  });
+
+  test("masks SSN preserving last 4 digits", () => {
+    const result = applyMask(match({ kind: "ssn", text: "123-45-6789" }));
+    expect(result).toBe("***-**-6789");
+  });
+
+  test("masks phone preserving last 4 digits", () => {
+    const result = applyMask(match({ kind: "phone", text: "555-123-4567" }));
+    expect(result).toBe("***-***-4567");
+  });
+
+  test("masks phone with country code preserving last 4", () => {
+    const result = applyMask(match({ kind: "phone", text: "+1-555-123-4567" }));
+    expect(result).toBe("***-***-4567");
+  });
+
+  test("fully masks custom kind", () => {
+    const result = applyMask(match({ kind: "custom_field" }));
+    expect(result).toBe("[MASKED_CUSTOM_FIELD]");
+  });
+});
+
+describe("applyHash", () => {
+  test("produces <kind:16-char-hex> format", () => {
+    const createHasher = () => new Bun.CryptoHasher("sha256", "test-secret");
+    const result = applyHash(match({ kind: "email", text: "user@example.com" }), createHasher);
+    expect(result).toMatch(/^<email:[0-9a-f]{16}>$/);
+  });
+
+  test("produces deterministic output for same input and key", () => {
+    const createHasher = () => new Bun.CryptoHasher("sha256", "test-secret");
+    const m = match({ kind: "email", text: "user@example.com" });
+    const result1 = applyHash(m, createHasher);
+    const result2 = applyHash(m, createHasher);
+    expect(result1).toBe(result2);
+  });
+
+  test("produces different output for different inputs", () => {
+    const createHasher = () => new Bun.CryptoHasher("sha256", "test-secret");
+    const result1 = applyHash(match({ kind: "email", text: "a@b.com" }), createHasher);
+    const result2 = applyHash(match({ kind: "email", text: "c@d.com" }), createHasher);
+    expect(result1).not.toBe(result2);
+  });
+});

--- a/packages/middleware-pii/src/strategies.ts
+++ b/packages/middleware-pii/src/strategies.ts
@@ -1,0 +1,67 @@
+/**
+ * PII replacement strategies — 4 pure functions for handling detected PII.
+ */
+
+import type { PIIMatch } from "./types.js";
+
+/** Hasher interface matching Bun.CryptoHasher's sync API. */
+export interface PIIHasher {
+  readonly update: (data: string) => PIIHasher;
+  readonly digest: (encoding: "hex") => string;
+}
+
+/** Factory for creating HMAC hashers. */
+export type PIIHasherFactory = () => PIIHasher;
+
+/** Redact: replace with `[REDACTED_<KIND>]`. */
+export function applyRedact(match: PIIMatch): string {
+  return `[REDACTED_${match.kind.toUpperCase()}]`;
+}
+
+/** Mask: per-type partial masking that preserves some useful info. */
+export function applyMask(match: PIIMatch): string {
+  switch (match.kind) {
+    case "email": {
+      const atIndex = match.text.indexOf("@");
+      if (atIndex <= 0) return `[MASKED_EMAIL]`;
+      const domain = match.text.slice(atIndex);
+      return `${match.text[0]}***${domain}`;
+    }
+    case "credit_card": {
+      const digits = match.text.replace(/\D/g, "");
+      const last4 = digits.slice(-4);
+      return `****-****-****-${last4}`;
+    }
+    case "ip": {
+      const octets = match.text.split(".");
+      const lastOctet = octets[octets.length - 1] ?? "0";
+      return `***.***.***.${lastOctet}`;
+    }
+    case "mac": {
+      // Preserve OUI (first 3 octets), mask last 3
+      const sep = match.text.includes(":") ? ":" : "-";
+      const parts = match.text.split(/[:-]/);
+      const oui = parts.slice(0, 3).join(sep);
+      return `${oui}${sep}**${sep}**${sep}**`;
+    }
+    case "ssn": {
+      // Preserve last 4 digits
+      const last4 = match.text.slice(-4);
+      return `***-**-${last4}`;
+    }
+    case "phone": {
+      // Preserve last 4 digits
+      const digits = match.text.replace(/\D/g, "");
+      const last4 = digits.slice(-4);
+      return `***-***-${last4}`;
+    }
+    default:
+      return `[MASKED_${match.kind.toUpperCase()}]`;
+  }
+}
+
+/** Hash: produce `<kind:16-char-hex>` using HMAC-SHA256. */
+export function applyHash(match: PIIMatch, createHasher: PIIHasherFactory): string {
+  const hex = createHasher().update(match.text).digest("hex").slice(0, 16);
+  return `<${match.kind}:${hex}>`;
+}

--- a/packages/middleware-pii/src/stream-buffer.ts
+++ b/packages/middleware-pii/src/stream-buffer.ts
@@ -1,0 +1,79 @@
+/**
+ * Sliding window buffer for PII detection in streaming output.
+ *
+ * Text chunks are appended to an internal buffer. The buffer is scanned
+ * for PII, and confirmed-safe prefix text (everything before the danger
+ * zone) is yielded. On flush, all remaining content is scanned and returned.
+ *
+ * Block strategy is downgraded to redact in streaming mode — we can't
+ * retract already-yielded content.
+ */
+
+import { scanString } from "./scan.js";
+import type { PIIHasherFactory } from "./strategies.js";
+import type { PIIDetector, PIIMatch, PIIStrategy } from "./types.js";
+
+/** Default sliding window buffer size in characters. */
+const DEFAULT_BUFFER_SIZE = 64;
+
+/** Result from push() or flush(). */
+export interface PIIStreamBufferResult {
+  readonly safe: string;
+  readonly matches: readonly PIIMatch[];
+}
+
+/** Pre-allocated singleton for the common buffering case. */
+const EMPTY_RESULT: PIIStreamBufferResult = { safe: "", matches: [] } as const;
+
+/** Stream buffer interface for PII scanning. */
+export interface PIIStreamBuffer {
+  readonly push: (text: string) => PIIStreamBufferResult;
+  readonly flush: () => PIIStreamBufferResult;
+}
+
+/**
+ * Create a sliding window stream buffer for PII detection in streaming output.
+ * Block strategy is downgraded to redact (can't un-yield sent chunks).
+ */
+export function createPIIStreamBuffer(
+  detectors: readonly PIIDetector[],
+  strategy: PIIStrategy,
+  createHasher?: PIIHasherFactory,
+  bufferSize: number = DEFAULT_BUFFER_SIZE,
+): PIIStreamBuffer {
+  // Downgrade block to redact for streaming
+  const effectiveStrategy: PIIStrategy = strategy === "block" ? "redact" : strategy;
+
+  // let justified: mutable internal buffer accumulating streaming text
+  let buffer = "";
+
+  function push(text: string): PIIStreamBufferResult {
+    buffer += text;
+
+    if (buffer.length <= bufferSize) {
+      return EMPTY_RESULT;
+    }
+
+    // The last bufferSize chars might contain a split PII pattern — keep them buffered
+    const safeEnd = buffer.length - bufferSize;
+    const safeChunk = buffer.slice(0, safeEnd);
+    buffer = buffer.slice(safeEnd);
+
+    const result = scanString(safeChunk, detectors, effectiveStrategy, createHasher);
+    return { safe: result.text, matches: result.matches };
+  }
+
+  function flush(): PIIStreamBufferResult {
+    if (buffer.length === 0) {
+      return EMPTY_RESULT;
+    }
+
+    const remaining = buffer;
+    buffer = "";
+
+    const result = scanString(remaining, detectors, effectiveStrategy, createHasher);
+    return { safe: result.text, matches: result.matches };
+  }
+
+  return { push, flush };
+}

--- a/packages/middleware-pii/src/types.ts
+++ b/packages/middleware-pii/src/types.ts
@@ -1,0 +1,38 @@
+/**
+ * PII middleware types — detection, strategy, and configuration contracts.
+ */
+
+/** A detected PII occurrence in a string. */
+export interface PIIMatch {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+  readonly kind: string;
+}
+
+/** Unified detector interface — all detectors implement this. */
+export interface PIIDetector {
+  readonly name: string;
+  readonly kind: string;
+  readonly detect: (text: string) => readonly PIIMatch[];
+}
+
+/** How to handle detected PII. */
+export type PIIStrategy = "block" | "redact" | "mask" | "hash";
+
+/** Where to scan for PII. */
+export interface PIIScope {
+  readonly input?: boolean | undefined;
+  readonly output?: boolean | undefined;
+  readonly toolResults?: boolean | undefined;
+}
+
+/** Factory configuration for createPIIMiddleware. */
+export interface PIIConfig {
+  readonly strategy: PIIStrategy;
+  readonly detectors?: readonly PIIDetector[] | undefined;
+  readonly customDetectors?: readonly PIIDetector[] | undefined;
+  readonly scope?: PIIScope | undefined;
+  readonly hashSecret?: string | undefined;
+  readonly onDetection?: ((matches: readonly PIIMatch[], location: string) => void) | undefined;
+}

--- a/packages/middleware-pii/tsconfig.json
+++ b/packages/middleware-pii/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-pii/tsup.config.ts
+++ b/packages/middleware-pii/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/middleware-planning/package.json
+++ b/packages/middleware-planning/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/middleware-planning",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-planning/src/config.ts
+++ b/packages/middleware-planning/src/config.ts
@@ -1,0 +1,39 @@
+/**
+ * Planning middleware configuration validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { PlanConfig } from "./types.js";
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: { code: "VALIDATION", message, retryable: RETRYABLE_DEFAULTS.VALIDATION },
+  };
+}
+
+export function validatePlanConfig(config: unknown): Result<PlanConfig, KoiError> {
+  if (config === null || config === undefined) {
+    // Config is optional — undefined/null means use defaults
+    return { ok: true, value: {} };
+  }
+
+  if (typeof config !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (c.onPlanUpdate !== undefined && typeof c.onPlanUpdate !== "function") {
+    return validationError("onPlanUpdate must be a function");
+  }
+
+  if (c.priority !== undefined) {
+    if (typeof c.priority !== "number" || !Number.isInteger(c.priority) || c.priority < 0) {
+      return validationError("priority must be a non-negative integer");
+    }
+  }
+
+  return { ok: true, value: config as PlanConfig };
+}

--- a/packages/middleware-planning/src/index.ts
+++ b/packages/middleware-planning/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @koi/middleware-planning — Structured multi-step task tracking (Layer 2)
+ *
+ * Injects a `write_plan` tool that lets agents create and maintain
+ * structured plans across conversation turns.
+ */
+
+export { validatePlanConfig } from "./config.js";
+export { createPlanMiddleware } from "./plan-middleware.js";
+export { PLAN_SYSTEM_PROMPT, WRITE_PLAN_DESCRIPTOR, WRITE_PLAN_TOOL_NAME } from "./plan-tool.js";
+export type { PlanConfig, PlanItem, PlanStatus } from "./types.js";

--- a/packages/middleware-planning/src/plan-middleware.test.ts
+++ b/packages/middleware-planning/src/plan-middleware.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from "bun:test";
+import type { JsonObject } from "@koi/core/common";
+import type { ToolDescriptor } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelChunk, ModelRequest, ModelResponse } from "@koi/core/middleware";
+import { createMockTurnContext, testMiddlewareContract } from "@koi/test-utils";
+import { createPlanMiddleware } from "./plan-middleware.js";
+import { WRITE_PLAN_TOOL_NAME } from "./plan-tool.js";
+import type { PlanItem } from "./types.js";
+
+function createRequest(text: string): ModelRequest {
+  return {
+    messages: [
+      {
+        senderId: "user",
+        timestamp: Date.now(),
+        content: [{ kind: "text" as const, text }],
+      },
+    ] satisfies readonly InboundMessage[],
+    model: "test-model",
+  };
+}
+
+function createResponse(content: string): ModelResponse {
+  return { content, model: "test-model" };
+}
+
+describe("createPlanMiddleware", () => {
+  test("creates middleware with default config", () => {
+    const mw = createPlanMiddleware();
+    expect(mw.name).toBe("plan");
+    expect(mw.priority).toBe(450);
+  });
+
+  test("accepts custom priority", () => {
+    const mw = createPlanMiddleware({ priority: 300 });
+    expect(mw.priority).toBe(300);
+  });
+
+  test("throws on invalid config", () => {
+    expect(() => createPlanMiddleware({ priority: -1 })).toThrow();
+  });
+});
+
+describe("middleware contract", () => {
+  testMiddlewareContract({
+    createMiddleware: () => createPlanMiddleware(),
+  });
+});
+
+describe("wrapModelCall — tool + prompt injection", () => {
+  test("injects plan system message into request messages", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    // let justified: captured inside callback for inspection
+    let capturedRequest: ModelRequest | undefined;
+    await mw.wrapModelCall?.(ctx, createRequest("hello"), async (req) => {
+      capturedRequest = req;
+      return createResponse("ok");
+    });
+
+    expect(capturedRequest).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: validated by expect above
+    const firstMsg = capturedRequest!.messages[0]!;
+    expect(firstMsg.senderId).toBe("system:plan");
+    expect((firstMsg.content[0] as { text: string }).text).toContain("write_plan");
+  });
+
+  test("injects write_plan tool descriptor", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    // let justified: captured inside callback for inspection
+    let capturedTools: readonly ToolDescriptor[] | undefined;
+    await mw.wrapModelCall?.(ctx, createRequest("hello"), async (req) => {
+      capturedTools = req.tools;
+      return createResponse("ok");
+    });
+
+    expect(capturedTools).toBeDefined();
+    const writePlanTool = capturedTools?.find(
+      (t: ToolDescriptor) => t.name === WRITE_PLAN_TOOL_NAME,
+    );
+    expect(writePlanTool).toBeDefined();
+  });
+
+  test("attaches currentPlan to response metadata", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    const response = await mw.wrapModelCall?.(ctx, createRequest("hello"), async () =>
+      createResponse("ok"),
+    );
+    expect(response?.metadata).toBeDefined();
+    expect(response?.metadata?.currentPlan).toBeDefined();
+  });
+});
+
+describe("wrapModelStream — tool injection", () => {
+  test("injects tools into stream request", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    async function* mockStream(req: ModelRequest): AsyncIterable<ModelChunk> {
+      expect(req.tools).toBeDefined();
+      yield { kind: "text_delta", delta: "hello" };
+      yield { kind: "done", response: createResponse("hello") };
+    }
+
+    const chunks: ModelChunk[] = [];
+    // biome-ignore lint/style/noNonNullAssertion: hook is guaranteed to exist on created middleware
+    for await (const chunk of mw.wrapModelStream!(ctx, createRequest("hi"), (req) =>
+      mockStream(req),
+    )) {
+      chunks.push(chunk);
+    }
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("wrapToolCall — write_plan interception", () => {
+  test("intercepts write_plan calls and stores plan", async () => {
+    // let justified: captured inside callback for inspection
+    let capturedPlan: readonly PlanItem[] | undefined;
+    const onPlanUpdate = (plan: readonly PlanItem[]): void => {
+      capturedPlan = plan;
+    };
+    const mw = createPlanMiddleware({ onPlanUpdate });
+    const ctx = createMockTurnContext();
+
+    const response = await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [
+            { content: "Step 1", status: "pending" },
+            { content: "Step 2", status: "in_progress" },
+          ],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "should not be called" }),
+    );
+
+    expect(response?.output).toContain("Plan updated");
+    expect(capturedPlan).toBeDefined();
+    expect(capturedPlan!).toHaveLength(2);
+    expect(capturedPlan?.[0]?.content).toBe("Step 1");
+  });
+
+  test("passes through non-plan tool calls", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+    const expected = { output: "tool result" };
+
+    const response = await mw.wrapToolCall?.(
+      ctx,
+      { toolId: "other_tool", input: {} satisfies JsonObject },
+      async () => expected,
+    );
+    expect(response).toBe(expected);
+  });
+
+  test("rejects second write_plan call in same turn", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    // Reset per-turn counter
+    await mw.onBeforeTurn?.(ctx);
+
+    const input = {
+      plan: [{ content: "Step 1", status: "pending" }],
+    } satisfies JsonObject;
+    const request = { toolId: WRITE_PLAN_TOOL_NAME, input };
+
+    // First call succeeds
+    const first = await mw.wrapToolCall?.(ctx, request, async () => ({ output: "x" }));
+    expect(first?.output).toContain("Plan updated");
+
+    // Second call in same turn fails
+    const second = await mw.wrapToolCall?.(ctx, request, async () => ({ output: "x" }));
+    expect((second?.output as Record<string, unknown>).error).toContain("once per response");
+  });
+
+  test("allows write_plan again after onBeforeTurn resets counter", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    const input = {
+      plan: [{ content: "Step 1", status: "pending" }],
+    } satisfies JsonObject;
+    const request = { toolId: WRITE_PLAN_TOOL_NAME, input };
+
+    await mw.onBeforeTurn?.(ctx);
+    const first = await mw.wrapToolCall?.(ctx, request, async () => ({ output: "x" }));
+    expect(first?.output).toContain("Plan updated");
+
+    // New turn
+    await mw.onBeforeTurn?.(ctx);
+    const second = await mw.wrapToolCall?.(ctx, request, async () => ({ output: "x" }));
+    expect(second?.output).toContain("Plan updated");
+  });
+
+  test("returns error for invalid plan input", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+    await mw.onBeforeTurn?.(ctx);
+
+    const response = await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: { plan: "not an array" } as unknown as JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+    expect((response?.output as Record<string, unknown>).error).toBeDefined();
+  });
+
+  test("returns error for plan items with invalid status", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+    await mw.onBeforeTurn?.(ctx);
+
+    const response = await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "Step 1", status: "invalid" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+    expect((response?.output as Record<string, unknown>).error).toContain("status");
+  });
+
+  test("atomically replaces plan on each call", async () => {
+    // let justified: captured plan from second call
+    let lastCapturedPlan: readonly PlanItem[] | undefined;
+    // let justified: tracks number of calls
+    let callCount = 0;
+    const onPlanUpdate = (plan: readonly PlanItem[]): void => {
+      callCount += 1;
+      lastCapturedPlan = plan;
+    };
+    const mw = createPlanMiddleware({ onPlanUpdate });
+    const ctx = createMockTurnContext();
+
+    await mw.onBeforeTurn?.(ctx);
+    await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [
+            { content: "A", status: "pending" },
+            { content: "B", status: "pending" },
+          ],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+
+    // New turn — second plan replaces first
+    await mw.onBeforeTurn?.(ctx);
+    await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "C", status: "completed" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+
+    expect(callCount).toBe(2);
+    expect(lastCapturedPlan).toBeDefined();
+    expect(lastCapturedPlan!).toHaveLength(1);
+    expect(lastCapturedPlan?.[0]?.content).toBe("C");
+  });
+});
+
+describe("plan persistence across turns", () => {
+  test("plan state persists after wrapModelCall", async () => {
+    const mw = createPlanMiddleware();
+    const ctx = createMockTurnContext();
+
+    // Turn 1: create plan
+    await mw.onBeforeTurn?.(ctx);
+    await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "Step 1", status: "in_progress" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+
+    // Turn 2: plan should be visible in metadata
+    await mw.onBeforeTurn?.(ctx);
+    const response = await mw.wrapModelCall?.(ctx, createRequest("continue"), async () =>
+      createResponse("ok"),
+    );
+
+    const plan = response?.metadata?.currentPlan as unknown as Array<{ content: string }>;
+    expect(plan).toHaveLength(1);
+    expect(plan[0]?.content).toBe("Step 1");
+  });
+});

--- a/packages/middleware-planning/src/plan-middleware.ts
+++ b/packages/middleware-planning/src/plan-middleware.ts
@@ -1,0 +1,171 @@
+/**
+ * Planning middleware factory — inject write_plan tool for structured task tracking.
+ *
+ * Priority 450 (default): runs after tool-selector (420), before soul (500).
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { InboundMessage } from "@koi/core/message";
+import type {
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import { validatePlanConfig } from "./config.js";
+import { PLAN_SYSTEM_PROMPT, WRITE_PLAN_DESCRIPTOR, WRITE_PLAN_TOOL_NAME } from "./plan-tool.js";
+import type { PlanConfig, PlanItem, PlanStatus } from "./types.js";
+
+const DEFAULT_PRIORITY = 450;
+const VALID_STATUSES = new Set<string>(["pending", "in_progress", "completed"]);
+
+/** The system message injected to instruct the model about planning. */
+const PLAN_SYSTEM_MESSAGE: InboundMessage = {
+  senderId: "system:plan",
+  timestamp: 0,
+  content: [{ kind: "text", text: PLAN_SYSTEM_PROMPT }],
+};
+
+/**
+ * Creates a planning middleware that injects a `write_plan` tool and
+ * intercepts its calls to maintain a structured plan across turns.
+ */
+export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
+  const validResult = validatePlanConfig(config);
+  if (!validResult.ok) {
+    throw KoiRuntimeError.from(validResult.error.code, validResult.error.message);
+  }
+
+  const validated = validResult.value;
+  const priority = validated.priority ?? DEFAULT_PRIORITY;
+  const onPlanUpdate = validated.onPlanUpdate;
+
+  // Closure state — persists across turns
+  // let justified: plan state that changes on each write_plan call
+  let currentPlan: readonly PlanItem[] = [];
+  // let justified: per-turn counter reset in onBeforeTurn
+  let writePlanCallsThisTurn = 0;
+
+  /** Enrich a model request with the plan system message and tool descriptor. */
+  function enrichRequest(request: ModelRequest): ModelRequest {
+    const messages = [PLAN_SYSTEM_MESSAGE, ...request.messages];
+    const tools =
+      request.tools !== undefined
+        ? [...request.tools, WRITE_PLAN_DESCRIPTOR]
+        : [WRITE_PLAN_DESCRIPTOR];
+    return { ...request, messages, tools };
+  }
+
+  /** Validate and parse plan items from tool input. */
+  function parsePlanInput(input: JsonObject): readonly PlanItem[] | string {
+    const rawPlan = input.plan;
+    if (!Array.isArray(rawPlan)) {
+      return "plan must be an array";
+    }
+
+    const items: PlanItem[] = [];
+    for (let i = 0; i < rawPlan.length; i++) {
+      const item = rawPlan[i] as Record<string, unknown> | undefined;
+      if (item === undefined || typeof item !== "object" || item === null) {
+        return `plan[${String(i)}] must be an object`;
+      }
+      if (typeof item.content !== "string" || item.content.length === 0) {
+        return `plan[${String(i)}].content must be a non-empty string`;
+      }
+      if (typeof item.status !== "string" || !VALID_STATUSES.has(item.status)) {
+        return `plan[${String(i)}].status must be one of: pending, in_progress, completed`;
+      }
+      items.push({ content: item.content, status: item.status as PlanStatus });
+    }
+
+    return items;
+  }
+
+  /** Format plan summary for tool response. */
+  function formatPlanSummary(plan: readonly PlanItem[]): string {
+    if (plan.length === 0) return "Plan cleared.";
+    const pending = plan.filter((i) => i.status === "pending").length;
+    const inProgress = plan.filter((i) => i.status === "in_progress").length;
+    const completed = plan.filter((i) => i.status === "completed").length;
+    return `Plan updated: ${String(plan.length)} items (${String(pending)} pending, ${String(inProgress)} in progress, ${String(completed)} completed)`;
+  }
+
+  return {
+    name: "plan",
+    priority,
+
+    async onBeforeTurn(_ctx: TurnContext): Promise<void> {
+      writePlanCallsThisTurn = 0;
+    },
+
+    async wrapModelCall(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      const enriched = enrichRequest(request);
+      const response = await next(enriched);
+
+      // Attach current plan to response metadata for observability
+      const metadata: JsonObject = {
+        ...response.metadata,
+        currentPlan: currentPlan as unknown as JsonObject,
+      };
+      return { ...response, metadata };
+    },
+
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      const enriched = enrichRequest(request);
+      yield* next(enriched);
+    },
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      // Pass through non-plan tool calls
+      if (request.toolId !== WRITE_PLAN_TOOL_NAME) {
+        return next(request);
+      }
+
+      // Enforce at-most-once per turn
+      writePlanCallsThisTurn += 1;
+      if (writePlanCallsThisTurn > 1) {
+        return {
+          output: { error: "write_plan can only be called once per response" },
+          metadata: { planError: true },
+        };
+      }
+
+      // Validate plan input
+      const parsed = parsePlanInput(request.input);
+      if (typeof parsed === "string") {
+        return {
+          output: { error: parsed },
+          metadata: { planError: true },
+        };
+      }
+
+      // Atomically replace the plan
+      currentPlan = parsed;
+      onPlanUpdate?.(currentPlan);
+
+      return {
+        output: formatPlanSummary(currentPlan),
+        metadata: { currentPlan: currentPlan as unknown as JsonObject },
+      };
+    },
+  };
+}

--- a/packages/middleware-planning/src/plan-tool.test.ts
+++ b/packages/middleware-planning/src/plan-tool.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { PLAN_SYSTEM_PROMPT, WRITE_PLAN_DESCRIPTOR, WRITE_PLAN_TOOL_NAME } from "./plan-tool.js";
+
+describe("WRITE_PLAN_TOOL_NAME", () => {
+  test("is write_plan", () => {
+    expect(WRITE_PLAN_TOOL_NAME).toBe("write_plan");
+  });
+});
+
+describe("WRITE_PLAN_DESCRIPTOR", () => {
+  test("has correct name", () => {
+    expect(WRITE_PLAN_DESCRIPTOR.name).toBe("write_plan");
+  });
+
+  test("has a description", () => {
+    expect(WRITE_PLAN_DESCRIPTOR.description.length).toBeGreaterThan(0);
+  });
+
+  test("has inputSchema with plan array", () => {
+    const schema = WRITE_PLAN_DESCRIPTOR.inputSchema as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["plan"]);
+    const props = schema.properties as Record<string, unknown>;
+    const plan = props.plan as Record<string, unknown>;
+    expect(plan.type).toBe("array");
+  });
+});
+
+describe("PLAN_SYSTEM_PROMPT", () => {
+  test("mentions write_plan", () => {
+    expect(PLAN_SYSTEM_PROMPT).toContain("write_plan");
+  });
+
+  test("is concise (under 500 chars)", () => {
+    expect(PLAN_SYSTEM_PROMPT.length).toBeLessThan(500);
+  });
+
+  test("mentions at-most-once rule", () => {
+    expect(PLAN_SYSTEM_PROMPT).toContain("at most once");
+  });
+});

--- a/packages/middleware-planning/src/plan-tool.ts
+++ b/packages/middleware-planning/src/plan-tool.ts
@@ -1,0 +1,45 @@
+/**
+ * Plan tool descriptor and system prompt constant.
+ */
+
+import type { ToolDescriptor } from "@koi/core/ecs";
+
+/** The tool name used for plan creation/updates. */
+export const WRITE_PLAN_TOOL_NAME = "write_plan" as const;
+
+/** Tool descriptor injected into model requests. */
+export const WRITE_PLAN_DESCRIPTOR: ToolDescriptor = {
+  name: WRITE_PLAN_TOOL_NAME,
+  description:
+    "Create or update a structured plan for multi-step tasks. Replaces the entire plan atomically. Call at most once per response.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      plan: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            content: { type: "string", description: "What needs to be done" },
+            status: {
+              type: "string",
+              enum: ["pending", "in_progress", "completed"],
+            },
+          },
+          required: ["content", "status"],
+        },
+      },
+    },
+    required: ["plan"],
+  },
+};
+
+/** System prompt injected to instruct the model about planning. */
+export const PLAN_SYSTEM_PROMPT = `## Planning
+For complex tasks (3+ steps), use \`write_plan\` to create a structured plan.
+Rules:
+- Call \`write_plan\` at most once per response — never in parallel
+- Mark items "in_progress" before starting work on them
+- Mark items "completed" immediately when done
+- Revise the plan freely as you learn more
+- Skip for simple, few-step requests` as const;

--- a/packages/middleware-planning/src/types.ts
+++ b/packages/middleware-planning/src/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Planning middleware types — plan items and configuration.
+ */
+
+/** Status of a single plan item. */
+export type PlanStatus = "pending" | "in_progress" | "completed";
+
+/** A single item in the structured plan. */
+export interface PlanItem {
+  readonly content: string;
+  readonly status: PlanStatus;
+}
+
+/** Factory configuration for createPlanMiddleware. */
+export interface PlanConfig {
+  /** Optional push notification when plan changes. */
+  readonly onPlanUpdate?: ((plan: readonly PlanItem[]) => void) | undefined;
+  /** Middleware priority (default: 450). */
+  readonly priority?: number | undefined;
+}

--- a/packages/middleware-planning/tsconfig.json
+++ b/packages/middleware-planning/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-planning/tsup.config.ts
+++ b/packages/middleware-planning/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- **`@koi/middleware-pii`** — PII detection and redaction in agent I/O
  - 7 built-in detectors: email, credit card, IP, MAC, URL, SSN, phone
  - 4 strategies: redact, mask (partial), hash (HMAC-SHA256), block
  - Sliding-window stream buffer for `wrapModelStream`
  - Per-direction scope control (input, output, toolResults)
  - Signal-character short-circuit + Luhn/SSA validation for performance

- **`@koi/middleware-planning`** — Structured multi-step task tracking via `write_plan` tool
  - `write_plan` tool injected into every model call
  - At-most-once-per-turn enforcement prevents plan churn
  - Plan state persists across turns in closure (zero I/O)
  - Observability via response metadata + `onPlanUpdate` callback

144 tests, 100% function coverage, 93%+ line coverage.

Closes #314, closes #315

## Test plan

- [x] 106 PII unit/integration tests pass (detectors, strategies, apply-matches, scan, streaming, middleware)
- [x] 38 planning unit/integration tests pass (tool descriptor, middleware hooks, state persistence)
- [x] Both packages build via tsup (ESM-only)
- [x] Both packages typecheck via tsc --noEmit
- [x] Biome lint clean (0 errors)
- [x] Full monorepo build (72 packages) passes
- [x] Layer check: only imports from @koi/core (L0) and @koi/errors (L0u)