### PR TITLE
feat: add @koi/identity per-channel agent personas with hot-reload

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -241,6 +241,19 @@
       "name": "@koi/hash",
       "version": "0.0.0",
     },
+    "packages/identity": {
+      "name": "@koi/identity",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/manifest": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/manifest": {
       "name": "@koi/manifest",
       "version": "0.0.0",
@@ -1049,6 +1062,8 @@
     "@koi/gateway": ["@koi/gateway@workspace:packages/gateway"],
 
     "@koi/hash": ["@koi/hash@workspace:packages/hash"],
+
+    "@koi/identity": ["@koi/identity@workspace:packages/identity"],
 
     "@koi/manifest": ["@koi/manifest@workspace:packages/manifest"],
 

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { BrickRef } from './brick-snapshot.js';
 export { BrickId, BrickSnapshot, BrickSource, SnapshotEvent, SnapshotId, SnapshotQuery, SnapshotStore, brickId, snapshotId } from './brick-snapshot.js';
-import { A as AgentId, P as ProcessState, a as Agent, S as SessionId, T as ToolCallId } from './ecs-DQiYwmx6.js';
-export { B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTraceOptions, x as BrowserTraceResult, y as BrowserTypeOptions, z as BrowserUploadFile, C as BrowserUploadOptions, D as BrowserWaitOptions, E as BrowserWaitUntil, F as COMPONENT_PRIORITY, G as CREDENTIALS, H as ChildHandle, I as ChildLifecycleEvent, J as ComponentEvent, K as ComponentEventKind, L as ComponentProvider, M as CredentialComponent, N as DELEGATION, O as EVENTS, Q as EventComponent, R as FILESYSTEM, U as GOVERNANCE, V as GovernanceComponent, W as GovernanceUsage, X as MEMORY, Y as MemoryComponent, Z as MemoryResult, _ as ProcessAccounter, $ as ProcessId, a0 as RunId, a1 as SkillMetadata, a2 as SpawnCheck, a3 as SpawnLedger, a4 as SubsystemToken, a5 as Tool, a6 as ToolDescriptor, a7 as TrustTier, a8 as TurnId, a9 as agentId, aa as channelToken, ab as engineToken, ac as middlewareToken, ad as providerToken, ae as resolverToken, af as runId, ag as sessionId, ah as skillToken, ai as token, aj as toolCallId, ak as toolToken, al as turnId } from './ecs-DQiYwmx6.js';
-import { E as EngineState, a as EngineInput } from './engine-DLEvsQgw.js';
-export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-DLEvsQgw.js';
+import { A as AgentId, P as ProcessState, a as Agent, S as SessionId, T as ToolCallId } from './ecs-DM4-kRhl.js';
+export { B as BROWSER, b as BrowserActionOptions, c as BrowserConsoleEntry, d as BrowserConsoleLevel, e as BrowserConsoleOptions, f as BrowserConsoleResult, g as BrowserDriver, h as BrowserEvaluateOptions, i as BrowserEvaluateResult, j as BrowserFormField, k as BrowserNavigateOptions, l as BrowserNavigateResult, m as BrowserRefInfo, n as BrowserScreenshotOptions, o as BrowserScreenshotResult, p as BrowserScrollOptions, q as BrowserSnapshotOptions, r as BrowserSnapshotResult, s as BrowserTabCloseOptions, t as BrowserTabFocusOptions, u as BrowserTabInfo, v as BrowserTabNewOptions, w as BrowserTraceOptions, x as BrowserTraceResult, y as BrowserTypeOptions, z as BrowserUploadFile, C as BrowserUploadOptions, D as BrowserWaitOptions, E as BrowserWaitUntil, F as COMPONENT_PRIORITY, G as CREDENTIALS, H as ChildHandle, I as ChildLifecycleEvent, J as ComponentEvent, K as ComponentEventKind, L as ComponentProvider, M as CredentialComponent, N as DELEGATION, O as EVENTS, Q as EventComponent, R as FILESYSTEM, U as GOVERNANCE, V as GovernanceComponent, W as GovernanceUsage, X as MEMORY, Y as MemoryComponent, Z as MemoryResult, _ as ProcessAccounter, $ as ProcessId, a0 as RunId, a1 as SkillMetadata, a2 as SpawnCheck, a3 as SpawnLedger, a4 as SubsystemToken, a5 as Tool, a6 as ToolDescriptor, a7 as TrustTier, a8 as TurnId, a9 as agentId, aa as channelToken, ab as engineToken, ac as middlewareToken, ad as providerToken, ae as resolverToken, af as runId, ag as sessionId, ah as skillToken, ai as token, aj as toolCallId, ak as toolToken, al as turnId } from './ecs-DM4-kRhl.js';
+import { E as EngineState, a as EngineInput } from './engine-pB71jm_G.js';
+export { A as AbortReason, C as ComposedCallHandlers, b as CorrelationIds, c as EngineAdapter, d as EngineEvent, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, h as EngineStopReason } from './engine-pB71jm_G.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
-import { A as AgentManifest } from './assembly-CFhPkvga.js';
-export { C as ChannelConfig, a as CircuitBreakerConfig, D as DEFAULT_CIRCUIT_BREAKER_CONFIG, b as DelegationComponent, c as DelegationConfig, d as DelegationDenyReason, e as DelegationEvent, f as DelegationGrant, g as DelegationId, h as DelegationManagerConfig, i as DelegationScope, j as DelegationVerifyResult, M as MiddlewareConfig, k as ModelConfig, P as PermissionConfig, R as RevocationRegistry, S as ScopeChecker, T as ToolConfig, l as delegationId } from './assembly-CFhPkvga.js';
+import { A as AgentManifest } from './assembly-Bp5WuiM8.js';
+export { C as ChannelConfig, a as ChannelIdentity, b as CircuitBreakerConfig, D as DEFAULT_CIRCUIT_BREAKER_CONFIG, c as DelegationComponent, d as DelegationConfig, e as DelegationDenyReason, f as DelegationEvent, g as DelegationGrant, h as DelegationId, i as DelegationManagerConfig, j as DelegationScope, k as DelegationVerifyResult, M as MiddlewareConfig, l as ModelConfig, P as PermissionConfig, R as RevocationRegistry, S as ScopeChecker, T as ToolConfig, m as delegationId } from './assembly-Bp5WuiM8.js';
 import { JsonObject } from './common.js';
 export { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, CompositeArtifact, ForgeQuery, ForgeStore, ImplementationArtifact, LockHandle, LockMode, LockRequest, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, ToolArtifact } from './brick-store.js';
 export { ChannelAdapter, ChannelCapabilities, ChannelStatus, ChannelStatusKind, MessageHandler } from './channel.js';
@@ -19,7 +19,7 @@ export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js
 export { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfig, EventEnvelope, EventInput, ReadOptions, ReadResult, SubscribeOptions, SubscriptionHandle } from './event-backend.js';
 export { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult } from './eviction.js';
 export { FileEdit, FileEditOptions, FileEditResult, FileEntryKind, FileListEntry, FileListOptions, FileListResult, FileReadOptions, FileReadResult, FileSearchMatch, FileSearchOptions, FileSearchResult, FileSystemBackend, FileWriteOptions, FileWriteResult } from './filesystem-backend.js';
-export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-DY3-Gwib.js';
+export { A as ALL_BRICK_KINDS, B as BrickKind, a as BrickLifecycle, F as ForgeScope, M as MIN_TRUST_BY_KIND, V as VALID_LIFECYCLE_TRANSITIONS } from './forge-types-DnKwM4xv.js';
 export { DEFAULT_HEALTH_MONITOR_CONFIG, HealthMonitor, HealthMonitorConfig, HealthMonitorStats, HealthSnapshot, HealthStatus } from './health.js';
 import { KoiMiddleware } from './middleware.js';
 export { ApprovalDecision, ApprovalHandler, ApprovalRequest, ModelChunk, ModelHandler, ModelRequest, ModelResponse, ModelStreamHandler, SessionContext, ToolHandler, ToolRequest, ToolResponse, TurnContext } from './middleware.js';
@@ -852,7 +852,7 @@ export type { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, Feat
 
 exports[`@koi/core API surface ./assembly has stable type surface 1`] = `
 "import './common.js';
-export { A as AgentManifest, C as ChannelConfig, M as MiddlewareConfig, k as ModelConfig, P as PermissionConfig, T as ToolConfig } from './assembly-CFhPkvga.js';
+export { A as AgentManifest, C as ChannelConfig, a as ChannelIdentity, M as MiddlewareConfig, l as ModelConfig, P as PermissionConfig, T as ToolConfig } from './assembly-Bp5WuiM8.js';
 import './webhook.js';
 "
 `;
@@ -956,15 +956,15 @@ export type { CompactionResult, ContextCompactor, TokenEstimator };
 `;
 
 exports[`@koi/core API surface ./delegation has stable type surface 1`] = `
-"export { a as CircuitBreakerConfig, D as DEFAULT_CIRCUIT_BREAKER_CONFIG, b as DelegationComponent, c as DelegationConfig, d as DelegationDenyReason, e as DelegationEvent, f as DelegationGrant, g as DelegationId, h as DelegationManagerConfig, i as DelegationScope, j as DelegationVerifyResult, R as RevocationRegistry, S as ScopeChecker, l as delegationId } from './assembly-CFhPkvga.js';
+"export { b as CircuitBreakerConfig, D as DEFAULT_CIRCUIT_BREAKER_CONFIG, c as DelegationComponent, d as DelegationConfig, e as DelegationDenyReason, f as DelegationEvent, g as DelegationGrant, h as DelegationId, i as DelegationManagerConfig, j as DelegationScope, k as DelegationVerifyResult, R as RevocationRegistry, S as ScopeChecker, m as delegationId } from './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 "
 `;
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
-"import './assembly-CFhPkvga.js';
-export { a as Agent, A as AgentId, B as BROWSER, F as COMPONENT_PRIORITY, G as CREDENTIALS, H as ChildHandle, I as ChildLifecycleEvent, J as ComponentEvent, K as ComponentEventKind, L as ComponentProvider, M as CredentialComponent, N as DELEGATION, O as EVENTS, Q as EventComponent, R as FILESYSTEM, U as GOVERNANCE, V as GovernanceComponent, W as GovernanceUsage, X as MEMORY, Y as MemoryComponent, Z as MemoryResult, _ as ProcessAccounter, $ as ProcessId, P as ProcessState, a0 as RunId, S as SessionId, a1 as SkillMetadata, a2 as SpawnCheck, a3 as SpawnLedger, a4 as SubsystemToken, a5 as Tool, T as ToolCallId, a6 as ToolDescriptor, a7 as TrustTier, a8 as TurnId, a9 as agentId, aa as channelToken, ab as engineToken, ac as middlewareToken, ad as providerToken, ae as resolverToken, af as runId, ag as sessionId, ah as skillToken, ai as token, aj as toolCallId, ak as toolToken, al as turnId } from './ecs-DQiYwmx6.js';
+"import './assembly-Bp5WuiM8.js';
+export { a as Agent, A as AgentId, B as BROWSER, F as COMPONENT_PRIORITY, G as CREDENTIALS, H as ChildHandle, I as ChildLifecycleEvent, J as ComponentEvent, K as ComponentEventKind, L as ComponentProvider, M as CredentialComponent, N as DELEGATION, O as EVENTS, Q as EventComponent, R as FILESYSTEM, U as GOVERNANCE, V as GovernanceComponent, W as GovernanceUsage, X as MEMORY, Y as MemoryComponent, Z as MemoryResult, _ as ProcessAccounter, $ as ProcessId, P as ProcessState, a0 as RunId, S as SessionId, a1 as SkillMetadata, a2 as SpawnCheck, a3 as SpawnLedger, a4 as SubsystemToken, a5 as Tool, T as ToolCallId, a6 as ToolDescriptor, a7 as TrustTier, a8 as TurnId, a9 as agentId, aa as channelToken, ab as engineToken, ac as middlewareToken, ad as providerToken, ae as resolverToken, af as runId, ag as sessionId, ah as skillToken, ai as token, aj as toolCallId, ak as toolToken, al as turnId } from './ecs-DM4-kRhl.js';
 import './channel.js';
 import './common.js';
 import './filesystem-backend.js';
@@ -976,11 +976,11 @@ import './message.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-DLEvsQgw.js';
-import './ecs-DQiYwmx6.js';
+export { A as AbortReason, C as ComposedCallHandlers, c as EngineAdapter, d as EngineEvent, a as EngineInput, e as EngineInputBase, f as EngineMetrics, g as EngineOutput, E as EngineState, h as EngineStopReason } from './engine-pB71jm_G.js';
+import './ecs-DM4-kRhl.js';
 import './message.js';
 import './middleware.js';
-import './assembly-CFhPkvga.js';
+import './assembly-Bp5WuiM8.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -1256,9 +1256,9 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import { ChannelStatus } from './channel.js';
 import { JsonObject } from './common.js';
-import { a6 as ToolDescriptor, T as ToolCallId, S as SessionId, a0 as RunId, a8 as TurnId } from './ecs-DQiYwmx6.js';
+import { a6 as ToolDescriptor, T as ToolCallId, S as SessionId, a0 as RunId, a8 as TurnId } from './ecs-DM4-kRhl.js';
 import { InboundMessage } from './message.js';
-import './assembly-CFhPkvga.js';
+import './assembly-Bp5WuiM8.js';
 import './webhook.js';
 import './errors.js';
 import './filesystem-backend.js';
@@ -1271,6 +1271,8 @@ interface SessionContext {
     readonly agentId: string;
     readonly sessionId: SessionId;
     readonly runId: RunId;
+    /** Injected by L1 at session start — package name of the active channel adapter (e.g. "@koi/channel-telegram"). */
+    readonly channelId?: string;
     readonly metadata: JsonObject;
 }
 interface TurnContext {
@@ -1382,8 +1384,8 @@ export type { ApprovalDecision, ApprovalHandler, ApprovalRequest, KoiMiddleware,
 `;
 
 exports[`@koi/core API surface ./eviction has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+"import { A as AgentId, P as ProcessState } from './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -1436,8 +1438,8 @@ export type { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult 
 `;
 
 exports[`@koi/core API surface ./health has stable type surface 1`] = `
-"import { A as AgentId } from './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+"import { A as AgentId } from './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -1508,9 +1510,9 @@ export { DEFAULT_HEALTH_MONITOR_CONFIG, type HealthMonitor, type HealthMonitorCo
 `;
 
 exports[`@koi/core API surface ./lifecycle has stable type surface 1`] = `
-"import { A as AgentId, P as ProcessState } from './ecs-DQiYwmx6.js';
+"import { A as AgentId, P as ProcessState } from './ecs-DM4-kRhl.js';
 import { Result, KoiError } from './errors.js';
-import './assembly-CFhPkvga.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './channel.js';
@@ -1736,10 +1738,10 @@ export type { Resolver, SourceBundle, SourceLanguage };
 
 exports[`@koi/core API surface ./brick-snapshot has stable type surface 1`] = `
 "import { Result, KoiError } from './errors.js';
-import { B as BrickKind } from './forge-types-DY3-Gwib.js';
+import { B as BrickKind } from './forge-types-DnKwM4xv.js';
 import './common.js';
-import './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+import './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './webhook.js';
 import './channel.js';
 import './message.js';
@@ -1855,10 +1857,10 @@ export { type BrickId, type BrickRef, type BrickSnapshot, type BrickSource, type
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"import { a7 as TrustTier } from './ecs-DQiYwmx6.js';
+"import { a7 as TrustTier } from './ecs-DM4-kRhl.js';
 import { Result, KoiError } from './errors.js';
-import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-DY3-Gwib.js';
-import './assembly-CFhPkvga.js';
+import { B as BrickKind, F as ForgeScope, a as BrickLifecycle } from './forge-types-DnKwM4xv.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './channel.js';
@@ -2012,8 +2014,8 @@ export type { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, Bri
 
 exports[`@koi/core API surface ./sandbox-adapter has stable type surface 1`] = `
 "import { SandboxProfile } from './sandbox-profile.js';
-import './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+import './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -2084,8 +2086,8 @@ export type { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxI
 `;
 
 exports[`@koi/core API surface ./sandbox-executor has stable type surface 1`] = `
-"import { a7 as TrustTier } from './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+"import { a7 as TrustTier } from './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -2148,8 +2150,8 @@ export type { SandboxError, SandboxErrorCode, SandboxExecutor, SandboxResult, Ti
 `;
 
 exports[`@koi/core API surface ./sandbox-profile has stable type surface 1`] = `
-"import { a7 as TrustTier } from './ecs-DQiYwmx6.js';
-import './assembly-CFhPkvga.js';
+"import { a7 as TrustTier } from './ecs-DM4-kRhl.js';
+import './assembly-Bp5WuiM8.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';

--- a/packages/core/src/assembly.ts
+++ b/packages/core/src/assembly.ts
@@ -18,9 +18,19 @@ export interface ToolConfig {
   readonly options?: JsonObject;
 }
 
+export interface ChannelIdentity {
+  /** Display name for this channel persona — injected as "You are <name>." in the system prompt. */
+  readonly name?: string;
+  /** Avatar URL or path — display metadata for the channel UI layer, not injected into the LLM prompt. */
+  readonly avatar?: string;
+  /** Behavioral instructions — injected verbatim into the system prompt. */
+  readonly instructions?: string;
+}
+
 export interface ChannelConfig {
   readonly name: string;
   readonly options?: JsonObject;
+  readonly identity?: ChannelIdentity;
 }
 
 export interface MiddlewareConfig {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export type { AgentSnapshot, AgentSnapshotStore } from "./agent-snapshot.js";
 export type {
   AgentManifest,
   ChannelConfig,
+  ChannelIdentity,
   MiddlewareConfig,
   ModelConfig,
   PermissionConfig,

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -11,6 +11,8 @@ export interface SessionContext {
   readonly agentId: string;
   readonly sessionId: SessionId;
   readonly runId: RunId;
+  /** Injected by L1 at session start — package name of the active channel adapter (e.g. "@koi/channel-telegram"). */
+  readonly channelId?: string;
   readonly metadata: JsonObject;
 }
 

--- a/packages/engine/src/koi.ts
+++ b/packages/engine/src/koi.ts
@@ -255,6 +255,7 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
             agentId: pid.id,
             sessionId: sid,
             runId: rid,
+            ...(options.channelId !== undefined ? { channelId: options.channelId } : {}),
             metadata: {},
           };
 

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -236,6 +236,8 @@ export interface CreateKoiOptions {
   readonly agentType?: "copilot" | "worker";
   /** Registry for agent lifecycle tracking. If provided, agent is registered on creation. */
   readonly registry?: AgentRegistry;
+  /** Channel adapter package name (e.g. "@koi/channel-telegram"). Injected into SessionContext. */
+  readonly channelId?: string;
 }
 
 export interface KoiRuntime {

--- a/packages/identity/__tests__/identity.integration.test.ts
+++ b/packages/identity/__tests__/identity.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration test: YAML manifest → channel identity → middleware injection.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { ModelRequest, ModelResponse, TurnContext } from "@koi/core/middleware";
+import { loadManifestFromString } from "@koi/manifest";
+import { createIdentityMiddleware } from "../src/identity.js";
+import { personasFromManifest } from "../src/manifest.js";
+
+const MOCK_RESPONSE: ModelResponse = {
+  content: "Hi",
+  model: "test-model",
+};
+
+function makeTurnCtx(channelId?: string): TurnContext {
+  return {
+    session: {
+      agentId: "agent-1",
+      sessionId: "session:agent:agent-1:abc" as import("@koi/core/ecs").SessionId,
+      runId: "run-uuid" as import("@koi/core/ecs").RunId,
+      ...(channelId !== undefined ? { channelId } : {}),
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "turn-uuid" as import("@koi/core/ecs").TurnId,
+    messages: [],
+    metadata: {},
+  };
+}
+
+describe("identity middleware integration", () => {
+  it("injects persona system message from YAML manifest channel identity", async () => {
+    const yaml = `
+name: test-agent
+version: 1.0.0
+model: anthropic:claude-haiku-4-5-20251001
+channels:
+  - name: "@koi/channel-telegram"
+    identity:
+      name: Alex
+      instructions: Be casual and friendly.
+  - name: "@koi/channel-slack"
+    identity:
+      name: Research Bot
+      instructions: Be formal and concise.
+`;
+
+    const result = await loadManifestFromString(yaml);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const manifest = result.value.manifest;
+    expect(manifest.channels).toHaveLength(2);
+
+    const telegramChannel = manifest.channels?.[0];
+    const slackChannel = manifest.channels?.[1];
+
+    expect(telegramChannel?.identity?.name).toBe("Alex");
+    expect(telegramChannel?.identity?.instructions).toBe("Be casual and friendly.");
+    expect(slackChannel?.identity?.name).toBe("Research Bot");
+
+    // Build identity middleware directly from manifest using helper
+    const mw = await createIdentityMiddleware(personasFromManifest(manifest));
+    const { wrapModelCall } = mw;
+    expect(wrapModelCall).toBeDefined();
+    if (wrapModelCall === undefined) return;
+
+    // Verify Telegram persona injection
+    const capturedTelegram: ModelRequest[] = [];
+    const nextTelegram = async (req: ModelRequest): Promise<ModelResponse> => {
+      capturedTelegram.push(req);
+      return MOCK_RESPONSE;
+    };
+
+    await wrapModelCall(
+      makeTurnCtx("@koi/channel-telegram"),
+      {
+        messages: [{ senderId: "user", timestamp: 1000, content: [{ kind: "text", text: "Hi" }] }],
+      },
+      nextTelegram,
+    );
+
+    expect(capturedTelegram[0]?.messages).toHaveLength(2);
+    const telegramFirst = capturedTelegram[0]?.messages[0];
+    expect(telegramFirst?.senderId).toBe("system:identity");
+    if (telegramFirst?.content[0]?.kind === "text") {
+      expect(telegramFirst.content[0].text).toContain("You are Alex.");
+      expect(telegramFirst.content[0].text).toContain("Be casual and friendly.");
+    }
+
+    // Verify Slack persona injection
+    const capturedSlack: ModelRequest[] = [];
+    const nextSlack = async (req: ModelRequest): Promise<ModelResponse> => {
+      capturedSlack.push(req);
+      return MOCK_RESPONSE;
+    };
+
+    await wrapModelCall(
+      makeTurnCtx("@koi/channel-slack"),
+      {
+        messages: [{ senderId: "user", timestamp: 1000, content: [{ kind: "text", text: "Hi" }] }],
+      },
+      nextSlack,
+    );
+
+    const slackFirst = capturedSlack[0]?.messages[0];
+    if (slackFirst?.content[0]?.kind === "text") {
+      expect(slackFirst.content[0].text).toContain("You are Research Bot.");
+      expect(slackFirst.content[0].text).toContain("Be formal and concise.");
+    }
+  });
+
+  it("no-ops when channel has no identity configured", async () => {
+    const yaml = `
+name: test-agent
+version: 1.0.0
+model: anthropic:claude-haiku-4-5-20251001
+channels:
+  - name: "@koi/channel-cli"
+`;
+
+    const result = await loadManifestFromString(yaml);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const manifest = result.value.manifest;
+    expect(manifest.channels?.[0]?.identity).toBeUndefined();
+
+    const mw = await createIdentityMiddleware({ personas: [] });
+    const { wrapModelCall: wrapCall } = mw;
+    expect(wrapCall).toBeDefined();
+    if (wrapCall === undefined) return;
+
+    const original: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1000, content: [{ kind: "text", text: "Hi" }] }],
+    };
+    let captured: ModelRequest | undefined;
+    await wrapCall(makeTurnCtx("@koi/channel-cli"), original, async (req) => {
+      captured = req;
+      return MOCK_RESPONSE;
+    });
+
+    // Same reference — no system message prepended
+    expect(captured).toBe(original);
+  });
+});

--- a/packages/identity/e2e.ts
+++ b/packages/identity/e2e.ts
@@ -1,0 +1,390 @@
+/**
+ * Manual E2E script for @koi/identity middleware.
+ *
+ * Tests the full stack: manifest → personasFromManifest → createIdentityMiddleware
+ * → createKoi (L1 assembly + guards + middleware chain) → createPiAdapter → real LLM.
+ *
+ * Run:
+ *   bun packages/identity/e2e.ts
+ *
+ * Requires ANTHROPIC_API_KEY in .env (auto-loaded by Bun).
+ */
+
+import type { AgentManifest, EngineEvent } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createIdentityMiddleware } from "./src/identity.js";
+import { personasFromManifest } from "./src/manifest.js";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+if (API_KEY.length === 0) {
+  console.error("ANTHROPIC_API_KEY not set — aborting.");
+  process.exit(1);
+}
+
+const MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function collectText(events: AsyncIterable<EngineEvent>): Promise<{
+  text: string;
+  tokens: number;
+  turns: number;
+  stopReason: string;
+}> {
+  const parts: string[] = [];
+  let tokens = 0;
+  let turns = 0;
+  let stopReason = "unknown";
+  for await (const e of events) {
+    if (e.kind === "text_delta") parts.push(e.delta);
+    if (e.kind === "done") {
+      tokens = e.output.metrics.totalTokens;
+      turns = e.output.metrics.turns;
+      stopReason = e.output.stopReason;
+    }
+  }
+  return { text: parts.join(""), tokens, turns, stopReason };
+}
+
+function pass(label: string, detail?: string): void {
+  console.log(`  ✓  ${label}${detail !== undefined ? `  (${detail})` : ""}`);
+}
+function fail(label: string, detail: string): void {
+  console.error(`  ✗  ${label}  →  ${detail}`);
+  process.exitCode = 1;
+}
+function section(title: string): void {
+  console.log(`\n── ${title} ${"─".repeat(Math.max(0, 55 - title.length))}`);
+}
+
+// ── Test 1: system message is injected for matching channelId ─────────────────
+
+async function testPersonaInjected(): Promise<void> {
+  section("1. Persona injected for matching channelId");
+
+  const manifest: AgentManifest = {
+    name: "identity-e2e",
+    version: "1.0.0",
+    model: { name: MODEL },
+    channels: [
+      {
+        name: "@koi/channel-telegram",
+        identity: {
+          name: "Zara",
+          instructions:
+            'You must begin every reply with the exact token "ZARA_ACTIVE" followed by a colon.',
+        },
+      },
+    ],
+  };
+
+  const identityMw = await createIdentityMiddleware(personasFromManifest(manifest));
+  const piAdapter = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+  const runtime = await createKoi({
+    manifest,
+    adapter: piAdapter,
+    middleware: [identityMw],
+    channelId: "@koi/channel-telegram",
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+  });
+
+  const { text, tokens, stopReason } = await collectText(
+    runtime.run({ kind: "text", text: "Say hello." }),
+  );
+  await runtime.dispose();
+
+  if (stopReason === "completed") {
+    pass("stopReason = completed");
+  } else {
+    fail("stopReason", stopReason);
+  }
+
+  if (tokens > 0) {
+    pass("tokens > 0", `${String(tokens)} tokens`);
+  } else {
+    fail("tokens", "got 0");
+  }
+
+  if (text.includes("ZARA_ACTIVE")) {
+    pass(
+      'response contains "ZARA_ACTIVE" — persona system message was honoured',
+      text.slice(0, 80),
+    );
+  } else {
+    fail('response should contain "ZARA_ACTIVE"', `got: "${text.slice(0, 120)}"`);
+  }
+}
+
+// ── Test 2: no injection when channelId does not match ────────────────────────
+
+async function testPersonaNotInjectedOnMismatch(): Promise<void> {
+  section("2. No persona injection when channelId does not match");
+
+  const manifest: AgentManifest = {
+    name: "identity-e2e-mismatch",
+    version: "1.0.0",
+    model: { name: MODEL },
+    channels: [
+      {
+        name: "@koi/channel-telegram",
+        identity: {
+          instructions:
+            'You must begin every reply with the exact token "ZARA_ACTIVE" followed by a colon.',
+        },
+      },
+    ],
+  };
+
+  // channelId = "@koi/channel-slack" — no matching persona
+  const identityMw = await createIdentityMiddleware(personasFromManifest(manifest));
+  const piAdapter = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+  const runtime = await createKoi({
+    manifest,
+    adapter: piAdapter,
+    middleware: [identityMw],
+    channelId: "@koi/channel-slack", // mismatch
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+  });
+
+  const { text, stopReason } = await collectText(
+    runtime.run({ kind: "text", text: 'Reply with exactly the word "hello" and nothing else.' }),
+  );
+  await runtime.dispose();
+
+  if (stopReason === "completed") {
+    pass("stopReason = completed");
+  } else {
+    fail("stopReason", stopReason);
+  }
+
+  if (!text.includes("ZARA_ACTIVE")) {
+    pass(
+      'response does NOT contain "ZARA_ACTIVE" — persona correctly suppressed',
+      text.slice(0, 80),
+    );
+  } else {
+    fail(
+      'response should NOT contain "ZARA_ACTIVE" when channelId mismatches',
+      `got: "${text.slice(0, 120)}"`,
+    );
+  }
+}
+
+// ── Test 3: no injection when channelId is absent ────────────────────────────
+
+async function testPersonaNotInjectedWithoutChannelId(): Promise<void> {
+  section("3. No persona injection when channelId is absent (undefined)");
+
+  const manifest: AgentManifest = {
+    name: "identity-e2e-no-channel",
+    version: "1.0.0",
+    model: { name: MODEL },
+    channels: [
+      {
+        name: "@koi/channel-telegram",
+        identity: {
+          instructions:
+            'You must begin every reply with the exact token "ZARA_ACTIVE" followed by a colon.',
+        },
+      },
+    ],
+  };
+
+  const identityMw = await createIdentityMiddleware(personasFromManifest(manifest));
+  const piAdapter = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+  // No channelId in CreateKoiOptions → SessionContext.channelId = undefined
+  const runtime = await createKoi({
+    manifest,
+    adapter: piAdapter,
+    middleware: [identityMw],
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+  });
+
+  const { text, stopReason } = await collectText(
+    runtime.run({ kind: "text", text: 'Reply with exactly the word "hello" and nothing else.' }),
+  );
+  await runtime.dispose();
+
+  if (stopReason === "completed") {
+    pass("stopReason = completed");
+  } else {
+    fail("stopReason", stopReason);
+  }
+
+  if (!text.includes("ZARA_ACTIVE")) {
+    pass('response does NOT contain "ZARA_ACTIVE" — no-op without channelId', text.slice(0, 80));
+  } else {
+    fail(
+      'response should NOT contain "ZARA_ACTIVE" when no channelId is set',
+      `got: "${text.slice(0, 120)}"`,
+    );
+  }
+}
+
+// ── Test 4: multiple channels — correct persona per channel ───────────────────
+
+async function testMultiChannelIsolation(): Promise<void> {
+  section("4. Multi-channel isolation — correct persona selected per channelId");
+
+  // Use persona names as the verification signal — the model reliably introduces
+  // itself by name when given "You are <Name>." via the system prompt.
+  const manifest: AgentManifest = {
+    name: "identity-e2e-multi",
+    version: "1.0.0",
+    model: { name: MODEL },
+    channels: [
+      {
+        name: "@koi/channel-telegram",
+        identity: { name: "Telegra", instructions: "Always introduce yourself by name first." },
+      },
+      {
+        name: "@koi/channel-slack",
+        identity: { name: "Slackra", instructions: "Always introduce yourself by name first." },
+      },
+    ],
+  };
+
+  const identityMw = await createIdentityMiddleware(personasFromManifest(manifest));
+
+  // Run with telegram channelId
+  const piA = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+  const rtA = await createKoi({
+    manifest,
+    adapter: piA,
+    middleware: [identityMw],
+    channelId: "@koi/channel-telegram",
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+  });
+  const { text: textA } = await collectText(rtA.run({ kind: "text", text: "Introduce yourself." }));
+  await rtA.dispose();
+
+  // Run with slack channelId
+  const piB = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+  const rtB = await createKoi({
+    manifest,
+    adapter: piB,
+    middleware: [identityMw],
+    channelId: "@koi/channel-slack",
+    loopDetection: false,
+    limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+  });
+  const { text: textB } = await collectText(rtB.run({ kind: "text", text: "Introduce yourself." }));
+  await rtB.dispose();
+
+  if (textA.toLowerCase().includes("telegra")) {
+    pass('telegram run → persona name "Telegra" present', textA.slice(0, 80));
+  } else {
+    fail('telegram run should contain "Telegra"', `got: "${textA.slice(0, 120)}"`);
+  }
+
+  if (!textA.toLowerCase().includes("slackra")) {
+    pass('telegram run → "Slackra" absent (correct isolation)');
+  } else {
+    fail('telegram run should NOT contain "Slackra"', `got: "${textA.slice(0, 120)}"`);
+  }
+
+  if (textB.toLowerCase().includes("slackra")) {
+    pass('slack run → persona name "Slackra" present', textB.slice(0, 80));
+  } else {
+    fail('slack run should contain "Slackra"', `got: "${textB.slice(0, 120)}"`);
+  }
+
+  if (!textB.toLowerCase().includes("telegra")) {
+    pass('slack run → "Telegra" absent (correct isolation)');
+  } else {
+    fail('slack run should NOT contain "Telegra"', `got: "${textB.slice(0, 120)}"`);
+  }
+}
+
+// ── Test 5: hot-reload via manual reload() ────────────────────────────────────
+
+async function testHotReload(): Promise<void> {
+  section("5. Hot-reload — reload() swaps persona mid-session");
+
+  // Use persona names (reliable signal) loaded from a file so reload() re-reads the file.
+  const tmpFile = "/tmp/koi-identity-e2e-persona.md";
+  await Bun.write(tmpFile, "You are Beforera. Always introduce yourself by name first.");
+
+  const manifest: AgentManifest = {
+    name: "identity-e2e-reload",
+    version: "1.0.0",
+    model: { name: MODEL },
+  };
+
+  const identityMw = await createIdentityMiddleware({
+    personas: [{ channelId: "@koi/channel-telegram", instructions: { path: tmpFile } }],
+  });
+
+  const makeRuntime = async () => {
+    const pi = createPiAdapter({ model: MODEL, getApiKey: async () => API_KEY });
+    return createKoi({
+      manifest,
+      adapter: pi,
+      middleware: [identityMw],
+      channelId: "@koi/channel-telegram",
+      loopDetection: false,
+      limits: { maxTurns: 3, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+  };
+
+  // Run before reload
+  const rtBefore = await makeRuntime();
+  const { text: textBefore } = await collectText(
+    rtBefore.run({ kind: "text", text: "Introduce yourself." }),
+  );
+  await rtBefore.dispose();
+
+  if (textBefore.toLowerCase().includes("beforera")) {
+    pass('before reload → persona "Beforera" present', textBefore.slice(0, 80));
+  } else {
+    fail('before reload should contain "Beforera"', `got: "${textBefore.slice(0, 120)}"`);
+  }
+
+  // Swap persona file and reload
+  await Bun.write(tmpFile, "You are Afterra. Always introduce yourself by name first.");
+  await identityMw.reload();
+  pass("reload() completed without error");
+
+  // Run after reload — new runtime, same middleware instance
+  const rtAfter = await makeRuntime();
+  const { text: textAfter } = await collectText(
+    rtAfter.run({ kind: "text", text: "Introduce yourself." }),
+  );
+  await rtAfter.dispose();
+
+  if (textAfter.toLowerCase().includes("afterra")) {
+    pass('after reload → persona "Afterra" present', textAfter.slice(0, 80));
+  } else {
+    fail('after reload should contain "Afterra"', `got: "${textAfter.slice(0, 120)}"`);
+  }
+
+  if (!textAfter.toLowerCase().includes("beforera")) {
+    pass('after reload → "Beforera" absent (old persona evicted)');
+  } else {
+    fail('after reload should NOT contain "Beforera"', `got: "${textAfter.slice(0, 120)}"`);
+  }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+console.log("@koi/identity E2E — createKoi + createPiAdapter + real LLM");
+console.log(`model: ${MODEL}`);
+
+const t0 = Date.now();
+await testPersonaInjected();
+await testPersonaNotInjectedOnMismatch();
+await testPersonaNotInjectedWithoutChannelId();
+await testMultiChannelIsolation();
+await testHotReload();
+
+const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+const ok = process.exitCode === undefined || process.exitCode === 0;
+console.log(`\n${"─".repeat(58)}`);
+console.log(`${ok ? "ALL PASS" : "FAILURES ABOVE"} — ${elapsed}s`);

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koi/identity",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/manifest": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "e2e": "bun e2e.ts"
+  }
+}

--- a/packages/identity/src/config.test.ts
+++ b/packages/identity/src/config.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for validateIdentityConfig.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { validateIdentityConfig } from "./config.js";
+
+describe("validateIdentityConfig", () => {
+  it("returns ok for minimal valid config with empty personas", () => {
+    const result = validateIdentityConfig({ personas: [] });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.personas).toHaveLength(0);
+    }
+  });
+
+  it("returns ok for config with a valid persona entry", () => {
+    const result = validateIdentityConfig({
+      personas: [
+        {
+          channelId: "@koi/channel-telegram",
+          name: "Alex",
+          instructions: "Be casual.",
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok for persona with instruction path object", () => {
+    const result = validateIdentityConfig({
+      personas: [
+        {
+          channelId: "@koi/channel-slack",
+          instructions: { path: "./persona.md" },
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok with basePath provided", () => {
+    const result = validateIdentityConfig({
+      personas: [{ channelId: "@koi/channel-cli" }],
+      basePath: "/some/path",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns error when config is not an object", () => {
+    const result = validateIdentityConfig("not an object");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  it("returns error when personas is missing", () => {
+    const result = validateIdentityConfig({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("personas");
+    }
+  });
+
+  it("returns error when personas is not an array", () => {
+    const result = validateIdentityConfig({ personas: "not an array" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error when persona entry is not an object", () => {
+    const result = validateIdentityConfig({ personas: ["bad"] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("personas[0]");
+    }
+  });
+
+  it("returns error when channelId is missing", () => {
+    const result = validateIdentityConfig({ personas: [{ name: "Alex" }] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("channelId");
+    }
+  });
+
+  it("returns error when channelId is empty string", () => {
+    const result = validateIdentityConfig({ personas: [{ channelId: "" }] });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error when instructions is neither string nor path object", () => {
+    const result = validateIdentityConfig({
+      personas: [{ channelId: "@koi/channel-telegram", instructions: 42 }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("instructions");
+    }
+  });
+
+  it("returns error when instructions.path is not a string", () => {
+    const result = validateIdentityConfig({
+      personas: [{ channelId: "@koi/channel-telegram", instructions: { path: 42 } }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns error when basePath is not a string", () => {
+    const result = validateIdentityConfig({
+      personas: [],
+      basePath: 123,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("basePath");
+    }
+  });
+
+  it("returns error when persona name is not a string", () => {
+    const result = validateIdentityConfig({
+      personas: [{ channelId: "@koi/channel-telegram", name: 42 }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  it("returns error when persona avatar is not a string", () => {
+    const result = validateIdentityConfig({
+      personas: [{ channelId: "@koi/channel-telegram", avatar: [] }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("avatar");
+    }
+  });
+});

--- a/packages/identity/src/config.ts
+++ b/packages/identity/src/config.ts
@@ -1,0 +1,128 @@
+/**
+ * Identity middleware configuration types and validation.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+
+/**
+ * Per-channel persona configuration.
+ * `channelId` matches the exact package name of the active channel adapter
+ * (e.g. "@koi/channel-telegram") as injected into `SessionContext.channelId` by L1.
+ */
+export interface ChannelPersonaConfig {
+  /** Exact channelId to match (e.g. "@koi/channel-telegram"). */
+  readonly channelId: string;
+  /** Display name for this channel persona. */
+  readonly name?: string;
+  /** Avatar URL or path for this channel persona. */
+  readonly avatar?: string;
+  /** Inline instructions string or file path reference for this persona. */
+  readonly instructions?: string | { readonly path: string };
+}
+
+/** Options for creating the identity middleware. */
+export interface CreateIdentityOptions {
+  readonly personas: readonly ChannelPersonaConfig[];
+  /** Base path for resolving relative instruction file paths. */
+  readonly basePath?: string;
+}
+
+/** Validates that a ChannelPersonaConfig entry is well-formed. */
+function validatePersonaEntry(entry: unknown, index: number): KoiError | undefined {
+  if (entry === null || typeof entry !== "object") {
+    return {
+      code: "VALIDATION",
+      message: `personas[${index}] must be a non-null object`,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    };
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.channelId !== "string" || e.channelId.length === 0) {
+    return {
+      code: "VALIDATION",
+      message: `personas[${index}].channelId must be a non-empty string`,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    };
+  }
+  if (e.name !== undefined && typeof e.name !== "string") {
+    return {
+      code: "VALIDATION",
+      message: `personas[${index}].name must be a string`,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    };
+  }
+  if (e.avatar !== undefined && typeof e.avatar !== "string") {
+    return {
+      code: "VALIDATION",
+      message: `personas[${index}].avatar must be a string`,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    };
+  }
+  if (e.instructions !== undefined) {
+    if (typeof e.instructions === "object" && e.instructions !== null) {
+      const ins = e.instructions as Record<string, unknown>;
+      if (typeof ins.path !== "string") {
+        return {
+          code: "VALIDATION",
+          message: `personas[${index}].instructions.path must be a string`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        };
+      }
+    } else if (typeof e.instructions !== "string") {
+      return {
+        code: "VALIDATION",
+        message: `personas[${index}].instructions must be a string or { path: string }`,
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      };
+    }
+  }
+  return undefined;
+}
+
+/** Validates CreateIdentityOptions, returning a typed Result. */
+export function validateIdentityConfig(config: unknown): Result<CreateIdentityOptions, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config must be a non-null object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (!Array.isArray(c.personas)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config requires a 'personas' array",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  for (let i = 0; i < c.personas.length; i++) {
+    const err = validatePersonaEntry(c.personas[i], i);
+    if (err !== undefined) {
+      return { ok: false, error: err };
+    }
+  }
+
+  if (c.basePath !== undefined && typeof c.basePath !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "basePath must be a string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return { ok: true, value: config as CreateIdentityOptions };
+}

--- a/packages/identity/src/identity.test.ts
+++ b/packages/identity/src/identity.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for createIdentityMiddleware — dispatch paths and reload behaviors.
+ */
+
+import { describe, expect, it, mock, spyOn } from "bun:test";
+import type { ModelRequest, ModelResponse, TurnContext } from "@koi/core/middleware";
+import { createIdentityMiddleware } from "./identity.js";
+import * as personaMapModule from "./persona-map.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTurnCtx(channelId?: string): TurnContext {
+  return {
+    session: {
+      agentId: "agent-1",
+      sessionId: "session:agent:agent-1:abc" as import("@koi/core/ecs").SessionId,
+      runId: "run-uuid" as import("@koi/core/ecs").RunId,
+      ...(channelId !== undefined ? { channelId } : {}),
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "turn-uuid" as import("@koi/core/ecs").TurnId,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function makeModelRequest(overrides?: Partial<ModelRequest>): ModelRequest {
+  return {
+    messages: [
+      {
+        senderId: "user",
+        timestamp: 1000,
+        content: [{ kind: "text", text: "Hello" }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const MOCK_RESPONSE: ModelResponse = {
+  content: "Hi there",
+  model: "test-model",
+};
+
+// ── Dispatch path tests ───────────────────────────────────────────────────────
+
+describe("createIdentityMiddleware — dispatch paths", () => {
+  it("1. channelId matches → system message prepended with name + instructions", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [
+        {
+          channelId: "@koi/channel-telegram",
+          name: "Alex",
+          instructions: "Be casual and friendly.",
+        },
+      ],
+    });
+
+    const captured: ModelRequest[] = [];
+    const next = mock(async (req: ModelRequest) => {
+      captured.push(req);
+      return MOCK_RESPONSE;
+    });
+
+    const ctx = makeTurnCtx("@koi/channel-telegram");
+    await mw.wrapModelCall(ctx, makeModelRequest(), next);
+
+    expect(captured).toHaveLength(1);
+    const req = captured[0];
+    expect(req?.messages).toHaveLength(2); // injected + original
+    const first = req?.messages[0];
+    expect(first?.senderId).toBe("system:identity");
+    if (first?.content[0]?.kind === "text") {
+      expect(first.content[0].text).toContain("You are Alex.");
+      expect(first.content[0].text).toContain("Be casual and friendly.");
+    }
+  });
+
+  it("2. channelId matches, name only → name injected without instructions separator", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Research Bot" }],
+    });
+
+    const captured: ModelRequest[] = [];
+    const next = mock(async (req: ModelRequest) => {
+      captured.push(req);
+      return MOCK_RESPONSE;
+    });
+
+    await mw.wrapModelCall(makeTurnCtx("@koi/channel-telegram"), makeModelRequest(), next);
+
+    const first = captured[0]?.messages[0];
+    expect(first?.senderId).toBe("system:identity");
+    if (first?.content[0]?.kind === "text") {
+      expect(first.content[0].text).toBe("You are Research Bot.");
+    }
+  });
+
+  it("3. channelId present, no matching persona → request unchanged (no-op)", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-slack", name: "Alex" }],
+    });
+
+    const captured: ModelRequest[] = [];
+    const next = mock(async (req: ModelRequest) => {
+      captured.push(req);
+      return MOCK_RESPONSE;
+    });
+
+    const original = makeModelRequest();
+    await mw.wrapModelCall(makeTurnCtx("@koi/channel-telegram"), original, next);
+
+    // Exact same request — no system message prepended
+    expect(captured[0]).toBe(original);
+  });
+
+  it("4. channelId absent (undefined) → request unchanged (no-op)", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Alex" }],
+    });
+
+    const captured: ModelRequest[] = [];
+    const next = mock(async (req: ModelRequest) => {
+      captured.push(req);
+      return MOCK_RESPONSE;
+    });
+
+    const original = makeModelRequest();
+    await mw.wrapModelCall(makeTurnCtx(undefined), original, next);
+
+    expect(captured[0]).toBe(original);
+  });
+});
+
+// ── wrapModelStream dispatch paths ───────────────────────────────────────────
+
+describe("createIdentityMiddleware — wrapModelStream dispatch", () => {
+  it("injects system message in stream path when channelId matches", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Alex", instructions: "Be helpful." }],
+    });
+
+    const chunk = { kind: "done" as const, response: MOCK_RESPONSE };
+
+    async function* mockStream(req: ModelRequest) {
+      // Verify message was prepended
+      expect(req.messages[0]?.senderId).toBe("system:identity");
+      yield chunk;
+    }
+
+    const ctx = makeTurnCtx("@koi/channel-telegram");
+    const stream = mw.wrapModelStream(ctx, makeModelRequest(), mockStream);
+    const results: unknown[] = [];
+    for await (const c of stream) {
+      results.push(c);
+    }
+    expect(results).toHaveLength(1);
+  });
+
+  it("passes request unchanged in stream path when no matching persona", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-slack", name: "Alex" }],
+    });
+
+    const original = makeModelRequest();
+    let captured: ModelRequest | undefined;
+
+    async function* mockStream(req: ModelRequest) {
+      captured = req;
+      yield { kind: "done" as const, response: MOCK_RESPONSE };
+    }
+
+    const ctx = makeTurnCtx("@koi/channel-telegram");
+    for await (const _ of mw.wrapModelStream(ctx, original, mockStream)) {
+      // consume
+    }
+
+    expect(captured).toBe(original);
+  });
+});
+
+// ── Reload behavior tests ─────────────────────────────────────────────────────
+
+describe("createIdentityMiddleware — reload behaviors", () => {
+  it("5. After reload(), next wrapModelCall uses new persona", async () => {
+    const personas = [{ channelId: "@koi/channel-telegram", instructions: "Old instructions." }];
+    const mw = await createIdentityMiddleware({ personas });
+
+    // Mutate the personas array reference for reload — simulate updated config
+    // by spying on buildPersonaMap to return a new map after reload
+    const newMap = new Map<string, import("./persona-map.js").CachedPersona>();
+    newMap.set("@koi/channel-telegram", {
+      message: {
+        senderId: "system:identity",
+        timestamp: Date.now(),
+        content: [{ kind: "text", text: "New instructions." }],
+      },
+      sources: [],
+    });
+
+    const spy = spyOn(personaMapModule, "buildPersonaMap").mockResolvedValueOnce(newMap);
+    await mw.reload();
+    spy.mockRestore();
+
+    const captured: ModelRequest[] = [];
+    const next = mock(async (req: ModelRequest) => {
+      captured.push(req);
+      return MOCK_RESPONSE;
+    });
+
+    await mw.wrapModelCall(makeTurnCtx("@koi/channel-telegram"), makeModelRequest(), next);
+
+    const injected = captured[0]?.messages[0];
+    if (injected?.content[0]?.kind === "text") {
+      expect(injected.content[0].text).toBe("New instructions.");
+    }
+  });
+
+  it("6. wrapToolCall: fs_write to tracked file → reload() called and persona updates", async () => {
+    const tmpFile = "/tmp/koi-identity-test-persona.md";
+    await Bun.write(tmpFile, "Original instructions.");
+
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", instructions: { path: tmpFile } }],
+    });
+
+    // Verify original instruction is used
+    const capturedBefore: ModelRequest[] = [];
+    await mw.wrapModelCall(
+      makeTurnCtx("@koi/channel-telegram"),
+      makeModelRequest(),
+      async (req) => {
+        capturedBefore.push(req);
+        return MOCK_RESPONSE;
+      },
+    );
+    const firstText = capturedBefore[0]?.messages[0]?.content[0];
+    if (firstText?.kind === "text") {
+      expect(firstText.text).toContain("Original instructions.");
+    }
+
+    // Update the file and trigger via fs_write
+    await Bun.write(tmpFile, "Updated instructions.");
+
+    const writeNext = mock(async (_req: import("@koi/core/middleware").ToolRequest) => ({
+      output: "ok",
+    }));
+    await mw.wrapToolCall(
+      makeTurnCtx("@koi/channel-telegram"),
+      { toolId: "fs_write", input: { path: tmpFile, content: "Updated instructions." } },
+      writeNext,
+    );
+
+    // After fs_write, next model call should use updated persona
+    const capturedAfter: ModelRequest[] = [];
+    await mw.wrapModelCall(
+      makeTurnCtx("@koi/channel-telegram"),
+      makeModelRequest(),
+      async (req) => {
+        capturedAfter.push(req);
+        return MOCK_RESPONSE;
+      },
+    );
+    const updatedText = capturedAfter[0]?.messages[0]?.content[0];
+    if (updatedText?.kind === "text") {
+      expect(updatedText.text).toContain("Updated instructions.");
+    }
+  });
+
+  it("7. wrapToolCall: fs_write to untracked file → reload() NOT called", async () => {
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", instructions: "Inline instructions." }],
+    });
+
+    const spy = spyOn(personaMapModule, "buildPersonaMap");
+    const next = mock(async (_req: import("@koi/core/middleware").ToolRequest) => ({
+      output: "ok",
+    }));
+
+    const ctx = makeTurnCtx("@koi/channel-telegram");
+    await mw.wrapToolCall(
+      ctx,
+      { toolId: "fs_write", input: { path: "/some/untracked/file.md", content: "x" } },
+      next,
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("8. wrapToolCall: non-fs_write tool → reload() NOT called", async () => {
+    const tmpFile = "/tmp/koi-identity-test-persona-2.md";
+    await Bun.write(tmpFile, "Persona.");
+
+    const mw = await createIdentityMiddleware({
+      personas: [{ channelId: "@koi/channel-telegram", instructions: { path: tmpFile } }],
+    });
+
+    const spy = spyOn(personaMapModule, "buildPersonaMap");
+    const next = mock(async (_req: import("@koi/core/middleware").ToolRequest) => ({
+      output: "ok",
+    }));
+
+    const ctx = makeTurnCtx("@koi/channel-telegram");
+    await mw.wrapToolCall(ctx, { toolId: "bash", input: { command: "echo hello" } }, next);
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ── Middleware metadata ───────────────────────────────────────────────────────
+
+describe("createIdentityMiddleware — metadata", () => {
+  it("has name 'identity'", async () => {
+    const mw = await createIdentityMiddleware({ personas: [] });
+    expect(mw.name).toBe("identity");
+  });
+
+  it("has priority 490", async () => {
+    const mw = await createIdentityMiddleware({ personas: [] });
+    expect(mw.priority).toBe(490);
+  });
+
+  it("exposes reload function", async () => {
+    const mw = await createIdentityMiddleware({ personas: [] });
+    expect(typeof mw.reload).toBe("function");
+  });
+});

--- a/packages/identity/src/identity.ts
+++ b/packages/identity/src/identity.ts
@@ -1,0 +1,120 @@
+/**
+ * Identity middleware factory — per-channel persona injection with hot-reload.
+ */
+
+import type { InboundMessage } from "@koi/core/message";
+import type {
+  KoiMiddleware,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import type { CreateIdentityOptions } from "./config.js";
+import type { CachedPersona } from "./persona-map.js";
+import { buildPersonaMap, buildWatchedPaths } from "./persona-map.js";
+
+/**
+ * Extended middleware with a `reload()` method for hot-reloading persona config.
+ *
+ * Automatically reloads when `fs_write` targets a tracked persona instruction file.
+ * Manual `reload()` is also available for programmatic use.
+ */
+export interface IdentityMiddleware extends KoiMiddleware {
+  /**
+   * Re-resolves all persona instruction files and rebuilds the persona map.
+   * Called automatically after successful `fs_write` to a tracked file.
+   * Can also be called manually after out-of-band file changes.
+   * Takes effect on the next model call.
+   */
+  readonly reload: () => Promise<void>;
+  // All three hooks are always implemented — narrow the optional to required.
+  readonly wrapToolCall: NonNullable<KoiMiddleware["wrapToolCall"]>;
+  readonly wrapModelCall: NonNullable<KoiMiddleware["wrapModelCall"]>;
+  readonly wrapModelStream: NonNullable<KoiMiddleware["wrapModelStream"]>;
+}
+
+/**
+ * Enriches a model request by prepending a persona system message.
+ * Pure function — does not mutate the input request.
+ */
+export function enrichRequest(request: ModelRequest, personaMessage: InboundMessage): ModelRequest {
+  return { ...request, messages: [personaMessage, ...request.messages] };
+}
+
+/**
+ * Creates an identity middleware that injects per-channel persona system messages
+ * into model calls, keyed by `SessionContext.channelId`.
+ *
+ * Priority 490 — runs just outside soul middleware (500) so identity wraps outermost.
+ *
+ * Returns `IdentityMiddleware` — a `KoiMiddleware` with `reload()` and auto-reload
+ * via `wrapToolCall` when `fs_write` targets a tracked instruction file.
+ */
+export async function createIdentityMiddleware(
+  options: CreateIdentityOptions,
+): Promise<IdentityMiddleware> {
+  // Mutable closure state — updated atomically by reload()
+  // let: reassigned by reload()
+  let personaMap: Map<string, CachedPersona> = await buildPersonaMap(options);
+  let watchedPaths: Set<string> = buildWatchedPaths(personaMap);
+
+  async function reload(): Promise<void> {
+    const newMap = await buildPersonaMap(options);
+    // Atomic update — both map and watched paths change together
+    personaMap = newMap;
+    watchedPaths = buildWatchedPaths(newMap);
+  }
+
+  return {
+    name: "identity",
+    // Priority 490: slightly ahead of soul (500) so identity wraps outside soul
+    priority: 490,
+
+    reload,
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      const response = await next(request);
+
+      // Auto-reload after successful fs_write to a tracked instruction file
+      if (request.toolId === "fs_write" && watchedPaths.size > 0) {
+        const writtenPath = typeof request.input.path === "string" ? request.input.path : undefined;
+        if (writtenPath !== undefined && watchedPaths.has(writtenPath)) {
+          await reload().catch((err: unknown) => console.error("[identity] reload failed:", err));
+        }
+      }
+
+      return response;
+    },
+
+    async wrapModelCall(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      const channelId = ctx.session.channelId;
+      const cached = channelId !== undefined ? personaMap.get(channelId) : undefined;
+      const enriched = cached !== undefined ? enrichRequest(request, cached.message) : request;
+      return next(enriched);
+    },
+
+    async *wrapModelStream(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<import("@koi/core/middleware").ModelChunk> {
+      const channelId = ctx.session.channelId;
+      const cached = channelId !== undefined ? personaMap.get(channelId) : undefined;
+      const enriched = cached !== undefined ? enrichRequest(request, cached.message) : request;
+      yield* next(enriched);
+    },
+  };
+}

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @koi/identity — Per-channel agent personas with hot-reload (Layer 2 middleware)
+ *
+ * Injects per-channel persona (name, avatar, instructions) as a system message prefix,
+ * keyed by `SessionContext.channelId`. Hot-reloads when instruction files change.
+ *
+ * Depends on @koi/core only (L2 package).
+ */
+
+export type { ChannelPersonaConfig, CreateIdentityOptions } from "./config.js";
+export { validateIdentityConfig } from "./config.js";
+export type { IdentityMiddleware } from "./identity.js";
+export { createIdentityMiddleware, enrichRequest } from "./identity.js";
+export { personasFromManifest } from "./manifest.js";
+export type { CachedPersona, ResolvedPersona } from "./persona-map.js";
+export { buildPersonaMap, buildWatchedPaths, resolvePersonaContent } from "./persona-map.js";

--- a/packages/identity/src/manifest.test.ts
+++ b/packages/identity/src/manifest.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for personasFromManifest.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { AgentManifest } from "@koi/core/assembly";
+import { personasFromManifest } from "./manifest.js";
+
+const BASE_MANIFEST: AgentManifest = {
+  name: "test-agent",
+  version: "1.0.0",
+  model: { name: "anthropic:claude-haiku-4-5-20251001" },
+};
+
+describe("personasFromManifest", () => {
+  it("returns empty personas when manifest has no channels", () => {
+    const result = personasFromManifest(BASE_MANIFEST);
+    expect(result.personas).toHaveLength(0);
+  });
+
+  it("returns empty personas when channels have no identity", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [{ name: "@koi/channel-cli" }],
+    };
+    const result = personasFromManifest(manifest);
+    expect(result.personas).toHaveLength(0);
+  });
+
+  it("extracts persona from channel with full identity", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [
+        {
+          name: "@koi/channel-telegram",
+          identity: { name: "Alex", avatar: "casual.png", instructions: "Be casual." },
+        },
+      ],
+    };
+    const result = personasFromManifest(manifest);
+    expect(result.personas).toHaveLength(1);
+    expect(result.personas[0]).toEqual({
+      channelId: "@koi/channel-telegram",
+      name: "Alex",
+      avatar: "casual.png",
+      instructions: "Be casual.",
+    });
+  });
+
+  it("skips channels without identity, extracts those with it", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [
+        { name: "@koi/channel-cli" },
+        { name: "@koi/channel-telegram", identity: { name: "Alex" } },
+        { name: "@koi/channel-slack", identity: { instructions: "Be formal." } },
+      ],
+    };
+    const result = personasFromManifest(manifest);
+    expect(result.personas).toHaveLength(2);
+    expect(result.personas[0]?.channelId).toBe("@koi/channel-telegram");
+    expect(result.personas[1]?.channelId).toBe("@koi/channel-slack");
+  });
+
+  it("sets channelId to channel.name", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [{ name: "@koi/channel-slack", identity: { name: "Bot" } }],
+    };
+    const result = personasFromManifest(manifest);
+    expect(result.personas[0]?.channelId).toBe("@koi/channel-slack");
+  });
+
+  it("omits undefined identity fields from persona", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [{ name: "@koi/channel-telegram", identity: { name: "Alex" } }],
+    };
+    const result = personasFromManifest(manifest);
+    const persona = result.personas[0];
+    expect(persona?.name).toBe("Alex");
+    expect("avatar" in (persona ?? {})).toBe(false);
+    expect("instructions" in (persona ?? {})).toBe(false);
+  });
+
+  it("passes basePath through when provided", () => {
+    const manifest: AgentManifest = {
+      ...BASE_MANIFEST,
+      channels: [{ name: "@koi/channel-telegram", identity: { name: "Alex" } }],
+    };
+    const result = personasFromManifest(manifest, { basePath: "/some/dir" });
+    expect(result.basePath).toBe("/some/dir");
+  });
+
+  it("omits basePath when not provided", () => {
+    const result = personasFromManifest(BASE_MANIFEST);
+    expect("basePath" in result).toBe(false);
+  });
+});

--- a/packages/identity/src/manifest.ts
+++ b/packages/identity/src/manifest.ts
@@ -1,0 +1,46 @@
+/**
+ * Helpers for wiring @koi/identity from a loaded manifest.
+ */
+
+import type { AgentManifest } from "@koi/core/assembly";
+import type { ChannelPersonaConfig, CreateIdentityOptions } from "./config.js";
+
+/**
+ * Extracts per-channel persona configs from an `AgentManifest`, ready to pass
+ * directly to `createIdentityMiddleware`.
+ *
+ * Channels without an `identity` block are silently skipped.
+ * The `channelId` is set to `channel.name` — the exact package name that L1
+ * injects into `SessionContext.channelId` (e.g. `"@koi/channel-telegram"`).
+ *
+ * @example
+ * ```ts
+ * const mw = await createIdentityMiddleware(
+ *   personasFromManifest(manifest, { basePath: import.meta.dir }),
+ * );
+ * ```
+ */
+export function personasFromManifest(
+  manifest: AgentManifest,
+  options?: { readonly basePath?: string },
+): CreateIdentityOptions {
+  const personas: ChannelPersonaConfig[] = [];
+
+  for (const channel of manifest.channels ?? []) {
+    if (channel.identity === undefined) continue;
+
+    const { name, avatar, instructions } = channel.identity;
+    const persona: ChannelPersonaConfig = {
+      channelId: channel.name,
+      ...(name !== undefined ? { name } : {}),
+      ...(avatar !== undefined ? { avatar } : {}),
+      ...(instructions !== undefined ? { instructions } : {}),
+    };
+    personas.push(persona);
+  }
+
+  return {
+    personas,
+    ...(options?.basePath !== undefined ? { basePath: options.basePath } : {}),
+  };
+}

--- a/packages/identity/src/persona-map.test.ts
+++ b/packages/identity/src/persona-map.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for buildPersonaMap and resolvePersonaContent.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { buildPersonaMap, buildWatchedPaths, resolvePersonaContent } from "./persona-map.js";
+
+describe("resolvePersonaContent", () => {
+  it("returns inline instructions with no sources tracked", () => {
+    const result = resolvePersonaContent(
+      { channelId: "@koi/channel-telegram", instructions: "Be casual." },
+      undefined,
+    );
+    expect(result.channelId).toBe("@koi/channel-telegram");
+    expect(result.instructions).toBe("Be casual.");
+    expect(result.sources).toHaveLength(0);
+  });
+
+  it("returns empty instructions when not provided", () => {
+    const result = resolvePersonaContent({ channelId: "@koi/channel-cli" }, undefined);
+    expect(result.instructions).toBe("");
+    expect(result.sources).toHaveLength(0);
+  });
+
+  it("includes name and avatar when provided", () => {
+    const result = resolvePersonaContent(
+      { channelId: "@koi/channel-slack", name: "Alex", avatar: "casual.png" },
+      undefined,
+    );
+    expect(result.name).toBe("Alex");
+    expect(result.avatar).toBe("casual.png");
+  });
+
+  it("omits name and avatar when not provided", () => {
+    const result = resolvePersonaContent({ channelId: "@koi/channel-cli" }, undefined);
+    expect("name" in result).toBe(false);
+    expect("avatar" in result).toBe(false);
+  });
+});
+
+describe("buildPersonaMap", () => {
+  it("creates map entries for personas with injectable content", async () => {
+    const map = await buildPersonaMap({
+      personas: [
+        { channelId: "@koi/channel-telegram", name: "Alex", instructions: "Be casual." },
+        { channelId: "@koi/channel-slack", instructions: "Be formal." },
+      ],
+    });
+    expect(map.size).toBe(2);
+    expect(map.has("@koi/channel-telegram")).toBe(true);
+    expect(map.has("@koi/channel-slack")).toBe(true);
+  });
+
+  it("excludes personas with no name and no instructions", async () => {
+    const map = await buildPersonaMap({
+      personas: [
+        { channelId: "@koi/channel-cli" }, // no name, no instructions
+        { channelId: "@koi/channel-telegram", name: "Alex" },
+      ],
+    });
+    expect(map.size).toBe(1);
+    expect(map.has("@koi/channel-cli")).toBe(false);
+    expect(map.has("@koi/channel-telegram")).toBe(true);
+  });
+
+  it("pre-builds system message with name prefix", async () => {
+    const map = await buildPersonaMap({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Alex", instructions: "Be casual." }],
+    });
+    const cached = map.get("@koi/channel-telegram");
+    expect(cached).toBeDefined();
+    if (cached !== undefined) {
+      const block = cached.message.content[0];
+      expect(block?.kind).toBe("text");
+      if (block?.kind === "text") {
+        expect(block.text).toContain("You are Alex.");
+        expect(block.text).toContain("Be casual.");
+      }
+    }
+  });
+
+  it("pre-builds system message with instructions only", async () => {
+    const map = await buildPersonaMap({
+      personas: [{ channelId: "@koi/channel-slack", instructions: "Be formal and concise." }],
+    });
+    const cached = map.get("@koi/channel-slack");
+    expect(cached?.message.content[0]?.kind).toBe("text");
+    if (cached?.message.content[0]?.kind === "text") {
+      expect(cached.message.content[0].text).toBe("Be formal and concise.");
+    }
+  });
+
+  it("returns empty map for empty personas array", async () => {
+    const map = await buildPersonaMap({ personas: [] });
+    expect(map.size).toBe(0);
+  });
+
+  it("sets senderId to system:identity", async () => {
+    const map = await buildPersonaMap({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Alex" }],
+    });
+    const cached = map.get("@koi/channel-telegram");
+    expect(cached?.message.senderId).toBe("system:identity");
+  });
+});
+
+describe("buildWatchedPaths", () => {
+  it("collects file paths from cached persona sources", async () => {
+    const map = await buildPersonaMap({
+      personas: [{ channelId: "@koi/channel-telegram", name: "Alex" }],
+    });
+    // No file sources for inline instructions
+    const paths = buildWatchedPaths(map);
+    expect(paths.size).toBe(0);
+  });
+
+  it("returns empty set for empty map", () => {
+    const paths = buildWatchedPaths(new Map());
+    expect(paths.size).toBe(0);
+  });
+});

--- a/packages/identity/src/persona-map.ts
+++ b/packages/identity/src/persona-map.ts
@@ -1,0 +1,128 @@
+/**
+ * Builds and manages the per-channel persona map.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { InboundMessage } from "@koi/core/message";
+import type { ChannelPersonaConfig, CreateIdentityOptions } from "./config.js";
+
+/** A resolved persona with loaded instruction text and tracked file paths. */
+export interface ResolvedPersona {
+  readonly channelId: string;
+  readonly name?: string;
+  readonly avatar?: string;
+  readonly instructions: string;
+  readonly sources: readonly string[];
+}
+
+/** Cached per-channel persona entry. Pre-built system message for O(1) lookup. */
+export interface CachedPersona {
+  /** Pre-built system message injected at the start of every model call for this channel. */
+  readonly message: InboundMessage;
+  /** File paths tracked for auto-reload on fs_write. */
+  readonly sources: readonly string[];
+}
+
+/**
+ * Resolves instruction content for a single persona config entry.
+ * If instructions is a `{ path }` object, reads from disk synchronously.
+ * If instructions is an inline string, uses it directly.
+ */
+export function resolvePersonaContent(
+  persona: ChannelPersonaConfig,
+  basePath: string | undefined,
+): ResolvedPersona {
+  let instructions = "";
+  const sources: string[] = [];
+
+  if (persona.instructions !== undefined) {
+    if (typeof persona.instructions === "string") {
+      instructions = persona.instructions;
+      // Inline — no file tracked
+    } else {
+      // { path: string } — load from file
+      const filePath =
+        basePath !== undefined
+          ? resolve(basePath, persona.instructions.path)
+          : resolve(persona.instructions.path);
+      instructions = readFileSync(filePath, "utf-8");
+      sources.push(filePath);
+    }
+  }
+
+  return {
+    channelId: persona.channelId,
+    ...(persona.name !== undefined ? { name: persona.name } : {}),
+    ...(persona.avatar !== undefined ? { avatar: persona.avatar } : {}),
+    instructions,
+    sources,
+  };
+}
+
+/**
+ * Builds the system message text from a resolved persona.
+ * Returns undefined when nothing meaningful to inject (no name, no instructions).
+ *
+ * Note: `avatar` is intentionally excluded — it is display metadata for the channel
+ * UI layer, not LLM-visible content. Channel adapters may surface it independently.
+ */
+function buildSystemText(resolved: ResolvedPersona): string | undefined {
+  const parts: string[] = [];
+  if (resolved.name !== undefined && resolved.name.length > 0) {
+    parts.push(`You are ${resolved.name}.`);
+  }
+  if (resolved.instructions.length > 0) {
+    parts.push(resolved.instructions);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+/**
+ * Builds the InboundMessage for a resolved persona.
+ * Returns undefined when there is nothing to inject.
+ */
+function buildPersonaMessage(resolved: ResolvedPersona): InboundMessage | undefined {
+  const text = buildSystemText(resolved);
+  if (text === undefined) return undefined;
+
+  return {
+    senderId: "system:identity",
+    timestamp: Date.now(),
+    content: [{ kind: "text", text }],
+  };
+}
+
+/**
+ * Resolves all personas in parallel and builds the channelId → CachedPersona map.
+ * Personas with no injectable content (no name, no instructions) are excluded.
+ */
+export async function buildPersonaMap(
+  options: CreateIdentityOptions,
+): Promise<Map<string, CachedPersona>> {
+  const resolved = await Promise.all(
+    options.personas.map((p): ResolvedPersona => resolvePersonaContent(p, options.basePath)),
+  );
+
+  const map = new Map<string, CachedPersona>();
+  for (const r of resolved) {
+    const message = buildPersonaMessage(r);
+    if (message === undefined) continue; // nothing to inject — skip
+
+    map.set(r.channelId, { message, sources: r.sources });
+  }
+  return map;
+}
+
+/**
+ * Collects all tracked file paths from a persona map into a Set.
+ */
+export function buildWatchedPaths(personaMap: Map<string, CachedPersona>): Set<string> {
+  const paths = new Set<string>();
+  for (const cached of personaMap.values()) {
+    for (const s of cached.sources) {
+      paths.add(s);
+    }
+  }
+  return paths;
+}

--- a/packages/identity/tsconfig.json
+++ b/packages/identity/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/identity/tsup.config.ts
+++ b/packages/identity/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/manifest/src/__tests__/schema.test.ts
+++ b/packages/manifest/src/__tests__/schema.test.ts
@@ -533,6 +533,61 @@ describe("rawManifestSchema — outboundWebhooks", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Channel identity
+// ---------------------------------------------------------------------------
+
+describe("rawManifestSchema — channel identity", () => {
+  test("accepts channel with full identity block", () => {
+    const result = parse({
+      channels: [
+        {
+          name: "@koi/channel-telegram",
+          identity: {
+            name: "Alex",
+            avatar: "casual.png",
+            instructions: "Be casual and friendly.",
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts channel with partial identity (name only)", () => {
+    const result = parse({
+      channels: [{ name: "@koi/channel-telegram", identity: { name: "Alex" } }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts channel without identity block", () => {
+    const result = parse({
+      channels: [{ name: "@koi/channel-cli" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("preserves identity fields in parsed result", () => {
+    const result = parse({
+      channels: [
+        {
+          name: "@koi/channel-slack",
+          identity: { name: "Research Bot", instructions: "Be formal." },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { channels?: unknown[] };
+      const ch = data.channels?.[0] as Record<string, unknown>;
+      const identity = ch.identity as Record<string, unknown>;
+      expect(identity.name).toBe("Research Bot");
+      expect(identity.instructions).toBe("Be formal.");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // zodToKoiError
 // ---------------------------------------------------------------------------
 

--- a/packages/manifest/src/__tests__/transform.test.ts
+++ b/packages/manifest/src/__tests__/transform.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  normalizeChannelConfig,
   normalizeConfigItem,
   normalizeModelConfig,
   transformToLoadedManifest,
@@ -35,6 +36,44 @@ describe("normalizeConfigItem", () => {
     const input = { "@koi/middleware-log": {} };
     const result = normalizeConfigItem(input);
     expect(result).toEqual({ name: "@koi/middleware-log", options: {} });
+  });
+});
+
+describe("normalizeChannelConfig", () => {
+  test("passes through channel without identity", () => {
+    const result = normalizeChannelConfig({ name: "@koi/channel-cli" });
+    expect(result).toEqual({ name: "@koi/channel-cli" });
+  });
+
+  test("preserves identity block on channel config", () => {
+    const input = {
+      name: "@koi/channel-telegram",
+      identity: { name: "Alex", instructions: "Be casual." },
+    };
+    const result = normalizeChannelConfig(input);
+    expect(result.name).toBe("@koi/channel-telegram");
+    expect(result.identity).toEqual({ name: "Alex", instructions: "Be casual." });
+  });
+
+  test("preserves full identity with avatar", () => {
+    const input = {
+      name: "@koi/channel-slack",
+      identity: { name: "Bot", avatar: "bot.png", instructions: "Be helpful." },
+    };
+    const result = normalizeChannelConfig(input);
+    expect(result.identity).toEqual({
+      name: "Bot",
+      avatar: "bot.png",
+      instructions: "Be helpful.",
+    });
+  });
+
+  test("omits identity properties not present in source", () => {
+    const input = { name: "@koi/channel-telegram", identity: { name: "Alex" } };
+    const result = normalizeChannelConfig(input);
+    expect(result.identity).toEqual({ name: "Alex" });
+    expect("avatar" in (result.identity ?? {})).toBe(false);
+    expect("instructions" in (result.identity ?? {})).toBe(false);
   });
 });
 
@@ -154,6 +193,25 @@ describe("transformToLoadedManifest", () => {
     const result = transformToLoadedManifest(raw);
     expect(result.engine).toBe("deepagents");
     expect(result.schedule).toBe("0 9 * * *");
+  });
+
+  test("transforms channels with identity block", () => {
+    const raw = {
+      name: "my-agent",
+      version: "1.0.0",
+      model: "anthropic:claude-sonnet-4-5-20250929",
+      channels: [
+        {
+          name: "@koi/channel-telegram",
+          identity: { name: "Alex", instructions: "Be casual." },
+        },
+        { name: "@koi/channel-cli" }, // no identity
+      ],
+    };
+    const result = transformToLoadedManifest(raw);
+    expect(result.channels).toHaveLength(2);
+    expect(result.channels?.[0]?.identity).toEqual({ name: "Alex", instructions: "Be casual." });
+    expect(result.channels?.[1]?.identity).toBeUndefined();
   });
 
   test("transforms permissions", () => {

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -114,6 +114,31 @@ const namedConfigSchema = z.union([
   jsonObjectSchema,
 ]);
 
+// ── Channel identity schema ──
+
+/** Per-channel persona config embedded in the channel config block. */
+const channelIdentitySchema = z
+  .object({
+    name: z.string().optional(),
+    avatar: z.string().optional(),
+    instructions: z.string().optional(),
+  })
+  .optional();
+
+/**
+ * Channel config item — same as namedConfigSchema but also supports `identity` block.
+ * Accepts either `{ name: string, options?: object, identity?: ChannelIdentity }` or a
+ * key-value map `{ "@koi/pkg": { ... } }` (identity not supported in shorthand form).
+ */
+const rawChannelSchema = z.union([
+  z.object({
+    name: z.string(),
+    options: jsonObjectSchema.optional(),
+    identity: channelIdentitySchema,
+  }),
+  jsonObjectSchema,
+]);
+
 // ── Model schema ──
 
 /** Model can be a string shorthand or a full config object. */
@@ -239,7 +264,7 @@ export const rawManifestSchema: z.ZodType<RawManifest> = z
     description: z.string().optional(),
     model: modelSchema,
     tools: toolsSchema.optional(),
-    channels: z.array(namedConfigSchema).optional(),
+    channels: z.array(rawChannelSchema).optional(),
     middleware: z.array(namedConfigSchema).optional(),
     permissions: permissionsSchema.optional(),
     metadata: jsonObjectSchema.optional(),

--- a/packages/manifest/src/transform.ts
+++ b/packages/manifest/src/transform.ts
@@ -6,6 +6,7 @@
 
 import type {
   ChannelConfig,
+  ChannelIdentity,
   JsonObject,
   MiddlewareConfig,
   ModelConfig,
@@ -101,6 +102,24 @@ export function normalizeConfigItem(raw: Readonly<Record<string, unknown>>): Nor
 }
 
 /**
+ * Normalizes a channel config item, preserving the `identity` block if present.
+ * Extends `normalizeConfigItem` with identity passthrough.
+ */
+export function normalizeChannelConfig(raw: Readonly<Record<string, unknown>>): ChannelConfig {
+  const base = normalizeConfigItem(raw);
+  if (typeof raw.identity === "object" && raw.identity !== null) {
+    const id = raw.identity as Readonly<Record<string, unknown>>;
+    const identity: ChannelIdentity = {
+      ...(typeof id.name === "string" ? { name: id.name } : {}),
+      ...(typeof id.avatar === "string" ? { avatar: id.avatar } : {}),
+      ...(typeof id.instructions === "string" ? { instructions: id.instructions } : {}),
+    };
+    return { ...base, identity };
+  }
+  return base;
+}
+
+/**
  * Flattens a keyed tools section into a flat `ToolConfig[]`.
  *
  * Input: `{ mcp: [{ name: "fs", command: "..." }] }`
@@ -162,9 +181,9 @@ export function transformToLoadedManifest(raw: RawManifest): LoadedManifest {
     (m): MiddlewareConfig => normalizeConfigItem(m),
   );
 
-  // Transform channels
+  // Transform channels — preserve identity block if present
   const channels: readonly ChannelConfig[] | undefined = raw.channels?.map(
-    (c): ChannelConfig => normalizeConfigItem(c),
+    (c): ChannelConfig => normalizeChannelConfig(c),
   );
 
   // Build base manifest with required fields

--- a/packages/middleware-soul/src/soul.ts
+++ b/packages/middleware-soul/src/soul.ts
@@ -202,7 +202,7 @@ export async function createSoulMiddleware(options: CreateSoulOptions): Promise<
       if (request.toolId === "fs_write" && watchedPaths.size > 0) {
         const writtenPath = typeof request.input.path === "string" ? request.input.path : undefined;
         if (writtenPath !== undefined && watchedPaths.has(writtenPath)) {
-          await reload();
+          await reload().catch((err: unknown) => console.error("[soul] reload failed:", err));
         }
       }
 


### PR DESCRIPTION
Closes #31

## Summary

- **`@koi/core` (L0)**: Add `ChannelIdentity` interface + `identity?` field on `ChannelConfig`; add `channelId?` to `SessionContext`
- **`@koi/manifest` (L0u)**: Add `identity` Zod schema to channel config parser; expose `ChannelIdentity` type in public exports
- **`@koi/engine` (L1)**: Inject `channelId` into `SessionContext` at session dispatch time from channel config
- **`@koi/identity` (L2, new package)**: Per-channel persona middleware — injects name/instructions as a system-message prefix keyed by `channelId`, hot-reloads on `fs_write` to tracked instruction files

## YAML example

```yaml
channels:
  - name: "@koi/channel-telegram"
    identity:
      name: "Alex"
      avatar: "casual.png"
      instructions: "Be casual and friendly."
  - name: "@koi/channel-slack"
    identity:
      name: "Research Bot"
      instructions: "Be formal and concise."
```

## Test plan

- [ ] `bun test packages/identity` — unit tests (dispatch paths, reload behaviors, metadata) + integration test (YAML manifest → middleware → injection)
- [ ] `bun test packages/manifest` — verify new `identity` Zod schema parses correctly
- [ ] `bun run typecheck` — all packages including `@koi/identity`
- [ ] `bun run build` — full monorepo build including `@koi/identity`
- [ ] Verify no-op when `channelId` is absent or no matching persona configured
- [ ] Verify hot-reload: `fs_write` to tracked persona file triggers `reload()` automatically
- [ ] Verify non-tracked or non-`fs_write` calls do NOT trigger reload