### PR TITLE
feat: add @koi/redaction (L0u) — structured log secret masking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -572,6 +572,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/redaction": {
+      "name": "@koi/redaction",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/middleware-audit": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/sandbox": {
       "name": "@koi/sandbox",
       "version": "0.0.0",
@@ -1161,6 +1174,8 @@
     "@koi/node": ["@koi/node@workspace:packages/node"],
 
     "@koi/parallel-minions": ["@koi/parallel-minions@workspace:packages/parallel-minions"],
+
+    "@koi/redaction": ["@koi/redaction@workspace:packages/redaction"],
 
     "@koi/sandbox": ["@koi/sandbox@workspace:packages/sandbox"],
 

--- a/packages/redaction/package.json
+++ b/packages/redaction/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koi/redaction",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/middleware-audit": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/redaction/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/redaction/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,177 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/redaction API surface . has stable type surface 1`] = `
+"import { Result, KoiError } from '@koi/core';
+
+/**
+ * @koi/redaction — Type definitions for structured log secret masking.
+ */
+/** A detected secret occurrence within a string value. */
+interface SecretMatch {
+    readonly text: string;
+    readonly start: number;
+    readonly end: number;
+    readonly kind: string;
+}
+/** Pattern detector — structurally compatible with PIIDetector. */
+interface SecretPattern {
+    readonly name: string;
+    readonly kind: string;
+    readonly detect: (text: string) => readonly SecretMatch[];
+}
+/** Named censor strategy for replacing detected secrets. */
+type CensorStrategy = "redact" | "mask" | "remove";
+/** Censor can be a strategy name or a custom function. */
+type Censor = CensorStrategy | ((match: SecretMatch, fieldName?: string) => string);
+/** Configuration for createRedactor(). Immutable after construction. */
+interface RedactionConfig {
+    readonly patterns: readonly SecretPattern[];
+    readonly customPatterns: readonly SecretPattern[];
+    readonly fieldNames: readonly (string | RegExp)[];
+    readonly censor: Censor;
+    readonly fieldCensor: Censor;
+    readonly maxDepth: number;
+    readonly maxStringLength: number;
+    readonly onError: ((error: unknown) => void) | undefined;
+}
+/** Result of object redaction. */
+interface RedactObjectResult<T> {
+    readonly value: T;
+    readonly changed: boolean;
+    readonly secretCount: number;
+    readonly fieldCount: number;
+}
+/** Result of string redaction. */
+interface RedactStringResult {
+    readonly text: string;
+    readonly changed: boolean;
+    readonly matchCount: number;
+}
+/** Compiled redactor — the main API surface. */
+interface Redactor {
+    readonly redactObject: <T>(value: T) => RedactObjectResult<T>;
+    readonly redactString: (text: string) => RedactStringResult;
+}
+
+/**
+ * Configuration validation + defaults for createRedactor().
+ */
+
+/** Default configuration for createRedactor(). */
+declare const DEFAULT_REDACTION_CONFIG: RedactionConfig;
+/**
+ * Validate a partial redaction config and merge with defaults.
+ * Returns a fully resolved \`RedactionConfig\` or a validation error.
+ */
+declare function validateRedactionConfig(config: unknown): Result<RedactionConfig, KoiError>;
+
+/**
+ * Anthropic API key detector — matches \`sk-ant-api03-\` and \`sk-ant-admin01-\` prefixed keys.
+ */
+
+declare function createAnthropicDetector(): SecretPattern;
+
+/**
+ * AWS Access Key ID detector — matches \`AKIA\` followed by 16 uppercase alphanumeric chars.
+ */
+
+declare function createAWSDetector(): SecretPattern;
+
+/**
+ * Basic auth detector — matches \`Basic <base64>\` in authorization headers.
+ */
+
+declare function createBasicAuthDetector(): SecretPattern;
+
+/**
+ * Bearer token detector — matches \`Bearer <token>\` in authorization headers.
+ */
+
+declare function createBearerDetector(): SecretPattern;
+
+/**
+ * Credential URI detector — matches database/service connection strings with embedded passwords.
+ * Covers: mongodb, postgres, mysql, redis, amqp (and their TLS variants).
+ */
+
+declare function createCredentialURIDetector(): SecretPattern;
+
+/**
+ * Generic secret detector — matches \`password=\`, \`api_key=\`, \`secret=\` assignment patterns
+ * in unstructured strings (log lines, config fragments, CLI output).
+ *
+ * This is the highest false-positive-risk pattern. Mitigations:
+ * - Minimum 8-char value length
+ * - Excludes known placeholder values ([REDACTED], ***, <placeholder>, etc.)
+ */
+
+declare function createGenericSecretDetector(): SecretPattern;
+
+/**
+ * GitHub token detector — matches \`ghp_\` and \`ghs_\` prefixed tokens.
+ */
+
+declare function createGitHubDetector(): SecretPattern;
+
+/**
+ * Google API key detector — matches \`AIza\` prefixed keys (Maps, Firebase, Vertex AI, Gemini).
+ */
+
+declare function createGoogleDetector(): SecretPattern;
+
+/**
+ * Pattern registry — all 13 built-in secret detectors + default sensitive field names.
+ */
+
+/** Create all 13 built-in secret pattern detectors. */
+declare function createAllSecretPatterns(): readonly SecretPattern[];
+/**
+ * Default sensitive field names for field-name-based redaction.
+ * Case-insensitive matching is applied by the field matcher.
+ */
+declare const DEFAULT_SENSITIVE_FIELDS: readonly string[];
+
+/**
+ * JWT token detector — matches base64url-encoded \`eyJ...\` three-part tokens.
+ */
+
+declare function createJWTDetector(): SecretPattern;
+
+/**
+ * OpenAI API key detector — matches \`sk-proj-\`, \`sk-svcacct-\`, \`sk-admin-\` prefixed keys.
+ */
+
+declare function createOpenAIDetector(): SecretPattern;
+
+/**
+ * PEM private key detector — matches \`-----BEGIN ... PRIVATE KEY-----\` blocks.
+ */
+
+declare function createPEMDetector(): SecretPattern;
+
+/**
+ * Slack token detector — matches \`xoxp-\`, \`xoxb-\`, \`xoxa-\`, \`xoxo-\` prefixed tokens.
+ */
+
+declare function createSlackDetector(): SecretPattern;
+
+/**
+ * Stripe key detector — matches \`sk_live_\` and \`pk_live_\` prefixed keys.
+ */
+
+declare function createStripeDetector(): SecretPattern;
+
+/**
+ * Redactor factory — compile-once, use-many secret masking engine.
+ */
+
+/**
+ * Create a compiled redactor from the given config.
+ * Validates config at construction and pre-compiles patterns and field matcher.
+ * Fail-closed: on any runtime error, returns \`[REDACTION_FAILED]\` and calls \`onError\`.
+ */
+declare function createRedactor(config?: Partial<RedactionConfig>): Redactor;
+
+export { type Censor, type CensorStrategy, DEFAULT_REDACTION_CONFIG, DEFAULT_SENSITIVE_FIELDS, type RedactObjectResult, type RedactStringResult, type RedactionConfig, type Redactor, type SecretMatch, type SecretPattern, createAWSDetector, createAllSecretPatterns, createAnthropicDetector, createBasicAuthDetector, createBearerDetector, createCredentialURIDetector, createGenericSecretDetector, createGitHubDetector, createGoogleDetector, createJWTDetector, createOpenAIDetector, createPEMDetector, createRedactor, createSlackDetector, createStripeDetector, validateRedactionConfig };
+"
+`;

--- a/packages/redaction/src/__tests__/api-surface.test.ts
+++ b/packages/redaction/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/redaction/src/__tests__/e2e.test.ts
+++ b/packages/redaction/src/__tests__/e2e.test.ts
@@ -1,0 +1,421 @@
+/**
+ * E2E test: @koi/redaction through the full L1 runtime (createKoi + createPiAdapter).
+ *
+ * Validates that @koi/redaction correctly detects and masks secrets in real
+ * LLM responses flowing through the middleware chain.
+ *
+ * Scenario:
+ *   1. Create a redactor + streaming observer middleware (wrapModelStream)
+ *   2. Prompt the LLM to echo back fake secrets embedded in the user message
+ *   3. Verify the redactor catches the secrets in the stream chunks
+ *   4. Verify redactObject works on structured event payloads
+ *   5. Verify audit lifecycle events fire with the middleware chain
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent, KoiMiddleware } from "@koi/core";
+import type {
+  ModelChunk,
+  ModelRequest,
+  ModelStreamHandler,
+  TurnContext,
+} from "@koi/core/middleware";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createAuditMiddleware, createInMemoryAuditSink } from "@koi/middleware-audit";
+import { createRedactor } from "../redactor.js";
+import type { Redactor } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Test secrets — NOT real secrets, but formatted to match pattern detectors
+// ---------------------------------------------------------------------------
+
+/** Fake JWT for detection. */
+const FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0MTIzNDU2Nzg5MCJ9.fakeSignatureValue123";
+
+/** Fake AWS access key for detection. */
+const FAKE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE";
+
+/** Fake GitHub token for detection. */
+const FAKE_GITHUB_TOKEN = `ghp_${"a1b2c3d4e5f6".repeat(3)}`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+/**
+ * Create a streaming middleware that intercepts model stream chunks using @koi/redaction.
+ * Captures raw text from text_delta chunks for post-hoc redaction assertions.
+ *
+ * Pi adapter routes through wrapModelStream (not wrapModelCall), so this is the
+ * correct hook for intercepting LLM responses in the onion chain.
+ */
+function createStreamingRedactionMiddleware(_redactor: Redactor): {
+  readonly middleware: KoiMiddleware;
+  readonly rawChunks: string[];
+  readonly streamIntercepted: boolean[];
+} {
+  const rawChunks: string[] = [];
+  const streamIntercepted: boolean[] = [];
+
+  const middleware: KoiMiddleware = {
+    name: "e2e:redaction-stream-observer",
+    priority: 450,
+
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      streamIntercepted.push(true);
+
+      for await (const chunk of next(request)) {
+        // Capture text_delta chunks for assertion
+        if (chunk.kind === "text_delta") {
+          rawChunks.push(chunk.delta);
+        }
+        yield chunk;
+      }
+    },
+  };
+
+  return { middleware, rawChunks, streamIntercepted };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: @koi/redaction through createKoi + createPiAdapter", () => {
+  test(
+    "streaming middleware intercepts LLM response and redactor catches secrets",
+    async () => {
+      const redactor = createRedactor();
+      const { middleware, rawChunks, streamIntercepted } =
+        createStreamingRedactionMiddleware(redactor);
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You are a test assistant. When given text to echo, repeat it back EXACTLY as given, character for character. Do not add any commentary.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "redaction-e2e-agent",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: piAdapter,
+        middleware: [middleware],
+        loopDetection: false,
+        limits: { maxTurns: 2, maxDurationMs: 110_000, maxTokens: 4_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: `Echo the following text exactly:\ntoken: ${FAKE_JWT}\naws_key: ${FAKE_AWS_KEY}`,
+        }),
+      );
+
+      // Verify the LLM actually responded
+      const fullText = extractText(events);
+      expect(fullText.length).toBeGreaterThan(0);
+      expect(runtime.agent.state).toBe("terminated");
+
+      // Verify streaming middleware intercepted the model stream
+      expect(streamIntercepted.length).toBeGreaterThan(0);
+      expect(rawChunks.length).toBeGreaterThan(0);
+
+      // Concatenate all captured chunks into a single string
+      const rawText = rawChunks.join("");
+
+      // Run redactString on the captured stream output
+      const scanResult = redactor.redactString(rawText);
+
+      console.log("[e2e] Stream chunks captured:", rawChunks.length);
+      console.log("[e2e] Raw text length:", rawText.length);
+      console.log("[e2e] Secrets found:", scanResult.matchCount);
+
+      // If the LLM echoed back our secrets, the redactor should catch them
+      if (rawText.includes("eyJ") || rawText.includes("AKIA")) {
+        expect(scanResult.changed).toBe(true);
+        expect(scanResult.matchCount).toBeGreaterThan(0);
+        // Redacted text should not contain original secrets
+        expect(scanResult.text).not.toContain(FAKE_JWT);
+        expect(scanResult.text).not.toContain(FAKE_AWS_KEY);
+        expect(scanResult.text).toContain("[REDACTED]");
+      }
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "audit middleware lifecycle events fire alongside redaction middleware",
+    async () => {
+      const redactor = createRedactor();
+      const auditSink = createInMemoryAuditSink();
+      const { middleware: redactionMiddleware } = createStreamingRedactionMiddleware(redactor);
+
+      // Audit middleware captures lifecycle events (session_start, session_end)
+      // and wrapModelCall/wrapToolCall. Pi adapter uses streaming so only
+      // lifecycle hooks fire on the audit middleware.
+      const auditMiddleware = createAuditMiddleware({ sink: auditSink });
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a test assistant. Repeat back any text given to you exactly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "redaction-audit-e2e",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+          middleware: [{ name: "audit" }],
+        },
+        adapter: piAdapter,
+        middleware: [redactionMiddleware, auditMiddleware],
+        loopDetection: false,
+        limits: { maxTurns: 2, maxDurationMs: 110_000, maxTokens: 4_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: `Please repeat: my token is ${FAKE_JWT}`,
+        }),
+      );
+
+      expect(runtime.agent.state).toBe("terminated");
+
+      // Allow fire-and-forget audit sink to flush
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Audit sink should have captured lifecycle events (session_start, session_end)
+      expect(auditSink.entries.length).toBeGreaterThan(0);
+
+      const kinds = auditSink.entries.map((e) => e.kind);
+      console.log("[e2e] Audit entry kinds:", kinds);
+      console.log("[e2e] Audit entries count:", auditSink.entries.length);
+
+      // Verify session lifecycle events were captured
+      expect(kinds).toContain("session_start");
+      expect(kinds).toContain("session_end");
+
+      // Verify redactString works on the serialized audit trail
+      const auditJson = JSON.stringify(auditSink.entries);
+      const auditRedacted = redactor.redactString(auditJson);
+
+      console.log("[e2e] Audit JSON length:", auditJson.length);
+      console.log("[e2e] Audit redaction changed:", auditRedacted.changed);
+
+      // The user prompt contains FAKE_JWT — if it leaked into audit, verify redaction catches it
+      if (auditJson.includes("eyJ")) {
+        expect(auditRedacted.changed).toBe(true);
+        expect(auditRedacted.text).not.toContain(FAKE_JWT);
+      }
+
+      // Verify LLM actually responded (ensures runtime was functional)
+      const fullText = extractText(events);
+      expect(fullText.length).toBeGreaterThan(0);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "redactObject handles real structured LLM event payloads",
+    async () => {
+      const redactor = createRedactor();
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a test assistant. When asked to echo, repeat the text exactly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "redaction-object-e2e",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: piAdapter,
+        loopDetection: false,
+        limits: { maxTurns: 2, maxDurationMs: 110_000, maxTokens: 4_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: `Echo: password=${FAKE_GITHUB_TOKEN} key=${FAKE_AWS_KEY}`,
+        }),
+      );
+
+      expect(runtime.agent.state).toBe("terminated");
+
+      // Build a synthetic audit-like payload using real events + injected secrets
+      const textDeltas = events.filter((e) => e.kind === "text_delta");
+      const doneEvent = events.find((e) => e.kind === "done");
+
+      const payload = {
+        events: textDeltas,
+        done: doneEvent,
+        metadata: {
+          token: FAKE_JWT,
+          password: "supersecretvalue123",
+          config: {
+            apiKey: FAKE_AWS_KEY,
+            nested: {
+              auth: `Bearer ${FAKE_JWT}`,
+            },
+          },
+        },
+      };
+
+      // Redact the entire structured payload
+      const result = redactor.redactObject(payload);
+
+      console.log("[e2e] Object redaction changed:", result.changed);
+      console.log("[e2e] Secret count:", result.secretCount);
+      console.log("[e2e] Field count:", result.fieldCount);
+
+      // Field-name matches: token, password, apiKey, auth
+      expect(result.fieldCount).toBeGreaterThanOrEqual(4);
+      expect(result.changed).toBe(true);
+
+      // Verify field-name redacted values
+      const redactedMeta = result.value.metadata;
+      expect(redactedMeta.token).toBe("[REDACTED]");
+      expect(redactedMeta.password).toBe("[REDACTED]");
+      expect(redactedMeta.config.apiKey).toBe("[REDACTED]");
+      expect(redactedMeta.config.nested.auth).toBe("[REDACTED]");
+
+      // Verify the original payload was NOT mutated (immutability)
+      expect(payload.metadata.token).toBe(FAKE_JWT);
+      expect(payload.metadata.password).toBe("supersecretvalue123");
+      expect(payload.metadata.config.apiKey).toBe(FAKE_AWS_KEY);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "redactString catches multiple secret types in concatenated LLM output",
+    async () => {
+      const redactor = createRedactor();
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You are a test assistant. When asked, output the exact text provided without modification.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "redaction-string-e2e",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: piAdapter,
+        loopDetection: false,
+        limits: { maxTurns: 2, maxDurationMs: 110_000, maxTokens: 4_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: [
+            "Output these values exactly, one per line:",
+            `JWT: ${FAKE_JWT}`,
+            `AWS: ${FAKE_AWS_KEY}`,
+            `GitHub: ${FAKE_GITHUB_TOKEN}`,
+            "Bearer: Bearer mytoken12345678",
+          ].join("\n"),
+        }),
+      );
+
+      const fullText = extractText(events);
+      expect(fullText.length).toBeGreaterThan(0);
+
+      // Run redactString on the concatenated LLM output
+      const result = redactor.redactString(fullText);
+
+      console.log("[e2e] Full LLM response length:", fullText.length);
+      console.log("[e2e] String redaction changed:", result.changed);
+      console.log("[e2e] Match count:", result.matchCount);
+      console.log("[e2e] Redacted preview:", result.text.slice(0, 200));
+
+      // Count how many secret signals appear in the raw text
+      const signals = [
+        fullText.includes("eyJ"),
+        fullText.includes("AKIA"),
+        fullText.includes("ghp_"),
+        fullText.includes("Bearer"),
+      ].filter(Boolean).length;
+
+      if (signals > 0) {
+        expect(result.changed).toBe(true);
+        expect(result.matchCount).toBeGreaterThan(0);
+
+        // Verify specific secrets are redacted
+        if (fullText.includes("eyJ")) {
+          expect(result.text).not.toContain(FAKE_JWT);
+        }
+        if (fullText.includes("AKIA")) {
+          expect(result.text).not.toContain(FAKE_AWS_KEY);
+        }
+        if (fullText.includes("ghp_")) {
+          expect(result.text).not.toContain(FAKE_GITHUB_TOKEN);
+        }
+      }
+
+      console.log("[e2e] Signals found in LLM output:", signals, "/ 4");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/redaction/src/__tests__/edge-cases.test.ts
+++ b/packages/redaction/src/__tests__/edge-cases.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { createRedactor } from "../redactor.js";
+
+describe("edge cases", () => {
+  const r = createRedactor();
+
+  test("circular references produce [Circular] placeholder", () => {
+    const obj: Record<string, unknown> = { name: "test" };
+    obj.self = obj;
+    const result = r.redactObject(obj);
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, unknown>).self).toBe("[Circular]");
+    expect((result.value as Record<string, unknown>).name).toBe("test");
+  });
+
+  test("prototype pollution keys are skipped", () => {
+    const obj = Object.create(null) as Record<string, string>;
+    obj.safe = "ok";
+    // biome-ignore lint/complexity/useLiteralKeys: testing __proto__ key specifically
+    obj["__proto__"] = "password=secret";
+    // biome-ignore lint/complexity/useLiteralKeys: testing constructor key specifically
+    obj["constructor"] = "should-not-walk";
+    const result = r.redactObject(obj);
+    // __proto__ and constructor values are preserved but not recursed into
+    expect((result.value as Record<string, string>).safe).toBe("ok");
+  });
+
+  test("deep nesting beyond maxDepth stops recursion", () => {
+    const r2 = createRedactor({ maxDepth: 2 });
+    const deep = { a: { b: { c: { password: "secret" } } } };
+    const result = r2.redactObject(deep);
+    // depth 0 -> a, depth 1 -> b, depth 2 -> c, depth 3 -> password exceeds maxDepth=2
+    const innerC = (
+      result.value as Record<string, Record<string, Record<string, Record<string, string>>>>
+    ).a?.b?.c;
+    expect(innerC?.password).toBe("secret"); // Not redacted — too deep
+  });
+
+  test("overlapping patterns resolve to longest match", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+    const text = `Bearer ${jwt}`;
+    const result = r.redactString(text);
+    expect(result.changed).toBe(true);
+    // Should be one redaction, not two
+    expect(result.matchCount).toBe(1);
+  });
+
+  test("empty string returns unchanged", () => {
+    const result = r.redactString("");
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe("");
+  });
+
+  test("null and undefined pass through unchanged", () => {
+    const resultNull = r.redactObject(null);
+    expect(resultNull.changed).toBe(false);
+    expect(resultNull.value).toBe(null);
+
+    const resultUndefined = r.redactObject(undefined);
+    expect(resultUndefined.changed).toBe(false);
+    expect(resultUndefined.value).toBe(undefined);
+  });
+
+  test("partial pattern match does not produce false positives", () => {
+    // "AKIA" prefix but not enough chars after
+    const result = r.redactString("AKIA1234");
+    expect(result.changed).toBe(false);
+  });
+
+  test("unicode in values is handled correctly", () => {
+    const obj = { password: "geheim\u00e9\u{1F512}", name: "\u{1F600} hello" };
+    const result = r.redactObject(obj);
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, string>).password).toBe("[REDACTED]");
+    expect((result.value as Record<string, string>).name).toBe("\u{1F600} hello");
+  });
+
+  test("large string exceeding maxStringLength is redacted", () => {
+    const r2 = createRedactor({ maxStringLength: 100 });
+    const longString = "a".repeat(200);
+    const result = r2.redactString(longString);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("[REDACTED_OVERSIZED]");
+  });
+
+  test("ReDoS resistance — built-in patterns complete quickly on adversarial input", () => {
+    const adversarial = "a".repeat(10_000);
+    const start = performance.now();
+    r.redactString(adversarial);
+    const elapsed = performance.now() - start;
+    // Should complete in well under 100ms even on slow hardware
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  test("mixed field-name and value-pattern on same object", () => {
+    const obj = {
+      token: "my-token-value", // field-name match
+      data: "AKIAIOSFODNN7EXAMPLE", // value-pattern match
+    };
+    const result = r.redactObject(obj);
+    expect(result.changed).toBe(true);
+    const v = result.value as Record<string, string>;
+    expect(v.token).toBe("[REDACTED]"); // field-name match
+    expect(v.data).toContain("[REDACTED]"); // value-pattern match
+    expect(result.fieldCount).toBe(1);
+    expect(result.secretCount).toBe(1);
+  });
+});

--- a/packages/redaction/src/__tests__/fixture.test.ts
+++ b/packages/redaction/src/__tests__/fixture.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createRedactor } from "../redactor.js";
+
+interface FixtureEntry {
+  readonly description: string;
+  readonly input: unknown;
+}
+
+const fixturesPath = resolve(__dirname, "fixtures/log-entries.json");
+const fixtures = JSON.parse(readFileSync(fixturesPath, "utf-8")) as readonly FixtureEntry[];
+
+const r = createRedactor();
+
+/** Safely navigate a nested unknown value. */
+function dig(value: unknown, ...keys: readonly string[]): unknown {
+  // let justified: accumulates the navigated value through the key path
+  let current: unknown = value;
+  for (const key of keys) {
+    if (current === null || current === undefined || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+describe("fixture corpus", () => {
+  test("fixture 0: API call with Bearer token — Authorization field redacted", () => {
+    const result = r.redactObject(fixtures[0]?.input);
+    expect(result.changed).toBe(true);
+    expect(dig(result.value, "request", "headers", "Authorization")).toBe("[REDACTED]");
+  });
+
+  test("fixture 1: AWS credentials — access key redacted in value", () => {
+    const result = r.redactObject(fixtures[1]?.input);
+    expect(result.changed).toBe(true);
+    const keyId = dig(result.value, "request", "config", "aws_access_key_id") as string;
+    expect(keyId).toContain("[REDACTED]");
+    expect(dig(result.value, "request", "config", "region")).toBe("us-east-1");
+  });
+
+  test("fixture 2: GitHub token in log message — value-pattern match", () => {
+    const result = r.redactObject(fixtures[2]?.input);
+    expect(result.changed).toBe(true);
+    const msg = dig(result.value, "request", "message") as string;
+    expect(msg).not.toContain("ghp_");
+  });
+
+  test("fixture 3: Mixed password field + Stripe key", () => {
+    const result = r.redactObject(fixtures[3]?.input);
+    expect(result.changed).toBe(true);
+    expect(dig(result.value, "metadata", "password")).toBe("[REDACTED]");
+    const paymentKey = dig(result.value, "metadata", "payment_key") as string;
+    expect(paymentKey).not.toContain("sk_live_");
+  });
+
+  test("fixture 4: PEM private key in response", () => {
+    const result = r.redactObject(fixtures[4]?.input);
+    expect(result.changed).toBe(true);
+    const cert = dig(result.value, "response", "certificate") as string;
+    expect(cert).not.toContain("-----BEGIN");
+  });
+
+  test("all fixtures produce changed=true", () => {
+    for (const fixture of fixtures) {
+      const result = r.redactObject(fixture.input);
+      expect(result.changed).toBe(true);
+    }
+  });
+});

--- a/packages/redaction/src/__tests__/fixtures/log-entries.json
+++ b/packages/redaction/src/__tests__/fixtures/log-entries.json
@@ -1,0 +1,64 @@
+[
+  {
+    "description": "API call with Bearer token",
+    "input": {
+      "timestamp": 1700000000,
+      "kind": "tool_call",
+      "request": {
+        "url": "https://api.example.com/users",
+        "headers": {
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": { "id": "user-1", "name": "Alice" }
+      }
+    }
+  },
+  {
+    "description": "AWS credentials in config",
+    "input": {
+      "timestamp": 1700000001,
+      "kind": "model_call",
+      "request": {
+        "config": {
+          "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+          "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          "region": "us-east-1"
+        }
+      }
+    }
+  },
+  {
+    "description": "GitHub token in log message",
+    "input": {
+      "timestamp": 1700000002,
+      "kind": "tool_call",
+      "request": {
+        "message": "Cloning repo with token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+      }
+    }
+  },
+  {
+    "description": "Mixed: password field + Stripe key in value",
+    "input": {
+      "timestamp": 1700000003,
+      "kind": "session_start",
+      "metadata": {
+        "password": "super-secret-password",
+        "payment_key": "pk_live_TESTKEY00000000000000000"
+      }
+    }
+  },
+  {
+    "description": "PEM private key in response",
+    "input": {
+      "timestamp": 1700000004,
+      "kind": "tool_call",
+      "response": {
+        "certificate": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAHudeSA/x3hB2f+2NRkJLA\n-----END RSA PRIVATE KEY-----"
+      }
+    }
+  }
+]

--- a/packages/redaction/src/__tests__/integration.test.ts
+++ b/packages/redaction/src/__tests__/integration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { createRedactor } from "../redactor.js";
+
+describe("integration: createRedactor full pipeline", () => {
+  const r = createRedactor();
+
+  test("redacts nested object with mixed secrets and field names", () => {
+    const input = {
+      user: "alice",
+      password: "my-password-123",
+      config: {
+        apiKey: `sk_live_${"x".repeat(24)}`,
+        endpoint: "https://api.example.com",
+        headers: {
+          Authorization: "Bearer abc123def456ghi789",
+          "Content-Type": "application/json",
+        },
+      },
+      logs: [
+        "Started at 10:00",
+        "Using key AKIAIOSFODNN7EXAMPLE for auth",
+        "Completed successfully",
+      ],
+    };
+
+    const result = r.redactObject(input);
+    expect(result.changed).toBe(true);
+
+    const v = result.value as Record<string, unknown>;
+    expect(v.user).toBe("alice");
+    expect(v.password).toBe("[REDACTED]");
+
+    const config = v.config as Record<string, unknown>;
+    expect(config.apiKey).toBe("[REDACTED]");
+    expect(config.endpoint).toBe("https://api.example.com");
+
+    const headers = config.headers as Record<string, string>;
+    // "Authorization" is a sensitive field name
+    expect(headers.Authorization).toBe("[REDACTED]");
+
+    const logs = v.logs as string[];
+    expect(logs[0]).toBe("Started at 10:00");
+    expect(logs[1]).toContain("[REDACTED]");
+    expect(logs[1]).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(logs[2]).toBe("Completed successfully");
+  });
+
+  test("redacts serialized JSON string with secrets", () => {
+    const json = JSON.stringify({
+      token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123",
+      data: "hello",
+    });
+    const result = r.redactString(json);
+    expect(result.changed).toBe(true);
+    expect(result.text).not.toContain("eyJ");
+  });
+
+  test("zero-config creates usable redactor", () => {
+    const r2 = createRedactor();
+    const result = r2.redactObject({ secret: "value", name: "test" });
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, string>).secret).toBe("[REDACTED]");
+    expect((result.value as Record<string, string>).name).toBe("test");
+  });
+
+  test("custom censor function receives match details", () => {
+    const r2 = createRedactor({
+      censor: (match) => `[${match.kind.toUpperCase()}_FOUND]`,
+    });
+    const result = r2.redactString("key=AKIAIOSFODNN7EXAMPLE");
+    expect(result.text).toContain("[AWS_ACCESS_KEY_FOUND]");
+  });
+
+  test("custom field censor differs from value censor", () => {
+    const r2 = createRedactor({
+      censor: "redact",
+      fieldCensor: "mask",
+    });
+    const result = r2.redactObject({
+      password: "my-long-secret",
+      data: "AKIAIOSFODNN7EXAMPLE",
+    });
+    const v = result.value as Record<string, string>;
+    expect(v.password).toBe("my-l***"); // mask
+    expect(v.data).toContain("[REDACTED]"); // redact
+  });
+
+  test("handles deeply nested structure", () => {
+    const deep = {
+      a: { b: { c: { d: { e: { password: "deep-secret" } } } } },
+    };
+    const result = r.redactObject(deep);
+    expect(result.changed).toBe(true);
+    const innerE = (
+      result.value as Record<
+        string,
+        Record<string, Record<string, Record<string, Record<string, Record<string, string>>>>>
+      >
+    ).a?.b?.c?.d?.e;
+    expect(innerE?.password).toBe("[REDACTED]");
+  });
+
+  test("handles array of objects", () => {
+    const arr = [
+      { name: "alice", token: "secret-1" },
+      { name: "bob", token: "secret-2" },
+    ];
+    const result = r.redactObject(arr);
+    expect(result.changed).toBe(true);
+    const v = result.value as Array<Record<string, string>>;
+    expect(v[0]?.token).toBe("[REDACTED]");
+    expect(v[1]?.token).toBe("[REDACTED]");
+    expect(v[0]?.name).toBe("alice");
+  });
+});

--- a/packages/redaction/src/censor.test.ts
+++ b/packages/redaction/src/censor.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { applyCensor, applyCensorToField } from "./censor.js";
+import type { SecretMatch } from "./types.js";
+
+const match: SecretMatch = {
+  text: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+  start: 0,
+  end: 33,
+  kind: "jwt",
+};
+
+describe("applyCensor", () => {
+  test("redact strategy returns [REDACTED]", () => {
+    expect(applyCensor(match, "redact")).toBe("[REDACTED]");
+  });
+
+  test("mask strategy returns first 4 chars + ***", () => {
+    expect(applyCensor(match, "mask")).toBe("eyJh***");
+  });
+
+  test("mask strategy with short text returns ***", () => {
+    const short: SecretMatch = { text: "abc", start: 0, end: 3, kind: "test" };
+    expect(applyCensor(short, "mask")).toBe("***");
+  });
+
+  test("remove strategy returns empty string", () => {
+    expect(applyCensor(match, "remove")).toBe("");
+  });
+
+  test("custom function is called with match and fieldName", () => {
+    const custom = (m: SecretMatch, field?: string): string => `<${m.kind}:${field ?? "none"}>`;
+    expect(applyCensor(match, custom, "authHeader")).toBe("<jwt:authHeader>");
+  });
+});
+
+describe("applyCensorToField", () => {
+  test("creates synthetic match and applies censor", () => {
+    expect(applyCensorToField("my-secret", "redact", "password")).toBe("[REDACTED]");
+  });
+
+  test("passes field name to custom censor", () => {
+    const custom = (_m: SecretMatch, field?: string): string => `***${field}***`;
+    expect(applyCensorToField("value", custom, "apiKey")).toBe("***apiKey***");
+  });
+});

--- a/packages/redaction/src/censor.ts
+++ b/packages/redaction/src/censor.ts
@@ -1,0 +1,52 @@
+/**
+ * Censor strategies — pure functions for replacing detected secrets.
+ */
+
+import type { Censor, CensorStrategy, SecretMatch } from "./types.js";
+
+/** Redact: replace with `[REDACTED]`. */
+function applyRedact(_match: SecretMatch): string {
+  return "[REDACTED]";
+}
+
+/** Mask: first 4 chars + `***` (preserves some info for debugging). */
+function applyMask(match: SecretMatch): string {
+  if (match.text.length <= 4) return "***";
+  return `${match.text.slice(0, 4)}***`;
+}
+
+/** Remove: strip entirely. */
+function applyRemove(_match: SecretMatch): string {
+  return "";
+}
+
+/** Dispatch a named strategy to its implementation. */
+function applyStrategy(match: SecretMatch, strategy: CensorStrategy): string {
+  switch (strategy) {
+    case "redact":
+      return applyRedact(match);
+    case "mask":
+      return applyMask(match);
+    case "remove":
+      return applyRemove(match);
+  }
+}
+
+/** Apply a censor (strategy name or custom function) to a match. */
+export function applyCensor(match: SecretMatch, censor: Censor, fieldName?: string): string {
+  if (typeof censor === "function") {
+    return censor(match, fieldName);
+  }
+  return applyStrategy(match, censor);
+}
+
+/** Apply a censor to an entire field value (field-name match). */
+export function applyCensorToField(value: string, censor: Censor, fieldName: string): string {
+  const syntheticMatch: SecretMatch = {
+    text: value,
+    start: 0,
+    end: value.length,
+    kind: "field",
+  };
+  return applyCensor(syntheticMatch, censor, fieldName);
+}

--- a/packages/redaction/src/config.test.ts
+++ b/packages/redaction/src/config.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_REDACTION_CONFIG, validateRedactionConfig } from "./config.js";
+
+describe("validateRedactionConfig", () => {
+  test("returns defaults for undefined config", () => {
+    const result = validateRedactionConfig(undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.maxDepth).toBe(10);
+      expect(result.value.maxStringLength).toBe(100_000);
+      expect(result.value.censor).toBe("redact");
+      expect(result.value.patterns.length).toBe(13);
+    }
+  });
+
+  test("returns defaults for empty object", () => {
+    const result = validateRedactionConfig({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object config", () => {
+    const result = validateRedactionConfig("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects invalid maxDepth", () => {
+    const result = validateRedactionConfig({ maxDepth: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects invalid maxStringLength", () => {
+    const result = validateRedactionConfig({ maxStringLength: 0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects invalid censor", () => {
+    const result = validateRedactionConfig({ censor: "invalid" });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects invalid fieldCensor", () => {
+    const result = validateRedactionConfig({ fieldCensor: 42 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts valid partial config", () => {
+    const result = validateRedactionConfig({
+      maxDepth: 5,
+      censor: "mask",
+      fieldNames: ["secret"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.maxDepth).toBe(5);
+      expect(result.value.censor).toBe("mask");
+      expect(result.value.fieldNames).toEqual(["secret"]);
+    }
+  });
+
+  test("accepts custom censor function", () => {
+    const result = validateRedactionConfig({
+      censor: () => "***",
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("DEFAULT_REDACTION_CONFIG", () => {
+  test("has 13 patterns", () => {
+    expect(DEFAULT_REDACTION_CONFIG.patterns.length).toBe(13);
+  });
+
+  test("has default sensitive fields", () => {
+    expect(DEFAULT_REDACTION_CONFIG.fieldNames.length).toBeGreaterThan(20);
+  });
+
+  test("uses redact censor", () => {
+    expect(DEFAULT_REDACTION_CONFIG.censor).toBe("redact");
+  });
+});

--- a/packages/redaction/src/config.ts
+++ b/packages/redaction/src/config.ts
@@ -1,0 +1,151 @@
+/**
+ * Configuration validation + defaults for createRedactor().
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { createAllSecretPatterns, DEFAULT_SENSITIVE_FIELDS } from "./patterns/index.js";
+import type { RedactionConfig } from "./types.js";
+
+/** Default configuration for createRedactor(). */
+export const DEFAULT_REDACTION_CONFIG: RedactionConfig = {
+  patterns: createAllSecretPatterns(),
+  customPatterns: [],
+  fieldNames: DEFAULT_SENSITIVE_FIELDS,
+  censor: "redact",
+  fieldCensor: "redact",
+  maxDepth: 10,
+  maxStringLength: 100_000,
+  onError: undefined,
+};
+
+/** Maximum time (ms) allowed for a custom pattern to execute against adversarial input. */
+const REDOS_THRESHOLD_MS = 5;
+
+/** Adversarial inputs for ReDoS detection — multiple patterns to catch diverse backtracking triggers. */
+const ADVERSARIAL_INPUTS = [
+  "a".repeat(50),
+  "a]a]a]a]a]a]a]a]a]a]".repeat(5),
+  `-----BEGIN a PRIVATE KEY-----${"x".repeat(50)}`,
+  `eyJ${".".repeat(50)}`,
+] as const;
+
+/**
+ * Validate a partial redaction config and merge with defaults.
+ * Returns a fully resolved `RedactionConfig` or a validation error.
+ */
+export function validateRedactionConfig(config: unknown): Result<RedactionConfig, KoiError> {
+  if (config !== undefined && config !== null && typeof config !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "RedactionConfig must be an object or undefined",
+        retryable: false,
+      },
+    };
+  }
+
+  const raw = (config ?? {}) as Record<string, unknown>;
+
+  // Validate maxDepth
+  if (raw.maxDepth !== undefined) {
+    if (typeof raw.maxDepth !== "number" || raw.maxDepth < 1) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "maxDepth must be a positive number",
+          retryable: false,
+        },
+      };
+    }
+  }
+
+  // Validate maxStringLength
+  if (raw.maxStringLength !== undefined) {
+    if (typeof raw.maxStringLength !== "number" || raw.maxStringLength < 1) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "maxStringLength must be a positive number",
+          retryable: false,
+        },
+      };
+    }
+  }
+
+  // Validate censor
+  if (raw.censor !== undefined) {
+    const c = raw.censor;
+    if (typeof c !== "function" && c !== "redact" && c !== "mask" && c !== "remove") {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: 'censor must be "redact", "mask", "remove", or a function',
+          retryable: false,
+        },
+      };
+    }
+  }
+
+  // Validate fieldCensor
+  if (raw.fieldCensor !== undefined) {
+    const fc = raw.fieldCensor;
+    if (typeof fc !== "function" && fc !== "redact" && fc !== "mask" && fc !== "remove") {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: 'fieldCensor must be "redact", "mask", "remove", or a function',
+          retryable: false,
+        },
+      };
+    }
+  }
+
+  const merged: RedactionConfig = {
+    patterns: Array.isArray(raw.patterns)
+      ? (raw.patterns as RedactionConfig["patterns"])
+      : DEFAULT_REDACTION_CONFIG.patterns,
+    customPatterns: Array.isArray(raw.customPatterns)
+      ? (raw.customPatterns as RedactionConfig["customPatterns"])
+      : DEFAULT_REDACTION_CONFIG.customPatterns,
+    fieldNames: Array.isArray(raw.fieldNames)
+      ? (raw.fieldNames as RedactionConfig["fieldNames"])
+      : DEFAULT_REDACTION_CONFIG.fieldNames,
+    censor:
+      (raw.censor as RedactionConfig["censor"] | undefined) ?? DEFAULT_REDACTION_CONFIG.censor,
+    fieldCensor:
+      (raw.fieldCensor as RedactionConfig["fieldCensor"] | undefined) ??
+      DEFAULT_REDACTION_CONFIG.fieldCensor,
+    maxDepth: (raw.maxDepth as number | undefined) ?? DEFAULT_REDACTION_CONFIG.maxDepth,
+    maxStringLength:
+      (raw.maxStringLength as number | undefined) ?? DEFAULT_REDACTION_CONFIG.maxStringLength,
+    onError: (raw.onError as RedactionConfig["onError"]) ?? DEFAULT_REDACTION_CONFIG.onError,
+  };
+
+  // ReDoS safety check for custom patterns — always runs (fail-closed)
+  for (const pattern of merged.customPatterns) {
+    for (const adversarial of ADVERSARIAL_INPUTS) {
+      const start = performance.now();
+      pattern.detect(adversarial);
+      const elapsed = performance.now() - start;
+      if (elapsed > REDOS_THRESHOLD_MS) {
+        const message = `Custom pattern "${pattern.name}" took ${elapsed.toFixed(1)}ms on adversarial input — possible ReDoS`;
+        merged.onError?.(new Error(message));
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION" as const,
+            message,
+            retryable: false,
+          },
+        };
+      }
+    }
+  }
+
+  return { ok: true, value: merged };
+}

--- a/packages/redaction/src/field-match.test.ts
+++ b/packages/redaction/src/field-match.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { createFieldMatcher } from "./field-match.js";
+
+describe("createFieldMatcher", () => {
+  test("returns false for empty fieldNames", () => {
+    const matcher = createFieldMatcher([]);
+    expect(matcher("password")).toBe(false);
+    expect(matcher("anything")).toBe(false);
+  });
+
+  test("matches exact strings case-insensitively", () => {
+    const matcher = createFieldMatcher(["password", "apiKey"]);
+    expect(matcher("password")).toBe(true);
+    expect(matcher("PASSWORD")).toBe(true);
+    expect(matcher("Password")).toBe(true);
+    expect(matcher("apiKey")).toBe(true);
+    expect(matcher("APIKEY")).toBe(true);
+    expect(matcher("username")).toBe(false);
+  });
+
+  test("matches regex patterns", () => {
+    const matcher = createFieldMatcher([/^secret_/i]);
+    expect(matcher("secret_key")).toBe(true);
+    expect(matcher("SECRET_TOKEN")).toBe(true);
+    expect(matcher("my_secret")).toBe(false);
+  });
+
+  test("matches mixed exact + regex", () => {
+    const matcher = createFieldMatcher(["token", /^x-api-/i]);
+    expect(matcher("token")).toBe(true);
+    expect(matcher("x-api-key")).toBe(true);
+    expect(matcher("other")).toBe(false);
+  });
+
+  test("exact match takes priority (fast path)", () => {
+    const matcher = createFieldMatcher(["password"]);
+    // Should match via Set.has — O(1)
+    expect(matcher("password")).toBe(true);
+    expect(matcher("not-password")).toBe(false);
+  });
+});

--- a/packages/redaction/src/field-match.ts
+++ b/packages/redaction/src/field-match.ts
@@ -1,0 +1,42 @@
+/**
+ * Field-name matching — Set<string> (exact, case-insensitive) + RegExp[] fallback.
+ */
+
+/** A compiled field matcher — returns true if the key is sensitive. */
+export type FieldMatcher = (key: string) => boolean;
+
+/** Always-false matcher for the no-fieldNames case. */
+const NEVER_MATCH: FieldMatcher = () => false;
+
+/**
+ * Create a field matcher from a list of exact strings and RegExp patterns.
+ * Strings are matched case-insensitively via Set. RegExps are tested sequentially.
+ */
+export function createFieldMatcher(fieldNames: readonly (string | RegExp)[]): FieldMatcher {
+  if (fieldNames.length === 0) return NEVER_MATCH;
+
+  const exactSet = new Set<string>();
+  const regexps: RegExp[] = [];
+
+  for (const name of fieldNames) {
+    if (typeof name === "string") {
+      exactSet.add(name.toLowerCase());
+    } else {
+      regexps.push(name);
+    }
+  }
+
+  // Fast path: only exact matches
+  if (regexps.length === 0) {
+    return (key: string): boolean => exactSet.has(key.toLowerCase());
+  }
+
+  // Combined path: exact O(1) + regex O(n)
+  return (key: string): boolean => {
+    if (exactSet.has(key.toLowerCase())) return true;
+    for (const re of regexps) {
+      if (re.test(key)) return true;
+    }
+    return false;
+  };
+}

--- a/packages/redaction/src/index.ts
+++ b/packages/redaction/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @koi/redaction — Structured log secret masking (L0u utility).
+ *
+ * Provides a compile-once redaction engine with 13 built-in secret pattern
+ * detectors, field-name matching, and both structured + serialized APIs.
+ */
+
+// Config
+export { DEFAULT_REDACTION_CONFIG, validateRedactionConfig } from "./config.js";
+export { createAnthropicDetector } from "./patterns/anthropic.js";
+export { createAWSDetector } from "./patterns/aws.js";
+export { createBasicAuthDetector } from "./patterns/basic-auth.js";
+export { createBearerDetector } from "./patterns/bearer.js";
+export { createCredentialURIDetector } from "./patterns/credential-uri.js";
+export { createGenericSecretDetector } from "./patterns/generic-secret.js";
+export { createGitHubDetector } from "./patterns/github.js";
+export { createGoogleDetector } from "./patterns/google.js";
+// Pattern factories (for custom composition)
+export { createAllSecretPatterns, DEFAULT_SENSITIVE_FIELDS } from "./patterns/index.js";
+export { createJWTDetector } from "./patterns/jwt.js";
+export { createOpenAIDetector } from "./patterns/openai.js";
+export { createPEMDetector } from "./patterns/pem.js";
+export { createSlackDetector } from "./patterns/slack.js";
+export { createStripeDetector } from "./patterns/stripe.js";
+// Factory (main entry point)
+export { createRedactor } from "./redactor.js";
+// Types
+export type {
+  Censor,
+  CensorStrategy,
+  RedactionConfig,
+  RedactObjectResult,
+  Redactor,
+  RedactStringResult,
+  SecretMatch,
+  SecretPattern,
+} from "./types.js";

--- a/packages/redaction/src/patterns/anthropic.ts
+++ b/packages/redaction/src/patterns/anthropic.ts
@@ -1,0 +1,19 @@
+/**
+ * Anthropic API key detector — matches `sk-ant-api03-` and `sk-ant-admin01-` prefixed keys.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const ANTHROPIC_PATTERN = /sk-ant-(?:api03|admin01)-[A-Za-z0-9_-]{80,100}/g;
+
+export function createAnthropicDetector(): SecretPattern {
+  return {
+    name: "anthropic_api_key",
+    kind: "anthropic_api_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("sk-ant-")) return EMPTY_MATCHES;
+      return collectMatches(text, ANTHROPIC_PATTERN, "anthropic_api_key");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/aws.ts
+++ b/packages/redaction/src/patterns/aws.ts
@@ -1,0 +1,19 @@
+/**
+ * AWS Access Key ID detector — matches `AKIA` followed by 16 uppercase alphanumeric chars.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const AWS_PATTERN = /AKIA[0-9A-Z]{16}/g;
+
+export function createAWSDetector(): SecretPattern {
+  return {
+    name: "aws_access_key",
+    kind: "aws_access_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("AKIA")) return EMPTY_MATCHES;
+      return collectMatches(text, AWS_PATTERN, "aws_access_key");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/basic-auth.ts
+++ b/packages/redaction/src/patterns/basic-auth.ts
@@ -1,0 +1,20 @@
+/**
+ * Basic auth detector — matches `Basic <base64>` in authorization headers.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+// Minimum 8-char base64 to avoid false positives like "Basic example..."
+const BASIC_PATTERN = /Basic\s+[A-Za-z0-9+/]{8,}=*/g;
+
+export function createBasicAuthDetector(): SecretPattern {
+  return {
+    name: "basic_auth",
+    kind: "basic_auth",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("Basic")) return EMPTY_MATCHES;
+      return collectMatches(text, BASIC_PATTERN, "basic_auth");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/bearer.ts
+++ b/packages/redaction/src/patterns/bearer.ts
@@ -1,0 +1,20 @@
+/**
+ * Bearer token detector — matches `Bearer <token>` in authorization headers.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+// Minimum 8-char token to avoid false positives like "Bearer in mind that..."
+const BEARER_PATTERN = /Bearer\s+[A-Za-z0-9\-._~+/]{8,}=*/g;
+
+export function createBearerDetector(): SecretPattern {
+  return {
+    name: "bearer_token",
+    kind: "bearer_token",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("Bearer")) return EMPTY_MATCHES;
+      return collectMatches(text, BEARER_PATTERN, "bearer_token");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/collect.ts
+++ b/packages/redaction/src/patterns/collect.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared regex match collection utility for secret pattern detectors.
+ */
+
+import type { SecretMatch } from "../types.js";
+
+/** Pre-allocated empty array for zero-allocation fast paths. */
+export const EMPTY_MATCHES: readonly SecretMatch[] = [];
+
+/**
+ * Collect all regex matches in a string, optionally validating each.
+ * Resets lastIndex before scanning for safe reuse of global regexps.
+ */
+export function collectMatches(
+  text: string,
+  pattern: RegExp,
+  kind: string,
+  validate?: (match: string) => boolean,
+): readonly SecretMatch[] {
+  const results: SecretMatch[] = [];
+  pattern.lastIndex = 0;
+
+  // let justified: regex exec loop variable
+  let m: RegExpExecArray | null = pattern.exec(text);
+  while (m !== null) {
+    const matchText = m[0];
+    if (validate === undefined || validate(matchText)) {
+      results.push({
+        text: matchText,
+        start: m.index,
+        end: m.index + matchText.length,
+        kind,
+      });
+    }
+    m = pattern.exec(text);
+  }
+  return results.length === 0 ? EMPTY_MATCHES : results;
+}

--- a/packages/redaction/src/patterns/credential-uri.ts
+++ b/packages/redaction/src/patterns/credential-uri.ts
@@ -1,0 +1,42 @@
+/**
+ * Credential URI detector — matches database/service connection strings with embedded passwords.
+ * Covers: mongodb, postgres, mysql, redis, amqp (and their TLS variants).
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const CREDENTIAL_URI_PATTERN =
+  /(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|rediss?|amqps?):\/\/[^\s:]+:[^\s@]+@[^\s]+/gi;
+
+/** Known database/service URI scheme prefixes for fast-path check. */
+const SIGNAL_PREFIXES = [
+  "mongodb://",
+  "mongodb+srv://",
+  "postgres://",
+  "postgresql://",
+  "mysql://",
+  "redis://",
+  "rediss://",
+  "amqp://",
+  "amqps://",
+] as const;
+
+function hasSignal(text: string): boolean {
+  const lower = text.toLowerCase();
+  for (const prefix of SIGNAL_PREFIXES) {
+    if (lower.includes(prefix)) return true;
+  }
+  return false;
+}
+
+export function createCredentialURIDetector(): SecretPattern {
+  return {
+    name: "credential_uri",
+    kind: "credential_uri",
+    detect(text: string): readonly SecretMatch[] {
+      if (!hasSignal(text)) return EMPTY_MATCHES;
+      return collectMatches(text, CREDENTIAL_URI_PATTERN, "credential_uri");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/generic-secret.ts
+++ b/packages/redaction/src/patterns/generic-secret.ts
@@ -1,0 +1,89 @@
+/**
+ * Generic secret detector — matches `password=`, `api_key=`, `secret=` assignment patterns
+ * in unstructured strings (log lines, config fragments, CLI output).
+ *
+ * This is the highest false-positive-risk pattern. Mitigations:
+ * - Minimum 8-char value length
+ * - Excludes known placeholder values ([REDACTED], ***, <placeholder>, etc.)
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { EMPTY_MATCHES } from "./collect.js";
+
+const GENERIC_PATTERN =
+  /(?:password|passwd|pwd|secret|api_?key|token|auth_?token|access_?key|private_?key|client_?secret)[\s]*[=:]\s*['"]?([^\s'"]{8,120})/gi;
+
+/** Signal keywords — lowercase for case-insensitive check. */
+const SIGNAL_KEYWORDS = [
+  "password",
+  "passwd",
+  "pwd",
+  "secret",
+  "apikey",
+  "api_key",
+  "token",
+  "auth_token",
+  "authtoken",
+  "access_key",
+  "accesskey",
+  "private_key",
+  "privatekey",
+  "client_secret",
+  "clientsecret",
+] as const;
+
+/** Values that are clearly not real secrets. */
+const PLACEHOLDER_VALUES = new Set([
+  "[redacted]",
+  "[redacted_oversized]",
+  "[redaction_failed]",
+  "***",
+  "****",
+  "*****",
+  "<placeholder>",
+  "<secret>",
+  "<password>",
+  "changeme",
+  "password",
+  "example",
+  "xxxxxxxx",
+]);
+
+function hasSignal(text: string): boolean {
+  const lower = text.toLowerCase();
+  for (const keyword of SIGNAL_KEYWORDS) {
+    if (lower.includes(keyword)) return true;
+  }
+  return false;
+}
+
+export function createGenericSecretDetector(): SecretPattern {
+  return {
+    name: "generic_secret",
+    kind: "generic_secret",
+    detect(text: string): readonly SecretMatch[] {
+      if (!hasSignal(text)) return EMPTY_MATCHES;
+
+      const results: SecretMatch[] = [];
+      GENERIC_PATTERN.lastIndex = 0;
+
+      // let justified: regex exec loop variable
+      let m: RegExpExecArray | null = GENERIC_PATTERN.exec(text);
+      while (m !== null) {
+        const capturedValue = m[1];
+        // Skip placeholder/dummy values
+        if (capturedValue !== undefined && !PLACEHOLDER_VALUES.has(capturedValue.toLowerCase())) {
+          results.push({
+            text: m[0],
+            start: m.index,
+            end: m.index + m[0].length,
+            kind: "generic_secret",
+          });
+        }
+        m = GENERIC_PATTERN.exec(text);
+      }
+
+      return results.length === 0 ? EMPTY_MATCHES : results;
+    },
+  };
+}

--- a/packages/redaction/src/patterns/github.ts
+++ b/packages/redaction/src/patterns/github.ts
@@ -1,0 +1,19 @@
+/**
+ * GitHub token detector — matches `ghp_` and `ghs_` prefixed tokens.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const GITHUB_PATTERN = /gh[ps]_[A-Za-z0-9_]{36,}/g;
+
+export function createGitHubDetector(): SecretPattern {
+  return {
+    name: "github_token",
+    kind: "github_token",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("ghp_") && !text.includes("ghs_")) return EMPTY_MATCHES;
+      return collectMatches(text, GITHUB_PATTERN, "github_token");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/google.ts
+++ b/packages/redaction/src/patterns/google.ts
@@ -1,0 +1,19 @@
+/**
+ * Google API key detector — matches `AIza` prefixed keys (Maps, Firebase, Vertex AI, Gemini).
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const GOOGLE_PATTERN = /AIza[0-9A-Za-z\-_]{35}/g;
+
+export function createGoogleDetector(): SecretPattern {
+  return {
+    name: "google_api_key",
+    kind: "google_api_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("AIza")) return EMPTY_MATCHES;
+      return collectMatches(text, GOOGLE_PATTERN, "google_api_key");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/index.ts
+++ b/packages/redaction/src/patterns/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Pattern registry — all 13 built-in secret detectors + default sensitive field names.
+ */
+
+import type { SecretPattern } from "../types.js";
+import { createAnthropicDetector } from "./anthropic.js";
+import { createAWSDetector } from "./aws.js";
+import { createBasicAuthDetector } from "./basic-auth.js";
+import { createBearerDetector } from "./bearer.js";
+import { createCredentialURIDetector } from "./credential-uri.js";
+import { createGenericSecretDetector } from "./generic-secret.js";
+import { createGitHubDetector } from "./github.js";
+import { createGoogleDetector } from "./google.js";
+import { createJWTDetector } from "./jwt.js";
+import { createOpenAIDetector } from "./openai.js";
+import { createPEMDetector } from "./pem.js";
+import { createSlackDetector } from "./slack.js";
+import { createStripeDetector } from "./stripe.js";
+
+/** Create all 13 built-in secret pattern detectors. */
+export function createAllSecretPatterns(): readonly SecretPattern[] {
+  return [
+    createJWTDetector(),
+    createAWSDetector(),
+    createOpenAIDetector(),
+    createAnthropicDetector(),
+    createGoogleDetector(),
+    createGitHubDetector(),
+    createSlackDetector(),
+    createStripeDetector(),
+    createPEMDetector(),
+    createBearerDetector(),
+    createBasicAuthDetector(),
+    createCredentialURIDetector(),
+    createGenericSecretDetector(),
+  ];
+}
+
+/**
+ * Default sensitive field names for field-name-based redaction.
+ * Case-insensitive matching is applied by the field matcher.
+ */
+export const DEFAULT_SENSITIVE_FIELDS: readonly string[] = [
+  "password",
+  "passwd",
+  "pwd",
+  "secret",
+  "token",
+  "apiKey",
+  "api_key",
+  "apikey",
+  "authorization",
+  "auth",
+  "credential",
+  "private_key",
+  "privateKey",
+  "access_token",
+  "accessToken",
+  "refresh_token",
+  "refreshToken",
+  "client_secret",
+  "clientSecret",
+  "session_id",
+  "sessionId",
+  "ssn",
+  "credit_card",
+  "creditCard",
+  "cvv",
+  "pin",
+  "encryption_key",
+  "encryptionKey",
+  "connection_string",
+  "connectionString",
+  "aws_secret_access_key",
+  "awsSecretAccessKey",
+  "database_url",
+  "databaseUrl",
+];

--- a/packages/redaction/src/patterns/jwt.ts
+++ b/packages/redaction/src/patterns/jwt.ts
@@ -1,0 +1,19 @@
+/**
+ * JWT token detector — matches base64url-encoded `eyJ...` three-part tokens.
+ */
+
+import type { SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g;
+
+export function createJWTDetector(): SecretPattern {
+  return {
+    name: "jwt",
+    kind: "jwt",
+    detect(text: string): readonly import("../types.js").SecretMatch[] {
+      if (!text.includes("eyJ")) return EMPTY_MATCHES;
+      return collectMatches(text, JWT_PATTERN, "jwt");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/openai.ts
+++ b/packages/redaction/src/patterns/openai.ts
@@ -1,0 +1,25 @@
+/**
+ * OpenAI API key detector — matches `sk-proj-`, `sk-svcacct-`, `sk-admin-` prefixed keys.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+// Modern project/service-account/admin keys
+const OPENAI_PATTERN = /sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,180}/g;
+
+export function createOpenAIDetector(): SecretPattern {
+  return {
+    name: "openai_api_key",
+    kind: "openai_api_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (
+        !text.includes("sk-proj-") &&
+        !text.includes("sk-svcacct-") &&
+        !text.includes("sk-admin-")
+      )
+        return EMPTY_MATCHES;
+      return collectMatches(text, OPENAI_PATTERN, "openai_api_key");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/patterns.test.ts
+++ b/packages/redaction/src/patterns/patterns.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from "bun:test";
+import { createAnthropicDetector } from "./anthropic.js";
+import { createAWSDetector } from "./aws.js";
+import { createBasicAuthDetector } from "./basic-auth.js";
+import { createBearerDetector } from "./bearer.js";
+import { createCredentialURIDetector } from "./credential-uri.js";
+import { createGenericSecretDetector } from "./generic-secret.js";
+import { createGitHubDetector } from "./github.js";
+import { createGoogleDetector } from "./google.js";
+import { createAllSecretPatterns, DEFAULT_SENSITIVE_FIELDS } from "./index.js";
+import { createJWTDetector } from "./jwt.js";
+import { createOpenAIDetector } from "./openai.js";
+import { createPEMDetector } from "./pem.js";
+import { createSlackDetector } from "./slack.js";
+import { createStripeDetector } from "./stripe.js";
+
+describe("createJWTDetector", () => {
+  const detector = createJWTDetector();
+
+  test("detects JWT token", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+    const matches = detector.detect(jwt);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("jwt");
+  });
+
+  test("returns empty for text without signal", () => {
+    expect(detector.detect("no tokens here")).toEqual([]);
+  });
+
+  test("detects multiple JWTs", () => {
+    const text = "first=eyJhbGciOiJIUzI1NiJ9.eyJhIn0.sig1 second=eyJhbGciOiJSUzI1NiJ9.eyJiIn0.sig2";
+    const matches = detector.detect(text);
+    expect(matches.length).toBe(2);
+  });
+});
+
+describe("createAWSDetector", () => {
+  const detector = createAWSDetector();
+
+  test("detects AWS access key", () => {
+    const matches = detector.detect("AKIAIOSFODNN7EXAMPLE");
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("aws_access_key");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("not an AWS key")).toEqual([]);
+  });
+});
+
+describe("createGitHubDetector", () => {
+  const detector = createGitHubDetector();
+
+  test("detects GitHub personal access token", () => {
+    const token = `ghp_${"a".repeat(36)}`;
+    const matches = detector.detect(token);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("github_token");
+  });
+
+  test("detects GitHub server token", () => {
+    const token = `ghs_${"B".repeat(36)}`;
+    const matches = detector.detect(token);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no github tokens")).toEqual([]);
+  });
+});
+
+describe("createSlackDetector", () => {
+  const detector = createSlackDetector();
+
+  test("detects Slack bot token", () => {
+    const token = "xoxb-1234567890-abcdefgh";
+    const matches = detector.detect(token);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("slack_token");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no slack tokens")).toEqual([]);
+  });
+});
+
+describe("createStripeDetector", () => {
+  const detector = createStripeDetector();
+
+  test("detects Stripe secret key", () => {
+    const key = `sk_live_${"a".repeat(24)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("stripe_key");
+  });
+
+  test("detects Stripe publishable key", () => {
+    const key = `pk_live_${"b".repeat(24)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no stripe keys")).toEqual([]);
+  });
+});
+
+describe("createPEMDetector", () => {
+  const detector = createPEMDetector();
+
+  test("detects PEM private key", () => {
+    const pem =
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAHudeSA/x3hB2f+2NRkJLA\n-----END RSA PRIVATE KEY-----";
+    const matches = detector.detect(pem);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("pem_private_key");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no PEM keys")).toEqual([]);
+  });
+});
+
+describe("createBearerDetector", () => {
+  const detector = createBearerDetector();
+
+  test("detects Bearer token", () => {
+    const matches = detector.detect("Bearer abc123def456");
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("bearer_token");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no bearer tokens")).toEqual([]);
+  });
+});
+
+describe("createBasicAuthDetector", () => {
+  const detector = createBasicAuthDetector();
+
+  test("detects Basic auth header", () => {
+    const matches = detector.detect("Basic dXNlcjpwYXNz");
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("basic_auth");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no basic auth")).toEqual([]);
+  });
+});
+
+describe("createOpenAIDetector", () => {
+  const detector = createOpenAIDetector();
+
+  test("detects sk-proj- key", () => {
+    const key = `sk-proj-${"a".repeat(40)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("openai_api_key");
+  });
+
+  test("detects sk-svcacct- key", () => {
+    const key = `sk-svcacct-${"b".repeat(40)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+  });
+
+  test("detects sk-admin- key", () => {
+    const key = `sk-admin-${"c".repeat(40)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no openai keys")).toEqual([]);
+  });
+
+  test("ignores too-short value after prefix", () => {
+    expect(detector.detect("sk-proj-short")).toEqual([]);
+  });
+});
+
+describe("createAnthropicDetector", () => {
+  const detector = createAnthropicDetector();
+
+  test("detects sk-ant-api03- key", () => {
+    const key = `sk-ant-api03-${"a".repeat(90)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("anthropic_api_key");
+  });
+
+  test("detects sk-ant-admin01- key", () => {
+    const key = `sk-ant-admin01-${"b".repeat(90)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no anthropic keys")).toEqual([]);
+  });
+
+  test("ignores too-short value after prefix", () => {
+    // Needs 80-100 chars after prefix
+    expect(detector.detect(`sk-ant-api03-${"x".repeat(10)}`)).toEqual([]);
+  });
+});
+
+describe("createGoogleDetector", () => {
+  const detector = createGoogleDetector();
+
+  test("detects Google API key", () => {
+    const key = `AIza${"a".repeat(35)}`;
+    const matches = detector.detect(key);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("google_api_key");
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("no google keys")).toEqual([]);
+  });
+
+  test("ignores too-short value after prefix", () => {
+    expect(detector.detect("AIza_short")).toEqual([]);
+  });
+});
+
+describe("createCredentialURIDetector", () => {
+  const detector = createCredentialURIDetector();
+
+  test("detects MongoDB connection string", () => {
+    const uri = "mongodb://admin:s3cret@db.example.com:27017/mydb";
+    const matches = detector.detect(uri);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("credential_uri");
+  });
+
+  test("detects PostgreSQL connection string", () => {
+    const uri = "postgresql://user:pass@localhost:5432/db";
+    const matches = detector.detect(uri);
+    expect(matches.length).toBe(1);
+  });
+
+  test("detects Redis connection string", () => {
+    const uri = "redis://default:mypassword@cache.example.com:6379";
+    const matches = detector.detect(uri);
+    expect(matches.length).toBe(1);
+  });
+
+  test("detects MongoDB+SRV", () => {
+    const uri = "mongodb+srv://user:pass@cluster.example.com/db";
+    const matches = detector.detect(uri);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal", () => {
+    expect(detector.detect("https://example.com")).toEqual([]);
+  });
+
+  test("ignores URI without credentials", () => {
+    // No user:pass@ portion — pattern requires credentials
+    expect(detector.detect("mongodb://localhost:27017/db")).toEqual([]);
+  });
+});
+
+describe("createGenericSecretDetector", () => {
+  const detector = createGenericSecretDetector();
+
+  test("detects password= assignment", () => {
+    const text = "password=my_super_secret_value";
+    const matches = detector.detect(text);
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.kind).toBe("generic_secret");
+  });
+
+  test("detects api_key: assignment", () => {
+    const text = 'api_key: "abcdefghij1234567890"';
+    const matches = detector.detect(text);
+    expect(matches.length).toBe(1);
+  });
+
+  test("detects token= with quotes", () => {
+    const text = "token='longvalue_abcdefgh'";
+    const matches = detector.detect(text);
+    expect(matches.length).toBe(1);
+  });
+
+  test("returns empty without signal keyword", () => {
+    expect(detector.detect("username=admin")).toEqual([]);
+  });
+
+  test("ignores placeholder values", () => {
+    expect(detector.detect("password=[REDACTED]")).toEqual([]);
+    expect(detector.detect("password=changeme")).toEqual([]);
+    expect(detector.detect("password=xxxxxxxx")).toEqual([]);
+  });
+
+  test("ignores short values (< 8 chars)", () => {
+    expect(detector.detect("password=short")).toEqual([]);
+  });
+
+  test("detects multiple assignments", () => {
+    const text = "password=abcdefghij token=klmnopqrst";
+    const matches = detector.detect(text);
+    expect(matches.length).toBe(2);
+  });
+});
+
+describe("createAllSecretPatterns", () => {
+  test("returns 13 patterns", () => {
+    const patterns = createAllSecretPatterns();
+    expect(patterns.length).toBe(13);
+  });
+
+  test("all patterns have name and kind", () => {
+    for (const p of createAllSecretPatterns()) {
+      expect(p.name).toBeTruthy();
+      expect(p.kind).toBeTruthy();
+      expect(typeof p.detect).toBe("function");
+    }
+  });
+});
+
+describe("DEFAULT_SENSITIVE_FIELDS", () => {
+  test("contains password", () => {
+    expect(DEFAULT_SENSITIVE_FIELDS).toContain("password");
+  });
+
+  test("contains apiKey", () => {
+    expect(DEFAULT_SENSITIVE_FIELDS).toContain("apiKey");
+  });
+
+  test("has at least 25 entries", () => {
+    expect(DEFAULT_SENSITIVE_FIELDS.length).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/packages/redaction/src/patterns/pem.ts
+++ b/packages/redaction/src/patterns/pem.ts
@@ -1,0 +1,21 @@
+/**
+ * PEM private key detector — matches `-----BEGIN ... PRIVATE KEY-----` blocks.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+// Constrained character class avoids catastrophic backtracking on large inputs without END marker.
+const PEM_PATTERN =
+  /-----BEGIN[A-Z ]+PRIVATE KEY-----[A-Za-z0-9+/=\s]{1,10000}-----END[A-Z ]+PRIVATE KEY-----/g;
+
+export function createPEMDetector(): SecretPattern {
+  return {
+    name: "pem_private_key",
+    kind: "pem_private_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("-----BEGIN")) return EMPTY_MATCHES;
+      return collectMatches(text, PEM_PATTERN, "pem_private_key");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/slack.ts
+++ b/packages/redaction/src/patterns/slack.ts
@@ -1,0 +1,25 @@
+/**
+ * Slack token detector — matches `xoxp-`, `xoxb-`, `xoxa-`, `xoxo-` prefixed tokens.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const SLACK_PATTERN = /xox[pboa]-[0-9]{10,}-[a-zA-Z0-9-]+/g;
+
+export function createSlackDetector(): SecretPattern {
+  return {
+    name: "slack_token",
+    kind: "slack_token",
+    detect(text: string): readonly SecretMatch[] {
+      if (
+        !text.includes("xoxp-") &&
+        !text.includes("xoxb-") &&
+        !text.includes("xoxa-") &&
+        !text.includes("xoxo-")
+      )
+        return EMPTY_MATCHES;
+      return collectMatches(text, SLACK_PATTERN, "slack_token");
+    },
+  };
+}

--- a/packages/redaction/src/patterns/stripe.ts
+++ b/packages/redaction/src/patterns/stripe.ts
@@ -1,0 +1,19 @@
+/**
+ * Stripe key detector — matches `sk_live_` and `pk_live_` prefixed keys.
+ */
+
+import type { SecretMatch, SecretPattern } from "../types.js";
+import { collectMatches, EMPTY_MATCHES } from "./collect.js";
+
+const STRIPE_PATTERN = /[sp]k_live_[0-9a-zA-Z]{24,}/g;
+
+export function createStripeDetector(): SecretPattern {
+  return {
+    name: "stripe_key",
+    kind: "stripe_key",
+    detect(text: string): readonly SecretMatch[] {
+      if (!text.includes("sk_live_") && !text.includes("pk_live_")) return EMPTY_MATCHES;
+      return collectMatches(text, STRIPE_PATTERN, "stripe_key");
+    },
+  };
+}

--- a/packages/redaction/src/redaction.bench.ts
+++ b/packages/redaction/src/redaction.bench.ts
@@ -1,0 +1,66 @@
+/**
+ * @koi/redaction — Performance benchmarks.
+ *
+ * Run with: bun run src/redaction.bench.ts
+ */
+
+import { createRedactor } from "./redactor.js";
+
+const r = createRedactor();
+
+// --- Inputs ---
+
+const CLEAN_1KB = "a".repeat(1024);
+const CLEAN_10KB = "a".repeat(10_240);
+
+const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+const aws = "AKIAIOSFODNN7EXAMPLE";
+const bearer = "Bearer some-token-value";
+const padding = "x".repeat(1024 - jwt.length - aws.length - bearer.length - 6);
+const WITH_SECRETS_1KB = `${jwt} ${aws} ${bearer} ${padding}`;
+
+const SHALLOW_OBJ = Object.fromEntries(
+  Array.from({ length: 10 }, (_, i) => [`key${i}`, `value-${i}`]),
+);
+
+const NESTED_OBJ = {
+  level1: {
+    password: "secret",
+    level2: {
+      data: "AKIAIOSFODNN7EXAMPLE",
+      level3: Object.fromEntries(Array.from({ length: 20 }, (_, i) => [`field${i}`, `val-${i}`])),
+    },
+    items: Array.from({ length: 20 }, (_, i) => ({ name: `item-${i}` })),
+  },
+};
+
+// --- Benchmark runner ---
+
+function benchmark(name: string, fn: () => void, iterations = 10_000): void {
+  // Warm up
+  for (let i = 0; i < 100; i++) fn();
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) fn();
+  const elapsed = performance.now() - start;
+
+  const opsPerSec = ((iterations / elapsed) * 1_000).toFixed(0);
+  const nsPerOp = ((elapsed / iterations) * 1_000_000).toFixed(0);
+  console.log(`  ${name}: ${opsPerSec} ops/s (${nsPerOp} ns/op)`);
+}
+
+console.log("\n--- redactString: clean input ---");
+benchmark("1KB clean", () => r.redactString(CLEAN_1KB));
+benchmark("10KB clean", () => r.redactString(CLEAN_10KB));
+
+console.log("\n--- redactString: with secrets ---");
+benchmark("1KB with 3 secrets", () => r.redactString(WITH_SECRETS_1KB));
+
+console.log("\n--- redactObject ---");
+benchmark("shallow (10 keys, no secrets)", () => r.redactObject(SHALLOW_OBJ));
+benchmark("nested (50 keys, 3 levels, 2 secrets)", () => r.redactObject(NESTED_OBJ));
+
+console.log("\n--- createRedactor: construction ---");
+benchmark("create with defaults", () => createRedactor(), 1_000);
+
+console.log("");

--- a/packages/redaction/src/redactor.test.ts
+++ b/packages/redaction/src/redactor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { createRedactor } from "./redactor.js";
+
+describe("createRedactor", () => {
+  test("creates a redactor with default config", () => {
+    const r = createRedactor();
+    expect(r.redactObject).toBeDefined();
+    expect(r.redactString).toBeDefined();
+  });
+
+  test("throws on invalid config", () => {
+    expect(() => createRedactor({ maxDepth: -1 })).toThrow("Invalid redaction config");
+  });
+
+  test("redactor is frozen", () => {
+    const r = createRedactor();
+    expect(Object.isFrozen(r)).toBe(true);
+  });
+
+  test("redactString detects JWT", () => {
+    const r = createRedactor();
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+    const result = r.redactString(`token: ${jwt}`);
+    expect(result.changed).toBe(true);
+    expect(result.text).not.toContain("eyJ");
+  });
+
+  test("redactString returns identity for clean text", () => {
+    const r = createRedactor();
+    const result = r.redactString("Hello, world!");
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe("Hello, world!");
+  });
+
+  test("redactObject redacts field names", () => {
+    const r = createRedactor();
+    const result = r.redactObject({ username: "alice", password: "s3cret!" });
+    expect(result.changed).toBe(true);
+    const v = result.value as Record<string, string>;
+    expect(v.username).toBe("alice");
+    expect(v.password).toBe("[REDACTED]");
+    expect(result.fieldCount).toBe(1);
+  });
+
+  test("redactObject redacts secrets in values", () => {
+    const r = createRedactor();
+    const result = r.redactObject({ data: "key=AKIAIOSFODNN7EXAMPLE" });
+    expect(result.changed).toBe(true);
+    expect(result.secretCount).toBe(1);
+  });
+
+  test("fail-closed on redactObject error", () => {
+    const errors: unknown[] = [];
+    const r = createRedactor({
+      onError: (e) => errors.push(e),
+      patterns: [
+        {
+          name: "boom",
+          kind: "boom",
+          detect() {
+            throw new Error("detector crash");
+          },
+        },
+      ],
+    });
+    const result = r.redactObject({ data: "test" });
+    expect(result.changed).toBe(true);
+    expect(result.value as unknown).toBe("[REDACTION_FAILED]");
+    expect(result.secretCount).toBe(-1);
+    expect(errors.length).toBe(1);
+  });
+
+  test("fail-closed on redactString error", () => {
+    const errors: unknown[] = [];
+    const r = createRedactor({
+      onError: (e) => errors.push(e),
+      patterns: [
+        {
+          name: "boom",
+          kind: "boom",
+          detect() {
+            throw new Error("detector crash");
+          },
+        },
+      ],
+    });
+    const result = r.redactString("test");
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("[REDACTION_FAILED]");
+    expect(result.matchCount).toBe(-1);
+  });
+
+  test("accepts custom patterns", () => {
+    const r = createRedactor({
+      customPatterns: [
+        {
+          name: "custom_secret",
+          kind: "custom",
+          detect(text) {
+            const idx = text.indexOf("SECRET_");
+            if (idx < 0) return [];
+            return [{ text: text.slice(idx, idx + 20), start: idx, end: idx + 20, kind: "custom" }];
+          },
+        },
+      ],
+    });
+    const result = r.redactString("data=SECRET_abc123xyzxyz");
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain("[REDACTED]");
+  });
+
+  test("accepts custom censor function", () => {
+    const r = createRedactor({
+      censor: (match) => `<${match.kind}>`,
+    });
+    const result = r.redactString("key=AKIAIOSFODNN7EXAMPLE");
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain("<aws_access_key>");
+  });
+});

--- a/packages/redaction/src/redactor.ts
+++ b/packages/redaction/src/redactor.ts
@@ -1,0 +1,81 @@
+/**
+ * Redactor factory — compile-once, use-many secret masking engine.
+ */
+
+import { validateRedactionConfig } from "./config.js";
+import { createFieldMatcher } from "./field-match.js";
+import { scanSecrets } from "./scan-string.js";
+import type {
+  RedactionConfig,
+  RedactObjectResult,
+  Redactor,
+  RedactStringResult,
+  SecretPattern,
+} from "./types.js";
+import { walkAndRedact } from "./walk.js";
+
+/** Fail-closed fallback for redactString when an error occurs. */
+const FAILED_STRING_RESULT: RedactStringResult = {
+  text: "[REDACTION_FAILED]",
+  changed: true,
+  matchCount: -1,
+};
+
+/**
+ * Create a compiled redactor from the given config.
+ * Validates config at construction and pre-compiles patterns and field matcher.
+ * Fail-closed: on any runtime error, returns `[REDACTION_FAILED]` and calls `onError`.
+ */
+export function createRedactor(config?: Partial<RedactionConfig>): Redactor {
+  const validated = validateRedactionConfig(config);
+  if (!validated.ok) {
+    throw new Error(`Invalid redaction config: ${validated.error.message}`);
+  }
+
+  const cfg = validated.value;
+
+  // Merge built-in + custom patterns
+  const allPatterns: readonly SecretPattern[] = [...cfg.patterns, ...cfg.customPatterns];
+
+  // Pre-compile field matcher
+  const fieldMatcher = createFieldMatcher(cfg.fieldNames);
+
+  const walkContext = Object.freeze({
+    patterns: allPatterns,
+    fieldMatcher,
+    censor: cfg.censor,
+    fieldCensor: cfg.fieldCensor,
+    maxDepth: cfg.maxDepth,
+    maxStringLength: cfg.maxStringLength,
+  });
+
+  const redactor: Redactor = {
+    redactObject<T>(value: T): RedactObjectResult<T> {
+      try {
+        return walkAndRedact(value, walkContext);
+      } catch (e: unknown) {
+        cfg.onError?.(e);
+        // Fail-closed: secretCount/fieldCount === -1 signals failure.
+        // Callers MUST check these sentinel values before trusting `value`.
+        // Cast justified: fail-closed sentinel — value is intentionally not T.
+        return {
+          value: "[REDACTION_FAILED]" as unknown as T,
+          changed: true,
+          secretCount: -1,
+          fieldCount: -1,
+        };
+      }
+    },
+
+    redactString(text: string): RedactStringResult {
+      try {
+        return scanSecrets(text, allPatterns, cfg.censor, cfg.maxStringLength);
+      } catch (e: unknown) {
+        cfg.onError?.(e);
+        return FAILED_STRING_RESULT;
+      }
+    },
+  };
+
+  return Object.freeze(redactor);
+}

--- a/packages/redaction/src/scan-string.test.ts
+++ b/packages/redaction/src/scan-string.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { createAWSDetector } from "./patterns/aws.js";
+import { createBearerDetector } from "./patterns/bearer.js";
+import { createJWTDetector } from "./patterns/jwt.js";
+import { scanSecrets } from "./scan-string.js";
+import type { SecretPattern } from "./types.js";
+
+const patterns: readonly SecretPattern[] = [
+  createJWTDetector(),
+  createAWSDetector(),
+  createBearerDetector(),
+];
+
+describe("scanSecrets", () => {
+  test("returns identity for empty string", () => {
+    const result = scanSecrets("", patterns, "redact", 100_000);
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe("");
+    expect(result.matchCount).toBe(0);
+  });
+
+  test("returns identity for clean text", () => {
+    const result = scanSecrets("Hello, world! No secrets here.", patterns, "redact", 100_000);
+    expect(result.changed).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  test("detects and redacts a JWT", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+    const text = `Authorization: Bearer ${jwt}`;
+    const result = scanSecrets(text, [createJWTDetector()], "redact", 100_000);
+    expect(result.changed).toBe(true);
+    expect(result.text).not.toContain("eyJ");
+    expect(result.matchCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test("detects and redacts an AWS key", () => {
+    const text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE";
+    const result = scanSecrets(text, [createAWSDetector()], "redact", 100_000);
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain("[REDACTED]");
+    expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+  });
+
+  test("handles overlapping patterns — longest match wins", () => {
+    // Bearer token contains a JWT — both patterns match, longest wins
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123";
+    const text = `Bearer ${jwt}`;
+    const result = scanSecrets(text, patterns, "redact", 100_000);
+    expect(result.changed).toBe(true);
+    // Should produce a single redaction (the longest match)
+    expect(result.matchCount).toBe(1);
+  });
+
+  test("redacts oversized strings", () => {
+    const result = scanSecrets("some text", patterns, "redact", 5);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("[REDACTED_OVERSIZED]");
+  });
+
+  test("applies mask censor strategy", () => {
+    const text = "key=AKIAIOSFODNN7EXAMPLE";
+    const result = scanSecrets(text, [createAWSDetector()], "mask", 100_000);
+    expect(result.changed).toBe(true);
+    expect(result.text).toContain("AKIA***");
+  });
+});

--- a/packages/redaction/src/scan-string.ts
+++ b/packages/redaction/src/scan-string.ts
@@ -1,0 +1,93 @@
+/**
+ * String scanning — detect and censor secrets in a string value.
+ */
+
+import { applyCensor } from "./censor.js";
+import { EMPTY_MATCHES } from "./patterns/collect.js";
+import type { Censor, RedactStringResult, SecretMatch, SecretPattern } from "./types.js";
+
+/** Pre-allocated result for the no-match fast path. */
+function identityResult(text: string): RedactStringResult {
+  return { text, changed: false, matchCount: 0 };
+}
+
+/**
+ * Resolve overlapping matches: keep the longer one. Ties: earlier start wins.
+ * Input must be sorted by start ascending.
+ */
+function resolveOverlaps(sorted: readonly SecretMatch[]): readonly SecretMatch[] {
+  if (sorted.length <= 1) return sorted;
+
+  const first = sorted[0];
+  if (first === undefined) return sorted;
+  const resolved: SecretMatch[] = [first];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i];
+    const prev = resolved[resolved.length - 1];
+    if (current === undefined || prev === undefined) continue;
+
+    if (current.start >= prev.end) {
+      resolved.push(current);
+      continue;
+    }
+
+    const prevLen = prev.end - prev.start;
+    const currLen = current.end - current.start;
+    if (currLen > prevLen) {
+      resolved[resolved.length - 1] = current;
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Scan a string for secrets using all patterns, resolve overlaps, apply censor.
+ * Returns the censored string and match count.
+ */
+export function scanSecrets(
+  text: string,
+  patterns: readonly SecretPattern[],
+  censor: Censor,
+  maxStringLength: number,
+): RedactStringResult {
+  if (text.length === 0) return identityResult(text);
+  if (text.length > maxStringLength) {
+    return { text: "[REDACTED_OVERSIZED]", changed: true, matchCount: 1 };
+  }
+
+  // Collect matches from all detectors
+  const allMatches: SecretMatch[] = [];
+  for (const pattern of patterns) {
+    const found = pattern.detect(text);
+    if (found !== EMPTY_MATCHES) {
+      for (const match of found) {
+        allMatches.push(match);
+      }
+    }
+  }
+
+  if (allMatches.length === 0) return identityResult(text);
+
+  // Sort by start ascending, then by length descending for stability
+  allMatches.sort((a, b) => {
+    const startDiff = a.start - b.start;
+    if (startDiff !== 0) return startDiff;
+    return b.end - b.start - (a.end - a.start);
+  });
+
+  const resolved = resolveOverlaps(allMatches);
+
+  // Apply replacements in reverse order to preserve indices
+  // let justified: accumulates the modified text through replacements
+  let result = text;
+  for (let i = resolved.length - 1; i >= 0; i--) {
+    const match = resolved[i];
+    if (match === undefined) continue;
+    const replacement = applyCensor(match, censor);
+    result = result.slice(0, match.start) + replacement + result.slice(match.end);
+  }
+
+  return { text: result, changed: true, matchCount: resolved.length };
+}

--- a/packages/redaction/src/types.ts
+++ b/packages/redaction/src/types.ts
@@ -1,0 +1,57 @@
+/**
+ * @koi/redaction — Type definitions for structured log secret masking.
+ */
+
+/** A detected secret occurrence within a string value. */
+export interface SecretMatch {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+  readonly kind: string;
+}
+
+/** Pattern detector — structurally compatible with PIIDetector. */
+export interface SecretPattern {
+  readonly name: string;
+  readonly kind: string;
+  readonly detect: (text: string) => readonly SecretMatch[];
+}
+
+/** Named censor strategy for replacing detected secrets. */
+export type CensorStrategy = "redact" | "mask" | "remove";
+
+/** Censor can be a strategy name or a custom function. */
+export type Censor = CensorStrategy | ((match: SecretMatch, fieldName?: string) => string);
+
+/** Configuration for createRedactor(). Immutable after construction. */
+export interface RedactionConfig {
+  readonly patterns: readonly SecretPattern[];
+  readonly customPatterns: readonly SecretPattern[];
+  readonly fieldNames: readonly (string | RegExp)[];
+  readonly censor: Censor;
+  readonly fieldCensor: Censor;
+  readonly maxDepth: number;
+  readonly maxStringLength: number;
+  readonly onError: ((error: unknown) => void) | undefined;
+}
+
+/** Result of object redaction. */
+export interface RedactObjectResult<T> {
+  readonly value: T;
+  readonly changed: boolean;
+  readonly secretCount: number;
+  readonly fieldCount: number;
+}
+
+/** Result of string redaction. */
+export interface RedactStringResult {
+  readonly text: string;
+  readonly changed: boolean;
+  readonly matchCount: number;
+}
+
+/** Compiled redactor — the main API surface. */
+export interface Redactor {
+  readonly redactObject: <T>(value: T) => RedactObjectResult<T>;
+  readonly redactString: (text: string) => RedactStringResult;
+}

--- a/packages/redaction/src/walk.test.ts
+++ b/packages/redaction/src/walk.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { createFieldMatcher } from "./field-match.js";
+import { createAWSDetector } from "./patterns/aws.js";
+import { createJWTDetector } from "./patterns/jwt.js";
+import type { SecretPattern } from "./types.js";
+import { walkAndRedact } from "./walk.js";
+
+const patterns: readonly SecretPattern[] = [createJWTDetector(), createAWSDetector()];
+const fieldMatcher = createFieldMatcher(["password", "token", "apiKey"]);
+
+const ctx = {
+  patterns,
+  fieldMatcher,
+  censor: "redact" as const,
+  fieldCensor: "redact" as const,
+  maxDepth: 10,
+  maxStringLength: 100_000,
+};
+
+describe("walkAndRedact", () => {
+  test("passes through primitives unchanged", () => {
+    expect(walkAndRedact(42, ctx).changed).toBe(false);
+    expect(walkAndRedact(null, ctx).changed).toBe(false);
+    expect(walkAndRedact(undefined, ctx).changed).toBe(false);
+    expect(walkAndRedact(true, ctx).changed).toBe(false);
+  });
+
+  test("passes through clean strings unchanged", () => {
+    const result = walkAndRedact("hello world", ctx);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe("hello world");
+  });
+
+  test("redacts field-name matches in objects", () => {
+    const obj = { username: "alice", password: "s3cret!" };
+    const result = walkAndRedact(obj, ctx);
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, string>).username).toBe("alice");
+    expect((result.value as Record<string, string>).password).toBe("[REDACTED]");
+    expect(result.fieldCount).toBe(1);
+    expect(result.secretCount).toBe(0);
+  });
+
+  test("redacts secrets in string values", () => {
+    const obj = { data: "key=AKIAIOSFODNN7EXAMPLE" };
+    const result = walkAndRedact(obj, ctx);
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, string>).data).toContain("[REDACTED]");
+    expect(result.secretCount).toBe(1);
+  });
+
+  test("handles nested objects", () => {
+    const obj = { level1: { level2: { token: "secret-value" } } };
+    const result = walkAndRedact(obj, ctx);
+    expect(result.changed).toBe(true);
+    const nested = (result.value as Record<string, Record<string, Record<string, string>>>).level1
+      ?.level2;
+    expect(nested?.token).toBe("[REDACTED]");
+  });
+
+  test("handles arrays", () => {
+    const arr = ["clean", "AKIAIOSFODNN7EXAMPLE", "also clean"];
+    const result = walkAndRedact(arr, ctx);
+    expect(result.changed).toBe(true);
+    expect((result.value as string[])[0]).toBe("clean");
+    expect((result.value as string[])[1]).toContain("[REDACTED]");
+    expect((result.value as string[])[2]).toBe("also clean");
+  });
+
+  test("preserves structural identity when unchanged", () => {
+    const obj = { name: "alice", count: 42 };
+    const result = walkAndRedact(obj, ctx);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBe(obj); // Same reference
+  });
+
+  test("detects circular references", () => {
+    const obj: Record<string, unknown> = { name: "test" };
+    obj.self = obj;
+    const result = walkAndRedact(obj, ctx);
+    expect(result.changed).toBe(true);
+    expect((result.value as Record<string, unknown>).self).toBe("[Circular]");
+  });
+
+  test("respects maxDepth", () => {
+    const deep = { a: { b: { c: { password: "secret" } } } };
+    const shallowCtx = { ...ctx, maxDepth: 2 };
+    const result = walkAndRedact(deep, shallowCtx);
+    // Depth 0 -> a, depth 1 -> b, depth 2 -> c, depth 3 -> password (exceeds maxDepth=2)
+    // The password field at depth 3 should NOT be redacted
+    const innerC = (
+      result.value as Record<string, Record<string, Record<string, Record<string, string>>>>
+    ).a?.b?.c;
+    expect(innerC?.password).toBe("secret");
+  });
+
+  test("skips __proto__ keys", () => {
+    const obj = Object.create(null) as Record<string, string>;
+    obj.safe = "ok";
+    obj.__proto__ = "malicious";
+    const result = walkAndRedact(obj, ctx);
+    expect((result.value as Record<string, string>).__proto__).toBe("malicious");
+  });
+});

--- a/packages/redaction/src/walk.ts
+++ b/packages/redaction/src/walk.ts
@@ -1,0 +1,170 @@
+/**
+ * Object walker — immutable copy-on-write traversal with field-name + value scanning.
+ */
+
+import { applyCensorToField } from "./censor.js";
+import type { FieldMatcher } from "./field-match.js";
+import { scanSecrets } from "./scan-string.js";
+import type { Censor, RedactObjectResult, SecretPattern } from "./types.js";
+
+/** Keys that must never be traversed to prevent prototype pollution. */
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/** Placeholder for circular references. */
+const CIRCULAR_PLACEHOLDER = "[Circular]";
+
+interface WalkContext {
+  readonly patterns: readonly SecretPattern[];
+  readonly fieldMatcher: FieldMatcher;
+  readonly censor: Censor;
+  readonly fieldCensor: Censor;
+  readonly maxDepth: number;
+  readonly maxStringLength: number;
+}
+
+interface WalkResult {
+  readonly value: unknown;
+  readonly changed: boolean;
+  readonly secretCount: number;
+  readonly fieldCount: number;
+}
+
+const UNCHANGED_ZERO: Pick<WalkResult, "secretCount" | "fieldCount"> = {
+  secretCount: 0,
+  fieldCount: 0,
+};
+
+function walkValue(
+  value: unknown,
+  key: string | undefined,
+  ctx: WalkContext,
+  depth: number,
+  seen: WeakSet<object>,
+): WalkResult {
+  // Depth guard
+  if (depth > ctx.maxDepth) {
+    return { value, changed: false, ...UNCHANGED_ZERO };
+  }
+
+  // Field-name match: censor the entire string value
+  if (key !== undefined && typeof value === "string" && ctx.fieldMatcher(key)) {
+    const censored = applyCensorToField(value, ctx.fieldCensor, key);
+    return {
+      value: censored,
+      changed: censored !== value,
+      secretCount: 0,
+      fieldCount: censored !== value ? 1 : 0,
+    };
+  }
+
+  // String leaf: scan for secrets
+  if (typeof value === "string") {
+    const result = scanSecrets(value, ctx.patterns, ctx.censor, ctx.maxStringLength);
+    return {
+      value: result.text,
+      changed: result.changed,
+      secretCount: result.matchCount,
+      fieldCount: 0,
+    };
+  }
+
+  // Non-object primitives: pass through
+  if (value === null || value === undefined || typeof value !== "object") {
+    return { value, changed: false, ...UNCHANGED_ZERO };
+  }
+
+  // Circular reference detection
+  if (seen.has(value)) {
+    return { value: CIRCULAR_PLACEHOLDER, changed: true, ...UNCHANGED_ZERO };
+  }
+  seen.add(value);
+
+  // Array
+  if (Array.isArray(value)) {
+    return walkArray(value, ctx, depth, seen);
+  }
+
+  // Plain object
+  return walkObject(value as Record<string, unknown>, ctx, depth, seen);
+}
+
+function walkArray(
+  arr: readonly unknown[],
+  ctx: WalkContext,
+  depth: number,
+  seen: WeakSet<object>,
+): WalkResult {
+  // let justified: tracks whether any element was modified
+  let anyChanged = false;
+  // let justified: accumulates secret count across elements
+  let totalSecrets = 0;
+  // let justified: accumulates field count across elements
+  let totalFields = 0;
+
+  const newArr = arr.map((item) => {
+    const result = walkValue(item, undefined, ctx, depth + 1, seen);
+    if (result.changed) anyChanged = true;
+    totalSecrets += result.secretCount;
+    totalFields += result.fieldCount;
+    return result.value;
+  });
+
+  return {
+    value: anyChanged ? newArr : arr,
+    changed: anyChanged,
+    secretCount: totalSecrets,
+    fieldCount: totalFields,
+  };
+}
+
+function walkObject(
+  obj: Record<string, unknown>,
+  ctx: WalkContext,
+  depth: number,
+  seen: WeakSet<object>,
+): WalkResult {
+  const keys = Object.keys(obj);
+  // let justified: tracks whether any field was modified
+  let anyChanged = false;
+  // let justified: accumulates secret count across fields
+  let totalSecrets = 0;
+  // let justified: accumulates field count across fields
+  let totalFields = 0;
+  const entries: Array<readonly [string, unknown]> = [];
+
+  for (const key of keys) {
+    // Prototype pollution guard
+    if (UNSAFE_KEYS.has(key) || !Object.hasOwn(obj, key)) {
+      entries.push([key, obj[key]] as const);
+      continue;
+    }
+
+    const result = walkValue(obj[key], key, ctx, depth + 1, seen);
+    if (result.changed) anyChanged = true;
+    totalSecrets += result.secretCount;
+    totalFields += result.fieldCount;
+    entries.push([key, result.value] as const);
+  }
+
+  if (!anyChanged) {
+    return { value: obj, changed: false, secretCount: totalSecrets, fieldCount: totalFields };
+  }
+
+  const newObj = Object.fromEntries(entries) as Record<string, unknown>;
+  return { value: newObj, changed: true, secretCount: totalSecrets, fieldCount: totalFields };
+}
+
+/**
+ * Walk an object graph, applying field-name matching and secret scanning.
+ * Returns an immutable copy-on-write result — only copies nodes that changed.
+ */
+export function walkAndRedact<T>(value: T, ctx: WalkContext): RedactObjectResult<T> {
+  const seen = new WeakSet<object>();
+  const result = walkValue(value, undefined, ctx, 0, seen);
+  return {
+    value: result.value as T,
+    changed: result.changed,
+    secretCount: result.secretCount,
+    fieldCount: result.fieldCount,
+  };
+}

--- a/packages/redaction/tsconfig.json
+++ b/packages/redaction/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../engine" },
+    { "path": "../engine-pi" },
+    { "path": "../middleware-audit" }
+  ]
+}

--- a/packages/redaction/tsup.config.ts
+++ b/packages/redaction/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Add `@koi/redaction` — a zero-dependency L0u utility package providing a compile-once redaction engine for structured log secret masking (OWASP ASI05 defense)
- 13 built-in secret pattern detectors: JWT, AWS, OpenAI, Anthropic, Google, GitHub, Slack, Stripe, PEM, Bearer, Basic Auth, Credential URI, Generic Secret
- Dual API: `redactObject<T>()` (copy-on-write immutable walker) + `redactString()` (pattern scan + censor)
- 34 default sensitive field names for field-name-based redaction
- Signal-character early bailout on all detectors, ReDoS protection, fail-closed error handling

## Architecture

- **Layer**: L0u — runtime dependency only on `@koi/core` (type-only import)
- **No layer leakage**: zero imports from L1 (`@koi/engine`) or L2 peers in production code
- **Performance**: ~97K ops/s clean 1KB string, ~168K ops/s shallow object, ~353K ops/s constructor

## Test Coverage

- 127 unit/integration tests (99%+ coverage)
- 4 E2E tests through full `createKoi` + `createPiAdapter` with real Anthropic API calls
- Edge cases: circular refs, prototype pollution, deep nesting, overlapping patterns, Unicode, ReDoS resistance

## Test plan

- [x] `bun run --filter @koi/redaction build` exits 0
- [x] `bun run --filter @koi/redaction typecheck` exits 0
- [x] `bun run --filter @koi/redaction lint` exits 0
- [x] 127 unit tests pass with 99%+ coverage
- [x] 4 E2E tests pass through full L1 runtime with real LLM calls
- [x] API surface snapshot generated and stable
- [x] No `@koi/engine` or `@koi/middleware-*` imports in production source
- [x] Pre-push hooks pass (turbo build + test + typecheck)

Closes #39