### PR TITLE
feat: add @koi/exec-approvals (L2) — progressive command allowlisting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -279,6 +279,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/exec-approvals": {
+      "name": "@koi/exec-approvals",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/execution-context": {
       "name": "@koi/execution-context",
       "version": "0.0.0",
@@ -1269,6 +1282,8 @@
     "@koi/eval": ["@koi/eval@workspace:packages/eval"],
 
     "@koi/events-memory": ["@koi/events-memory@workspace:packages/events-memory"],
+
+    "@koi/exec-approvals": ["@koi/exec-approvals@workspace:packages/exec-approvals"],
 
     "@koi/execution-context": ["@koi/execution-context@workspace:packages/execution-context"],
 

--- a/packages/exec-approvals/e2e-manual.ts
+++ b/packages/exec-approvals/e2e-manual.ts
@@ -1,0 +1,657 @@
+#!/usr/bin/env bun
+/**
+ * Comprehensive manual E2E test for @koi/exec-approvals
+ * through the full createKoi + createPiAdapter path (real LLM calls).
+ *
+ * Covers all 5 ProgressiveDecision variants, cross-session persistence,
+ * compound patterns, base-deny absolute invariant, approval timeout,
+ * and store-failure resilience.
+ *
+ * Requires ANTHROPIC_API_KEY in .env (auto-loaded by Bun).
+ *
+ * Run from repo root:
+ *   bun packages/exec-approvals/e2e-manual.ts
+ */
+
+import type { AgentManifest, EngineEvent, EngineOutput } from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+// Self-import via relative path — the package is not self-symlinked
+import type { ExecApprovalRequest, ProgressiveDecision } from "./src/index.js";
+import { createExecApprovalsMiddleware, createInMemoryRulesStore } from "./src/index.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+if (!API_KEY) {
+  console.error("❌ ANTHROPIC_API_KEY not set — add it to .env");
+  process.exit(1);
+}
+
+const MODEL = "anthropic:claude-haiku-4-5-20251001";
+const TOOL_TIMEOUT = 90_000;
+const SYSTEM_PROMPT =
+  "You are a helpful assistant. " +
+  "When asked to do arithmetic, you MUST use the add_numbers tool — never compute yourself. " +
+  "When asked to run a shell command, you MUST use the bash tool.";
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+function ok(msg: string): void {
+  passed++;
+  console.log(`  ✅ ${msg}`);
+}
+
+function fail(label: string, reason: string): void {
+  failed++;
+  failures.push(`${label}: ${reason}`);
+  console.log(`  ❌ ${reason}`);
+}
+
+async function test(label: string, fn: () => Promise<void>): Promise<void> {
+  console.log(`\n▶ ${label}`);
+  try {
+    await fn();
+  } catch (e: unknown) {
+    fail(label, e instanceof Error ? e.message : String(e));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function collect(iter: AsyncIterable<EngineEvent>): Promise<readonly EngineEvent[]> {
+  const acc: EngineEvent[] = [];
+  for await (const ev of iter) acc.push(ev);
+  return acc;
+}
+
+function output(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function text(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Tool providers
+// ---------------------------------------------------------------------------
+
+function makeAddProvider(spy?: () => void): {
+  name: string;
+  attach: () => Promise<Map<string, unknown>>;
+} {
+  return {
+    name: "add-provider",
+    attach: async () =>
+      new Map([
+        [
+          toolToken("add_numbers") as string,
+          {
+            descriptor: {
+              name: "add_numbers",
+              description: "Adds two integers and returns the sum.",
+              inputSchema: {
+                type: "object" as const,
+                properties: {
+                  a: { type: "integer" as const, description: "First number" },
+                  b: { type: "integer" as const, description: "Second number" },
+                },
+                required: ["a", "b"],
+              },
+            },
+            trustTier: "verified" as const,
+            execute: async (input: unknown) => {
+              spy?.();
+              const { a, b } = input as { a: number; b: number };
+              return String(a + b);
+            },
+          },
+        ],
+      ]),
+  };
+}
+
+function makeBashProvider(spy?: (cmd: string) => void): {
+  name: string;
+  attach: () => Promise<Map<string, unknown>>;
+} {
+  return {
+    name: "bash-provider",
+    attach: async () =>
+      new Map([
+        [
+          toolToken("bash") as string,
+          {
+            descriptor: {
+              name: "bash",
+              description: "Runs a shell command and returns its output.",
+              inputSchema: {
+                type: "object" as const,
+                properties: { command: { type: "string" as const } },
+                required: ["command"],
+              },
+            },
+            trustTier: "verified" as const,
+            execute: async (input: unknown) => {
+              const { command } = input as { command: string };
+              spy?.(command);
+              return `(simulated) $ ${command}\nok`;
+            },
+          },
+        ],
+      ]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function manifest(name: string): AgentManifest {
+  return { name, version: "1.0.0", model: { name: "test" } };
+}
+
+function pi(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: MODEL,
+    systemPrompt: SYSTEM_PROMPT,
+    getApiKey: async () => API_KEY,
+  });
+}
+
+function limits() {
+  return { maxTurns: 8, maxDurationMs: TOOL_TIMEOUT, maxTokens: 12_000 };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// ── 1. ALLOW ──────────────────────────────────────────────────────────────
+
+await test("1. ALLOW — tool runs, onAsk never called", async () => {
+  let askCalled = false;
+  let toolRan = false;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: ["add_numbers"], deny: [], ask: [] },
+    onAsk: async () => {
+      askCalled = true;
+      return { kind: "allow_once" };
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-1"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeAddProvider(() => {
+        toolRan = true;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts = await collect(rt.run({ kind: "text", text: "Use add_numbers to compute 4 + 8." }));
+  const out = output(evts);
+
+  if (out?.stopReason !== "completed")
+    return fail("1", `expected completed, got ${out?.stopReason}`);
+  if (!toolRan) return fail("1", "tool was not executed");
+  if (askCalled) return fail("1", "onAsk must not fire for allow pattern");
+  if (!text(evts).includes("12")) return fail("1", `expected "12" in response`);
+
+  ok(`allow rule → tool executed, onAsk not called, result contains "12"`);
+});
+
+// ── 2. DENY ───────────────────────────────────────────────────────────────
+
+await test("2. DENY — tool blocked, onAsk never called", async () => {
+  let askCalled = false;
+  let toolRan = false;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: ["add_numbers"], ask: [] },
+    onAsk: async () => {
+      askCalled = true;
+      return { kind: "allow_once" };
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-2"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeAddProvider(() => {
+        toolRan = true;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  await collect(rt.run({ kind: "text", text: "Use the add_numbers tool to compute 6 + 7." }));
+
+  if (toolRan) return fail("2", "tool must not execute under deny rule");
+  if (askCalled) return fail("2", "onAsk must not fire for deny pattern");
+
+  ok("deny rule → tool blocked, onAsk not called");
+});
+
+// ── 3. ASK → allow_once ───────────────────────────────────────────────────
+
+await test("3. ASK → allow_once — onAsk fires, request captured correctly", async () => {
+  let askCount = 0;
+  let captured: ExecApprovalRequest | undefined;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async (req) => {
+      askCount++;
+      captured = req;
+      return { kind: "allow_once" };
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-3"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [makeAddProvider()],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts = await collect(rt.run({ kind: "text", text: "Use add_numbers to compute 3 + 4." }));
+  const out = output(evts);
+
+  if (out?.stopReason !== "completed")
+    return fail("3", `expected completed, got ${out?.stopReason}`);
+  if (askCount < 1) return fail("3", "onAsk was never called");
+  if (captured?.toolId !== "add_numbers") return fail("3", `bad toolId: ${captured?.toolId}`);
+  if (captured?.matchedPattern !== "add_numbers")
+    return fail("3", `bad matchedPattern: ${captured?.matchedPattern}`);
+  if (!text(evts).includes("7")) return fail("3", `expected "7" in response`);
+
+  ok(`onAsk called (${askCount}x), toolId=add_numbers, matchedPattern=add_numbers, result=7`);
+});
+
+// ── 4. ASK → allow_session ────────────────────────────────────────────────
+
+await test("4. ASK → allow_session — two tool calls in one session, onAsk fires only once", async () => {
+  let askCount = 0;
+  let execCount = 0;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCount++;
+      return { kind: "allow_session", pattern: "add_numbers" };
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-4"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeAddProvider(() => {
+        execCount++;
+      }),
+    ],
+    loopDetection: false,
+    limits: { maxTurns: 12, maxDurationMs: TOOL_TIMEOUT, maxTokens: 15_000 },
+  });
+
+  const evts = await collect(
+    rt.run({
+      kind: "text",
+      text:
+        "Call add_numbers TWICE: first compute 2 + 3, then compute 5 + 6. " +
+        "Use the tool for each separately. Tell me both results.",
+    }),
+  );
+  const out = output(evts);
+
+  if (out?.stopReason !== "completed")
+    return fail("4", `expected completed, got ${out?.stopReason}`);
+  if (execCount < 2) return fail("4", `expected ≥2 tool executions, got ${execCount}`);
+  if (askCount !== 1) return fail("4", `expected onAsk called exactly once, got ${askCount}`);
+
+  ok(`tool called ${execCount}x in one session, onAsk fired only once (allow_session)`);
+});
+
+// ── 5. ASK → allow_always ─────────────────────────────────────────────────
+
+await test("5. ASK → allow_always — persists to store, session 2 skips onAsk", async () => {
+  const store = createInMemoryRulesStore();
+  let askCount = 0;
+
+  const mw1 = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCount++;
+      return { kind: "allow_always", pattern: "add_numbers" };
+    },
+    store,
+  });
+
+  const rt1 = await createKoi({
+    manifest: manifest("e2e-5a"),
+    adapter: pi(),
+    middleware: [mw1],
+    providers: [makeAddProvider()],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts1 = await collect(rt1.run({ kind: "text", text: "Use add_numbers to compute 2 + 2." }));
+  if (output(evts1)?.stopReason !== "completed") return fail("5", `session 1: expected completed`);
+  if (askCount !== 1) return fail("5", `session 1: expected 1 ask, got ${askCount}`);
+
+  const stored = await store.load();
+  if (!stored.allow.includes("add_numbers"))
+    return fail("5", `not saved to store: ${JSON.stringify(stored.allow)}`);
+
+  // Session 2 — new middleware instance, same store
+  const mw2 = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCount++;
+      return { kind: "allow_once" };
+    },
+    store,
+  });
+
+  const rt2 = await createKoi({
+    manifest: manifest("e2e-5b"),
+    adapter: pi(),
+    middleware: [mw2],
+    providers: [makeAddProvider()],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts2 = await collect(rt2.run({ kind: "text", text: "Use add_numbers to compute 3 + 5." }));
+  if (output(evts2)?.stopReason !== "completed") return fail("5", `session 2: expected completed`);
+  if (askCount !== 1)
+    return fail("5", `session 2: onAsk fired again (expected still 1, got ${askCount})`);
+
+  ok("session 1 asked + persisted; session 2 loaded store → no ask");
+});
+
+// ── 6. ASK → deny_always ──────────────────────────────────────────────────
+
+await test("6. ASK → deny_always — blocked both sessions, onAsk stays at 0 or 1", async () => {
+  const store = createInMemoryRulesStore();
+  let askCount = 0;
+  let toolRan = false;
+
+  const mw1 = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCount++;
+      return { kind: "deny_always", pattern: "add_numbers", reason: "nope" };
+    },
+    store,
+  });
+
+  const rt1 = await createKoi({
+    manifest: manifest("e2e-6a"),
+    adapter: pi(),
+    middleware: [mw1],
+    providers: [
+      makeAddProvider(() => {
+        toolRan = true;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  await collect(rt1.run({ kind: "text", text: "Use the add_numbers tool to compute 5 + 5." }));
+
+  if (toolRan) return fail("6", "session 1: tool must not execute on deny_always");
+
+  const stored = await store.load();
+  if (!stored.deny.includes("add_numbers"))
+    return fail("6", `not saved to deny store: ${JSON.stringify(stored.deny)}`);
+
+  const s1Asks = askCount; // 0 if LLM didn't try tool, 1 if it did
+
+  const mw2 = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCount++;
+      return { kind: "allow_once" };
+    },
+    store,
+  });
+
+  const rt2 = await createKoi({
+    manifest: manifest("e2e-6b"),
+    adapter: pi(),
+    middleware: [mw2],
+    providers: [
+      makeAddProvider(() => {
+        toolRan = true;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  await collect(rt2.run({ kind: "text", text: "Use the add_numbers tool to compute 2 + 2." }));
+
+  if (toolRan) return fail("6", "session 2: tool must not execute — persisted deny");
+  if (askCount > s1Asks)
+    return fail("6", `session 2: onAsk fired again (grew from ${s1Asks} to ${askCount})`);
+
+  ok(`deny_always: tool blocked both sessions, persisted in store, onAsk stayed at ${s1Asks}`);
+});
+
+// ── 7. BASE DENY ABSOLUTE ─────────────────────────────────────────────────
+
+await test("7. BASE DENY ABSOLUTE — deny + ask on same tool → deny wins, onAsk never called", async () => {
+  let askCalled = false;
+  let toolRan = false;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: ["add_numbers"], ask: ["add_numbers"] },
+    onAsk: async () => {
+      askCalled = true;
+      return { kind: "allow_once" };
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-7"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeAddProvider(() => {
+        toolRan = true;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  await collect(rt.run({ kind: "text", text: "Use the add_numbers tool to compute 9 + 1." }));
+
+  if (toolRan) return fail("7", "tool must not run — base deny is absolute");
+  if (askCalled) return fail("7", "onAsk must NOT fire — deny is checked before ask step");
+
+  ok("base deny fires before ask (evaluation order step 1 vs 5) — tool blocked, onAsk not called");
+});
+
+// ── 8. COMPOUND PATTERN ───────────────────────────────────────────────────
+
+await test("8. COMPOUND PATTERN — bash:git* allows git, blocks rm -rf", async () => {
+  let lastCmd: string | undefined;
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: ["bash:git*"], deny: [], ask: [] },
+    onAsk: async () => ({ kind: "allow_once" }),
+  });
+
+  // 8a: git status — matches bash:git* → allowed
+  lastCmd = undefined;
+  const rt1 = await createKoi({
+    manifest: manifest("e2e-8a"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeBashProvider((cmd) => {
+        lastCmd = cmd;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts1 = await collect(
+    rt1.run({
+      kind: "text",
+      text: "Use the bash tool to run: git status. Tell me what it returned.",
+    }),
+  );
+  if (output(evts1)?.stopReason !== "completed") return fail("8a", `expected completed`);
+  if (lastCmd === undefined || !lastCmd.startsWith("git")) {
+    return fail("8a", `expected git command executed, got: ${lastCmd}`);
+  }
+  ok(`8a: git command allowed → bash executed "${lastCmd}"`);
+
+  // 8b: rm -rf — doesn't match bash:git* → default deny
+  lastCmd = undefined;
+  const rt2 = await createKoi({
+    manifest: manifest("e2e-8b"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [
+      makeBashProvider((cmd) => {
+        lastCmd = cmd;
+      }),
+    ],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  await collect(
+    rt2.run({
+      kind: "text",
+      text: "Use the bash tool to run: rm -rf /tmp/test. Tell me the result.",
+    }),
+  );
+
+  if (lastCmd?.startsWith("rm")) {
+    return fail("8b", `rm should be blocked by compound pattern, but bash executed: "${lastCmd}"`);
+  }
+  ok(`8b: rm -rf blocked (bash:git* pattern only allows git commands)`);
+});
+
+// ── 9. APPROVAL TIMEOUT ───────────────────────────────────────────────────
+
+await test("9. APPROVAL TIMEOUT — stalling onAsk times out, session ends with max_turns", async () => {
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () =>
+      new Promise<ProgressiveDecision>((resolve) =>
+        setTimeout(() => resolve({ kind: "allow_once" }), 5_000),
+      ),
+    approvalTimeoutMs: 100,
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-9"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [makeAddProvider()],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts = await collect(rt.run({ kind: "text", text: "Use add_numbers to compute 1 + 1." }));
+  const out = output(evts);
+
+  if (out?.stopReason === "max_turns") {
+    ok("TIMEOUT error → stopReason=max_turns");
+  } else if (out?.stopReason === "completed") {
+    ok(
+      "LLM answered without calling the tool — timeout not triggered (valid: model chose not to use tool)",
+    );
+  } else {
+    fail("9", `unexpected stopReason: ${out?.stopReason}`);
+  }
+});
+
+// ── 10. STORE LOAD ERROR ──────────────────────────────────────────────────
+
+await test("10. STORE LOAD ERROR — session proceeds normally, onLoadError called", async () => {
+  let loadErrorCalled = false;
+
+  const mw = createExecApprovalsMiddleware({
+    rules: { allow: [], deny: [], ask: ["add_numbers"] },
+    onAsk: async () => ({ kind: "allow_once" }),
+    store: {
+      load: async () => {
+        throw new Error("disk failure");
+      },
+      save: async () => {},
+    },
+    onLoadError: () => {
+      loadErrorCalled = true;
+    },
+  });
+
+  const rt = await createKoi({
+    manifest: manifest("e2e-10"),
+    adapter: pi(),
+    middleware: [mw],
+    providers: [makeAddProvider()],
+    loopDetection: false,
+    limits: limits(),
+  });
+
+  const evts = await collect(rt.run({ kind: "text", text: "Use add_numbers to compute 5 + 3." }));
+  const out = output(evts);
+
+  if (!loadErrorCalled) return fail("10", "onLoadError was not called");
+  if (out?.stopReason !== "completed")
+    return fail("10", `expected completed, got ${out?.stopReason}`);
+
+  ok("onLoadError called, session continued with empty state fallback");
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${"─".repeat(60)}`);
+console.log(`\n  ${passed} passed  ${failed} failed\n`);
+
+if (failures.length > 0) {
+  console.log("  Failures:");
+  for (const f of failures) console.log(`    • ${f}`);
+  console.log();
+}
+
+process.exit(failed > 0 ? 1 : 0);

--- a/packages/exec-approvals/package.json
+++ b/packages/exec-approvals/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koi/exec-approvals",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/exec-approvals/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/exec-approvals/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,126 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/exec-approvals API surface . has stable type surface 1`] = `
+"import { JsonObject } from '@koi/core/common';
+import { Result, KoiError } from '@koi/core/errors';
+import { KoiMiddleware } from '@koi/core/middleware';
+
+/**
+ * Domain types for @koi/exec-approvals.
+ */
+
+/**
+ * The 5 decisions a user can make when prompted for approval.
+ *
+ * - allow_once: allow this single invocation only
+ * - allow_session: allow for the remainder of this session
+ * - allow_always: allow permanently (pattern written to store)
+ * - deny_once: deny this single invocation
+ * - deny_always: deny permanently (pattern written to store)
+ */
+type ProgressiveDecision = {
+    readonly kind: "allow_once";
+} | {
+    readonly kind: "allow_session";
+    readonly pattern: string;
+} | {
+    readonly kind: "allow_always";
+    readonly pattern: string;
+} | {
+    readonly kind: "deny_once";
+    readonly reason: string;
+} | {
+    readonly kind: "deny_always";
+    readonly pattern: string;
+    readonly reason: string;
+};
+/**
+ * The shape persisted in the backing store.
+ */
+interface PersistedRules {
+    readonly allow: readonly string[];
+    readonly deny: readonly string[];
+}
+/**
+ * Pluggable backing store for "always" decisions.
+ * Use createInMemoryRulesStore() for testing/development.
+ */
+interface ExecRulesStore {
+    readonly load: () => Promise<PersistedRules>;
+    readonly save: (rules: PersistedRules) => Promise<void>;
+}
+/**
+ * The request passed to onAsk when an ask rule fires.
+ */
+interface ExecApprovalRequest {
+    readonly toolId: string;
+    readonly input: JsonObject;
+    /** Which ask pattern triggered this request. */
+    readonly matchedPattern: string;
+}
+
+/**
+ * ExecApprovalsConfig interface and validation.
+ */
+
+declare const DEFAULT_APPROVAL_TIMEOUT_MS = 30000;
+interface ExecApprovalsConfig {
+    readonly rules: {
+        readonly allow: readonly string[];
+        readonly deny: readonly string[];
+        readonly ask: readonly string[];
+    };
+    /** Called when an ask rule fires. Must return a ProgressiveDecision. */
+    readonly onAsk: (req: ExecApprovalRequest) => Promise<ProgressiveDecision>;
+    /** Backing store for "always" decisions. Defaults to createInMemoryRulesStore(). */
+    readonly store?: ExecRulesStore;
+    /** Timeout for onAsk. Defaults to DEFAULT_APPROVAL_TIMEOUT_MS (30_000 ms). */
+    readonly approvalTimeoutMs?: number;
+    /** Called when store.save() fails. Tool call proceeds regardless. */
+    readonly onSaveError?: (error: unknown) => void;
+    /** Called when store.load() fails. Session starts with empty accumulated state. */
+    readonly onLoadError?: (error: unknown) => void;
+    /**
+     * Extract a command string from the tool input for compound pattern matching.
+     * Defaults to defaultExtractCommand.
+     */
+    readonly extractCommand?: (input: JsonObject) => string;
+}
+declare function validateExecApprovalsConfig(config: unknown): Result<ExecApprovalsConfig, KoiError>;
+
+/**
+ * Progressive command allowlisting middleware factory.
+ */
+
+declare function createExecApprovalsMiddleware(rawConfig: ExecApprovalsConfig): KoiMiddleware;
+
+/**
+ * Compound pattern matching for @koi/exec-approvals.
+ *
+ * Patterns have two optional parts separated by the FIRST colon:
+ *   "bash:cat /etc:shadow"  →  toolPattern="bash", inputPattern="cat /etc:shadow"
+ *   "bash"                  →  toolPattern="bash", inputPattern=undefined (any input)
+ *   "*"                     →  matches any tool, any input
+ *   "bash:*"                →  matches bash with any input (including empty)
+ *
+ * Wildcards: only \`*\` at the end of a segment → prefix match.
+ * \`**\` is normalized to \`*\` at construction time.
+ */
+
+/**
+ * Default command extractor: tries input.command, then input.args joined, then JSON.stringify.
+ */
+declare function defaultExtractCommand(input: JsonObject): string;
+
+/**
+ * In-memory ExecRulesStore implementation.
+ *
+ * Starts empty. "Always" decisions accumulate in memory only.
+ * Useful for testing and development.
+ */
+
+declare function createInMemoryRulesStore(): ExecRulesStore;
+
+export { DEFAULT_APPROVAL_TIMEOUT_MS, type ExecApprovalRequest, type ExecApprovalsConfig, type ExecRulesStore, type PersistedRules, type ProgressiveDecision, createExecApprovalsMiddleware, createInMemoryRulesStore, defaultExtractCommand, validateExecApprovalsConfig };
+"
+`;

--- a/packages/exec-approvals/src/__tests__/api-surface.test.ts
+++ b/packages/exec-approvals/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/exec-approvals/src/__tests__/e2e.test.ts
+++ b/packages/exec-approvals/src/__tests__/e2e.test.ts
@@ -1,0 +1,1000 @@
+/**
+ * E2E tests for @koi/exec-approvals through the full createKoi path.
+ *
+ * Part 1 (describeE2E) — real Pi adapter + real LLM calls:
+ *   Gated on ANTHROPIC_API_KEY + E2E_TESTS=1.
+ *   Smoke-tests that the middleware integrates cleanly with a live LLM call.
+ *   Run: E2E_TESTS=1 ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e.test.ts
+ *
+ * Part 2 (describe) — createKoi integration via cooperating adapter (no LLM):
+ *   Runs always. Full middleware chain through L1. Covers:
+ *     - All 5 ProgressiveDecision variants (allow_once/session/always, deny_once/always)
+ *     - Session isolation (A's allow_session doesn't leak to B)
+ *     - Cross-session persistence (allow_always via shared store)
+ *     - Base deny security invariant (absolute, cannot be overridden)
+ *     - Timeout on approval
+ *     - Store failure resilience (load/save errors)
+ *     - Compound pattern matching (tool:command prefix)
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  EngineAdapter,
+  EngineEvent,
+  EngineInput,
+  EngineOutput,
+} from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import type { ExecApprovalRequest, ProgressiveDecision } from "../index.js";
+import { createExecApprovalsMiddleware, createInMemoryRulesStore } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate (Part 1 only)
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_ENABLED = HAS_KEY && process.env.E2E_TESTS === "1";
+const describeE2E = E2E_ENABLED ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// add_numbers tool — used in both parts
+// ---------------------------------------------------------------------------
+
+const ADD_NUMBERS_DESCRIPTOR = {
+  name: "add_numbers",
+  description: "Adds two integers together and returns the sum.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      a: { type: "integer" as const, description: "First number" },
+      b: { type: "integer" as const, description: "Second number" },
+    },
+    required: ["a", "b"],
+  },
+};
+
+function makeAddNumbersProvider(onExecute?: () => void): {
+  readonly name: string;
+  readonly attach: () => Promise<Map<string, unknown>>;
+} {
+  return {
+    name: "add-numbers-provider",
+    attach: async () =>
+      new Map([
+        [
+          toolToken("add_numbers") as string,
+          {
+            descriptor: ADD_NUMBERS_DESCRIPTOR,
+            trustTier: "verified" as const,
+            execute: async (input: unknown) => {
+              onExecute?.();
+              const { a, b } = input as { readonly a: number; readonly b: number };
+              return String(a + b);
+            },
+          },
+        ],
+      ]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cooperating adapter helpers (Part 2 — no real LLM)
+// ---------------------------------------------------------------------------
+
+function makeDoneOutput(): EngineOutput {
+  return {
+    content: [{ kind: "text", text: "done" }],
+    stopReason: "completed",
+    metrics: { totalTokens: 0, inputTokens: 0, outputTokens: 0, turns: 1, durationMs: 0 },
+  };
+}
+
+/**
+ * Creates a cooperating adapter that calls callHandlers.toolCall() for each
+ * entry in `calls`, then emits done. If any call throws, the error propagates
+ * out of the async generator, which createKoi catches and converts to
+ * done { stopReason: "error" }.
+ */
+function makeCooperatingAdapter(
+  calls: ReadonlyArray<{ readonly toolId: string; readonly input?: Record<string, unknown> }>,
+): EngineAdapter {
+  return {
+    engineId: "e2e-cooperating",
+    terminals: {
+      modelCall: async () => ({ content: "ok", model: "test" }),
+    },
+    stream: (input: EngineInput) => ({
+      async *[Symbol.asyncIterator]() {
+        if (input.callHandlers) {
+          for (const call of calls) {
+            await input.callHandlers.toolCall({ toolId: call.toolId, input: call.input ?? {} });
+          }
+        }
+        yield { kind: "done" as const, output: makeDoneOutput() };
+      },
+    }),
+  };
+}
+
+const BASE_MANIFEST: AgentManifest = {
+  name: "exec-approvals-e2e",
+  version: "1.0.0",
+  model: { name: "test-model" },
+};
+
+// ---------------------------------------------------------------------------
+// Part 1: Real Pi adapter + real LLM
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: exec-approvals + Pi adapter (real LLM)", () => {
+  // ── Test 1: Allow pattern — tool executes, no onAsk call ─────────────────
+
+  test(
+    "allow pattern: tool executes without calling onAsk",
+    async () => {
+      let askCalled = false;
+      let toolExecuted = false;
+
+      const middleware = createExecApprovalsMiddleware({
+        rules: { allow: ["add_numbers"], deny: [], ask: [] },
+        onAsk: async () => {
+          askCalled = true;
+          return { kind: "allow_once" };
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-allow-test",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: createPiAdapter({
+          model: E2E_MODEL,
+          systemPrompt:
+            "You MUST use the add_numbers tool for any arithmetic. Do not compute in your head.",
+          getApiKey: async () => ANTHROPIC_KEY,
+        }),
+        middleware: [middleware],
+        providers: [
+          makeAddNumbersProvider(() => {
+            toolExecuted = true;
+          }),
+        ],
+        loopDetection: false,
+        limits: { maxTurns: 5, maxDurationMs: 110_000, maxTokens: 10_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use add_numbers to compute 7 + 5. Tell me the result.",
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Tool should have run, onAsk should never fire
+      expect(toolExecuted).toBe(true);
+      expect(askCalled).toBe(false);
+
+      // LLM should mention the result in its response
+      const text = extractText(events);
+      expect(text).toContain("12");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Ask → allow_once — onAsk fires, tool runs ────────────────────
+
+  test(
+    "ask → allow_once: onAsk fires and tool executes for the real LLM call",
+    async () => {
+      let askCallCount = 0;
+      let capturedRequest: ExecApprovalRequest | undefined;
+
+      const middleware = createExecApprovalsMiddleware({
+        rules: { allow: [], deny: [], ask: ["add_numbers"] },
+        onAsk: async (req) => {
+          askCallCount++;
+          capturedRequest = req;
+          return { kind: "allow_once" };
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-ask-once-test",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: createPiAdapter({
+          model: E2E_MODEL,
+          systemPrompt:
+            "You MUST use the add_numbers tool for any arithmetic. Do not compute in your head.",
+          getApiKey: async () => ANTHROPIC_KEY,
+        }),
+        middleware: [middleware],
+        providers: [makeAddNumbersProvider()],
+        loopDetection: false,
+        limits: { maxTurns: 5, maxDurationMs: 110_000, maxTokens: 10_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use add_numbers to compute 3 + 4. Tell me the result.",
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // onAsk must have been called at least once
+      expect(askCallCount).toBeGreaterThanOrEqual(1);
+      expect(capturedRequest?.toolId).toBe("add_numbers");
+      expect(capturedRequest?.matchedPattern).toBe("add_numbers");
+
+      const text = extractText(events);
+      expect(text).toContain("7");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Deny rule — onAsk never fires, tool never executes ───────────
+  //
+  // We can't deterministically force the LLM to call the tool, so we verify
+  // the invariants that hold regardless of whether the LLM calls it:
+  //   - onAsk is NEVER invoked when a tool is in the deny list
+  //   - the tool's execute() is NEVER called when denied
+  // If the LLM does try the tool → PERMISSION → stopReason=error.
+  // If the LLM answers directly → stopReason=completed.
+  // Both outcomes are acceptable here; the invariants are what matter.
+
+  test(
+    "deny rule: onAsk never called and tool never executed regardless of LLM behavior",
+    async () => {
+      let askCalled = false;
+      let toolExecuted = false;
+
+      const middleware = createExecApprovalsMiddleware({
+        rules: { allow: [], deny: ["add_numbers"], ask: [] },
+        onAsk: async () => {
+          askCalled = true;
+          return { kind: "allow_once" };
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-deny-test",
+          version: "1.0.0",
+          model: { name: "claude-haiku" },
+        },
+        adapter: createPiAdapter({
+          model: E2E_MODEL,
+          systemPrompt:
+            "You MUST use the add_numbers tool for any arithmetic. Do not compute in your head.",
+          getApiKey: async () => ANTHROPIC_KEY,
+        }),
+        middleware: [middleware],
+        providers: [
+          makeAddNumbersProvider(() => {
+            toolExecuted = true;
+          }),
+        ],
+        loopDetection: false,
+        limits: { maxTurns: 5, maxDurationMs: 110_000, maxTokens: 10_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use the add_numbers tool to compute 7 + 5. Tell me the result.",
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      // Core invariants: deny blocks tool execution and preempts onAsk
+      expect(toolExecuted).toBe(false);
+      expect(askCalled).toBe(false);
+      // stopReason is "error" if LLM tried the tool, "completed" if it answered directly
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Part 2: Full createKoi integration via cooperating adapter
+// ---------------------------------------------------------------------------
+
+describe("exec-approvals middleware integration via createKoi (cooperating adapter)", () => {
+  // ── Basic allow/deny/default-deny ─────────────────────────────────────────
+
+  test("allow pattern: tool executes without onAsk", async () => {
+    let toolExecuted = false;
+    let askCalled = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: ["add_numbers"], deny: [], ask: [] },
+      onAsk: async () => {
+        askCalled = true;
+        return { kind: "allow_once" };
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 7, b: 5 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("completed");
+    expect(toolExecuted).toBe(true);
+    expect(askCalled).toBe(false);
+  });
+
+  test("deny pattern: tool blocked, done.stopReason=error, onAsk not called", async () => {
+    let toolExecuted = false;
+    let askCalled = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: ["add_numbers"], ask: [] },
+      onAsk: async () => {
+        askCalled = true;
+        return { kind: "allow_once" };
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 7, b: 5 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("error");
+    expect(toolExecuted).toBe(false);
+    expect(askCalled).toBe(false);
+  });
+
+  test("default deny: unmatched tool is blocked", async () => {
+    let toolExecuted = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: [] },
+      onAsk: async () => ({ kind: "allow_once" }),
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("error");
+    expect(toolExecuted).toBe(false);
+  });
+
+  // ── Ask → all 5 ProgressiveDecision variants ─────────────────────────────
+
+  test("ask → allow_once: tool runs, onAsk called with correct request", async () => {
+    let toolExecuted = false;
+    let capturedReq: ExecApprovalRequest | undefined;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async (req) => {
+        capturedReq = req;
+        return { kind: "allow_once" };
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 3, b: 4 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("completed");
+    expect(toolExecuted).toBe(true);
+    expect(capturedReq?.toolId).toBe("add_numbers");
+    expect(capturedReq?.matchedPattern).toBe("add_numbers");
+  });
+
+  test("ask → allow_session: subsequent calls in same session skip onAsk", async () => {
+    let askCallCount = 0;
+    let toolExecuteCount = 0;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "allow_session", pattern: "add_numbers" };
+      },
+    });
+
+    // Two calls to add_numbers in the same session
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([
+        { toolId: "add_numbers", input: { a: 1, b: 2 } },
+        { toolId: "add_numbers", input: { a: 3, b: 4 } },
+      ]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuteCount++;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("completed");
+    expect(toolExecuteCount).toBe(2);
+    // onAsk only fires once — second call uses session allow
+    expect(askCallCount).toBe(1);
+  });
+
+  test("ask → allow_always: tool runs and pattern saved to store", async () => {
+    let toolExecuted = false;
+    let saveCallCount = 0;
+    const store = createInMemoryRulesStore();
+    const originalSave = store.save.bind(store);
+    const spyStore = {
+      load: store.load.bind(store),
+      save: async (rules: Parameters<typeof originalSave>[0]) => {
+        saveCallCount++;
+        return originalSave(rules);
+      },
+    };
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => ({ kind: "allow_always", pattern: "add_numbers" }),
+      store: spyStore,
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 5, b: 6 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("completed");
+    expect(toolExecuted).toBe(true);
+    expect(saveCallCount).toBe(1);
+
+    // Verify the store now contains the persisted pattern
+    const persisted = await store.load();
+    expect(persisted.allow).toContain("add_numbers");
+  });
+
+  test("ask → deny_once: tool blocked, no state change, next call asks again", async () => {
+    let askCallCount = 0;
+    let toolExecuted = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "deny_once", reason: "test denial" };
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      // First call will be denied (deny_once, no state change)
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    expect(output?.stopReason).toBe("error");
+    expect(toolExecuted).toBe(false);
+    expect(askCallCount).toBe(1);
+
+    // Since deny_once doesn't accumulate state, a NEW session will ask again
+    const _secondSessionAskCount = 0;
+    const runtime2 = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 3, b: 4 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    // Override decision for second session — allow this time
+    // But the spied askCallCount will increment
+    // (We can't easily override the middleware decision here, so just check count increments)
+    await collectEvents(runtime2.run({ kind: "text", text: "test" }));
+    // onAsk was called for the second session too (deny_once left no state)
+    expect(askCallCount).toBe(2);
+  });
+
+  test("ask → deny_always: pattern saved, future calls in same session blocked without asking", async () => {
+    let askCallCount = 0;
+    let toolExecuted = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "deny_always", pattern: "add_numbers", reason: "always denied" };
+      },
+    });
+
+    // First call: deny_always fires, adds to extraDeny
+    const runtime1 = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events1 = await collectEvents(runtime1.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events1)?.stopReason).toBe("error");
+    expect(toolExecuted).toBe(false);
+    expect(askCallCount).toBe(1);
+
+    // Second call in new session: store has the deny, onAsk should NOT fire
+    // (session extraDeny is populated from store on session start)
+    const runtime2 = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 3, b: 4 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    const events2 = await collectEvents(runtime2.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events2)?.stopReason).toBe("error");
+    // onAsk NOT called again — the persisted deny blocked it before the ask step
+    expect(askCallCount).toBe(1);
+  });
+
+  // ── Security invariant ────────────────────────────────────────────────────
+
+  test("base deny is absolute: fires before ask, onAsk is never called", async () => {
+    let askCalled = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      // Both deny AND ask for add_numbers — deny must fire first (evaluation step 1 vs 5)
+      rules: { allow: [], deny: ["add_numbers"], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCalled = true;
+        return { kind: "allow_once" };
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 2, b: 3 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("error");
+    // Base deny checked at step 1 — ask rule at step 5 never fires
+    expect(askCalled).toBe(false);
+  });
+
+  // ── Session isolation ─────────────────────────────────────────────────────
+
+  test("session isolation: allow_session in session A does not affect session B", async () => {
+    let askCallCount = 0;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "allow_session", pattern: "add_numbers" };
+      },
+    });
+
+    // Session A: two calls, only one ask (second uses session allow)
+    const runtimeA = await createKoi({
+      manifest: { ...BASE_MANIFEST, name: "session-a" },
+      adapter: makeCooperatingAdapter([
+        { toolId: "add_numbers", input: { a: 1, b: 2 } },
+        { toolId: "add_numbers", input: { a: 3, b: 4 } },
+      ]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+    await collectEvents(runtimeA.run({ kind: "text", text: "test" }));
+    expect(askCallCount).toBe(1); // A asked only once (second call used session allow)
+
+    // Session B: starts fresh — no session state from A, ask fires again
+    const runtimeB = await createKoi({
+      manifest: { ...BASE_MANIFEST, name: "session-b" },
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 5, b: 6 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+    await collectEvents(runtimeB.run({ kind: "text", text: "test" }));
+    // Session B is isolated — its tool call triggers a fresh ask
+    expect(askCallCount).toBe(2);
+  });
+
+  // ── Cross-session persistence via allow_always ────────────────────────────
+
+  test("allow_always persists across sessions via shared store", async () => {
+    const sharedStore = createInMemoryRulesStore();
+    let askCallCount = 0;
+
+    // Session 1: ask fires, allow_always saves to shared store
+    const mw1 = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "allow_always", pattern: "add_numbers" };
+      },
+      store: sharedStore,
+    });
+
+    const runtime1 = await createKoi({
+      manifest: { ...BASE_MANIFEST, name: "persist-session-1" },
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [mw1],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+    const events1 = await collectEvents(runtime1.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+    expect(askCallCount).toBe(1);
+
+    // Session 2: different middleware instance, same shared store
+    // onSessionStart loads store → extraAllow has "add_numbers" → no ask
+    const mw2 = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCallCount++;
+        return { kind: "allow_once" };
+      },
+      store: sharedStore,
+    });
+
+    const runtime2 = await createKoi({
+      manifest: { ...BASE_MANIFEST, name: "persist-session-2" },
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 3, b: 4 } }]),
+      middleware: [mw2],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+    const events2 = await collectEvents(runtime2.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events2)?.stopReason).toBe("completed");
+    // No second ask — persisted pattern loaded from store
+    expect(askCallCount).toBe(1);
+  });
+
+  // ── Session lifecycle hooks ───────────────────────────────────────────────
+
+  test("onSessionStart and onSessionEnd are called exactly once per session", async () => {
+    let sessionStartCount = 0;
+    let sessionEndCount = 0;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: ["add_numbers"], deny: [], ask: [] },
+      onAsk: async () => ({ kind: "allow_once" }),
+    });
+
+    // We verify lifecycle by adding a second tracking middleware alongside exec-approvals
+    const trackingMiddleware = {
+      name: "session-tracker",
+      priority: 200,
+      onSessionStart: async () => {
+        sessionStartCount++;
+      },
+      onSessionEnd: async () => {
+        sessionEndCount++;
+      },
+    };
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware, trackingMiddleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(sessionStartCount).toBe(1);
+    expect(sessionEndCount).toBe(1);
+  });
+
+  // ── Error resilience ──────────────────────────────────────────────────────
+
+  test("store.load failure: onLoadError called, session proceeds with empty state", async () => {
+    let loadErrorCalled = false;
+    let capturedLoadError: unknown;
+    let askCalled = false;
+
+    const failingStore = {
+      load: async () => {
+        throw new Error("disk unavailable");
+      },
+      save: async () => {},
+    };
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => {
+        askCalled = true;
+        return { kind: "allow_once" };
+      },
+      store: failingStore,
+      onLoadError: (e) => {
+        loadErrorCalled = true;
+        capturedLoadError = e;
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    // Session should proceed (load failure → empty state, tool gets asked)
+    expect(loadErrorCalled).toBe(true);
+    expect((capturedLoadError as Error).message).toBe("disk unavailable");
+    expect(askCalled).toBe(true);
+    expect(output?.stopReason).toBe("completed");
+  });
+
+  test("store.save failure: onSaveError called, allow_always tool call still succeeds", async () => {
+    let saveErrorCalled = false;
+    let toolExecuted = false;
+
+    const failingStore = {
+      load: async () => ({ allow: [], deny: [] }),
+      save: async () => {
+        throw new Error("write permission denied");
+      },
+    };
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () => ({ kind: "allow_always", pattern: "add_numbers" }),
+      store: failingStore,
+      onSaveError: () => {
+        saveErrorCalled = true;
+      },
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    // Save failed, but the tool call must still succeed
+    expect(saveErrorCalled).toBe(true);
+    expect(toolExecuted).toBe(true);
+    expect(output?.stopReason).toBe("completed");
+  });
+
+  // ── Timeout ───────────────────────────────────────────────────────────────
+
+  test("onAsk timeout: approval times out, session ends with error", async () => {
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["add_numbers"] },
+      onAsk: async () =>
+        new Promise<ProgressiveDecision>((resolve) =>
+          setTimeout(() => resolve({ kind: "allow_once" }), 500),
+        ),
+      approvalTimeoutMs: 50, // 50ms timeout, onAsk takes 500ms → always times out
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [makeAddNumbersProvider()],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    const output = findDoneOutput(events);
+    // Timeout → TIMEOUT KoiRuntimeError → koi.ts maps TIMEOUT code to "max_turns"
+    expect(output?.stopReason).toBe("max_turns");
+  });
+
+  // ── Compound pattern matching ─────────────────────────────────────────────
+
+  test("compound pattern: bash:git* allows matching commands, blocks others", async () => {
+    let gitStatusExecuted = false;
+    let gitPushExecuted = false;
+
+    // Register two bash tools: one with command "git status", one with "rm -rf /"
+    const bashProvider = {
+      name: "bash-provider",
+      attach: async () =>
+        new Map([
+          [
+            toolToken("bash") as string,
+            {
+              descriptor: {
+                name: "bash",
+                description: "Execute a bash command.",
+                inputSchema: {
+                  type: "object" as const,
+                  properties: { command: { type: "string" as const } },
+                  required: ["command"],
+                },
+              },
+              trustTier: "verified" as const,
+              execute: async (input: unknown) => {
+                const { command } = input as { readonly command: string };
+                if (command.startsWith("git")) gitStatusExecuted = true;
+                if (command.startsWith("rm")) gitPushExecuted = true;
+                return `executed: ${command}`;
+              },
+            },
+          ],
+        ]),
+    };
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: ["bash:git*"], deny: [], ask: [] },
+      onAsk: async () => ({ kind: "allow_once" }),
+    });
+
+    // Call 1: bash with "git status" — matches bash:git* → allowed
+    const runtime1 = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "bash", input: { command: "git status" } }]),
+      middleware: [middleware],
+      providers: [bashProvider],
+      loopDetection: false,
+    });
+    const events1 = await collectEvents(runtime1.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+    expect(gitStatusExecuted).toBe(true);
+
+    // Call 2: bash with "rm -rf /" — does NOT match bash:git* → default deny
+    const runtime2 = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "bash", input: { command: "rm -rf /" } }]),
+      middleware: [middleware],
+      providers: [bashProvider],
+      loopDetection: false,
+    });
+    const events2 = await collectEvents(runtime2.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events2)?.stopReason).toBe("error");
+    expect(gitPushExecuted).toBe(false);
+  });
+
+  test("wildcard allow * matches any tool", async () => {
+    let toolExecuted = false;
+
+    const middleware = createExecApprovalsMiddleware({
+      rules: { allow: ["*"], deny: [], ask: [] },
+      onAsk: async () => ({ kind: "allow_once" }),
+    });
+
+    const runtime = await createKoi({
+      manifest: BASE_MANIFEST,
+      adapter: makeCooperatingAdapter([{ toolId: "add_numbers", input: { a: 1, b: 2 } }]),
+      middleware: [middleware],
+      providers: [
+        makeAddNumbersProvider(() => {
+          toolExecuted = true;
+        }),
+      ],
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "test" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+    expect(toolExecuted).toBe(true);
+  });
+});

--- a/packages/exec-approvals/src/config.test.ts
+++ b/packages/exec-approvals/src/config.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_APPROVAL_TIMEOUT_MS, validateExecApprovalsConfig } from "./config.js";
+
+const noop = async () => ({ kind: "allow_once" as const });
+
+describe("DEFAULT_APPROVAL_TIMEOUT_MS", () => {
+  test("is 30_000", () => {
+    expect(DEFAULT_APPROVAL_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe("validateExecApprovalsConfig", () => {
+  const validConfig = {
+    rules: { allow: [], deny: [], ask: [] },
+    onAsk: noop,
+  };
+
+  test("returns ok for valid config", () => {
+    const result = validateExecApprovalsConfig(validConfig);
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns error for null", () => {
+    const result = validateExecApprovalsConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("non-null object");
+    }
+  });
+
+  test("returns error for undefined", () => {
+    const result = validateExecApprovalsConfig(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("returns error for non-object", () => {
+    const result = validateExecApprovalsConfig("string");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("returns error when rules is missing", () => {
+    const result = validateExecApprovalsConfig({ onAsk: noop });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("rules");
+  });
+
+  test("returns error when rules is not an object", () => {
+    const result = validateExecApprovalsConfig({ rules: "bad", onAsk: noop });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("rules");
+  });
+
+  test("returns error when rules.allow is missing", () => {
+    const result = validateExecApprovalsConfig({
+      rules: { deny: [], ask: [] },
+      onAsk: noop,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("allow");
+  });
+
+  test("returns error when rules.allow is not an array", () => {
+    const result = validateExecApprovalsConfig({
+      rules: { allow: "bad", deny: [], ask: [] },
+      onAsk: noop,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("returns error when onAsk is missing", () => {
+    const result = validateExecApprovalsConfig({
+      rules: { allow: [], deny: [], ask: [] },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("onAsk");
+  });
+
+  test("returns error when onAsk is not a function", () => {
+    const result = validateExecApprovalsConfig({
+      rules: { allow: [], deny: [], ask: [] },
+      onAsk: "not-a-function",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("onAsk");
+    }
+  });
+
+  test("returns error when approvalTimeoutMs is zero", () => {
+    const result = validateExecApprovalsConfig({ ...validConfig, approvalTimeoutMs: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("approvalTimeoutMs");
+  });
+
+  test("returns error when approvalTimeoutMs is negative", () => {
+    const result = validateExecApprovalsConfig({ ...validConfig, approvalTimeoutMs: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("approvalTimeoutMs");
+  });
+
+  test("returns error when approvalTimeoutMs is not a number", () => {
+    const result = validateExecApprovalsConfig({ ...validConfig, approvalTimeoutMs: "fast" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("returns ok when approvalTimeoutMs is a positive number", () => {
+    const result = validateExecApprovalsConfig({ ...validConfig, approvalTimeoutMs: 5000 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns ok with optional store provided", () => {
+    const result = validateExecApprovalsConfig({
+      ...validConfig,
+      store: { load: async () => ({ allow: [], deny: [] }), save: async () => {} },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("retryable is false for VALIDATION errors", () => {
+    const result = validateExecApprovalsConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.retryable).toBe(false);
+  });
+});

--- a/packages/exec-approvals/src/config.ts
+++ b/packages/exec-approvals/src/config.ts
@@ -1,0 +1,99 @@
+/**
+ * ExecApprovalsConfig interface and validation.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ExecApprovalRequest, ExecRulesStore, ProgressiveDecision } from "./types.js";
+
+export const DEFAULT_APPROVAL_TIMEOUT_MS = 30_000;
+
+export interface ExecApprovalsConfig {
+  readonly rules: {
+    readonly allow: readonly string[];
+    readonly deny: readonly string[];
+    readonly ask: readonly string[];
+  };
+  /** Called when an ask rule fires. Must return a ProgressiveDecision. */
+  readonly onAsk: (req: ExecApprovalRequest) => Promise<ProgressiveDecision>;
+  /** Backing store for "always" decisions. Defaults to createInMemoryRulesStore(). */
+  readonly store?: ExecRulesStore;
+  /** Timeout for onAsk. Defaults to DEFAULT_APPROVAL_TIMEOUT_MS (30_000 ms). */
+  readonly approvalTimeoutMs?: number;
+  /** Called when store.save() fails. Tool call proceeds regardless. */
+  readonly onSaveError?: (error: unknown) => void;
+  /** Called when store.load() fails. Session starts with empty accumulated state. */
+  readonly onLoadError?: (error: unknown) => void;
+  /**
+   * Extract a command string from the tool input for compound pattern matching.
+   * Defaults to defaultExtractCommand.
+   */
+  readonly extractCommand?: (input: JsonObject) => string;
+}
+
+export function validateExecApprovalsConfig(
+  config: unknown,
+): Result<ExecApprovalsConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config must be a non-null object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (!c.rules || typeof c.rules !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config requires 'rules' with allow, deny, and ask arrays",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const rules = c.rules as Record<string, unknown>;
+  if (!Array.isArray(rules.allow) || !Array.isArray(rules.deny) || !Array.isArray(rules.ask)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Rules must contain 'allow', 'deny', and 'ask' arrays",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (typeof c.onAsk !== "function") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config requires 'onAsk' to be a function",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (c.approvalTimeoutMs !== undefined) {
+    if (typeof c.approvalTimeoutMs !== "number" || c.approvalTimeoutMs <= 0) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "approvalTimeoutMs must be a positive number",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+  }
+
+  return { ok: true, value: config as ExecApprovalsConfig };
+}

--- a/packages/exec-approvals/src/index.ts
+++ b/packages/exec-approvals/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @koi/exec-approvals — Progressive command allowlisting middleware (Layer 2)
+ *
+ * Intercepts tool calls with allow/deny/ask patterns. Users make runtime
+ * approval decisions (allow-once, allow-session, allow-always, deny-once,
+ * deny-always) that accumulate progressively across the session.
+ *
+ * Depends on @koi/core and @koi/errors only.
+ */
+
+export type { ExecApprovalsConfig } from "./config.js";
+export { DEFAULT_APPROVAL_TIMEOUT_MS, validateExecApprovalsConfig } from "./config.js";
+export { createExecApprovalsMiddleware } from "./middleware.js";
+// defaultExtractCommand exported for callers who want to extend it
+export { defaultExtractCommand } from "./pattern.js";
+export { createInMemoryRulesStore } from "./store.js";
+export type {
+  ExecApprovalRequest,
+  ExecRulesStore,
+  PersistedRules,
+  ProgressiveDecision,
+} from "./types.js";

--- a/packages/exec-approvals/src/middleware.test.ts
+++ b/packages/exec-approvals/src/middleware.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { KoiError } from "@koi/core/errors";
+import type { ToolRequest } from "@koi/core/middleware";
+import {
+  createMockSessionContext,
+  createMockTurnContext,
+  createSpyToolHandler,
+} from "@koi/test-utils";
+import { createExecApprovalsMiddleware } from "./middleware.js";
+import { createInMemoryRulesStore } from "./store.js";
+import type { ExecApprovalRequest, ExecRulesStore, ProgressiveDecision } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const makeToolRequest = (toolId: string, command?: string): ToolRequest => ({
+  toolId,
+  input: command !== undefined ? { command } : {},
+});
+
+/** Creates a mock onAsk that always returns the given decision. */
+function makeOnAsk(
+  decision: ProgressiveDecision,
+): (req: ExecApprovalRequest) => Promise<ProgressiveDecision> {
+  return async (_req) => decision;
+}
+
+/** Creates a session context + turn context pair sharing the same sessionId. */
+function makeSession(sessionId = "session-1") {
+  const session = createMockSessionContext({
+    sessionId: sessionId as ReturnType<typeof createMockSessionContext>["sessionId"],
+  });
+  const ctx = createMockTurnContext({ session });
+  return { session, ctx };
+}
+
+// ---------------------------------------------------------------------------
+// Basic allow / deny / default-deny
+// ---------------------------------------------------------------------------
+
+describe("createExecApprovalsMiddleware — static rules", () => {
+  test("allow pattern: calls next() without prompting", async () => {
+    const { session, ctx } = makeSession();
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["bash"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    const response = await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(response?.output).toEqual({ result: "mock" });
+  });
+
+  test("deny pattern: throws PERMISSION without prompting", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(makeOnAsk({ kind: "allow_once" }));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: ["bash"], ask: [] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+      expect(spy.calls).toHaveLength(0);
+      expect(onAsk).not.toHaveBeenCalled();
+    }
+  });
+
+  test("default deny blocks unmatched tools", async () => {
+    const { session, ctx } = makeSession();
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("unknown-tool"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+      expect(err.message).toContain("default deny");
+    }
+  });
+
+  test("wildcard allow '*' passes all tools", async () => {
+    const { session, ctx } = makeSession();
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["*"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("anything"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+  });
+
+  test("onAsk is NOT called for allow patterns", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(makeOnAsk({ kind: "allow_once" }));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["bash"], deny: [], ask: [] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(onAsk).not.toHaveBeenCalled();
+  });
+
+  test("onAsk is NOT called for deny patterns", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(makeOnAsk({ kind: "allow_once" }));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: ["bash"], ask: [] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    } catch {
+      // expected
+    }
+    expect(onAsk).not.toHaveBeenCalled();
+  });
+
+  test("has name 'exec-approvals'", () => {
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["*"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    expect(mw.name).toBe("exec-approvals");
+  });
+
+  test("has priority 100", () => {
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["*"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    expect(mw.priority).toBe(100);
+  });
+
+  test("wrapModelCall is undefined", () => {
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["*"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+    });
+    expect(mw.wrapModelCall).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ask flow — ProgressiveDecision variants
+// ---------------------------------------------------------------------------
+
+describe("createExecApprovalsMiddleware — ask flow", () => {
+  test("ask + allow_once: calls next(), does NOT cache for next call", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(makeOnAsk({ kind: "allow_once" }));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(onAsk).toHaveBeenCalledTimes(1);
+    // Second call — should prompt again
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(onAsk).toHaveBeenCalledTimes(2);
+  });
+
+  test("ask + allow_session: calls next() and skips prompt on repeat", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(
+      async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => ({
+        kind: "allow_session",
+        pattern: "bash",
+      }),
+    );
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(onAsk).toHaveBeenCalledTimes(1);
+    // Second call — cached in session, no prompt
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(onAsk).toHaveBeenCalledTimes(1);
+    expect(spy.calls).toHaveLength(2);
+  });
+
+  test("ask + allow_always: calls next() and store.save() is called", async () => {
+    const { session, ctx } = makeSession();
+    const store = createInMemoryRulesStore();
+    const saveSpy = mock(store.save.bind(store));
+    const mockStore: ExecRulesStore = { load: store.load.bind(store), save: saveSpy };
+    const onAsk = mock(
+      async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => ({
+        kind: "allow_always",
+        pattern: "bash",
+      }),
+    );
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+      store: mockStore,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    // Second call — pattern is now in session allow list
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(onAsk).toHaveBeenCalledTimes(1);
+    expect(spy.calls).toHaveLength(2);
+  });
+
+  test("ask + deny_once: throws PERMISSION, no state change", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(
+      async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => ({
+        kind: "deny_once",
+        reason: "Denied for now",
+      }),
+    );
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+      expect(err.message).toContain("Denied for now");
+      expect(spy.calls).toHaveLength(0);
+    }
+    // Second call should prompt again (deny_once does not persist)
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    } catch {
+      // expected
+    }
+    expect(onAsk).toHaveBeenCalledTimes(2);
+  });
+
+  test("ask + deny_always: throws PERMISSION and store.save() is called", async () => {
+    const { session, ctx } = makeSession();
+    const store = createInMemoryRulesStore();
+    const saveSpy = mock(store.save.bind(store));
+    const mockStore: ExecRulesStore = { load: store.load.bind(store), save: saveSpy };
+    const onAsk = mock(
+      async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => ({
+        kind: "deny_always",
+        pattern: "bash",
+        reason: "Never allowed",
+      }),
+    );
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+      store: mockStore,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+      expect(err.message).toContain("Never allowed");
+    }
+    expect(spy.calls).toHaveLength(0);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("ask timeout throws TIMEOUT error (retryable: true)", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> =>
+      new Promise((resolve) => setTimeout(() => resolve({ kind: "allow_once" }), 5000));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+      approvalTimeoutMs: 50,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("TIMEOUT");
+      expect(err.retryable).toBe(true);
+      expect(spy.calls).toHaveLength(0);
+    }
+  });
+
+  test("onAsk receives the matched pattern in ExecApprovalRequest", async () => {
+    const { session, ctx } = makeSession();
+    const captured: ExecApprovalRequest[] = [];
+    const onAsk = async (req: ExecApprovalRequest): Promise<ProgressiveDecision> => {
+      captured.push(req);
+      return { kind: "allow_once" };
+    };
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash:git push*"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    await mw.wrapToolCall?.(
+      ctx,
+      makeToolRequest("bash", "git push origin"),
+      createSpyToolHandler().handler,
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.matchedPattern).toBe("bash:git push*");
+    expect(captured[0]?.toolId).toBe("bash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security invariants
+// ---------------------------------------------------------------------------
+
+describe("security invariants", () => {
+  test("base deny overrides session allow (base deny is absolute)", async () => {
+    const { session, ctx } = makeSession();
+    // Simulate: a prior session has an allow_always for "bash"
+    // But base deny has "bash" too — base deny must win
+    const store = createInMemoryRulesStore();
+    // Pre-seed store with an allow for bash
+    await store.save({ allow: ["bash"], deny: [] });
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: ["bash"], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+      store,
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      const err = e as KoiError;
+      expect(err.code).toBe("PERMISSION");
+      expect(spy.calls).toHaveLength(0);
+    }
+  });
+
+  test("deny_once does NOT add to session deny list", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(
+      async (): Promise<ProgressiveDecision> => ({
+        kind: "deny_once",
+        reason: "test",
+      }),
+    );
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+    // After deny_once, the next call still goes through ask (not pre-denied by session)
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    } catch {
+      /* expected */
+    }
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    } catch {
+      /* expected */
+    }
+    expect(onAsk).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session isolation
+// ---------------------------------------------------------------------------
+
+describe("session isolation", () => {
+  test("session A's allow_session does NOT affect session B", async () => {
+    const sessionA = createMockSessionContext({
+      sessionId: "session-a" as ReturnType<typeof createMockSessionContext>["sessionId"],
+    });
+    const ctxA = createMockTurnContext({ session: sessionA });
+    const sessionB = createMockSessionContext({
+      sessionId: "session-b" as ReturnType<typeof createMockSessionContext>["sessionId"],
+    });
+    const ctxB = createMockTurnContext({ session: sessionB });
+
+    let callCount = 0;
+    const onAsk = async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => {
+      callCount++;
+      return { kind: "allow_session", pattern: "bash" };
+    };
+
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+
+    await mw.onSessionStart?.(sessionA);
+    await mw.onSessionStart?.(sessionB);
+
+    // A gets allow_session
+    await mw.wrapToolCall?.(ctxA, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(1);
+
+    // A's second call uses cached session allow — no prompt
+    await mw.wrapToolCall?.(ctxA, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(1);
+
+    // B must still prompt — not affected by A's session allow
+    await mw.wrapToolCall?.(ctxB, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(2);
+  });
+
+  test("after onSessionEnd, re-started session does not see old state", async () => {
+    const { session, ctx } = makeSession("session-cleanup");
+    let callCount = 0;
+    const onAsk = async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => {
+      callCount++;
+      return { kind: "allow_session", pattern: "bash" };
+    };
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+    });
+
+    await mw.onSessionStart?.(session);
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(1);
+
+    // Cached — no prompt
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(1);
+
+    // End session — clears state
+    await mw.onSessionEnd?.(session);
+
+    // Re-start session — fresh state, no cache
+    await mw.onSessionStart?.(session);
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), createSpyToolHandler().handler);
+    expect(callCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error resilience
+// ---------------------------------------------------------------------------
+
+describe("error resilience", () => {
+  test("store.load() failure → onLoadError called, session starts normally", async () => {
+    const { session, ctx } = makeSession();
+    const loadError = new Error("disk failure");
+    const badStore: ExecRulesStore = {
+      load: async () => {
+        throw loadError;
+      },
+      save: async () => {},
+    };
+    const loadErrors: unknown[] = [];
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["bash"], deny: [], ask: [] },
+      onAsk: makeOnAsk({ kind: "allow_once" }),
+      store: badStore,
+      onLoadError: (e) => loadErrors.push(e),
+    });
+    await mw.onSessionStart?.(session);
+    expect(loadErrors).toHaveLength(1);
+    expect(loadErrors[0]).toBe(loadError);
+    // Session started normally — allow rule works
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+  });
+
+  test("store.save() failure → onSaveError called, tool call still proceeds", async () => {
+    const { session, ctx } = makeSession();
+    const saveError = new Error("disk full");
+    const flakyStore: ExecRulesStore = {
+      load: async () => ({ allow: [], deny: [] }),
+      save: async () => {
+        throw saveError;
+      },
+    };
+    const saveErrors: unknown[] = [];
+    const onAsk = async (_req: ExecApprovalRequest): Promise<ProgressiveDecision> => ({
+      kind: "allow_always",
+      pattern: "bash",
+    });
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: [], deny: [], ask: ["bash"] },
+      onAsk,
+      store: flakyStore,
+      onSaveError: (e) => saveErrors.push(e),
+    });
+    await mw.onSessionStart?.(session);
+    const spy = createSpyToolHandler();
+    // Should NOT throw even though save fails
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(saveErrors).toHaveLength(1);
+    expect(saveErrors[0]).toBe(saveError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound pattern integration
+// ---------------------------------------------------------------------------
+
+describe("compound pattern integration", () => {
+  test("ask pattern with input matches correct commands only", async () => {
+    const { session, ctx } = makeSession();
+    const onAsk = mock(makeOnAsk({ kind: "allow_once" }));
+    const mw = createExecApprovalsMiddleware({
+      rules: { allow: ["bash:ls*"], deny: ["bash:rm*"], ask: ["bash:git push*"] },
+      onAsk,
+    });
+    await mw.onSessionStart?.(session);
+
+    // allow pattern
+    const spy = createSpyToolHandler();
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash", "ls -la"), spy.handler);
+    expect(spy.calls).toHaveLength(1);
+    expect(onAsk).not.toHaveBeenCalled();
+
+    // deny pattern
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash", "rm -rf /"), spy.handler);
+      expect.unreachable();
+    } catch (e) {
+      expect((e as KoiError).code).toBe("PERMISSION");
+    }
+    expect(onAsk).not.toHaveBeenCalled();
+
+    // ask pattern
+    await mw.wrapToolCall?.(ctx, makeToolRequest("bash", "git push origin main"), spy.handler);
+    expect(onAsk).toHaveBeenCalledTimes(1);
+    expect(spy.calls).toHaveLength(2);
+
+    // unmatched → default deny
+    try {
+      await mw.wrapToolCall?.(ctx, makeToolRequest("bash", "cat /etc/passwd"), spy.handler);
+      expect.unreachable();
+    } catch (e) {
+      expect((e as KoiError).code).toBe("PERMISSION");
+    }
+  });
+});

--- a/packages/exec-approvals/src/middleware.ts
+++ b/packages/exec-approvals/src/middleware.ts
@@ -1,0 +1,247 @@
+/**
+ * Progressive command allowlisting middleware factory.
+ */
+
+import type {
+  KoiMiddleware,
+  SessionContext,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import { DEFAULT_APPROVAL_TIMEOUT_MS, type ExecApprovalsConfig } from "./config.js";
+import {
+  defaultExtractCommand,
+  findFirstAskMatch,
+  matchesAnyCompound,
+  normalizePattern,
+} from "./pattern.js";
+import { createInMemoryRulesStore } from "./store.js";
+import type { ExecRulesStore, PersistedRules } from "./types.js";
+
+/**
+ * Per-session mutable state: accumulated allow/deny patterns beyond the base config.
+ * Entries added by allow_session, allow_always, deny_always decisions.
+ */
+interface SessionRulesState {
+  // let-justified: accumulated during session, grows with progressive decisions
+  extraAllow: string[];
+  extraDeny: string[];
+}
+
+export function createExecApprovalsMiddleware(rawConfig: ExecApprovalsConfig): KoiMiddleware {
+  const {
+    rules,
+    onAsk,
+    store: storeOption,
+    approvalTimeoutMs = DEFAULT_APPROVAL_TIMEOUT_MS,
+    onSaveError,
+    onLoadError,
+    extractCommand = defaultExtractCommand,
+  } = rawConfig;
+
+  // Resolve store — default to in-memory
+  const store: ExecRulesStore = storeOption ?? createInMemoryRulesStore();
+
+  // Normalize all base patterns once at construction time
+  const baseAllow = rules.allow.map(normalizePattern);
+  const baseDeny = rules.deny.map(normalizePattern);
+  const baseAsk = rules.ask.map(normalizePattern);
+
+  // Session state keyed by sessionId
+  const sessions = new Map<string, SessionRulesState>();
+
+  async function persistRules(state: SessionRulesState): Promise<void> {
+    const loaded = await store.load();
+    // Merge: combine loaded + session extra, deduplicate
+    const mergedAllow = dedupe([...loaded.allow, ...state.extraAllow]);
+    const mergedDeny = dedupe([...loaded.deny, ...state.extraDeny]);
+    await store.save({ allow: mergedAllow, deny: mergedDeny });
+  }
+
+  return {
+    name: "exec-approvals",
+    priority: 100,
+
+    async onSessionStart(ctx: SessionContext): Promise<void> {
+      // Load persisted rules — on failure, start with empty state (less permissive)
+      let loaded: PersistedRules = { allow: [], deny: [] };
+      try {
+        loaded = await store.load();
+      } catch (e: unknown) {
+        onLoadError?.(e);
+      }
+
+      sessions.set(ctx.sessionId, {
+        extraAllow: loaded.allow.map(normalizePattern),
+        extraDeny: loaded.deny.map(normalizePattern),
+      });
+    },
+
+    async onSessionEnd(ctx: SessionContext): Promise<void> {
+      sessions.delete(ctx.sessionId);
+    },
+
+    async wrapToolCall(
+      ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      const { toolId, input } = request;
+      const state = sessions.get(ctx.session.sessionId);
+
+      // -----------------------------------------------------------------------
+      // Evaluation order (security invariant):
+      // 1. base deny    → ABSOLUTE, cannot be overridden by any session approval
+      // 2. session deny → accumulated deny_always decisions
+      // 3. session allow → accumulated allow_session / allow_always decisions
+      // 4. base allow   → static allow list
+      // 5. base ask     → trigger onAsk, handle ProgressiveDecision
+      // 6. default deny → no rule matched
+      // -----------------------------------------------------------------------
+
+      // 1. Base deny — absolute
+      if (matchesAnyCompound(baseDeny, toolId, input, extractCommand)) {
+        throw KoiRuntimeError.from("PERMISSION", `Tool "${toolId}" is denied by policy`, {
+          context: { toolId },
+        });
+      }
+
+      // 2. Session deny (accumulated deny_always)
+      if (
+        state !== undefined &&
+        matchesAnyCompound(state.extraDeny, toolId, input, extractCommand)
+      ) {
+        throw KoiRuntimeError.from("PERMISSION", `Tool "${toolId}" is denied by session policy`, {
+          context: { toolId },
+        });
+      }
+
+      // 3. Session allow (accumulated allow_session / allow_always)
+      if (
+        state !== undefined &&
+        matchesAnyCompound(state.extraAllow, toolId, input, extractCommand)
+      ) {
+        return next(request);
+      }
+
+      // 4. Base allow
+      if (matchesAnyCompound(baseAllow, toolId, input, extractCommand)) {
+        return next(request);
+      }
+
+      // 5. Base ask
+      const matchedPattern = findFirstAskMatch(baseAsk, toolId, input, extractCommand);
+      if (matchedPattern !== undefined) {
+        const decision = await askWithTimeout(
+          onAsk,
+          { toolId, input, matchedPattern },
+          approvalTimeoutMs,
+        );
+
+        switch (decision.kind) {
+          case "allow_once": {
+            return next(request);
+          }
+
+          case "allow_session": {
+            if (state !== undefined) {
+              state.extraAllow.push(normalizePattern(decision.pattern));
+            }
+            return next(request);
+          }
+
+          case "allow_always": {
+            if (state !== undefined) {
+              state.extraAllow.push(normalizePattern(decision.pattern));
+            }
+            try {
+              if (state !== undefined) {
+                await persistRules(state);
+              }
+            } catch (e: unknown) {
+              onSaveError?.(e);
+            }
+            return next(request);
+          }
+
+          case "deny_once": {
+            throw KoiRuntimeError.from("PERMISSION", decision.reason, {
+              context: { toolId },
+            });
+          }
+
+          case "deny_always": {
+            if (state !== undefined) {
+              state.extraDeny.push(normalizePattern(decision.pattern));
+            }
+            try {
+              if (state !== undefined) {
+                await persistRules(state);
+              }
+            } catch (e: unknown) {
+              onSaveError?.(e);
+            }
+            throw KoiRuntimeError.from("PERMISSION", decision.reason, {
+              context: { toolId },
+            });
+          }
+
+          default: {
+            // Exhaustive check
+            const _exhaustive: never = decision;
+            throw new Error(
+              `Unhandled decision kind: ${String((_exhaustive as { kind: string }).kind)}`,
+            );
+          }
+        }
+      }
+
+      // 6. Default deny
+      throw KoiRuntimeError.from(
+        "PERMISSION",
+        `Tool "${toolId}" is not in the allow list (default deny)`,
+        { context: { toolId } },
+      );
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import type { ExecApprovalRequest, ProgressiveDecision } from "./types.js";
+
+async function askWithTimeout(
+  onAsk: (req: ExecApprovalRequest) => Promise<ProgressiveDecision>,
+  req: ExecApprovalRequest,
+  timeoutMs: number,
+): Promise<ProgressiveDecision> {
+  const ac = new AbortController();
+  return Promise.race([
+    onAsk(req),
+    new Promise<never>((_, reject) => {
+      const timerId = setTimeout(() => {
+        reject(
+          KoiRuntimeError.from(
+            "TIMEOUT",
+            `Approval timed out after ${timeoutMs}ms for tool "${req.toolId}"`,
+            {
+              context: { toolId: req.toolId, timeoutMs },
+            },
+          ),
+        );
+      }, timeoutMs);
+      ac.signal.addEventListener("abort", () => clearTimeout(timerId), { once: true });
+    }),
+  ]).finally(() => {
+    ac.abort();
+  });
+}
+
+function dedupe(arr: readonly string[]): string[] {
+  return [...new Set(arr)];
+}

--- a/packages/exec-approvals/src/pattern.test.ts
+++ b/packages/exec-approvals/src/pattern.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import {
+  defaultExtractCommand,
+  findFirstAskMatch,
+  matchesAnyCompound,
+  matchesCompoundPattern,
+  normalizePattern,
+} from "./pattern.js";
+
+// ---------------------------------------------------------------------------
+// normalizePattern
+// ---------------------------------------------------------------------------
+
+describe("normalizePattern", () => {
+  test("leaves patterns without ** unchanged", () => {
+    expect(normalizePattern("bash")).toBe("bash");
+    expect(normalizePattern("bash:git push*")).toBe("bash:git push*");
+    expect(normalizePattern("*")).toBe("*");
+  });
+
+  test("replaces ** with *", () => {
+    expect(normalizePattern("bash:**")).toBe("bash:*");
+    expect(normalizePattern("**")).toBe("*");
+    expect(normalizePattern("bash:git **")).toBe("bash:git *");
+  });
+
+  test("replaces multiple ** occurrences", () => {
+    expect(normalizePattern("**:**")).toBe("*:*");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultExtractCommand
+// ---------------------------------------------------------------------------
+
+describe("defaultExtractCommand", () => {
+  test("returns input.command when present", () => {
+    expect(defaultExtractCommand({ command: "cat /etc/passwd" })).toBe("cat /etc/passwd");
+  });
+
+  test("joins input.args array when no command", () => {
+    expect(defaultExtractCommand({ args: ["git", "push", "origin", "main"] })).toBe(
+      "git push origin main",
+    );
+  });
+
+  test("falls back to JSON.stringify when neither command nor args", () => {
+    const input = { path: "/etc/shadow" };
+    expect(defaultExtractCommand(input)).toBe(JSON.stringify(input));
+  });
+
+  test("uses command over args when both present", () => {
+    expect(defaultExtractCommand({ command: "explicit", args: ["ignored"] })).toBe("explicit");
+  });
+
+  test("handles empty object", () => {
+    expect(defaultExtractCommand({})).toBe("{}");
+  });
+
+  test("handles empty args array", () => {
+    expect(defaultExtractCommand({ args: [] })).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesCompoundPattern — no-colon patterns (tool-only)
+// ---------------------------------------------------------------------------
+
+describe("matchesCompoundPattern — tool-only patterns", () => {
+  const extract = defaultExtractCommand;
+
+  test("exact tool name matches", () => {
+    expect(matchesCompoundPattern("bash", "bash", {}, extract)).toBe(true);
+  });
+
+  test("exact tool name does NOT match different tool", () => {
+    expect(matchesCompoundPattern("bash", "zsh", {}, extract)).toBe(false);
+  });
+
+  test("'*' pattern matches any tool regardless of input", () => {
+    expect(matchesCompoundPattern("*", "bash", { command: "rm -rf /" }, extract)).toBe(true);
+    expect(matchesCompoundPattern("*", "anything", {}, extract)).toBe(true);
+  });
+
+  test("tool prefix wildcard (no colon) matches tools with that prefix", () => {
+    // "fs*" (no colon) → matchesSegment on toolId → prefix match
+    expect(matchesCompoundPattern("fs*", "fs:read", {}, extract)).toBe(true);
+    expect(matchesCompoundPattern("fs*", "fs:write", {}, extract)).toBe(true);
+    expect(matchesCompoundPattern("fs*", "db:query", {}, extract)).toBe(false);
+  });
+
+  test("'fs:*' is a compound pattern — matches tool 'fs' with any input (NOT tool 'fs:read')", () => {
+    // "fs:*" → toolPattern="fs", inputPattern="*" → only matches toolId exactly "fs"
+    expect(matchesCompoundPattern("fs:*", "fs", { command: "anything" }, extract)).toBe(true);
+    expect(matchesCompoundPattern("fs:*", "fs:read", {}, extract)).toBe(false);
+  });
+
+  test("no-colon pattern matches any input for that tool", () => {
+    expect(matchesCompoundPattern("bash", "bash", { command: "cat /etc/shadow" }, extract)).toBe(
+      true,
+    );
+    expect(matchesCompoundPattern("bash", "bash", { command: "ls" }, extract)).toBe(true);
+    expect(matchesCompoundPattern("bash", "bash", {}, extract)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesCompoundPattern — compound patterns (tool:input)
+// ---------------------------------------------------------------------------
+
+describe("matchesCompoundPattern — compound patterns", () => {
+  const extract = defaultExtractCommand;
+
+  test("colon in pattern separates tool from input", () => {
+    expect(matchesCompoundPattern("bash:ls", "bash", { command: "ls" }, extract)).toBe(true);
+  });
+
+  test("FIRST colon only is separator — colon in value is NOT a second separator", () => {
+    // Pattern "bash:cat /etc:shadow" → toolPattern="bash", inputPattern="cat /etc:shadow"
+    expect(
+      matchesCompoundPattern(
+        "bash:cat /etc:shadow",
+        "bash",
+        { command: "cat /etc:shadow" },
+        extract,
+      ),
+    ).toBe(true);
+    // Should NOT match partial command
+    expect(
+      matchesCompoundPattern("bash:cat /etc:shadow", "bash", { command: "cat /etc" }, extract),
+    ).toBe(false);
+  });
+
+  test("input wildcard 'bash:*' matches bash with any input", () => {
+    expect(matchesCompoundPattern("bash:*", "bash", { command: "ls" }, extract)).toBe(true);
+    expect(matchesCompoundPattern("bash:*", "bash", {}, extract)).toBe(true);
+    expect(matchesCompoundPattern("bash:*", "zsh", { command: "ls" }, extract)).toBe(false);
+  });
+
+  test("prefix input pattern matches prefixed commands", () => {
+    expect(
+      matchesCompoundPattern(
+        "bash:git push*",
+        "bash",
+        { command: "git push origin main" },
+        extract,
+      ),
+    ).toBe(true);
+    expect(matchesCompoundPattern("bash:git push*", "bash", { command: "git push" }, extract)).toBe(
+      true,
+    );
+  });
+
+  test("prefix input pattern does NOT match other commands", () => {
+    expect(
+      matchesCompoundPattern("bash:git push*", "bash", { command: "git checkout" }, extract),
+    ).toBe(false);
+  });
+
+  test("ECS token format: 'tool:calculator' treated as toolId='tool', inputPattern='calculator'", () => {
+    // Documented behavior: the first colon separates tool from input
+    expect(
+      matchesCompoundPattern("tool:calculator", "tool", { command: "calculator" }, extract),
+    ).toBe(true);
+    expect(matchesCompoundPattern("tool:calculator", "tool:calculator", {}, extract)).toBe(false); // "tool:calculator" as toolId doesn't match toolPattern="tool"
+  });
+
+  test("input match fails when extracted command doesn't match", () => {
+    expect(matchesCompoundPattern("bash:cat", "bash", { command: "ls" }, extract)).toBe(false);
+  });
+
+  test("uses args fallback when command field absent", () => {
+    expect(
+      matchesCompoundPattern("bash:git push", "bash", { args: ["git", "push"] }, extract),
+    ).toBe(true);
+  });
+
+  test("uses JSON.stringify fallback when neither command nor args", () => {
+    const input = { path: "/etc/shadow" };
+    const jsonStr = JSON.stringify(input);
+    expect(matchesCompoundPattern(`bash:${jsonStr}`, "bash", input, extract)).toBe(true);
+  });
+
+  test("multiple colons in input value — only first colon is separator", () => {
+    const pattern = "bash:a:b:c";
+    // toolPattern="bash", inputPattern="a:b:c"
+    expect(matchesCompoundPattern(pattern, "bash", { command: "a:b:c" }, extract)).toBe(true);
+    expect(matchesCompoundPattern(pattern, "bash", { command: "a:b" }, extract)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesAnyCompound
+// ---------------------------------------------------------------------------
+
+describe("matchesAnyCompound", () => {
+  const extract = defaultExtractCommand;
+
+  test("returns true if any pattern matches", () => {
+    expect(matchesAnyCompound(["calc", "bash"], "bash", {}, extract)).toBe(true);
+  });
+
+  test("returns false if no pattern matches", () => {
+    expect(matchesAnyCompound(["calc", "zsh"], "bash", {}, extract)).toBe(false);
+  });
+
+  test("returns false for empty patterns list", () => {
+    expect(matchesAnyCompound([], "bash", {}, extract)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findFirstAskMatch
+// ---------------------------------------------------------------------------
+
+describe("findFirstAskMatch", () => {
+  const extract = defaultExtractCommand;
+
+  test("returns matched pattern string", () => {
+    expect(
+      findFirstAskMatch(["bash:git push*"], "bash", { command: "git push origin" }, extract),
+    ).toBe("bash:git push*");
+  });
+
+  test("returns undefined when no match", () => {
+    expect(
+      findFirstAskMatch(["bash:git push*"], "bash", { command: "ls" }, extract),
+    ).toBeUndefined();
+  });
+
+  test("returns first matching pattern", () => {
+    const patterns = ["bash:git*", "bash:git push*"];
+    // First match wins
+    expect(findFirstAskMatch(patterns, "bash", { command: "git push" }, extract)).toBe("bash:git*");
+  });
+
+  test("returns undefined for empty patterns list", () => {
+    expect(findFirstAskMatch([], "bash", {}, extract)).toBeUndefined();
+  });
+});

--- a/packages/exec-approvals/src/pattern.ts
+++ b/packages/exec-approvals/src/pattern.ts
@@ -1,0 +1,115 @@
+/**
+ * Compound pattern matching for @koi/exec-approvals.
+ *
+ * Patterns have two optional parts separated by the FIRST colon:
+ *   "bash:cat /etc:shadow"  →  toolPattern="bash", inputPattern="cat /etc:shadow"
+ *   "bash"                  →  toolPattern="bash", inputPattern=undefined (any input)
+ *   "*"                     →  matches any tool, any input
+ *   "bash:*"                →  matches bash with any input (including empty)
+ *
+ * Wildcards: only `*` at the end of a segment → prefix match.
+ * `**` is normalized to `*` at construction time.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+
+/**
+ * Normalize a pattern: replace `**` with `*` (once).
+ */
+export function normalizePattern(pattern: string): string {
+  return pattern.replace(/\*\*/g, "*");
+}
+
+/**
+ * Split a compound pattern on the FIRST colon only.
+ * Returns [toolPattern, inputPattern | undefined].
+ */
+function splitPattern(pattern: string): readonly [string, string | undefined] {
+  const colonIdx = pattern.indexOf(":");
+  if (colonIdx === -1) {
+    return [pattern, undefined];
+  }
+  return [pattern.slice(0, colonIdx), pattern.slice(colonIdx + 1)];
+}
+
+/**
+ * Match a single string segment against a pattern segment.
+ * Supports:
+ * - Exact match: "bash"
+ * - Wildcard: "*" (matches any string)
+ * - Suffix wildcard: "git push*" (prefix match)
+ */
+function matchesSegment(value: string, pattern: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("*")) {
+    const prefix = pattern.slice(0, -1);
+    return value.startsWith(prefix);
+  }
+  return value === pattern;
+}
+
+/**
+ * Default command extractor: tries input.command, then input.args joined, then JSON.stringify.
+ */
+export function defaultExtractCommand(input: JsonObject): string {
+  if (typeof input.command === "string") {
+    return input.command;
+  }
+  if (Array.isArray(input.args)) {
+    return (input.args as unknown[]).map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+  }
+  return JSON.stringify(input);
+}
+
+/**
+ * Match a (toolId, input) pair against a compound pattern.
+ *
+ * @param pattern - Already-normalized compound pattern string
+ * @param toolId  - Tool identifier to match against toolPattern part
+ * @param input   - Tool input object; extractFn derives the command string
+ * @param extractFn - Extracts a matchable string from input
+ */
+export function matchesCompoundPattern(
+  pattern: string,
+  toolId: string,
+  input: JsonObject,
+  extractFn: (input: JsonObject) => string,
+): boolean {
+  const [toolPattern, inputPattern] = splitPattern(pattern);
+
+  if (!matchesSegment(toolId, toolPattern)) {
+    return false;
+  }
+
+  if (inputPattern === undefined) {
+    // No colon in pattern — matches any input for this tool
+    return true;
+  }
+
+  const command = extractFn(input);
+  return matchesSegment(command, inputPattern);
+}
+
+/**
+ * Returns true if (toolId, input) matches any pattern in the list.
+ */
+export function matchesAnyCompound(
+  patterns: readonly string[],
+  toolId: string,
+  input: JsonObject,
+  extractFn: (input: JsonObject) => string,
+): boolean {
+  return patterns.some((p) => matchesCompoundPattern(p, toolId, input, extractFn));
+}
+
+/**
+ * Returns the first matching ask pattern, or undefined if none match.
+ */
+export function findFirstAskMatch(
+  askPatterns: readonly string[],
+  toolId: string,
+  input: JsonObject,
+  extractFn: (input: JsonObject) => string,
+): string | undefined {
+  return askPatterns.find((p) => matchesCompoundPattern(p, toolId, input, extractFn));
+}

--- a/packages/exec-approvals/src/store.test.ts
+++ b/packages/exec-approvals/src/store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryRulesStore } from "./store.js";
+
+describe("createInMemoryRulesStore", () => {
+  test("load() returns empty rules initially", async () => {
+    const store = createInMemoryRulesStore();
+    const rules = await store.load();
+    expect(rules.allow).toEqual([]);
+    expect(rules.deny).toEqual([]);
+  });
+
+  test("save() then load() returns saved rules", async () => {
+    const store = createInMemoryRulesStore();
+    await store.save({ allow: ["bash:ls"], deny: ["bash:rm*"] });
+    const rules = await store.load();
+    expect(rules.allow).toEqual(["bash:ls"]);
+    expect(rules.deny).toEqual(["bash:rm*"]);
+  });
+
+  test("multiple saves overwrite (not append)", async () => {
+    const store = createInMemoryRulesStore();
+    await store.save({ allow: ["bash:ls"], deny: [] });
+    await store.save({ allow: ["bash:cat"], deny: ["bash:rm"] });
+    const rules = await store.load();
+    expect(rules.allow).toEqual(["bash:cat"]);
+    expect(rules.deny).toEqual(["bash:rm"]);
+  });
+
+  test("load() returns a fresh copy — mutating returned array does not affect store", async () => {
+    const store = createInMemoryRulesStore();
+    await store.save({ allow: ["bash:ls"], deny: [] });
+    const rules = await store.load();
+    // Mutate the returned array
+    (rules.allow as string[]).push("bash:evil");
+    // Load again — store should be unaffected
+    const rules2 = await store.load();
+    expect(rules2.allow).toEqual(["bash:ls"]);
+  });
+
+  test("save() with empty arrays clears rules", async () => {
+    const store = createInMemoryRulesStore();
+    await store.save({ allow: ["bash:ls"], deny: ["bash:rm"] });
+    await store.save({ allow: [], deny: [] });
+    const rules = await store.load();
+    expect(rules.allow).toEqual([]);
+    expect(rules.deny).toEqual([]);
+  });
+
+  test("multiple stores are independent", async () => {
+    const store1 = createInMemoryRulesStore();
+    const store2 = createInMemoryRulesStore();
+    await store1.save({ allow: ["bash:ls"], deny: [] });
+    const r2 = await store2.load();
+    expect(r2.allow).toEqual([]);
+  });
+});

--- a/packages/exec-approvals/src/store.ts
+++ b/packages/exec-approvals/src/store.ts
@@ -1,0 +1,23 @@
+/**
+ * In-memory ExecRulesStore implementation.
+ *
+ * Starts empty. "Always" decisions accumulate in memory only.
+ * Useful for testing and development.
+ */
+
+import type { ExecRulesStore, PersistedRules } from "./types.js";
+
+export function createInMemoryRulesStore(): ExecRulesStore {
+  // let is justified: the store must track mutable accumulated state across saves
+  let current: PersistedRules = { allow: [], deny: [] };
+
+  return {
+    load: async (): Promise<PersistedRules> => {
+      // Return new arrays to prevent callers from mutating internal state
+      return { allow: [...current.allow], deny: [...current.deny] };
+    },
+    save: async (rules: PersistedRules): Promise<void> => {
+      current = { allow: [...rules.allow], deny: [...rules.deny] };
+    },
+  };
+}

--- a/packages/exec-approvals/src/types.ts
+++ b/packages/exec-approvals/src/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Domain types for @koi/exec-approvals.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+
+/**
+ * The 5 decisions a user can make when prompted for approval.
+ *
+ * - allow_once: allow this single invocation only
+ * - allow_session: allow for the remainder of this session
+ * - allow_always: allow permanently (pattern written to store)
+ * - deny_once: deny this single invocation
+ * - deny_always: deny permanently (pattern written to store)
+ */
+export type ProgressiveDecision =
+  | { readonly kind: "allow_once" }
+  | { readonly kind: "allow_session"; readonly pattern: string }
+  | { readonly kind: "allow_always"; readonly pattern: string }
+  | { readonly kind: "deny_once"; readonly reason: string }
+  | { readonly kind: "deny_always"; readonly pattern: string; readonly reason: string };
+
+/**
+ * The shape persisted in the backing store.
+ */
+export interface PersistedRules {
+  readonly allow: readonly string[];
+  readonly deny: readonly string[];
+}
+
+/**
+ * Pluggable backing store for "always" decisions.
+ * Use createInMemoryRulesStore() for testing/development.
+ */
+export interface ExecRulesStore {
+  readonly load: () => Promise<PersistedRules>;
+  readonly save: (rules: PersistedRules) => Promise<void>;
+}
+
+/**
+ * The request passed to onAsk when an ask rule fires.
+ */
+export interface ExecApprovalRequest {
+  readonly toolId: string;
+  readonly input: JsonObject;
+  /** Which ask pattern triggered this request. */
+  readonly matchedPattern: string;
+}

--- a/packages/exec-approvals/tsconfig.json
+++ b/packages/exec-approvals/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/exec-approvals/tsup.config.ts
+++ b/packages/exec-approvals/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/check-layers.ts
+++ b/scripts/check-layers.ts
@@ -29,6 +29,7 @@ const L0U_PACKAGES = new Set([
   "@koi/execution-context",
   "@koi/hash",
   "@koi/manifest",
+  "@koi/sandbox-cloud-base",
   "@koi/shutdown",
   "@koi/skill-scanner",
   "@koi/snapshot-chain-store",


### PR DESCRIPTION
## Summary

- Implements \`@koi/exec-approvals\` — progressive command allowlisting middleware (L2, #23)
- 5-variant \`ProgressiveDecision\`: allow-once, allow-session, allow-always, deny-once, deny-always
- Compound pattern engine (\`bash:git push*\`), pluggable backing store, all 4 security invariants enforced
- Also registers \`@koi/sandbox-cloud-base\` as L0u in \`check-layers.ts\` (fixes 5 pre-existing violations)

## Test plan

- [x] 97 tests pass (unit + \`createKoi\` integration)
- [x] 11/11 comprehensive E2E tests pass with real Anthropic API + \`createPiAdapter\` — all 5 decision variants, cross-session persistence, compound patterns, base-deny invariant, timeout, store-failure resilience (\`packages/exec-approvals/e2e-manual.ts\`)
- [x] \`bun scripts/check-layers.ts\` → ✅ no violations
- [x] Biome check clean
- [x] Full monorepo build + typecheck + test pass (pre-push hook)

Closes #23