### PR TITLE
feat: gateway tool routing + architecture docs

### DIFF
--- a/docs/architecture/Gateway.md
+++ b/docs/architecture/Gateway.md
@@ -1,0 +1,647 @@
+# Gateway: WebSocket Control Plane
+
+## Overview
+
+`@koi/gateway` is an L2 package that provides the WebSocket control plane for Koi. It manages two distinct connection types through a single transport:
+
+- **Client sessions** — browsers, mobile apps, CLIs, and other frontends that send and receive `GatewayFrame` messages through authenticated sessions.
+- **Compute nodes** — local device runtimes (`@koi/node`) that register tools and capacity, exchange `NodeFrame` messages, and optionally route tool calls between each other.
+
+The gateway handles authentication, protocol negotiation, session lifecycle, message sequencing, backpressure, routing, webhook ingestion, scheduled dispatch, and opt-in tool routing between nodes. It depends only on `@koi/core` (L0) and `@koi/errors` (L0u).
+
+---
+
+## Architecture
+
+```
+                     ┌─────────────────────────┐
+                     │      Transport (WS)      │
+                     │  Bun.serve() WebSocket    │
+                     └────────────┬────────────┘
+                                  │ onOpen / onMessage / onClose / onDrain
+                                  │
+                     ┌────────────▼────────────┐
+                     │     First-Message Router  │
+                     │  peekFrameKind(data)      │
+                     └──────┬──────────┬────────┘
+                            │          │
+               kind="connect"     kind="node:*"
+                            │          │
+               ┌────────────▼──┐  ┌────▼─────────────┐
+               │  Client Path  │  │   Node Path       │
+               │               │  │                    │
+               │  Auth/Handshake│  │  Node Handshake    │
+               │  Session Store │  │  Capabilities      │
+               │  Seq Tracker  │  │  Registration Ack   │
+               │  Backpressure │  │  Node Registry      │
+               │  Routing      │  │  Heartbeat/Capacity │
+               └───────────────┘  └─────────┬──────────┘
+                                            │
+                                  ┌─────────▼──────────┐
+                                  │  Tool Router (opt-in)│
+                                  │  Affinity / Capacity  │
+                                  │  Queue / Timeout      │
+                                  └───────────────────────┘
+         ┌──────────────┐   ┌──────────────┐
+         │ Webhook Server│   │  Scheduler   │
+         │ HTTP POST     │   │  Periodic    │
+         │ → dispatch()  │   │  → dispatch()│
+         └──────────────┘   └──────────────┘
+```
+
+Both webhook and scheduler inject frames into the same `resolveAndDispatch` pipeline that client frames use, ensuring consistent routing regardless of ingestion source.
+
+---
+
+## Wire Protocol
+
+The gateway uses two distinct frame formats: `GatewayFrame` for client connections and `NodeFrame` for compute-node connections.
+
+### ConnectFrame (Client Handshake)
+
+The first message a client sends must be a `ConnectFrame`:
+
+```typescript
+interface ConnectFrame {
+  readonly kind: "connect";
+  readonly minProtocol: number;     // minimum protocol version (positive integer)
+  readonly maxProtocol: number;     // maximum protocol version (>= minProtocol)
+  readonly auth: { readonly token: string };
+  readonly client?: {               // optional client metadata
+    readonly id?: string;
+    readonly version?: string;
+    readonly platform?: string;     // "web", "ios", "cli", "node"
+  };
+  readonly resume?: {               // session resume request
+    readonly sessionId: string;
+    readonly lastSeq: number;
+  };
+}
+```
+
+Legacy clients may send `protocol` (single integer) instead of the range format. The parser accepts both.
+
+### GatewayFrame (Post-Handshake)
+
+All subsequent client messages use `GatewayFrame`:
+
+```typescript
+interface GatewayFrame {
+  readonly kind: GatewayFrameKind;
+  readonly id: string;              // unique message ID (dedup key)
+  readonly seq: number;             // monotonic sequence number
+  readonly ref?: string;            // correlates response to originating request
+  readonly payload: unknown;
+  readonly timestamp: number;
+}
+```
+
+| `GatewayFrameKind` | Direction | Purpose |
+|---------------------|-----------|---------|
+| `request` | client -> server | Client-initiated request |
+| `response` | server -> client | Server response to a request |
+| `event` | server -> client | Server-pushed event |
+| `ack` | server -> client | Delivery acknowledgement |
+| `error` | server -> client | Error response |
+
+### NodeFrame (Compute Node)
+
+Nodes use a separate frame format with different routing semantics:
+
+```typescript
+interface NodeFrame {
+  readonly kind: NodeFrameKind;
+  readonly nodeId: string;
+  readonly agentId: string;
+  readonly correlationId: string;
+  readonly ttl?: number;            // optional per-frame TTL override
+  readonly payload: unknown;
+}
+```
+
+| `NodeFrameKind` | Direction | Purpose |
+|------------------|-----------|---------|
+| `node:handshake` | node -> gw | Initial registration request |
+| `node:capabilities` | node -> gw | Tool list + node type declaration |
+| `node:registered` | gw -> node | Registration acknowledgement |
+| `node:heartbeat` | node -> gw | Keep-alive signal |
+| `node:capacity` | node -> gw | Updated capacity report |
+| `node:error` | gw -> node | Error response |
+| `agent:dispatch` | gw -> node | Dispatch work to an agent on the node |
+| `agent:message` | node -> gw | Agent output message |
+| `agent:status` | node -> gw | Agent lifecycle status update |
+| `agent:terminate` | gw -> node | Request agent termination |
+| `tool_call` | node -> gw | Cross-node tool invocation request |
+| `tool_result` | gw -> node | Tool call result (routed back) |
+| `tool_error` | gw -> node | Tool call error (routed back) |
+
+---
+
+## Connection Lifecycle
+
+When a WebSocket connection opens, the gateway does not immediately know whether the peer is a client or a compute node. The first message determines the path:
+
+```
+  connection opens
+       │
+       ▼
+  start auth timer (authTimeoutMs)
+       │
+       ▼
+  receive first message
+       │
+       ├── peekFrameKind → "connect"  ──→  Client handshake path
+       │
+       ├── peekFrameKind → "node:*"   ──→  Node handshake path
+       │
+       └── other / timeout            ──→  Close(4001 or 4002)
+```
+
+Before routing, the gateway checks:
+1. `maxConnections` — rejects if at capacity (close code 4005)
+2. Global buffer limit — rejects if global backpressure exceeded (close code 4006)
+
+The auth timer fires if no first message arrives within `authTimeoutMs` (default: 5000ms), closing the connection with code 4001.
+
+---
+
+## Authentication and Handshake
+
+The client handshake follows this sequence:
+
+```
+  Client                          Gateway
+    │                               │
+    │──── ConnectFrame ────────────→│
+    │                               │ parse + validate
+    │                               │ negotiate protocol version
+    │                               │ authenticate(connectFrame)
+    │                               │
+    │←──── HandshakeAck ───────────│  (on success)
+    │  or                           │
+    │←──── Error + Close ──────────│  (on failure)
+```
+
+**Protocol negotiation** computes the highest mutually supported version from the overlap of `[clientMin, clientMax]` and `[serverMin, serverMax]`. If no overlap exists, the connection is closed with code 4010.
+
+**HandshakeAckPayload** returned on success:
+
+```typescript
+interface HandshakeAckPayload {
+  readonly sessionId: string;
+  readonly protocol: number;          // negotiated version
+  readonly capabilities: {
+    readonly compression: boolean;
+    readonly resumption: boolean;      // true when sessionTtlMs > 0
+    readonly maxFrameBytes: number;
+  };
+  readonly snapshot?: {
+    readonly serverTime: number;       // enables clock-skew detection
+    readonly activeConnections: number; // coarse load signal
+  };
+}
+```
+
+**Auth failure codes**: `INVALID_TOKEN`, `EXPIRED`, `FORBIDDEN`. Each results in a close code of 4003.
+
+The `GatewayAuthenticator` interface that callers must implement:
+
+```typescript
+interface GatewayAuthenticator {
+  readonly authenticate: (frame: ConnectFrame) => Promise<AuthResult>;
+  readonly validate: (sessionId: string) => Promise<boolean>;
+}
+```
+
+`validate` is called during periodic heartbeat sweeps to re-check session validity. The sweep is sharded (10 shards) and batched (50 concurrent validations) to avoid thundering herd on the auth service. On auth service failure, the sweep fails open — the session stays alive and retries next sweep.
+
+---
+
+## Sessions
+
+A session is created after successful authentication and represents a client's logical connection to the gateway.
+
+```typescript
+interface Session {
+  readonly id: string;
+  readonly agentId: string;
+  readonly connectedAt: number;
+  readonly lastHeartbeat: number;
+  readonly seq: number;            // local outbound sequence counter
+  readonly remoteSeq: number;      // last accepted inbound sequence
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly routing?: RoutingContext;
+}
+```
+
+**SessionStore** is pluggable — the default `createInMemorySessionStore` uses a `Map`. All methods return `Result<T, KoiError> | Promise<Result<T, KoiError>>` so implementations can be sync (in-memory) or async (database-backed).
+
+### Session Events
+
+Subscribers receive lifecycle events via `gateway.onSessionEvent()`:
+
+| Event kind | When emitted |
+|------------|-------------|
+| `created` | New session established after handshake |
+| `resumed` | Disconnected session reconnected within TTL |
+| `destroyed` | Session force-destroyed via `destroySession()` |
+| `expired` | Disconnected session TTL elapsed without reconnect |
+
+### Session Resume
+
+When `sessionTtlMs > 0`, a disconnecting client's session is kept alive:
+
+1. On disconnect, the session's `SequenceTracker` is preserved and a TTL timer starts.
+2. Frames sent to the session during the TTL window are buffered (up to 1,000 frames).
+3. The client reconnects with `resume: { sessionId, lastSeq }` in the `ConnectFrame`.
+4. On successful resume, buffered frames are flushed to the client immediately.
+5. If the TTL expires without reconnection, the session is deleted and an `expired` event fires.
+
+The handshake ack advertises `capabilities.resumption = true` when `sessionTtlMs > 0`.
+
+### Force Destroy
+
+`gateway.destroySession(sessionId, reason?)` works for both connected and disconnected sessions. Connected sessions are closed with code 4012. Disconnected sessions have their TTL timer cancelled and state cleaned up.
+
+---
+
+## Sequencing and Deduplication
+
+Each client session has a `SequenceTracker` that enforces ordering and prevents duplicate processing.
+
+**Sliding window**: Frames are accepted within a window of `[nextExpected, nextExpected + windowSize)`. The window size is controlled by `dedupWindowSize` (default: 128).
+
+**Accept outcomes**:
+
+| Result | Condition | Gateway response |
+|--------|-----------|-----------------|
+| `accepted` | `seq === nextExpected` | Ack frame, dispatch to handlers |
+| `buffered` | `seq` within window but ahead of `nextExpected` | Buffered, released when gap fills |
+| `duplicate` | `seq < nextExpected` or ID already seen | Ack frame (idempotent) |
+| `out_of_window` | `seq >= nextExpected + windowSize` | Error frame |
+
+When a gap fills, all buffered frames up to the new contiguous frontier are flushed in sequence order. Seen IDs are pruned as the window advances.
+
+---
+
+## Routing
+
+Routing determines which `agentId` handles a frame based on the session's `RoutingContext` (channel, account, peer).
+
+### Scoping Modes
+
+The `ScopingMode` controls how dispatch keys are computed:
+
+| Mode | Dispatch key | Use case |
+|------|-------------|----------|
+| `main` | `"main"` | Single agent handles everything |
+| `per-peer` | `"{peer}"` | Per-user agent instance |
+| `per-channel-peer` | `"{channel}:{peer}"` | Per-user per-channel |
+| `per-account-channel-peer` | `"{account}:{channel}:{peer}"` | Multi-tenant |
+
+Missing segments default to `"_"`.
+
+### Route Bindings
+
+Pattern-based agent selection. Patterns are `:` delimited with support for `*` (single segment) and `**` (terminal wildcard):
+
+```typescript
+interface RouteBinding {
+  readonly pattern: string;    // e.g. "slack:*", "**"
+  readonly agentId: string;
+}
+```
+
+Bindings are compiled and cached (via `WeakMap`) for hot-path performance. First match wins.
+
+### Channel Bindings
+
+Direct channel-to-agent mapping with the highest priority in route resolution:
+
+- **Static**: declared in `GatewayConfig.channelBindings`, loaded at startup.
+- **Runtime**: `gateway.bindChannel(name, agentId)` / `gateway.unbindChannel(name)`.
+
+### Resolution Order
+
+```
+1. Channel binding (channelName → agentId)     highest priority
+2. Pattern binding (dispatchKey → agentId)
+3. Fallback (session.agentId)                   lowest priority
+```
+
+---
+
+## Node Registry
+
+The node registry tracks connected compute nodes, their tools, and capacity. It maintains an inverted tool index for O(1) tool-to-nodes lookups.
+
+### Registration Flow
+
+```
+  Node                             Gateway
+    │                                │
+    │── node:handshake ────────────→│  validate payload (nodeId, version, capacity)
+    │                                │  evict stale connection if same nodeId
+    │── node:capabilities ─────────→│  validate tools + nodeType
+    │                                │  register in NodeRegistry
+    │                                │  build inverted tool index
+    │←── node:registered ──────────│  ack with registeredAt timestamp
+    │                                │  emit "registered" NodeRegistryEvent
+```
+
+Two-step handshake: the first message provides identity and capacity, the second provides tool capabilities and node type (`"full"` or `"thin"`).
+
+### RegisteredNode
+
+```typescript
+interface RegisteredNode {
+  readonly nodeId: string;
+  readonly mode: "full" | "thin";
+  readonly tools: readonly AdvertisedTool[];
+  readonly capacity: CapacityReport;   // { current, max, available }
+  readonly connectedAt: number;
+  readonly lastHeartbeat: number;
+  readonly connId: string;
+}
+```
+
+### Inverted Tool Index
+
+`toolName -> Set<nodeId>` mapping built at registration time. `registry.findByTool(name)` returns all nodes advertising a given tool in O(1) lookup time. The index is incrementally maintained — entries are added on register and removed on deregister.
+
+### Heartbeat and Capacity
+
+- **Heartbeat**: nodes send `node:heartbeat` frames periodically. The gateway updates `lastHeartbeat` on the registered node.
+- **Capacity**: nodes send `node:capacity` frames when their load changes. The gateway updates the `CapacityReport`.
+- **Stale sweep**: a periodic timer (every `sweepIntervalMs`) checks all nodes. Any node whose `lastHeartbeat` is older than `nodeHeartbeatTimeoutMs` (default: 90s, 3x the heartbeat interval) is evicted.
+
+### Reconnect
+
+When a node reconnects with the same `nodeId`, the gateway evicts the old connection (close code 4014 "Replaced by reconnecting node"), cleans up all state, then processes the new handshake normally. This prevents ghost connections from holding registry slots.
+
+### Node Events
+
+Subscribers receive events via `gateway.onNodeEvent()`:
+
+| Event kind | When emitted |
+|------------|-------------|
+| `registered` | Node completed handshake and capability exchange |
+| `deregistered` | Node disconnected or evicted |
+| `heartbeat` | Node sent heartbeat |
+| `capacity_updated` | Node reported new capacity |
+
+---
+
+## Tool Routing
+
+Tool routing enables nodes to invoke tools hosted on other nodes through the gateway. It is entirely opt-in — disabled by default, enabled by setting `GatewayConfig.toolRouting`.
+
+### Why tool routing exists
+
+In a multi-node deployment, Node-A may need to call a tool that only Node-B provides. Without tool routing, the calling node would need direct knowledge of peer nodes. Tool routing lets the gateway act as a transparent broker: nodes only communicate with the gateway, and the gateway handles discovery, forwarding, correlation, and error propagation.
+
+### Routing Algorithm
+
+When a `tool_call` frame arrives, the router applies a 5-priority decision tree:
+
+```
+1. Validate payload (toolName, callerAgentId present)
+2. Check pending limit (maxPendingCalls)
+3. Resolve target node:
+   a. Find all nodes advertising the tool (inverted index)
+   b. Exclude the source node (it already tried locally)
+   c. Check affinity rules (glob pattern → preferred node)
+   d. Pick highest available capacity among remaining candidates
+4. If no candidate: queue with TTL (if queue not full)
+5. If queue full or disabled: return tool_error to source
+```
+
+### Cross-Node Flow
+
+```
+  Node-A                    Gateway                     Node-B
+    │                          │                           │
+    │── tool_call ───────────→│                           │
+    │   correlationId: "abc"   │ resolve target            │
+    │                          │ generate routing ID       │
+    │                          │   "route-abc-{ts}"        │
+    │                          │── tool_call ─────────────→│
+    │                          │   correlationId:           │
+    │                          │     "route-abc-{ts}"       │
+    │                          │                           │
+    │                          │←── tool_result ──────────│
+    │                          │   correlationId:           │
+    │                          │     "route-abc-{ts}"       │
+    │                          │ lookup pending entry       │
+    │                          │ restore original corr ID   │
+    │←── tool_result ─────────│                           │
+    │   correlationId: "abc"   │                           │
+```
+
+The gateway generates a routing correlation ID (`route-{original}-{timestamp}`) to track the forwarded call. When the result returns, the gateway maps it back to the original caller's correlation ID.
+
+### Affinity
+
+Affinity rules provide static preferences for routing specific tools to specific nodes:
+
+```typescript
+interface ToolAffinity {
+  readonly pattern: string;    // glob pattern, e.g. "search_*", "db.*"
+  readonly nodeId: string;     // preferred target node
+}
+```
+
+Glob patterns are compiled to `RegExp` at construction time (`*` becomes `.*`). Affinity is a preference, not a requirement — if the preferred node is offline or is the source node, the router falls back to capacity-based selection.
+
+### Queue
+
+When no node is available for a tool call, it is queued in memory:
+
+- **Max size**: `maxQueuedCalls` (default: 1,000)
+- **TTL**: `queueTimeoutMs` (default: 60,000ms)
+- **Dequeue**: when a new node registers, the router checks if any queued calls match the node's tools and dispatches them immediately.
+- **Expiry**: a TTL timer fires `tool_error` back to the source if no node becomes available.
+
+### Timeout
+
+Each routed call has a timeout:
+
+- **Default**: `defaultTimeoutMs` (default: 30,000ms)
+- **Per-call override**: if the `NodeFrame.ttl` field is set, it overrides the default.
+- On timeout, the pending entry is cleaned up and a `tool_error` with code `"timeout"` is sent to the source node.
+
+### Disconnect Handling
+
+**Target node disconnects**: all pending calls targeting that node receive `tool_error` with `"not_found"` code. The source node can retry or handle the failure.
+
+**Source node disconnects**: pending calls from that node are silently cleaned up (no one to receive the result). Queued calls from that node are also removed.
+
+### ToolRouter Interface
+
+```typescript
+interface ToolRouter {
+  readonly handleToolCall: (frame: NodeFrame) => void;
+  readonly handleToolResult: (frame: NodeFrame) => void;
+  readonly handleToolError: (frame: NodeFrame) => void;
+  readonly handleNodeDisconnect: (nodeId: string) => void;
+  readonly handleNodeRegistered: (nodeId: string) => void;
+  readonly pendingCount: () => number;
+  readonly queuedCount: () => number;
+  readonly dispose: () => void;
+}
+```
+
+The tool router is wired into the node connection handler via callback — `tool_call`, `tool_result`, and `tool_error` frame kinds are intercepted and forwarded to the router. The router also subscribes to node registry events to handle disconnect cleanup and queue drain on registration.
+
+---
+
+## Backpressure
+
+The backpressure monitor tracks per-connection and global buffer usage, transitioning through three states:
+
+```
+  normal ──→ warning ──→ critical ──→ force-close
+           (watermark)  (max buffer)  (timeout)
+```
+
+| State | Condition | Behavior |
+|-------|-----------|----------|
+| `normal` | `buffered < warningThreshold` | All frames processed |
+| `warning` | `buffered >= maxBuffer * highWatermark` | Frames still processed (signal only) |
+| `critical` | `buffered >= maxBufferBytesPerConnection` | Frames dropped; timeout starts |
+
+- **Warning threshold**: `maxBufferBytesPerConnection * backpressureHighWatermark` (default: 80% of 1MB = ~819KB)
+- **Critical timeout**: if a connection remains in critical state for `backpressureCriticalTimeoutMs` (default: 30s), it is force-closed (code 4009).
+- **Global limit**: `globalBufferLimitBytes` (default: 500MB). New connections are rejected when the global buffer is exceeded (code 4006).
+- **Drain recovery**: when the transport reports a drain event, buffered bytes are decremented and the state may recover to warning or normal.
+
+---
+
+## Webhooks
+
+The webhook server provides HTTP POST ingestion that converts requests into `GatewayFrame` events dispatched through the same routing pipeline as WebSocket frames.
+
+- **Activation**: set `GatewayConfig.webhookPort` to enable (undefined = disabled).
+- **Path routing**: requests must match `{webhookPath}/{channel?}/{account?}`. Default path prefix: `/webhook`.
+- **Peer identification**: `X-Webhook-Peer` header (defaults to `"webhook"`).
+- **Authentication**: optional `WebhookAuthenticator` receives the raw request and body (for HMAC signature verification).
+- **Body limits**: 1MB default max body size with streaming enforcement (no Content-Length required).
+- **Virtual session**: each webhook creates a transient session with `id: "webhook-{frameId}"` that passes through `resolveAndDispatch`.
+
+---
+
+## Scheduler
+
+The scheduler generates periodic `GatewayFrame` events at fixed intervals, useful for cron-like agent dispatch.
+
+```typescript
+interface SchedulerDef {
+  readonly id: string;
+  readonly intervalMs: number;    // minimum: 100ms
+  readonly agentId: string;
+  readonly payload?: unknown;
+}
+```
+
+Each scheduler definition produces:
+- A virtual session with `id: "scheduler-{def.id}"` and `agentId` from the definition.
+- An event frame with the configured payload (or `{ schedulerId, type: "tick" }` by default).
+
+Frames are dispatched through `resolveAndDispatch`, so routing rules apply. The minimum interval is 100ms to prevent accidental self-DoS.
+
+---
+
+## Configuration Reference
+
+### GatewayConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `minProtocolVersion` | `number` | `1` | Minimum protocol version the server supports |
+| `maxProtocolVersion` | `number` | `1` | Maximum protocol version the server supports |
+| `capabilities` | `GatewayCapabilities` | `{ compression: false, resumption: false, maxFrameBytes: 1_048_576 }` | Capabilities advertised during handshake |
+| `includeSnapshot` | `boolean` | `true` | Whether to include runtime snapshot in handshake ack |
+| `maxConnections` | `number` | `10_000` | Maximum concurrent connections |
+| `backpressureHighWatermark` | `number` | `0.8` | Buffer utilization ratio that triggers warning state |
+| `maxBufferBytesPerConnection` | `number` | `1_048_576` (1MB) | Maximum buffered bytes per connection |
+| `globalBufferLimitBytes` | `number` | `524_288_000` (500MB) | Global buffer limit across all connections |
+| `dedupWindowSize` | `number` | `128` | Sliding window size for deduplication |
+| `heartbeatIntervalMs` | `number` | `30_000` | Heartbeat interval for session validation |
+| `authTimeoutMs` | `number` | `5_000` | Auth handshake timeout |
+| `backpressureCriticalTimeoutMs` | `number` | `30_000` | Time before force-closing a critical connection |
+| `sweepIntervalMs` | `number` | `10_000` | Timer sweep interval for heartbeat/stale checks |
+| `nodeHeartbeatTimeoutMs` | `number` | `90_000` | Node heartbeat timeout (3x heartbeat interval) |
+| `sessionTtlMs` | `number` | `0` | Session TTL after disconnect (0 = immediate cleanup) |
+| `routing` | `RoutingConfig?` | `undefined` | Routing configuration for session dispatch |
+| `channelBindings` | `ChannelBinding[]?` | `undefined` | Static channel-to-agent bindings |
+| `webhookPort` | `number?` | `undefined` | Port for webhook HTTP server (undefined = disabled) |
+| `webhookPath` | `string?` | `"/webhook"` | URL path prefix for webhook endpoints |
+| `schedulers` | `SchedulerDef[]?` | `undefined` | Scheduler definitions for periodic dispatch |
+| `toolRouting` | `Partial<ToolRoutingConfig>?` | `undefined` | Tool routing config (undefined = disabled) |
+
+### ToolRoutingConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `defaultTimeoutMs` | `number` | `30_000` | Default timeout for routed tool calls |
+| `maxPendingCalls` | `number` | `10_000` | Maximum concurrently pending routed calls |
+| `maxQueuedCalls` | `number` | `1_000` | Maximum tool calls queued waiting for a node |
+| `queueTimeoutMs` | `number` | `60_000` | TTL for queued tool calls |
+| `affinities` | `ToolAffinity[]?` | `undefined` | Static tool-to-node routing preferences |
+
+---
+
+## Gateway Public API
+
+The `createGateway(config, deps)` factory returns a `Gateway` object:
+
+```typescript
+interface Gateway {
+  readonly start: (port: number) => Promise<void>;
+  readonly stop: () => Promise<void>;
+  readonly sessions: () => SessionStore;
+  readonly onFrame: (handler: (session: Session, frame: GatewayFrame) => void) => () => void;
+  readonly send: (sessionId: string, frame: GatewayFrame) => Result<number, KoiError>;
+  readonly dispatch: (session: Session, frame: GatewayFrame) => void;
+  readonly webhookPort: () => number | undefined;
+  readonly nodeRegistry: () => NodeRegistry;
+  readonly onNodeEvent: (handler: (event: NodeRegistryEvent) => void) => () => void;
+  readonly destroySession: (sessionId: string, reason?: string) => Result<void, KoiError>;
+  readonly onSessionEvent: (handler: (event: SessionEvent) => void) => () => void;
+  readonly bindChannel: (channelName: string, agentId: string) => void;
+  readonly unbindChannel: (channelName: string) => boolean;
+  readonly channelBindings: () => ReadonlyMap<string, string>;
+  readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
+}
+```
+
+**Dependencies** (`GatewayDeps`):
+
+| Dep | Required | Purpose |
+|-----|----------|---------|
+| `transport` | yes | WebSocket transport (use `createBunTransport()`) |
+| `auth` | yes | Authentication provider (must implement `GatewayAuthenticator`) |
+| `store` | no | Session persistence (defaults to in-memory) |
+| `webhookAuth` | no | Webhook request authenticator (for HMAC verification) |
+
+---
+
+## Close Codes
+
+| Code | Meaning |
+|------|---------|
+| 1001 | Server shutting down (graceful) |
+| 4001 | Auth timeout — no first message within `authTimeoutMs` |
+| 4002 | Invalid first message (parse error, wrong kind, bad handshake) |
+| 4003 | Authentication failed (`INVALID_TOKEN`, `EXPIRED`, `FORBIDDEN`) |
+| 4004 | Session expired (heartbeat sweep) |
+| 4005 | Max connections exceeded |
+| 4006 | Global buffer limit exceeded |
+| 4007 | No session (post-handshake message without session) |
+| 4008 | Session store failure |
+| 4009 | Backpressure timeout (critical state exceeded threshold) |
+| 4010 | Protocol version mismatch |
+| 4011 | Session expired (resume attempt for expired session) |
+| 4012 | Session destroyed (via `destroySession()`) |
+| 4013 | Node heartbeat expired |
+| 4014 | Replaced by reconnecting node (same nodeId) |

--- a/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -4,8 +4,133 @@ exports[`@koi/gateway API surface . has stable type surface 1`] = `
 "import { Result, KoiError } from '@koi/core';
 
 /**
+ * Node registration and health tracking for connected compute nodes.
+ * Maintains an inverted tool index for O(1) tool-to-node lookups.
+ *
+ * Internal to @koi/gateway (L2) — not an L0 contract.
+ */
+
+interface AdvertisedTool {
+    readonly name: string;
+    readonly description?: string | undefined;
+    readonly schema?: Readonly<Record<string, unknown>> | undefined;
+}
+interface CapacityReport {
+    readonly current: number;
+    readonly max: number;
+    readonly available: number;
+}
+interface RegisteredNode {
+    readonly nodeId: string;
+    readonly mode: "full" | "thin";
+    readonly tools: readonly AdvertisedTool[];
+    readonly capacity: CapacityReport;
+    readonly connectedAt: number;
+    readonly lastHeartbeat: number;
+    readonly connId: string;
+}
+type NodeRegistryEvent = {
+    readonly kind: "registered";
+    readonly node: RegisteredNode;
+} | {
+    readonly kind: "deregistered";
+    readonly nodeId: string;
+} | {
+    readonly kind: "heartbeat";
+    readonly nodeId: string;
+} | {
+    readonly kind: "capacity_updated";
+    readonly nodeId: string;
+    readonly capacity: CapacityReport;
+};
+interface NodeRegistry {
+    readonly register: (node: RegisteredNode) => Result<void, KoiError>;
+    readonly deregister: (nodeId: string) => Result<boolean, KoiError>;
+    readonly lookup: (nodeId: string) => RegisteredNode | undefined;
+    readonly findByTool: (toolName: string) => readonly RegisteredNode[];
+    readonly nodes: () => ReadonlyMap<string, RegisteredNode>;
+    readonly size: () => number;
+    readonly updateHeartbeat: (nodeId: string) => Result<void, KoiError>;
+    readonly updateCapacity: (nodeId: string, capacity: CapacityReport) => Result<void, KoiError>;
+}
+declare function createInMemoryNodeRegistry(): NodeRegistry;
+
+/**
+ * Node frame types, parsing, and encoding for compute-node connections.
+ *
+ * All types are local to @koi/gateway — no imports from @koi/node (L2 peer).
+ * Nodes use a different wire format (NodeFrame) than clients (GatewayFrame).
+ */
+
+type NodeFrameKind = "node:handshake" | "node:capabilities" | "node:registered" | "node:heartbeat" | "node:capacity" | "node:error" | "agent:dispatch" | "agent:message" | "agent:status" | "agent:terminate" | "tool_call" | "tool_result" | "tool_error";
+interface NodeFrame {
+    readonly nodeId: string;
+    readonly agentId: string;
+    readonly correlationId: string;
+    readonly ttl?: number | undefined;
+    readonly kind: NodeFrameKind;
+    readonly payload: unknown;
+}
+interface HandshakePayload {
+    readonly nodeId: string;
+    readonly version: string;
+    readonly capacity: CapacityReport;
+}
+interface CapabilitiesPayload {
+    readonly nodeType: "full" | "thin";
+    readonly tools: readonly AdvertisedTool[];
+}
+declare function peekFrameKind(data: string): string | undefined;
+declare function parseNodeFrame(data: string): Result<NodeFrame, KoiError>;
+declare function validateHandshakePayload(payload: unknown): Result<HandshakePayload, KoiError>;
+declare function validateCapabilitiesPayload(payload: unknown): Result<CapabilitiesPayload, KoiError>;
+declare function validateCapacityPayload(payload: unknown): Result<CapacityReport, KoiError>;
+declare function encodeNodeFrame(frame: NodeFrame): string;
+
+/**
+ * Gateway tool routing — intercepts tool_call frames, resolves target nodes,
+ * forwards calls, tracks pending responses, and routes results back.
+ *
+ * Routing priority:
+ * 1. Exclude source node (if tool_call reached gateway, source can't execute it)
+ * 2. Affinity match (glob patterns -> preferred node)
+ * 3. Highest available capacity
+ * 4. Queue with TTL (if no candidates online)
+ * 5. Error (queue full or disabled)
+ */
+
+interface ToolRoutingConfig {
+    readonly defaultTimeoutMs: number;
+    readonly maxPendingCalls: number;
+    readonly maxQueuedCalls: number;
+    readonly queueTimeoutMs: number;
+    readonly affinities?: readonly ToolAffinity[] | undefined;
+}
+interface ToolAffinity {
+    readonly pattern: string;
+    readonly nodeId: string;
+}
+interface ToolRouter {
+    readonly handleToolCall: (frame: NodeFrame) => void;
+    readonly handleToolResult: (frame: NodeFrame) => void;
+    readonly handleToolError: (frame: NodeFrame) => void;
+    readonly handleNodeDisconnect: (nodeId: string) => void;
+    readonly handleNodeRegistered: (nodeId: string) => void;
+    readonly pendingCount: () => number;
+    readonly queuedCount: () => number;
+    readonly dispose: () => void;
+}
+interface ToolRouterDeps {
+    readonly registry: NodeRegistry;
+    readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
+}
+declare const DEFAULT_TOOL_ROUTING_CONFIG: ToolRoutingConfig;
+declare function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps): ToolRouter;
+
+/**
  * Gateway-specific types. No runtime code.
  */
+
 interface ConnectClient {
     /** Client instance identifier. */
     readonly id?: string;
@@ -154,6 +279,8 @@ interface GatewayConfig {
     readonly sessionTtlMs: number;
     /** Static channel-to-agent bindings, loaded at startup. */
     readonly channelBindings?: readonly ChannelBinding[];
+    /** Tool routing configuration. Undefined = tool routing disabled (backward compatible). Partial fields are merged with DEFAULT_TOOL_ROUTING_CONFIG. */
+    readonly toolRouting?: Partial<ToolRoutingConfig> | undefined;
 }
 declare const DEFAULT_GATEWAY_CONFIG: GatewayConfig;
 type BackpressureState = "normal" | "warning" | "critical";
@@ -265,90 +392,6 @@ interface BackpressureMonitor {
     readonly criticalSince: (connId: string) => number | undefined;
 }
 declare function createBackpressureMonitor(config: Pick<GatewayConfig, "maxBufferBytesPerConnection" | "backpressureHighWatermark" | "globalBufferLimitBytes">): BackpressureMonitor;
-
-/**
- * Node registration and health tracking for connected compute nodes.
- * Maintains an inverted tool index for O(1) tool-to-node lookups.
- *
- * Internal to @koi/gateway (L2) — not an L0 contract.
- */
-
-interface AdvertisedTool {
-    readonly name: string;
-    readonly description?: string | undefined;
-    readonly schema?: Readonly<Record<string, unknown>> | undefined;
-}
-interface CapacityReport {
-    readonly current: number;
-    readonly max: number;
-    readonly available: number;
-}
-interface RegisteredNode {
-    readonly nodeId: string;
-    readonly mode: "full" | "thin";
-    readonly tools: readonly AdvertisedTool[];
-    readonly capacity: CapacityReport;
-    readonly connectedAt: number;
-    readonly lastHeartbeat: number;
-    readonly connId: string;
-}
-type NodeRegistryEvent = {
-    readonly kind: "registered";
-    readonly node: RegisteredNode;
-} | {
-    readonly kind: "deregistered";
-    readonly nodeId: string;
-} | {
-    readonly kind: "heartbeat";
-    readonly nodeId: string;
-} | {
-    readonly kind: "capacity_updated";
-    readonly nodeId: string;
-    readonly capacity: CapacityReport;
-};
-interface NodeRegistry {
-    readonly register: (node: RegisteredNode) => Result<void, KoiError>;
-    readonly deregister: (nodeId: string) => Result<boolean, KoiError>;
-    readonly lookup: (nodeId: string) => RegisteredNode | undefined;
-    readonly findByTool: (toolName: string) => readonly RegisteredNode[];
-    readonly nodes: () => ReadonlyMap<string, RegisteredNode>;
-    readonly size: () => number;
-    readonly updateHeartbeat: (nodeId: string) => Result<void, KoiError>;
-    readonly updateCapacity: (nodeId: string, capacity: CapacityReport) => Result<void, KoiError>;
-}
-declare function createInMemoryNodeRegistry(): NodeRegistry;
-
-/**
- * Node frame types, parsing, and encoding for compute-node connections.
- *
- * All types are local to @koi/gateway — no imports from @koi/node (L2 peer).
- * Nodes use a different wire format (NodeFrame) than clients (GatewayFrame).
- */
-
-type NodeFrameKind = "node:handshake" | "node:capabilities" | "node:registered" | "node:heartbeat" | "node:capacity" | "node:error" | "agent:dispatch" | "agent:message" | "agent:status" | "agent:terminate" | "tool_call" | "tool_result" | "tool_error";
-interface NodeFrame {
-    readonly nodeId: string;
-    readonly agentId: string;
-    readonly correlationId: string;
-    readonly ttl?: number | undefined;
-    readonly kind: NodeFrameKind;
-    readonly payload: unknown;
-}
-interface HandshakePayload {
-    readonly nodeId: string;
-    readonly version: string;
-    readonly capacity: CapacityReport;
-}
-interface CapabilitiesPayload {
-    readonly nodeType: "full" | "thin";
-    readonly tools: readonly AdvertisedTool[];
-}
-declare function peekFrameKind(data: string): string | undefined;
-declare function parseNodeFrame(data: string): Result<NodeFrame, KoiError>;
-declare function validateHandshakePayload(payload: unknown): Result<HandshakePayload, KoiError>;
-declare function validateCapabilitiesPayload(payload: unknown): Result<CapabilitiesPayload, KoiError>;
-declare function validateCapacityPayload(payload: unknown): Result<CapacityReport, KoiError>;
-declare function encodeNodeFrame(frame: NodeFrame): string;
 
 /**
  * Webhook ingestion: HTTP server that converts POST requests
@@ -548,6 +591,6 @@ interface SequenceTracker {
 }
 declare function createSequenceTracker(windowSize: number): SequenceTracker;
 
-export { type AcceptResult, type AdvertisedTool, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CapabilitiesPayload, type CapacityReport, type ChannelBinding, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SweepError, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createScheduler, createSequenceTracker, createWebhookServer, encodeFrame, encodeNodeFrame, handleHandshake, negotiateProtocol, parseConnectFrame, parseFrame, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
+export { type AcceptResult, type AdvertisedTool, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CapabilitiesPayload, type CapacityReport, type ChannelBinding, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, DEFAULT_TOOL_ROUTING_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SweepError, type ToolAffinity, type ToolRouter, type ToolRouterDeps, type ToolRoutingConfig, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createScheduler, createSequenceTracker, createToolRouter, createWebhookServer, encodeFrame, encodeNodeFrame, handleHandshake, negotiateProtocol, parseConnectFrame, parseFrame, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
 "
 `;

--- a/packages/gateway/src/__tests__/test-utils.ts
+++ b/packages/gateway/src/__tests__/test-utils.ts
@@ -331,6 +331,64 @@ export function createNodeHeartbeatMessage(nodeId: string): string {
   });
 }
 
+/** Build a JSON-encoded tool_call frame string. */
+export function createToolCallFrameMessage(
+  nodeId: string,
+  toolName: string,
+  args?: Readonly<Record<string, unknown>>,
+  overrides?: {
+    readonly agentId?: string;
+    readonly correlationId?: string;
+    readonly ttl?: number;
+  },
+): string {
+  return JSON.stringify({
+    kind: "tool_call",
+    nodeId,
+    agentId: overrides?.agentId ?? "agent-1",
+    correlationId: overrides?.correlationId ?? crypto.randomUUID(),
+    payload: {
+      toolName,
+      args: args ?? {},
+      callerAgentId: overrides?.agentId ?? "agent-1",
+    },
+    ...(overrides?.ttl !== undefined ? { ttl: overrides.ttl } : {}),
+  });
+}
+
+/** Build a JSON-encoded tool_result frame string. */
+export function createToolResultFrameMessage(
+  nodeId: string,
+  toolName: string,
+  result: unknown,
+  correlationId: string,
+): string {
+  return JSON.stringify({
+    kind: "tool_result",
+    nodeId,
+    agentId: "agent-1",
+    correlationId,
+    payload: { toolName, result },
+  });
+}
+
+/** Build a JSON-encoded tool_error frame string. */
+export function createToolErrorFrameMessage(
+  nodeId: string,
+  toolName: string,
+  code: string,
+  message: string,
+  correlationId: string,
+): string {
+  return JSON.stringify({
+    kind: "tool_error",
+    nodeId,
+    agentId: "agent-1",
+    correlationId,
+    payload: { toolName, code, message },
+  });
+}
+
 /** Build a JSON-encoded node:capacity frame string. */
 export function createNodeCapacityMessage(
   nodeId: string,

--- a/packages/gateway/src/__tests__/tool-routing.integration.test.ts
+++ b/packages/gateway/src/__tests__/tool-routing.integration.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Integration tests for tool routing through the full gateway.
+ *
+ * Verifies: end-to-end tool_call routing, error paths, queue dequeuing,
+ * affinity, capacity selection, and backward-compatible no-op when disabled.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Gateway } from "../gateway.js";
+import { createGateway } from "../gateway.js";
+import type { MockConnection, MockTransport } from "./test-utils.js";
+import {
+  createMockTransport,
+  createNodeCapabilitiesMessage,
+  createNodeHandshakeMessage,
+  createTestAuthenticator,
+  createToolCallFrameMessage,
+  createToolErrorFrameMessage,
+  createToolResultFrameMessage,
+  waitForCondition,
+} from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function registerNode(
+  transport: MockTransport,
+  nodeId: string,
+  tools: readonly { readonly name: string }[],
+  capacity?: { readonly current: number; readonly max: number; readonly available: number },
+): MockConnection {
+  const conn = transport.simulateOpen();
+  transport.simulateMessage(
+    conn.id,
+    createNodeHandshakeMessage(nodeId, capacity ?? { current: 0, max: 10, available: 10 }),
+  );
+  transport.simulateMessage(conn.id, createNodeCapabilitiesMessage(nodeId, tools));
+  return conn;
+}
+
+function findSentFrame(conn: MockConnection, kind: string): Record<string, unknown> | undefined {
+  for (const msg of conn.sent) {
+    const parsed = JSON.parse(msg) as Record<string, unknown>;
+    if (parsed.kind === kind) return parsed;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Tool routing integration", () => {
+  let transport: MockTransport;
+  let gateway: Gateway;
+
+  beforeEach(async () => {
+    transport = createMockTransport();
+    gateway = createGateway({ toolRouting: {} }, { transport, auth: createTestAuthenticator() });
+    await gateway.start(0);
+  });
+
+  afterEach(async () => {
+    await gateway.stop();
+  });
+
+  test("tool_call from node-A routed to node-B, result returned to node-A", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    // Node-A sends tool_call for camera.capture
+    const correlationId = "test-corr-1";
+    transport.simulateMessage(
+      connA.id,
+      createToolCallFrameMessage(
+        "node-a",
+        "camera.capture",
+        {},
+        {
+          correlationId,
+        },
+      ),
+    );
+
+    // Node-B should receive the forwarded tool_call
+    await waitForCondition(() => findSentFrame(connB, "tool_call") !== undefined);
+    const forwarded = findSentFrame(connB, "tool_call");
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.correlationId).toMatch(/^route-/);
+    const routingCorrelationId = forwarded?.correlationId as string;
+
+    // Node-B responds with tool_result
+    transport.simulateMessage(
+      connB.id,
+      createToolResultFrameMessage(
+        "node-b",
+        "camera.capture",
+        { photo: "data:image/..." },
+        routingCorrelationId,
+      ),
+    );
+
+    // Node-A should receive the result with original correlationId
+    await waitForCondition(() => findSentFrame(connA, "tool_result") !== undefined);
+    const result = findSentFrame(connA, "tool_result");
+    expect(result).toBeDefined();
+    expect(result?.correlationId).toBe(correlationId);
+  });
+
+  test("tool_call for unknown tool — tool_error sent to source", async () => {
+    registerNode(transport, "node-a", [{ name: "search" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+    // Disable queue for this test by recreating gateway
+    await gateway.stop();
+    gateway = createGateway(
+      { toolRouting: { maxQueuedCalls: 0 } },
+      { transport, auth: createTestAuthenticator() },
+    );
+    await gateway.start(0);
+
+    const connA2 = registerNode(transport, "node-a2", [{ name: "search" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+    transport.simulateMessage(connA2.id, createToolCallFrameMessage("node-a2", "nonexistent-tool"));
+
+    await waitForCondition(() => findSentFrame(connA2, "tool_error") !== undefined);
+    const error = findSentFrame(connA2, "tool_error");
+    expect(error).toBeDefined();
+    const payload = error?.payload as Record<string, unknown>;
+    expect(payload.code).toBe("not_found");
+  });
+
+  test("target node disconnects mid-call — error sent to source", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    transport.simulateMessage(
+      connA.id,
+      createToolCallFrameMessage(
+        "node-a",
+        "camera.capture",
+        {},
+        {
+          correlationId: "corr-dc",
+        },
+      ),
+    );
+
+    await waitForCondition(() => findSentFrame(connB, "tool_call") !== undefined);
+
+    // Disconnect node-B
+    transport.simulateClose(connB.id);
+
+    // Node-A should receive a tool_error
+    await waitForCondition(() => findSentFrame(connA, "tool_error") !== undefined);
+    const error = findSentFrame(connA, "tool_error");
+    expect(error).toBeDefined();
+    expect(error?.correlationId).toBe("corr-dc");
+  });
+
+  test("tool routing disabled (no config) — tool frames are no-op", async () => {
+    await gateway.stop();
+    // Create gateway without toolRouting config
+    gateway = createGateway({}, { transport, auth: createTestAuthenticator() });
+    await gateway.start(0);
+
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    transport.simulateMessage(connA.id, createToolCallFrameMessage("node-a", "camera.capture"));
+
+    // Give a moment for any async processing
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Node-B should NOT receive any forwarded tool_call
+    const forwarded = findSentFrame(connB, "tool_call");
+    expect(forwarded).toBeUndefined();
+
+    // Node-A should NOT receive any error (frame was silently dropped as no-op)
+    const error = findSentFrame(connA, "tool_error");
+    expect(error).toBeUndefined();
+  });
+
+  test("multiple nodes with tool — routes to highest capacity", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "code" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "search" }], {
+      current: 7,
+      max: 10,
+      available: 3,
+    });
+    const connC = registerNode(transport, "node-c", [{ name: "search" }], {
+      current: 2,
+      max: 10,
+      available: 8,
+    });
+    await waitForCondition(() => gateway.nodeRegistry().size() === 3);
+
+    transport.simulateMessage(connA.id, createToolCallFrameMessage("node-a", "search"));
+
+    // Should route to node-c (higher available capacity)
+    await waitForCondition(
+      () =>
+        findSentFrame(connC, "tool_call") !== undefined ||
+        findSentFrame(connB, "tool_call") !== undefined,
+    );
+
+    const sentC = findSentFrame(connC, "tool_call");
+    expect(sentC).toBeDefined();
+    const sentB = findSentFrame(connB, "tool_call");
+    expect(sentB).toBeUndefined();
+  });
+
+  test("queue: tool_call arrives with no capable node, node connects later, call dequeued", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+    // Send tool_call for a tool no node has
+    transport.simulateMessage(
+      connA.id,
+      createToolCallFrameMessage(
+        "node-a",
+        "camera.capture",
+        {},
+        {
+          correlationId: "corr-queued",
+        },
+      ),
+    );
+
+    // No error yet — should be queued
+    await new Promise((r) => setTimeout(r, 50));
+    const errorBefore = findSentFrame(connA, "tool_error");
+    expect(errorBefore).toBeUndefined();
+
+    // Register a node with camera.capture
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    // The queued call should be dequeued and routed to node-b
+    await waitForCondition(() => findSentFrame(connB, "tool_call") !== undefined);
+    const forwarded = findSentFrame(connB, "tool_call");
+    expect(forwarded).toBeDefined();
+  });
+
+  test("affinity: tool_call routes to preferred node over higher-capacity alternative", async () => {
+    await gateway.stop();
+    gateway = createGateway(
+      {
+        toolRouting: {
+          affinities: [{ pattern: "camera.*", nodeId: "node-b" }],
+        },
+      },
+      { transport, auth: createTestAuthenticator() },
+    );
+    await gateway.start(0);
+
+    const connA = registerNode(transport, "node-a", [{ name: "code" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }], {
+      current: 8,
+      max: 10,
+      available: 2,
+    });
+    const connC = registerNode(transport, "node-c", [{ name: "camera.capture" }], {
+      current: 1,
+      max: 10,
+      available: 9,
+    });
+    await waitForCondition(() => gateway.nodeRegistry().size() === 3);
+
+    transport.simulateMessage(connA.id, createToolCallFrameMessage("node-a", "camera.capture"));
+
+    // Should route to node-b (affinity) despite node-c having higher capacity
+    await waitForCondition(
+      () =>
+        findSentFrame(connB, "tool_call") !== undefined ||
+        findSentFrame(connC, "tool_call") !== undefined,
+    );
+
+    expect(findSentFrame(connB, "tool_call")).toBeDefined();
+    expect(findSentFrame(connC, "tool_call")).toBeUndefined();
+  });
+
+  test("tool_error from target forwarded back with original correlationId", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "camera.capture" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    const correlationId = "corr-err-fwd";
+    transport.simulateMessage(
+      connA.id,
+      createToolCallFrameMessage(
+        "node-a",
+        "camera.capture",
+        {},
+        {
+          correlationId,
+        },
+      ),
+    );
+
+    await waitForCondition(() => findSentFrame(connB, "tool_call") !== undefined);
+    const forwarded = findSentFrame(connB, "tool_call");
+    const routingCorrelationId = forwarded?.correlationId as string;
+
+    // Node-B sends tool_error
+    transport.simulateMessage(
+      connB.id,
+      createToolErrorFrameMessage(
+        "node-b",
+        "camera.capture",
+        "execution_error",
+        "Camera offline",
+        routingCorrelationId,
+      ),
+    );
+
+    // Node-A should receive the error with original correlationId
+    await waitForCondition(() => findSentFrame(connA, "tool_error") !== undefined);
+    const error = findSentFrame(connA, "tool_error");
+    expect(error).toBeDefined();
+    expect(error?.correlationId).toBe(correlationId);
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -29,6 +29,8 @@ import type { SequenceTracker } from "./sequence-tracker.js";
 import { createSequenceTracker } from "./sequence-tracker.js";
 import type { SessionStore } from "./session-store.js";
 import { createInMemorySessionStore } from "./session-store.js";
+import type { ToolRouter } from "./tool-router.js";
+import { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG } from "./tool-router.js";
 import type { Transport, TransportConnection } from "./transport.js";
 import type { GatewayConfig, GatewayFrame, Session } from "./types.js";
 import { DEFAULT_GATEWAY_CONFIG } from "./types.js";
@@ -106,6 +108,10 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
   const nextId: FrameIdGenerator = createFrameIdGenerator();
   const registry = createInMemoryNodeRegistry();
 
+  // Tool routing (opt-in via config.toolRouting)
+  // let: set once at construction, cleared in stop()
+  let toolRouter: ToolRouter | undefined;
+
   // Per-connection state (mutable internal, not exposed)
   const connMap = new Map<string, TransportConnection>();
   const sessionByConn = new Map<string, string>(); // connId → sessionId
@@ -161,16 +167,58 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
       }
     }
   }
-  const nodeHandler = createNodeConnectionHandler(registry, emitNodeEvent, (connId: string) => {
-    const conn = connMap.get(connId);
-    if (conn !== undefined) {
-      conn.close(4014, "Replaced by reconnecting node");
-    }
-    // Note: cleanupNode already called by the handler before onEvict
-    connMap.delete(connId);
-    pendingHandshakes.delete(connId);
-    bp.remove(connId);
-  });
+  const nodeHandler = createNodeConnectionHandler(
+    registry,
+    emitNodeEvent,
+    (connId: string) => {
+      const conn = connMap.get(connId);
+      if (conn !== undefined) {
+        conn.close(4014, "Replaced by reconnecting node");
+      }
+      // Note: cleanupNode already called by the handler before onEvict
+      connMap.delete(connId);
+      pendingHandshakes.delete(connId);
+      bp.remove(connId);
+    },
+    // Tool routing callback — only wired when tool routing is enabled
+    config.toolRouting !== undefined
+      ? (frame: NodeFrame) => {
+          if (toolRouter === undefined) return;
+          switch (frame.kind) {
+            case "tool_call":
+              toolRouter.handleToolCall(frame);
+              break;
+            case "tool_result":
+              toolRouter.handleToolResult(frame);
+              break;
+            case "tool_error":
+              toolRouter.handleToolError(frame);
+              break;
+          }
+        }
+      : undefined,
+  );
+
+  // Initialize tool router after nodeHandler (needs sendToNode)
+  if (config.toolRouting !== undefined) {
+    toolRouter = createToolRouter(
+      { ...DEFAULT_TOOL_ROUTING_CONFIG, ...config.toolRouting },
+      {
+        registry,
+        sendToNode: (nodeId, frame) => nodeHandler.sendToNode(nodeId, frame, connMap),
+      },
+    );
+
+    nodeEventHandlers.add((event: NodeRegistryEvent) => {
+      if (toolRouter === undefined) return;
+      if (event.kind === "deregistered") {
+        toolRouter.handleNodeDisconnect(event.nodeId);
+      }
+      if (event.kind === "registered") {
+        toolRouter.handleNodeRegistered(event.node.nodeId);
+      }
+    });
+  }
 
   function closeConnection(connId: string, code: number, reason: string): void {
     const conn = connMap.get(connId);
@@ -533,6 +581,8 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
     },
 
     async stop(): Promise<void> {
+      toolRouter?.dispose();
+      toolRouter = undefined;
       scheduler?.stop();
       webhookServer?.stop();
       stopSweep?.();

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -73,6 +73,14 @@ export { createSequenceTracker } from "./sequence-tracker.js";
 // session store
 export type { SessionStore } from "./session-store.js";
 export { createInMemorySessionStore } from "./session-store.js";
+// tool router
+export type {
+  ToolAffinity,
+  ToolRouter,
+  ToolRouterDeps,
+  ToolRoutingConfig,
+} from "./tool-router.js";
+export { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG } from "./tool-router.js";
 // transport
 export type {
   BunTransport,

--- a/packages/gateway/src/node-connection.ts
+++ b/packages/gateway/src/node-connection.ts
@@ -56,6 +56,7 @@ export function createNodeConnectionHandler(
   registry: NodeRegistry,
   emitNodeEvent: (event: NodeRegistryEvent) => void,
   onEvict: (connId: string) => void,
+  onToolFrame?: ((frame: NodeFrame) => void) | undefined,
 ): NodeConnectionHandler {
   const nodeConnMap = new Map<string, string>(); // connId → nodeId
   const connByNode = new Map<string, string>(); // nodeId → connId
@@ -192,8 +193,15 @@ export function createNodeConnectionHandler(
         return;
       }
 
+      case "tool_call":
+      case "tool_result":
+      case "tool_error": {
+        onToolFrame?.(frame);
+        return;
+      }
+
       default:
-        // tool_result, tool_error, agent:* — future dispatch, currently no-op
+        // agent:* — future dispatch, currently no-op
         return;
     }
   }

--- a/packages/gateway/src/tool-router.test.ts
+++ b/packages/gateway/src/tool-router.test.ts
@@ -1,0 +1,673 @@
+/**
+ * Unit tests for tool-router: resolveTargetNode, handleToolCall, handleToolResult,
+ * handleToolError, timeout, handleNodeDisconnect, handleNodeRegistered, dispose.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { KoiError, Result } from "@koi/core";
+import type { NodeFrame } from "./node-handler.js";
+import type { NodeRegistry, RegisteredNode } from "./node-registry.js";
+import { createInMemoryNodeRegistry } from "./node-registry.js";
+import type { ToolRouter } from "./tool-router.js";
+import { compileAffinities, createToolRouter, resolveTargetNode } from "./tool-router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRegisteredNode(
+  nodeId: string,
+  tools: readonly string[],
+  available = 5,
+): RegisteredNode {
+  return {
+    nodeId,
+    mode: "full",
+    tools: tools.map((name) => ({ name })),
+    capacity: { current: 10 - available, max: 10, available },
+    connectedAt: Date.now(),
+    lastHeartbeat: Date.now(),
+    connId: `conn-${nodeId}`,
+  };
+}
+
+function createToolCallFrame(
+  nodeId: string,
+  toolName: string,
+  overrides?: Partial<NodeFrame>,
+): NodeFrame {
+  return {
+    kind: "tool_call",
+    nodeId,
+    agentId: overrides?.agentId ?? "agent-1",
+    correlationId: overrides?.correlationId ?? `corr-${crypto.randomUUID()}`,
+    payload: {
+      toolName,
+      args: {},
+      callerAgentId: overrides?.agentId ?? "agent-1",
+    },
+    ...(overrides?.ttl !== undefined ? { ttl: overrides.ttl } : {}),
+  };
+}
+
+function createToolResultFrame(
+  nodeId: string,
+  correlationId: string,
+  toolName = "some-tool",
+): NodeFrame {
+  return {
+    kind: "tool_result",
+    nodeId,
+    agentId: "agent-1",
+    correlationId,
+    payload: { toolName, result: { data: "ok" } },
+  };
+}
+
+function createToolErrorFrame(
+  nodeId: string,
+  correlationId: string,
+  toolName = "some-tool",
+): NodeFrame {
+  return {
+    kind: "tool_error",
+    nodeId,
+    agentId: "agent-1",
+    correlationId,
+    payload: { toolName, code: "execution_error", message: "Something failed" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveTargetNode
+// ---------------------------------------------------------------------------
+
+describe("resolveTargetNode", () => {
+  let registry: NodeRegistry;
+
+  beforeEach(() => {
+    registry = createInMemoryNodeRegistry();
+  });
+
+  test("returns routed to remote node when tool exists on other node", () => {
+    registry.register(createRegisteredNode("node-a", ["search"]));
+    registry.register(createRegisteredNode("node-b", ["camera.capture"]));
+
+    const result = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-b");
+    }
+  });
+
+  test("excludes source node from candidates", () => {
+    registry.register(createRegisteredNode("node-a", ["search"]));
+
+    const result = resolveTargetNode("search", "node-a", registry, []);
+    expect(result.kind).toBe("not_available");
+  });
+
+  test("returns not_available when no remote node has the tool", () => {
+    registry.register(createRegisteredNode("node-a", ["search"]));
+
+    const result = resolveTargetNode("unknown-tool", "node-a", registry, []);
+    expect(result.kind).toBe("not_available");
+  });
+
+  test("returns not_available for empty registry", () => {
+    const result = resolveTargetNode("search", "node-a", registry, []);
+    expect(result.kind).toBe("not_available");
+  });
+
+  test("selects node with highest available capacity", () => {
+    registry.register(createRegisteredNode("node-b", ["search"], 3));
+    registry.register(createRegisteredNode("node-c", ["search"], 8));
+    registry.register(createRegisteredNode("node-d", ["search"], 5));
+
+    const result = resolveTargetNode("search", "node-a", registry, []);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-c");
+    }
+  });
+
+  test("affinity match overrides capacity selection", () => {
+    registry.register(createRegisteredNode("node-b", ["search"], 8));
+    registry.register(createRegisteredNode("node-c", ["search"], 3));
+
+    const compiled = compileAffinities([{ pattern: "search", nodeId: "node-c" }]);
+    const result = resolveTargetNode("search", "node-a", registry, compiled);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-c");
+    }
+  });
+
+  test("affinity glob pattern matching (camera.* matches camera.capture)", () => {
+    registry.register(createRegisteredNode("node-b", ["camera.capture"], 5));
+    registry.register(createRegisteredNode("node-c", ["camera.capture"], 8));
+
+    const compiled = compileAffinities([{ pattern: "camera.*", nodeId: "node-b" }]);
+    const result = resolveTargetNode("camera.capture", "node-a", registry, compiled);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-b");
+    }
+  });
+
+  test("affinity miss falls through to capacity selection", () => {
+    registry.register(createRegisteredNode("node-b", ["search"], 3));
+    registry.register(createRegisteredNode("node-c", ["search"], 8));
+
+    // Affinity targets node-d which doesn't exist
+    const compiled = compileAffinities([{ pattern: "search", nodeId: "node-d" }]);
+    const result = resolveTargetNode("search", "node-a", registry, compiled);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-c");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createToolRouter
+// ---------------------------------------------------------------------------
+
+describe("createToolRouter", () => {
+  let registry: NodeRegistry;
+  let sentFrames: Array<{ readonly nodeId: string; readonly frame: NodeFrame }>;
+  let router: ToolRouter;
+
+  function mockSendToNode(nodeId: string, frame: NodeFrame): Result<number, KoiError> {
+    sentFrames.push({ nodeId, frame });
+    return { ok: true, value: 1 };
+  }
+
+  function findSent(
+    nodeId: string,
+    kind?: string,
+  ): { readonly nodeId: string; readonly frame: NodeFrame } | undefined {
+    return sentFrames.find(
+      (s) => s.nodeId === nodeId && (kind === undefined || s.frame.kind === kind),
+    );
+  }
+
+  function findAllSent(
+    nodeId: string,
+    kind?: string,
+  ): ReadonlyArray<{ readonly nodeId: string; readonly frame: NodeFrame }> {
+    return sentFrames.filter(
+      (s) => s.nodeId === nodeId && (kind === undefined || s.frame.kind === kind),
+    );
+  }
+
+  beforeEach(() => {
+    registry = createInMemoryNodeRegistry();
+    sentFrames = [];
+    router = createToolRouter(
+      {
+        defaultTimeoutMs: 5_000,
+        maxPendingCalls: 100,
+        maxQueuedCalls: 50,
+        queueTimeoutMs: 10_000,
+      },
+      { registry, sendToNode: mockSendToNode },
+    );
+  });
+
+  afterEach(() => {
+    router.dispose();
+  });
+
+  // -----------------------------------------------------------------------
+  // handleToolCall
+  // -----------------------------------------------------------------------
+
+  describe("handleToolCall", () => {
+    test("routes tool_call to remote node", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["camera.capture"]));
+
+      const frame = createToolCallFrame("node-a", "camera.capture");
+      router.handleToolCall(frame);
+
+      expect(router.pendingCount()).toBe(1);
+      const sent = findSent("node-b", "tool_call");
+      expect(sent).toBeDefined();
+      expect(sent?.frame.correlationId).toStartWith("route-");
+    });
+
+    test("sends tool_error when no node has the tool and queue is full", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+
+      // Fill queue first with disabled queue (maxQueuedCalls = 0)
+      router.dispose();
+      router = createToolRouter(
+        {
+          defaultTimeoutMs: 5_000,
+          maxPendingCalls: 100,
+          maxQueuedCalls: 0,
+          queueTimeoutMs: 10_000,
+        },
+        { registry, sendToNode: mockSendToNode },
+      );
+
+      const frame = createToolCallFrame("node-a", "unknown-tool");
+      router.handleToolCall(frame);
+
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("not_found");
+    });
+
+    test("queues tool_call when no node available and queue has space", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "camera.capture");
+      router.handleToolCall(frame);
+
+      expect(router.queuedCount()).toBe(1);
+      expect(router.pendingCount()).toBe(0);
+    });
+
+    test("sends tool_error when payload is malformed", () => {
+      const frame: NodeFrame = {
+        kind: "tool_call",
+        nodeId: "node-a",
+        agentId: "agent-1",
+        correlationId: "corr-bad",
+        payload: { invalid: true },
+      };
+      router.handleToolCall(frame);
+
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("validation");
+    });
+
+    test("sends tool_error when max pending calls reached", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      router.dispose();
+      router = createToolRouter(
+        {
+          defaultTimeoutMs: 5_000,
+          maxPendingCalls: 1,
+          maxQueuedCalls: 50,
+          queueTimeoutMs: 10_000,
+        },
+        { registry, sendToNode: mockSendToNode },
+      );
+
+      // First call succeeds
+      router.handleToolCall(createToolCallFrame("node-a", "search"));
+      expect(router.pendingCount()).toBe(1);
+
+      // Second call hits limit
+      router.handleToolCall(createToolCallFrame("node-a", "search", { correlationId: "corr-2" }));
+
+      const errors = findAllSent("node-a", "tool_error");
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      const lastError = errors[errors.length - 1];
+      const payload = lastError?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("rate_limit");
+    });
+
+    test("uses frame.ttl when present instead of default timeout", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "search", { ttl: 1_000 });
+      router.handleToolCall(frame);
+
+      expect(router.pendingCount()).toBe(1);
+      // TTL is stored internally; we verify via timeout behavior in timeout tests
+    });
+
+    test("sends tool_error when sendToNode fails", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      // let: reassigned in callback
+      let callCount = 0;
+      const failingRouter = createToolRouter(
+        {
+          defaultTimeoutMs: 5_000,
+          maxPendingCalls: 100,
+          maxQueuedCalls: 50,
+          queueTimeoutMs: 10_000,
+        },
+        {
+          registry,
+          sendToNode: (nodeId, frame) => {
+            callCount++;
+            if (callCount === 1) {
+              // First call (forwarding to target) fails
+              return {
+                ok: false,
+                error: { code: "NOT_FOUND", message: "Node gone", retryable: false },
+              };
+            }
+            // Second call (error back to source) succeeds
+            sentFrames.push({ nodeId, frame });
+            return { ok: true, value: 1 };
+          },
+        },
+      );
+
+      const frame = createToolCallFrame("node-a", "search");
+      failingRouter.handleToolCall(frame);
+
+      expect(failingRouter.pendingCount()).toBe(0);
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      failingRouter.dispose();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // handleToolResult
+  // -----------------------------------------------------------------------
+
+  describe("handleToolResult", () => {
+    test("forwards result back to source node with original correlationId", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const originalCorrelationId = "corr-original";
+      const frame = createToolCallFrame("node-a", "search", {
+        correlationId: originalCorrelationId,
+      });
+      router.handleToolCall(frame);
+      expect(router.pendingCount()).toBe(1);
+
+      // Find the routing correlation ID from the forwarded frame
+      const forwarded = findSent("node-b", "tool_call");
+      expect(forwarded).toBeDefined();
+      const routingCorrelationId = forwarded?.frame.correlationId ?? "";
+
+      sentFrames = [];
+      const resultFrame = createToolResultFrame("node-b", routingCorrelationId);
+      router.handleToolResult(resultFrame);
+
+      expect(router.pendingCount()).toBe(0);
+      const sent = findSent("node-a", "tool_result");
+      expect(sent).toBeDefined();
+      expect(sent?.frame.correlationId).toBe(originalCorrelationId);
+    });
+
+    test("discards orphan result (no pending call)", () => {
+      const resultFrame = createToolResultFrame("node-b", "nonexistent-corr");
+      router.handleToolResult(resultFrame);
+
+      expect(sentFrames).toHaveLength(0);
+    });
+
+    test("clears timeout timer on successful result", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "search");
+      router.handleToolCall(frame);
+
+      const forwarded = findSent("node-b", "tool_call");
+      const routingCorrelationId = forwarded?.frame.correlationId ?? "";
+
+      router.handleToolResult(createToolResultFrame("node-b", routingCorrelationId));
+
+      expect(router.pendingCount()).toBe(0);
+      // If timer wasn't cleared, it would fire later and try to send error — no assertion needed,
+      // just verify no errors appear (covered by dispose in afterEach)
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // handleToolError
+  // -----------------------------------------------------------------------
+
+  describe("handleToolError", () => {
+    test("forwards error back to source node with original correlationId", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "search", {
+        correlationId: "corr-err",
+      });
+      router.handleToolCall(frame);
+
+      const forwarded = findSent("node-b", "tool_call");
+      const routingCorrelationId = forwarded?.frame.correlationId ?? "";
+
+      sentFrames = [];
+      const errorFrame = createToolErrorFrame("node-b", routingCorrelationId);
+      router.handleToolError(errorFrame);
+
+      expect(router.pendingCount()).toBe(0);
+      const sent = findSent("node-a", "tool_error");
+      expect(sent).toBeDefined();
+      expect(sent?.frame.correlationId).toBe("corr-err");
+    });
+
+    test("discards orphan error", () => {
+      router.handleToolError(createToolErrorFrame("node-b", "nonexistent-corr"));
+      expect(sentFrames).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // timeout
+  // -----------------------------------------------------------------------
+
+  describe("timeout", () => {
+    test("sends timeout error to source after configured timeout", async () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const shortTimeoutRouter = createToolRouter(
+        {
+          defaultTimeoutMs: 50,
+          maxPendingCalls: 100,
+          maxQueuedCalls: 50,
+          queueTimeoutMs: 10_000,
+        },
+        { registry, sendToNode: mockSendToNode },
+      );
+
+      const frame = createToolCallFrame("node-a", "search");
+      shortTimeoutRouter.handleToolCall(frame);
+      expect(shortTimeoutRouter.pendingCount()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(shortTimeoutRouter.pendingCount()).toBe(0);
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("timeout");
+
+      shortTimeoutRouter.dispose();
+    });
+
+    test("cleans up pending entry on timeout", async () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const shortTimeoutRouter = createToolRouter(
+        {
+          defaultTimeoutMs: 50,
+          maxPendingCalls: 100,
+          maxQueuedCalls: 50,
+          queueTimeoutMs: 10_000,
+        },
+        { registry, sendToNode: mockSendToNode },
+      );
+
+      shortTimeoutRouter.handleToolCall(createToolCallFrame("node-a", "search"));
+      expect(shortTimeoutRouter.pendingCount()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(shortTimeoutRouter.pendingCount()).toBe(0);
+
+      shortTimeoutRouter.dispose();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // handleNodeDisconnect
+  // -----------------------------------------------------------------------
+
+  describe("handleNodeDisconnect", () => {
+    test("sends error to source when target node disconnects", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "search", {
+        correlationId: "corr-dc",
+      });
+      router.handleToolCall(frame);
+      expect(router.pendingCount()).toBe(1);
+
+      sentFrames = [];
+      router.handleNodeDisconnect("node-b");
+
+      expect(router.pendingCount()).toBe(0);
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      expect(errorSent?.frame.correlationId).toBe("corr-dc");
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("not_found");
+    });
+
+    test("cleans up pending when source node disconnects (no error sent)", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      router.handleToolCall(createToolCallFrame("node-a", "search"));
+      expect(router.pendingCount()).toBe(1);
+
+      sentFrames = [];
+      router.handleNodeDisconnect("node-a");
+
+      expect(router.pendingCount()).toBe(0);
+      // No error sent to anyone (source is gone)
+      const errorToB = findSent("node-b", "tool_error");
+      expect(errorToB).toBeUndefined();
+    });
+
+    test("handles disconnect affecting multiple pending calls", () => {
+      registry.register(createRegisteredNode("node-a", ["search", "browse"]));
+      registry.register(createRegisteredNode("node-b", ["search", "browse"]));
+
+      router.handleToolCall(createToolCallFrame("node-a", "search", { correlationId: "c1" }));
+      router.handleToolCall(createToolCallFrame("node-a", "browse", { correlationId: "c2" }));
+      expect(router.pendingCount()).toBe(2);
+
+      sentFrames = [];
+      router.handleNodeDisconnect("node-b");
+
+      expect(router.pendingCount()).toBe(0);
+      const errors = findAllSent("node-a", "tool_error");
+      expect(errors).toHaveLength(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // handleNodeRegistered
+  // -----------------------------------------------------------------------
+
+  describe("handleNodeRegistered", () => {
+    test("dequeues matching tool calls when capable node registers", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+
+      // Queue a call for a tool no node has
+      const frame = createToolCallFrame("node-a", "camera.capture", {
+        correlationId: "corr-q1",
+      });
+      router.handleToolCall(frame);
+      expect(router.queuedCount()).toBe(1);
+
+      // Register a new node with the needed tool
+      registry.register(createRegisteredNode("node-b", ["camera.capture"]));
+      router.handleNodeRegistered("node-b");
+
+      expect(router.queuedCount()).toBe(0);
+      expect(router.pendingCount()).toBe(1);
+
+      const sent = findSent("node-b", "tool_call");
+      expect(sent).toBeDefined();
+    });
+
+    test("does not dequeue calls for tools the new node doesn't have", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+
+      const frame = createToolCallFrame("node-a", "camera.capture", {
+        correlationId: "corr-q2",
+      });
+      router.handleToolCall(frame);
+      expect(router.queuedCount()).toBe(1);
+
+      registry.register(createRegisteredNode("node-b", ["browse"]));
+      router.handleNodeRegistered("node-b");
+
+      expect(router.queuedCount()).toBe(1);
+    });
+
+    test("queue TTL expiry sends timeout error to source", async () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+
+      const shortQueueRouter = createToolRouter(
+        {
+          defaultTimeoutMs: 5_000,
+          maxPendingCalls: 100,
+          maxQueuedCalls: 50,
+          queueTimeoutMs: 50,
+        },
+        { registry, sendToNode: mockSendToNode },
+      );
+
+      shortQueueRouter.handleToolCall(createToolCallFrame("node-a", "camera.capture"));
+      expect(shortQueueRouter.queuedCount()).toBe(1);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(shortQueueRouter.queuedCount()).toBe(0);
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("timeout");
+
+      shortQueueRouter.dispose();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // dispose
+  // -----------------------------------------------------------------------
+
+  describe("dispose", () => {
+    test("clears all pending calls, queued calls, and timers", () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      // Create pending call
+      router.handleToolCall(createToolCallFrame("node-a", "search"));
+      expect(router.pendingCount()).toBe(1);
+
+      // Create queued call
+      router.handleToolCall(
+        createToolCallFrame("node-a", "camera.capture", {
+          correlationId: "corr-q",
+        }),
+      );
+      expect(router.queuedCount()).toBe(1);
+
+      router.dispose();
+
+      expect(router.pendingCount()).toBe(0);
+      expect(router.queuedCount()).toBe(0);
+    });
+  });
+});

--- a/packages/gateway/src/tool-router.ts
+++ b/packages/gateway/src/tool-router.ts
@@ -1,0 +1,402 @@
+/**
+ * Gateway tool routing — intercepts tool_call frames, resolves target nodes,
+ * forwards calls, tracks pending responses, and routes results back.
+ *
+ * Routing priority:
+ * 1. Exclude source node (if tool_call reached gateway, source can't execute it)
+ * 2. Affinity match (glob patterns -> preferred node)
+ * 3. Highest available capacity
+ * 4. Queue with TTL (if no candidates online)
+ * 5. Error (queue full or disabled)
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import type { NodeFrame } from "./node-handler.js";
+import type { NodeRegistry, RegisteredNode } from "./node-registry.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolRoutingConfig {
+  readonly defaultTimeoutMs: number;
+  readonly maxPendingCalls: number;
+  readonly maxQueuedCalls: number;
+  readonly queueTimeoutMs: number;
+  readonly affinities?: readonly ToolAffinity[] | undefined;
+}
+
+export interface ToolAffinity {
+  readonly pattern: string;
+  readonly nodeId: string;
+}
+
+export interface ToolRouter {
+  readonly handleToolCall: (frame: NodeFrame) => void;
+  readonly handleToolResult: (frame: NodeFrame) => void;
+  readonly handleToolError: (frame: NodeFrame) => void;
+  readonly handleNodeDisconnect: (nodeId: string) => void;
+  readonly handleNodeRegistered: (nodeId: string) => void;
+  readonly pendingCount: () => number;
+  readonly queuedCount: () => number;
+  readonly dispose: () => void;
+}
+
+export interface ToolRouterDeps {
+  readonly registry: NodeRegistry;
+  readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface PendingToolCall {
+  readonly sourceNodeId: string;
+  readonly sourceAgentId: string;
+  readonly correlationId: string;
+  readonly toolName: string;
+  readonly targetNodeId: string;
+  readonly dispatchedAt: number;
+  readonly timeoutMs: number;
+  readonly timeoutTimer: ReturnType<typeof setTimeout>;
+}
+
+interface QueuedToolCall {
+  readonly frame: NodeFrame;
+  readonly toolName: string;
+  readonly sourceNodeId: string;
+  readonly queuedAt: number;
+  readonly ttlTimer: ReturnType<typeof setTimeout>;
+}
+
+export interface CompiledAffinity {
+  readonly regex: RegExp;
+  readonly nodeId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Routing resolution result
+// ---------------------------------------------------------------------------
+
+export type RouteResult =
+  | { readonly kind: "routed"; readonly targetNodeId: string }
+  | { readonly kind: "not_available" };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TOOL_ROUTING_CONFIG: ToolRoutingConfig = {
+  defaultTimeoutMs: 30_000,
+  maxPendingCalls: 10_000,
+  maxQueuedCalls: 1_000,
+  queueTimeoutMs: 60_000,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Type guard (duplicated from @koi/node — gateway cannot import L2 peers)
+// ---------------------------------------------------------------------------
+
+interface ToolCallPayload {
+  readonly toolName: string;
+  readonly args: Readonly<Record<string, unknown>>;
+  readonly callerAgentId: string;
+  readonly zone?: string | undefined;
+}
+
+export function isToolCallPayload(value: unknown): value is ToolCallPayload {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.toolName === "string" &&
+    obj.toolName.length > 0 &&
+    typeof obj.callerAgentId === "string"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Glob pattern compilation
+// ---------------------------------------------------------------------------
+
+export function compileAffinities(
+  affinities: readonly ToolAffinity[],
+): readonly CompiledAffinity[] {
+  return affinities.map((a) => ({
+    regex: compileGlobPattern(a.pattern),
+    nodeId: a.nodeId,
+  }));
+}
+
+function compileGlobPattern(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+export function matchAffinity(
+  toolName: string,
+  compiled: readonly CompiledAffinity[],
+): string | undefined {
+  for (const a of compiled) {
+    if (a.regex.test(toolName)) return a.nodeId;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Routing resolution — pure function
+// ---------------------------------------------------------------------------
+
+export function resolveTargetNode(
+  toolName: string,
+  sourceNodeId: string,
+  registry: NodeRegistry,
+  compiledAffinities: readonly CompiledAffinity[],
+): RouteResult {
+  const candidates = registry.findByTool(toolName);
+  if (candidates.length === 0) return { kind: "not_available" };
+
+  const remote: readonly RegisteredNode[] = candidates.filter((n) => n.nodeId !== sourceNodeId);
+  if (remote.length === 0) return { kind: "not_available" };
+
+  // Affinity: check if preferred node is in remote candidates
+  const affinityNodeId = matchAffinity(toolName, compiledAffinities);
+  if (affinityNodeId !== undefined) {
+    const affinityNode = remote.find((n) => n.nodeId === affinityNodeId);
+    if (affinityNode !== undefined) {
+      return { kind: "routed", targetNodeId: affinityNode.nodeId };
+    }
+  }
+
+  // Capacity: sort by available descending, pick highest
+  const sorted = [...remote].sort((a, b) => b.capacity.available - a.capacity.available);
+  const best = sorted[0];
+  // best is defined: remote.length > 0 checked above
+  if (best === undefined) return { kind: "not_available" };
+  return { kind: "routed", targetNodeId: best.nodeId };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps): ToolRouter {
+  const pending = new Map<string, PendingToolCall>();
+  const queued = new Map<string, QueuedToolCall>();
+  const compiledAffs = compileAffinities(config.affinities ?? []);
+
+  function sendToolError(
+    sourceNodeId: string,
+    agentId: string,
+    correlationId: string,
+    toolName: string,
+    code: string,
+    message: string,
+  ): void {
+    deps.sendToNode(sourceNodeId, {
+      kind: "tool_error",
+      nodeId: sourceNodeId,
+      agentId,
+      correlationId,
+      payload: { toolName, code, message },
+    });
+  }
+
+  function handleTimeout(routingCorrelationId: string): void {
+    const entry = pending.get(routingCorrelationId);
+    if (entry === undefined) return;
+    pending.delete(routingCorrelationId);
+
+    sendToolError(
+      entry.sourceNodeId,
+      entry.sourceAgentId,
+      entry.correlationId,
+      entry.toolName,
+      "timeout",
+      `Tool call "${entry.toolName}" timed out after ${String(entry.timeoutMs)}ms`,
+    );
+  }
+
+  function routeCall(frame: NodeFrame, toolName: string): void {
+    const route = resolveTargetNode(toolName, frame.nodeId, deps.registry, compiledAffs);
+
+    if (route.kind === "not_available") {
+      if (config.maxQueuedCalls > 0 && queued.size < config.maxQueuedCalls) {
+        const queueKey = frame.correlationId;
+        const ttlTimer = setTimeout(() => {
+          const qEntry = queued.get(queueKey);
+          if (qEntry === undefined) return;
+          queued.delete(queueKey);
+          sendToolError(
+            frame.nodeId,
+            frame.agentId,
+            frame.correlationId,
+            toolName,
+            "timeout",
+            `Queued tool call "${toolName}" expired after ${String(config.queueTimeoutMs)}ms`,
+          );
+        }, config.queueTimeoutMs);
+
+        queued.set(queueKey, {
+          frame,
+          toolName,
+          sourceNodeId: frame.nodeId,
+          queuedAt: Date.now(),
+          ttlTimer,
+        });
+        return;
+      }
+
+      sendToolError(
+        frame.nodeId,
+        frame.agentId,
+        frame.correlationId,
+        toolName,
+        "not_found",
+        `No node available for tool "${toolName}"`,
+      );
+      return;
+    }
+
+    const routingCorrelationId = `route-${frame.correlationId}-${String(Date.now())}`;
+    const timeoutMs = frame.ttl ?? config.defaultTimeoutMs;
+    const timeoutTimer = setTimeout(() => handleTimeout(routingCorrelationId), timeoutMs);
+
+    pending.set(routingCorrelationId, {
+      sourceNodeId: frame.nodeId,
+      sourceAgentId: frame.agentId,
+      correlationId: frame.correlationId,
+      toolName,
+      targetNodeId: route.targetNodeId,
+      dispatchedAt: Date.now(),
+      timeoutMs,
+      timeoutTimer,
+    });
+
+    const forwardedFrame: NodeFrame = {
+      ...frame,
+      nodeId: route.targetNodeId,
+      correlationId: routingCorrelationId,
+    };
+
+    const sendResult = deps.sendToNode(route.targetNodeId, forwardedFrame);
+    if (!sendResult.ok) {
+      clearTimeout(timeoutTimer);
+      pending.delete(routingCorrelationId);
+      sendToolError(
+        frame.nodeId,
+        frame.agentId,
+        frame.correlationId,
+        toolName,
+        "not_found",
+        `Failed to send to target node: ${sendResult.error.message}`,
+      );
+    }
+  }
+
+  function handleToolCall(frame: NodeFrame): void {
+    if (!isToolCallPayload(frame.payload)) {
+      sendToolError(
+        frame.nodeId,
+        frame.agentId,
+        frame.correlationId,
+        "unknown",
+        "validation",
+        "Malformed tool_call payload",
+      );
+      return;
+    }
+
+    if (pending.size >= config.maxPendingCalls) {
+      sendToolError(
+        frame.nodeId,
+        frame.agentId,
+        frame.correlationId,
+        frame.payload.toolName,
+        "rate_limit",
+        `Max pending tool calls reached (${String(config.maxPendingCalls)})`,
+      );
+      return;
+    }
+
+    routeCall(frame, frame.payload.toolName);
+  }
+
+  function handleToolResponse(frame: NodeFrame): void {
+    const entry = pending.get(frame.correlationId);
+    if (entry === undefined) return;
+
+    clearTimeout(entry.timeoutTimer);
+    pending.delete(frame.correlationId);
+
+    deps.sendToNode(entry.sourceNodeId, {
+      ...frame,
+      nodeId: entry.sourceNodeId,
+      correlationId: entry.correlationId,
+    });
+  }
+
+  function handleNodeDisconnect(nodeId: string): void {
+    for (const [routingId, entry] of pending) {
+      if (entry.targetNodeId === nodeId) {
+        clearTimeout(entry.timeoutTimer);
+        pending.delete(routingId);
+        sendToolError(
+          entry.sourceNodeId,
+          entry.sourceAgentId,
+          entry.correlationId,
+          entry.toolName,
+          "not_found",
+          `Target node "${nodeId}" disconnected during tool call`,
+        );
+      } else if (entry.sourceNodeId === nodeId) {
+        clearTimeout(entry.timeoutTimer);
+        pending.delete(routingId);
+      }
+    }
+
+    for (const [queueKey, qEntry] of queued) {
+      if (qEntry.sourceNodeId === nodeId) {
+        clearTimeout(qEntry.ttlTimer);
+        queued.delete(queueKey);
+      }
+    }
+  }
+
+  function handleNodeRegistered(nodeId: string): void {
+    const node = deps.registry.lookup(nodeId);
+    if (node === undefined) return;
+
+    const toolNames = new Set(node.tools.map((t) => t.name));
+
+    for (const [queueKey, qEntry] of queued) {
+      if (toolNames.has(qEntry.toolName)) {
+        clearTimeout(qEntry.ttlTimer);
+        queued.delete(queueKey);
+        routeCall(qEntry.frame, qEntry.toolName);
+      }
+    }
+  }
+
+  function dispose(): void {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timeoutTimer);
+    }
+    pending.clear();
+    for (const entry of queued.values()) {
+      clearTimeout(entry.ttlTimer);
+    }
+    queued.clear();
+  }
+
+  return {
+    handleToolCall,
+    handleToolResult: handleToolResponse,
+    handleToolError: handleToolResponse,
+    handleNodeDisconnect,
+    handleNodeRegistered,
+    pendingCount: () => pending.size,
+    queuedCount: () => queued.size,
+    dispose,
+  };
+}

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -2,6 +2,8 @@
  * Gateway-specific types. No runtime code.
  */
 
+import type { ToolRoutingConfig } from "./tool-router.js";
+
 // ---------------------------------------------------------------------------
 // Wire protocol
 // ---------------------------------------------------------------------------
@@ -204,6 +206,8 @@ export interface GatewayConfig {
   readonly sessionTtlMs: number;
   /** Static channel-to-agent bindings, loaded at startup. */
   readonly channelBindings?: readonly ChannelBinding[];
+  /** Tool routing configuration. Undefined = tool routing disabled (backward compatible). Partial fields are merged with DEFAULT_TOOL_ROUTING_CONFIG. */
+  readonly toolRouting?: Partial<ToolRoutingConfig> | undefined;
 }
 
 export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {


### PR DESCRIPTION
## Summary

- Add cross-node tool routing to `@koi/gateway` — nodes can invoke tools hosted on other nodes through the gateway as a transparent broker
- Add comprehensive architecture documentation (`docs/architecture/Gateway.md`, 647 lines) covering the entire gateway subsystem
- Wire tool routing into the node connection handler and gateway factory with opt-in activation via `GatewayConfig.toolRouting`

## Tool Routing

5-priority routing algorithm: validate payload → check pending limit → resolve target (affinity → capacity) → queue with TTL → error. Includes correlation ID mapping, glob-pattern affinities, in-memory queue with TTL drain on node registration, per-call timeouts, and disconnect handling for both source and target nodes.

## Documentation

Full gateway architecture doc covering: wire protocol (ConnectFrame, GatewayFrame, NodeFrame), connection lifecycle, auth/handshake, sessions (resume, destroy, events), sequencing/dedup, routing (scoping modes, pattern bindings, channel bindings), node registry, tool routing, backpressure, webhooks, scheduler, config reference, public API, and close codes.

Closes #182
Ref #180 (implements in-memory gateway-side capability registry; full L0 interface + Nexus backend remain)

## Test plan

- [x] Unit tests for tool router (`tool-router.test.ts`)
- [x] Integration tests for tool routing through the gateway (`tool-routing.integration.test.ts`)
- [x] API surface snapshot updated
- [x] All 120 turbo tasks pass (build, test, typecheck)
- [x] Documentation reviewed for factual accuracy against source code (zero errors found)