### PR TITLE
feat: node capability registry — close spec gaps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1058,6 +1058,7 @@
         "@koi/engine-loop": "workspace:*",
         "@koi/engine-pi": "workspace:*",
         "@koi/forge": "workspace:*",
+        "@koi/gateway": "workspace:*",
         "@koi/hash": "workspace:*",
         "@koi/middleware-audit": "workspace:*",
         "@koi/middleware-call-limits": "workspace:*",

--- a/docs/L2/gateway.md
+++ b/docs/L2/gateway.md
@@ -1,0 +1,622 @@
+# @koi/gateway — WebSocket Control Plane
+
+WebSocket gateway for Koi's multi-node architecture. Manages two distinct connection types through a single transport: **client sessions** (browsers, CLIs) exchanging `GatewayFrame` messages, and **compute nodes** (`@koi/node`) exchanging `NodeFrame` messages for tool routing, capacity reporting, and agent dispatch. Handles authentication, protocol negotiation, sequencing, backpressure, routing, webhook ingestion, scheduled dispatch, and cross-node tool execution.
+
+---
+
+## Why It Exists
+
+Koi agents run on distributed compute nodes — a laptop running a Pi agent, a cloud VM exposing search tools, a Raspberry Pi with camera access. These nodes need a central coordination point that:
+
+- **Routes tool calls** — Agent A on Node-1 calls `camera.capture`, which only Node-2 provides. The gateway discovers the target, forwards the call, tracks the response, and routes the result back.
+- **Manages sessions** — Clients connect, authenticate, resume after disconnects, and receive ordered, deduplicated frames.
+- **Tracks capacity** — Nodes report their load. The gateway selects the best target for each tool call (affinity > capacity > queue).
+- **Handles backpressure** — Per-connection and global buffer monitoring prevents slow consumers from overwhelming the system.
+- **Ingests webhooks** — External HTTP events (Slack, GitHub, Stripe) flow through the same routing pipeline as WebSocket frames.
+
+Without this package, every agent would need direct knowledge of every other agent's location, tools, and availability.
+
+---
+
+## Architecture
+
+`@koi/gateway` is an **L2 feature package** — it depends only on L0 (`@koi/core`) and L0-utility (`@koi/errors`).
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  @koi/gateway  (L2)                                          │
+│                                                              │
+│  gateway.ts          ← factory: createGateway()              │
+│  transport.ts        ← Bun.serve() WebSocket abstraction     │
+│  auth.ts             ← handshake + heartbeat sweep           │
+│  protocol.ts         ← frame parsing, negotiation, encoding  │
+│  routing.ts          ← dispatch key + pattern binding        │
+│  session-store.ts    ← pluggable session persistence         │
+│  sequence-tracker.ts ← ordering + deduplication              │
+│  backpressure.ts     ← per-conn + global buffer monitoring   │
+│  node-handler.ts     ← node frame parsing + validation       │
+│  node-connection.ts  ← node lifecycle + stale sweep          │
+│  node-registry.ts    ← node registration + inverted index    │
+│  tool-router.ts      ← cross-node tool call routing          │
+│  scheduler.ts        ← periodic frame generation             │
+│  webhook.ts          ← HTTP POST ingestion                   │
+│  types.ts            ← config, frame, session types          │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│  Dependencies                                                │
+│                                                              │
+│  @koi/core    (L0)   Result, KoiError, AdvertisedTool,       │
+│                      CapacityReport, ToolCallPayload,         │
+│                      isToolCallPayload                        │
+│  @koi/errors  (L0u)  error factories                         │
+│  Bun.serve()  (rt)   built-in WebSocket server               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+For the full architecture deep-dive (wire protocol, connection lifecycle, close codes), see [docs/architecture/Gateway.md](../architecture/Gateway.md).
+
+---
+
+## Two Connection Types
+
+The gateway serves two kinds of peers over the same WebSocket port:
+
+```
+┌──────────────────┐                        ┌──────────────────┐
+│  CLIENT           │                        │  COMPUTE NODE     │
+│  (browser, CLI)   │                        │  (full or thin)   │
+│                   │                        │                   │
+│  Sends:           │                        │  Sends:           │
+│  ConnectFrame     │                        │  node:handshake   │
+│  GatewayFrame     │                        │  node:capabilities│
+│                   │                        │  tool_call        │
+│  Receives:        │                        │  tool_result      │
+│  HandshakeAck     │                        │  node:heartbeat   │
+│  GatewayFrame     │                        │                   │
+└────────┬─────────┘                        └────────┬─────────┘
+         │                                           │
+         │        ┌───────────────────────┐          │
+         └───────▶│      GATEWAY          │◀─────────┘
+                  │                       │
+                  │  First message peek   │
+                  │  determines path:     │
+                  │  "connect" → client   │
+                  │  "node:*" → node      │
+                  └───────────────────────┘
+```
+
+### Node Types
+
+| | Full Node | Thin Node |
+|---|-----------|-----------|
+| Agents | Runs Pi/Loop engines | None |
+| Tools | Optional local tools | Exposes local tools |
+| Tool calls | Dispatches `tool_call` frames | Executes `tool_call` frames |
+| Use case | Laptop running an agent | Raspberry Pi with camera |
+
+A full node's agent calls a tool. If the tool isn't local, the gateway routes it to a thin node that has it.
+
+---
+
+## Node Registry
+
+The registry tracks connected nodes, their tools, and their capacity. An **inverted tool index** provides O(1) tool-to-nodes lookup.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Node Registry                                               │
+│                                                              │
+│  Nodes:                  Inverted Index:                     │
+│  ┌───────────────────┐   ┌──────────────────────────────┐   │
+│  │ node-laptop        │   │ "search"     → {node-laptop} │   │
+│  │  mode: full        │   │ "camera.*"   → {node-pi}     │   │
+│  │  tools: [search]   │   │ "fetch_url"  → {node-laptop, │   │
+│  │  cap: 8/10         │   │                node-cloud}   │   │
+│  ├───────────────────┤   └──────────────────────────────┘   │
+│  │ node-pi            │                                      │
+│  │  mode: thin        │   Events:                            │
+│  │  tools: [camera.*] │   ├ registered                       │
+│  │  cap: 2/4          │   ├ deregistered                     │
+│  ├───────────────────┤   ├ heartbeat                         │
+│  │ node-cloud         │   ├ capacity_updated                 │
+│  │  mode: thin        │   ├ tools_added                      │
+│  │  tools: [fetch_url]│   └ tools_removed                    │
+│  │  cap: 50/100       │                                      │
+│  └───────────────────┘                                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Registration Flow
+
+```
+Node                           Gateway
+  │                              │
+  │── node:handshake ──────────▶│  validate nodeId, version, capacity
+  │── node:capabilities ───────▶│  validate tools + nodeType
+  │                              │  register in NodeRegistry
+  │                              │  build inverted tool index
+  │◀── node:registered ────────│  ack with timestamp
+```
+
+### Dynamic Tool Re-advertisement
+
+Nodes can update their tool set at runtime without disconnecting:
+
+```
+Node                           Gateway
+  │                              │
+  │── node:tools_updated ──────▶│  payload: {
+  │   {                          │    added: [{ name: "deploy" }],
+  │     added: [deploy],         │    removed: ["search"]
+  │     removed: [search]        │  }
+  │   }                          │
+  │                              │  registry.updateTools():
+  │                              │    add "deploy" to inverted index
+  │                              │    remove "search" from index
+  │                              │    emit tools_added event
+  │                              │    emit tools_removed event
+  │                              │
+  │                              │  toolRouter.handleToolsUpdated():
+  │                              │    drain queued calls matching "deploy"
+```
+
+This enables hot-plugging: a node starts with a base tool set and advertises new capabilities as plugins load.
+
+---
+
+## Tool Routing
+
+Cross-node tool execution with a 5-priority decision tree. Entirely opt-in — disabled by default.
+
+### Routing Algorithm
+
+```
+tool_call arrives from Node-A
+          │
+          ▼
+1. isToolCallPayload(payload)?  ──no──▶ VALIDATION error
+          │ yes
+          ▼
+2. pending.size < maxPendingCalls?  ──no──▶ RATE_LIMIT error
+          │ yes
+          ▼
+3. registry.findByTool(toolName)
+          │
+          ├── no candidates ──▶ queue (if space) or NOT_FOUND error
+          │
+          ▼
+4. exclude source node (Node-A)
+          │
+          ├── no remote candidates ──▶ queue or NOT_FOUND error
+          │
+          ▼
+5a. affinity match?  ──yes──▶ route to preferred node
+          │ no
+          ▼
+5b. O(N) capacity scan ──▶ route to highest-available node
+```
+
+### Error Codes
+
+All tool routing errors use typed constants:
+
+```typescript
+const TOOL_ROUTING_ERROR_CODES = {
+  NOT_FOUND: "not_found",       // no node available for tool
+  TIMEOUT: "timeout",           // routed call exceeded TTL
+  RATE_LIMIT: "rate_limit",     // maxPendingCalls reached
+  VALIDATION: "validation",     // malformed tool_call payload
+} as const;
+```
+
+### Cross-Node Round Trip
+
+```
+Full Node (Agent)              Gateway                  Thin Node (Tools)
+     │                            │                            │
+     │── tool_call ──────────────▶│                            │
+     │   corr: "abc"              │  resolve → thin-node       │
+     │                            │  track: "route-abc-{ts}"   │
+     │                            │── tool_call ──────────────▶│
+     │                            │   corr: "route-abc-{ts}"   │
+     │                            │                            │
+     │                            │                            │ execute tool
+     │                            │                            │
+     │                            │◀── tool_result ───────────│
+     │                            │   corr: "route-abc-{ts}"   │
+     │                            │                            │
+     │                            │  lookup pending → restore  │
+     │◀── tool_result ───────────│                            │
+     │   corr: "abc"  (restored)  │                            │
+```
+
+The gateway generates a routing correlation ID to track forwarded calls. When the result returns, it restores the original caller's correlation ID — the calling agent sees a transparent tool invocation.
+
+### Affinity
+
+Static tool-to-node preferences via glob patterns:
+
+```typescript
+const config: ToolRoutingConfig = {
+  defaultTimeoutMs: 30_000,
+  maxPendingCalls: 10_000,
+  maxQueuedCalls: 1_000,
+  queueTimeoutMs: 60_000,
+  affinities: [
+    { pattern: "camera.*", nodeId: "node-pi" },
+    { pattern: "db_*", nodeId: "node-cloud" },
+  ],
+};
+```
+
+Patterns are compiled to `RegExp` at construction time. Affinity is a preference — if the preferred node is offline, the router falls back to capacity-based selection.
+
+### Queue and Drain
+
+When no node is available, tool calls are queued with a TTL:
+
+```
+t=0  tool_call("deploy") arrives
+     → no node has "deploy" → QUEUED (TTL: 60s)
+
+     Queue: [ deploy (TTL: 60s) ]
+
+t=5  Node-3 connects, advertises: [deploy]
+     → handleNodeRegistered("node-3")
+     → scan queue → match "deploy" → DRAIN
+
+     Queue: [ ] (empty)
+
+     tool_call forwarded to Node-3 → result back to caller
+```
+
+Queue drain also triggers on `node:tools_updated` — when an existing node adds a tool that matches queued calls.
+
+---
+
+## API Reference
+
+### Factory Functions
+
+#### `createGateway(config, deps)`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | `Partial<GatewayConfig>` | Merged with `DEFAULT_GATEWAY_CONFIG` |
+| `deps.transport` | `Transport` | WebSocket server (use `createBunTransport()`) |
+| `deps.auth` | `GatewayAuthenticator` | Authentication provider |
+| `deps.store` | `SessionStore?` | Session persistence (defaults to in-memory) |
+| `deps.webhookAuth` | `WebhookAuthenticator?` | Webhook HMAC verification |
+
+Returns `Gateway`.
+
+#### `createBunTransport()`
+
+Returns `BunTransport` wrapping `Bun.serve()` with WebSocket upgrade.
+
+#### `createInMemorySessionStore()`
+
+Returns `SessionStore`. Map-based. Process-lifetime only.
+
+#### `createInMemoryNodeRegistry()`
+
+Returns `NodeRegistry` with inverted tool index.
+
+#### `createToolRouter(config, deps)`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | `ToolRoutingConfig` | Timeouts, limits, affinities |
+| `deps.registry` | `NodeRegistry` | Node lookup |
+| `deps.sendToNode` | `(nodeId, frame) => Result<number, KoiError>` | Frame delivery |
+
+Returns `ToolRouter`.
+
+#### `createBackpressureMonitor(config)`
+
+Returns `BackpressureMonitor` with per-connection and global tracking.
+
+#### `createSequenceTracker(windowSize)`
+
+Returns `SequenceTracker` for ordering and deduplication.
+
+#### `createScheduler(defs, dispatcher)`
+
+Returns `GatewayScheduler` for periodic frame generation.
+
+#### `createWebhookServer(config, dispatcher, auth?)`
+
+Returns `WebhookServer` for HTTP POST ingestion.
+
+### Pure Functions
+
+| Function | Purpose |
+|----------|---------|
+| `parseFrame(raw)` | Parse JSON string to `GatewayFrame` |
+| `parseConnectFrame(data)` | Parse connect handshake |
+| `encodeFrame(frame)` | Serialize `GatewayFrame` to JSON |
+| `parseNodeFrame(data)` | Parse JSON string to `NodeFrame` |
+| `encodeNodeFrame(frame)` | Serialize `NodeFrame` to JSON |
+| `peekFrameKind(data)` | Extract frame kind without full parse |
+| `negotiateProtocol(cMin, cMax, sMin, sMax)` | Highest mutual version |
+| `handleHandshake(conn, auth, timeout, opts, onMsg)` | Client handshake orchestration |
+| `startHeartbeatSweep(store, auth, interval, sweep, onExpired)` | Periodic session validation |
+| `computeDispatchKey(scopingMode, routing)` | Generate dispatch key |
+| `validateBindingPattern(pattern)` | Validate route pattern |
+| `resolveBinding(dispatchKey, bindings)` | Match pattern to agent |
+| `resolveRoute(config, ctx, agentId, channelMap)` | Full route resolution |
+| `resolveTargetNode(tool, source, registry, affinities)` | Tool routing resolution |
+| `compileAffinities(affinities)` | Pre-compile glob patterns |
+| `matchAffinity(toolName, compiled)` | Match tool against affinities |
+| `validateHandshakePayload(p)` | Validate node handshake |
+| `validateCapabilitiesPayload(p)` | Validate node capabilities |
+| `validateCapacityPayload(p)` | Validate capacity report |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `Gateway` | Main gateway interface (start, stop, send, dispatch, routing) |
+| `GatewayDeps` | Dependencies for `createGateway` |
+| `GatewayConfig` | Full configuration (see architecture doc for all fields) |
+| `GatewayFrame` | Client frame (kind, id, seq, ref, payload, timestamp) |
+| `NodeFrame` | Compute node frame (kind, nodeId, agentId, correlationId, payload) |
+| `Session` | Client session state |
+| `SessionStore` | Pluggable persistence interface |
+| `SessionEvent` | Session lifecycle event |
+| `RegisteredNode` | Registered compute node |
+| `NodeRegistry` | Node management + inverted tool index |
+| `NodeRegistryEvent` | Node lifecycle event |
+| `ToolRouter` | Cross-node tool call router |
+| `ToolRoutingConfig` | Router configuration |
+| `ToolAffinity` | Pattern-to-node preference |
+| `RouteResult` | Routing resolution outcome |
+| `Transport` | WebSocket server abstraction |
+| `TransportConnection` | Individual connection handle |
+| `BackpressureMonitor` | Buffer tracking per connection |
+| `SequenceTracker` | Ordering + deduplication |
+| `AcceptResult` | Frame accept outcome |
+| `GatewayScheduler` | Timer-based frame generator |
+| `WebhookServer` | HTTP POST ingestion server |
+
+### Constants
+
+| Constant | Value |
+|----------|-------|
+| `DEFAULT_GATEWAY_CONFIG` | Full config defaults (see architecture doc) |
+| `DEFAULT_TOOL_ROUTING_CONFIG` | `{ defaultTimeoutMs: 30_000, maxPendingCalls: 10_000, maxQueuedCalls: 1_000, queueTimeoutMs: 60_000 }` |
+| `TOOL_ROUTING_ERROR_CODES` | `{ NOT_FOUND, TIMEOUT, RATE_LIMIT, VALIDATION }` |
+
+---
+
+## Examples
+
+### Minimal Gateway
+
+```typescript
+import { createGateway, createBunTransport } from "@koi/gateway";
+import type { GatewayAuthenticator, ConnectFrame, AuthResult } from "@koi/gateway";
+
+const auth: GatewayAuthenticator = {
+  authenticate: async (frame: ConnectFrame): Promise<AuthResult> => ({
+    ok: true,
+    sessionId: `session-${Date.now()}`,
+    agentId: "default-agent",
+    metadata: {},
+  }),
+  validate: async (_sessionId: string): Promise<boolean> => true,
+};
+
+const gateway = createGateway({}, {
+  transport: createBunTransport(),
+  auth,
+});
+
+await gateway.start(8080);
+```
+
+### Gateway with Tool Routing
+
+```typescript
+import { createGateway, createBunTransport } from "@koi/gateway";
+
+const gateway = createGateway(
+  {
+    toolRouting: {
+      defaultTimeoutMs: 30_000,
+      maxPendingCalls: 10_000,
+      maxQueuedCalls: 1_000,
+      queueTimeoutMs: 60_000,
+      affinities: [
+        { pattern: "camera.*", nodeId: "node-pi" },
+        { pattern: "search_*", nodeId: "node-cloud" },
+      ],
+    },
+  },
+  { transport: createBunTransport(), auth },
+);
+
+// Subscribe to node lifecycle events
+const unsub = gateway.onNodeEvent((event) => {
+  switch (event.kind) {
+    case "registered":
+      console.log(`Node ${event.nodeId} connected`);
+      break;
+    case "tools_added":
+      console.log(`Node ${event.nodeId} added tools: ${event.tools.map((t) => t.name)}`);
+      break;
+    case "tools_removed":
+      console.log(`Node ${event.nodeId} removed tools: ${event.toolNames}`);
+      break;
+  }
+});
+
+await gateway.start(8080);
+```
+
+### Direct Tool Routing (Unit-Level)
+
+```typescript
+import {
+  createInMemoryNodeRegistry,
+  createToolRouter,
+  resolveTargetNode,
+  compileAffinities,
+  DEFAULT_TOOL_ROUTING_CONFIG,
+} from "@koi/gateway";
+import type { AdvertisedTool, CapacityReport } from "@koi/core";
+
+const registry = createInMemoryNodeRegistry();
+
+// Register two thin nodes with different tools
+registry.register({
+  nodeId: "node-pi",
+  mode: "thin",
+  tools: [{ name: "camera.capture" }, { name: "camera.zoom" }],
+  capacity: { current: 1, max: 4, available: 3 },
+  connectedAt: Date.now(),
+  lastHeartbeat: Date.now(),
+  connId: "conn-1",
+});
+
+registry.register({
+  nodeId: "node-cloud",
+  mode: "thin",
+  tools: [{ name: "search" }, { name: "fetch_url" }],
+  capacity: { current: 10, max: 100, available: 90 },
+  connectedAt: Date.now(),
+  lastHeartbeat: Date.now(),
+  connId: "conn-2",
+});
+
+// Resolve routing with affinity
+const affinities = compileAffinities([
+  { pattern: "camera.*", nodeId: "node-pi" },
+]);
+
+const result = resolveTargetNode("camera.capture", "node-agent", registry, affinities);
+// result = { kind: "routed", targetNodeId: "node-pi" }
+```
+
+### Dynamic Tool Updates
+
+```typescript
+import { createInMemoryNodeRegistry } from "@koi/gateway";
+
+const registry = createInMemoryNodeRegistry();
+
+// Node starts with search only
+registry.register({
+  nodeId: "node-a",
+  mode: "thin",
+  tools: [{ name: "search" }],
+  capacity: { current: 0, max: 10, available: 10 },
+  connectedAt: Date.now(),
+  lastHeartbeat: Date.now(),
+  connId: "conn-1",
+});
+
+// Later: node loads a plugin, adds "deploy" tool
+const result = registry.updateTools(
+  "node-a",
+  [{ name: "deploy", description: "Deploy to staging" }],  // added
+  ["search"],                                                // removed
+);
+// result.ok === true
+
+// Registry now reflects the change
+const deployers = registry.findByTool("deploy");
+// deployers = [{ nodeId: "node-a", tools: [deploy], ... }]
+
+const searchers = registry.findByTool("search");
+// searchers = [] (removed)
+```
+
+### Webhook + Scheduler
+
+```typescript
+const gateway = createGateway(
+  {
+    webhookPort: 9090,
+    webhookPath: "/hook",
+    schedulers: [
+      {
+        id: "health-check",
+        intervalMs: 60_000,
+        agentId: "monitor-agent",
+        payload: { type: "health_check" },
+      },
+    ],
+  },
+  { transport: createBunTransport(), auth },
+);
+
+// Webhooks POST to http://localhost:9090/hook/{channel}/{account}
+// Scheduler ticks every 60s, dispatched as GatewayFrame events
+```
+
+---
+
+## Backpressure
+
+Three-state model per connection with global limits:
+
+```
+normal ──▶ warning ──▶ critical ──▶ force-close
+          (80% buffer)  (100% buffer)  (30s timeout)
+```
+
+| State | Threshold | Behavior |
+|-------|-----------|----------|
+| `normal` | `< 80% of maxBuffer` | All frames processed |
+| `warning` | `>= 80% of maxBuffer` | Signal only (observable) |
+| `critical` | `>= maxBufferBytesPerConnection` | Frames dropped; timeout starts |
+
+Global limit: 500MB across all connections. New connections rejected when exceeded.
+
+---
+
+## Session Lifecycle
+
+```
+connect ──▶ authenticate ──▶ session created
+                                   │
+                              disconnect
+                                   │
+               ┌───────────────────┼───────────────────┐
+               ▼                   ▼                   ▼
+          sessionTtlMs=0    sessionTtlMs>0       destroySession()
+               │                   │                   │
+               ▼                   ▼                   ▼
+           destroyed          kept alive           destroyed
+                               (buffering)
+                                   │
+                    ┌──────────────┼──────────────┐
+                    ▼                             ▼
+              reconnect within TTL          TTL expires
+                    │                             │
+                    ▼                             ▼
+              session resumed               session expired
+              (flush buffer)
+```
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ───────────────────────────────────────┐
+    Result, KoiError, AdvertisedTool, CapacityReport,  │
+    ToolCallPayload, isToolCallPayload                 │
+                                                       │
+L0u @koi/errors ────────────────────┐                 │
+    error factories                 │                 │
+                                    ▼                 ▼
+L2  @koi/gateway ◀─────────────────┴─────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages (@koi/node, @koi/forge, etc.)
+    ✓ Bun.serve() is a runtime built-in
+```
+
+Shared wire types (`AdvertisedTool`, `CapacityReport`, `ToolCallPayload`) live in `@koi/core` (L0) — both `@koi/gateway` and `@koi/node` import from the same source, eliminating duplication between L2 peers.

--- a/docs/architecture/Gateway.md
+++ b/docs/architecture/Gateway.md
@@ -126,6 +126,7 @@ interface NodeFrame {
 | `node:registered` | gw -> node | Registration acknowledgement |
 | `node:heartbeat` | node -> gw | Keep-alive signal |
 | `node:capacity` | node -> gw | Updated capacity report |
+| `node:tools_updated` | node -> gw | Dynamic tool add/remove (hot-plug) |
 | `node:error` | gw -> node | Error response |
 | `agent:dispatch` | gw -> node | Dispatch work to an agent on the node |
 | `agent:message` | node -> gw | Agent output message |
@@ -367,7 +368,26 @@ interface RegisteredNode {
 
 ### Inverted Tool Index
 
-`toolName -> Set<nodeId>` mapping built at registration time. `registry.findByTool(name)` returns all nodes advertising a given tool in O(1) lookup time. The index is incrementally maintained — entries are added on register and removed on deregister.
+`toolName -> Set<nodeId>` mapping built at registration time. `registry.findByTool(name)` returns all nodes advertising a given tool in O(1) lookup time. The index is incrementally maintained — entries are added on register, removed on deregister, and updated on `node:tools_updated`.
+
+### Dynamic Tool Re-advertisement
+
+Nodes can update their tool set at runtime without disconnecting by sending a `node:tools_updated` frame:
+
+```typescript
+interface ToolsUpdatedPayload {
+  readonly added: readonly AdvertisedTool[];   // new tools to advertise
+  readonly removed: readonly string[];         // tool names to withdraw
+}
+```
+
+The gateway processes this atomically via `registry.updateTools(nodeId, added, removed)`:
+1. Removes withdrawn tools from the node's tool list and the inverted index
+2. Adds new tools to the node's tool list and the inverted index
+3. Emits `tools_added` and/or `tools_removed` events
+4. Triggers the tool router's queue drain — any queued `tool_call` frames matching the newly added tools are dispatched immediately
+
+This enables hot-plugging: a node starts with a base tool set and advertises new capabilities as plugins load, without reconnecting.
 
 ### Heartbeat and Capacity
 
@@ -389,6 +409,8 @@ Subscribers receive events via `gateway.onNodeEvent()`:
 | `deregistered` | Node disconnected or evicted |
 | `heartbeat` | Node sent heartbeat |
 | `capacity_updated` | Node reported new capacity |
+| `tools_added` | Node advertised new tools (via `node:tools_updated`) |
+| `tools_removed` | Node withdrew tools (via `node:tools_updated`) |
 
 ---
 
@@ -415,6 +437,19 @@ When a `tool_call` frame arrives, the router applies a 5-priority decision tree:
 4. If no candidate: queue with TTL (if queue not full)
 5. If queue full or disabled: return tool_error to source
 ```
+
+Capacity selection uses an O(N) linear scan (not sort) — zero array allocation, picks the node with the highest `capacity.available`.
+
+### Error Codes
+
+All tool routing errors use typed constants (`TOOL_ROUTING_ERROR_CODES`):
+
+| Code | Constant | When |
+|------|----------|------|
+| `"not_found"` | `NOT_FOUND` | No node available for the tool, or send to target failed |
+| `"timeout"` | `TIMEOUT` | Routed call exceeded TTL (per-frame or default) |
+| `"rate_limit"` | `RATE_LIMIT` | `maxPendingCalls` reached |
+| `"validation"` | `VALIDATION` | Malformed `tool_call` payload |
 
 ### Cross-Node Flow
 
@@ -459,7 +494,8 @@ When no node is available for a tool call, it is queued in memory:
 
 - **Max size**: `maxQueuedCalls` (default: 1,000)
 - **TTL**: `queueTimeoutMs` (default: 60,000ms)
-- **Dequeue**: when a new node registers, the router checks if any queued calls match the node's tools and dispatches them immediately.
+- **Dequeue on register**: when a new node registers (`handleNodeRegistered`), the router checks if any queued calls match the node's tools and dispatches them immediately.
+- **Dequeue on tools_updated**: when an existing node adds tools (`handleToolsUpdated`), the same drain logic fires — queued calls matching the newly added tools are dispatched.
 - **Expiry**: a TTL timer fires `tool_error` back to the source if no node becomes available.
 
 ### Timeout
@@ -485,13 +521,14 @@ interface ToolRouter {
   readonly handleToolError: (frame: NodeFrame) => void;
   readonly handleNodeDisconnect: (nodeId: string) => void;
   readonly handleNodeRegistered: (nodeId: string) => void;
+  readonly handleToolsUpdated: (nodeId: string) => void;
   readonly pendingCount: () => number;
   readonly queuedCount: () => number;
   readonly dispose: () => void;
 }
 ```
 
-The tool router is wired into the node connection handler via callback — `tool_call`, `tool_result`, and `tool_error` frame kinds are intercepted and forwarded to the router. The router also subscribes to node registry events to handle disconnect cleanup and queue drain on registration.
+The tool router is wired into the node connection handler via callback — `tool_call`, `tool_result`, and `tool_error` frame kinds are intercepted and forwarded to the router. The router also subscribes to node registry events to handle disconnect cleanup, queue drain on registration, and queue drain on dynamic tool updates (`node:tools_updated`).
 
 ---
 

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -322,6 +322,68 @@ interface BrickRegistryBackend extends BrickRegistryReader, BrickRegistryWriter 
 }
 
 /**
+ * Capability registry — shared wire types and contracts for node capability
+ * advertisement and tool routing.
+ *
+ * These types are shared between @koi/gateway and @koi/node (L2 peers that
+ * cannot import each other). Placing them in L0 eliminates duplication.
+ */
+/** Descriptor for a single tool advertised by a Node. */
+interface AdvertisedTool {
+    readonly name: string;
+    readonly description?: string | undefined;
+    /** JSON Schema for the tool's arguments. */
+    readonly schema?: Readonly<Record<string, unknown>> | undefined;
+}
+/** Capacity snapshot reported by a Node. */
+interface CapacityReport {
+    readonly current: number;
+    readonly max: number;
+    readonly available: number;
+}
+/** Gateway → Node: execute a tool on this Node (may originate from a remote agent). */
+interface ToolCallPayload {
+    readonly toolName: string;
+    readonly args: Readonly<Record<string, unknown>>;
+    /** Agent requesting the tool call (for permission checks). */
+    readonly callerAgentId: string;
+    /** Zone scope for permission enforcement (backend-dependent). */
+    readonly zone?: string | undefined;
+}
+/** Node → Gateway: tool execution result returned to calling agent. */
+interface ToolResultPayload {
+    readonly toolName: string;
+    readonly result: unknown;
+}
+/** Node → Gateway: tool execution failed or permission denied. */
+interface ToolErrorPayload {
+    readonly toolName: string;
+    readonly code: string;
+    readonly message: string;
+}
+/** A node's advertised capability set. */
+interface NodeCapability {
+    readonly nodeId: string;
+    readonly nodeType: "full" | "thin";
+    readonly tools: readonly AdvertisedTool[];
+}
+/**
+ * Registry of node capabilities — maps tool names to nodes that can execute them.
+ *
+ * L0 interface with swappable L2 backends (in-memory, distributed, etc.).
+ */
+interface CapabilityRegistry {
+    /** Advertise tools for a node. Replaces any previous advertisement. */
+    readonly advertise: (nodeId: string, tools: readonly AdvertisedTool[]) => void | Promise<void>;
+    /** Withdraw specific tools from a node's advertisement. */
+    readonly withdraw: (nodeId: string, toolNames: readonly string[]) => void | Promise<void>;
+    /** Resolve which nodes can execute a given tool. */
+    readonly resolve: (toolName: string) => readonly NodeCapability[] | Promise<readonly NodeCapability[]>;
+}
+/** Type guard — validates ToolCallPayload shape without \`as\` assertion. */
+declare function isToolCallPayload(value: unknown): value is ToolCallPayload;
+
+/**
  * Pure data constructors for KoiError objects.
  *
  * Eliminates duplication of error helper functions across store
@@ -1035,7 +1097,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { Agent, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_SCHEDULER_CONFIG, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GuardContext, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskFilter, type TaskId, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskOptions, type TaskResult, type TaskScheduler, type TaskStatus, type TaskStore, Tool, ToolCallId, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, chainId, conflict, evolveRegistryEntry, external, internal, isAgentStateEvent, isProcessState, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, taskItemId, timeout, validateNonEmpty, validation };
+export { type AdvertisedTool, Agent, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type CapabilityRegistry, type CapacityReport, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_SCHEDULER_CONFIG, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GuardContext, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeCapability, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskFilter, type TaskId, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskOptions, type TaskResult, type TaskScheduler, type TaskStatus, type TaskStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, chainId, conflict, evolveRegistryEntry, external, internal, isAgentStateEvent, isProcessState, isToolCallPayload, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, taskItemId, timeout, validateNonEmpty, validation };
 "
 `;
 

--- a/packages/core/src/__tests__/build.test.ts
+++ b/packages/core/src/__tests__/build.test.ts
@@ -35,9 +35,9 @@ describe.skipIf(!distExists)("build output", () => {
     }
   });
 
-  test("index bundle is under 7KB", async () => {
+  test("index bundle is under 8KB", async () => {
     const file = Bun.file(resolve(DIST_DIR, "index.js"));
     const size = file.size;
-    expect(size).toBeLessThan(7168);
+    expect(size).toBeLessThan(8192);
   });
 });

--- a/packages/core/src/__tests__/exports.test.ts
+++ b/packages/core/src/__tests__/exports.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from "bun:test";
  */
 
 import type {
+  // capability registry
+  AdvertisedTool,
   Agent,
   // lifecycle
   AgentCondition,
@@ -16,6 +18,8 @@ import type {
   AgentStatus,
   BrickComponentMap,
   ButtonBlock,
+  CapabilityRegistry,
+  CapacityReport,
   ChannelAdapter,
   // channel
   ChannelCapabilities,
@@ -66,6 +70,7 @@ import type {
   ModelHandler,
   ModelRequest,
   ModelResponse,
+  NodeCapability,
   OutboundMessage,
   PermissionConfig,
   ProcessAccounter,
@@ -90,11 +95,14 @@ import type {
   // message
   TextBlock,
   Tool,
+  ToolCallPayload,
   ToolConfig,
   ToolDescriptor,
+  ToolErrorPayload,
   ToolHandler,
   ToolRequest,
   ToolResponse,
+  ToolResultPayload,
   TransitionReason,
   TrustTier,
   TurnContext,
@@ -111,6 +119,7 @@ import {
   GOVERNANCE,
   GOVERNANCE_VARIABLES,
   governanceContributorToken,
+  isToolCallPayload,
   MEMORY,
   MIN_TRUST_BY_KIND,
   middlewareToken,
@@ -210,7 +219,15 @@ type _TypeGuard =
   | AssertDefined<BrickComponentMap>
   // ecs extensions
   | AssertDefined<SkillComponent>
-  | AssertDefined<AgentDescriptor>;
+  | AssertDefined<AgentDescriptor>
+  // capability registry
+  | AssertDefined<AdvertisedTool>
+  | AssertDefined<CapacityReport>
+  | AssertDefined<ToolCallPayload>
+  | AssertDefined<ToolResultPayload>
+  | AssertDefined<ToolErrorPayload>
+  | AssertDefined<NodeCapability>
+  | AssertDefined<CapabilityRegistry>;
 
 describe("export inventory", () => {
   test("all runtime values are defined", () => {
@@ -233,6 +250,7 @@ describe("export inventory", () => {
     expect(ALL_BRICK_KINDS).toBeDefined();
     expect(MIN_TRUST_BY_KIND).toBeDefined();
     expect(COMPONENT_PRIORITY).toBeDefined();
+    expect(isToolCallPayload).toBeDefined();
   });
 
   test("runtime values are functions, strings, or objects", () => {
@@ -251,5 +269,6 @@ describe("export inventory", () => {
     expect(typeof VALID_TRANSITIONS).toBe("object");
     expect(typeof DEFAULT_HEALTH_MONITOR_CONFIG).toBe("object");
     expect(typeof COMPONENT_PRIORITY).toBe("object");
+    expect(typeof isToolCallPayload).toBe("function");
   });
 });

--- a/packages/core/src/capability-registry.ts
+++ b/packages/core/src/capability-registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Capability registry — shared wire types and contracts for node capability
+ * advertisement and tool routing.
+ *
+ * These types are shared between @koi/gateway and @koi/node (L2 peers that
+ * cannot import each other). Placing them in L0 eliminates duplication.
+ */
+
+// ---------------------------------------------------------------------------
+// Wire protocol types
+// ---------------------------------------------------------------------------
+
+/** Descriptor for a single tool advertised by a Node. */
+export interface AdvertisedTool {
+  readonly name: string;
+  readonly description?: string | undefined;
+  /** JSON Schema for the tool's arguments. */
+  readonly schema?: Readonly<Record<string, unknown>> | undefined;
+}
+
+/** Capacity snapshot reported by a Node. */
+export interface CapacityReport {
+  readonly current: number;
+  readonly max: number;
+  readonly available: number;
+}
+
+/** Gateway → Node: execute a tool on this Node (may originate from a remote agent). */
+export interface ToolCallPayload {
+  readonly toolName: string;
+  readonly args: Readonly<Record<string, unknown>>;
+  /** Agent requesting the tool call (for permission checks). */
+  readonly callerAgentId: string;
+  /** Zone scope for permission enforcement (backend-dependent). */
+  readonly zone?: string | undefined;
+}
+
+/** Node → Gateway: tool execution result returned to calling agent. */
+export interface ToolResultPayload {
+  readonly toolName: string;
+  readonly result: unknown;
+}
+
+/** Node → Gateway: tool execution failed or permission denied. */
+export interface ToolErrorPayload {
+  readonly toolName: string;
+  readonly code: string;
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Capability registry contract
+// ---------------------------------------------------------------------------
+
+/** A node's advertised capability set. */
+export interface NodeCapability {
+  readonly nodeId: string;
+  readonly nodeType: "full" | "thin";
+  readonly tools: readonly AdvertisedTool[];
+}
+
+/**
+ * Registry of node capabilities — maps tool names to nodes that can execute them.
+ *
+ * L0 interface with swappable L2 backends (in-memory, distributed, etc.).
+ */
+export interface CapabilityRegistry {
+  /** Advertise tools for a node. Replaces any previous advertisement. */
+  readonly advertise: (nodeId: string, tools: readonly AdvertisedTool[]) => void | Promise<void>;
+  /** Withdraw specific tools from a node's advertisement. */
+  readonly withdraw: (nodeId: string, toolNames: readonly string[]) => void | Promise<void>;
+  /** Resolve which nodes can execute a given tool. */
+  readonly resolve: (
+    toolName: string,
+  ) => readonly NodeCapability[] | Promise<readonly NodeCapability[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Type guard (pure function on L0 types — permitted in L0)
+// ---------------------------------------------------------------------------
+
+/** Type guard — validates ToolCallPayload shape without `as` assertion. */
+export function isToolCallPayload(value: unknown): value is ToolCallPayload {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.toolName === "string" &&
+    obj.toolName.length > 0 &&
+    typeof obj.callerAgentId === "string"
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,17 @@ export type {
   BrowserWaitOptions,
   BrowserWaitUntil,
 } from "./browser-driver.js";
+// capability registry — shared wire types for node capability advertisement
+export type {
+  AdvertisedTool,
+  CapabilityRegistry,
+  CapacityReport,
+  NodeCapability,
+  ToolCallPayload,
+  ToolErrorPayload,
+  ToolResultPayload,
+} from "./capability-registry.js";
+export { isToolCallPayload } from "./capability-registry.js";
 // channel
 export type {
   ChannelAdapter,

--- a/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,59 +1,8 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/gateway API surface . has stable type surface 1`] = `
-"import { Result, KoiError } from '@koi/core';
-
-/**
- * Node registration and health tracking for connected compute nodes.
- * Maintains an inverted tool index for O(1) tool-to-node lookups.
- *
- * Internal to @koi/gateway (L2) — not an L0 contract.
- */
-
-interface AdvertisedTool {
-    readonly name: string;
-    readonly description?: string | undefined;
-    readonly schema?: Readonly<Record<string, unknown>> | undefined;
-}
-interface CapacityReport {
-    readonly current: number;
-    readonly max: number;
-    readonly available: number;
-}
-interface RegisteredNode {
-    readonly nodeId: string;
-    readonly mode: "full" | "thin";
-    readonly tools: readonly AdvertisedTool[];
-    readonly capacity: CapacityReport;
-    readonly connectedAt: number;
-    readonly lastHeartbeat: number;
-    readonly connId: string;
-}
-type NodeRegistryEvent = {
-    readonly kind: "registered";
-    readonly node: RegisteredNode;
-} | {
-    readonly kind: "deregistered";
-    readonly nodeId: string;
-} | {
-    readonly kind: "heartbeat";
-    readonly nodeId: string;
-} | {
-    readonly kind: "capacity_updated";
-    readonly nodeId: string;
-    readonly capacity: CapacityReport;
-};
-interface NodeRegistry {
-    readonly register: (node: RegisteredNode) => Result<void, KoiError>;
-    readonly deregister: (nodeId: string) => Result<boolean, KoiError>;
-    readonly lookup: (nodeId: string) => RegisteredNode | undefined;
-    readonly findByTool: (toolName: string) => readonly RegisteredNode[];
-    readonly nodes: () => ReadonlyMap<string, RegisteredNode>;
-    readonly size: () => number;
-    readonly updateHeartbeat: (nodeId: string) => Result<void, KoiError>;
-    readonly updateCapacity: (nodeId: string, capacity: CapacityReport) => Result<void, KoiError>;
-}
-declare function createInMemoryNodeRegistry(): NodeRegistry;
+"import { AdvertisedTool, CapacityReport, Result, KoiError } from '@koi/core';
+export { AdvertisedTool, CapacityReport } from '@koi/core';
 
 /**
  * Node frame types, parsing, and encoding for compute-node connections.
@@ -62,7 +11,7 @@ declare function createInMemoryNodeRegistry(): NodeRegistry;
  * Nodes use a different wire format (NodeFrame) than clients (GatewayFrame).
  */
 
-type NodeFrameKind = "node:handshake" | "node:capabilities" | "node:registered" | "node:heartbeat" | "node:capacity" | "node:error" | "agent:dispatch" | "agent:message" | "agent:status" | "agent:terminate" | "tool_call" | "tool_result" | "tool_error";
+type NodeFrameKind = "node:handshake" | "node:capabilities" | "node:registered" | "node:heartbeat" | "node:capacity" | "node:tools_updated" | "node:error" | "agent:dispatch" | "agent:message" | "agent:status" | "agent:terminate" | "tool_call" | "tool_result" | "tool_error";
 interface NodeFrame {
     readonly nodeId: string;
     readonly agentId: string;
@@ -86,6 +35,57 @@ declare function validateHandshakePayload(payload: unknown): Result<HandshakePay
 declare function validateCapabilitiesPayload(payload: unknown): Result<CapabilitiesPayload, KoiError>;
 declare function validateCapacityPayload(payload: unknown): Result<CapacityReport, KoiError>;
 declare function encodeNodeFrame(frame: NodeFrame): string;
+
+/**
+ * Node registration and health tracking for connected compute nodes.
+ * Maintains an inverted tool index for O(1) tool-to-node lookups.
+ *
+ * Internal to @koi/gateway (L2) — not an L0 contract.
+ */
+
+interface RegisteredNode {
+    readonly nodeId: string;
+    readonly mode: "full" | "thin";
+    readonly tools: readonly AdvertisedTool[];
+    readonly capacity: CapacityReport;
+    readonly connectedAt: number;
+    readonly lastHeartbeat: number;
+    readonly connId: string;
+}
+type NodeRegistryEvent = {
+    readonly kind: "registered";
+    readonly node: RegisteredNode;
+} | {
+    readonly kind: "deregistered";
+    readonly nodeId: string;
+} | {
+    readonly kind: "heartbeat";
+    readonly nodeId: string;
+} | {
+    readonly kind: "capacity_updated";
+    readonly nodeId: string;
+    readonly capacity: CapacityReport;
+} | {
+    readonly kind: "tools_added";
+    readonly nodeId: string;
+    readonly tools: readonly AdvertisedTool[];
+} | {
+    readonly kind: "tools_removed";
+    readonly nodeId: string;
+    readonly toolNames: readonly string[];
+};
+interface NodeRegistry {
+    readonly register: (node: RegisteredNode) => Result<void, KoiError>;
+    readonly deregister: (nodeId: string) => Result<boolean, KoiError>;
+    readonly lookup: (nodeId: string) => RegisteredNode | undefined;
+    readonly findByTool: (toolName: string) => readonly RegisteredNode[];
+    readonly nodes: () => ReadonlyMap<string, RegisteredNode>;
+    readonly size: () => number;
+    readonly updateHeartbeat: (nodeId: string) => Result<void, KoiError>;
+    readonly updateCapacity: (nodeId: string, capacity: CapacityReport) => Result<void, KoiError>;
+    readonly updateTools: (nodeId: string, added: readonly AdvertisedTool[], removed: readonly string[]) => Result<void, KoiError>;
+}
+declare function createInMemoryNodeRegistry(): NodeRegistry;
 
 /**
  * Gateway tool routing — intercepts tool_call frames, resolves target nodes,
@@ -116,6 +116,7 @@ interface ToolRouter {
     readonly handleToolError: (frame: NodeFrame) => void;
     readonly handleNodeDisconnect: (nodeId: string) => void;
     readonly handleNodeRegistered: (nodeId: string) => void;
+    readonly handleToolsUpdated: (nodeId: string) => void;
     readonly pendingCount: () => number;
     readonly queuedCount: () => number;
     readonly dispose: () => void;
@@ -124,7 +125,27 @@ interface ToolRouterDeps {
     readonly registry: NodeRegistry;
     readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
 }
+interface CompiledAffinity {
+    readonly regex: RegExp;
+    readonly nodeId: string;
+}
+type RouteResult = {
+    readonly kind: "routed";
+    readonly targetNodeId: string;
+} | {
+    readonly kind: "not_available";
+};
 declare const DEFAULT_TOOL_ROUTING_CONFIG: ToolRoutingConfig;
+declare const TOOL_ROUTING_ERROR_CODES: {
+    readonly NOT_FOUND: "not_found";
+    readonly TIMEOUT: "timeout";
+    readonly RATE_LIMIT: "rate_limit";
+    readonly VALIDATION: "validation";
+};
+type ToolRoutingErrorCode = (typeof TOOL_ROUTING_ERROR_CODES)[keyof typeof TOOL_ROUTING_ERROR_CODES];
+declare function compileAffinities(affinities: readonly ToolAffinity[]): readonly CompiledAffinity[];
+declare function matchAffinity(toolName: string, compiled: readonly CompiledAffinity[]): string | undefined;
+declare function resolveTargetNode(toolName: string, sourceNodeId: string, registry: NodeRegistry, compiledAffinities: readonly CompiledAffinity[]): RouteResult;
 declare function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps): ToolRouter;
 
 /**
@@ -591,6 +612,6 @@ interface SequenceTracker {
 }
 declare function createSequenceTracker(windowSize: number): SequenceTracker;
 
-export { type AcceptResult, type AdvertisedTool, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CapabilitiesPayload, type CapacityReport, type ChannelBinding, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, DEFAULT_TOOL_ROUTING_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SweepError, type ToolAffinity, type ToolRouter, type ToolRouterDeps, type ToolRoutingConfig, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createScheduler, createSequenceTracker, createToolRouter, createWebhookServer, encodeFrame, encodeNodeFrame, handleHandshake, negotiateProtocol, parseConnectFrame, parseFrame, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
+export { type AcceptResult, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CapabilitiesPayload, type ChannelBinding, type CompiledAffinity, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, DEFAULT_TOOL_ROUTING_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RouteResult, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SweepError, TOOL_ROUTING_ERROR_CODES, type ToolAffinity, type ToolRouter, type ToolRouterDeps, type ToolRoutingConfig, type ToolRoutingErrorCode, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, compileAffinities, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createScheduler, createSequenceTracker, createToolRouter, createWebhookServer, encodeFrame, encodeNodeFrame, handleHandshake, matchAffinity, negotiateProtocol, parseConnectFrame, parseFrame, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, resolveTargetNode, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
 "
 `;

--- a/packages/gateway/src/__tests__/node-connection.test.ts
+++ b/packages/gateway/src/__tests__/node-connection.test.ts
@@ -18,6 +18,7 @@ import {
   createNodeCapacityMessage,
   createNodeHandshakeMessage,
   createNodeHeartbeatMessage,
+  createNodeToolsUpdatedMessage,
   createTestAuthenticator,
   storeHas,
   waitForCondition,
@@ -496,6 +497,163 @@ describe("Node connections", () => {
       // Node should still be registered
       expect(gateway.nodeRegistry().size()).toBe(1);
       expect(conn.closed).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // node:tools_updated
+  // -----------------------------------------------------------------------
+
+  describe("node:tools_updated", () => {
+    test("adds tools to registered node", async () => {
+      const events: NodeRegistryEvent[] = [];
+      gateway.onNodeEvent((e) => events.push(e));
+
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      transport.simulateMessage(
+        conn.id,
+        createNodeCapabilitiesMessage("node-1", [{ name: "search" }]),
+      );
+      await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+      transport.simulateMessage(
+        conn.id,
+        createNodeToolsUpdatedMessage("node-1", [{ name: "camera.capture" }]),
+      );
+
+      await waitForCondition(() => events.some((e) => e.kind === "tools_added"));
+
+      const node = gateway.nodeRegistry().lookup("node-1");
+      expect(node?.tools).toHaveLength(2);
+      expect(node?.tools.map((t) => t.name).sort()).toEqual(["camera.capture", "search"]);
+      expect(gateway.nodeRegistry().findByTool("camera.capture")).toHaveLength(1);
+
+      const addedEvent = events.find((e) => e.kind === "tools_added");
+      expect(addedEvent).toBeDefined();
+      if (addedEvent?.kind === "tools_added") {
+        expect(addedEvent.nodeId).toBe("node-1");
+        expect(addedEvent.tools).toHaveLength(1);
+        expect(addedEvent.tools[0]?.name).toBe("camera.capture");
+      }
+    });
+
+    test("removes tools from registered node", async () => {
+      const events: NodeRegistryEvent[] = [];
+      gateway.onNodeEvent((e) => events.push(e));
+
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      transport.simulateMessage(
+        conn.id,
+        createNodeCapabilitiesMessage("node-1", [{ name: "search" }, { name: "browse" }]),
+      );
+      await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+      transport.simulateMessage(conn.id, createNodeToolsUpdatedMessage("node-1", [], ["browse"]));
+
+      await waitForCondition(() => events.some((e) => e.kind === "tools_removed"));
+
+      const node = gateway.nodeRegistry().lookup("node-1");
+      expect(node?.tools).toHaveLength(1);
+      expect(node?.tools[0]?.name).toBe("search");
+      expect(gateway.nodeRegistry().findByTool("browse")).toHaveLength(0);
+    });
+
+    test("with mixed add/remove", async () => {
+      const events: NodeRegistryEvent[] = [];
+      gateway.onNodeEvent((e) => events.push(e));
+
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      transport.simulateMessage(
+        conn.id,
+        createNodeCapabilitiesMessage("node-1", [{ name: "search" }, { name: "browse" }]),
+      );
+      await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+      transport.simulateMessage(
+        conn.id,
+        createNodeToolsUpdatedMessage("node-1", [{ name: "camera.capture" }], ["browse"]),
+      );
+
+      await waitForCondition(() => events.some((e) => e.kind === "tools_added"));
+
+      const node = gateway.nodeRegistry().lookup("node-1");
+      expect(node?.tools.map((t) => t.name).sort()).toEqual(["camera.capture", "search"]);
+    });
+
+    test("before registration is rejected", async () => {
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      // Send tools_updated before capabilities (still in pending handshake)
+      transport.simulateMessage(
+        conn.id,
+        createNodeToolsUpdatedMessage("node-1", [{ name: "camera.capture" }]),
+      );
+
+      await waitForCondition(() => conn.closed);
+      expect(conn.closed).toBe(true);
+      expect(conn.closeCode).toBe(4002);
+    });
+
+    test("with invalid payload is silently handled", async () => {
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      transport.simulateMessage(conn.id, createNodeCapabilitiesMessage("node-1"));
+      await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+      // Send invalid tools_updated payload (added is not an array)
+      transport.simulateMessage(
+        conn.id,
+        JSON.stringify({
+          kind: "node:tools_updated",
+          nodeId: "node-1",
+          agentId: "",
+          correlationId: crypto.randomUUID(),
+          payload: { added: "not-an-array" },
+        }),
+      );
+
+      // Should not crash or disconnect — just swallow the error
+      await new Promise((r) => setTimeout(r, 50));
+      expect(conn.closed).toBe(false);
+      expect(gateway.nodeRegistry().size()).toBe(1);
+    });
+
+    test("emits tools_added and tools_removed events", async () => {
+      const events: NodeRegistryEvent[] = [];
+      gateway.onNodeEvent((e) => events.push(e));
+
+      const conn = transport.simulateOpen();
+      transport.simulateMessage(conn.id, createNodeHandshakeMessage("node-1"));
+      transport.simulateMessage(
+        conn.id,
+        createNodeCapabilitiesMessage("node-1", [{ name: "search" }]),
+      );
+      await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+      transport.simulateMessage(
+        conn.id,
+        createNodeToolsUpdatedMessage("node-1", [{ name: "camera.capture" }], ["search"]),
+      );
+
+      await waitForCondition(
+        () =>
+          events.some((e) => e.kind === "tools_added") &&
+          events.some((e) => e.kind === "tools_removed"),
+      );
+
+      const addedEvent = events.find((e) => e.kind === "tools_added");
+      const removedEvent = events.find((e) => e.kind === "tools_removed");
+      expect(addedEvent).toBeDefined();
+      expect(removedEvent).toBeDefined();
+      if (addedEvent?.kind === "tools_added") {
+        expect(addedEvent.tools[0]?.name).toBe("camera.capture");
+      }
+      if (removedEvent?.kind === "tools_removed") {
+        expect(removedEvent.toolNames).toEqual(["search"]);
+      }
     });
   });
 

--- a/packages/gateway/src/__tests__/node-registry.test.ts
+++ b/packages/gateway/src/__tests__/node-registry.test.ts
@@ -214,6 +214,92 @@ describe("NodeRegistry", () => {
     });
   });
 
+  describe("updateTools()", () => {
+    test("adds new tools and updates inverted index", () => {
+      const node = createTestNode({
+        nodeId: "node-1",
+        tools: [{ name: "search" }],
+      });
+      registry.register(node);
+
+      const result = registry.updateTools("node-1", [{ name: "browse" }], []);
+      expect(result.ok).toBe(true);
+
+      const updated = registry.lookup("node-1");
+      expect(updated?.tools).toHaveLength(2);
+      expect(updated?.tools.map((t) => t.name).sort()).toEqual(["browse", "search"]);
+      expect(registry.findByTool("browse")).toHaveLength(1);
+    });
+
+    test("removes tools and cleans inverted index", () => {
+      const node = createTestNode({
+        nodeId: "node-1",
+        tools: [{ name: "search" }, { name: "browse" }],
+      });
+      registry.register(node);
+      expect(registry.findByTool("search")).toHaveLength(1);
+
+      const result = registry.updateTools("node-1", [], ["search"]);
+      expect(result.ok).toBe(true);
+
+      const updated = registry.lookup("node-1");
+      expect(updated?.tools).toHaveLength(1);
+      expect(updated?.tools[0]?.name).toBe("browse");
+      expect(registry.findByTool("search")).toHaveLength(0);
+    });
+
+    test("with both added and removed", () => {
+      const node = createTestNode({
+        nodeId: "node-1",
+        tools: [{ name: "search" }, { name: "browse" }],
+      });
+      registry.register(node);
+
+      const result = registry.updateTools("node-1", [{ name: "camera.capture" }], ["browse"]);
+      expect(result.ok).toBe(true);
+
+      const updated = registry.lookup("node-1");
+      const names = updated?.tools.map((t) => t.name).sort();
+      expect(names).toEqual(["camera.capture", "search"]);
+      expect(registry.findByTool("browse")).toHaveLength(0);
+      expect(registry.findByTool("camera.capture")).toHaveLength(1);
+    });
+
+    test("returns NOT_FOUND for non-existent node", () => {
+      const result = registry.updateTools("no-such-node", [{ name: "search" }], []);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    });
+
+    test("with empty added and empty removed is no-op", () => {
+      const node = createTestNode({
+        nodeId: "node-1",
+        tools: [{ name: "search" }],
+      });
+      registry.register(node);
+
+      const result = registry.updateTools("node-1", [], []);
+      expect(result.ok).toBe(true);
+
+      const updated = registry.lookup("node-1");
+      expect(updated?.tools).toHaveLength(1);
+    });
+
+    test("registers node with empty tools array", () => {
+      const node = createTestNode({
+        nodeId: "node-1",
+        tools: [],
+      });
+      const result = registry.register(node);
+      expect(result.ok).toBe(true);
+      expect(registry.size()).toBe(1);
+      expect(registry.findByTool("search")).toHaveLength(0);
+      expect(registry.lookup("node-1")).toBeDefined();
+    });
+  });
+
   describe("updateCapacity()", () => {
     test("updates capacity for existing node", () => {
       const node = createTestNode({ nodeId: "node-1" });

--- a/packages/gateway/src/__tests__/test-utils.ts
+++ b/packages/gateway/src/__tests__/test-utils.ts
@@ -389,6 +389,21 @@ export function createToolErrorFrameMessage(
   });
 }
 
+/** Build a JSON-encoded node:tools_updated frame string. */
+export function createNodeToolsUpdatedMessage(
+  nodeId: string,
+  added: readonly { readonly name: string; readonly description?: string }[] = [],
+  removed: readonly string[] = [],
+): string {
+  return JSON.stringify({
+    kind: "node:tools_updated",
+    nodeId,
+    agentId: "",
+    correlationId: crypto.randomUUID(),
+    payload: { added, removed },
+  });
+}
+
 /** Build a JSON-encoded node:capacity frame string. */
 export function createNodeCapacityMessage(
   nodeId: string,

--- a/packages/gateway/src/__tests__/tool-routing.integration.test.ts
+++ b/packages/gateway/src/__tests__/tool-routing.integration.test.ts
@@ -13,6 +13,7 @@ import {
   createMockTransport,
   createNodeCapabilitiesMessage,
   createNodeHandshakeMessage,
+  createNodeToolsUpdatedMessage,
   createTestAuthenticator,
   createToolCallFrameMessage,
   createToolErrorFrameMessage,
@@ -283,6 +284,38 @@ describe("Tool routing integration", () => {
 
     expect(findSentFrame(connB, "tool_call")).toBeDefined();
     expect(findSentFrame(connC, "tool_call")).toBeUndefined();
+  });
+
+  test("queued tool_call is dequeued when node:tools_updated adds the needed tool", async () => {
+    const connA = registerNode(transport, "node-a", [{ name: "search" }]);
+    const connB = registerNode(transport, "node-b", [{ name: "browse" }]);
+    await waitForCondition(() => gateway.nodeRegistry().size() === 2);
+
+    // Send tool_call for a tool no node currently has → queued
+    transport.simulateMessage(
+      connA.id,
+      createToolCallFrameMessage(
+        "node-a",
+        "camera.capture",
+        {},
+        { correlationId: "corr-tools-updated" },
+      ),
+    );
+
+    // No error yet — should be queued
+    await new Promise((r) => setTimeout(r, 50));
+    expect(findSentFrame(connA, "tool_error")).toBeUndefined();
+
+    // Node-B dynamically advertises camera.capture via tools_updated
+    transport.simulateMessage(
+      connB.id,
+      createNodeToolsUpdatedMessage("node-b", [{ name: "camera.capture" }]),
+    );
+
+    // The queued call should be dequeued and routed to node-B
+    await waitForCondition(() => findSentFrame(connB, "tool_call") !== undefined);
+    const forwarded = findSentFrame(connB, "tool_call");
+    expect(forwarded).toBeDefined();
   });
 
   test("tool_error from target forwarded back with original correlationId", async () => {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -197,6 +197,12 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
           }
         }
       : undefined,
+    // Tools updated callback — drain queued calls when node advertises new tools
+    config.toolRouting !== undefined
+      ? (nodeId: string) => {
+          toolRouter?.handleToolsUpdated(nodeId);
+        }
+      : undefined,
   );
 
   // Initialize tool router after nodeHandler (needs sendToNode)

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -75,12 +75,22 @@ export type { SessionStore } from "./session-store.js";
 export { createInMemorySessionStore } from "./session-store.js";
 // tool router
 export type {
+  CompiledAffinity,
+  RouteResult,
   ToolAffinity,
   ToolRouter,
   ToolRouterDeps,
   ToolRoutingConfig,
+  ToolRoutingErrorCode,
 } from "./tool-router.js";
-export { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG } from "./tool-router.js";
+export {
+  compileAffinities,
+  createToolRouter,
+  DEFAULT_TOOL_ROUTING_CONFIG,
+  matchAffinity,
+  resolveTargetNode,
+  TOOL_ROUTING_ERROR_CODES,
+} from "./tool-router.js";
 // transport
 export type {
   BunTransport,

--- a/packages/gateway/src/node-connection.ts
+++ b/packages/gateway/src/node-connection.ts
@@ -15,6 +15,7 @@ import {
   validateCapabilitiesPayload,
   validateCapacityPayload,
   validateHandshakePayload,
+  validateToolsUpdatedPayload,
 } from "./node-handler.js";
 import type { NodeRegistry, NodeRegistryEvent } from "./node-registry.js";
 import type { TransportConnection } from "./transport.js";
@@ -57,6 +58,7 @@ export function createNodeConnectionHandler(
   emitNodeEvent: (event: NodeRegistryEvent) => void,
   onEvict: (connId: string) => void,
   onToolFrame?: ((frame: NodeFrame) => void) | undefined,
+  onToolsUpdated?: ((nodeId: string) => void) | undefined,
 ): NodeConnectionHandler {
   const nodeConnMap = new Map<string, string>(); // connId → nodeId
   const connByNode = new Map<string, string>(); // nodeId → connId
@@ -189,6 +191,48 @@ export function createNodeConnectionHandler(
             nodeId,
             capacity: capResult.value,
           });
+        }
+        return;
+      }
+
+      case "node:tools_updated": {
+        const nodeId = nodeConnMap.get(conn.id);
+        if (nodeId === undefined) {
+          conn.close(4002, "Received tools_updated before registration");
+          cleanupNode(conn.id);
+          return;
+        }
+
+        // Reject if node is still in pending handshake state (not yet registered)
+        if (pendingNodeHandshakes.has(conn.id)) {
+          conn.close(4002, "Received tools_updated before registration");
+          cleanupNode(conn.id);
+          return;
+        }
+
+        const tuResult = validateToolsUpdatedPayload(frame.payload);
+        if (!tuResult.ok) {
+          swallowError(tuResult.error, { package: "gateway", operation: "node:tools_updated" });
+          return;
+        }
+
+        const { added, removed } = tuResult.value;
+        const updateResult = registry.updateTools(nodeId, added, removed);
+        if (!updateResult.ok) {
+          swallowError(updateResult.error, { package: "gateway", operation: "node:tools_updated" });
+          return;
+        }
+
+        if (added.length > 0) {
+          emitNodeEvent({ kind: "tools_added", nodeId, tools: added });
+        }
+        if (removed.length > 0) {
+          emitNodeEvent({ kind: "tools_removed", nodeId, toolNames: removed });
+        }
+
+        // Notify tool router so queued calls can be dequeued
+        if (added.length > 0) {
+          onToolsUpdated?.(nodeId);
         }
         return;
       }

--- a/packages/gateway/src/node-handler.ts
+++ b/packages/gateway/src/node-handler.ts
@@ -5,9 +5,8 @@
  * Nodes use a different wire format (NodeFrame) than clients (GatewayFrame).
  */
 
-import type { KoiError, Result } from "@koi/core";
+import type { AdvertisedTool, CapacityReport, KoiError, Result } from "@koi/core";
 import { validation } from "@koi/core";
-import type { AdvertisedTool, CapacityReport } from "./node-registry.js";
 
 // ---------------------------------------------------------------------------
 // NodeFrame kinds
@@ -19,6 +18,7 @@ const NODE_FRAME_KINDS = new Set([
   "node:registered",
   "node:heartbeat",
   "node:capacity",
+  "node:tools_updated",
   "node:error",
   "agent:dispatch",
   "agent:message",
@@ -35,6 +35,7 @@ export type NodeFrameKind =
   | "node:registered"
   | "node:heartbeat"
   | "node:capacity"
+  | "node:tools_updated"
   | "node:error"
   | "agent:dispatch"
   | "agent:message"
@@ -206,6 +207,67 @@ export function validateCapabilitiesPayload(
     });
   }
   return { ok: true, value: { nodeType: obj.nodeType, tools } };
+}
+
+// ---------------------------------------------------------------------------
+// Tools updated payload
+// ---------------------------------------------------------------------------
+
+export interface ToolsUpdatedPayload {
+  readonly added: readonly AdvertisedTool[];
+  readonly removed: readonly string[];
+}
+
+export function validateToolsUpdatedPayload(
+  payload: unknown,
+): Result<ToolsUpdatedPayload, KoiError> {
+  if (typeof payload !== "object" || payload === null) {
+    return { ok: false, error: validation("ToolsUpdated payload must be an object") };
+  }
+  const obj = payload as Record<string, unknown>;
+
+  // added: optional array of AdvertisedTool
+  const added: AdvertisedTool[] = [];
+  if (obj.added !== undefined) {
+    if (!Array.isArray(obj.added)) {
+      return { ok: false, error: validation("payload.added must be an array") };
+    }
+    for (const t of obj.added) {
+      if (typeof t !== "object" || t === null) {
+        return { ok: false, error: validation("Each added tool must be an object") };
+      }
+      const tool = t as Record<string, unknown>;
+      if (typeof tool.name !== "string" || tool.name.length === 0) {
+        return { ok: false, error: validation("Each added tool must have a non-empty name") };
+      }
+      added.push({
+        name: tool.name,
+        ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+        ...(typeof tool.schema === "object" && tool.schema !== null
+          ? { schema: tool.schema as Readonly<Record<string, unknown>> }
+          : {}),
+      });
+    }
+  }
+
+  // removed: optional array of tool name strings
+  const removed: string[] = [];
+  if (obj.removed !== undefined) {
+    if (!Array.isArray(obj.removed)) {
+      return { ok: false, error: validation("payload.removed must be an array") };
+    }
+    for (const name of obj.removed) {
+      if (typeof name !== "string" || name.length === 0) {
+        return {
+          ok: false,
+          error: validation("Each removed tool name must be a non-empty string"),
+        };
+      }
+      removed.push(name);
+    }
+  }
+
+  return { ok: true, value: { added, removed } };
 }
 
 export function validateCapacityPayload(payload: unknown): Result<CapacityReport, KoiError> {

--- a/packages/gateway/src/node-registry.ts
+++ b/packages/gateway/src/node-registry.ts
@@ -5,24 +5,10 @@
  * Internal to @koi/gateway (L2) — not an L0 contract.
  */
 
-import type { KoiError, Result } from "@koi/core";
+import type { AdvertisedTool, CapacityReport, KoiError, Result } from "@koi/core";
 import { conflict, notFound, validation } from "@koi/core";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface AdvertisedTool {
-  readonly name: string;
-  readonly description?: string | undefined;
-  readonly schema?: Readonly<Record<string, unknown>> | undefined;
-}
-
-export interface CapacityReport {
-  readonly current: number;
-  readonly max: number;
-  readonly available: number;
-}
+export type { AdvertisedTool, CapacityReport } from "@koi/core";
 
 export interface RegisteredNode {
   readonly nodeId: string;
@@ -46,6 +32,16 @@ export type NodeRegistryEvent =
       readonly kind: "capacity_updated";
       readonly nodeId: string;
       readonly capacity: CapacityReport;
+    }
+  | {
+      readonly kind: "tools_added";
+      readonly nodeId: string;
+      readonly tools: readonly AdvertisedTool[];
+    }
+  | {
+      readonly kind: "tools_removed";
+      readonly nodeId: string;
+      readonly toolNames: readonly string[];
     };
 
 // ---------------------------------------------------------------------------
@@ -61,6 +57,11 @@ export interface NodeRegistry {
   readonly size: () => number;
   readonly updateHeartbeat: (nodeId: string) => Result<void, KoiError>;
   readonly updateCapacity: (nodeId: string, capacity: CapacityReport) => Result<void, KoiError>;
+  readonly updateTools: (
+    nodeId: string,
+    added: readonly AdvertisedTool[],
+    removed: readonly string[],
+  ) => Result<void, KoiError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -167,6 +168,35 @@ export function createInMemoryNodeRegistry(): NodeRegistry {
         };
       }
       nodeMap.set(nodeId, { ...existing, capacity });
+      return { ok: true, value: undefined };
+    },
+
+    updateTools(
+      nodeId: string,
+      added: readonly AdvertisedTool[],
+      removed: readonly string[],
+    ): Result<void, KoiError> {
+      const existing = nodeMap.get(nodeId);
+      if (existing === undefined) {
+        return {
+          ok: false,
+          error: notFound(nodeId, `Node not found: ${nodeId}`),
+        };
+      }
+
+      // Remove tools from index by name
+      const removedSet = new Set(removed);
+      const removedTools = existing.tools.filter((t) => removedSet.has(t.name));
+      removeFromToolIndex(nodeId, removedTools);
+
+      // Add new tools to index
+      addToToolIndex(nodeId, added);
+
+      // Build new tools array: keep non-removed, append added (immutable)
+      const keptTools = existing.tools.filter((t) => !removedSet.has(t.name));
+      const newTools = [...keptTools, ...added];
+
+      nodeMap.set(nodeId, { ...existing, tools: newTools });
       return { ok: true, value: undefined };
     },
   };

--- a/packages/gateway/src/tool-router.test.ts
+++ b/packages/gateway/src/tool-router.test.ts
@@ -155,6 +155,18 @@ describe("resolveTargetNode", () => {
     }
   });
 
+  test("routes to one of equal-capacity nodes (any is valid)", () => {
+    registry.register(createRegisteredNode("node-b", ["search"], 5));
+    registry.register(createRegisteredNode("node-c", ["search"], 5));
+
+    const result = resolveTargetNode("search", "node-a", registry, []);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      // Either node is a valid pick; both have identical capacity
+      expect(["node-b", "node-c"]).toContain(result.targetNodeId);
+    }
+  });
+
   test("affinity miss falls through to capacity selection", () => {
     registry.register(createRegisteredNode("node-b", ["search"], 3));
     registry.register(createRegisteredNode("node-c", ["search"], 8));
@@ -489,6 +501,25 @@ describe("createToolRouter", () => {
       expect(payload.code).toBe("timeout");
 
       shortTimeoutRouter.dispose();
+    });
+
+    test("uses frame.ttl for timeout instead of defaultTimeoutMs", async () => {
+      registry.register(createRegisteredNode("node-a", ["search"]));
+      registry.register(createRegisteredNode("node-b", ["search"]));
+
+      // defaultTimeoutMs is 5_000ms, but frame.ttl is 50ms
+      const frame = createToolCallFrame("node-a", "search", { ttl: 50 });
+      router.handleToolCall(frame);
+      expect(router.pendingCount()).toBe(1);
+
+      // Wait 100ms — enough for 50ms TTL but well under 5_000ms default
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(router.pendingCount()).toBe(0);
+      const errorSent = findSent("node-a", "tool_error");
+      expect(errorSent).toBeDefined();
+      const payload = errorSent?.frame.payload as Record<string, unknown>;
+      expect(payload.code).toBe("timeout");
     });
 
     test("cleans up pending entry on timeout", async () => {

--- a/packages/gateway/src/tool-router.ts
+++ b/packages/gateway/src/tool-router.ts
@@ -11,6 +11,7 @@
  */
 
 import type { KoiError, Result } from "@koi/core";
+import { isToolCallPayload } from "@koi/core";
 import type { NodeFrame } from "./node-handler.js";
 import type { NodeRegistry, RegisteredNode } from "./node-registry.js";
 
@@ -37,6 +38,7 @@ export interface ToolRouter {
   readonly handleToolError: (frame: NodeFrame) => void;
   readonly handleNodeDisconnect: (nodeId: string) => void;
   readonly handleNodeRegistered: (nodeId: string) => void;
+  readonly handleToolsUpdated: (nodeId: string) => void;
   readonly pendingCount: () => number;
   readonly queuedCount: () => number;
   readonly dispose: () => void;
@@ -94,26 +96,20 @@ export const DEFAULT_TOOL_ROUTING_CONFIG: ToolRoutingConfig = {
   queueTimeoutMs: 60_000,
 } as const;
 
-// ---------------------------------------------------------------------------
-// Type guard (duplicated from @koi/node — gateway cannot import L2 peers)
-// ---------------------------------------------------------------------------
+export const TOOL_ROUTING_ERROR_CODES: {
+  readonly NOT_FOUND: "not_found";
+  readonly TIMEOUT: "timeout";
+  readonly RATE_LIMIT: "rate_limit";
+  readonly VALIDATION: "validation";
+} = {
+  NOT_FOUND: "not_found",
+  TIMEOUT: "timeout",
+  RATE_LIMIT: "rate_limit",
+  VALIDATION: "validation",
+} as const satisfies Record<string, string>;
 
-interface ToolCallPayload {
-  readonly toolName: string;
-  readonly args: Readonly<Record<string, unknown>>;
-  readonly callerAgentId: string;
-  readonly zone?: string | undefined;
-}
-
-export function isToolCallPayload(value: unknown): value is ToolCallPayload {
-  if (value === null || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.toolName === "string" &&
-    obj.toolName.length > 0 &&
-    typeof obj.callerAgentId === "string"
-  );
-}
+export type ToolRoutingErrorCode =
+  (typeof TOOL_ROUTING_ERROR_CODES)[keyof typeof TOOL_ROUTING_ERROR_CODES];
 
 // ---------------------------------------------------------------------------
 // Glob pattern compilation
@@ -168,11 +164,17 @@ export function resolveTargetNode(
     }
   }
 
-  // Capacity: sort by available descending, pick highest
-  const sorted = [...remote].sort((a, b) => b.capacity.available - a.capacity.available);
-  const best = sorted[0];
-  // best is defined: remote.length > 0 checked above
-  if (best === undefined) return { kind: "not_available" };
+  // Capacity: O(N) scan for highest available — no array allocation
+  // let justified: accumulator pattern for max scan
+  const first = remote[0];
+  if (first === undefined) return { kind: "not_available" };
+  let best = first;
+  for (let i = 1; i < remote.length; i++) {
+    const candidate = remote[i];
+    if (candidate !== undefined && candidate.capacity.available > best.capacity.available) {
+      best = candidate;
+    }
+  }
   return { kind: "routed", targetNodeId: best.nodeId };
 }
 
@@ -212,7 +214,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
       entry.sourceAgentId,
       entry.correlationId,
       entry.toolName,
-      "timeout",
+      TOOL_ROUTING_ERROR_CODES.TIMEOUT,
       `Tool call "${entry.toolName}" timed out after ${String(entry.timeoutMs)}ms`,
     );
   }
@@ -232,7 +234,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
             frame.agentId,
             frame.correlationId,
             toolName,
-            "timeout",
+            TOOL_ROUTING_ERROR_CODES.TIMEOUT,
             `Queued tool call "${toolName}" expired after ${String(config.queueTimeoutMs)}ms`,
           );
         }, config.queueTimeoutMs);
@@ -252,7 +254,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
         frame.agentId,
         frame.correlationId,
         toolName,
-        "not_found",
+        TOOL_ROUTING_ERROR_CODES.NOT_FOUND,
         `No node available for tool "${toolName}"`,
       );
       return;
@@ -288,7 +290,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
         frame.agentId,
         frame.correlationId,
         toolName,
-        "not_found",
+        TOOL_ROUTING_ERROR_CODES.NOT_FOUND,
         `Failed to send to target node: ${sendResult.error.message}`,
       );
     }
@@ -301,7 +303,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
         frame.agentId,
         frame.correlationId,
         "unknown",
-        "validation",
+        TOOL_ROUTING_ERROR_CODES.VALIDATION,
         "Malformed tool_call payload",
       );
       return;
@@ -313,7 +315,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
         frame.agentId,
         frame.correlationId,
         frame.payload.toolName,
-        "rate_limit",
+        TOOL_ROUTING_ERROR_CODES.RATE_LIMIT,
         `Max pending tool calls reached (${String(config.maxPendingCalls)})`,
       );
       return;
@@ -346,7 +348,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
           entry.sourceAgentId,
           entry.correlationId,
           entry.toolName,
-          "not_found",
+          TOOL_ROUTING_ERROR_CODES.NOT_FOUND,
           `Target node "${nodeId}" disconnected during tool call`,
         );
       } else if (entry.sourceNodeId === nodeId) {
@@ -363,7 +365,7 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
     }
   }
 
-  function handleNodeRegistered(nodeId: string): void {
+  function drainQueueForNode(nodeId: string): void {
     const node = deps.registry.lookup(nodeId);
     if (node === undefined) return;
 
@@ -394,7 +396,8 @@ export function createToolRouter(config: ToolRoutingConfig, deps: ToolRouterDeps
     handleToolResult: handleToolResponse,
     handleToolError: handleToolResponse,
     handleNodeDisconnect,
-    handleNodeRegistered,
+    handleNodeRegistered: drainQueueForNode,
+    handleToolsUpdated: drainQueueForNode,
     pendingCount: () => pending.size,
     queuedCount: () => queued.size,
     dispose,

--- a/packages/node/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/node/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,8 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/node API surface . has stable type surface 1`] = `
-"import { SessionPersistence, SessionCheckpoint, PendingFrame, RecoveryPlan, SessionRecord, Result, KoiError, ProcessId, AgentManifest, EngineAdapter, ComponentProvider, Agent, AgentId, Tool, SourceBundle, ScopeChecker, DelegationScope } from '@koi/core';
+"import { AdvertisedTool, SessionPersistence, CapacityReport, SessionCheckpoint, PendingFrame, RecoveryPlan, SessionRecord, Result, KoiError, ProcessId, AgentManifest, EngineAdapter, ComponentProvider, Agent, AgentId, Tool, SourceBundle, ScopeChecker, DelegationScope } from '@koi/core';
+export { AdvertisedTool, CapacityReport, ToolCallPayload, ToolErrorPayload, ToolResultPayload, isToolCallPayload } from '@koi/core';
 export { ShutdownCallbacks, ShutdownEmit, ShutdownHandler, createShutdownHandler } from '@koi/shutdown';
 
 /**
@@ -98,33 +99,6 @@ interface AuthAckPayload {
     readonly success: boolean;
     readonly reason?: string | undefined;
 }
-/** Gateway → Node: execute a tool on this Node (may originate from a remote agent). */
-interface ToolCallPayload {
-    readonly toolName: string;
-    readonly args: Readonly<Record<string, unknown>>;
-    /** Agent requesting the tool call (for permission checks). */
-    readonly callerAgentId: string;
-    /** Zone scope for permission enforcement (backend-dependent). */
-    readonly zone?: string | undefined;
-}
-/** Node → Gateway: tool execution result returned to calling agent. */
-interface ToolResultPayload {
-    readonly toolName: string;
-    readonly result: unknown;
-}
-/** Node → Gateway: tool execution failed or permission denied. */
-interface ToolErrorPayload {
-    readonly toolName: string;
-    readonly code: "permission_denied" | "not_found" | "execution_error" | "timeout";
-    readonly message: string;
-}
-/** Descriptor for a single tool advertised by a Node. */
-interface AdvertisedTool {
-    readonly name: string;
-    readonly description?: string | undefined;
-    /** JSON Schema for the tool's arguments. */
-    readonly schema?: Readonly<Record<string, unknown>> | undefined;
-}
 /** Node → Gateway: advertise this Node's tool surface. */
 interface CapabilitiesPayload {
     readonly nodeType: "full" | "thin";
@@ -134,11 +108,6 @@ interface HandshakePayload {
     readonly nodeId: string;
     readonly version: string;
     readonly capacity: CapacityReport;
-}
-interface CapacityReport {
-    readonly current: number;
-    readonly max: number;
-    readonly available: number;
 }
 interface AgentStatusPayload {
     readonly agentId: string;
@@ -693,8 +662,6 @@ interface ToolCallHandlerDeps {
     /** Milliseconds before a tool execution is considered timed out. Defaults to DEFAULT_TOOL_CALL_TIMEOUT_MS. */
     readonly timeoutMs?: number | undefined;
 }
-/** Type guard — validates ToolCallPayload shape without \`as\` assertion. */
-declare function isToolCallPayload(value: unknown): value is ToolCallPayload;
 /** Handle a tool_call frame: validate -> permission check -> resolve -> execute -> respond. */
 declare function handleToolCall(frame: NodeFrame, deps: ToolCallHandlerDeps): Promise<void>;
 
@@ -721,6 +688,6 @@ declare function createFilesystemTool(allowedPaths?: readonly string[]): Tool;
 
 declare function createShellTool(): Tool;
 
-export { type AdvertisedTool, type AgentHost, type AgentStatusPayload, type AuthAckPayload, type AuthChallengePayload, type AuthConfig, type AuthHandshake, type AuthHandshakeConfig, type AuthPayload, type AuthResponsePayload, type CapabilitiesPayload, type CapacityReport, type CheckpointManager, type CheckpointManagerDeps, type CheckpointingEngineConfig, DEFAULT_DELIVERY_CONFIG, DEFAULT_TOOL_CALL_TIMEOUT_MS, type DeliveryManager, type DeliveryManagerConfig, type DeliveryManagerDeps, type DiscoveryConfig, type DiscoveryService, type FrameCounterState, type FrameCounters, type FrameDeduplicator, type FullKoiNode, type GatewayConnectionConfig, type HandshakePayload, type HeartbeatCallbacks, type HeartbeatConfig, type HeartbeatMonitor, type KoiNode, type LocalResolver, type MemoryMetrics, type MemoryMonitor, type NodeCheckpoint, type NodeConfig, type NodeDeps, type NodeEvent, type NodeEventListener, type NodeEventType, type NodeFrame, type NodeFrameKind, type NodeMode, type NodePendingFrame, type NodeRecoveryPlan, type NodeSessionRecord, type NodeSessionStore, type NodeState, type ReconnectState, type RecoveryResult, type ResourcesConfig, type ServiceInfo, type StatusReporter, type ThinKoiNode, type ToolCallHandlerDeps, type ToolCallPayload, type ToolErrorPayload, type ToolMeta, type ToolResolverConfig, type ToolResultPayload, type Transport, type TransportState, type WriteQueue, type WriteQueueConfig, computeReconnectDelay, createAgentHost, createAuthHandshake, createAuthPayload, createCheckpointManager, createCheckpointingEngine, createDeliveryManager, createDiscoveryService, createFilesystemTool, createFrameCounters, createFrameDeduplicator, createHeartbeatMonitor, createLocalResolver, createMemoryMonitor, createNode, createReconnectState, createShellTool, createStatusReporter, createTransport, createWriteQueue, decodeFrame, encodeFrame, generateCorrelationId, handleToolCall, isCleanClose, isToolCallPayload, nextAttempt, parseNodeConfig, resetReconnectState, signChallenge };
+export { type AgentHost, type AgentStatusPayload, type AuthAckPayload, type AuthChallengePayload, type AuthConfig, type AuthHandshake, type AuthHandshakeConfig, type AuthPayload, type AuthResponsePayload, type CapabilitiesPayload, type CheckpointManager, type CheckpointManagerDeps, type CheckpointingEngineConfig, DEFAULT_DELIVERY_CONFIG, DEFAULT_TOOL_CALL_TIMEOUT_MS, type DeliveryManager, type DeliveryManagerConfig, type DeliveryManagerDeps, type DiscoveryConfig, type DiscoveryService, type FrameCounterState, type FrameCounters, type FrameDeduplicator, type FullKoiNode, type GatewayConnectionConfig, type HandshakePayload, type HeartbeatCallbacks, type HeartbeatConfig, type HeartbeatMonitor, type KoiNode, type LocalResolver, type MemoryMetrics, type MemoryMonitor, type NodeCheckpoint, type NodeConfig, type NodeDeps, type NodeEvent, type NodeEventListener, type NodeEventType, type NodeFrame, type NodeFrameKind, type NodeMode, type NodePendingFrame, type NodeRecoveryPlan, type NodeSessionRecord, type NodeSessionStore, type NodeState, type ReconnectState, type RecoveryResult, type ResourcesConfig, type ServiceInfo, type StatusReporter, type ThinKoiNode, type ToolCallHandlerDeps, type ToolMeta, type ToolResolverConfig, type Transport, type TransportState, type WriteQueue, type WriteQueueConfig, computeReconnectDelay, createAgentHost, createAuthHandshake, createAuthPayload, createCheckpointManager, createCheckpointingEngine, createDeliveryManager, createDiscoveryService, createFilesystemTool, createFrameCounters, createFrameDeduplicator, createHeartbeatMonitor, createLocalResolver, createMemoryMonitor, createNode, createReconnectState, createShellTool, createStatusReporter, createTransport, createWriteQueue, decodeFrame, encodeFrame, generateCorrelationId, handleToolCall, isCleanClose, nextAttempt, parseNodeConfig, resetReconnectState, signChallenge };
 "
 `;

--- a/packages/node/src/tool-call-handler.ts
+++ b/packages/node/src/tool-call-handler.ts
@@ -3,15 +3,12 @@
  * with explicit dependencies for direct unit testing.
  */
 
-import type { DelegationScope, ScopeChecker } from "@koi/core";
+import type { DelegationScope, ScopeChecker, ToolErrorPayload, ToolResultPayload } from "@koi/core";
+import { isToolCallPayload } from "@koi/core";
 import type { LocalResolver } from "./tools/local-resolver.js";
-import type {
-  NodeEvent,
-  NodeFrame,
-  ToolCallPayload,
-  ToolErrorPayload,
-  ToolResultPayload,
-} from "./types.js";
+import type { NodeEvent, NodeFrame } from "./types.js";
+
+export { isToolCallPayload };
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -38,21 +35,6 @@ export interface ToolCallHandlerDeps {
   readonly emit: (type: NodeEvent["type"], data?: unknown) => void;
   /** Milliseconds before a tool execution is considered timed out. Defaults to DEFAULT_TOOL_CALL_TIMEOUT_MS. */
   readonly timeoutMs?: number | undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Type guard
-// ---------------------------------------------------------------------------
-
-/** Type guard — validates ToolCallPayload shape without `as` assertion. */
-export function isToolCallPayload(value: unknown): value is ToolCallPayload {
-  if (value === null || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.toolName === "string" &&
-    obj.toolName.length > 0 &&
-    typeof obj.callerAgentId === "string"
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -9,6 +9,8 @@
  */
 
 import type {
+  AdvertisedTool,
+  CapacityReport,
   KoiError,
   PendingFrame,
   RecoveryPlan,
@@ -18,6 +20,15 @@ import type {
   SessionRecord,
 } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core";
+
+export type {
+  AdvertisedTool,
+  CapacityReport,
+  ToolCallPayload,
+  ToolErrorPayload,
+  ToolResultPayload,
+} from "@koi/core";
+
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
@@ -239,43 +250,8 @@ export interface AuthAckPayload {
 }
 
 // ---------------------------------------------------------------------------
-// Tool routing payloads (remote tool invocation between Nodes)
-// ---------------------------------------------------------------------------
-
-/** Gateway → Node: execute a tool on this Node (may originate from a remote agent). */
-export interface ToolCallPayload {
-  readonly toolName: string;
-  readonly args: Readonly<Record<string, unknown>>;
-  /** Agent requesting the tool call (for permission checks). */
-  readonly callerAgentId: string;
-  /** Zone scope for permission enforcement (backend-dependent). */
-  readonly zone?: string | undefined;
-}
-
-/** Node → Gateway: tool execution result returned to calling agent. */
-export interface ToolResultPayload {
-  readonly toolName: string;
-  readonly result: unknown;
-}
-
-/** Node → Gateway: tool execution failed or permission denied. */
-export interface ToolErrorPayload {
-  readonly toolName: string;
-  readonly code: "permission_denied" | "not_found" | "execution_error" | "timeout";
-  readonly message: string;
-}
-
-// ---------------------------------------------------------------------------
 // Capability advertisement payloads
 // ---------------------------------------------------------------------------
-
-/** Descriptor for a single tool advertised by a Node. */
-export interface AdvertisedTool {
-  readonly name: string;
-  readonly description?: string | undefined;
-  /** JSON Schema for the tool's arguments. */
-  readonly schema?: Readonly<Record<string, unknown>> | undefined;
-}
 
 /** Node → Gateway: advertise this Node's tool surface. */
 export interface CapabilitiesPayload {
@@ -291,12 +267,6 @@ export interface HandshakePayload {
   readonly nodeId: string;
   readonly version: string;
   readonly capacity: CapacityReport;
-}
-
-export interface CapacityReport {
-  readonly current: number;
-  readonly max: number;
-  readonly available: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/capability-registry-e2e.test.ts
+++ b/tests/e2e/capability-registry-e2e.test.ts
@@ -1,0 +1,1029 @@
+/**
+ * Capability Registry E2E — validates Issue #180 changes through the full
+ * createKoi + createPiAdapter / createLoopAdapter runtime stack with real LLM calls.
+ *
+ * What this validates end-to-end:
+ * - L0 shared types (AdvertisedTool, ToolCallPayload, isToolCallPayload) work across packages
+ * - Tool registration via ComponentProvider + toolToken
+ * - Tool calling through the full middleware chain (wrapToolCall)
+ * - Lifecycle hooks (onSessionStart/End, onBeforeTurn/AfterTurn)
+ * - Pi agent streaming middleware (wrapModelStream)
+ * - Loop adapter with deterministic tool call + real LLM follow-up
+ * - Multiple tools with capacity-based selection validation
+ * - Gateway tool router unit integration (mock transport, real tool routing logic)
+ * - Dynamic tool re-advertisement (node:tools_updated → queue drain)
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   bun test tests/e2e/capability-registry-e2e.test.ts
+ *
+ * Cost: ~$0.05-0.10 per run (haiku model, minimal prompts).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AdvertisedTool,
+  CapacityReport,
+  ComponentProvider,
+  EngineEvent,
+  JsonObject,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  Tool,
+  ToolHandler,
+  ToolRequest,
+} from "@koi/core";
+import { isToolCallPayload } from "@koi/core";
+import { toolToken } from "@koi/core/ecs";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeLLM = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const PI_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const MODEL_NAME = "claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+function createWeatherTool(): Tool {
+  return {
+    descriptor: {
+      name: "get_weather",
+      description: "Get current weather for a city. Returns temperature and condition.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          city: { type: "string", description: "City name" },
+        },
+        required: ["city"],
+      },
+    },
+    trustTier: "sandbox",
+    execute: async (input: JsonObject) => {
+      const city = typeof input.city === "string" ? input.city : "unknown";
+      return { city, temperature: "22C", condition: "sunny", source: "mock" };
+    },
+  };
+}
+
+function createSearchTool(): Tool {
+  return {
+    descriptor: {
+      name: "web_search",
+      description: "Search the web for information. Returns a list of results.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+        },
+        required: ["query"],
+      },
+    },
+    trustTier: "sandbox",
+    execute: async (input: JsonObject) => {
+      const query = typeof input.query === "string" ? input.query : "";
+      return {
+        results: [
+          { title: `Result for: ${query}`, url: "https://example.com/1", snippet: "Mock result" },
+        ],
+      };
+    },
+  };
+}
+
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-capability-tools",
+    attach: async () => {
+      const components = new Map<string, unknown>();
+      for (const tool of tools) {
+        components.set(toolToken(tool.descriptor.name), tool);
+      }
+      return components;
+    },
+  };
+}
+
+// ===========================================================================
+// 1. L0 shared types work across package boundaries
+// ===========================================================================
+
+describe("L0 shared types", () => {
+  test("isToolCallPayload validates correct payloads", () => {
+    const valid = { toolName: "get_weather", args: { city: "Tokyo" }, callerAgentId: "agent-1" };
+    expect(isToolCallPayload(valid)).toBe(true);
+  });
+
+  test("isToolCallPayload rejects malformed payloads", () => {
+    expect(isToolCallPayload(null)).toBe(false);
+    expect(isToolCallPayload({})).toBe(false);
+    expect(isToolCallPayload({ toolName: "" })).toBe(false);
+    expect(isToolCallPayload({ toolName: "x" })).toBe(false); // missing callerAgentId
+    expect(isToolCallPayload({ toolName: 42, callerAgentId: "a" })).toBe(false);
+  });
+
+  test("AdvertisedTool shape is importable and usable from @koi/core", () => {
+    const tool: AdvertisedTool = {
+      name: "test_tool",
+      description: "A test tool",
+      schema: { type: "object" },
+    };
+    expect(tool.name).toBe("test_tool");
+    expect(tool.description).toBe("A test tool");
+  });
+
+  test("CapacityReport shape is importable and usable from @koi/core", () => {
+    const report: CapacityReport = { current: 3, max: 10, available: 7 };
+    expect(report.available).toBe(7);
+  });
+});
+
+// ===========================================================================
+// 2. Pi agent with single tool — full stack through real LLM
+// ===========================================================================
+
+describeLLM("e2e: Pi agent with tool calling (capability registry types)", () => {
+  test(
+    "Pi agent calls get_weather tool and generates response using tool result",
+    async () => {
+      const weatherTool = createWeatherTool();
+      const toolProvider = createToolProvider([weatherTool]);
+
+      let toolWasCalled = false; // let justified: toggled in middleware
+      const interceptedTools: string[] = []; // let justified: test accumulator
+      const textChunks: string[] = []; // let justified: test accumulator
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-tool-observer",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          interceptedTools.push(request.toolId);
+          toolWasCalled = true;
+          return next(request);
+        },
+      };
+
+      const textObserver: KoiMiddleware = {
+        name: "e2e-text-observer",
+        priority: 100,
+        wrapModelStream: async function* (_ctx, request, next: ModelStreamHandler) {
+          for await (const chunk of next(request)) {
+            if (chunk.kind === "text_delta") {
+              textChunks.push(chunk.delta);
+            }
+            yield chunk;
+          }
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: PI_MODEL,
+        systemPrompt:
+          "You are a weather assistant. When asked about weather, ALWAYS use the get_weather tool. After getting the result, summarize it briefly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+        thinkingLevel: "off",
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-capability-weather",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        providers: [toolProvider],
+        middleware: [toolObserver, textObserver],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "What is the weather in Tokyo?" }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+          expect(doneEvent.output.metrics.turns).toBeGreaterThan(0);
+        }
+
+        // Tool was called through the middleware chain
+        expect(toolWasCalled).toBe(true);
+        expect(interceptedTools).toContain("get_weather");
+
+        // Tool call events were emitted
+        const toolStartEvents = events.filter((e) => e.kind === "tool_call_start");
+        expect(toolStartEvents.length).toBeGreaterThan(0);
+        if (toolStartEvents[0]?.kind === "tool_call_start") {
+          expect(toolStartEvents[0].toolName).toBe("get_weather");
+        }
+        const toolEndEvents = events.filter((e) => e.kind === "tool_call_end");
+        expect(toolEndEvents.length).toBeGreaterThan(0);
+
+        // LLM generated text (observed via wrapModelStream)
+        expect(textChunks.length).toBeGreaterThan(0);
+        const fullText = textChunks.join("");
+        expect(fullText.length).toBeGreaterThan(0);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// 3. Pi agent with multiple tools — validates tool descriptor discovery
+// ===========================================================================
+
+describeLLM("e2e: Pi agent with multiple tools", () => {
+  test(
+    "Pi agent selects correct tool from multiple options",
+    async () => {
+      const weatherTool = createWeatherTool();
+      const searchTool = createSearchTool();
+      const toolProvider = createToolProvider([weatherTool, searchTool]);
+
+      const calledTools: string[] = []; // let justified: test accumulator
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-multi-tool-observer",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          calledTools.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: PI_MODEL,
+        systemPrompt:
+          "You have two tools: get_weather (for weather queries) and web_search (for general queries). Use the correct tool based on the question. After using the tool, give a brief answer.",
+        getApiKey: async () => ANTHROPIC_KEY,
+        thinkingLevel: "off",
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-capability-multi-tool",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        providers: [toolProvider],
+        middleware: [toolObserver],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Search the web for TypeScript best practices",
+          }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // LLM chose the search tool (not weather)
+        expect(calledTools).toContain("web_search");
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// 4. Loop adapter with deterministic tool call + real LLM follow-up
+// ===========================================================================
+
+describeLLM("e2e: Loop adapter tool calling (capability types)", () => {
+  test(
+    "deterministic tool call phase 1 + real LLM phase 2 through middleware",
+    async () => {
+      const weatherTool = createWeatherTool();
+      const _toolProvider = createToolProvider([weatherTool]);
+
+      let toolExecuted = false; // let justified: toggled in execute
+      let modelCallCount = 0; // let justified: tracks call phases
+      const interceptedTools: string[] = []; // let justified: test accumulator
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-loop-tool-observer",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          interceptedTools.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      // Two-phase model handler:
+      //   Call 1: deterministic tool call (tests tool dispatch)
+      //   Call 2: real Anthropic LLM generates answer using tool result
+      const modelCall = async (request: ModelRequest): Promise<ModelResponse> => {
+        modelCallCount++;
+        if (modelCallCount === 1) {
+          return {
+            content: "Let me check the weather for you.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 10, outputTokens: 15 },
+            metadata: {
+              toolCalls: [
+                { toolName: "get_weather", callId: "call-e2e-cap-1", input: { city: "Tokyo" } },
+              ],
+            },
+          };
+        }
+        // Real LLM call — model sees tool result in context
+        const { createAnthropicAdapter } = await import("@koi/model-router");
+        const anthropic = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+        return anthropic.complete({ ...request, model: MODEL_NAME, maxTokens: 150 });
+      };
+
+      const weatherToolWithTracking: Tool = {
+        ...weatherTool,
+        execute: async (input: JsonObject) => {
+          toolExecuted = true;
+          return weatherTool.execute(input);
+        },
+      };
+
+      const trackedProvider = createToolProvider([weatherToolWithTracking]);
+
+      const { createLoopAdapter } = await import("@koi/engine-loop");
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-loop-capability",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        middleware: [toolObserver],
+        providers: [trackedProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "What is the weather in Tokyo?" }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // Tool executed through the full chain
+        expect(toolExecuted).toBe(true);
+        expect(interceptedTools).toContain("get_weather");
+
+        // Two model calls: deterministic + real LLM
+        expect(modelCallCount).toBeGreaterThanOrEqual(2);
+
+        // Tool call events emitted
+        const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+        expect(toolStarts.length).toBeGreaterThan(0);
+        const toolEnds = events.filter((e) => e.kind === "tool_call_end");
+        expect(toolEnds.length).toBeGreaterThan(0);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// 5. Full lifecycle + middleware composition with tools
+// ===========================================================================
+
+describeLLM("e2e: Full middleware chain with capability tools", () => {
+  test(
+    "lifecycle hooks + wrapToolCall + wrapModelStream compose correctly",
+    async () => {
+      const weatherTool = createWeatherTool();
+      const toolProvider = createToolProvider([weatherTool]);
+
+      const hookLog: string[] = []; // let justified: test accumulator
+
+      const lifecycle: KoiMiddleware = {
+        name: "e2e-cap-lifecycle",
+        priority: 100,
+        onSessionStart: async () => {
+          hookLog.push("session:start");
+        },
+        onBeforeTurn: async (ctx) => {
+          hookLog.push(`turn:before:${String(ctx.turnIndex)}`);
+        },
+        onAfterTurn: async (ctx) => {
+          hookLog.push(`turn:after:${String(ctx.turnIndex)}`);
+        },
+        onSessionEnd: async () => {
+          hookLog.push("session:end");
+        },
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          hookLog.push(`tool:${request.toolId}`);
+          return next(request);
+        },
+        wrapModelStream: async function* (_ctx, request, next: ModelStreamHandler) {
+          hookLog.push("stream:start");
+          for await (const chunk of next(request)) {
+            yield chunk;
+          }
+          hookLog.push("stream:end");
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: PI_MODEL,
+        systemPrompt:
+          "You are a weather assistant. ALWAYS use the get_weather tool when asked about weather. After getting the result, summarize it in one sentence.",
+        getApiKey: async () => ANTHROPIC_KEY,
+        thinkingLevel: "off",
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-cap-full-chain",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        providers: [toolProvider],
+        middleware: [lifecycle],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "What is the weather in London?" }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // Lifecycle order: session:start → turn:before → ... → turn:after → session:end
+        expect(hookLog.at(0)).toBe("session:start");
+        expect(hookLog.at(-1)).toBe("session:end");
+        expect(hookLog).toContain("turn:before:0");
+
+        // Streaming middleware intercepted Pi's model call
+        // Note: Pi may abort the generator early, so stream:end is not guaranteed.
+        // stream:start is sufficient to prove wrapModelStream was invoked.
+        expect(hookLog).toContain("stream:start");
+
+        // Tool was intercepted through wrapToolCall
+        expect(hookLog).toContain("tool:get_weather");
+
+        // Correct ordering: session:start before any turn, tool after stream
+        const sessionStartIdx = hookLog.indexOf("session:start");
+        const firstTurnIdx = hookLog.indexOf("turn:before:0");
+        expect(sessionStartIdx).toBeLessThan(firstTurnIdx);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// 6. Gateway tool router integration (no real LLM, validates routing logic)
+// ===========================================================================
+
+describe("Gateway tool router with L0 types", () => {
+  test("resolveTargetNode uses AdvertisedTool from @koi/core", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { resolveTargetNode } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    // Register nodes using AdvertisedTool shape from @koi/core
+    const toolA: AdvertisedTool = { name: "search", description: "Search tool" };
+    const toolB: AdvertisedTool = { name: "camera.capture", description: "Camera tool" };
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [toolA],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [toolB],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    // Route from node-a to node-b (camera.capture)
+    const result = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-b");
+    }
+  });
+
+  test("updateTools uses AdvertisedTool from @koi/core for dynamic re-advertisement", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { resolveTargetNode } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [{ name: "browse" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    // camera.capture not available yet
+    const before = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(before.kind).toBe("not_available");
+
+    // Dynamic re-advertisement: node-b adds camera.capture
+    const updateResult = registry.updateTools(
+      "node-b",
+      [{ name: "camera.capture", description: "Capture photos" }],
+      [],
+    );
+    expect(updateResult.ok).toBe(true);
+
+    // Now camera.capture routes to node-b
+    const after = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(after.kind).toBe("routed");
+    if (after.kind === "routed") {
+      expect(after.targetNodeId).toBe("node-b");
+    }
+  });
+
+  test("updateTools removes tools and routing reflects the change", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { resolveTargetNode } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [{ name: "code" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [{ name: "search" }, { name: "camera.capture" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    // camera.capture routes to node-b
+    const before = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(before.kind).toBe("routed");
+
+    // node-b withdraws camera.capture
+    registry.updateTools("node-b", [], ["camera.capture"]);
+
+    // camera.capture no longer available
+    const after = resolveTargetNode("camera.capture", "node-a", registry, []);
+    expect(after.kind).toBe("not_available");
+  });
+
+  test("capacity-based routing selects highest-capacity node", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { resolveTargetNode } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "source",
+      mode: "full",
+      tools: [{ name: "code" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-source",
+    });
+
+    registry.register({
+      nodeId: "node-low",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 8, max: 10, available: 2 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-low",
+    });
+
+    registry.register({
+      nodeId: "node-high",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 1, max: 10, available: 9 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-high",
+    });
+
+    const result = resolveTargetNode("search", "source", registry, []);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      expect(result.targetNodeId).toBe("node-high");
+    }
+  });
+
+  test("affinity routing overrides capacity", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { resolveTargetNode, compileAffinities } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "source",
+      mode: "full",
+      tools: [{ name: "code" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-source",
+    });
+
+    registry.register({
+      nodeId: "preferred",
+      mode: "full",
+      tools: [{ name: "camera.capture" }],
+      capacity: { current: 8, max: 10, available: 2 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-preferred",
+    });
+
+    registry.register({
+      nodeId: "high-cap",
+      mode: "full",
+      tools: [{ name: "camera.capture" }],
+      capacity: { current: 1, max: 10, available: 9 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-high",
+    });
+
+    const affinities = compileAffinities([{ pattern: "camera.*", nodeId: "preferred" }]);
+    const result = resolveTargetNode("camera.capture", "source", registry, affinities);
+    expect(result.kind).toBe("routed");
+    if (result.kind === "routed") {
+      // Affinity wins over capacity
+      expect(result.targetNodeId).toBe("preferred");
+    }
+  });
+});
+
+// ===========================================================================
+// 7. Full gateway tool router E2E with mock transport
+// ===========================================================================
+
+describe("Gateway tool router full flow (mock transport)", () => {
+  test("tool_call routed, executed, result returned via full createToolRouter", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG, TOOL_ROUTING_ERROR_CODES } =
+      await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [{ name: "camera.capture" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    const sentFrames: Array<{ readonly nodeId: string; readonly frame: unknown }> = [];
+
+    const router = createToolRouter(
+      { ...DEFAULT_TOOL_ROUTING_CONFIG, maxQueuedCalls: 10 },
+      {
+        registry,
+        sendToNode: (nodeId, frame) => {
+          sentFrames.push({ nodeId, frame });
+          return { ok: true, value: 1 };
+        },
+      },
+    );
+
+    // Node-A sends a tool_call for camera.capture
+    router.handleToolCall({
+      kind: "tool_call",
+      nodeId: "node-a",
+      agentId: "agent-1",
+      correlationId: "corr-e2e-1",
+      payload: { toolName: "camera.capture", args: {}, callerAgentId: "agent-1" },
+    });
+
+    expect(router.pendingCount()).toBe(1);
+
+    // Verify frame was forwarded to node-b
+    const forwarded = sentFrames.find(
+      (s) => s.nodeId === "node-b" && (s.frame as { kind: string }).kind === "tool_call",
+    );
+    expect(forwarded).toBeDefined();
+
+    const forwardedFrame = forwarded?.frame as { correlationId: string };
+    expect(forwardedFrame.correlationId).toMatch(/^route-/);
+
+    // Node-B responds with tool_result
+    router.handleToolResult({
+      kind: "tool_result",
+      nodeId: "node-b",
+      agentId: "agent-1",
+      correlationId: forwardedFrame.correlationId,
+      payload: { toolName: "camera.capture", result: { photo: "base64data" } },
+    });
+
+    expect(router.pendingCount()).toBe(0);
+
+    // Verify result was sent back to node-a with original correlationId
+    const resultFrame = sentFrames.find(
+      (s) => s.nodeId === "node-a" && (s.frame as { kind: string }).kind === "tool_result",
+    );
+    expect(resultFrame).toBeDefined();
+    expect((resultFrame?.frame as { correlationId: string }).correlationId).toBe("corr-e2e-1");
+
+    // Verify error codes are typed
+    expect(TOOL_ROUTING_ERROR_CODES.NOT_FOUND).toBe("not_found");
+    expect(TOOL_ROUTING_ERROR_CODES.TIMEOUT).toBe("timeout");
+    expect(TOOL_ROUTING_ERROR_CODES.RATE_LIMIT).toBe("rate_limit");
+    expect(TOOL_ROUTING_ERROR_CODES.VALIDATION).toBe("validation");
+
+    router.dispose();
+  });
+
+  test("queue drains when node registers with needed tool", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    const sentFrames: Array<{ readonly nodeId: string; readonly frame: unknown }> = [];
+
+    const router = createToolRouter(
+      { ...DEFAULT_TOOL_ROUTING_CONFIG, maxQueuedCalls: 10 },
+      {
+        registry,
+        sendToNode: (nodeId, frame) => {
+          sentFrames.push({ nodeId, frame });
+          return { ok: true, value: 1 };
+        },
+      },
+    );
+
+    // Tool call for camera.capture — no node has it yet → queued
+    router.handleToolCall({
+      kind: "tool_call",
+      nodeId: "node-a",
+      agentId: "agent-1",
+      correlationId: "corr-queued-e2e",
+      payload: { toolName: "camera.capture", args: {}, callerAgentId: "agent-1" },
+    });
+
+    expect(router.queuedCount()).toBe(1);
+    expect(router.pendingCount()).toBe(0);
+
+    // No error sent — call is queued
+    const errorBefore = sentFrames.find((s) => (s.frame as { kind: string }).kind === "tool_error");
+    expect(errorBefore).toBeUndefined();
+
+    // Node-B registers with camera.capture
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [{ name: "camera.capture" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    // Trigger queue drain
+    router.handleNodeRegistered("node-b");
+
+    // Queued call was dequeued and routed
+    expect(router.queuedCount()).toBe(0);
+    expect(router.pendingCount()).toBe(1);
+
+    const forwarded = sentFrames.find(
+      (s) => s.nodeId === "node-b" && (s.frame as { kind: string }).kind === "tool_call",
+    );
+    expect(forwarded).toBeDefined();
+
+    router.dispose();
+  });
+
+  test("queue drains on handleToolsUpdated (dynamic re-advertisement)", async () => {
+    const { createInMemoryNodeRegistry } = await import("@koi/gateway");
+    const { createToolRouter, DEFAULT_TOOL_ROUTING_CONFIG } = await import("@koi/gateway");
+
+    const registry = createInMemoryNodeRegistry();
+
+    registry.register({
+      nodeId: "node-a",
+      mode: "full",
+      tools: [{ name: "search" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-a",
+    });
+
+    registry.register({
+      nodeId: "node-b",
+      mode: "full",
+      tools: [{ name: "browse" }],
+      capacity: { current: 0, max: 10, available: 10 },
+      connectedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+      connId: "conn-b",
+    });
+
+    const sentFrames: Array<{ readonly nodeId: string; readonly frame: unknown }> = [];
+
+    const router = createToolRouter(
+      { ...DEFAULT_TOOL_ROUTING_CONFIG, maxQueuedCalls: 10 },
+      {
+        registry,
+        sendToNode: (nodeId, frame) => {
+          sentFrames.push({ nodeId, frame });
+          return { ok: true, value: 1 };
+        },
+      },
+    );
+
+    // Queue a tool call for camera.capture (nobody has it)
+    router.handleToolCall({
+      kind: "tool_call",
+      nodeId: "node-a",
+      agentId: "agent-1",
+      correlationId: "corr-tools-updated-e2e",
+      payload: { toolName: "camera.capture", args: {}, callerAgentId: "agent-1" },
+    });
+
+    expect(router.queuedCount()).toBe(1);
+
+    // Node-B dynamically adds camera.capture (tools_updated)
+    registry.updateTools("node-b", [{ name: "camera.capture" }], []);
+
+    // Trigger queue drain via handleToolsUpdated (Phase 3 feature)
+    router.handleToolsUpdated("node-b");
+
+    // Call was dequeued and routed to node-b
+    expect(router.queuedCount()).toBe(0);
+    expect(router.pendingCount()).toBe(1);
+
+    const forwarded = sentFrames.find(
+      (s) => s.nodeId === "node-b" && (s.frame as { kind: string }).kind === "tool_call",
+    );
+    expect(forwarded).toBeDefined();
+
+    router.dispose();
+  });
+});
+
+// ===========================================================================
+// 8. Pi agent with audit middleware + tools (full middleware stack)
+// ===========================================================================
+
+describeLLM("e2e: Pi agent audit middleware + tools", () => {
+  test(
+    "audit captures tool calls and session lifecycle with real LLM",
+    async () => {
+      const { createAuditMiddleware, createInMemoryAuditSink } = await import(
+        "@koi/middleware-audit"
+      );
+      const weatherTool = createWeatherTool();
+      const toolProvider = createToolProvider([weatherTool]);
+      const auditSink = createInMemoryAuditSink();
+      const audit = createAuditMiddleware({ sink: auditSink });
+
+      const adapter = createPiAdapter({
+        model: PI_MODEL,
+        systemPrompt:
+          "You are a weather assistant. ALWAYS use the get_weather tool when asked about weather. After getting the result, summarize it.",
+        getApiKey: async () => ANTHROPIC_KEY,
+        thinkingLevel: "off",
+      });
+
+      const runtime = await createKoi({
+        manifest: {
+          name: "e2e-cap-audit",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        providers: [toolProvider],
+        middleware: [audit],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "What is the weather in Paris?" }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // Audit captured session lifecycle
+        const kinds = auditSink.entries.map((e) => e.kind);
+        expect(kinds).toContain("session_start");
+        expect(kinds).toContain("session_end");
+
+        // Audit captured tool call event (tool was invoked)
+        expect(kinds).toContain("tool_call");
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -14,6 +14,7 @@
     "@koi/middleware-turn-ack": "workspace:*",
     "@koi/model-router": "workspace:*",
     "@koi/forge": "workspace:*",
+    "@koi/gateway": "workspace:*",
     "@koi/hash": "workspace:*",
     "@koi/node": "workspace:*",
     "@koi/delegation": "workspace:*",


### PR DESCRIPTION
## Summary

Closes #180 — closes all 6 spec gaps identified in the node capability registry feature.

- **Extract shared L0 types** — `AdvertisedTool`, `CapacityReport`, `ToolCallPayload`, `ToolResultPayload`, `ToolErrorPayload`, `NodeCapability`, `CapabilityRegistry`, and `isToolCallPayload()` type guard moved to `@koi/core`, eliminating duplication between `@koi/gateway` and `@koi/node` (L2 peers that can't import each other)
- **Dynamic tool re-advertisement** — new `node:tools_updated` frame lets nodes add/remove tools at runtime without disconnecting. `NodeRegistry.updateTools()` performs incremental inverted index updates and emits `tools_added`/`tools_removed` events
- **O(N) capacity scan** — replace O(N log N) sort with zero-allocation linear max scan in `resolveTargetNode`
- **Typed error codes** — `TOOL_ROUTING_ERROR_CODES` const object (`not_found`, `timeout`, `rate_limit`, `validation`) replaces bare string literals
- **Queue drain on tools_updated** — `handleToolsUpdated()` on `ToolRouter` drains queued tool calls when an existing node adds matching tools
- **Edge-case tests** — TTL timeout, equal-capacity routing, zero-tools node registration
- **E2E tests** — 17 tests (5 with real Haiku LLM calls) validate the full `createKoi` + `createPiAdapter`/`createLoopAdapter` runtime stack including middleware chain, tool calling, and gateway routing
- **Documentation** — new `docs/L2/gateway.md` (622 lines) and updated `docs/architecture/Gateway.md` (+40 lines)

### Packages changed

| Package | Changes |
|---------|---------|
| `@koi/core` | New `capability-registry.ts` with shared types + type guard |
| `@koi/gateway` | `updateTools()`, `node:tools_updated` frame, typed error codes, O(N) scan, queue drain |
| `@koi/node` | Import shared types from L0, remove local duplicates |
| `tests/e2e` | New `capability-registry-e2e.test.ts` |
| `docs/` | New L2 doc + architecture doc updates |

### Anti-leak compliance

- [x] `@koi/core` has zero imports from other `@koi/*` packages
- [x] Only pure type guard (`isToolCallPayload`) as function body in L0
- [x] L2 packages import only from L0 + L0u
- [x] All interface properties are `readonly`
- [x] No vendor types in L0/L1

## Test plan

- [x] 1024 unit/integration tests pass across core/gateway/node (0 fail)
- [x] 17 E2E tests pass (5 with real Anthropic Haiku LLM calls)
- [x] Biome lint + format clean
- [x] `turbo build` + `turbo typecheck` pass
- [x] API surface snapshots updated