### PR TITLE
feat: @koi/worktree-merge — branch reconciliation (#380)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,13 @@
         "@koi/engine-pi": "workspace:*",
       },
     },
+    "packages/git-utils": {
+      "name": "@koi/git-utils",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/hash": {
       "name": "@koi/hash",
       "version": "0.0.0",
@@ -1068,12 +1075,21 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "@koi/git-utils": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",
         "@koi/engine-loop": "workspace:*",
         "@koi/model-router": "workspace:*",
         "@koi/test-utils": "workspace:*",
+      },
+    },
+    "packages/worktree-merge": {
+      "name": "@koi/worktree-merge",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/git-utils": "workspace:*",
       },
     },
     "tests/e2e": {
@@ -1089,6 +1105,7 @@
         "@koi/engine-pi": "workspace:*",
         "@koi/forge": "workspace:*",
         "@koi/gateway": "workspace:*",
+        "@koi/git-utils": "workspace:*",
         "@koi/hash": "workspace:*",
         "@koi/middleware-audit": "workspace:*",
         "@koi/middleware-call-limits": "workspace:*",
@@ -1098,6 +1115,7 @@
         "@koi/node": "workspace:*",
         "@koi/orchestrator": "workspace:*",
         "@koi/test-utils": "workspace:*",
+        "@koi/worktree-merge": "workspace:*",
       },
     },
   },
@@ -1429,6 +1447,8 @@
 
     "@koi/gateway": ["@koi/gateway@workspace:packages/gateway"],
 
+    "@koi/git-utils": ["@koi/git-utils@workspace:packages/git-utils"],
+
     "@koi/hash": ["@koi/hash@workspace:packages/hash"],
 
     "@koi/identity": ["@koi/identity@workspace:packages/identity"],
@@ -1552,6 +1572,8 @@
     "@koi/webhook-delivery": ["@koi/webhook-delivery@workspace:packages/webhook-delivery"],
 
     "@koi/workspace": ["@koi/workspace@workspace:packages/workspace"],
+
+    "@koi/worktree-merge": ["@koi/worktree-merge@workspace:packages/worktree-merge"],
 
     "@livekit/agents": ["@livekit/agents@1.0.47", "", { "dependencies": { "@ffmpeg-installer/ffmpeg": "^1.1.0", "@livekit/mutex": "^1.1.1", "@livekit/protocol": "^1.43.0", "@livekit/typed-emitter": "^3.0.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.54.0", "@opentelemetry/core": "^2.2.0", "@opentelemetry/exporter-logs-otlp-proto": "^0.54.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.54.0", "@opentelemetry/instrumentation-pino": "^0.43.0", "@opentelemetry/otlp-exporter-base": "^0.208.0", "@opentelemetry/resources": "^1.28.0", "@opentelemetry/sdk-logs": "^0.54.0", "@opentelemetry/sdk-trace-base": "^1.28.0", "@opentelemetry/sdk-trace-node": "^1.28.0", "@opentelemetry/semantic-conventions": "^1.28.0", "@types/pidusage": "^2.0.5", "commander": "^12.0.0", "fluent-ffmpeg": "^2.1.3", "form-data": "^4.0.5", "heap-js": "^2.6.0", "json-schema": "^0.4.0", "livekit-server-sdk": "^2.14.1", "openai": "^6.8.1", "pidusage": "^4.0.1", "pino": "^8.19.0", "pino-pretty": "^11.0.0", "sharp": "0.34.5", "uuid": "^11.1.0", "ws": "^8.18.0", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "@livekit/rtc-node": "^0.13.24", "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Iy995PAdObU2niimqYNvJxLGAvrTktrJAMd+vFOmMRmB1IRafcwEBIcSBM1N5csT7Snu6mwS9/3SmjkHgysXyg=="],
 

--- a/docs/L2/worktree-merge.md
+++ b/docs/L2/worktree-merge.md
@@ -1,0 +1,471 @@
+# @koi/worktree-merge — Branch Reconciliation for Parallel Agent Work
+
+Automated N-branch reconciliation with topological ordering, pluggable strategies, conflict resolution, verification gates, and structured result reporting. The reunification step after `@koi/workspace` isolates agents into worktrees and `@koi/orchestrator` coordinates their work.
+
+---
+
+## Why It Exists
+
+When multiple agents work in parallel worktrees, each produces a branch:
+
+```
+Agent A ──► worktree-a ──► branch: feat-auth
+Agent B ──► worktree-b ──► branch: feat-payments
+Agent C ──► worktree-c ──► branch: feat-tests (depends on auth + payments)
+```
+
+Merging these branches back into `main` requires:
+
+- **Dependency ordering** — `feat-tests` must merge after `feat-auth` and `feat-payments`
+- **Strategy choice** — merge commit, octopus, or rebase depending on the workflow
+- **Conflict handling** — two branches may modify the same file
+- **Verification** — merged code must typecheck/pass tests before accepting
+- **Staleness detection** — a branch may have changed since planning time
+- **Atomicity** — if anything fails, restore to the pre-merge state
+
+Without this package, the orchestrator would need to shell out to ad-hoc git commands with no structured error handling, no dependency ordering, and no rollback.
+
+---
+
+## Architecture
+
+`@koi/worktree-merge` is an **L2 feature package** — depends only on L0 (`@koi/core`) and L0u (`@koi/git-utils`).
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  @koi/worktree-merge  (L2)                                 │
+│                                                            │
+│  types.ts              ← Config, outcomes, events, strategy│
+│  merge-order.ts        ← Kahn's algorithm, topo levels    │
+│  git-operations.ts     ← Typed wrappers around runGit     │
+│  merge-sequential.ts   ← git merge --no-ff strategy       │
+│  merge-octopus.ts      ← git merge N branches at once     │
+│  merge-rebase-chain.ts ← git rebase + ff merge strategy   │
+│  execute-merge.ts      ← Main entry point, orchestrates   │
+│  index.ts              ← Public API surface                │
+│                                                            │
+├────────────────────────────────────────────────────────────│
+│  Dependencies                                              │
+│                                                            │
+│  @koi/core      (L0)   Result, KoiError                   │
+│  @koi/git-utils (L0u)  runGit()                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Where It Fits
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Copilot Agent — "Refactor auth across 12 files"                    │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  @koi/orchestrator  ─  Decompose into DAG, dispatch workers         │
+│                                                                     │
+│  ┌─────┐     ┌─────┐                                               │
+│  │  A  │────>│  C  │──┐        Task DAG                             │
+│  └─────┘     └─────┘  │     ┌─────┐                                │
+│    │                   ├────>│  D  │                                 │
+│    ▼                   │     └─────┘                                │
+│  ┌─────┐               │                                            │
+│  │  B  │───────────────┘                                            │
+│  └─────┘                                                            │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │ spawn()
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  @koi/workspace  ─  Isolate each worker into a git worktree         │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐              │
+│  │ worktree-a/  │  │ worktree-b/  │  │ worktree-c/  │              │
+│  │              │  │              │  │              │              │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │              │
+│  │ │code-mode │ │  │ │code-mode │ │  │ │code-mode │ │              │
+│  │ │propose → │ │  │ │propose → │ │  │ │propose → │ │              │
+│  │ │apply     │ │  │ │apply     │ │  │ │apply     │ │              │
+│  │ └──────────┘ │  │ └──────────┘ │  │ └──────────┘ │              │
+│  │ git commit   │  │ git commit   │  │ git commit   │              │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘              │
+│     branch: A         branch: B         branch: C                   │
+└──────────┬────────────────┬────────────────┬────────────────────────┘
+           │                │                │
+           └────────────────┼────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  @koi/worktree-merge  ─  Reconcile N branches back into main        │
+│                                                                     │
+│  1. Topological sort by dependsOn                                   │
+│  2. Group into independence levels                                  │
+│  3. Merge level by level (strategy: sequential/octopus/rebase)      │
+│  4. Verify after each level (typecheck, tests)                      │
+│  5. Roll back to restore point on any failure                       │
+│                                                                     │
+│  MergeResult { outcomes: Map<branch, merged|conflict|skipped|...> } │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼
+                       main (unified result)
+```
+
+### Two Safety Layers
+
+| Layer | Package | Scope | Staleness Guard | Atomicity |
+|-------|---------|-------|-----------------|-----------|
+| File-level | `@koi/code-mode` | Single agent, single worktree | FNV-1a hash per file | LIFO rollback of file steps |
+| Branch-level | `@koi/worktree-merge` | N agents, N worktrees → 1 target | `expectedRef` SHA per branch | `git reset --hard` to restore point |
+
+Code-mode ensures each agent's **individual changes** are safe. Worktree-merge ensures the **combined result** is correct.
+
+---
+
+## How It Works
+
+### 1. Topological Sort
+
+Branches declare dependencies. Kahn's algorithm produces an ordered sequence grouped into independence levels:
+
+```
+Input:
+  core       → dependsOn: []
+  api        → dependsOn: [core]
+  ui         → dependsOn: [core]
+  tests      → dependsOn: [api, ui]
+  docs       → dependsOn: []
+
+Output (3 levels):
+  Level 0: [core, docs]        ← independent, merge first
+  Level 1: [api, ui]           ← depend on core
+  Level 2: [tests]             ← depends on api + ui
+```
+
+Cycles are detected and returned as a validation error with the cycle path.
+
+### 2. Level-by-Level Merge
+
+```
+main ──────────────────────────────────────────────────►
+        │                │                │
+        ▼                ▼                ▼
+   merge core       merge api        merge tests
+   merge docs       merge ui
+        │                │                │
+        ▼                ▼                ▼
+   verify(L0)       verify(L1)       verify(L2)
+   typecheck ✓      typecheck ✓      typecheck ✓
+```
+
+If verification fails at any level, the entire merge is rolled back to the restore point captured before the first merge.
+
+### 3. Strategy Dispatch
+
+| Strategy | Git Commands | When to Use |
+|----------|-------------|-------------|
+| `sequential` | `git merge --no-ff <branch>` per branch | Default. Clean history with merge commits |
+| `octopus` | `git merge <b1> <b2> <b3>` in one operation | All branches are independent, no conflicts expected |
+| `rebase-chain` | `git rebase <target> <branch>` then `git merge --ff-only` | Linear history preferred (rewrites branch commits) |
+
+Octopus falls back to sequential on conflict. Rebase-chain aborts rebase on conflict and calls the resolver.
+
+### 4. SHA Pinning (Stale-Branch Guard)
+
+```
+Planning time:  feat-auth tip = a1b2c3d4
+                                  │
+                (time passes, someone pushes to feat-auth)
+                                  │
+Merge time:     feat-auth tip = e5f6g7h8  ← STALE!
+                                  │
+                executeMerge checks expectedRef
+                                  │
+                a1b2c3d4 ≠ e5f6g7h8 → skipped
+```
+
+Set `expectedRef` on `MergeBranch` to reject branches that changed between planning and merge execution. Optional — omitting it merges unconditionally.
+
+---
+
+## Configuration
+
+```typescript
+interface MergeConfig {
+  readonly repoPath: string;              // Git repo path
+  readonly targetBranch: string;           // Branch to merge into (e.g., "main")
+  readonly branches: readonly MergeBranch[];
+  readonly strategy: MergeStrategyKind;    // "sequential" | "octopus" | "rebase-chain"
+  readonly verifyAfter?: VerifyAfter;      // "each" | "levels" | "all" (default: "levels")
+  readonly verify?: VerifyFn;              // Optional: run typecheck/tests after merge
+  readonly resolveConflict?: ConflictResolverFn;  // Optional: default aborts on conflict
+  readonly signal?: AbortSignal;           // Optional: cancel mid-merge
+  readonly onEvent?: (event: MergeEvent) => void; // Optional: progress notifications
+}
+```
+
+### MergeBranch
+
+```typescript
+interface MergeBranch {
+  readonly name: string;                   // Branch name (e.g., "feat-auth")
+  readonly dependsOn: readonly string[];   // Branch names this depends on
+  readonly expectedRef?: string;           // SHA pin — skip if branch tip differs
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+```
+
+### ConflictResolverFn
+
+Called when a merge produces conflicts. The default resolver aborts (fail-fast):
+
+```typescript
+type ConflictResolverFn = (conflict: ConflictInfo) => Promise<ConflictResolution>;
+
+interface ConflictInfo {
+  readonly branch: string;
+  readonly conflictFiles: readonly string[];
+  readonly targetRef: string;
+  readonly branchRef: string;
+}
+
+type ConflictResolution =
+  | { readonly kind: "resolved"; readonly commitSha: string }
+  | { readonly kind: "abort" };
+```
+
+### VerifyFn
+
+Called after merges (timing controlled by `verifyAfter`). Return `{ passed: false }` to trigger rollback:
+
+```typescript
+type VerifyFn = (
+  mergedRef: string,
+  mergedBranches: readonly string[],
+) => Promise<VerifyResult>;
+```
+
+---
+
+## Verification Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `"each"` | Verify after every single branch merge | Maximum safety, catches issues early |
+| `"levels"` | Verify after all branches in a level complete | Balanced — default |
+| `"all"` | Single verify after all branches merged | Fastest, least safe |
+
+```
+verifyAfter: "each"       verifyAfter: "levels"      verifyAfter: "all"
+
+merge A → verify          merge A                     merge A
+merge B → verify          merge B                     merge B
+merge C → verify          verify (level 0)            merge C
+                          merge C                     merge D
+                          verify (level 1)            merge E
+                          merge D                     verify (once)
+                          merge E
+                          verify (level 2)
+```
+
+---
+
+## Outcomes
+
+Every branch gets a `BranchMergeOutcome` — a discriminated union with 5 kinds:
+
+| Kind | Meaning | Fields |
+|------|---------|--------|
+| `merged` | Successfully merged | `commitSha` |
+| `conflict` | Merge conflict detected | `conflictFiles`, `resolved` |
+| `skipped` | Branch skipped (stale, or dep failed) | `reason` |
+| `failed` | Git operation failed | `error: KoiError` |
+| `reverted` | Merged then rolled back (verify failed) | `reason` |
+
+---
+
+## Events
+
+Progress notifications via `onEvent` callback — 12 kinds:
+
+| Event | Payload | When |
+|-------|---------|------|
+| `level:started` | `{ level, branches }` | Beginning a topo level |
+| `level:completed` | `{ level }` | All branches in level merged |
+| `merge:started` | `{ branch, index, total }` | About to merge a branch |
+| `merge:completed` | `{ branch, commitSha }` | Branch merged successfully |
+| `merge:conflict` | `{ branch, files }` | Conflict detected |
+| `merge:skipped` | `{ branch, reason }` | Branch skipped (stale/dep) |
+| `merge:failed` | `{ branch, error }` | Git operation failed |
+| `merge:reverted` | `{ branch, reason }` | Merged then rolled back |
+| `verify:started` | `{ branches }` | Running verify function |
+| `verify:passed` | — | Verify succeeded |
+| `verify:failed` | `{ message }` | Verify failed (triggers rollback) |
+| `aborted` | `{ restoreRef }` | AbortSignal fired, restored |
+
+---
+
+## Usage
+
+### Basic: Sequential merge with verification
+
+```typescript
+import { executeMerge } from "@koi/worktree-merge";
+
+const result = await executeMerge({
+  repoPath: "/path/to/repo",
+  targetBranch: "main",
+  strategy: "sequential",
+  branches: [
+    { name: "feat-auth", dependsOn: [] },
+    { name: "feat-payments", dependsOn: [] },
+    { name: "feat-tests", dependsOn: ["feat-auth", "feat-payments"] },
+  ],
+  verify: async (mergedRef, branches) => {
+    const { runGit } = await import("@koi/git-utils");
+    const result = await runGit(["run", "typecheck"], "/path/to/repo");
+    return { passed: result.ok, message: result.ok ? undefined : result.error.message };
+  },
+  onEvent: (event) => console.log(`[merge] ${event.kind}`, event),
+});
+
+if (result.ok) {
+  console.log(`Strategy: ${result.value.strategy}`);
+  console.log(`Verified: ${result.value.verified}`);
+  console.log(`Duration: ${result.value.durationMs}ms`);
+  for (const [branch, outcome] of result.value.outcomes) {
+    console.log(`  ${branch}: ${outcome.kind}`);
+  }
+}
+```
+
+### With SHA pinning
+
+```typescript
+// Capture branch SHAs at planning time
+const branches = workerResults.map((w) => ({
+  name: w.branchName,
+  dependsOn: w.dependencies,
+  expectedRef: w.commitSha,  // Captured when worker finished
+}));
+
+const result = await executeMerge({
+  repoPath,
+  targetBranch: "main",
+  strategy: "sequential",
+  branches,
+});
+
+// Check for stale branches
+for (const [branch, outcome] of result.value.outcomes) {
+  if (outcome.kind === "skipped") {
+    console.warn(`${branch}: ${outcome.reason}`);
+  }
+}
+```
+
+### With AbortSignal
+
+```typescript
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 60_000); // 1 minute timeout
+
+const result = await executeMerge({
+  repoPath,
+  targetBranch: "main",
+  strategy: "octopus",
+  branches: [...],
+  signal: controller.signal,
+});
+
+if (result.ok && result.value.aborted) {
+  console.log("Merge was cancelled — repo restored to pre-merge state");
+}
+```
+
+---
+
+## API Reference
+
+### Entry Point
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `executeMerge(config)` | `(MergeConfig) → Promise<Result<MergeResult, KoiError>>` | Main entry point |
+
+### Strategy Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `mergeSequential(branch, target, repoPath, resolver)` | `→ Promise<BranchMergeOutcome>` | `git merge --no-ff` |
+| `mergeOctopus(branch, target, repoPath, resolver)` | `→ Promise<BranchMergeOutcome>` | Single-branch octopus (delegates to sequential) |
+| `mergeOctopusLevel(branches, target, repoPath, resolver)` | `→ Promise<ReadonlyMap<string, BranchMergeOutcome>>` | Batch octopus with sequential fallback |
+| `mergeRebaseChain(branch, target, repoPath, resolver)` | `→ Promise<BranchMergeOutcome>` | Rebase onto target + ff merge |
+
+### Ordering Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `computeMergeOrder(branches)` | `→ Result<readonly string[], KoiError>` | Kahn's topo sort |
+| `computeMergeLevels(branches)` | `→ Result<readonly (readonly string[])[], KoiError>` | Group into independence levels |
+
+### Validation
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `validateMergeConfig(config)` | `→ Result<void, KoiError>` | Validate repoPath, targetBranch, deps |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `MergeConfig` | Full configuration for `executeMerge()` |
+| `MergeBranch` | Branch with name, dependencies, optional SHA pin |
+| `MergeResult` | Aggregate result with outcomes map, timing, verified/aborted flags |
+| `BranchMergeOutcome` | Per-branch outcome: merged, conflict, skipped, failed, reverted |
+| `MergeEvent` | Progress notification (12 kinds) |
+| `MergeStrategyKind` | `"sequential" \| "octopus" \| "rebase-chain"` |
+| `MergeStrategyFn` | Shared signature for all strategy functions |
+| `ConflictResolverFn` | `(ConflictInfo) → Promise<ConflictResolution>` |
+| `VerifyFn` | `(mergedRef, branches) → Promise<VerifyResult>` |
+| `VerifyAfter` | `"each" \| "levels" \| "all"` |
+
+---
+
+## Abort & Restore
+
+Every `executeMerge` call captures a restore point (`git rev-parse HEAD`) before the first merge. The repo is restored on:
+
+- **AbortSignal** — `signal.abort()` fires mid-merge
+- **Verify failure** — verify function returns `{ passed: false }`
+- **Unexpected error** — any uncaught exception during merge
+
+```
+Before merge:  HEAD = abc123 (captured as restore point)
+
+merge A ✓
+merge B ✓
+merge C ✓
+verify → FAILED
+
+git reset --hard abc123  ←  restored to pre-merge state
+```
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────────┐
+    Result, KoiError                                         │
+                                                             ▼
+L0u @koi/git-utils ─────────────────────────────────────────┐
+    runGit()                                                 │
+                                                             ▼
+L2  @koi/worktree-merge <───────────────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external dependencies
+    ~ package.json: { "dependencies": { "@koi/core": "workspace:*", "@koi/git-utils": "workspace:*" } }
+```

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@koi/git-utils",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  }
+}

--- a/packages/git-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/git-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,31 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/git-utils API surface . has stable type surface 1`] = `
+"import { KoiError, Result } from '@koi/core';
+
+/**
+ * Path resolution utilities for git worktrees.
+ */
+/** Resolve the base path for worktrees relative to the repo. */
+declare function resolveWorktreeBasePath(repoPath: string, explicit?: string): string;
+
+/**
+ * Git command execution utilities.
+ *
+ * Thin wrapper around Bun.spawn for running git commands and
+ * mapping stderr to KoiError values.
+ */
+
+/**
+ * Run a git command and return the stdout as a Result.
+ *
+ * On non-zero exit, returns a Result.error with the stderr parsed
+ * into a KoiError. Side-effect: spawns a child process.
+ */
+declare function runGit(args: readonly string[], cwd: string): Promise<Result<string, KoiError>>;
+/** Map git stderr messages to structured KoiError values. */
+declare function parseGitError(stderr: string, args: readonly string[]): KoiError;
+
+export { parseGitError, resolveWorktreeBasePath, runGit };
+"
+`;

--- a/packages/git-utils/src/__tests__/api-surface.test.ts
+++ b/packages/git-utils/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/git-utils/src/index.ts
+++ b/packages/git-utils/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @koi/git-utils — Shared git CLI wrapper for workspace-related packages.
+ *
+ * Provides typed wrappers around Bun.spawn for running git commands and
+ * resolving worktree paths.
+ */
+
+export { resolveWorktreeBasePath } from "./paths.js";
+export { parseGitError, runGit } from "./run-git.js";

--- a/packages/git-utils/src/paths.test.ts
+++ b/packages/git-utils/src/paths.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { resolveWorktreeBasePath } from "./paths.js";
+
+describe("resolveWorktreeBasePath", () => {
+  it("returns explicit path when provided", () => {
+    expect(resolveWorktreeBasePath("/repos/myrepo", "/custom/base")).toBe("/custom/base");
+  });
+
+  it("derives path from repo name when no explicit path", () => {
+    const result = resolveWorktreeBasePath("/repos/myrepo");
+    expect(result).toBe("/repos/myrepo/../myrepo-workspaces");
+  });
+
+  it("handles repo path ending with slash", () => {
+    const result = resolveWorktreeBasePath("/repos/myrepo/");
+    expect(result).toContain("-workspaces");
+  });
+
+  it("falls back to 'repo' for edge case paths", () => {
+    const result = resolveWorktreeBasePath("/");
+    expect(result).toContain("repo-workspaces");
+  });
+});

--- a/packages/git-utils/src/paths.ts
+++ b/packages/git-utils/src/paths.ts
@@ -1,0 +1,10 @@
+/**
+ * Path resolution utilities for git worktrees.
+ */
+
+/** Resolve the base path for worktrees relative to the repo. */
+export function resolveWorktreeBasePath(repoPath: string, explicit?: string): string {
+  if (explicit) return explicit;
+  const repoName = repoPath.split("/").pop() || "repo";
+  return `${repoPath}/../${repoName}-workspaces`;
+}

--- a/packages/git-utils/src/run-git.test.ts
+++ b/packages/git-utils/src/run-git.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseGitError, resolveWorktreeBasePath } from "./git-utils.js";
+import { parseGitError } from "./run-git.js";
 
 describe("parseGitError", () => {
   it("maps 'already exists' to CONFLICT", () => {
@@ -36,28 +36,5 @@ describe("parseGitError", () => {
   it("includes command in context", () => {
     const err = parseGitError("error", ["worktree", "add", "/path"]);
     expect(err.context).toEqual({ command: "git worktree add /path" });
-  });
-});
-
-describe("resolveWorktreeBasePath", () => {
-  it("returns explicit path when provided", () => {
-    expect(resolveWorktreeBasePath("/repos/myrepo", "/custom/base")).toBe("/custom/base");
-  });
-
-  it("derives path from repo name when no explicit path", () => {
-    const result = resolveWorktreeBasePath("/repos/myrepo");
-    expect(result).toBe("/repos/myrepo/../myrepo-workspaces");
-  });
-
-  it("handles repo path ending with slash", () => {
-    // path.split("/").pop() on trailing slash gives ""
-    const result = resolveWorktreeBasePath("/repos/myrepo/");
-    // pop() returns "" for trailing slash, fallback to "repo"
-    expect(result).toContain("-workspaces");
-  });
-
-  it("falls back to 'repo' for edge case paths", () => {
-    const result = resolveWorktreeBasePath("/");
-    expect(result).toContain("repo-workspaces");
   });
 });

--- a/packages/git-utils/src/run-git.ts
+++ b/packages/git-utils/src/run-git.ts
@@ -96,10 +96,3 @@ export function parseGitError(stderr: string, args: readonly string[]): KoiError
     context: { command: `git ${args.join(" ")}` },
   };
 }
-
-/** Resolve the base path for worktrees relative to the repo. */
-export function resolveWorktreeBasePath(repoPath: string, explicit?: string): string {
-  if (explicit) return explicit;
-  const repoName = repoPath.split("/").pop() || "repo";
-  return `${repoPath}/../${repoName}-workspaces`;
-}

--- a/packages/git-utils/tsconfig.json
+++ b/packages/git-utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/git-utils/tsup.config.ts
+++ b/packages/git-utils/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -10,7 +10,8 @@
     }
   },
   "dependencies": {
-    "@koi/core": "workspace:*"
+    "@koi/core": "workspace:*",
+    "@koi/git-utils": "workspace:*"
   },
   "devDependencies": {
     "@koi/engine": "workspace:*",

--- a/packages/workspace/src/git-backend.ts
+++ b/packages/workspace/src/git-backend.ts
@@ -9,7 +9,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { AgentId, KoiError, Result } from "@koi/core";
-import { resolveWorktreeBasePath, runGit } from "./git-utils.js";
+import { resolveWorktreeBasePath, runGit } from "@koi/git-utils";
 import type { ResolvedWorkspaceConfig, WorkspaceBackend, WorkspaceInfo } from "./types.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/workspace/src/prune.ts
+++ b/packages/workspace/src/prune.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import type { KoiError } from "@koi/core";
-import { runGit } from "./git-utils.js";
+import { runGit } from "@koi/git-utils";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/worktree-merge/package.json
+++ b/packages/worktree-merge/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@koi/worktree-merge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/git-utils": "workspace:*"
+  }
+}

--- a/packages/worktree-merge/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/worktree-merge/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,207 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/worktree-merge API surface . has stable type surface 1`] = `
+"import { KoiError, Result } from '@koi/core';
+
+/**
+ * Types for branch reconciliation after parallel worktree-based agent work.
+ */
+
+/** A branch to merge, with optional ordering dependencies. */
+interface MergeBranch {
+    readonly name: string;
+    readonly dependsOn: readonly string[];
+    /** If set, merge is skipped when branch tip differs (stale-branch guard). */
+    readonly expectedRef?: string;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+}
+/** Merge strategy discriminant. */
+type MergeStrategyKind = "sequential" | "octopus" | "rebase-chain";
+/** When to run the verify function. */
+type VerifyAfter = "each" | "all" | "levels";
+/** Information about a merge conflict, passed to the resolver callback. */
+interface ConflictInfo {
+    readonly branch: string;
+    readonly conflictFiles: readonly string[];
+    readonly targetRef: string;
+    readonly branchRef: string;
+}
+/** Resolution returned by the conflict resolver. */
+type ConflictResolution = {
+    readonly kind: "resolved";
+    readonly commitSha: string;
+} | {
+    readonly kind: "abort";
+};
+/** Pluggable conflict resolution callback. */
+type ConflictResolverFn = (conflict: ConflictInfo) => Promise<ConflictResolution>;
+/** Verification callback invoked after merges. */
+type VerifyFn = (mergedRef: string, mergedBranches: readonly string[]) => Promise<VerifyResult>;
+/** Result of a verification step. */
+interface VerifyResult {
+    readonly passed: boolean;
+    readonly message?: string;
+}
+/** Full configuration for executeMerge(). */
+interface MergeConfig {
+    readonly repoPath: string;
+    readonly targetBranch: string;
+    readonly branches: readonly MergeBranch[];
+    readonly strategy: MergeStrategyKind;
+    readonly verifyAfter?: VerifyAfter;
+    readonly verify?: VerifyFn;
+    readonly resolveConflict?: ConflictResolverFn;
+    readonly signal?: AbortSignal;
+    readonly onEvent?: (event: MergeEvent) => void;
+}
+/** Discriminated union of all merge progress events. */
+type MergeEvent = {
+    readonly kind: "merge:started";
+    readonly branch: string;
+    readonly index: number;
+    readonly total: number;
+} | {
+    readonly kind: "merge:completed";
+    readonly branch: string;
+    readonly commitSha: string;
+} | {
+    readonly kind: "merge:conflict";
+    readonly branch: string;
+    readonly files: readonly string[];
+} | {
+    readonly kind: "merge:skipped";
+    readonly branch: string;
+    readonly reason: string;
+} | {
+    readonly kind: "merge:reverted";
+    readonly branch: string;
+    readonly reason: string;
+} | {
+    readonly kind: "merge:failed";
+    readonly branch: string;
+    readonly error: KoiError;
+} | {
+    readonly kind: "verify:started";
+    readonly branches: readonly string[];
+} | {
+    readonly kind: "verify:passed";
+} | {
+    readonly kind: "verify:failed";
+    readonly message: string;
+} | {
+    readonly kind: "level:started";
+    readonly level: number;
+    readonly branches: readonly string[];
+} | {
+    readonly kind: "level:completed";
+    readonly level: number;
+} | {
+    readonly kind: "aborted";
+    readonly restoreRef: string;
+};
+/** Per-branch outcome after a merge attempt. */
+type BranchMergeOutcome = {
+    readonly kind: "merged";
+    readonly commitSha: string;
+} | {
+    readonly kind: "conflict";
+    readonly conflictFiles: readonly string[];
+    readonly resolved: boolean;
+} | {
+    readonly kind: "skipped";
+    readonly reason: string;
+} | {
+    readonly kind: "failed";
+    readonly error: KoiError;
+} | {
+    readonly kind: "reverted";
+    readonly reason: string;
+};
+/** Aggregate result of executeMerge(). */
+interface MergeResult {
+    readonly strategy: MergeStrategyKind;
+    readonly targetBranch: string;
+    readonly mergeOrder: readonly string[];
+    readonly outcomes: ReadonlyMap<string, BranchMergeOutcome>;
+    readonly verified: boolean;
+    readonly durationMs: number;
+    readonly aborted: boolean;
+}
+/** Signature shared by all strategy functions. */
+type MergeStrategyFn = (branch: string, targetBranch: string, repoPath: string, resolveConflict: ConflictResolverFn) => Promise<BranchMergeOutcome>;
+/** Validate MergeConfig, returning an error for invalid inputs. */
+declare function validateMergeConfig(config: MergeConfig): Result<void, KoiError>;
+
+/**
+ * Main entry point for branch reconciliation.
+ *
+ * Orchestrates topological ordering, strategy dispatch, verification,
+ * and abort handling into a single executeMerge() call.
+ */
+
+/** Execute a merge plan according to the given configuration. */
+declare function executeMerge(config: MergeConfig): Promise<Result<MergeResult, KoiError>>;
+
+/**
+ * Octopus merge strategy: merge multiple branches at once.
+ *
+ * Only works for conflict-free branches at the same level. On conflict,
+ * falls back to sequential merging of individual branches.
+ */
+
+/** Merge a single branch via octopus (delegates to git merge). */
+declare function mergeOctopus(branch: string, targetBranch: string, repoPath: string, resolveConflict: ConflictResolverFn): Promise<BranchMergeOutcome>;
+/**
+ * Attempt an octopus merge of all branches in a level.
+ *
+ * Returns outcomes per branch. If octopus fails, resets and
+ * falls back to sequential merging.
+ */
+declare function mergeOctopusLevel(branches: readonly string[], targetBranch: string, repoPath: string, resolveConflict: ConflictResolverFn): Promise<ReadonlyMap<string, BranchMergeOutcome>>;
+
+/**
+ * Topological ordering for merge branches.
+ *
+ * Uses Kahn's algorithm to compute a merge order that respects
+ * dependency constraints, and groups branches into independence levels.
+ */
+
+/**
+ * Compute topological merge order via Kahn's algorithm.
+ *
+ * Returns branch names in an order where every branch appears after
+ * all of its dependencies. Returns an error if a cycle is detected.
+ */
+declare function computeMergeOrder(branches: readonly MergeBranch[]): Result<readonly string[], KoiError>;
+/**
+ * Group branches into independence levels (same BFS depth).
+ *
+ * Each level contains branches that can be processed after all
+ * branches in previous levels have completed. Within a level,
+ * branches are independent of each other.
+ */
+declare function computeMergeLevels(branches: readonly MergeBranch[]): Result<readonly (readonly string[])[], KoiError>;
+
+/**
+ * Rebase-chain merge strategy: rebase each branch onto target, then ff merge.
+ *
+ * Rewrites history (documented as explicit tradeoff). On conflict during
+ * replay, calls the conflict resolver. If resolution fails, aborts rebase.
+ */
+
+/** Rebase a branch onto target, then fast-forward merge. */
+declare function mergeRebaseChain(branch: string, targetBranch: string, repoPath: string, resolveConflict: ConflictResolverFn): Promise<BranchMergeOutcome>;
+
+/**
+ * Sequential merge strategy: git merge --no-ff for each branch.
+ *
+ * On conflict: calls the conflict resolver. If resolution fails or
+ * is aborted, reverts the merge attempt.
+ */
+
+/** Merge a single branch using --no-ff. */
+declare function mergeSequential(branch: string, _targetBranch: string, repoPath: string, resolveConflict: ConflictResolverFn): Promise<BranchMergeOutcome>;
+
+export { type BranchMergeOutcome, type ConflictInfo, type ConflictResolution, type ConflictResolverFn, type MergeBranch, type MergeConfig, type MergeEvent, type MergeResult, type MergeStrategyFn, type MergeStrategyKind, type VerifyAfter, type VerifyFn, type VerifyResult, computeMergeLevels, computeMergeOrder, executeMerge, mergeOctopus, mergeOctopusLevel, mergeRebaseChain, mergeSequential, validateMergeConfig };
+"
+`;

--- a/packages/worktree-merge/src/__tests__/api-surface.test.ts
+++ b/packages/worktree-merge/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/worktree-merge/src/__tests__/edge-cases.test.ts
+++ b/packages/worktree-merge/src/__tests__/edge-cases.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runGit } from "@koi/git-utils";
+import { executeMerge } from "../execute-merge.js";
+import type { MergeConfig, VerifyFn } from "../types.js";
+import { addCommit, createBranchWithChange, createTestRepo } from "./helpers.js";
+
+let repoPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const repo = await createTestRepo();
+  repoPath = repo.path;
+  cleanup = repo.cleanup;
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe("edge cases", () => {
+  // Case 1: Zero branches
+  it("returns immediate success for zero branches", async () => {
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.size).toBe(0);
+      expect(result.value.mergeOrder).toEqual([]);
+      expect(result.value.verified).toBe(true);
+      expect(result.value.aborted).toBe(false);
+    }
+  });
+
+  // Case 2: Single branch
+  it("merges single branch without ordering issues", async () => {
+    await createBranchWithChange(repoPath, "solo", "solo.ts", "solo\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "solo", dependsOn: [] }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.size).toBe(1);
+      expect(result.value.outcomes.get("solo")?.kind).toBe("merged");
+    }
+  });
+
+  // Case 3: Circular dependency
+  it("returns validation error for circular dependency", async () => {
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "a", dependsOn: ["b"] },
+        { name: "b", dependsOn: ["c"] },
+        { name: "c", dependsOn: ["a"] },
+      ],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("Cycle");
+    }
+  });
+
+  // Case 4: Branch deleted between planning and merge
+  it("returns failed outcome when branch does not exist", async () => {
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "ghost-branch", dependsOn: [] }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const outcome = result.value.outcomes.get("ghost-branch");
+      expect(outcome?.kind).toBe("failed");
+    }
+  });
+
+  // Case 5: Target branch advanced (other merges happened)
+  it("merges from current HEAD even after target advances", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    // Advance main with another commit
+    await addCommit(repoPath, "advance.ts", "advanced\n", "advance main");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.get("feat-a")?.kind).toBe("merged");
+    }
+  });
+
+  // Case 6: Binary file conflict
+  it("detects conflict with binary-like files", async () => {
+    // Simulate binary-like conflict with same file, different content
+    await createBranchWithChange(repoPath, "bin-1", "data.bin", "\x00\x01\x02");
+    await createBranchWithChange(repoPath, "bin-2", "data.bin", "\x03\x04\x05");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "bin-1", dependsOn: [] },
+        { name: "bin-2", dependsOn: [] },
+      ],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // First should merge, second should conflict
+      expect(result.value.outcomes.get("bin-1")?.kind).toBe("merged");
+      const bin2 = result.value.outcomes.get("bin-2");
+      expect(bin2?.kind).toBe("conflict");
+    }
+  });
+
+  // Case 7: Branch with no new commits
+  it("handles branch with no new commits", async () => {
+    await runGit(["branch", "no-change"], repoPath);
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "no-change", dependsOn: [] }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const outcome = result.value.outcomes.get("no-change");
+      // Either merged (no-op) or failed (already up to date)
+      expect(outcome).toBeDefined();
+    }
+  });
+
+  // Case 8: Verify function throws
+  it("handles verify function that throws", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+      verifyAfter: "levels",
+      verify: (async () => {
+        throw new Error("verify exploded");
+      }) as VerifyFn,
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Verify threw, so verified should be false
+      expect(result.value.verified).toBe(false);
+    }
+  });
+
+  // Case 9: AbortSignal mid-merge
+  it("aborts and restores on AbortSignal", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+    await createBranchWithChange(repoPath, "feat-b", "b.ts", "b\n");
+
+    const headBefore = await runGit(["rev-parse", "HEAD"], repoPath);
+
+    const controller = new AbortController();
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "feat-a", dependsOn: [] },
+        { name: "feat-b", dependsOn: ["feat-a"] },
+      ],
+      strategy: "sequential",
+      signal: controller.signal,
+      onEvent: (event) => {
+        // Abort after first merge completes
+        if (event.kind === "merge:completed") {
+          controller.abort();
+        }
+      },
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.aborted).toBe(true);
+    }
+
+    // HEAD should be restored
+    const headAfter = await runGit(["rev-parse", "HEAD"], repoPath);
+    if (headBefore.ok && headAfter.ok) {
+      expect(headAfter.value).toBe(headBefore.value);
+    }
+  });
+
+  // Case 10: Stale branch detected via expectedRef
+  it("skips branch when expectedRef does not match (stale-branch guard)", async () => {
+    const sha = await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    // Advance the branch after capturing the SHA
+    await runGit(["checkout", "feat-a"], repoPath);
+    await addCommit(repoPath, "a2.ts", "a2\n", "advance feat-a");
+    await runGit(["checkout", "main"], repoPath);
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [], expectedRef: sha }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const outcome = result.value.outcomes.get("feat-a");
+      expect(outcome?.kind).toBe("skipped");
+      if (outcome?.kind === "skipped") {
+        expect(outcome.reason).toContain("stale");
+      }
+    }
+  });
+
+  // Case 11: expectedRef matches — merge proceeds normally
+  it("merges branch when expectedRef matches (fresh branch)", async () => {
+    const sha = await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [], expectedRef: sha }],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.get("feat-a")?.kind).toBe("merged");
+    }
+  });
+
+  // Case 12: Concurrent executeMerge on same repo — second should fail with git lock
+  it("fails gracefully on concurrent merge attempts", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+    await createBranchWithChange(repoPath, "feat-b", "b.ts", "b\n");
+
+    const config1: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+    };
+    const config2: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-b", dependsOn: [] }],
+      strategy: "sequential",
+    };
+
+    // Run both concurrently — at least one should succeed
+    const [result1, result2] = await Promise.all([executeMerge(config1), executeMerge(config2)]);
+
+    // At least one should succeed
+    const anyOk =
+      (result1.ok && result1.value.outcomes.size > 0) ||
+      (result2.ok && result2.value.outcomes.size > 0);
+    expect(anyOk).toBe(true);
+  });
+});

--- a/packages/worktree-merge/src/__tests__/execute-merge.test.ts
+++ b/packages/worktree-merge/src/__tests__/execute-merge.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { executeMerge } from "../execute-merge.js";
+import type { MergeConfig, MergeEvent } from "../types.js";
+import { createBranchWithChange, createTestRepo } from "./helpers.js";
+
+let repoPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const repo = await createTestRepo();
+  repoPath = repo.path;
+  cleanup = repo.cleanup;
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe("executeMerge (integration)", () => {
+  it("merges 3 independent branches with sequential strategy", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+    await createBranchWithChange(repoPath, "feat-b", "b.ts", "b\n");
+    await createBranchWithChange(repoPath, "feat-c", "c.ts", "c\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "feat-a", dependsOn: [] },
+        { name: "feat-b", dependsOn: [] },
+        { name: "feat-c", dependsOn: [] },
+      ],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.size).toBe(3);
+      expect(result.value.aborted).toBe(false);
+      expect(result.value.verified).toBe(true);
+      for (const [, outcome] of result.value.outcomes) {
+        expect(outcome.kind).toBe("merged");
+      }
+    }
+  });
+
+  it("merges branches with dependencies in correct order", async () => {
+    await createBranchWithChange(repoPath, "base", "base.ts", "base\n");
+    await createBranchWithChange(repoPath, "derived", "derived.ts", "derived\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "derived", dependsOn: ["base"] },
+        { name: "base", dependsOn: [] },
+      ],
+      strategy: "sequential",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.mergeOrder).toEqual(["base", "derived"]);
+      expect(result.value.outcomes.size).toBe(2);
+    }
+  });
+
+  it("collects onEvent callbacks", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    const events: MergeEvent[] = [];
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+      onEvent: (event) => {
+        events.push(event);
+      },
+    };
+
+    await executeMerge(config);
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain("level:started");
+    expect(kinds).toContain("merge:started");
+    expect(kinds).toContain("merge:completed");
+    expect(kinds).toContain("level:completed");
+  });
+
+  it("runs verify after levels", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    let verifyCalled = false;
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+      verifyAfter: "levels",
+      verify: async () => {
+        verifyCalled = true;
+        return { passed: true };
+      },
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.verified).toBe(true);
+    }
+    expect(verifyCalled).toBe(true);
+  });
+
+  it("reverts on verify failure", async () => {
+    const { runGit } = await import("@koi/git-utils");
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+    // Get initial HEAD
+    const headBefore = await runGit(["rev-parse", "HEAD"], repoPath);
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [{ name: "feat-a", dependsOn: [] }],
+      strategy: "sequential",
+      verifyAfter: "levels",
+      verify: async () => ({ passed: false, message: "tests failed" }),
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.verified).toBe(false);
+    }
+
+    // HEAD should be restored
+    const headAfter = await runGit(["rev-parse", "HEAD"], repoPath);
+    expect(headAfter.ok && headBefore.ok && headAfter.value).toBe(
+      headBefore.ok ? headBefore.value : "unreachable",
+    );
+  });
+
+  it("uses octopus strategy for independent branches", async () => {
+    await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+    await createBranchWithChange(repoPath, "feat-b", "b.ts", "b\n");
+
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "feat-a", dependsOn: [] },
+        { name: "feat-b", dependsOn: [] },
+      ],
+      strategy: "octopus",
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.strategy).toBe("octopus");
+      expect(result.value.outcomes.size).toBe(2);
+    }
+  });
+
+  it("handles 5 branches with deps using sequential + verify:levels", async () => {
+    await createBranchWithChange(repoPath, "core", "core.ts", "core\n");
+    await createBranchWithChange(repoPath, "api", "api.ts", "api\n");
+    await createBranchWithChange(repoPath, "ui", "ui.ts", "ui\n");
+    await createBranchWithChange(repoPath, "tests", "tests.ts", "tests\n");
+    await createBranchWithChange(repoPath, "docs", "docs.ts", "docs\n");
+
+    let verifyCount = 0;
+    const config: MergeConfig = {
+      repoPath,
+      targetBranch: "main",
+      branches: [
+        { name: "core", dependsOn: [] },
+        { name: "api", dependsOn: ["core"] },
+        { name: "ui", dependsOn: ["core"] },
+        { name: "tests", dependsOn: ["api", "ui"] },
+        { name: "docs", dependsOn: [] },
+      ],
+      strategy: "sequential",
+      verifyAfter: "levels",
+      verify: async () => {
+        verifyCount++;
+        return { passed: true };
+      },
+    };
+
+    const result = await executeMerge(config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.outcomes.size).toBe(5);
+      expect(result.value.verified).toBe(true);
+      // Levels: [core, docs], [api, ui], [tests] = 3 levels
+      expect(verifyCount).toBe(3);
+    }
+  });
+});

--- a/packages/worktree-merge/src/__tests__/helpers.ts
+++ b/packages/worktree-merge/src/__tests__/helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * Test helpers for creating temporary git repos with branches.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGit } from "@koi/git-utils";
+
+/** Creates a temp git repo with an initial commit. */
+export async function createTestRepo(): Promise<{
+  readonly path: string;
+  readonly cleanup: () => Promise<void>;
+}> {
+  const path = await mkdtemp(join(tmpdir(), "koi-merge-test-"));
+
+  await runGit(["init", "--initial-branch=main"], path);
+  await runGit(["config", "user.email", "test@koi.dev"], path);
+  await runGit(["config", "user.name", "Koi Test"], path);
+
+  // Create initial commit
+  await Bun.write(join(path, "README.md"), "# Test repo\n");
+  await runGit(["add", "README.md"], path);
+  await runGit(["commit", "-m", "initial commit"], path);
+
+  return {
+    path,
+    cleanup: async () => {
+      await rm(path, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Adds a file with content and commits, returns the commit SHA. */
+export async function addCommit(
+  repoPath: string,
+  file: string,
+  content: string,
+  message: string,
+): Promise<string> {
+  await Bun.write(join(repoPath, file), content);
+  await runGit(["add", file], repoPath);
+  await runGit(["commit", "-m", message], repoPath);
+  const result = await runGit(["rev-parse", "HEAD"], repoPath);
+  if (!result.ok) throw new Error(`Failed to get HEAD: ${result.error.message}`);
+  return result.value;
+}
+
+/** Creates a branch from a ref (default: HEAD). */
+export async function createBranch(repoPath: string, branch: string, from?: string): Promise<void> {
+  if (from) {
+    await runGit(["branch", branch, from], repoPath);
+  } else {
+    await runGit(["branch", branch], repoPath);
+  }
+}
+
+/**
+ * Creates a branch with a specific file change.
+ *
+ * Creates the branch from main, checks it out, adds a commit
+ * with the given file/content, then switches back to main.
+ */
+export async function createBranchWithChange(
+  repoPath: string,
+  branch: string,
+  file: string,
+  content: string,
+): Promise<string> {
+  await runGit(["checkout", "-b", branch], repoPath);
+  const sha = await addCommit(repoPath, file, content, `Add ${file} on ${branch}`);
+  await runGit(["checkout", "main"], repoPath);
+  return sha;
+}

--- a/packages/worktree-merge/src/__tests__/octopus.test.ts
+++ b/packages/worktree-merge/src/__tests__/octopus.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mergeOctopusLevel } from "../merge-octopus.js";
+import type { ConflictResolverFn } from "../types.js";
+import { createBranchWithChange, createTestRepo } from "./helpers.js";
+
+const abortResolver: ConflictResolverFn = async () => ({ kind: "abort" });
+
+let repoPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const repo = await createTestRepo();
+  repoPath = repo.path;
+  cleanup = repo.cleanup;
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe("mergeOctopusLevel (integration)", () => {
+  it("merges multiple clean branches at once", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+    await createBranchWithChange(repoPath, "feature-b", "b.ts", "export const b = 2;\n");
+    await createBranchWithChange(repoPath, "feature-c", "c.ts", "export const c = 3;\n");
+
+    const outcomes = await mergeOctopusLevel(
+      ["feature-a", "feature-b", "feature-c"],
+      "main",
+      repoPath,
+      abortResolver,
+    );
+
+    expect(outcomes.size).toBe(3);
+    for (const [, outcome] of outcomes) {
+      expect(outcome.kind).toBe("merged");
+    }
+  });
+
+  it("falls back to sequential on conflict", async () => {
+    await createBranchWithChange(repoPath, "branch-1", "shared.ts", "version 1\n");
+    await createBranchWithChange(repoPath, "branch-2", "shared.ts", "version 2\n");
+
+    const outcomes = await mergeOctopusLevel(
+      ["branch-1", "branch-2"],
+      "main",
+      repoPath,
+      abortResolver,
+    );
+
+    expect(outcomes.size).toBe(2);
+    // First should succeed (sequential fallback), second should conflict
+    expect(outcomes.get("branch-1")?.kind).toBe("merged");
+    expect(outcomes.get("branch-2")?.kind).toBe("conflict");
+  });
+
+  it("handles single branch (degenerates to sequential)", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+
+    const outcomes = await mergeOctopusLevel(["feature-a"], "main", repoPath, abortResolver);
+
+    expect(outcomes.size).toBe(1);
+    expect(outcomes.get("feature-a")?.kind).toBe("merged");
+  });
+
+  it("handles empty branches array", async () => {
+    const outcomes = await mergeOctopusLevel([], "main", repoPath, abortResolver);
+
+    expect(outcomes.size).toBe(0);
+  });
+
+  it("merges all independent branches", async () => {
+    await createBranchWithChange(repoPath, "feat-1", "f1.ts", "1\n");
+    await createBranchWithChange(repoPath, "feat-2", "f2.ts", "2\n");
+
+    const outcomes = await mergeOctopusLevel(["feat-1", "feat-2"], "main", repoPath, abortResolver);
+
+    expect(outcomes.size).toBe(2);
+    for (const [, outcome] of outcomes) {
+      expect(outcome.kind).toBe("merged");
+    }
+  });
+});

--- a/packages/worktree-merge/src/__tests__/rebase-chain.test.ts
+++ b/packages/worktree-merge/src/__tests__/rebase-chain.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mergeRebaseChain } from "../merge-rebase-chain.js";
+import type { ConflictResolverFn } from "../types.js";
+import { addCommit, createBranchWithChange, createTestRepo } from "./helpers.js";
+
+const abortResolver: ConflictResolverFn = async () => ({ kind: "abort" });
+
+let repoPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const repo = await createTestRepo();
+  repoPath = repo.path;
+  cleanup = repo.cleanup;
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe("mergeRebaseChain (integration)", () => {
+  it("rebases and fast-forward merges a clean branch", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+
+    const outcome = await mergeRebaseChain("feature-a", "main", repoPath, abortResolver);
+
+    expect(outcome.kind).toBe("merged");
+    if (outcome.kind === "merged") {
+      expect(outcome.commitSha).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it("rebases two branches sequentially", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+    await createBranchWithChange(repoPath, "feature-b", "b.ts", "export const b = 2;\n");
+
+    const outcomeA = await mergeRebaseChain("feature-a", "main", repoPath, abortResolver);
+    expect(outcomeA.kind).toBe("merged");
+
+    const outcomeB = await mergeRebaseChain("feature-b", "main", repoPath, abortResolver);
+    expect(outcomeB.kind).toBe("merged");
+  });
+
+  it("detects conflict during rebase", async () => {
+    await createBranchWithChange(repoPath, "branch-1", "shared.ts", "version 1\n");
+    await createBranchWithChange(repoPath, "branch-2", "shared.ts", "version 2\n");
+
+    // Rebase first (succeeds)
+    await mergeRebaseChain("branch-1", "main", repoPath, abortResolver);
+
+    // Rebase second (conflicts)
+    const outcome = await mergeRebaseChain("branch-2", "main", repoPath, abortResolver);
+    // Should be either conflict or failed depending on git state
+    expect(["conflict", "failed"]).toContain(outcome.kind);
+  });
+
+  it("handles multi-commit branch", async () => {
+    const { runGit } = await import("@koi/git-utils");
+    await runGit(["checkout", "-b", "multi-commit"], repoPath);
+    await addCommit(repoPath, "file1.ts", "commit 1\n", "first commit");
+    await addCommit(repoPath, "file2.ts", "commit 2\n", "second commit");
+    await addCommit(repoPath, "file3.ts", "commit 3\n", "third commit");
+    await runGit(["checkout", "main"], repoPath);
+
+    const outcome = await mergeRebaseChain("multi-commit", "main", repoPath, abortResolver);
+
+    expect(outcome.kind).toBe("merged");
+  });
+});

--- a/packages/worktree-merge/src/__tests__/sequential.test.ts
+++ b/packages/worktree-merge/src/__tests__/sequential.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mergeSequential } from "../merge-sequential.js";
+import type { ConflictResolverFn } from "../types.js";
+import { createBranchWithChange, createTestRepo } from "./helpers.js";
+
+const abortResolver: ConflictResolverFn = async () => ({ kind: "abort" });
+
+let repoPath: string;
+let cleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  const repo = await createTestRepo();
+  repoPath = repo.path;
+  cleanup = repo.cleanup;
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe("mergeSequential (integration)", () => {
+  it("merges a clean branch", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+
+    const outcome = await mergeSequential("feature-a", "main", repoPath, abortResolver);
+
+    expect(outcome.kind).toBe("merged");
+    if (outcome.kind === "merged") {
+      expect(outcome.commitSha).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it("merges two branches sequentially", async () => {
+    await createBranchWithChange(repoPath, "feature-a", "a.ts", "export const a = 1;\n");
+    await createBranchWithChange(repoPath, "feature-b", "b.ts", "export const b = 2;\n");
+
+    const outcomeA = await mergeSequential("feature-a", "main", repoPath, abortResolver);
+    expect(outcomeA.kind).toBe("merged");
+
+    const outcomeB = await mergeSequential("feature-b", "main", repoPath, abortResolver);
+    expect(outcomeB.kind).toBe("merged");
+  });
+
+  it("detects conflict and calls resolver", async () => {
+    // Both branches modify the same file
+    await createBranchWithChange(repoPath, "branch-1", "shared.ts", "version 1\n");
+    await createBranchWithChange(repoPath, "branch-2", "shared.ts", "version 2\n");
+
+    // Merge first branch (succeeds)
+    await mergeSequential("branch-1", "main", repoPath, abortResolver);
+
+    // Merge second branch (conflicts)
+    const outcome = await mergeSequential("branch-2", "main", repoPath, abortResolver);
+    expect(outcome.kind).toBe("conflict");
+    if (outcome.kind === "conflict") {
+      expect(outcome.resolved).toBe(false);
+      expect(outcome.conflictFiles).toContain("shared.ts");
+    }
+  });
+
+  it("handles branch with no new commits", async () => {
+    // Create a branch from main with no additional commits
+    const { runGit } = await import("@koi/git-utils");
+    await runGit(["branch", "empty-branch"], repoPath);
+
+    const outcome = await mergeSequential("empty-branch", "main", repoPath, abortResolver);
+
+    // Git merge with no changes should succeed (already up to date)
+    // The merge --no-ff may fail or succeed depending on git behavior
+    // Either merged or failed is acceptable for empty branch
+    expect(["merged", "failed"]).toContain(outcome.kind);
+  });
+
+  it("handles same-file modification across branches with different files", async () => {
+    await createBranchWithChange(repoPath, "feature-x", "x.ts", "export const x = 'x';\n");
+    await createBranchWithChange(repoPath, "feature-y", "y.ts", "export const y = 'y';\n");
+    await createBranchWithChange(repoPath, "feature-z", "z.ts", "export const z = 'z';\n");
+
+    const outcomes = [];
+    for (const branch of ["feature-x", "feature-y", "feature-z"]) {
+      const outcome = await mergeSequential(branch, "main", repoPath, abortResolver);
+      outcomes.push(outcome);
+    }
+
+    // All should succeed since they touch different files
+    expect(outcomes.every((o) => o.kind === "merged")).toBe(true);
+  });
+});

--- a/packages/worktree-merge/src/execute-merge.ts
+++ b/packages/worktree-merge/src/execute-merge.ts
@@ -1,0 +1,381 @@
+/**
+ * Main entry point for branch reconciliation.
+ *
+ * Orchestrates topological ordering, strategy dispatch, verification,
+ * and abort handling into a single executeMerge() call.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { gitCheckout, gitResetHard, gitRevParseBranch, gitRevParseHead } from "./git-operations.js";
+import { mergeOctopusLevel } from "./merge-octopus.js";
+import { computeMergeLevels } from "./merge-order.js";
+import { mergeRebaseChain } from "./merge-rebase-chain.js";
+import { mergeSequential } from "./merge-sequential.js";
+import type {
+  BranchMergeOutcome,
+  ConflictResolverFn,
+  MergeBranch,
+  MergeConfig,
+  MergeEvent,
+  MergeResult,
+  MergeStrategyFn,
+} from "./types.js";
+import { validateMergeConfig } from "./types.js";
+
+/** Default conflict resolver: always aborts (fail-fast). */
+const DEFAULT_CONFLICT_RESOLVER: ConflictResolverFn = async () => ({
+  kind: "abort" as const,
+});
+
+/** Execute a merge plan according to the given configuration. */
+export async function executeMerge(config: MergeConfig): Promise<Result<MergeResult, KoiError>> {
+  const startTime = performance.now();
+  const emit = config.onEvent ?? (() => {});
+  const resolveConflict = config.resolveConflict ?? DEFAULT_CONFLICT_RESOLVER;
+  const verifyAfter = config.verifyAfter ?? "levels";
+
+  // 1. Validate config
+  const validation = validateMergeConfig(config);
+  if (!validation.ok) return validation;
+
+  // 2. Handle zero-branch case
+  if (config.branches.length === 0) {
+    return {
+      ok: true,
+      value: {
+        strategy: config.strategy,
+        targetBranch: config.targetBranch,
+        mergeOrder: [],
+        outcomes: new Map(),
+        verified: true,
+        durationMs: performance.now() - startTime,
+        aborted: false,
+      },
+    };
+  }
+
+  // 3. Compute merge levels
+  const levelsResult = computeMergeLevels(config.branches);
+  if (!levelsResult.ok) return levelsResult;
+  const levels = levelsResult.value;
+
+  // Flat ordered list for result
+  const mergeOrder = levels.flat();
+  const total = mergeOrder.length;
+
+  // Lookup map for expectedRef checks
+  const branchByName = new Map(config.branches.map((b) => [b.name, b]));
+
+  // 4. Capture restore point
+  const headResult = await gitRevParseHead(config.repoPath);
+  if (!headResult.ok) return headResult;
+  const restoreRef = headResult.value;
+
+  // Ensure we're on the target branch
+  const checkoutResult = await gitCheckout(config.targetBranch, config.repoPath);
+  if (!checkoutResult.ok) return checkoutResult;
+
+  // 5. Track abort state
+  let aborted = false;
+  const onAbort = (): void => {
+    aborted = true;
+  };
+  config.signal?.addEventListener("abort", onAbort, { once: true });
+
+  // 6. Process levels
+  const outcomes = new Map<string, BranchMergeOutcome>();
+  let globalIndex = 0;
+  let verified = false;
+  const mergedBranches: string[] = [];
+
+  try {
+    for (let levelIdx = 0; levelIdx < levels.length; levelIdx++) {
+      // Safe: loop guard ensures index is in bounds
+      const level = levels[levelIdx] as readonly string[];
+
+      if (aborted) break;
+
+      emit({
+        kind: "level:started",
+        level: levelIdx,
+        branches: level,
+      });
+
+      if (config.strategy === "octopus") {
+        // Stale-branch guard: check each branch before octopus merge
+        const freshBranches: string[] = [];
+        for (const branch of level) {
+          const branchDef = branchByName.get(branch);
+          const staleOutcome = branchDef
+            ? await checkStaleBranch(branchDef, config.repoPath)
+            : undefined;
+          if (staleOutcome) {
+            outcomes.set(branch, staleOutcome);
+            emitOutcome(emit, branch, staleOutcome);
+          } else {
+            freshBranches.push(branch);
+          }
+        }
+
+        // Octopus: try batch merge per level (only fresh branches)
+        const levelOutcomes = await mergeOctopusLevel(
+          freshBranches,
+          config.targetBranch,
+          config.repoPath,
+          resolveConflict,
+        );
+        for (const branch of level) {
+          if (aborted) break;
+          // Skip branches already handled by staleness check
+          if (outcomes.has(branch)) {
+            globalIndex++;
+            continue;
+          }
+          const outcome = levelOutcomes.get(branch);
+          if (outcome) {
+            emit({
+              kind: "merge:started",
+              branch,
+              index: globalIndex,
+              total,
+            });
+            emitOutcome(emit, branch, outcome);
+            outcomes.set(branch, outcome);
+            if (outcome.kind === "merged" || (outcome.kind === "conflict" && outcome.resolved)) {
+              mergedBranches.push(branch);
+            }
+          }
+          globalIndex++;
+        }
+      } else {
+        // Sequential or rebase-chain: process branches one by one
+        const strategyFn = selectStrategy(config.strategy);
+
+        for (const branch of level) {
+          if (aborted) break;
+
+          emit({
+            kind: "merge:started",
+            branch,
+            index: globalIndex,
+            total,
+          });
+
+          // Stale-branch guard: skip if expectedRef doesn't match
+          const branchDef = branchByName.get(branch);
+          const staleOutcome = branchDef
+            ? await checkStaleBranch(branchDef, config.repoPath)
+            : undefined;
+
+          const outcome =
+            staleOutcome ??
+            (await strategyFn(branch, config.targetBranch, config.repoPath, resolveConflict));
+
+          emitOutcome(emit, branch, outcome);
+          outcomes.set(branch, outcome);
+          if (outcome.kind === "merged" || (outcome.kind === "conflict" && outcome.resolved)) {
+            mergedBranches.push(branch);
+          }
+          globalIndex++;
+
+          // Verify after each branch if configured
+          if (verifyAfter === "each" && config.verify && !aborted) {
+            const verifyResult = await runVerify(config, mergedBranches, emit);
+            if (!verifyResult.passed) {
+              // Revert to restore point
+              await gitResetHard(restoreRef, config.repoPath);
+              return {
+                ok: true,
+                value: {
+                  strategy: config.strategy,
+                  targetBranch: config.targetBranch,
+                  mergeOrder,
+                  outcomes,
+                  verified: false,
+                  durationMs: performance.now() - startTime,
+                  aborted: false,
+                },
+              };
+            }
+          }
+        }
+      }
+
+      if (!aborted) {
+        emit({ kind: "level:completed", level: levelIdx });
+      }
+
+      // Verify after each level if configured
+      if (verifyAfter === "levels" && config.verify && !aborted) {
+        const verifyResult = await runVerify(config, mergedBranches, emit);
+        if (!verifyResult.passed) {
+          await gitResetHard(restoreRef, config.repoPath);
+          return {
+            ok: true,
+            value: {
+              strategy: config.strategy,
+              targetBranch: config.targetBranch,
+              mergeOrder,
+              outcomes,
+              verified: false,
+              durationMs: performance.now() - startTime,
+              aborted: false,
+            },
+          };
+        }
+      }
+    }
+
+    // 7. Handle abort
+    if (aborted) {
+      await gitResetHard(restoreRef, config.repoPath);
+      emit({ kind: "aborted", restoreRef });
+      return {
+        ok: true,
+        value: {
+          strategy: config.strategy,
+          targetBranch: config.targetBranch,
+          mergeOrder,
+          outcomes,
+          verified: false,
+          durationMs: performance.now() - startTime,
+          aborted: true,
+        },
+      };
+    }
+
+    // 8. Final verify if configured
+    if (verifyAfter === "all" && config.verify) {
+      const verifyResult = await runVerify(config, mergedBranches, emit);
+      verified = verifyResult.passed;
+      if (!verified) {
+        await gitResetHard(restoreRef, config.repoPath);
+      }
+    } else if (config.verify) {
+      // Already verified per-level or per-each
+      verified = true;
+    } else {
+      // No verify function — mark as verified
+      verified = true;
+    }
+
+    return {
+      ok: true,
+      value: {
+        strategy: config.strategy,
+        targetBranch: config.targetBranch,
+        mergeOrder,
+        outcomes,
+        verified,
+        durationMs: performance.now() - startTime,
+        aborted: false,
+      },
+    };
+  } catch (e: unknown) {
+    // Unexpected failure — restore and report
+    await gitResetHard(restoreRef, config.repoPath);
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL",
+        message: `executeMerge failed: ${e instanceof Error ? e.message : String(e)}`,
+        retryable: false,
+        cause: e,
+      },
+    };
+  } finally {
+    config.signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+/** Select the strategy function based on kind. */
+function selectStrategy(kind: "sequential" | "rebase-chain"): MergeStrategyFn {
+  switch (kind) {
+    case "sequential":
+      return mergeSequential;
+    case "rebase-chain":
+      return mergeRebaseChain;
+  }
+}
+
+/** Run the verify function and emit events. */
+async function runVerify(
+  config: MergeConfig,
+  mergedBranches: readonly string[],
+  emit: (event: MergeEvent) => void,
+): Promise<{ readonly passed: boolean }> {
+  if (!config.verify) return { passed: true };
+
+  emit({ kind: "verify:started", branches: mergedBranches });
+
+  try {
+    const headResult = await gitRevParseHead(config.repoPath);
+    const mergedRef = headResult.ok ? headResult.value : "unknown";
+    const result = await config.verify(mergedRef, mergedBranches);
+
+    if (result.passed) {
+      emit({ kind: "verify:passed" });
+    } else {
+      emit({
+        kind: "verify:failed",
+        message: result.message ?? "Verification failed",
+      });
+    }
+
+    return { passed: result.passed };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    emit({ kind: "verify:failed", message });
+    return { passed: false };
+  }
+}
+
+/**
+ * Check if a branch tip matches expectedRef (stale-branch guard).
+ * Returns a "skipped" outcome if stale, or undefined to proceed.
+ */
+async function checkStaleBranch(
+  branchDef: MergeBranch,
+  repoPath: string,
+): Promise<BranchMergeOutcome | undefined> {
+  if (branchDef.expectedRef === undefined) return undefined;
+
+  const actual = await gitRevParseBranch(branchDef.name, repoPath);
+  if (!actual.ok) {
+    return { kind: "failed", error: actual.error };
+  }
+
+  if (actual.value !== branchDef.expectedRef) {
+    return {
+      kind: "skipped",
+      reason: `Branch "${branchDef.name}" is stale: expected ${branchDef.expectedRef.slice(0, 8)}, actual ${actual.value.slice(0, 8)}`,
+    };
+  }
+
+  return undefined;
+}
+
+/** Emit the appropriate event for a branch outcome. */
+function emitOutcome(
+  emit: (event: MergeEvent) => void,
+  branch: string,
+  outcome: BranchMergeOutcome,
+): void {
+  switch (outcome.kind) {
+    case "merged":
+      emit({ kind: "merge:completed", branch, commitSha: outcome.commitSha });
+      break;
+    case "conflict":
+      emit({ kind: "merge:conflict", branch, files: outcome.conflictFiles });
+      break;
+    case "skipped":
+      emit({ kind: "merge:skipped", branch, reason: outcome.reason });
+      break;
+    case "failed":
+      emit({ kind: "merge:failed", branch, error: outcome.error });
+      break;
+    case "reverted":
+      emit({ kind: "merge:reverted", branch, reason: outcome.reason });
+      break;
+  }
+}

--- a/packages/worktree-merge/src/git-operations.test.ts
+++ b/packages/worktree-merge/src/git-operations.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runGit } from "@koi/git-utils";
+import {
+  gitBranchExists,
+  gitCheckout,
+  gitDiffConflictFiles,
+  gitMergeNoFf,
+  gitResetHard,
+  gitRevParseBranch,
+  gitRevParseHead,
+} from "./git-operations.js";
+
+let repoPath: string;
+
+beforeEach(async () => {
+  repoPath = await mkdtemp(join(tmpdir(), "koi-gitops-test-"));
+  await runGit(["init", "--initial-branch=main"], repoPath);
+  await runGit(["config", "user.email", "test@koi.dev"], repoPath);
+  await runGit(["config", "user.name", "Koi Test"], repoPath);
+  await Bun.write(join(repoPath, "README.md"), "# Test\n");
+  await runGit(["add", "README.md"], repoPath);
+  await runGit(["commit", "-m", "initial"], repoPath);
+});
+
+afterEach(async () => {
+  await rm(repoPath, { recursive: true, force: true });
+});
+
+describe("gitRevParseHead", () => {
+  it("returns the HEAD sha", async () => {
+    const result = await gitRevParseHead(repoPath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+});
+
+describe("gitMergeNoFf", () => {
+  it("returns commit sha on successful merge", async () => {
+    await runGit(["checkout", "-b", "feature"], repoPath);
+    await Bun.write(join(repoPath, "feat.ts"), "feat\n");
+    await runGit(["add", "feat.ts"], repoPath);
+    await runGit(["commit", "-m", "add feat"], repoPath);
+    await runGit(["checkout", "main"], repoPath);
+
+    const result = await gitMergeNoFf("feature", repoPath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it("returns error on merge failure", async () => {
+    const result = await gitMergeNoFf("nonexistent", repoPath);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("gitResetHard", () => {
+  it("resets to a ref", async () => {
+    const head1 = await gitRevParseHead(repoPath);
+    await Bun.write(join(repoPath, "new.ts"), "new\n");
+    await runGit(["add", "new.ts"], repoPath);
+    await runGit(["commit", "-m", "new commit"], repoPath);
+
+    if (head1.ok) {
+      const result = await gitResetHard(head1.value, repoPath);
+      expect(result).toEqual({ ok: true, value: undefined });
+      const head2 = await gitRevParseHead(repoPath);
+      expect(head2.ok && head2.value).toBe(head1.value);
+    }
+  });
+});
+
+describe("gitDiffConflictFiles", () => {
+  it("returns empty for clean repo", async () => {
+    const result = await gitDiffConflictFiles(repoPath);
+    expect(result).toEqual({ ok: true, value: [] });
+  });
+});
+
+describe("gitBranchExists", () => {
+  it("returns true for existing branch", async () => {
+    const result = await gitBranchExists("main", repoPath);
+    expect(result).toEqual({ ok: true, value: true });
+  });
+
+  it("returns false for nonexistent branch", async () => {
+    const result = await gitBranchExists("nonexistent", repoPath);
+    expect(result).toEqual({ ok: true, value: false });
+  });
+});
+
+describe("gitCheckout", () => {
+  it("switches branch", async () => {
+    await runGit(["branch", "develop"], repoPath);
+    const result = await gitCheckout("develop", repoPath);
+    expect(result).toEqual({ ok: true, value: undefined });
+  });
+});
+
+describe("gitRevParseBranch", () => {
+  it("returns the SHA for an existing branch", async () => {
+    const result = await gitRevParseBranch("main", repoPath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it("returns error for nonexistent branch", async () => {
+    const result = await gitRevParseBranch("nonexistent", repoPath);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/worktree-merge/src/git-operations.ts
+++ b/packages/worktree-merge/src/git-operations.ts
@@ -1,0 +1,106 @@
+/**
+ * Typed wrappers around runGit for merge-specific git operations.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { runGit } from "@koi/git-utils";
+
+/** Merge a branch with --no-ff (creates a merge commit). */
+export async function gitMergeNoFf(branch: string, cwd: string): Promise<Result<string, KoiError>> {
+  const result = await runGit(["merge", "--no-ff", branch, "-m", `Merge branch '${branch}'`], cwd);
+  if (!result.ok) return result;
+  return gitRevParseHead(cwd);
+}
+
+/** Octopus merge: merge multiple branches at once. */
+export async function gitMergeOctopus(
+  branches: readonly string[],
+  cwd: string,
+): Promise<Result<string, KoiError>> {
+  const result = await runGit(
+    ["merge", ...branches, "-m", `Octopus merge: ${branches.join(", ")}`],
+    cwd,
+  );
+  if (!result.ok) return result;
+  return gitRevParseHead(cwd);
+}
+
+/** Rebase a branch onto target, then fast-forward merge. */
+export async function gitRebase(
+  onto: string,
+  branch: string,
+  cwd: string,
+): Promise<Result<string, KoiError>> {
+  const rebaseResult = await runGit(["rebase", onto, branch], cwd);
+  if (!rebaseResult.ok) return rebaseResult;
+  // Switch to the target branch and fast-forward
+  const checkoutResult = await runGit(["checkout", onto], cwd);
+  if (!checkoutResult.ok) return checkoutResult;
+  const ffResult = await runGit(["merge", "--ff-only", branch], cwd);
+  if (!ffResult.ok) return ffResult;
+  return gitRevParseHead(cwd);
+}
+
+/** Hard reset to a ref. Side-effect: destroys uncommitted changes. */
+export async function gitResetHard(ref: string, cwd: string): Promise<Result<void, KoiError>> {
+  const result = await runGit(["reset", "--hard", ref], cwd);
+  if (!result.ok) return result;
+  return { ok: true, value: undefined };
+}
+
+/** Get the current HEAD commit SHA. */
+export async function gitRevParseHead(cwd: string): Promise<Result<string, KoiError>> {
+  return runGit(["rev-parse", "HEAD"], cwd);
+}
+
+/** Abort an in-progress merge. */
+export async function gitMergeAbort(cwd: string): Promise<Result<void, KoiError>> {
+  const result = await runGit(["merge", "--abort"], cwd);
+  if (!result.ok) return result;
+  return { ok: true, value: undefined };
+}
+
+/** Abort an in-progress rebase. */
+export async function gitRebaseAbort(cwd: string): Promise<Result<void, KoiError>> {
+  const result = await runGit(["rebase", "--abort"], cwd);
+  if (!result.ok) return result;
+  return { ok: true, value: undefined };
+}
+
+/** List files with merge conflicts. */
+export async function gitDiffConflictFiles(
+  cwd: string,
+): Promise<Result<readonly string[], KoiError>> {
+  const result = await runGit(["diff", "--name-only", "--diff-filter=U"], cwd);
+  if (!result.ok) return result;
+  const files = result.value.split("\n").filter((f) => f.length > 0);
+  return { ok: true, value: files };
+}
+
+/** Resolve a local branch name to its tip SHA. */
+export async function gitRevParseBranch(
+  branch: string,
+  cwd: string,
+): Promise<Result<string, KoiError>> {
+  return runGit(["rev-parse", `refs/heads/${branch}`], cwd);
+}
+
+/** Check if a branch exists locally. */
+export async function gitBranchExists(
+  branch: string,
+  cwd: string,
+): Promise<Result<boolean, KoiError>> {
+  const result = await runGit(["rev-parse", "--verify", `refs/heads/${branch}`], cwd);
+  if (result.ok) return { ok: true, value: true };
+  if (result.error.code === "EXTERNAL") {
+    return { ok: true, value: false };
+  }
+  return result;
+}
+
+/** Ensure we're on the specified branch. */
+export async function gitCheckout(branch: string, cwd: string): Promise<Result<void, KoiError>> {
+  const result = await runGit(["checkout", branch], cwd);
+  if (!result.ok) return result;
+  return { ok: true, value: undefined };
+}

--- a/packages/worktree-merge/src/index.ts
+++ b/packages/worktree-merge/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @koi/worktree-merge — Branch reconciliation for parallel worktree-based agent work.
+ *
+ * Provides topological ordering, strategy-based merging, pluggable conflict
+ * resolution, configurable verification gates, and structured result reporting.
+ */
+
+export { executeMerge } from "./execute-merge.js";
+export { mergeOctopus, mergeOctopusLevel } from "./merge-octopus.js";
+export { computeMergeLevels, computeMergeOrder } from "./merge-order.js";
+export { mergeRebaseChain } from "./merge-rebase-chain.js";
+export { mergeSequential } from "./merge-sequential.js";
+export type {
+  BranchMergeOutcome,
+  ConflictInfo,
+  ConflictResolution,
+  ConflictResolverFn,
+  MergeBranch,
+  MergeConfig,
+  MergeEvent,
+  MergeResult,
+  MergeStrategyFn,
+  MergeStrategyKind,
+  VerifyAfter,
+  VerifyFn,
+  VerifyResult,
+} from "./types.js";
+export { validateMergeConfig } from "./types.js";

--- a/packages/worktree-merge/src/merge-octopus.ts
+++ b/packages/worktree-merge/src/merge-octopus.ts
@@ -1,0 +1,76 @@
+/**
+ * Octopus merge strategy: merge multiple branches at once.
+ *
+ * Only works for conflict-free branches at the same level. On conflict,
+ * falls back to sequential merging of individual branches.
+ */
+
+import { gitMergeOctopus, gitResetHard, gitRevParseHead } from "./git-operations.js";
+import { mergeSequential } from "./merge-sequential.js";
+import type { BranchMergeOutcome, ConflictResolverFn } from "./types.js";
+
+/** Merge a single branch via octopus (delegates to git merge). */
+export async function mergeOctopus(
+  branch: string,
+  targetBranch: string,
+  repoPath: string,
+  resolveConflict: ConflictResolverFn,
+): Promise<BranchMergeOutcome> {
+  // Single-branch octopus is just a regular merge
+  return mergeSequential(branch, targetBranch, repoPath, resolveConflict);
+}
+
+/**
+ * Attempt an octopus merge of all branches in a level.
+ *
+ * Returns outcomes per branch. If octopus fails, resets and
+ * falls back to sequential merging.
+ */
+export async function mergeOctopusLevel(
+  branches: readonly string[],
+  targetBranch: string,
+  repoPath: string,
+  resolveConflict: ConflictResolverFn,
+): Promise<ReadonlyMap<string, BranchMergeOutcome>> {
+  if (branches.length === 0) {
+    return new Map();
+  }
+
+  if (branches.length === 1) {
+    // Safe: length check above guarantees index 0 exists
+    const name = branches[0] as string;
+    const outcome = await mergeSequential(name, targetBranch, repoPath, resolveConflict);
+    return new Map([[name, outcome]]);
+  }
+
+  // Capture restore point for rollback
+  const headResult = await gitRevParseHead(repoPath);
+  if (!headResult.ok) {
+    const outcomes = new Map<string, BranchMergeOutcome>();
+    for (const branch of branches) {
+      outcomes.set(branch, { kind: "failed", error: headResult.error });
+    }
+    return outcomes;
+  }
+  const restoreRef = headResult.value;
+
+  // Try octopus merge
+  const octopusResult = await gitMergeOctopus(branches, repoPath);
+  if (octopusResult.ok) {
+    const outcomes = new Map<string, BranchMergeOutcome>();
+    for (const branch of branches) {
+      outcomes.set(branch, { kind: "merged", commitSha: octopusResult.value });
+    }
+    return outcomes;
+  }
+
+  // Octopus failed — reset and fall back to sequential
+  await gitResetHard(restoreRef, repoPath);
+
+  const outcomes = new Map<string, BranchMergeOutcome>();
+  for (const branch of branches) {
+    const outcome = await mergeSequential(branch, targetBranch, repoPath, resolveConflict);
+    outcomes.set(branch, outcome);
+  }
+  return outcomes;
+}

--- a/packages/worktree-merge/src/merge-order.test.ts
+++ b/packages/worktree-merge/src/merge-order.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { computeMergeLevels, computeMergeOrder } from "./merge-order.js";
+import type { MergeBranch } from "./types.js";
+
+describe("computeMergeOrder", () => {
+  it("returns empty array for empty input", () => {
+    const result = computeMergeOrder([]);
+    expect(result).toEqual({ ok: true, value: [] });
+  });
+
+  it("handles single branch with no deps", () => {
+    const result = computeMergeOrder([{ name: "a", dependsOn: [] }]);
+    expect(result).toEqual({ ok: true, value: ["a"] });
+  });
+
+  it("orders two independent branches alphabetically", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "b", dependsOn: [] },
+      { name: "a", dependsOn: [] },
+    ];
+    const result = computeMergeOrder(branches);
+    expect(result).toEqual({ ok: true, value: ["a", "b"] });
+  });
+
+  it("orders chain: c depends on b depends on a", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "c", dependsOn: ["b"] },
+      { name: "a", dependsOn: [] },
+      { name: "b", dependsOn: ["a"] },
+    ];
+    const result = computeMergeOrder(branches);
+    expect(result).toEqual({ ok: true, value: ["a", "b", "c"] });
+  });
+
+  it("orders diamond dependency: d depends on b,c; b,c depend on a", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "d", dependsOn: ["b", "c"] },
+      { name: "b", dependsOn: ["a"] },
+      { name: "c", dependsOn: ["a"] },
+      { name: "a", dependsOn: [] },
+    ];
+    const result = computeMergeOrder(branches);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value[0]).toBe("a");
+      expect(result.value.indexOf("b")).toBeLessThan(result.value.indexOf("d"));
+      expect(result.value.indexOf("c")).toBeLessThan(result.value.indexOf("d"));
+    }
+  });
+
+  it("detects cycle: a -> b -> a", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "a", dependsOn: ["b"] },
+      { name: "b", dependsOn: ["a"] },
+    ];
+    const result = computeMergeOrder(branches);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("Cycle");
+    }
+  });
+
+  it("detects 3-node cycle: a -> b -> c -> a", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "a", dependsOn: ["c"] },
+      { name: "b", dependsOn: ["a"] },
+      { name: "c", dependsOn: ["b"] },
+    ];
+    const result = computeMergeOrder(branches);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("computeMergeLevels", () => {
+  it("returns empty array for empty input", () => {
+    const result = computeMergeLevels([]);
+    expect(result).toEqual({ ok: true, value: [] });
+  });
+
+  it("places independent branches in same level", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "a", dependsOn: [] },
+      { name: "b", dependsOn: [] },
+      { name: "c", dependsOn: [] },
+    ];
+    const result = computeMergeLevels(branches);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  it("separates chain into levels", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "c", dependsOn: ["b"] },
+      { name: "a", dependsOn: [] },
+      { name: "b", dependsOn: ["a"] },
+    ];
+    const result = computeMergeLevels(branches);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([["a"], ["b"], ["c"]]);
+    }
+  });
+
+  it("handles diamond dependency with correct levels", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "d", dependsOn: ["b", "c"] },
+      { name: "b", dependsOn: ["a"] },
+      { name: "c", dependsOn: ["a"] },
+      { name: "a", dependsOn: [] },
+    ];
+    const result = computeMergeLevels(branches);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([["a"], ["b", "c"], ["d"]]);
+    }
+  });
+
+  it("detects cycle", () => {
+    const branches: readonly MergeBranch[] = [
+      { name: "a", dependsOn: ["b"] },
+      { name: "b", dependsOn: ["a"] },
+    ];
+    const result = computeMergeLevels(branches);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+});

--- a/packages/worktree-merge/src/merge-order.ts
+++ b/packages/worktree-merge/src/merge-order.ts
@@ -1,0 +1,169 @@
+/**
+ * Topological ordering for merge branches.
+ *
+ * Uses Kahn's algorithm to compute a merge order that respects
+ * dependency constraints, and groups branches into independence levels.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import type { MergeBranch } from "./types.js";
+
+/**
+ * Compute topological merge order via Kahn's algorithm.
+ *
+ * Returns branch names in an order where every branch appears after
+ * all of its dependencies. Returns an error if a cycle is detected.
+ */
+export function computeMergeOrder(
+  branches: readonly MergeBranch[],
+): Result<readonly string[], KoiError> {
+  if (branches.length === 0) {
+    return { ok: true, value: [] };
+  }
+
+  const names = new Set(branches.map((b) => b.name));
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, readonly string[]>();
+
+  for (const branch of branches) {
+    inDegree.set(branch.name, 0);
+    adjacency.set(branch.name, []);
+  }
+
+  for (const branch of branches) {
+    for (const dep of branch.dependsOn) {
+      if (!names.has(dep)) continue;
+      const current = inDegree.get(branch.name) ?? 0;
+      inDegree.set(branch.name, current + 1);
+      const existing = adjacency.get(dep) ?? [];
+      adjacency.set(dep, [...existing, branch.name]);
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [name, degree] of inDegree) {
+    if (degree === 0) {
+      queue.push(name);
+    }
+  }
+  // Sort for deterministic output
+  queue.sort();
+
+  const order: string[] = [];
+
+  // Kahn's algorithm: process zero-degree nodes
+  while (queue.length > 0) {
+    // Safe: loop guard ensures queue is non-empty
+    const current = queue.shift() as string;
+    order.push(current);
+
+    const dependents = adjacency.get(current) ?? [];
+    const newReady: string[] = [];
+    for (const dep of dependents) {
+      const degree = (inDegree.get(dep) ?? 1) - 1;
+      inDegree.set(dep, degree);
+      if (degree === 0) {
+        newReady.push(dep);
+      }
+    }
+    // Sort newly ready nodes for deterministic ordering
+    newReady.sort();
+    for (const n of newReady) {
+      queue.push(n);
+    }
+  }
+
+  if (order.length !== branches.length) {
+    const remaining = branches.filter((b) => !order.includes(b.name)).map((b) => b.name);
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `Cycle detected among branches: ${remaining.join(" -> ")}`,
+        retryable: false,
+        context: { cycleBranches: remaining },
+      },
+    };
+  }
+
+  return { ok: true, value: order };
+}
+
+/**
+ * Group branches into independence levels (same BFS depth).
+ *
+ * Each level contains branches that can be processed after all
+ * branches in previous levels have completed. Within a level,
+ * branches are independent of each other.
+ */
+export function computeMergeLevels(
+  branches: readonly MergeBranch[],
+): Result<readonly (readonly string[])[], KoiError> {
+  if (branches.length === 0) {
+    return { ok: true, value: [] };
+  }
+
+  const names = new Set(branches.map((b) => b.name));
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, readonly string[]>();
+
+  for (const branch of branches) {
+    inDegree.set(branch.name, 0);
+    adjacency.set(branch.name, []);
+  }
+
+  for (const branch of branches) {
+    for (const dep of branch.dependsOn) {
+      if (!names.has(dep)) continue;
+      const current = inDegree.get(branch.name) ?? 0;
+      inDegree.set(branch.name, current + 1);
+      const existing = adjacency.get(dep) ?? [];
+      adjacency.set(dep, [...existing, branch.name]);
+    }
+  }
+
+  let currentLevel: string[] = [];
+  for (const [name, degree] of inDegree) {
+    if (degree === 0) {
+      currentLevel.push(name);
+    }
+  }
+  currentLevel.sort();
+
+  const levels: (readonly string[])[] = [];
+  let processed = 0;
+
+  while (currentLevel.length > 0) {
+    levels.push(currentLevel);
+    processed += currentLevel.length;
+
+    const nextLevel: string[] = [];
+    for (const current of currentLevel) {
+      const dependents = adjacency.get(current) ?? [];
+      for (const dep of dependents) {
+        const degree = (inDegree.get(dep) ?? 1) - 1;
+        inDegree.set(dep, degree);
+        if (degree === 0) {
+          nextLevel.push(dep);
+        }
+      }
+    }
+    nextLevel.sort();
+    currentLevel = nextLevel;
+  }
+
+  if (processed !== branches.length) {
+    const remaining = branches.filter((b) => (inDegree.get(b.name) ?? 0) > 0).map((b) => b.name);
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `Cycle detected among branches: ${remaining.join(" -> ")}`,
+        retryable: false,
+        context: { cycleBranches: remaining },
+      },
+    };
+  }
+
+  return { ok: true, value: levels };
+}

--- a/packages/worktree-merge/src/merge-rebase-chain.ts
+++ b/packages/worktree-merge/src/merge-rebase-chain.ts
@@ -1,0 +1,73 @@
+/**
+ * Rebase-chain merge strategy: rebase each branch onto target, then ff merge.
+ *
+ * Rewrites history (documented as explicit tradeoff). On conflict during
+ * replay, calls the conflict resolver. If resolution fails, aborts rebase.
+ */
+
+import {
+  gitCheckout,
+  gitDiffConflictFiles,
+  gitRebase,
+  gitRebaseAbort,
+  gitRevParseHead,
+} from "./git-operations.js";
+import type { BranchMergeOutcome, ConflictResolverFn } from "./types.js";
+
+/** Rebase a branch onto target, then fast-forward merge. */
+export async function mergeRebaseChain(
+  branch: string,
+  targetBranch: string,
+  repoPath: string,
+  resolveConflict: ConflictResolverFn,
+): Promise<BranchMergeOutcome> {
+  // Ensure we're on the target branch first
+  const checkoutResult = await gitCheckout(targetBranch, repoPath);
+  if (!checkoutResult.ok) {
+    return { kind: "failed", error: checkoutResult.error };
+  }
+
+  const rebaseResult = await gitRebase(targetBranch, branch, repoPath);
+
+  if (rebaseResult.ok) {
+    return { kind: "merged", commitSha: rebaseResult.value };
+  }
+
+  // Check if this is a rebase conflict
+  const conflictFilesResult = await gitDiffConflictFiles(repoPath);
+  if (!conflictFilesResult.ok || conflictFilesResult.value.length === 0) {
+    // Not a conflict — abort rebase and return failure
+    await gitRebaseAbort(repoPath);
+    // Switch back to target
+    await gitCheckout(targetBranch, repoPath);
+    return { kind: "failed", error: rebaseResult.error };
+  }
+
+  const conflictFiles = conflictFilesResult.value;
+  const headResult = await gitRevParseHead(repoPath);
+  const targetRef = headResult.ok ? headResult.value : "unknown";
+
+  const resolution = await resolveConflict({
+    branch,
+    conflictFiles,
+    targetRef,
+    branchRef: branch,
+  });
+
+  if (resolution.kind === "resolved") {
+    return {
+      kind: "conflict",
+      conflictFiles,
+      resolved: true,
+    };
+  }
+
+  // Resolution was aborted — revert rebase
+  await gitRebaseAbort(repoPath);
+  await gitCheckout(targetBranch, repoPath);
+  return {
+    kind: "conflict",
+    conflictFiles,
+    resolved: false,
+  };
+}

--- a/packages/worktree-merge/src/merge-sequential.ts
+++ b/packages/worktree-merge/src/merge-sequential.ts
@@ -1,0 +1,63 @@
+/**
+ * Sequential merge strategy: git merge --no-ff for each branch.
+ *
+ * On conflict: calls the conflict resolver. If resolution fails or
+ * is aborted, reverts the merge attempt.
+ */
+
+import {
+  gitDiffConflictFiles,
+  gitMergeAbort,
+  gitMergeNoFf,
+  gitRevParseHead,
+} from "./git-operations.js";
+import type { BranchMergeOutcome, ConflictResolverFn } from "./types.js";
+
+/** Merge a single branch using --no-ff. */
+export async function mergeSequential(
+  branch: string,
+  _targetBranch: string,
+  repoPath: string,
+  resolveConflict: ConflictResolverFn,
+): Promise<BranchMergeOutcome> {
+  const mergeResult = await gitMergeNoFf(branch, repoPath);
+
+  if (mergeResult.ok) {
+    return { kind: "merged", commitSha: mergeResult.value };
+  }
+
+  // Check if this is a merge conflict (not a different error)
+  const conflictFilesResult = await gitDiffConflictFiles(repoPath);
+  if (!conflictFilesResult.ok || conflictFilesResult.value.length === 0) {
+    // Not a conflict — abort merge state and return failure
+    await gitMergeAbort(repoPath);
+    return { kind: "failed", error: mergeResult.error };
+  }
+
+  const conflictFiles = conflictFilesResult.value;
+  const headResult = await gitRevParseHead(repoPath);
+  const targetRef = headResult.ok ? headResult.value : "unknown";
+
+  const resolution = await resolveConflict({
+    branch,
+    conflictFiles,
+    targetRef,
+    branchRef: branch,
+  });
+
+  if (resolution.kind === "resolved") {
+    return {
+      kind: "conflict",
+      conflictFiles,
+      resolved: true,
+    };
+  }
+
+  // Resolution was aborted — revert merge
+  await gitMergeAbort(repoPath);
+  return {
+    kind: "conflict",
+    conflictFiles,
+    resolved: false,
+  };
+}

--- a/packages/worktree-merge/src/types.test.ts
+++ b/packages/worktree-merge/src/types.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import type { MergeConfig } from "./types.js";
+import { validateMergeConfig } from "./types.js";
+
+const BASE_CONFIG: MergeConfig = {
+  repoPath: "/tmp/repo",
+  targetBranch: "main",
+  branches: [],
+  strategy: "sequential",
+};
+
+describe("validateMergeConfig", () => {
+  it("accepts empty branches", () => {
+    const result = validateMergeConfig(BASE_CONFIG);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts valid config with branches", () => {
+    const result = validateMergeConfig({
+      ...BASE_CONFIG,
+      branches: [
+        { name: "a", dependsOn: [] },
+        { name: "b", dependsOn: ["a"] },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects missing repoPath", () => {
+    const result = validateMergeConfig({
+      ...BASE_CONFIG,
+      repoPath: "",
+      branches: [{ name: "a", dependsOn: [] }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("repoPath");
+    }
+  });
+
+  it("rejects missing targetBranch", () => {
+    const result = validateMergeConfig({
+      ...BASE_CONFIG,
+      targetBranch: "",
+      branches: [{ name: "a", dependsOn: [] }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("targetBranch");
+    }
+  });
+
+  it("rejects dependency on unknown branch", () => {
+    const result = validateMergeConfig({
+      ...BASE_CONFIG,
+      branches: [{ name: "a", dependsOn: ["nonexistent"] }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("nonexistent");
+    }
+  });
+});

--- a/packages/worktree-merge/src/types.ts
+++ b/packages/worktree-merge/src/types.ts
@@ -1,0 +1,194 @@
+/**
+ * Types for branch reconciliation after parallel worktree-based agent work.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+
+// --- Input types ---
+
+/** A branch to merge, with optional ordering dependencies. */
+export interface MergeBranch {
+  readonly name: string;
+  readonly dependsOn: readonly string[];
+  /** If set, merge is skipped when branch tip differs (stale-branch guard). */
+  readonly expectedRef?: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** Merge strategy discriminant. */
+export type MergeStrategyKind = "sequential" | "octopus" | "rebase-chain";
+
+/** When to run the verify function. */
+export type VerifyAfter = "each" | "all" | "levels";
+
+/** Information about a merge conflict, passed to the resolver callback. */
+export interface ConflictInfo {
+  readonly branch: string;
+  readonly conflictFiles: readonly string[];
+  readonly targetRef: string;
+  readonly branchRef: string;
+}
+
+/** Resolution returned by the conflict resolver. */
+export type ConflictResolution =
+  | { readonly kind: "resolved"; readonly commitSha: string }
+  | { readonly kind: "abort" };
+
+/** Pluggable conflict resolution callback. */
+export type ConflictResolverFn = (conflict: ConflictInfo) => Promise<ConflictResolution>;
+
+/** Verification callback invoked after merges. */
+export type VerifyFn = (
+  mergedRef: string,
+  mergedBranches: readonly string[],
+) => Promise<VerifyResult>;
+
+/** Result of a verification step. */
+export interface VerifyResult {
+  readonly passed: boolean;
+  readonly message?: string;
+}
+
+// --- Config ---
+
+/** Full configuration for executeMerge(). */
+export interface MergeConfig {
+  readonly repoPath: string;
+  readonly targetBranch: string;
+  readonly branches: readonly MergeBranch[];
+  readonly strategy: MergeStrategyKind;
+  readonly verifyAfter?: VerifyAfter;
+  readonly verify?: VerifyFn;
+  readonly resolveConflict?: ConflictResolverFn;
+  readonly signal?: AbortSignal;
+  readonly onEvent?: (event: MergeEvent) => void;
+}
+
+// --- Events (progress notifications, not event-sourced) ---
+
+/** Discriminated union of all merge progress events. */
+export type MergeEvent =
+  | {
+      readonly kind: "merge:started";
+      readonly branch: string;
+      readonly index: number;
+      readonly total: number;
+    }
+  | {
+      readonly kind: "merge:completed";
+      readonly branch: string;
+      readonly commitSha: string;
+    }
+  | {
+      readonly kind: "merge:conflict";
+      readonly branch: string;
+      readonly files: readonly string[];
+    }
+  | {
+      readonly kind: "merge:skipped";
+      readonly branch: string;
+      readonly reason: string;
+    }
+  | {
+      readonly kind: "merge:reverted";
+      readonly branch: string;
+      readonly reason: string;
+    }
+  | {
+      readonly kind: "merge:failed";
+      readonly branch: string;
+      readonly error: KoiError;
+    }
+  | { readonly kind: "verify:started"; readonly branches: readonly string[] }
+  | { readonly kind: "verify:passed" }
+  | { readonly kind: "verify:failed"; readonly message: string }
+  | {
+      readonly kind: "level:started";
+      readonly level: number;
+      readonly branches: readonly string[];
+    }
+  | { readonly kind: "level:completed"; readonly level: number }
+  | { readonly kind: "aborted"; readonly restoreRef: string };
+
+// --- Output types ---
+
+/** Per-branch outcome after a merge attempt. */
+export type BranchMergeOutcome =
+  | { readonly kind: "merged"; readonly commitSha: string }
+  | {
+      readonly kind: "conflict";
+      readonly conflictFiles: readonly string[];
+      readonly resolved: boolean;
+    }
+  | { readonly kind: "skipped"; readonly reason: string }
+  | { readonly kind: "failed"; readonly error: KoiError }
+  | { readonly kind: "reverted"; readonly reason: string };
+
+/** Aggregate result of executeMerge(). */
+export interface MergeResult {
+  readonly strategy: MergeStrategyKind;
+  readonly targetBranch: string;
+  readonly mergeOrder: readonly string[];
+  readonly outcomes: ReadonlyMap<string, BranchMergeOutcome>;
+  readonly verified: boolean;
+  readonly durationMs: number;
+  readonly aborted: boolean;
+}
+
+/** Signature shared by all strategy functions. */
+export type MergeStrategyFn = (
+  branch: string,
+  targetBranch: string,
+  repoPath: string,
+  resolveConflict: ConflictResolverFn,
+) => Promise<BranchMergeOutcome>;
+
+// --- Config validation ---
+
+/** Validate MergeConfig, returning an error for invalid inputs. */
+export function validateMergeConfig(config: MergeConfig): Result<void, KoiError> {
+  if (config.branches.length === 0) {
+    return { ok: true, value: undefined };
+  }
+
+  if (!config.repoPath) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "repoPath is required",
+        retryable: false,
+      },
+    };
+  }
+
+  if (!config.targetBranch) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "targetBranch is required",
+        retryable: false,
+      },
+    };
+  }
+
+  const branchNames = new Set(config.branches.map((b) => b.name));
+  for (const branch of config.branches) {
+    for (const dep of branch.dependsOn) {
+      if (!branchNames.has(dep)) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: `Branch "${branch.name}" depends on unknown branch "${dep}"`,
+            retryable: false,
+            context: { branch: branch.name, dependency: dep },
+          },
+        };
+      }
+    }
+  }
+
+  return { ok: true, value: undefined };
+}

--- a/packages/worktree-merge/tsconfig.json
+++ b/packages/worktree-merge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../git-utils" }]
+}

--- a/packages/worktree-merge/tsup.config.ts
+++ b/packages/worktree-merge/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/check-layers.ts
+++ b/scripts/check-layers.ts
@@ -27,6 +27,7 @@ const L0U_PACKAGES = new Set([
   "@koi/channel-base",
   "@koi/errors",
   "@koi/execution-context",
+  "@koi/git-utils",
   "@koi/hash",
   "@koi/manifest",
   "@koi/sandbox-cloud-base",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -21,7 +21,9 @@
     "@koi/engine-external": "workspace:*",
     "@koi/canvas": "workspace:*",
     "@koi/orchestrator": "workspace:*",
-    "@koi/test-utils": "workspace:*"
+    "@koi/test-utils": "workspace:*",
+    "@koi/git-utils": "workspace:*",
+    "@koi/worktree-merge": "workspace:*"
   },
   "scripts": {
     "test": "bun test",

--- a/tests/e2e/worktree-merge-e2e.test.ts
+++ b/tests/e2e/worktree-merge-e2e.test.ts
@@ -1,0 +1,868 @@
+/**
+ * worktree-merge end-to-end validation through createKoi + createLoopAdapter.
+ *
+ * Tests the full L1 runtime path — middleware chain, tool resolution,
+ * lifecycle hooks — with worktree-merge's executeMerge as a tool, using
+ * a two-phase model handler (deterministic tool calls + real Anthropic
+ * LLM final answer).
+ *
+ * Validates:
+ * - executeMerge works through the full L1 middleware chain
+ * - All 3 merge strategies (sequential, octopus, rebase-chain)
+ * - SHA pinning (expectedRef stale-branch guard)
+ * - Conflict detection and resolver callback
+ * - Verification gates (verifyAfter: "levels")
+ * - AbortSignal cancellation
+ * - Real LLM summarization of merge results
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   bun test tests/e2e/worktree-merge-e2e.test.ts
+ *
+ * Cost: ~$0.10-0.20 per run (haiku model, multiple prompts).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ComponentProvider,
+  EngineEvent,
+  JsonObject,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  Tool,
+  ToolHandler,
+  ToolRequest,
+} from "@koi/core";
+import { toolToken } from "@koi/core/ecs";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { runGit } from "@koi/git-utils";
+import type { BranchMergeOutcome, MergeConfig, MergeEvent, MergeResult } from "@koi/worktree-merge";
+import { executeMerge } from "@koi/worktree-merge";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 90_000;
+const MODEL_NAME = "claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Git repo helpers
+// ---------------------------------------------------------------------------
+
+let repoPath: string;
+
+async function createTestRepo(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "koi-merge-e2e-"));
+  await runGit(["init", "--initial-branch=main"], path);
+  await runGit(["config", "user.email", "test@koi.dev"], path);
+  await runGit(["config", "user.name", "Koi E2E"], path);
+  await Bun.write(join(path, "README.md"), "# E2E Test\n");
+  await runGit(["add", "README.md"], path);
+  await runGit(["commit", "-m", "initial commit"], path);
+  return path;
+}
+
+async function createBranchWithChange(
+  path: string,
+  branch: string,
+  file: string,
+  content: string,
+): Promise<string> {
+  await runGit(["checkout", "-b", branch], path);
+  await Bun.write(join(path, file), content);
+  await runGit(["add", file], path);
+  await runGit(["commit", "-m", `Add ${file} on ${branch}`], path);
+  const result = await runGit(["rev-parse", "HEAD"], path);
+  if (!result.ok) throw new Error(`Failed to get HEAD: ${result.error.message}`);
+  await runGit(["checkout", "main"], path);
+  return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// L1 runtime helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+// Lazy singleton for the Anthropic adapter
+// let justified: lazily initialized on first real LLM call
+let cachedAnthropicAdapter:
+  | { readonly complete: (request: ModelRequest) => Promise<ModelResponse> }
+  | undefined;
+
+async function getAnthropicAdapter(): Promise<{
+  readonly complete: (request: ModelRequest) => Promise<ModelResponse>;
+}> {
+  if (cachedAnthropicAdapter === undefined) {
+    const { createAnthropicAdapter } = await import("@koi/model-router");
+    cachedAnthropicAdapter = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+  }
+  return cachedAnthropicAdapter;
+}
+
+function createPhasedModelHandler(phases: readonly ModelResponse[]): {
+  readonly modelCall: (request: ModelRequest) => Promise<ModelResponse>;
+  readonly callCount: () => number;
+} {
+  // let justified: mutable counter tracking which phase we're in
+  let count = 0;
+  return {
+    modelCall: async (request: ModelRequest): Promise<ModelResponse> => {
+      const phase = count;
+      count++;
+      if (phase < phases.length) {
+        // Safe: bounds-checked on the line above
+        const response = phases[phase];
+        if (response === undefined) throw new Error(`Unreachable: phase ${phase} missing`);
+        return response;
+      }
+      // Final phase: real Anthropic LLM call
+      const anthropic = await getAnthropicAdapter();
+      return anthropic.complete({ ...request, model: MODEL_NAME, maxTokens: 200 });
+    },
+    callCount: () => count,
+  };
+}
+
+function toolCallResponse(toolName: string, callId: string, input: JsonObject): ModelResponse {
+  return {
+    content: "",
+    model: MODEL_NAME,
+    usage: { inputTokens: 10, outputTokens: 15 },
+    metadata: {
+      toolCalls: [{ toolName, callId, input }],
+    },
+  };
+}
+
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-merge-tools",
+    attach: async () => {
+      const components = new Map<string, unknown>();
+      for (const tool of tools) {
+        components.set(toolToken(tool.descriptor.name), tool);
+      }
+      return components;
+    },
+  };
+}
+
+function createToolObserver(): {
+  readonly middleware: KoiMiddleware;
+  readonly interceptedToolIds: readonly string[];
+} {
+  const intercepted: string[] = []; // let justified: test accumulator
+  return {
+    middleware: {
+      name: "e2e-merge-tool-observer",
+      wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+        intercepted.push(request.toolId);
+        return next(request);
+      },
+    },
+    interceptedToolIds: intercepted,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge tool factory — wraps executeMerge as a Koi tool
+// ---------------------------------------------------------------------------
+
+function createMergeTools(): {
+  readonly tools: readonly Tool[];
+  readonly lastMergeResult: () => MergeResult | undefined;
+  readonly mergeEvents: readonly MergeEvent[];
+} {
+  // let justified: captures last merge result for assertions
+  let lastResult: MergeResult | undefined;
+  const mergeEvents: MergeEvent[] = []; // let justified: test accumulator
+
+  const mergeTool: Tool = {
+    descriptor: {
+      name: "merge_branches",
+      description: "Merge branches into target using worktree-merge. Returns merge result summary.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          strategy: { type: "string", description: "sequential | octopus | rebase-chain" },
+          branches: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                dependsOn: { type: "array", items: { type: "string" } },
+                expectedRef: { type: "string" },
+              },
+              required: ["name"],
+            },
+          },
+          targetBranch: { type: "string" },
+          verifyAfter: { type: "string" },
+        },
+        required: ["strategy", "branches", "targetBranch"],
+      },
+    },
+    trustTier: "sandbox",
+    execute: async (args: JsonObject) => {
+      const config: MergeConfig = {
+        repoPath,
+        targetBranch: (args.targetBranch as string) ?? "main",
+        branches: ((args.branches as readonly JsonObject[]) ?? []).map((b) => ({
+          name: b.name as string,
+          dependsOn: (b.dependsOn as readonly string[]) ?? [],
+          expectedRef: b.expectedRef as string | undefined,
+        })),
+        strategy: (args.strategy as MergeConfig["strategy"]) ?? "sequential",
+        verifyAfter: (args.verifyAfter as MergeConfig["verifyAfter"]) ?? undefined,
+        onEvent: (event) => mergeEvents.push(event),
+      };
+
+      const result = await executeMerge(config);
+      if (!result.ok) {
+        return { error: result.error.message };
+      }
+
+      lastResult = result.value;
+
+      // Build a serializable summary
+      const outcomeSummary: Record<string, string> = {};
+      for (const [branch, outcome] of result.value.outcomes) {
+        outcomeSummary[branch] = formatOutcome(outcome);
+      }
+
+      return {
+        strategy: result.value.strategy,
+        targetBranch: result.value.targetBranch,
+        mergeOrder: result.value.mergeOrder,
+        outcomes: outcomeSummary,
+        verified: result.value.verified,
+        aborted: result.value.aborted,
+        durationMs: Math.round(result.value.durationMs),
+      };
+    },
+  };
+
+  return {
+    tools: [mergeTool],
+    lastMergeResult: () => lastResult,
+    mergeEvents,
+  };
+}
+
+function formatOutcome(outcome: BranchMergeOutcome): string {
+  switch (outcome.kind) {
+    case "merged":
+      return `merged (${outcome.commitSha.slice(0, 8)})`;
+    case "conflict":
+      return `conflict (files: ${outcome.conflictFiles.join(", ")}, resolved: ${outcome.resolved})`;
+    case "skipped":
+      return `skipped: ${outcome.reason}`;
+    case "failed":
+      return `failed: ${outcome.error.message}`;
+    case "reverted":
+      return `reverted: ${outcome.reason}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  repoPath = await createTestRepo();
+});
+
+afterEach(async () => {
+  await rm(repoPath, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: Sequential merge of 3 branches through full L1 stack
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: worktree-merge through createKoi + createLoopAdapter", () => {
+  test(
+    "sequential merge of 3 independent branches + real LLM summary",
+    async () => {
+      await createBranchWithChange(repoPath, "feat-a", "a.ts", "export const a = 1;\n");
+      await createBranchWithChange(repoPath, "feat-b", "b.ts", "export const b = 2;\n");
+      await createBranchWithChange(repoPath, "feat-c", "c.ts", "export const c = 3;\n");
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [
+            { name: "feat-a", dependsOn: [] },
+            { name: "feat-b", dependsOn: [] },
+            { name: "feat-c", dependsOn: [] },
+          ],
+        }),
+      ];
+
+      const { modelCall, callCount } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-sequential", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Merge the 3 feature branches and summarize the result.",
+          }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // Tool was called through middleware chain
+        expect(observer.interceptedToolIds).toContain("merge_branches");
+
+        // executeMerge succeeded
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+        expect(result?.strategy).toBe("sequential");
+        expect(result?.outcomes.size).toBe(3);
+        for (const [, outcome] of result?.outcomes ?? []) {
+          expect(outcome.kind).toBe("merged");
+        }
+
+        // Merge events were emitted
+        const levelStarts = merge.mergeEvents.filter((e) => e.kind === "level:started");
+        expect(levelStarts.length).toBeGreaterThan(0);
+
+        // Real LLM summarized the result
+        expect(callCount()).toBeGreaterThanOrEqual(2);
+        const textEvents = events.filter((e) => e.kind === "text_delta");
+        expect(textEvents.length).toBeGreaterThan(0);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 2: Octopus merge of independent branches
+  // ---------------------------------------------------------------------------
+
+  test(
+    "octopus merge of 2 independent branches",
+    async () => {
+      await createBranchWithChange(repoPath, "feat-x", "x.ts", "export const x = 'x';\n");
+      await createBranchWithChange(repoPath, "feat-y", "y.ts", "export const y = 'y';\n");
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "octopus",
+          targetBranch: "main",
+          branches: [
+            { name: "feat-x", dependsOn: [] },
+            { name: "feat-y", dependsOn: [] },
+          ],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-octopus", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Merge branches via octopus and summarize." }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+        expect(result?.strategy).toBe("octopus");
+        expect(result?.outcomes.size).toBe(2);
+        for (const [, outcome] of result?.outcomes ?? []) {
+          expect(outcome.kind).toBe("merged");
+        }
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 3: Rebase-chain merge
+  // ---------------------------------------------------------------------------
+
+  test(
+    "rebase-chain merge of a single branch",
+    async () => {
+      await createBranchWithChange(repoPath, "feat-r", "r.ts", "export const r = 'rebase';\n");
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "rebase-chain",
+          targetBranch: "main",
+          branches: [{ name: "feat-r", dependsOn: [] }],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-rebase", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Rebase and merge the branch, then summarize." }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+        expect(result?.strategy).toBe("rebase-chain");
+        expect(result?.outcomes.get("feat-r")?.kind).toBe("merged");
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 4: SHA pinning — expectedRef stale-branch guard
+  // ---------------------------------------------------------------------------
+
+  test(
+    "expectedRef skips stale branch, merges fresh branch",
+    async () => {
+      const shaA = await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+      const shaB = await createBranchWithChange(repoPath, "feat-b", "b.ts", "b\n");
+
+      // Advance feat-a after capturing its SHA (makes it stale)
+      await runGit(["checkout", "feat-a"], repoPath);
+      await Bun.write(join(repoPath, "a2.ts"), "a2\n");
+      await runGit(["add", "a2.ts"], repoPath);
+      await runGit(["commit", "-m", "advance feat-a"], repoPath);
+      await runGit(["checkout", "main"], repoPath);
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [
+            { name: "feat-a", dependsOn: [], expectedRef: shaA },
+            { name: "feat-b", dependsOn: [], expectedRef: shaB },
+          ],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-sha-pin", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Merge branches with SHA pinning, summarize which succeeded.",
+          }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+
+        // feat-a should be skipped (stale)
+        const outcomeA = result?.outcomes.get("feat-a");
+        expect(outcomeA?.kind).toBe("skipped");
+        if (outcomeA?.kind === "skipped") {
+          expect(outcomeA.reason).toContain("stale");
+        }
+
+        // feat-b should merge (fresh)
+        const outcomeB = result?.outcomes.get("feat-b");
+        expect(outcomeB?.kind).toBe("merged");
+
+        // Tool call events were emitted
+        const toolEndEvents = events.filter((e) => e.kind === "tool_call_end");
+        expect(toolEndEvents.length).toBeGreaterThan(0);
+
+        // Tool result contains "skipped" for stale branch
+        const toolResult = toolEndEvents.find(
+          (e) => e.kind === "tool_call_end" && JSON.stringify(e.result).includes("skipped"),
+        );
+        expect(toolResult).toBeDefined();
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 5: Conflict detection through full stack
+  // ---------------------------------------------------------------------------
+
+  test(
+    "conflict detection: both branches modify same file",
+    async () => {
+      await createBranchWithChange(repoPath, "branch-1", "shared.ts", "version 1\n");
+      await createBranchWithChange(repoPath, "branch-2", "shared.ts", "version 2\n");
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [
+            { name: "branch-1", dependsOn: [] },
+            { name: "branch-2", dependsOn: [] },
+          ],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-conflict", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Merge the conflicting branches and report the result.",
+          }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+
+        // First branch merged
+        expect(result?.outcomes.get("branch-1")?.kind).toBe("merged");
+
+        // Second branch conflicted
+        const outcome2 = result?.outcomes.get("branch-2");
+        expect(outcome2?.kind).toBe("conflict");
+        if (outcome2?.kind === "conflict") {
+          expect(outcome2.conflictFiles).toContain("shared.ts");
+          expect(outcome2.resolved).toBe(false);
+        }
+
+        // Merge events include conflict notification
+        const conflictEvents = merge.mergeEvents.filter((e) => e.kind === "merge:conflict");
+        expect(conflictEvents.length).toBeGreaterThan(0);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 6: Dependency ordering through full stack (5 branches, diamond DAG)
+  // ---------------------------------------------------------------------------
+
+  test(
+    "dependency ordering: 5 branches with diamond DAG",
+    async () => {
+      await createBranchWithChange(repoPath, "core", "core.ts", "core\n");
+      await createBranchWithChange(repoPath, "api", "api.ts", "api\n");
+      await createBranchWithChange(repoPath, "ui", "ui.ts", "ui\n");
+      await createBranchWithChange(repoPath, "tests", "tests.ts", "tests\n");
+      await createBranchWithChange(repoPath, "docs", "docs.ts", "docs\n");
+
+      const merge = createMergeTools();
+      const observer = createToolObserver();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [
+            { name: "core", dependsOn: [] },
+            { name: "api", dependsOn: ["core"] },
+            { name: "ui", dependsOn: ["core"] },
+            { name: "tests", dependsOn: ["api", "ui"] },
+            { name: "docs", dependsOn: [] },
+          ],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-dag", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [observer.middleware],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({
+            kind: "text",
+            text: "Merge the 5 branches respecting their dependency graph.",
+          }),
+        );
+
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+
+        const result = merge.lastMergeResult();
+        expect(result).toBeDefined();
+        expect(result?.outcomes.size).toBe(5);
+
+        // All merged successfully
+        for (const [, outcome] of result?.outcomes ?? []) {
+          expect(outcome.kind).toBe("merged");
+        }
+
+        // Merge order respects dependencies:
+        // core and docs are first (level 0), then api and ui (level 1), then tests (level 2)
+        const order = result?.mergeOrder ?? [];
+        const coreIdx = order.indexOf("core");
+        const apiIdx = order.indexOf("api");
+        const uiIdx = order.indexOf("ui");
+        const testsIdx = order.indexOf("tests");
+        expect(coreIdx).toBeLessThan(apiIdx);
+        expect(coreIdx).toBeLessThan(uiIdx);
+        expect(apiIdx).toBeLessThan(testsIdx);
+        expect(uiIdx).toBeLessThan(testsIdx);
+
+        // Merge events show 3 levels
+        const levelStarts = merge.mergeEvents.filter((e) => e.kind === "level:started");
+        expect(levelStarts.length).toBe(3);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 7: Middleware lifecycle hooks fire with merge tool
+  // ---------------------------------------------------------------------------
+
+  test(
+    "lifecycle hooks fire correctly around merge tool execution",
+    async () => {
+      await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+      const hookLog: string[] = []; // let justified: test accumulator
+
+      const lifecycle: KoiMiddleware = {
+        name: "e2e-merge-lifecycle",
+        priority: 100,
+        onSessionStart: async () => {
+          hookLog.push("session:start");
+        },
+        onBeforeTurn: async () => {
+          hookLog.push("turn:before");
+        },
+        onAfterTurn: async () => {
+          hookLog.push("turn:after");
+        },
+        onSessionEnd: async () => {
+          hookLog.push("session:end");
+        },
+      };
+
+      const merge = createMergeTools();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [{ name: "feat-a", dependsOn: [] }],
+        }),
+      ];
+
+      const { modelCall } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-lifecycle", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [lifecycle],
+        providers: [toolProvider],
+      });
+
+      try {
+        await collectEvents(runtime.run({ kind: "text", text: "Merge feat-a and summarize." }));
+
+        // Session lifecycle brackets correctly
+        expect(hookLog.at(0)).toBe("session:start");
+        expect(hookLog.at(-1)).toBe("session:end");
+
+        // At least one turn happened
+        expect(hookLog).toContain("turn:before");
+        expect(hookLog).toContain("turn:after");
+
+        // Turns bracket correctly
+        const firstBefore = hookLog.indexOf("turn:before");
+        const firstAfter = hookLog.indexOf("turn:after");
+        expect(firstBefore).toBeLessThan(firstAfter);
+
+        // Merge actually happened
+        expect(merge.lastMergeResult()?.outcomes.size).toBe(1);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Test 8: wrapToolCall middleware intercepts merge_branches call
+  // ---------------------------------------------------------------------------
+
+  test(
+    "wrapToolCall intercepts merge_branches, then real LLM uses result",
+    async () => {
+      await createBranchWithChange(repoPath, "feat-a", "a.ts", "a\n");
+
+      // let justified: tracks whether middleware intercepted the tool call
+      let interceptedInput: JsonObject | undefined;
+
+      const toolInspector: KoiMiddleware = {
+        name: "e2e-merge-inspector",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          if (request.toolId === "merge_branches") {
+            interceptedInput = request.input;
+          }
+          return next(request);
+        },
+      };
+
+      const merge = createMergeTools();
+      const toolProvider = createToolProvider(merge.tools);
+
+      const phases: ModelResponse[] = [
+        toolCallResponse("merge_branches", "call-1", {
+          strategy: "sequential",
+          targetBranch: "main",
+          branches: [{ name: "feat-a", dependsOn: [] }],
+        }),
+      ];
+
+      const { modelCall, callCount } = createPhasedModelHandler(phases);
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      const runtime = await createKoi({
+        manifest: { name: "e2e-merge-intercept", version: "0.0.1", model: { name: MODEL_NAME } },
+        adapter,
+        middleware: [toolInspector],
+        providers: [toolProvider],
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Merge feat-a and tell me about the result." }),
+        );
+
+        // Agent completed with real LLM final answer
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // wrapToolCall intercepted the merge call
+        expect(interceptedInput).toBeDefined();
+        expect((interceptedInput as Record<string, unknown>).strategy).toBe("sequential");
+
+        // Real LLM called after tool execution
+        expect(callCount()).toBeGreaterThanOrEqual(2);
+
+        // Text output from real LLM
+        const textEvents = events.filter((e) => e.kind === "text_delta");
+        expect(textEvents.length).toBeGreaterThan(0);
+      } finally {
+        await runtime.dispose?.();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
## Summary

Implements **branch reconciliation** after parallel worktree-based agent work (closes #380).

Two new packages:

- **`@koi/git-utils`** (L0u) — extracted git CLI wrapper (`runGit`, `parseGitError`, `resolveWorktreeBasePath`) shared by `@koi/workspace` and `@koi/worktree-merge`
- **`@koi/worktree-merge`** (L2) — topological ordering via Kahn's algorithm, 3 merge strategies (sequential, octopus, rebase-chain), pluggable conflict resolution, configurable verification gates (`each`/`levels`/`all`), SHA pinning via `expectedRef` stale-branch guard, abort/restore safety, and structured event reporting

Depends on: #325 (`@koi/workspace`), #414 (`@koi/orchestrator`)
Enables: #382 (`@koi/handoff`), #381 (`@koi/middleware-report`)

## Changes

- `packages/git-utils/` — new L0u package (5 source files, extracted from `@koi/workspace`)
- `packages/worktree-merge/` — new L2 package (8 source files, ~600 LOC)
- `packages/workspace/` — migrated imports to `@koi/git-utils`, deleted old `git-utils.ts`
- `scripts/check-layers.ts` — added `@koi/git-utils` to L0U_PACKAGES
- `tests/e2e/worktree-merge-e2e.test.ts` — 8 E2E tests through full L1 runtime with real Anthropic API
- `docs/L2/worktree-merge.md` — full documentation

## Test plan

- [x] 119 unit/integration tests across both packages (`bun test packages/git-utils packages/worktree-merge`)
- [x] 8 E2E tests through `createKoi + createLoopAdapter` with real Anthropic API calls
- [x] API surface snapshots for both packages
- [x] `@koi/workspace` tests pass after import migration
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (biome pre-commit hook)
- [x] Layer check passes (`@koi/git-utils` in L0U, `@koi/worktree-merge` in L2)