### PR TITLE
chore: add demo-strategy.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-results.json
 workstream.md
 prompt
 plan-work.md
+demo-strategy.md


### PR DESCRIPTION
## Summary

- Add `demo-strategy.md` to `.gitignore` (local working file, same as `workstream.md` and `plan-work.md`)

## Test plan

- [ ] Verify `demo-strategy.md` is no longer tracked