### PR TITLE
feat: add @koi/bundle — portable agent export/import bundles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,21 @@
         "playwright": "^1.49.0",
       },
     },
+    "packages/bundle": {
+      "name": "@koi/bundle",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/hash": "workspace:*",
+        "@koi/validation": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/forge": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/canvas": {
       "name": "@koi/canvas",
       "version": "0.0.0",
@@ -1388,6 +1403,8 @@
     "@koi/bootstrap": ["@koi/bootstrap@workspace:packages/bootstrap"],
 
     "@koi/browser-playwright": ["@koi/browser-playwright@workspace:packages/browser-playwright"],
+
+    "@koi/bundle": ["@koi/bundle@workspace:packages/bundle"],
 
     "@koi/canvas": ["@koi/canvas@workspace:packages/canvas"],
 

--- a/docs/L2/bundle.md
+++ b/docs/L2/bundle.md
@@ -1,0 +1,578 @@
+# @koi/bundle — Portable Agent Export/Import
+
+Docker-style `export` / `import` for Koi agents. Packages an agent's manifest + all forged bricks (tools, skills, middleware, channels) into a single `.koibundle` JSON file. Import into another deployment with SHA-256 integrity verification, content-addressed deduplication, and automatic trust downgrading.
+
+---
+
+## Why It Exists
+
+Koi agents are composed of a manifest plus forged bricks — tools, skills, middleware, channels — each content-addressed by SHA-256. Today there's no portable packaging: if you forge an agent in dev and want to run it in staging, you manually copy bricks and hope nothing is missing or corrupted.
+
+`@koi/bundle` solves this by providing a single-file portable artifact that:
+
+- Contains everything needed to reconstruct an agent's brick set
+- Verifies integrity at every level (bundle hash + per-brick hash)
+- Prevents accidental duplication via content-addressed dedup
+- Enforces security boundaries by downgrading trust on import
+
+---
+
+## What This Enables
+
+### Before vs After
+
+```
+WITHOUT BUNDLE                              WITH BUNDLE
+──────────────                              ───────────
+
+Dev environment:                            Dev environment:
+  "I forged 5 tools for the                   createBundle() → sales.koibundle
+   sales agent. Let me copy                     (single JSON file, integrity-sealed)
+   them one by one to staging..."
+                                                    │
+  ┌─ manual copy ─┐                                 │  email / S3 / git / USB
+  │  tool-1.json   │                                │
+  │  tool-2.json   │  ← error-prone                 ▼
+  │  tool-3.json   │  ← no integrity check
+  │  oops-forgot-4 │  ← missing brick!         Staging environment:
+  │  tool-5.json   │                              importBundle() → 5 bricks imported
+  └────────────────┘                                ✓ integrity verified
+                                                    ✓ duplicates skipped
+Staging:                                            ✓ trust downgraded to sandbox
+  "Why is tool 4 missing?"                          ✓ provenance rewritten
+  "Did tool 3 get corrupted?"
+  "These are running as verified?!"
+```
+
+### Full Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     DEPLOYMENT A (Dev)                          │
+│                                                                 │
+│  ┌──────────────┐    ┌──────────────────────────────────────┐   │
+│  │  Agent YAML   │    │           ForgeStore A               │   │
+│  │               │    │                                      │   │
+│  │  name: sales  │    │  ┌─────────┐ ┌─────────┐ ┌────────┐ │   │
+│  │  model: ...   │    │  │ tool:   │ │ tool:   │ │ skill: │ │   │
+│  │  tools:       │    │  │ search  │ │ draft   │ │ close  │ │   │
+│  │   - search    │    │  │ sha256: │ │ sha256: │ │ sha256:│ │   │
+│  │   - draft     │    │  │ a1b2c3  │ │ d4e5f6  │ │ 789abc │ │   │
+│  │   - close     │    │  │ trust:  │ │ trust:  │ │ trust: │ │   │
+│  │               │    │  │ verified│ │ verified│ │verified│ │   │
+│  └──────┬───────┘    │  └─────────┘ └─────────┘ └────────┘ │   │
+│         │            └──────────────┬───────────────────────┘   │
+│         └───────────┬───────────────┘                           │
+│                     ▼                                           │
+│            ┌────────────────┐                                   │
+│            │ createBundle() │  gather manifest + bricks         │
+│            └───────┬────────┘                                   │
+│                    ▼                                            │
+│         ┌──────────────────────┐                                │
+│         │ serializeBundle()    │  → JSON string                 │
+│         └──────────┬───────────┘                                │
+└────────────────────┼────────────────────────────────────────────┘
+                     │
+                     ▼
+          ┌──────────────────────────┐
+          │  sales-agent.koibundle   │
+          │                          │
+          │  {                       │
+          │   version: "1",          │
+          │   id: "bundle:sha...",   │
+          │   name: "sales-agent",   │
+          │   manifestYaml: "...",   │
+          │   bricks: [ ... ],       │
+          │   contentHash: "abc..."  │
+          │  }                       │
+          └────────────┬─────────────┘
+                       │
+           ────────────┼──────────────
+             file transfer / network
+           ────────────┼──────────────
+                       │
+┌──────────────────────┼──────────────────────────────────────────┐
+│                      ▼              DEPLOYMENT B (Staging)      │
+│          ┌───────────────────────┐                              │
+│          │ deserializeBundle()   │  ← parse + validate JSON     │
+│          └───────────┬───────────┘                              │
+│                      ▼                                          │
+│             ┌────────────────┐                                  │
+│             │ importBundle() │  ← verify + dedup + downgrade    │
+│             └───────┬────────┘                                  │
+│                     ▼                                           │
+│   ┌──────────────────────────────────────┐                      │
+│   │           ForgeStore B               │                      │
+│   │                                      │                      │
+│   │  ┌─────────┐ ┌─────────┐ ┌────────┐ │                      │
+│   │  │ tool:   │ │ tool:   │ │ skill: │ │                      │
+│   │  │ search  │ │ draft   │ │ close  │ │  Same content,       │
+│   │  │ sha256: │ │ sha256: │ │ sha256:│ │  different trust     │
+│   │  │ a1b2c3  │ │ d4e5f6  │ │ 789abc │ │                      │
+│   │  │ trust:  │ │ trust:  │ │ trust: │ │                      │
+│   │  │ SANDBOX │ │ SANDBOX │ │SANDBOX │ │◄── not "verified"    │
+│   │  │ origin: │ │ origin: │ │origin: │ │                      │
+│   │  │ bundled │ │ bundled │ │bundled │ │◄── not "forged"      │
+│   │  └─────────┘ └─────────┘ └────────┘ │                      │
+│   └──────────────────┬───────────────────┘                      │
+│                      ▼                                          │
+│              ┌──────────────┐                                   │
+│              │  createKoi() │  Wire into live agent runtime     │
+│              │  + adapter   │                                   │
+│              └──────────────┘                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Architecture
+
+`@koi/bundle` is an **L2 feature package** — it depends only on `@koi/core` (L0), `@koi/hash` (L0u), and `@koi/validation` (L0u).
+
+```
+┌───────────────────────────────────────────────────────┐
+│  @koi/bundle  (L2)                                    │
+│                                                       │
+│  types.ts            ← config types, result types      │
+│  brick-content.ts    ← extract primary content string  │
+│  export-bundle.ts    ← createBundle()                  │
+│  import-bundle.ts    ← importBundle()                  │
+│  serialize.ts        ← serializeBundle/deserialize     │
+│  index.ts            ← public API surface              │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  Dependencies                                         │
+│                                                       │
+│  @koi/core        (L0)   AgentBundle, BundleId,       │
+│                           BrickArtifact, ForgeStore,   │
+│                           Result, KoiError             │
+│  @koi/hash        (L0u)  computeBrickId(),            │
+│                           computeContentHash()         │
+│  @koi/validation  (L0u)  validateBrickArtifact()      │
+└───────────────────────────────────────────────────────┘
+```
+
+### L0 Types (in `@koi/core`)
+
+The bundle envelope and branded ID live in L0 so any package can reference them:
+
+```typescript
+// Branded type — prevents mixing with other ID types
+type BundleId = string & { readonly [__bundleIdBrand]: "BundleId" };
+function bundleId(raw: string): BundleId;
+
+// Version constant
+const BUNDLE_FORMAT_VERSION = "1" as const;
+
+// The portable artifact envelope
+interface AgentBundle {
+  readonly version: typeof BUNDLE_FORMAT_VERSION;
+  readonly id: BundleId;
+  readonly name: string;
+  readonly description: string;
+  readonly manifestYaml: string;
+  readonly bricks: readonly BrickArtifact[];
+  readonly contentHash: string;
+  readonly createdAt: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+```
+
+---
+
+## Export Pipeline
+
+```
+createBundle(config)
+  │
+  ▼
+┌─────────────────────────────────────────────────────────┐
+│  1. Validate inputs                                     │
+│     name ≠ empty, manifestYaml ≠ empty, brickIds ≠ []   │
+│     Fail → VALIDATION error                             │
+│                                                         │
+│  2. Deduplicate brick IDs                               │
+│     [a, b, a, c] → Set → [a, b, c]                     │
+│                                                         │
+│  3. Parallel load from ForgeStore                       │
+│     Promise.all(ids.map(id => store.load(id)))          │
+│     Missing? → NOT_FOUND error listing missing IDs      │
+│                                                         │
+│  4. Verify integrity of each brick                      │
+│     recompute BrickId from content via computeBrickId() │
+│     Mismatch? → VALIDATION error                        │
+│                                                         │
+│  5. Compute bundle content hash                         │
+│     computeContentHash({                                │
+│       manifest: manifestYaml,                           │
+│       brickIds: sorted                                  │
+│     })                                                  │
+│                                                         │
+│  6. Return AgentBundle envelope                         │
+│     id = bundleId(`bundle:${contentHash}`)              │
+└─────────────────────────────────────────────────────────┘
+  │
+  ▼
+Result<AgentBundle, KoiError>
+```
+
+### Content Hash
+
+The bundle's `contentHash` is deterministic — same manifest + same brick IDs (sorted) always produces the same hash. This enables tamper detection on import.
+
+```
+contentHash = computeContentHash({
+  manifest: "name: sales-agent\nversion: 1.0",
+  brickIds: ["sha256:111...", "sha256:222...", "sha256:333..."]  ← sorted
+})
+```
+
+---
+
+## Import Pipeline
+
+```
+importBundle(config)
+  │
+  ▼
+┌─────────────────────────────────────────────────────────┐
+│  1. Validate bundle version                             │
+│     bundle.version === BUNDLE_FORMAT_VERSION ("1")      │
+│     Wrong? → VALIDATION error                           │
+│                                                         │
+│  2. Verify bundle content hash                          │
+│     Recompute from manifest + sorted brick IDs          │
+│     Mismatch? → VALIDATION error (tamper detected)      │
+│                                                         │
+│  3. For each brick (in parallel):                       │
+│     ┌─────────────────────────────────────────────┐     │
+│     │ a. Validate structure (validateBrickArtifact)│     │
+│     │    Invalid? → error for this brick           │     │
+│     │                                              │     │
+│     │ b. Verify integrity (recompute BrickId)      │     │
+│     │    Hash mismatch? → error for this brick     │     │
+│     │                                              │     │
+│     │ c. Dedup check (store.exists(brick.id))      │     │
+│     │    Already exists? → skip                    │     │
+│     │                                              │     │
+│     │ d. Downgrade trust + save                    │     │
+│     │    trustTier: "verified" → "sandbox"         │     │
+│     │    scope: → "agent"                          │     │
+│     │    provenance.source: → "bundled"            │     │
+│     │    store.save(downgraded)                    │     │
+│     └─────────────────────────────────────────────┘     │
+│                                                         │
+│  4. Return { imported, skipped, errors }                │
+└─────────────────────────────────────────────────────────┘
+  │
+  ▼
+Result<ImportBundleResult, KoiError>
+```
+
+### Trust Downgrade
+
+Every imported brick is downgraded — no exceptions. Imported code runs in sandbox until explicitly promoted.
+
+```
+BEFORE IMPORT (origin store)              AFTER IMPORT (destination store)
+────────────────────────                  ──────────────────────────────
+
+trustTier: "verified"                     trustTier: "sandbox"
+scope:     "system"                       scope:     "agent"
+provenance.source:                        provenance.source:
+  { origin: "forged",                       { origin: "bundled",
+    forgedBy: "dev-agent" }                   bundleName: "sales-agent",
+                                              bundleVersion: "1" }
+```
+
+### Deduplication
+
+Bricks are content-addressed — same code always produces the same SHA-256 ID. If a brick with the same ID already exists in the destination store, it's skipped.
+
+```
+Import #1:  3 bricks → imported: 3, skipped: 0  ✓
+Import #2:  3 bricks → imported: 0, skipped: 3  (same SHA-256 IDs)
+Import #3:  4 bricks → imported: 1, skipped: 3  (1 new brick)
+```
+
+### Tamper Detection
+
+If an attacker modifies the `.koibundle` file (e.g., changes the manifest or swaps a brick), import detects it at two levels:
+
+```
+Level 1 — Bundle content hash:
+
+  Attacker changes manifestYaml in .koibundle
+           │
+           ▼
+  importBundle() recomputes contentHash from manifest + brick IDs
+           │
+           ▼
+  expected: "abc123..."  got: "xyz789..."  → VALIDATION ERROR
+
+Level 2 — Per-brick integrity:
+
+  Attacker changes brick implementation but keeps original ID
+           │
+           ▼
+  importBundle() recomputes BrickId from brick content
+           │
+           ▼
+  expected: "sha256:aaa..."  got: "sha256:bbb..."  → brick-level error
+```
+
+---
+
+## Serialization
+
+```
+serializeBundle(bundle)    JSON.stringify(bundle, null, 2)  → human-readable JSON
+deserializeBundle(json)    JSON.parse + field-by-field validation → Result<AgentBundle>
+```
+
+`deserializeBundle` validates every field before returning:
+
+```
+Raw JSON string
+  │
+  ▼
+┌──────────────────────────────────────────────────┐
+│  1. JSON.parse()                                 │
+│     Invalid JSON? → VALIDATION error             │
+│                                                  │
+│  2. Field-by-field checks:                       │
+│     version:      string, matches FORMAT_VERSION │
+│     id:           non-empty string               │
+│     name:         non-empty string               │
+│     description:  non-empty string               │
+│     manifestYaml: non-empty string               │
+│     contentHash:  non-empty string               │
+│     createdAt:    number                         │
+│     bricks:       array                          │
+│     metadata:     object or undefined            │
+│                                                  │
+│  3. Deep validation of each brick                │
+│     validateBrickArtifact() from @koi/validation │
+│                                                  │
+│  Fail at any step → VALIDATION error with detail │
+└──────────────────────────────────────────────────┘
+  │
+  ▼
+Result<AgentBundle, KoiError>
+```
+
+---
+
+## Examples
+
+### Export an Agent's Bricks
+
+```typescript
+import { createBundle, serializeBundle } from "@koi/bundle";
+import type { ForgeStore } from "@koi/core";
+
+// store: ForgeStore — your existing brick storage
+// brickIds: string[] — the IDs of bricks to include
+
+const result = await createBundle({
+  name: "sales-agent",
+  description: "Sales agent with CRM tools",
+  manifestYaml: "name: sales-agent\nversion: 1.0\nmodel: claude-sonnet-4-5",
+  brickIds: ["sha256:aaa...", "sha256:bbb...", "sha256:ccc..."],
+  store,
+  metadata: { exportedBy: "admin", environment: "dev" },
+});
+
+if (result.ok) {
+  const json = serializeBundle(result.value);
+  // Write json to sales-agent.koibundle file
+  await Bun.write("sales-agent.koibundle", json);
+}
+```
+
+### Import into Another Deployment
+
+```typescript
+import { deserializeBundle, importBundle } from "@koi/bundle";
+import type { ForgeStore } from "@koi/core";
+
+// Read the .koibundle file
+const json = await Bun.file("sales-agent.koibundle").text();
+
+// Deserialize with validation
+const parsed = deserializeBundle(json);
+if (!parsed.ok) {
+  console.error("Invalid bundle:", parsed.error.message);
+  return;
+}
+
+// Import into destination store
+const result = await importBundle({
+  bundle: parsed.value,
+  store: destinationStore,
+});
+
+if (result.ok) {
+  console.log(`Imported: ${result.value.imported}`);
+  console.log(`Skipped (dedup): ${result.value.skipped}`);
+  console.log(`Errors: ${result.value.errors.length}`);
+  for (const err of result.value.errors) {
+    console.error(`  Brick ${err.brickId}: ${err.reason}`);
+  }
+}
+```
+
+### Wire Imported Bricks into a Live Agent
+
+```typescript
+import { importBundle, deserializeBundle } from "@koi/bundle";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import type { ForgeStore, ComponentProvider, Tool } from "@koi/core";
+import { toolToken } from "@koi/core";
+
+// 1. Import bundle into store
+const json = await Bun.file("sales-agent.koibundle").text();
+const bundle = deserializeBundle(json);
+if (!bundle.ok) throw new Error(bundle.error.message);
+
+const store: ForgeStore = /* your store */;
+await importBundle({ bundle: bundle.value, store });
+
+// 2. Create a ComponentProvider that resolves tools from the store
+const toolProvider: ComponentProvider = {
+  name: "bundle-tool-provider",
+  attach: async () => {
+    const result = await store.search({ kind: "tool" });
+    if (!result.ok) return new Map();
+
+    const entries: Array<[string, Tool]> = [];
+    for (const brick of result.value) {
+      if (brick.kind !== "tool") continue;
+      entries.push([
+        toolToken(brick.name) as string,
+        {
+          descriptor: {
+            name: brick.name,
+            description: brick.description,
+            inputSchema: brick.inputSchema,
+          },
+          trustTier: brick.trustTier,   // "sandbox" after import
+          execute: async (input) => {
+            // Your sandbox executor here
+            return "result";
+          },
+        },
+      ]);
+    }
+    return new Map(entries);
+  },
+};
+
+// 3. Wire into Koi runtime
+const runtime = await createKoi({
+  manifest: { name: "Sales Agent", version: "1.0.0", model: { name: "claude-sonnet-4-5" } },
+  adapter: createPiAdapter({
+    model: "anthropic:claude-sonnet-4-5",
+    getApiKey: async () => process.env.ANTHROPIC_API_KEY!,
+  }),
+  providers: [toolProvider],
+});
+
+// 4. Run the agent — imported tools are available
+for await (const event of runtime.run({ kind: "text", text: "Search CRM for leads" })) {
+  if (event.kind === "text_delta") process.stdout.write(event.delta);
+}
+```
+
+---
+
+## Bundle File Format
+
+A `.koibundle` file is pretty-printed JSON:
+
+```json
+{
+  "version": "1",
+  "id": "bundle:sha256:a1b2c3d4e5f6...",
+  "name": "sales-agent",
+  "description": "Sales agent with CRM tools",
+  "manifestYaml": "name: sales-agent\nversion: 1.0\nmodel: claude-sonnet-4-5",
+  "bricks": [
+    {
+      "id": "sha256:aaa111...",
+      "kind": "tool",
+      "name": "search_crm",
+      "description": "Search CRM for customer records",
+      "implementation": "async function search(input) { ... }",
+      "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } } },
+      "trustTier": "verified",
+      "scope": "agent",
+      "lifecycle": "active",
+      "provenance": { "..." : "..." },
+      "version": "1.0.0",
+      "tags": ["crm"],
+      "usageCount": 42
+    }
+  ],
+  "contentHash": "sha256:deadbeef...",
+  "createdAt": 1709000000000,
+  "metadata": {
+    "exportedBy": "admin",
+    "environment": "dev"
+  }
+}
+```
+
+---
+
+## API Reference
+
+### Core Functions
+
+| Function | Returns | Purpose |
+|----------|---------|---------|
+| `createBundle(config)` | `Promise<Result<AgentBundle, KoiError>>` | Export bricks from store into bundle |
+| `importBundle(config)` | `Promise<Result<ImportBundleResult, KoiError>>` | Import bundle into store with dedup + downgrade |
+| `serializeBundle(bundle)` | `string` | Bundle → JSON string |
+| `deserializeBundle(json)` | `Result<AgentBundle, KoiError>` | JSON string → validated bundle |
+
+### Config Types
+
+| Type | Purpose |
+|------|---------|
+| `ExportBundleConfig` | Input to `createBundle()` — name, description, manifest, brick IDs, store |
+| `ImportBundleConfig` | Input to `importBundle()` — bundle, store |
+| `ImportBundleResult` | Output of `importBundle()` — imported/skipped/errors counts |
+| `ImportBrickError` | Per-brick error detail — brickId + reason |
+
+### Error Cases
+
+| Error Code | When | Example |
+|------------|------|---------|
+| `VALIDATION` | Empty name, bad version, tampered hash, invalid brick | `"Bundle content hash mismatch"` |
+| `NOT_FOUND` | Brick ID not found in source store | `"Bricks not found: sha256:abc..."` |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ─────────────────────────────────────────┐
+    AgentBundle, BundleId, BrickArtifact,               │
+    ForgeStore, Result<T,E>, KoiError — types only       │
+                                                        │
+L0u @koi/hash ─────────────────────────────┐           │
+    computeBrickId(), computeContentHash() │           │
+                                           │           │
+L0u @koi/validation ───────────────┐       │           │
+    validateBrickArtifact()        │       │           │
+                                   ▼       ▼           ▼
+L2  @koi/bundle ◄──────────────────┴───────┴───────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✓ zero external dependencies
+```
+
+**Dev-only:** `@koi/engine`, `@koi/engine-pi`, `@koi/forge`, `@koi/test-utils` used in E2E tests but not runtime imports.

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@koi/bundle",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/hash": "workspace:*",
+    "@koi/validation": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/forge": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  }
+}

--- a/packages/bundle/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/bundle/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,80 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/bundle API surface . has stable type surface 1`] = `
+"import { ForgeStore, AgentBundle, Result, KoiError } from '@koi/core';
+
+/**
+ * Config and result types for bundle export/import operations.
+ */
+
+/** Configuration for creating an agent bundle. */
+interface ExportBundleConfig {
+    readonly name: string;
+    readonly description: string;
+    readonly manifestYaml: string;
+    readonly brickIds: readonly string[];
+    readonly store: ForgeStore;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+}
+/** Configuration for importing an agent bundle into a store. */
+interface ImportBundleConfig {
+    readonly bundle: AgentBundle;
+    readonly store: ForgeStore;
+}
+/** Result of a bundle import operation. */
+interface ImportBundleResult {
+    readonly imported: number;
+    readonly skipped: number;
+    readonly errors: readonly ImportBrickError[];
+}
+/** Details about a brick that failed to import. */
+interface ImportBrickError {
+    readonly brickId: string;
+    readonly reason: string;
+}
+
+/**
+ * Bundle export — serialize an agent's manifest + bricks into a portable artifact.
+ *
+ * Algorithm:
+ * 1. Validate inputs (name, manifestYaml, brickIds non-empty)
+ * 2. Deduplicate brick IDs
+ * 3. Load all bricks in parallel from ForgeStore
+ * 4. Verify integrity of each loaded brick
+ * 5. Compute content hash for the bundle envelope
+ * 6. Return AgentBundle
+ */
+
+/** Create a portable agent bundle from a manifest + brick IDs. */
+declare function createBundle(config: ExportBundleConfig): Promise<Result<AgentBundle, KoiError>>;
+
+/**
+ * Bundle import — load bricks from a portable artifact into a ForgeStore.
+ *
+ * Algorithm:
+ * 1. Validate bundle version
+ * 2. Verify bundle content hash (detect manifest/brick-list tampering)
+ * 3. Validate each brick with validateBrickArtifact()
+ * 4. Verify integrity: recompute BrickId from content, compare to stored ID
+ * 5. For each valid brick, check-then-save with dedup and trust downgrade
+ * 6. Return imported/skipped/errors counts
+ */
+
+/** Import bricks from an agent bundle into a store with dedup and trust downgrade. */
+declare function importBundle(config: ImportBundleConfig): Promise<Result<ImportBundleResult, KoiError>>;
+
+/**
+ * Bundle serialization — JSON encode/decode for \`.koibundle\` files.
+ *
+ * Serialize: JSON.stringify with 2-space indent for inspectability.
+ * Deserialize: JSON.parse + field-by-field validation + brick validation.
+ */
+
+/** Serialize an AgentBundle to a pretty-printed JSON string. */
+declare function serializeBundle(bundle: AgentBundle): string;
+/** Deserialize a JSON string into a validated AgentBundle. */
+declare function deserializeBundle(json: string): Result<AgentBundle, KoiError>;
+
+export { type ExportBundleConfig, type ImportBrickError, type ImportBundleConfig, type ImportBundleResult, createBundle, deserializeBundle, importBundle, serializeBundle };
+"
+`;

--- a/packages/bundle/src/__tests__/api-surface.test.ts
+++ b/packages/bundle/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/bundle/src/__tests__/e2e-bundle-runtime.test.ts
+++ b/packages/bundle/src/__tests__/e2e-bundle-runtime.test.ts
@@ -1,0 +1,616 @@
+/**
+ * E2E: Bundle export → serialize → deserialize → import → real LLM agent.
+ *
+ * Validates the full @koi/bundle lifecycle end-to-end:
+ *   1. Forge tools into store A
+ *   2. Export agent bundle from store A
+ *   3. Serialize to JSON → deserialize back (simulates .koibundle file transfer)
+ *   4. Import into store B (trust downgrade, dedup, integrity)
+ *   5. Wire store B tools into a real createKoi + createPiAdapter agent
+ *   6. Run the agent with real Anthropic API calls
+ *   7. Verify the imported tool was called through the middleware chain
+ *
+ * @koi/engine and @koi/engine-pi are devDependencies (test-only — no layer violation).
+ *
+ * Run:
+ *   E2E_TESTS=1 ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e-bundle-runtime.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  BrickArtifact,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  ForgeStore,
+  KoiMiddleware,
+  Tool,
+  ToolArtifact,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { computeBrickId } from "@koi/hash";
+
+import { createBundle } from "../export-bundle.js";
+import { importBundle } from "../import-bundle.js";
+import { deserializeBundle, serializeBundle } from "../serialize.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function testManifest(): AgentManifest {
+  return {
+    name: "Bundle E2E Agent",
+    version: "0.1.0",
+    model: { name: "claude-haiku-4-5" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// In-memory ForgeStore factory (shared across tests)
+// ---------------------------------------------------------------------------
+
+function createInMemoryStore(initialBricks?: readonly BrickArtifact[]): ForgeStore & {
+  readonly getAll: () => readonly BrickArtifact[];
+} {
+  const map = new Map<string, BrickArtifact>();
+  if (initialBricks) {
+    for (const brick of initialBricks) {
+      map.set(brick.id, brick);
+    }
+  }
+  return {
+    save: async (brick) => {
+      map.set(brick.id, brick);
+      return { ok: true, value: undefined };
+    },
+    load: async (id) => {
+      const brick = map.get(id);
+      if (brick === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Not found: ${id}`, retryable: false },
+        };
+      }
+      return { ok: true, value: brick };
+    },
+    search: async () => ({ ok: true, value: [...map.values()] }),
+    remove: async (id) => {
+      map.delete(id);
+      return { ok: true, value: undefined };
+    },
+    update: async () => ({ ok: true, value: undefined }),
+    exists: async (id) => ({ ok: true, value: map.has(id) }),
+    getAll: () => [...map.values()],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test brick factories
+// ---------------------------------------------------------------------------
+
+function createTestProvenance(): ToolArtifact["provenance"] {
+  return {
+    source: { origin: "forged", forgedBy: "e2e-agent" },
+    buildDefinition: { buildType: "forge", externalParameters: {} },
+    builder: { id: "e2e-builder" },
+    metadata: {
+      invocationId: "e2e-inv-1",
+      startedAt: Date.now() - 1000,
+      finishedAt: Date.now(),
+      sessionId: "e2e-session",
+      agentId: "e2e-agent",
+      depth: 0,
+    },
+    verification: {
+      passed: true,
+      finalTrustTier: "verified",
+      totalDurationMs: 1000,
+      stageResults: [],
+    },
+    classification: "public",
+    contentMarkers: [],
+    contentHash: "e2e-hash",
+  };
+}
+
+function createMultiplyBrick(): ToolArtifact {
+  const implementation = "return String(Number(input.a) * Number(input.b));";
+  const id = computeBrickId("tool", implementation);
+  return {
+    id,
+    kind: "tool",
+    name: "multiply",
+    description: "Multiplies two numbers together and returns the product.",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["math", "e2e"],
+    usageCount: 0,
+    implementation,
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First number" },
+        b: { type: "number", description: "Second number" },
+      },
+      required: ["a", "b"],
+    },
+  };
+}
+
+function createWeatherBrick(): ToolArtifact {
+  const implementation =
+    'return JSON.stringify({ city: String(input.city), temperature: 22, condition: "sunny" });';
+  const id = computeBrickId("tool", implementation);
+  return {
+    id,
+    kind: "tool",
+    name: "get_weather",
+    description: "Returns the current weather for a city. Always returns sunny 22C for testing.",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["weather", "e2e"],
+    usageCount: 0,
+    implementation,
+    inputSchema: {
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City name" },
+      },
+      required: ["city"],
+    },
+  };
+}
+
+/**
+ * Resolve imported ToolArtifacts from a ForgeStore into live Tool components.
+ *
+ * In production, ForgeRuntime handles this. For E2E we wire it manually
+ * so the test stays self-contained and doesn't depend on sandbox executors.
+ */
+function createToolProviderFromStore(
+  store: ForgeStore,
+  toolExecutors: ReadonlyMap<string, Tool["execute"]>,
+): ComponentProvider {
+  return {
+    name: "bundle-e2e-tool-provider",
+    attach: async () => {
+      const searchResult = await store.search({ kind: "tool" });
+      if (!searchResult.ok) return new Map();
+
+      const entries: Array<[string, Tool]> = [];
+      for (const brick of searchResult.value) {
+        if (brick.kind !== "tool") continue;
+        const executor = toolExecutors.get(brick.name);
+        if (executor === undefined) continue;
+        entries.push([
+          toolToken(brick.name) as string,
+          {
+            descriptor: {
+              name: brick.name,
+              description: brick.description,
+              inputSchema: brick.inputSchema,
+            },
+            trustTier: brick.trustTier,
+            execute: executor,
+          },
+        ]);
+      }
+      return new Map(entries);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool executors (real implementations matching the brick "implementation" strings)
+// ---------------------------------------------------------------------------
+
+const TOOL_EXECUTORS = new Map<string, Tool["execute"]>([
+  [
+    "multiply",
+    async (input: Readonly<Record<string, unknown>>) => {
+      const a = Number(input.a ?? 0);
+      const b = Number(input.b ?? 0);
+      return String(a * b);
+    },
+  ],
+  [
+    "get_weather",
+    async (input: Readonly<Record<string, unknown>>) => {
+      const city = String(input.city ?? "unknown");
+      return JSON.stringify({ city, temperature: 22, condition: "sunny" });
+    },
+  ],
+]);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: bundle export → import → real LLM agent", () => {
+  test(
+    "full pipeline: export tools, transfer bundle, import, run agent with real LLM",
+    async () => {
+      // ── Step 1: Create bricks and save to origin store ───────────────
+      const multiplyBrick = createMultiplyBrick();
+      const weatherBrick = createWeatherBrick();
+      const originStore = createInMemoryStore([multiplyBrick, weatherBrick]);
+
+      // ── Step 2: Export bundle from origin store ──────────────────────
+      const exportResult = await createBundle({
+        name: "e2e-portable-agent",
+        description: "E2E test agent with math and weather tools",
+        manifestYaml: "name: e2e-agent\nversion: 1.0.0\nmodel: claude-haiku-4-5",
+        brickIds: [multiplyBrick.id, weatherBrick.id],
+        store: originStore,
+        metadata: { testRun: true, timestamp: Date.now() },
+      });
+
+      expect(exportResult.ok).toBe(true);
+      if (!exportResult.ok) return;
+
+      const bundle = exportResult.value;
+      expect(bundle.bricks).toHaveLength(2);
+      expect(bundle.name).toBe("e2e-portable-agent");
+
+      // ── Step 3: Serialize → simulate file transfer → deserialize ─────
+      const json = serializeBundle(bundle);
+      expect(json.length).toBeGreaterThan(0);
+
+      const deserializeResult = deserializeBundle(json);
+      expect(deserializeResult.ok).toBe(true);
+      if (!deserializeResult.ok) return;
+
+      const transferredBundle = deserializeResult.value;
+      expect(transferredBundle.contentHash).toBe(bundle.contentHash);
+
+      // ── Step 4: Import into destination store ────────────────────────
+      const destStore = createInMemoryStore();
+      const importResult = await importBundle({
+        bundle: transferredBundle,
+        store: destStore,
+      });
+
+      expect(importResult.ok).toBe(true);
+      if (!importResult.ok) return;
+      expect(importResult.value.imported).toBe(2);
+      expect(importResult.value.skipped).toBe(0);
+      expect(importResult.value.errors).toHaveLength(0);
+
+      // ── Step 5: Verify trust downgrade and provenance ────────────────
+      const loadedMultiply = await destStore.load(multiplyBrick.id);
+      expect(loadedMultiply.ok).toBe(true);
+      if (!loadedMultiply.ok) return;
+      expect(loadedMultiply.value.trustTier).toBe("sandbox");
+      expect(loadedMultiply.value.provenance.source).toEqual({
+        origin: "bundled",
+        bundleName: "e2e-portable-agent",
+        bundleVersion: BUNDLE_FORMAT_VERSION,
+      });
+
+      // ── Step 6: Wire imported tools into a real Koi agent ────────────
+      const toolProvider = createToolProviderFromStore(destStore, TOOL_EXECUTORS);
+
+      // let justified: capture tool calls for assertion
+      let toolCallObserved = false;
+      let observedToolId: string | undefined;
+
+      const observerMiddleware: KoiMiddleware = {
+        name: "e2e-bundle-observer",
+        wrapToolCall: async (
+          _ctx: unknown,
+          request: ToolRequest,
+          next: (r: ToolRequest) => Promise<ToolResponse>,
+        ) => {
+          toolCallObserved = true;
+          observedToolId = request.toolId;
+          return next(request);
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the multiply tool to answer math questions. Never compute in your head. Always use the tool.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [observerMiddleware],
+        providers: [toolProvider],
+        loopDetection: false,
+      });
+
+      expect(runtime.agent.state).toBe("created");
+
+      // ── Step 7: Run the agent with a real LLM call ───────────────────
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use the multiply tool to compute 7 * 8. Tell me the result.",
+        }),
+      );
+
+      expect(runtime.agent.state).toBe("terminated");
+
+      // ── Step 8: Verify results ───────────────────────────────────────
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      if (output === undefined) return;
+      expect(output.stopReason).toBe("completed");
+      expect(output.metrics.inputTokens).toBeGreaterThan(0);
+      expect(output.metrics.outputTokens).toBeGreaterThan(0);
+
+      // Middleware observed the tool call
+      expect(toolCallObserved).toBe(true);
+      expect(observedToolId).toBe("multiply");
+
+      // Tool call events were emitted
+      const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+      const toolEnds = events.filter((e) => e.kind === "tool_call_end");
+      expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+      expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+      // LLM response includes the correct answer
+      const text = extractText(events);
+      expect(text).toContain("56");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "imported tools have sandbox trust — provenance is rewritten correctly",
+    async () => {
+      // Export and import a single tool
+      const brick = createMultiplyBrick();
+      const originStore = createInMemoryStore([brick]);
+
+      const exportResult = await createBundle({
+        name: "trust-test-bundle",
+        description: "Tests trust downgrade",
+        manifestYaml: "name: trust-test\nversion: 1.0",
+        brickIds: [brick.id],
+        store: originStore,
+      });
+      expect(exportResult.ok).toBe(true);
+      if (!exportResult.ok) return;
+
+      // Roundtrip through serialization
+      const json = serializeBundle(exportResult.value);
+      const deserialized = deserializeBundle(json);
+      expect(deserialized.ok).toBe(true);
+      if (!deserialized.ok) return;
+
+      // Import into fresh store
+      const destStore = createInMemoryStore();
+      const importResult = await importBundle({ bundle: deserialized.value, store: destStore });
+      expect(importResult.ok).toBe(true);
+      if (!importResult.ok) return;
+
+      // Verify trust properties
+      const loaded = await destStore.load(brick.id);
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) return;
+
+      // Original was "verified" — imported must be "sandbox"
+      expect(brick.trustTier).toBe("verified");
+      expect(loaded.value.trustTier).toBe("sandbox");
+
+      // Original was "forged" — imported must be "bundled"
+      expect(brick.provenance.source.origin).toBe("forged");
+      expect(loaded.value.provenance.source.origin).toBe("bundled");
+      expect(loaded.value.provenance.source).toEqual({
+        origin: "bundled",
+        bundleName: "trust-test-bundle",
+        bundleVersion: BUNDLE_FORMAT_VERSION,
+      });
+
+      // Scope downgraded to "agent"
+      expect(loaded.value.scope).toBe("agent");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "second import deduplicates — same bricks are skipped",
+    async () => {
+      const brick = createMultiplyBrick();
+      const originStore = createInMemoryStore([brick]);
+
+      const exportResult = await createBundle({
+        name: "dedup-test",
+        description: "Tests dedup on re-import",
+        manifestYaml: "name: dedup\nversion: 1.0",
+        brickIds: [brick.id],
+        store: originStore,
+      });
+      expect(exportResult.ok).toBe(true);
+      if (!exportResult.ok) return;
+
+      const json = serializeBundle(exportResult.value);
+      const deserialized = deserializeBundle(json);
+      expect(deserialized.ok).toBe(true);
+      if (!deserialized.ok) return;
+
+      const destStore = createInMemoryStore();
+
+      // First import
+      const first = await importBundle({ bundle: deserialized.value, store: destStore });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.value.imported).toBe(1);
+      expect(first.value.skipped).toBe(0);
+
+      // Second import — same bricks → all skipped
+      const second = await importBundle({ bundle: deserialized.value, store: destStore });
+      expect(second.ok).toBe(true);
+      if (!second.ok) return;
+      expect(second.value.imported).toBe(0);
+      expect(second.value.skipped).toBe(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "content hash tamper detection rejects corrupted bundles",
+    async () => {
+      const brick = createMultiplyBrick();
+      const originStore = createInMemoryStore([brick]);
+
+      const exportResult = await createBundle({
+        name: "tamper-test",
+        description: "Tests tamper detection",
+        manifestYaml: "name: tamper\nversion: 1.0",
+        brickIds: [brick.id],
+        store: originStore,
+      });
+      expect(exportResult.ok).toBe(true);
+      if (!exportResult.ok) return;
+
+      // Serialize, then tamper with the manifest
+      const json = serializeBundle(exportResult.value);
+      const parsed = JSON.parse(json) as Record<string, unknown>;
+      parsed.manifestYaml = "name: EVIL-AGENT\nversion: 666";
+      const tamperedJson = JSON.stringify(parsed, null, 2);
+
+      const deserialized = deserializeBundle(tamperedJson);
+      expect(deserialized.ok).toBe(true);
+      if (!deserialized.ok) return;
+
+      // Import should fail because contentHash no longer matches
+      const destStore = createInMemoryStore();
+      const importResult = await importBundle({ bundle: deserialized.value, store: destStore });
+      expect(importResult.ok).toBe(false);
+      if (importResult.ok) return;
+      expect(importResult.error.code).toBe("VALIDATION");
+      expect(importResult.error.message).toContain("content hash mismatch");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "multi-tool agent: LLM uses weather tool from imported bundle",
+    async () => {
+      const weatherBrick = createWeatherBrick();
+      const originStore = createInMemoryStore([weatherBrick]);
+
+      const exportResult = await createBundle({
+        name: "weather-bundle",
+        description: "Weather tool bundle",
+        manifestYaml: "name: weather-agent\nversion: 1.0",
+        brickIds: [weatherBrick.id],
+        store: originStore,
+      });
+      expect(exportResult.ok).toBe(true);
+      if (!exportResult.ok) return;
+
+      const json = serializeBundle(exportResult.value);
+      const deserialized = deserializeBundle(json);
+      expect(deserialized.ok).toBe(true);
+      if (!deserialized.ok) return;
+
+      const destStore = createInMemoryStore();
+      const importResult = await importBundle({ bundle: deserialized.value, store: destStore });
+      expect(importResult.ok).toBe(true);
+
+      // Wire the imported weather tool into a real agent
+      const toolProvider = createToolProviderFromStore(destStore, TOOL_EXECUTORS);
+      const toolCalls: string[] = [];
+
+      const spy: KoiMiddleware = {
+        name: "weather-spy",
+        wrapToolCall: async (_ctx, req: ToolRequest, next) => {
+          toolCalls.push(req.toolId);
+          return next(req);
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You have the get_weather tool. Use it when asked about weather. Always use the tool.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [spy],
+        providers: [toolProvider],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "What is the weather in Tokyo? Use the get_weather tool.",
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Weather tool was called
+      expect(toolCalls).toContain("get_weather");
+
+      // Response mentions weather data
+      const text = extractText(events);
+      const hasWeatherInfo =
+        text.includes("22") || text.includes("sunny") || text.includes("Tokyo");
+      expect(hasWeatherInfo).toBe(true);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/bundle/src/__tests__/roundtrip.integration.test.ts
+++ b/packages/bundle/src/__tests__/roundtrip.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Integration test — full export → serialize → deserialize → import pipeline.
+ *
+ * Verifies the complete roundtrip including dedup, trust downgrade, and
+ * provenance rewriting.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifact, ForgeStore, ToolArtifact } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION } from "@koi/core";
+import { computeBrickId } from "@koi/hash";
+
+import { createBundle } from "../export-bundle.js";
+import { importBundle } from "../import-bundle.js";
+import { deserializeBundle, serializeBundle } from "../serialize.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestProvenance(): ToolArtifact["provenance"] {
+  return {
+    source: { origin: "forged", forgedBy: "test-agent" },
+    buildDefinition: { buildType: "forge", externalParameters: {} },
+    builder: { id: "test-builder" },
+    metadata: {
+      invocationId: "inv-1",
+      startedAt: 1000,
+      finishedAt: 2000,
+      sessionId: "sess-1",
+      agentId: "agent-1",
+      depth: 0,
+    },
+    verification: {
+      passed: true,
+      finalTrustTier: "verified",
+      totalDurationMs: 1000,
+      stageResults: [],
+    },
+    classification: "public",
+    contentMarkers: [],
+    contentHash: "abc123",
+  };
+}
+
+function createTestBrick(implementation: string): ToolArtifact {
+  const id = computeBrickId("tool", implementation);
+  return {
+    id,
+    kind: "tool",
+    name: "test-tool",
+    description: "A test tool",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["test"],
+    usageCount: 0,
+    implementation,
+    inputSchema: { type: "object" },
+  };
+}
+
+function createInMemoryStore(initialBricks?: readonly BrickArtifact[]): ForgeStore & {
+  readonly getAll: () => readonly BrickArtifact[];
+} {
+  const map = new Map<string, BrickArtifact>();
+  if (initialBricks) {
+    for (const brick of initialBricks) {
+      map.set(brick.id, brick);
+    }
+  }
+  return {
+    save: async (brick) => {
+      map.set(brick.id, brick);
+      return { ok: true, value: undefined };
+    },
+    load: async (id) => {
+      const brick = map.get(id);
+      if (brick === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Not found: ${id}`, retryable: false },
+        };
+      }
+      return { ok: true, value: brick };
+    },
+    search: async () => ({ ok: true, value: [...map.values()] }),
+    remove: async (id) => {
+      map.delete(id);
+      return { ok: true, value: undefined };
+    },
+    update: async () => ({ ok: true, value: undefined }),
+    exists: async (id) => ({ ok: true, value: map.has(id) }),
+    getAll: () => [...map.values()],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("export → serialize → deserialize → import roundtrip", () => {
+  test("full pipeline preserves all brick content", async () => {
+    // 1. Create test bricks and save to store A
+    const brick1 = createTestBrick("function greet() { return 'hello'; }");
+    const brick2 = createTestBrick("function farewell() { return 'goodbye'; }");
+    const storeA = createInMemoryStore([brick1, brick2]);
+
+    // 2. Export from store A
+    const exportResult = await createBundle({
+      name: "roundtrip-test",
+      description: "Integration test bundle",
+      manifestYaml: "name: test-agent\nversion: 1.0",
+      brickIds: [brick1.id, brick2.id],
+      store: storeA,
+    });
+    expect(exportResult.ok).toBe(true);
+    if (!exportResult.ok) return;
+
+    // 3. Serialize to JSON
+    const json = serializeBundle(exportResult.value);
+    expect(json.length).toBeGreaterThan(0);
+
+    // 4. Deserialize from JSON
+    const deserializeResult = deserializeBundle(json);
+    expect(deserializeResult.ok).toBe(true);
+    if (!deserializeResult.ok) return;
+
+    // 5. Import into store B
+    const storeB = createInMemoryStore();
+    const importResult = await importBundle({
+      bundle: deserializeResult.value,
+      store: storeB,
+    });
+    expect(importResult.ok).toBe(true);
+    if (!importResult.ok) return;
+    expect(importResult.value.imported).toBe(2);
+    expect(importResult.value.skipped).toBe(0);
+    expect(importResult.value.errors).toHaveLength(0);
+
+    // 6. Verify bricks in store B match store A content
+    const loadResult1 = await storeB.load(brick1.id);
+    const loadResult2 = await storeB.load(brick2.id);
+    expect(loadResult1.ok).toBe(true);
+    expect(loadResult2.ok).toBe(true);
+    if (!loadResult1.ok || !loadResult2.ok) return;
+
+    expect((loadResult1.value as ToolArtifact).implementation).toBe(
+      "function greet() { return 'hello'; }",
+    );
+    expect((loadResult2.value as ToolArtifact).implementation).toBe(
+      "function farewell() { return 'goodbye'; }",
+    );
+
+    // 7. Verify trust tier is sandbox in store B
+    expect(loadResult1.value.trustTier).toBe("sandbox");
+    expect(loadResult2.value.trustTier).toBe("sandbox");
+
+    // 8. Verify provenance source is bundled in store B
+    expect(loadResult1.value.provenance.source).toEqual({
+      origin: "bundled",
+      bundleName: "roundtrip-test",
+      bundleVersion: BUNDLE_FORMAT_VERSION,
+    });
+    expect(loadResult2.value.provenance.source).toEqual({
+      origin: "bundled",
+      bundleName: "roundtrip-test",
+      bundleVersion: BUNDLE_FORMAT_VERSION,
+    });
+
+    // 9. Second import → all skipped (dedup)
+    const reimportResult = await importBundle({
+      bundle: deserializeResult.value,
+      store: storeB,
+    });
+    expect(reimportResult.ok).toBe(true);
+    if (!reimportResult.ok) return;
+    expect(reimportResult.value.imported).toBe(0);
+    expect(reimportResult.value.skipped).toBe(2);
+    expect(reimportResult.value.errors).toHaveLength(0);
+  });
+});

--- a/packages/bundle/src/brick-content.ts
+++ b/packages/bundle/src/brick-content.ts
@@ -1,0 +1,22 @@
+/**
+ * Brick content extraction — maps brick kind to hashable primary content.
+ *
+ * Reimplemented within @koi/bundle to avoid L2→L2 dependency on @koi/forge
+ * which has the same function. If a new BrickKind is added, update both.
+ */
+
+import type { BrickArtifact } from "@koi/core";
+
+/** Extract the primary content string from a brick artifact for ID recomputation. */
+export function extractBrickContent(brick: BrickArtifact): string {
+  switch (brick.kind) {
+    case "tool":
+    case "middleware":
+    case "channel":
+      return brick.implementation;
+    case "skill":
+      return brick.content;
+    case "agent":
+      return brick.manifestYaml;
+  }
+}

--- a/packages/bundle/src/export-bundle.test.ts
+++ b/packages/bundle/src/export-bundle.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for createBundle() — export pipeline.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifact, ForgeStore, ToolArtifact } from "@koi/core";
+import { computeBrickId } from "@koi/hash";
+
+import { createBundle } from "./export-bundle.js";
+import type { ExportBundleConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestProvenance(): ToolArtifact["provenance"] {
+  return {
+    source: { origin: "forged", forgedBy: "test-agent" },
+    buildDefinition: { buildType: "forge", externalParameters: {} },
+    builder: { id: "test-builder" },
+    metadata: {
+      invocationId: "inv-1",
+      startedAt: 1000,
+      finishedAt: 2000,
+      sessionId: "sess-1",
+      agentId: "agent-1",
+      depth: 0,
+    },
+    verification: {
+      passed: true,
+      finalTrustTier: "verified",
+      totalDurationMs: 1000,
+      stageResults: [],
+    },
+    classification: "public",
+    contentMarkers: [],
+    contentHash: "abc123",
+  };
+}
+
+function createTestBrick(overrides?: {
+  readonly implementation?: string;
+  readonly files?: Readonly<Record<string, string>>;
+}): ToolArtifact {
+  const implementation = overrides?.implementation ?? "function hello() { return 'world'; }";
+  const files = overrides?.files;
+  const id = computeBrickId("tool", implementation, files);
+  return {
+    id,
+    kind: "tool",
+    name: "test-tool",
+    description: "A test tool",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["test"],
+    usageCount: 0,
+    implementation,
+    inputSchema: { type: "object" },
+    ...(files !== undefined ? { files } : {}),
+  };
+}
+
+function createTestStore(bricks: readonly BrickArtifact[]): ForgeStore {
+  const map = new Map<string, BrickArtifact>();
+  for (const brick of bricks) {
+    map.set(brick.id, brick);
+  }
+  return {
+    save: async (brick) => {
+      map.set(brick.id, brick);
+      return { ok: true, value: undefined };
+    },
+    load: async (id) => {
+      const brick = map.get(id);
+      if (brick === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Not found: ${id}`, retryable: false },
+        };
+      }
+      return { ok: true, value: brick };
+    },
+    search: async () => ({ ok: true, value: [...map.values()] }),
+    remove: async (id) => {
+      map.delete(id);
+      return { ok: true, value: undefined };
+    },
+    update: async () => ({ ok: true, value: undefined }),
+    exists: async (id) => ({ ok: true, value: map.has(id) }),
+  };
+}
+
+function makeConfig(overrides?: Partial<ExportBundleConfig>): ExportBundleConfig {
+  const brick = createTestBrick();
+  const store = createTestStore([brick]);
+  return {
+    name: "test-bundle",
+    description: "A test bundle",
+    manifestYaml: "name: test-agent\nversion: 1.0",
+    brickIds: [brick.id],
+    store,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createBundle", () => {
+  test("creates bundle with correct fields", async () => {
+    const brick = createTestBrick();
+    const config = makeConfig({ brickIds: [brick.id], store: createTestStore([brick]) });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.version).toBe("1");
+    expect(result.value.name).toBe("test-bundle");
+    expect(result.value.description).toBe("A test bundle");
+    expect(result.value.manifestYaml).toBe("name: test-agent\nversion: 1.0");
+    expect(result.value.bricks).toHaveLength(1);
+    expect(result.value.bricks[0]?.id).toBe(brick.id);
+    expect(result.value.contentHash).toBeTruthy();
+    expect(result.value.id).toContain("bundle:");
+    expect(result.value.createdAt).toBeGreaterThan(0);
+  });
+
+  test("returns VALIDATION error for empty brick list", async () => {
+    const config = makeConfig({ brickIds: [] });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("brick ID");
+  });
+
+  test("returns VALIDATION error for empty name", async () => {
+    const config = makeConfig({ name: "" });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("name");
+  });
+
+  test("returns VALIDATION error for empty manifestYaml", async () => {
+    const config = makeConfig({ manifestYaml: "" });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("Manifest");
+  });
+
+  test("returns NOT_FOUND when brick not in store", async () => {
+    const store = createTestStore([]);
+    const config = makeConfig({
+      brickIds: ["sha256:0000000000000000000000000000000000000000000000000000000000000000"],
+      store,
+    });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("deduplicates brick IDs silently", async () => {
+    const brick = createTestBrick();
+    const store = createTestStore([brick]);
+    const config = makeConfig({
+      brickIds: [brick.id, brick.id, brick.id],
+      store,
+    });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.bricks).toHaveLength(1);
+  });
+
+  test("includes brick companion files in bundle", async () => {
+    const brick = createTestBrick({
+      implementation: "function withFiles() {}",
+      files: { "readme.md": "# Hello", "config.json": "{}" },
+    });
+    const store = createTestStore([brick]);
+    const config = makeConfig({ brickIds: [brick.id], store });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.bricks[0]?.files).toEqual({
+      "readme.md": "# Hello",
+      "config.json": "{}",
+    });
+  });
+
+  test("content hash is deterministic", async () => {
+    const brick = createTestBrick();
+    const store = createTestStore([brick]);
+    const config = makeConfig({ brickIds: [brick.id], store });
+
+    const result1 = await createBundle(config);
+    const result2 = await createBundle(config);
+
+    expect(result1.ok).toBe(true);
+    expect(result2.ok).toBe(true);
+    if (!result1.ok || !result2.ok) return;
+    expect(result1.value.contentHash).toBe(result2.value.contentHash);
+  });
+
+  test("bundle ID is derived from content hash", async () => {
+    const brick = createTestBrick();
+    const store = createTestStore([brick]);
+    const config = makeConfig({ brickIds: [brick.id], store });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(String(result.value.id)).toBe(`bundle:${result.value.contentHash}`);
+  });
+
+  test("includes metadata when provided", async () => {
+    const brick = createTestBrick();
+    const store = createTestStore([brick]);
+    const config = makeConfig({
+      brickIds: [brick.id],
+      store,
+      metadata: { author: "tester", version: 2 },
+    });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.metadata).toEqual({ author: "tester", version: 2 });
+  });
+});

--- a/packages/bundle/src/export-bundle.ts
+++ b/packages/bundle/src/export-bundle.ts
@@ -1,0 +1,99 @@
+/**
+ * Bundle export — serialize an agent's manifest + bricks into a portable artifact.
+ *
+ * Algorithm:
+ * 1. Validate inputs (name, manifestYaml, brickIds non-empty)
+ * 2. Deduplicate brick IDs
+ * 3. Load all bricks in parallel from ForgeStore
+ * 4. Verify integrity of each loaded brick
+ * 5. Compute content hash for the bundle envelope
+ * 6. Return AgentBundle
+ */
+
+import type { AgentBundle, BrickArtifact, KoiError, Result } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, brickId, bundleId, notFound, validation } from "@koi/core";
+import { computeBrickId, computeContentHash } from "@koi/hash";
+
+import { extractBrickContent } from "./brick-content.js";
+import type { ExportBundleConfig } from "./types.js";
+
+/** Create a portable agent bundle from a manifest + brick IDs. */
+export async function createBundle(
+  config: ExportBundleConfig,
+): Promise<Result<AgentBundle, KoiError>> {
+  // 1. Validate inputs
+  if (config.name.length === 0) {
+    return { ok: false, error: validation("Bundle name must not be empty") };
+  }
+  if (config.manifestYaml.length === 0) {
+    return { ok: false, error: validation("Manifest YAML must not be empty") };
+  }
+  if (config.brickIds.length === 0) {
+    return { ok: false, error: validation("At least one brick ID is required") };
+  }
+
+  // 2. Deduplicate brick IDs
+  const uniqueIds = [...new Set(config.brickIds)];
+
+  // 3. Load all bricks in parallel
+  const loadResults = await Promise.all(uniqueIds.map((id) => config.store.load(brickId(id))));
+
+  // 4. Collect bricks, fail on missing
+  const bricks: BrickArtifact[] = [];
+  const missingIds: string[] = [];
+
+  for (let i = 0; i < loadResults.length; i++) {
+    const result = loadResults[i];
+    if (result === undefined) continue;
+    if (!result.ok) {
+      const id = uniqueIds[i];
+      if (id !== undefined) {
+        missingIds.push(id);
+      }
+    } else {
+      bricks.push(result.value);
+    }
+  }
+
+  if (missingIds.length > 0) {
+    return {
+      ok: false,
+      error: notFound(missingIds.join(", "), `Bricks not found in store: ${missingIds.join(", ")}`),
+    };
+  }
+
+  // 5. Verify integrity of each brick
+  for (const brick of bricks) {
+    const content = extractBrickContent(brick);
+    const expectedId = computeBrickId(brick.kind, content, brick.files);
+    if (expectedId !== brick.id) {
+      return {
+        ok: false,
+        error: validation(`Brick integrity check failed for ${brick.id}: expected ${expectedId}`),
+      };
+    }
+  }
+
+  // 6. Compute bundle content hash
+  const sortedBrickIds = [...bricks.map((b) => b.id)].sort();
+  const contentHash = computeContentHash({
+    manifest: config.manifestYaml,
+    brickIds: sortedBrickIds,
+  });
+
+  const id = bundleId(`bundle:${contentHash}`);
+
+  const bundle: AgentBundle = {
+    version: BUNDLE_FORMAT_VERSION,
+    id,
+    name: config.name,
+    description: config.description,
+    manifestYaml: config.manifestYaml,
+    bricks,
+    contentHash,
+    createdAt: Date.now(),
+    ...(config.metadata !== undefined ? { metadata: config.metadata } : {}),
+  };
+
+  return { ok: true, value: bundle };
+}

--- a/packages/bundle/src/import-bundle.test.ts
+++ b/packages/bundle/src/import-bundle.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for importBundle() — import pipeline.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentBundle, BrickArtifact, ForgeStore, ToolArtifact } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, bundleId } from "@koi/core";
+import { computeBrickId, computeContentHash } from "@koi/hash";
+
+import { importBundle } from "./import-bundle.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestProvenance(): ToolArtifact["provenance"] {
+  return {
+    source: { origin: "forged", forgedBy: "test-agent" },
+    buildDefinition: { buildType: "forge", externalParameters: {} },
+    builder: { id: "test-builder" },
+    metadata: {
+      invocationId: "inv-1",
+      startedAt: 1000,
+      finishedAt: 2000,
+      sessionId: "sess-1",
+      agentId: "agent-1",
+      depth: 0,
+    },
+    verification: {
+      passed: true,
+      finalTrustTier: "verified",
+      totalDurationMs: 1000,
+      stageResults: [],
+    },
+    classification: "public",
+    contentMarkers: [],
+    contentHash: "abc123",
+  };
+}
+
+function createTestBrick(overrides?: { readonly implementation?: string }): ToolArtifact {
+  const implementation = overrides?.implementation ?? "function hello() { return 'world'; }";
+  const id = computeBrickId("tool", implementation);
+  return {
+    id,
+    kind: "tool",
+    name: "test-tool",
+    description: "A test tool",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["test"],
+    usageCount: 0,
+    implementation,
+    inputSchema: { type: "object" },
+  };
+}
+
+function createTestStore(initialBricks?: readonly BrickArtifact[]): ForgeStore & {
+  readonly getAll: () => readonly BrickArtifact[];
+} {
+  const map = new Map<string, BrickArtifact>();
+  if (initialBricks) {
+    for (const brick of initialBricks) {
+      map.set(brick.id, brick);
+    }
+  }
+  return {
+    save: async (brick) => {
+      map.set(brick.id, brick);
+      return { ok: true, value: undefined };
+    },
+    load: async (id) => {
+      const brick = map.get(id);
+      if (brick === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Not found: ${id}`, retryable: false },
+        };
+      }
+      return { ok: true, value: brick };
+    },
+    search: async () => ({ ok: true, value: [...map.values()] }),
+    remove: async (id) => {
+      map.delete(id);
+      return { ok: true, value: undefined };
+    },
+    update: async () => ({ ok: true, value: undefined }),
+    exists: async (id) => ({ ok: true, value: map.has(id) }),
+    getAll: () => [...map.values()],
+  };
+}
+
+function createTestBundle(bricks: readonly BrickArtifact[]): AgentBundle {
+  const manifestYaml = "name: test-agent\nversion: 1.0";
+  const sortedBrickIds = [...bricks.map((b) => b.id)].sort();
+  const contentHash = computeContentHash({ manifest: manifestYaml, brickIds: sortedBrickIds });
+  return {
+    version: BUNDLE_FORMAT_VERSION,
+    id: bundleId(`bundle:${contentHash}`),
+    name: "test-bundle",
+    description: "A test bundle",
+    manifestYaml,
+    bricks,
+    contentHash,
+    createdAt: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("importBundle", () => {
+  test("imports all bricks and returns correct counts", async () => {
+    const brick1 = createTestBrick({ implementation: "function a() {}" });
+    const brick2 = createTestBrick({ implementation: "function b() {}" });
+    const bundle = createTestBundle([brick1, brick2]);
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.imported).toBe(2);
+    expect(result.value.skipped).toBe(0);
+    expect(result.value.errors).toHaveLength(0);
+  });
+
+  test("skips all when all bricks already exist", async () => {
+    const brick = createTestBrick();
+    const bundle = createTestBundle([brick]);
+    const store = createTestStore([brick]);
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.imported).toBe(0);
+    expect(result.value.skipped).toBe(1);
+    expect(result.value.errors).toHaveLength(0);
+  });
+
+  test("handles mix of existing and new bricks", async () => {
+    const existing = createTestBrick({ implementation: "function existing() {}" });
+    const newBrick = createTestBrick({ implementation: "function brand_new() {}" });
+    const bundle = createTestBundle([existing, newBrick]);
+    const store = createTestStore([existing]);
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.imported).toBe(1);
+    expect(result.value.skipped).toBe(1);
+    expect(result.value.errors).toHaveLength(0);
+  });
+
+  test("reports error for corrupted brick (hash mismatch)", async () => {
+    const brick = createTestBrick();
+    // Corrupt the brick by changing its ID while keeping content the same
+    const corruptedBrick: ToolArtifact = {
+      ...brick,
+      id: computeBrickId("tool", "totally-different-content"),
+    };
+    const bundle = createTestBundle([corruptedBrick]);
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.errors).toHaveLength(1);
+    expect(result.value.errors[0]?.reason).toContain("Integrity check failed");
+  });
+
+  test("returns VALIDATION error for wrong bundle version", async () => {
+    const brick = createTestBrick();
+    const bundle = {
+      ...createTestBundle([brick]),
+      version: "99" as typeof BUNDLE_FORMAT_VERSION,
+    };
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("version");
+  });
+
+  test("downgrades trust tier to sandbox for imported bricks", async () => {
+    const brick = createTestBrick();
+    const bundle = createTestBundle([brick]);
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+    expect(result.ok).toBe(true);
+
+    const loadResult = await store.load(brick.id);
+    expect(loadResult.ok).toBe(true);
+    if (!loadResult.ok) return;
+    expect(loadResult.value.trustTier).toBe("sandbox");
+  });
+
+  test("sets provenance source to bundled origin", async () => {
+    const brick = createTestBrick();
+    const bundle = createTestBundle([brick]);
+    const store = createTestStore();
+
+    await importBundle({ bundle, store });
+
+    const loadResult = await store.load(brick.id);
+    expect(loadResult.ok).toBe(true);
+    if (!loadResult.ok) return;
+    expect(loadResult.value.provenance.source).toEqual({
+      origin: "bundled",
+      bundleName: "test-bundle",
+      bundleVersion: BUNDLE_FORMAT_VERSION,
+    });
+  });
+
+  test("returns VALIDATION error when content hash is tampered", async () => {
+    const brick = createTestBrick();
+    const bundle: AgentBundle = {
+      ...createTestBundle([brick]),
+      contentHash: "tampered-hash-value",
+    };
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("content hash mismatch");
+  });
+
+  test("succeeds with empty bricks array", async () => {
+    const bundle = createTestBundle([]);
+    const store = createTestStore();
+
+    const result = await importBundle({ bundle, store });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.imported).toBe(0);
+    expect(result.value.skipped).toBe(0);
+    expect(result.value.errors).toHaveLength(0);
+  });
+});

--- a/packages/bundle/src/import-bundle.ts
+++ b/packages/bundle/src/import-bundle.ts
@@ -1,0 +1,146 @@
+/**
+ * Bundle import — load bricks from a portable artifact into a ForgeStore.
+ *
+ * Algorithm:
+ * 1. Validate bundle version
+ * 2. Verify bundle content hash (detect manifest/brick-list tampering)
+ * 3. Validate each brick with validateBrickArtifact()
+ * 4. Verify integrity: recompute BrickId from content, compare to stored ID
+ * 5. For each valid brick, check-then-save with dedup and trust downgrade
+ * 6. Return imported/skipped/errors counts
+ */
+
+import type { BrickArtifact, KoiError, Result } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, validation } from "@koi/core";
+import { computeBrickId, computeContentHash } from "@koi/hash";
+import { validateBrickArtifact } from "@koi/validation";
+
+import { extractBrickContent } from "./brick-content.js";
+import type { ImportBrickError, ImportBundleConfig, ImportBundleResult } from "./types.js";
+
+/** Downgrade a brick's trust to sandbox and set bundled provenance source. */
+function downgradeBrick(brick: BrickArtifact, bundleName: string): BrickArtifact {
+  return {
+    ...brick,
+    trustTier: "sandbox",
+    scope: "agent",
+    provenance: {
+      ...brick.provenance,
+      source: {
+        origin: "bundled",
+        bundleName,
+        bundleVersion: BUNDLE_FORMAT_VERSION,
+      },
+    },
+  };
+}
+
+/** Import bricks from an agent bundle into a store with dedup and trust downgrade. */
+export async function importBundle(
+  config: ImportBundleConfig,
+): Promise<Result<ImportBundleResult, KoiError>> {
+  const { bundle, store } = config;
+
+  // 1. Validate bundle version
+  if (bundle.version !== BUNDLE_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: validation(
+        `Unsupported bundle version "${String(bundle.version)}", expected "${BUNDLE_FORMAT_VERSION}"`,
+      ),
+    };
+  }
+
+  // 2. Verify bundle content hash — detect tampering of manifest or brick list
+  const sortedBrickIds = [...bundle.bricks.map((b) => b.id)].sort();
+  const expectedHash = computeContentHash({
+    manifest: bundle.manifestYaml,
+    brickIds: sortedBrickIds,
+  });
+  if (expectedHash !== bundle.contentHash) {
+    return {
+      ok: false,
+      error: validation(
+        `Bundle content hash mismatch: expected ${expectedHash}, got ${bundle.contentHash}`,
+      ),
+    };
+  }
+
+  // 3. Empty bricks is a valid edge case
+  if (bundle.bricks.length === 0) {
+    return { ok: true, value: { imported: 0, skipped: 0, errors: [] } };
+  }
+
+  // 4. Validate and verify each brick, then import in parallel
+  const importTasks = bundle.bricks.map(
+    async (
+      rawBrick,
+    ): Promise<{
+      readonly kind: "imported" | "skipped" | "error";
+      readonly error?: ImportBrickError;
+    }> => {
+      // Validate structure
+      const validationResult = validateBrickArtifact(rawBrick, `bundle:${bundle.name}`);
+      if (!validationResult.ok) {
+        return {
+          kind: "error",
+          error: { brickId: String(rawBrick.id), reason: validationResult.error.message },
+        };
+      }
+
+      const brick = validationResult.value;
+
+      // Verify integrity: recompute BrickId from content
+      const content = extractBrickContent(brick);
+      const expectedId = computeBrickId(brick.kind, content, brick.files);
+      if (expectedId !== brick.id) {
+        return {
+          kind: "error",
+          error: {
+            brickId: brick.id,
+            reason: `Integrity check failed: expected ${expectedId}, got ${brick.id}`,
+          },
+        };
+      }
+
+      // Check-then-save with dedup
+      const existsResult = await store.exists(brick.id);
+      if (!existsResult.ok) {
+        return {
+          kind: "error",
+          error: { brickId: brick.id, reason: existsResult.error.message },
+        };
+      }
+
+      if (existsResult.value) {
+        return { kind: "skipped" };
+      }
+
+      // Downgrade trust and save
+      const downgraded = downgradeBrick(brick, bundle.name);
+      const saveResult = await store.save(downgraded);
+      if (!saveResult.ok) {
+        return {
+          kind: "error",
+          error: { brickId: brick.id, reason: saveResult.error.message },
+        };
+      }
+
+      return { kind: "imported" };
+    },
+  );
+
+  const results = await Promise.all(importTasks);
+
+  // 5. Aggregate results (immutable)
+  const imported = results.filter((r) => r.kind === "imported").length;
+  const skipped = results.filter((r) => r.kind === "skipped").length;
+  const errors: readonly ImportBrickError[] = results
+    .filter(
+      (r): r is typeof r & { readonly error: ImportBrickError } =>
+        r.kind === "error" && r.error !== undefined,
+    )
+    .map((r) => r.error);
+
+  return { ok: true, value: { imported, skipped, errors } };
+}

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @koi/bundle — Portable agent export/import bundles (Layer 2).
+ *
+ * Docker-style export/import for Koi agents: serialize an agent's manifest +
+ * referenced bricks into a `.koibundle` JSON file, import into another
+ * deployment with integrity verification, deduplication, and trust downgrading.
+ */
+
+export { createBundle } from "./export-bundle.js";
+export { importBundle } from "./import-bundle.js";
+export { deserializeBundle, serializeBundle } from "./serialize.js";
+export type {
+  ExportBundleConfig,
+  ImportBrickError,
+  ImportBundleConfig,
+  ImportBundleResult,
+} from "./types.js";

--- a/packages/bundle/src/serialize.test.ts
+++ b/packages/bundle/src/serialize.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for serializeBundle() / deserializeBundle() — serialization pipeline.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentBundle, ToolArtifact } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, bundleId } from "@koi/core";
+import { computeBrickId, computeContentHash } from "@koi/hash";
+
+import { deserializeBundle, serializeBundle } from "./serialize.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestProvenance(): ToolArtifact["provenance"] {
+  return {
+    source: { origin: "forged", forgedBy: "test-agent" },
+    buildDefinition: { buildType: "forge", externalParameters: {} },
+    builder: { id: "test-builder" },
+    metadata: {
+      invocationId: "inv-1",
+      startedAt: 1000,
+      finishedAt: 2000,
+      sessionId: "sess-1",
+      agentId: "agent-1",
+      depth: 0,
+    },
+    verification: {
+      passed: true,
+      finalTrustTier: "verified",
+      totalDurationMs: 1000,
+      stageResults: [],
+    },
+    classification: "public",
+    contentMarkers: [],
+    contentHash: "abc123",
+  };
+}
+
+function createTestBrick(implementation?: string): ToolArtifact {
+  const impl = implementation ?? "function hello() { return 'world'; }";
+  const id = computeBrickId("tool", impl);
+  return {
+    id,
+    kind: "tool",
+    name: "test-tool",
+    description: "A test tool",
+    scope: "agent",
+    trustTier: "verified",
+    lifecycle: "active",
+    provenance: createTestProvenance(),
+    version: "1.0.0",
+    tags: ["test"],
+    usageCount: 0,
+    implementation: impl,
+    inputSchema: { type: "object" },
+  };
+}
+
+function createTestBundle(bricks?: readonly ToolArtifact[]): AgentBundle {
+  const manifestYaml = "name: test-agent\nversion: 1.0";
+  const allBricks = bricks ?? [createTestBrick()];
+  const sortedBrickIds = [...allBricks.map((b) => b.id)].sort();
+  const contentHash = computeContentHash({ manifest: manifestYaml, brickIds: sortedBrickIds });
+  return {
+    version: BUNDLE_FORMAT_VERSION,
+    id: bundleId(`bundle:${contentHash}`),
+    name: "test-bundle",
+    description: "A test bundle",
+    manifestYaml,
+    bricks: allBricks,
+    contentHash,
+    createdAt: 1700000000000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("serializeBundle / deserializeBundle", () => {
+  test("roundtrip: serialize then deserialize produces identical bundle", () => {
+    const bundle = createTestBundle();
+    const json = serializeBundle(bundle);
+    const result = deserializeBundle(json);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.version).toBe(bundle.version);
+    expect(result.value.id).toBe(bundle.id);
+    expect(result.value.name).toBe(bundle.name);
+    expect(result.value.description).toBe(bundle.description);
+    expect(result.value.manifestYaml).toBe(bundle.manifestYaml);
+    expect(result.value.bricks).toHaveLength(bundle.bricks.length);
+    expect(result.value.bricks[0]?.id).toBe(bundle.bricks[0]?.id);
+    expect(result.value.contentHash).toBe(bundle.contentHash);
+    expect(result.value.createdAt).toBe(bundle.createdAt);
+  });
+
+  test("returns VALIDATION error for invalid JSON string", () => {
+    const result = deserializeBundle("{not valid json");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("Invalid JSON");
+  });
+
+  test("returns VALIDATION error for valid JSON missing required field", () => {
+    const bundle = createTestBundle();
+    const json = serializeBundle(bundle);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    delete parsed.name;
+    const modifiedJson = JSON.stringify(parsed);
+
+    const result = deserializeBundle(modifiedJson);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("name");
+  });
+
+  test("handles unicode content in brick implementations", () => {
+    const brick = createTestBrick("function greet() { return '你好世界 🌍'; }");
+    const bundle = createTestBundle([brick]);
+    const json = serializeBundle(bundle);
+    const result = deserializeBundle(json);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const importedBrick = result.value.bricks[0] as ToolArtifact;
+    expect(importedBrick.implementation).toBe("function greet() { return '你好世界 🌍'; }");
+  });
+
+  test("returns VALIDATION error for empty string", () => {
+    const result = deserializeBundle("");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("empty");
+  });
+
+  test("returns VALIDATION error for unsupported format version", () => {
+    const bundle = createTestBundle();
+    const json = serializeBundle(bundle);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    parsed.version = "99";
+    const modifiedJson = JSON.stringify(parsed);
+
+    const result = deserializeBundle(modifiedJson);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("version");
+  });
+
+  test("returns VALIDATION error for missing bricks array", () => {
+    const bundle = createTestBundle();
+    const json = serializeBundle(bundle);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    delete parsed.bricks;
+    const modifiedJson = JSON.stringify(parsed);
+
+    const result = deserializeBundle(modifiedJson);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("bricks");
+  });
+
+  test("preserves metadata through roundtrip", () => {
+    const bundle: AgentBundle = {
+      ...createTestBundle(),
+      metadata: { author: "tester", tags: ["portable"] },
+    };
+    const json = serializeBundle(bundle);
+    const result = deserializeBundle(json);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.metadata).toEqual({ author: "tester", tags: ["portable"] });
+  });
+});

--- a/packages/bundle/src/serialize.ts
+++ b/packages/bundle/src/serialize.ts
@@ -1,0 +1,115 @@
+/**
+ * Bundle serialization — JSON encode/decode for `.koibundle` files.
+ *
+ * Serialize: JSON.stringify with 2-space indent for inspectability.
+ * Deserialize: JSON.parse + field-by-field validation + brick validation.
+ */
+
+import type { AgentBundle, KoiError, Result } from "@koi/core";
+import { BUNDLE_FORMAT_VERSION, bundleId, validation } from "@koi/core";
+import { validateBrickArtifact } from "@koi/validation";
+
+/** Serialize an AgentBundle to a pretty-printed JSON string. */
+export function serializeBundle(bundle: AgentBundle): string {
+  return JSON.stringify(bundle, null, 2);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** Deserialize a JSON string into a validated AgentBundle. */
+export function deserializeBundle(json: string): Result<AgentBundle, KoiError> {
+  if (json.length === 0) {
+    return { ok: false, error: validation("Bundle JSON must not be empty") };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch (e: unknown) {
+    const message = e instanceof SyntaxError ? e.message : "unknown parse error";
+    return { ok: false, error: validation(`Invalid JSON: ${message}`) };
+  }
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, error: validation("Bundle must be a JSON object") };
+  }
+
+  const data = raw as Record<string, unknown>;
+
+  // Validate version
+  if (data.version !== BUNDLE_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: validation(
+        `Unsupported bundle version "${String(data.version)}", expected "${BUNDLE_FORMAT_VERSION}"`,
+      ),
+    };
+  }
+
+  // Validate required string fields
+  if (!isNonEmptyString(data.id)) {
+    return { ok: false, error: validation("Missing or empty 'id' field") };
+  }
+  if (!isNonEmptyString(data.name)) {
+    return { ok: false, error: validation("Missing or empty 'name' field") };
+  }
+  if (typeof data.description !== "string") {
+    return { ok: false, error: validation("Missing 'description' field") };
+  }
+  if (!isNonEmptyString(data.manifestYaml)) {
+    return { ok: false, error: validation("Missing or empty 'manifestYaml' field") };
+  }
+  if (!isNonEmptyString(data.contentHash)) {
+    return { ok: false, error: validation("Missing or empty 'contentHash' field") };
+  }
+
+  // Validate createdAt
+  if (typeof data.createdAt !== "number") {
+    return { ok: false, error: validation("Missing or non-number 'createdAt' field") };
+  }
+
+  // Validate bricks array
+  if (!Array.isArray(data.bricks)) {
+    return { ok: false, error: validation("Missing or non-array 'bricks' field") };
+  }
+
+  // Deep validate each brick
+  const validatedBricks = [];
+  for (let i = 0; i < data.bricks.length; i++) {
+    const brickResult = validateBrickArtifact(data.bricks[i], `bundle.bricks[${String(i)}]`);
+    if (!brickResult.ok) {
+      return {
+        ok: false,
+        error: validation(`Invalid brick at index ${String(i)}: ${brickResult.error.message}`),
+      };
+    }
+    validatedBricks.push(brickResult.value);
+  }
+
+  // Validate metadata if present
+  if (
+    data.metadata !== undefined &&
+    (typeof data.metadata !== "object" || data.metadata === null || Array.isArray(data.metadata))
+  ) {
+    return { ok: false, error: validation("'metadata' must be a plain object if present") };
+  }
+
+  // After all guards pass, reconstruct with branded constructors
+  const bundle: AgentBundle = {
+    version: BUNDLE_FORMAT_VERSION,
+    id: bundleId(data.id as string),
+    name: data.name as string,
+    description: data.description as string,
+    manifestYaml: data.manifestYaml as string,
+    bricks: validatedBricks,
+    contentHash: data.contentHash as string,
+    createdAt: data.createdAt as number,
+    ...(data.metadata !== undefined
+      ? { metadata: data.metadata as Readonly<Record<string, unknown>> }
+      : {}),
+  };
+
+  return { ok: true, value: bundle };
+}

--- a/packages/bundle/src/types.ts
+++ b/packages/bundle/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Config and result types for bundle export/import operations.
+ */
+
+import type { AgentBundle, ForgeStore } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+/** Configuration for creating an agent bundle. */
+export interface ExportBundleConfig {
+  readonly name: string;
+  readonly description: string;
+  readonly manifestYaml: string;
+  readonly brickIds: readonly string[];
+  readonly store: ForgeStore;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+/** Configuration for importing an agent bundle into a store. */
+export interface ImportBundleConfig {
+  readonly bundle: AgentBundle;
+  readonly store: ForgeStore;
+}
+
+/** Result of a bundle import operation. */
+export interface ImportBundleResult {
+  readonly imported: number;
+  readonly skipped: number;
+  readonly errors: readonly ImportBrickError[];
+}
+
+/** Details about a brick that failed to import. */
+export interface ImportBrickError {
+  readonly brickId: string;
+  readonly reason: string;
+}

--- a/packages/bundle/tsconfig.json
+++ b/packages/bundle/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../hash" },
+    { "path": "../validation" },
+    { "path": "../engine" },
+    { "path": "../engine-pi" },
+    { "path": "../forge" }
+  ]
+}

--- a/packages/bundle/tsup.config.ts
+++ b/packages/bundle/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -322,6 +322,44 @@ interface BrickRegistryBackend extends BrickRegistryReader, BrickRegistryWriter 
 }
 
 /**
+ * Agent bundle types — portable export/import envelope.
+ *
+ * Defines the \`.koibundle\` format: a JSON artifact containing an agent's
+ * manifest + all referenced bricks. Follows the BrickId/SnapshotId pattern
+ * for branded identity.
+ */
+
+declare const __bundleIdBrand: unique symbol;
+/**
+ * Branded string for bundle identity.
+ * Prevents mixing bundle IDs with other string-typed IDs at compile time.
+ */
+type BundleId = string & {
+    readonly [__bundleIdBrand]: "BundleId";
+};
+/** Create a BundleId from a raw string. */
+declare function bundleId(raw: string): BundleId;
+/** Current \`.koibundle\` format version. Incremented on breaking format changes. */
+declare const BUNDLE_FORMAT_VERSION: "1";
+/**
+ * Portable agent bundle — serializable envelope containing an agent's
+ * full definition (manifest + forged bricks).
+ *
+ * Design: Docker-style export/import. Content-addressed for integrity.
+ */
+interface AgentBundle {
+    readonly version: typeof BUNDLE_FORMAT_VERSION;
+    readonly id: BundleId;
+    readonly name: string;
+    readonly description: string;
+    readonly manifestYaml: string;
+    readonly bricks: readonly BrickArtifact[];
+    readonly contentHash: string;
+    readonly createdAt: number;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
  * Capability registry — shared wire types and contracts for node capability
  * advertisement and tool routing.
  *
@@ -1097,7 +1135,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { type AdvertisedTool, Agent, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type CapabilityRegistry, type CapacityReport, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_SCHEDULER_CONFIG, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GuardContext, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeCapability, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskFilter, type TaskId, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskOptions, type TaskResult, type TaskScheduler, type TaskStatus, type TaskStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, chainId, conflict, evolveRegistryEntry, external, internal, isAgentStateEvent, isProcessState, isToolCallPayload, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, taskItemId, timeout, validateNonEmpty, validation };
+export { type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type BundleId, type CapabilityRegistry, type CapacityReport, type ChainCompactor, type ChainId, type CompensatingOp, type CronSchedule, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_SCHEDULER_CONFIG, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineInput, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GuardContext, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeCapability, type NodeId, type PendingFrame, ProcessState, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ScheduleId, type ScheduleStore, type ScheduledTask, type SchedulerConfig, type SchedulerEvent, type SchedulerStats, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskFilter, type TaskId, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskOptions, type TaskResult, type TaskScheduler, type TaskStatus, type TaskStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, bundleId, chainId, conflict, evolveRegistryEntry, external, internal, isAgentStateEvent, isProcessState, isToolCallPayload, nodeId, notFound, permission, rateLimit, scheduleId, staleRef, taskId, taskItemId, timeout, validateNonEmpty, validation };
 "
 `;
 

--- a/packages/core/src/bundle-types.ts
+++ b/packages/core/src/bundle-types.ts
@@ -1,0 +1,55 @@
+/**
+ * Agent bundle types — portable export/import envelope.
+ *
+ * Defines the `.koibundle` format: a JSON artifact containing an agent's
+ * manifest + all referenced bricks. Follows the BrickId/SnapshotId pattern
+ * for branded identity.
+ */
+
+import type { BrickArtifact } from "./brick-store.js";
+
+// ---------------------------------------------------------------------------
+// Branded type
+// ---------------------------------------------------------------------------
+
+declare const __bundleIdBrand: unique symbol;
+
+/**
+ * Branded string for bundle identity.
+ * Prevents mixing bundle IDs with other string-typed IDs at compile time.
+ */
+export type BundleId = string & { readonly [__bundleIdBrand]: "BundleId" };
+
+/** Create a BundleId from a raw string. */
+export function bundleId(raw: string): BundleId {
+  return raw as BundleId;
+}
+
+// ---------------------------------------------------------------------------
+// Format version
+// ---------------------------------------------------------------------------
+
+/** Current `.koibundle` format version. Incremented on breaking format changes. */
+export const BUNDLE_FORMAT_VERSION = "1" as const;
+
+// ---------------------------------------------------------------------------
+// AgentBundle — the portable artifact
+// ---------------------------------------------------------------------------
+
+/**
+ * Portable agent bundle — serializable envelope containing an agent's
+ * full definition (manifest + forged bricks).
+ *
+ * Design: Docker-style export/import. Content-addressed for integrity.
+ */
+export interface AgentBundle {
+  readonly version: typeof BUNDLE_FORMAT_VERSION;
+  readonly id: BundleId;
+  readonly name: string;
+  readonly description: string;
+  readonly manifestYaml: string;
+  readonly bricks: readonly BrickArtifact[];
+  readonly contentHash: string;
+  readonly createdAt: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,9 @@ export type {
   BrowserWaitOptions,
   BrowserWaitUntil,
 } from "./browser-driver.js";
+// bundle types — portable agent export/import envelope
+export type { AgentBundle, BundleId } from "./bundle-types.js";
+export { BUNDLE_FORMAT_VERSION, bundleId } from "./bundle-types.js";
 // capability registry — shared wire types for node capability advertisement
 export type {
   AdvertisedTool,


### PR DESCRIPTION
## Summary

Closes #122

Docker-style `export`/`import` for Koi agents — packages an agent's manifest + all forged bricks (tools, skills, middleware, channels) into a single `.koibundle` JSON file with SHA-256 integrity verification, content-addressed dedup, and automatic trust downgrading.

- **L0 types** (`@koi/core`): `AgentBundle`, `BundleId`, `BUNDLE_FORMAT_VERSION`
- **L2 package** (`@koi/bundle`): `createBundle()`, `importBundle()`, `serializeBundle()`, `deserializeBundle()`
- **Trust downgrade**: imported bricks always downgraded to `sandbox` trust + `bundled` provenance
- **Tamper detection**: bundle content hash + per-brick SHA-256 integrity checks
- **Dedup**: content-addressed — re-importing skips existing bricks
- **Documentation**: `docs/L2/bundle.md` with full architecture, examples, and ASCII diagrams

### Files

| File | Action | Layer |
|------|--------|-------|
| `packages/core/src/bundle-types.ts` | CREATE | L0 |
| `packages/core/src/index.ts` | EDIT | L0 |
| `packages/bundle/**` (16 files) | CREATE | L2 |
| `docs/L2/bundle.md` | CREATE | docs |

## Test plan

- [x] 30 unit/integration tests passing (`bun test --cwd packages/bundle`)
- [x] 5 E2E tests with real Anthropic API calls via `createKoi` + `createPiAdapter`
- [x] 345 core tests passing (no regressions)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (`biome check`)
- [x] Build clean (`tsup`)
- [x] API surface snapshots updated
- [x] Layer compliance verified (L2 imports only from L0/L0u)
- [x] Zero external dependencies