### PR TITLE
feat: canvas REST API + SSE streaming + A2UI HTML viewer demo

### DIFF
--- a/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/gateway/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -302,6 +302,20 @@ interface GatewayConfig {
     readonly channelBindings?: readonly ChannelBinding[];
     /** Tool routing configuration. Undefined = tool routing disabled (backward compatible). Partial fields are merged with DEFAULT_TOOL_ROUTING_CONFIG. */
     readonly toolRouting?: Partial<ToolRoutingConfig> | undefined;
+    /** Port for canvas HTTP server. Undefined = disabled. */
+    readonly canvasPort?: number;
+    /** URL path prefix for canvas endpoints. Default: "/gateway/canvas". */
+    readonly canvasPath?: string;
+    /** Maximum canvas request body size in bytes. Default: 1_048_576 (1MB). */
+    readonly canvasMaxBodyBytes?: number;
+    /** Maximum number of stored surfaces. Default: 10_000. */
+    readonly canvasMaxSurfaces?: number;
+    /** Maximum SSE subscribers per surface. Default: 100. */
+    readonly canvasMaxSsePerSurface?: number;
+    /** Maximum total SSE subscribers across all surfaces. Default: 10_000. */
+    readonly canvasMaxSseTotal?: number;
+    /** SSE keep-alive interval in ms. Default: 15_000. */
+    readonly canvasSseKeepAliveMs?: number;
 }
 declare const DEFAULT_GATEWAY_CONFIG: GatewayConfig;
 type BackpressureState = "normal" | "warning" | "critical";
@@ -415,6 +429,127 @@ interface BackpressureMonitor {
 declare function createBackpressureMonitor(config: Pick<GatewayConfig, "maxBufferBytesPerConnection" | "backpressureHighWatermark" | "globalBufferLimitBytes">): BackpressureMonitor;
 
 /**
+ * SSE (Server-Sent Events) subscriber registry for canvas surfaces.
+ *
+ * Manages per-surface fan-out, keep-alive pings, connection limits,
+ * and automatic dead-subscriber cleanup.
+ */
+
+interface SseEvent {
+    /** Monotonic event ID for Last-Event-ID reconnection. */
+    readonly id: string;
+    /** Event type: "updated" | "deleted". */
+    readonly event: string;
+    /** JSON payload string. */
+    readonly data: string;
+}
+/**
+ * Callback that receives raw SSE bytes.
+ * Returns false if the subscriber is dead (connection closed).
+ */
+type SseSubscriber = (data: Uint8Array) => boolean;
+interface CanvasSseManager {
+    /**
+     * Register a subscriber for a surface's event stream.
+     * Returns an unsubscribe function on success.
+     * Fails with RATE_LIMIT if per-surface or global limit reached.
+     */
+    readonly subscribe: (surfaceId: string, subscriber: SseSubscriber) => Result<() => void, KoiError>;
+    /** Fan out an event to all subscribers for a surface. */
+    readonly publish: (surfaceId: string, event: SseEvent) => void;
+    /** Send "deleted" event and remove all subscribers for a surface. */
+    readonly close: (surfaceId: string) => void;
+    /** Stop keep-alive timer and clear all subscribers. */
+    readonly dispose: () => void;
+    /** Get the next monotonic event ID for a surface. */
+    readonly nextEventId: (surfaceId: string) => string;
+    readonly subscriberCount: (surfaceId: string) => number;
+    readonly totalSubscribers: () => number;
+}
+interface CanvasSseConfig {
+    /** Max subscribers per surface. Default: 100. */
+    readonly maxSubscribersPerSurface: number;
+    /** Max total subscribers across all surfaces. Default: 10_000. */
+    readonly maxTotalSubscribers: number;
+    /** Keep-alive interval in ms. Default: 15_000. */
+    readonly keepAliveIntervalMs: number;
+}
+/** Format an SSE event to wire format bytes. */
+declare function formatSseEvent(event: SseEvent): Uint8Array;
+declare function createCanvasSseManager(configOverrides?: Partial<CanvasSseConfig>): CanvasSseManager;
+
+/**
+ * SurfaceStore: pluggable surface persistence for canvas rendering.
+ *
+ * Surfaces are opaque blobs — the store does not understand A2UI structure.
+ * Default in-memory implementation with LRU eviction provided.
+ */
+
+interface SurfaceEntry {
+    readonly surfaceId: string;
+    /** Opaque serialized surface content. */
+    readonly content: string;
+    /** SHA-256 hex digest of content — used as ETag. */
+    readonly contentHash: string;
+    readonly createdAt: number;
+    readonly updatedAt: number;
+    /** Tracks access time for LRU eviction. */
+    readonly lastAccessedAt: number;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+}
+interface SurfaceStore {
+    readonly get: (id: string) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+    readonly create: (id: string, content: string, metadata?: Readonly<Record<string, unknown>>) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+    /**
+     * Update surface content.
+     * If expectedHash is provided and doesn't match current hash → CONFLICT error (CAS).
+     * If expectedHash is undefined → unconditional update.
+     */
+    readonly update: (id: string, content: string, expectedHash: string | undefined) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+    readonly delete: (id: string) => Result<boolean, KoiError> | Promise<Result<boolean, KoiError>>;
+    readonly has: (id: string) => Result<boolean, KoiError> | Promise<Result<boolean, KoiError>>;
+    readonly size: () => number;
+}
+interface SurfaceStoreConfig {
+    /** Maximum number of surfaces before LRU eviction. Default: 10_000. */
+    readonly maxSurfaces: number;
+}
+/** Compute SHA-256 hex digest of content using Bun native crypto. */
+declare function computeContentHash(content: string): string;
+declare function createInMemorySurfaceStore(configOverrides?: Partial<SurfaceStoreConfig>): SurfaceStore;
+
+/**
+ * HTTP route handler for canvas surface CRUD + SSE streaming.
+ *
+ * Routes:
+ *   POST   {prefix}/{surfaceId}         Create surface (auth required)
+ *   GET    {prefix}/{surfaceId}         Fetch surface (public)
+ *   PATCH  {prefix}/{surfaceId}         Update surface (auth required)
+ *   DELETE {prefix}/{surfaceId}         Delete surface (auth required)
+ *   GET    {prefix}/{surfaceId}/events  SSE stream (public)
+ */
+
+interface CanvasRouteConfig {
+    /** URL path prefix. Default: "/gateway/canvas". */
+    readonly pathPrefix: string;
+    /** Maximum request body size in bytes. Default: 1_048_576 (1MB). */
+    readonly maxBodyBytes: number;
+}
+interface CanvasServer {
+    readonly start: () => Promise<void>;
+    readonly stop: () => void;
+    readonly port: () => number;
+}
+type CanvasAuthenticator = (request: Request) => Promise<Result<CanvasAuthResult, KoiError>>;
+interface CanvasAuthResult {
+    readonly agentId: string;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+}
+declare function createCanvasServer(config: Partial<CanvasRouteConfig> & {
+    readonly port: number;
+}, store: SurfaceStore, sse: CanvasSseManager, authenticator?: CanvasAuthenticator): CanvasServer;
+
+/**
  * Webhook ingestion: HTTP server that converts POST requests
  * into GatewayFrames dispatched through the gateway pipeline.
  */
@@ -486,14 +621,59 @@ interface Gateway {
     readonly channelBindings: () => ReadonlyMap<string, string>;
     /** Send a NodeFrame to a connected compute node. */
     readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
+    /** Returns the canvas server port, or undefined if canvas is not configured. */
+    readonly canvasPort: () => number | undefined;
+    /** Access the surface store for external use. Undefined if canvas is not configured. */
+    readonly surfaceStore: () => SurfaceStore | undefined;
 }
 interface GatewayDeps {
     readonly transport: Transport;
     readonly auth: GatewayAuthenticator;
     readonly store?: SessionStore;
     readonly webhookAuth?: WebhookAuthenticator;
+    readonly canvasAuth?: CanvasAuthenticator;
 }
 declare function createGateway(configOverrides: Partial<GatewayConfig>, deps: GatewayDeps): Gateway;
+
+/**
+ * Shared HTTP utilities for gateway HTTP servers (webhook, canvas, etc.).
+ */
+/** Create a JSON Response with the given status code and body. */
+declare function jsonResponse(status: number, body: Record<string, unknown>): Response;
+interface ParsedBody {
+    readonly ok: true;
+    readonly raw: string;
+    readonly parsed: unknown;
+}
+interface ParseBodyError {
+    readonly ok: false;
+    readonly status: number;
+    readonly message: string;
+}
+type ParseBodyResult = ParsedBody | ParseBodyError;
+/**
+ * Read and parse a JSON request body with streaming size enforcement.
+ *
+ * Returns the raw string (useful for HMAC verification) and the parsed JSON.
+ * Returns a typed error with HTTP status code on failure.
+ */
+declare function parseJsonBody(request: Request, maxBytes: number): Promise<ParseBodyResult>;
+interface PathMatch {
+    readonly match: true;
+    readonly segments: readonly string[];
+}
+interface PathNoMatch {
+    readonly match: false;
+}
+type PathMatchResult = PathMatch | PathNoMatch;
+/**
+ * Match a URL pathname against a prefix with boundary safety.
+ *
+ * Prevents "/webhook" from matching "/webhookadmin" by requiring
+ * an exact match or a "/" boundary after the prefix.
+ * Returns the path segments after the prefix.
+ */
+declare function matchPath(pathname: string, prefix: string): PathMatchResult;
 
 /**
  * Wire protocol: parse and encode GatewayFrame.
@@ -612,6 +792,6 @@ interface SequenceTracker {
 }
 declare function createSequenceTracker(windowSize: number): SequenceTracker;
 
-export { type AcceptResult, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CapabilitiesPayload, type ChannelBinding, type CompiledAffinity, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, DEFAULT_TOOL_ROUTING_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RouteResult, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SweepError, TOOL_ROUTING_ERROR_CODES, type ToolAffinity, type ToolRouter, type ToolRouterDeps, type ToolRoutingConfig, type ToolRoutingErrorCode, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, compileAffinities, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createScheduler, createSequenceTracker, createToolRouter, createWebhookServer, encodeFrame, encodeNodeFrame, handleHandshake, matchAffinity, negotiateProtocol, parseConnectFrame, parseFrame, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, resolveTargetNode, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
+export { type AcceptResult, type AuthResult, type BackpressureMonitor, type BackpressureState, type BunTransport, type CanvasAuthResult, type CanvasAuthenticator, type CanvasRouteConfig, type CanvasServer, type CanvasSseConfig, type CanvasSseManager, type CapabilitiesPayload, type ChannelBinding, type CompiledAffinity, type ConnectClient, type ConnectFrame, DEFAULT_GATEWAY_CONFIG, DEFAULT_TOOL_ROUTING_CONFIG, type FrameIdGenerator, type Gateway, type GatewayAuthenticator, type GatewayCapabilities, type GatewayConfig, type GatewayDeps, type GatewayFrame, type GatewayFrameKind, type GatewayScheduler, type HandshakeAckPayload, type HandshakeOptions, type HandshakePayload, type HandshakeResult, type HandshakeSnapshot, type NodeFrame, type NodeFrameKind, type NodeRegistry, type NodeRegistryEvent, type RegisteredNode, type ResolvedRoute, type ResumeRequest, type RouteBinding, type RouteResult, type RoutingConfig, type RoutingContext, type SchedulerDef, type SchedulerDispatcher, type ScopingMode, type SequenceTracker, type Session, type SessionEvent, type SessionStore, type SseEvent, type SseSubscriber, type SurfaceEntry, type SurfaceStore, type SurfaceStoreConfig, type SweepError, TOOL_ROUTING_ERROR_CODES, type ToolAffinity, type ToolRouter, type ToolRouterDeps, type ToolRoutingConfig, type ToolRoutingErrorCode, type Transport, type TransportConnection, type TransportHandler, type TransportSendResult, type WebhookAuthResult, type WebhookAuthenticator, type WebhookConfig, type WebhookDispatcher, type WebhookServer, compileAffinities, computeContentHash, computeDispatchKey, createAckFrame, createBackpressureMonitor, createBunTransport, createCanvasServer, createCanvasSseManager, createErrorFrame, createFrameIdGenerator, createGateway, createInMemoryNodeRegistry, createInMemorySessionStore, createInMemorySurfaceStore, createScheduler, createSequenceTracker, createToolRouter, createWebhookServer, encodeFrame, encodeNodeFrame, formatSseEvent, handleHandshake, jsonResponse, matchAffinity, matchPath, negotiateProtocol, parseConnectFrame, parseFrame, parseJsonBody, parseNodeFrame, peekFrameKind, resolveBinding, resolveRoute, resolveTargetNode, startHeartbeatSweep, validateBindingPattern, validateCapabilitiesPayload, validateCapacityPayload, validateHandshakePayload };
 "
 `;

--- a/packages/gateway/src/__tests__/canvas-routes.test.ts
+++ b/packages/gateway/src/__tests__/canvas-routes.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Result } from "@koi/core";
+import type { CanvasAuthenticator, CanvasAuthResult, CanvasServer } from "../canvas-routes.js";
+import { createCanvasServer } from "../canvas-routes.js";
+import type { CanvasSseManager } from "../canvas-sse.js";
+import { createCanvasSseManager } from "../canvas-sse.js";
+import type { SurfaceStore } from "../canvas-store.js";
+import { createInMemorySurfaceStore } from "../canvas-store.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const PREFIX = "/gateway/canvas";
+
+function url(server: CanvasServer, path: string): string {
+  return `http://localhost:${server.port()}${PREFIX}${path}`;
+}
+
+/** Default authenticator that accepts any Bearer token. */
+const acceptAllAuth: CanvasAuthenticator = async (
+  request: Request,
+): Promise<Result<CanvasAuthResult>> => {
+  const header = request.headers.get("Authorization");
+  if (header === null || !header.startsWith("Bearer ")) {
+    return { ok: false, error: { code: "PERMISSION", message: "Unauthorized", retryable: false } };
+  }
+  return { ok: true, value: { agentId: "test-agent" } };
+};
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: "Bearer test-token", "Content-Type": "application/json" };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("canvas routes", () => {
+  let store: SurfaceStore;
+  let sse: CanvasSseManager;
+  let server: CanvasServer;
+
+  beforeEach(async () => {
+    store = createInMemorySurfaceStore();
+    sse = createCanvasSseManager({ keepAliveIntervalMs: 60_000 });
+    server = createCanvasServer(
+      { port: 0, pathPrefix: PREFIX, maxBodyBytes: 1024 },
+      store,
+      sse,
+      acceptAllAuth,
+    );
+    await server.start();
+  });
+
+  afterEach(() => {
+    server.stop();
+    sse.dispose();
+  });
+
+  // -------------------------------------------------------------------
+  // POST (create)
+  // -------------------------------------------------------------------
+
+  test("POST creates surface → 201 + ETag + Location", async () => {
+    const res = await fetch(url(server, "/test-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "hello world" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.headers.get("ETag")).toBeTruthy();
+    expect(res.headers.get("Location")).toBe(`${PREFIX}/test-1`);
+
+    const body = (await res.json()) as { ok: boolean; surfaceId: string };
+    expect(body.ok).toBe(true);
+    expect(body.surfaceId).toBe("test-1");
+  });
+
+  test("POST duplicate → 409 Conflict", async () => {
+    await fetch(url(server, "/dup"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    const res = await fetch(url(server, "/dup"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v2" }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  test("POST without auth → 401", async () => {
+    const res = await fetch(url(server, "/no-auth"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "test" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  test("POST with invalid body → 400", async () => {
+    const res = await fetch(url(server, "/bad-body"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ wrong: "field" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  // -------------------------------------------------------------------
+  // GET (read)
+  // -------------------------------------------------------------------
+
+  test("GET existing → 200 + content + ETag", async () => {
+    await fetch(url(server, "/read-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "hello" }),
+    });
+
+    const res = await fetch(url(server, "/read-1"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toBeTruthy();
+
+    const body = (await res.json()) as { ok: boolean; surface: { content: string } };
+    expect(body.ok).toBe(true);
+    expect(body.surface.content).toBe("hello");
+  });
+
+  test("GET nonexistent → 404", async () => {
+    const res = await fetch(url(server, "/nope"));
+    expect(res.status).toBe(404);
+  });
+
+  test("GET with matching If-None-Match → 304", async () => {
+    const createRes = await fetch(url(server, "/etag-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "hello" }),
+    });
+    const etag = createRes.headers.get("ETag") ?? "";
+
+    const res = await fetch(url(server, "/etag-1"), {
+      headers: { "If-None-Match": etag },
+    });
+    expect(res.status).toBe(304);
+  });
+
+  test("GET with non-matching If-None-Match → 200", async () => {
+    await fetch(url(server, "/etag-2"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "hello" }),
+    });
+
+    const res = await fetch(url(server, "/etag-2"), {
+      headers: { "If-None-Match": '"stale-hash"' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("GET does not require auth", async () => {
+    await fetch(url(server, "/public"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "public data" }),
+    });
+
+    // No auth headers
+    const res = await fetch(url(server, "/public"));
+    expect(res.status).toBe(200);
+  });
+
+  // -------------------------------------------------------------------
+  // PATCH (update)
+  // -------------------------------------------------------------------
+
+  test("PATCH with If-Match → 200 + new ETag", async () => {
+    const createRes = await fetch(url(server, "/patch-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+    const etag = createRes.headers.get("ETag") ?? "";
+
+    const res = await fetch(url(server, "/patch-1"), {
+      method: "PATCH",
+      headers: { ...authHeaders(), "If-Match": etag },
+      body: JSON.stringify({ content: "v2" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toBeTruthy();
+    expect(res.headers.get("ETag")).not.toBe(etag);
+  });
+
+  test("PATCH with stale If-Match → 412", async () => {
+    await fetch(url(server, "/patch-2"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    const res = await fetch(url(server, "/patch-2"), {
+      method: "PATCH",
+      headers: { ...authHeaders(), "If-Match": '"stale-hash"' },
+      body: JSON.stringify({ content: "v2" }),
+    });
+
+    expect(res.status).toBe(412);
+  });
+
+  test("PATCH without If-Match → 200 (unconditional)", async () => {
+    await fetch(url(server, "/patch-3"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    const res = await fetch(url(server, "/patch-3"), {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v2" }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("PATCH nonexistent → 404", async () => {
+    const res = await fetch(url(server, "/nope"), {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  test("PATCH without auth → 401", async () => {
+    const res = await fetch(url(server, "/no-auth"), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------
+  // DELETE
+  // -------------------------------------------------------------------
+
+  test("DELETE existing → 204", async () => {
+    await fetch(url(server, "/del-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    const res = await fetch(url(server, "/del-1"), {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-token" },
+    });
+
+    expect(res.status).toBe(204);
+  });
+
+  test("DELETE nonexistent → 404", async () => {
+    const res = await fetch(url(server, "/nope"), {
+      method: "DELETE",
+      headers: { Authorization: "Bearer test-token" },
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  test("DELETE without auth → 401", async () => {
+    const res = await fetch(url(server, "/no-auth"), {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  // -------------------------------------------------------------------
+  // Body size limit
+  // -------------------------------------------------------------------
+
+  test("POST body exceeding maxBodyBytes → 413", async () => {
+    const largeContent = "x".repeat(2048);
+    const res = await fetch(url(server, "/big"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: largeContent }),
+    });
+
+    expect(res.status).toBe(413);
+  });
+
+  // -------------------------------------------------------------------
+  // Path / method edge cases
+  // -------------------------------------------------------------------
+
+  test("wrong path → 404", async () => {
+    const res = await fetch(`http://localhost:${server.port()}/wrong/path`);
+    expect(res.status).toBe(404);
+  });
+
+  test("unsupported method → 405", async () => {
+    const res = await fetch(url(server, "/test"), {
+      method: "PUT",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    expect(res.status).toBe(405);
+  });
+
+  test("missing surface ID → 404", async () => {
+    const res = await fetch(`http://localhost:${server.port()}${PREFIX}`);
+    expect(res.status).toBe(404);
+  });
+
+  test("invalid surface ID → 400", async () => {
+    // Spaces, slashes, and special chars are rejected
+    const res = await fetch(url(server, "/invalid%20id"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("surface ID exceeding 128 chars → 400", async () => {
+    const longId = "a".repeat(129);
+    const res = await fetch(url(server, `/${longId}`), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // -------------------------------------------------------------------
+  // SSE endpoint
+  // -------------------------------------------------------------------
+
+  test("SSE for nonexistent surface → 404", async () => {
+    const res = await fetch(url(server, "/nope/events"));
+    expect(res.status).toBe(404);
+  });
+
+  test("SSE endpoint returns text/event-stream", async () => {
+    await fetch(url(server, "/sse-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    const controller = new AbortController();
+    const res = await fetch(url(server, "/sse-1/events"), {
+      signal: controller.signal,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+    controller.abort();
+  });
+
+  test("SSE does not require auth", async () => {
+    await fetch(url(server, "/sse-pub"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+
+    // No auth headers
+    const controller = new AbortController();
+    const res = await fetch(url(server, "/sse-pub/events"), {
+      signal: controller.signal,
+    });
+
+    expect(res.status).toBe(200);
+    controller.abort();
+  });
+
+  // -------------------------------------------------------------------
+  // Server without authenticator (all writes fail)
+  // -------------------------------------------------------------------
+
+  test("server without authenticator rejects all writes", async () => {
+    const noAuthServer = createCanvasServer(
+      { port: 0, pathPrefix: PREFIX },
+      store,
+      sse,
+      // No authenticator
+    );
+    await noAuthServer.start();
+
+    try {
+      const res = await fetch(`http://localhost:${noAuthServer.port()}${PREFIX}/test`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "v1" }),
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      noAuthServer.stop();
+    }
+  });
+
+  // -------------------------------------------------------------------
+  // POST with metadata
+  // -------------------------------------------------------------------
+
+  test("POST with metadata preserves it", async () => {
+    await fetch(url(server, "/meta-1"), {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "hello", metadata: { author: "test" } }),
+    });
+
+    const res = await fetch(url(server, "/meta-1"));
+    const body = (await res.json()) as { surface: { metadata: Record<string, unknown> } };
+    expect(body.surface.metadata).toEqual({ author: "test" });
+  });
+});

--- a/packages/gateway/src/__tests__/canvas-sse.test.ts
+++ b/packages/gateway/src/__tests__/canvas-sse.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { CanvasSseManager, SseEvent, SseSubscriber } from "../canvas-sse.js";
+import { createCanvasSseManager, formatSseEvent } from "../canvas-sse.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const decoder = new TextDecoder();
+
+/** Create a subscriber that collects all received data as strings. */
+function createMockSubscriber(): { subscriber: SseSubscriber; chunks: string[] } {
+  const chunks: string[] = [];
+  const subscriber: SseSubscriber = (data: Uint8Array) => {
+    chunks.push(decoder.decode(data));
+    return true;
+  };
+  return { subscriber, chunks };
+}
+
+/** Create a subscriber that returns false (simulates dead connection). */
+function createDeadSubscriber(): SseSubscriber {
+  return () => false;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("formatSseEvent", () => {
+  test("formats event to SSE wire format", () => {
+    const event: SseEvent = { id: "1", event: "updated", data: '{"content":"hello"}' };
+    const bytes = formatSseEvent(event);
+    expect(decoder.decode(bytes)).toBe('id: 1\nevent: updated\ndata: {"content":"hello"}\n\n');
+  });
+
+  test("sanitizes newlines from id and event fields", () => {
+    const event: SseEvent = { id: "1\n2", event: "up\r\ndated", data: '{"x":1}' };
+    const output = decoder.decode(formatSseEvent(event));
+    expect(output).toBe('id: 12\nevent: updated\ndata: {"x":1}\n\n');
+  });
+
+  test("handles multi-line data by prefixing each line", () => {
+    const event: SseEvent = { id: "1", event: "updated", data: "line1\nline2\nline3" };
+    const output = decoder.decode(formatSseEvent(event));
+    expect(output).toBe("id: 1\nevent: updated\ndata: line1\ndata: line2\ndata: line3\n\n");
+  });
+});
+
+describe("createCanvasSseManager", () => {
+  let sse: CanvasSseManager;
+
+  beforeEach(() => {
+    sse = createCanvasSseManager({
+      maxSubscribersPerSurface: 3,
+      maxTotalSubscribers: 5,
+      keepAliveIntervalMs: 60_000, // Long interval to avoid interference
+    });
+  });
+
+  afterEach(() => {
+    sse.dispose();
+  });
+
+  test("subscribe → publish → subscriber receives event in SSE format", () => {
+    const mock = createMockSubscriber();
+    const result = sse.subscribe("s1", mock.subscriber);
+    expect(result.ok).toBe(true);
+
+    const event: SseEvent = { id: "1", event: "updated", data: '{"content":"hello"}' };
+    sse.publish("s1", event);
+
+    expect(mock.chunks).toHaveLength(1);
+    expect(mock.chunks[0]).toBe('id: 1\nevent: updated\ndata: {"content":"hello"}\n\n');
+  });
+
+  test("subscribe multiple → all receive published event", () => {
+    const mock1 = createMockSubscriber();
+    const mock2 = createMockSubscriber();
+    sse.subscribe("s1", mock1.subscriber);
+    sse.subscribe("s1", mock2.subscriber);
+
+    sse.publish("s1", { id: "1", event: "updated", data: "{}" });
+
+    expect(mock1.chunks).toHaveLength(1);
+    expect(mock2.chunks).toHaveLength(1);
+  });
+
+  test("unsubscribe → subscriber stops receiving events", () => {
+    const mock = createMockSubscriber();
+    const result = sse.subscribe("s1", mock.subscriber);
+    if (!result.ok) throw new Error("setup failed");
+
+    result.value(); // unsubscribe
+
+    sse.publish("s1", { id: "1", event: "updated", data: "{}" });
+
+    expect(mock.chunks).toHaveLength(0);
+    expect(sse.subscriberCount("s1")).toBe(0);
+  });
+
+  test("per-surface limit → returns RATE_LIMIT error", () => {
+    for (let i = 0; i < 3; i++) {
+      const mock = createMockSubscriber();
+      expect(sse.subscribe("s1", mock.subscriber).ok).toBe(true);
+    }
+
+    const extra = createMockSubscriber();
+    const result = sse.subscribe("s1", extra.subscriber);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("RATE_LIMIT");
+      expect(result.error.message).toContain("Per-surface");
+    }
+  });
+
+  test("global limit → returns RATE_LIMIT error", () => {
+    for (let i = 0; i < 5; i++) {
+      const mock = createMockSubscriber();
+      expect(sse.subscribe(`surface-${i}`, mock.subscriber).ok).toBe(true);
+    }
+
+    const extra = createMockSubscriber();
+    const result = sse.subscribe("overflow", extra.subscriber);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("RATE_LIMIT");
+      expect(result.error.message).toContain("Global");
+    }
+  });
+
+  test("close(surfaceId) → sends deleted event + removes subscribers", () => {
+    const mock = createMockSubscriber();
+    sse.subscribe("s1", mock.subscriber);
+
+    sse.close("s1");
+
+    expect(mock.chunks).toHaveLength(1);
+    expect(mock.chunks[0]).toContain("event: deleted");
+    expect(mock.chunks[0]).toContain('"surfaceId":"s1"');
+    expect(sse.subscriberCount("s1")).toBe(0);
+    expect(sse.totalSubscribers()).toBe(0);
+  });
+
+  test("dispose() → clears all state", () => {
+    const mock1 = createMockSubscriber();
+    const mock2 = createMockSubscriber();
+    sse.subscribe("s1", mock1.subscriber);
+    sse.subscribe("s2", mock2.subscriber);
+    expect(sse.totalSubscribers()).toBe(2);
+
+    sse.dispose();
+
+    expect(sse.totalSubscribers()).toBe(0);
+    expect(sse.subscriberCount("s1")).toBe(0);
+    expect(sse.subscriberCount("s2")).toBe(0);
+  });
+
+  test("dead subscriber automatically removed on publish", () => {
+    const dead = createDeadSubscriber();
+    const alive = createMockSubscriber();
+    sse.subscribe("s1", dead);
+    sse.subscribe("s1", alive.subscriber);
+    expect(sse.subscriberCount("s1")).toBe(2);
+
+    sse.publish("s1", { id: "1", event: "updated", data: "{}" });
+
+    expect(sse.subscriberCount("s1")).toBe(1);
+    expect(alive.chunks).toHaveLength(1);
+  });
+
+  test("subscriberCount returns 0 for unknown surface", () => {
+    expect(sse.subscriberCount("unknown")).toBe(0);
+  });
+
+  test("publish to surface with no subscribers is a no-op", () => {
+    // Should not throw
+    sse.publish("unknown", { id: "1", event: "updated", data: "{}" });
+  });
+
+  test("nextEventId returns monotonic IDs", () => {
+    expect(sse.nextEventId("s1")).toBe("1");
+    expect(sse.nextEventId("s1")).toBe("2");
+    expect(sse.nextEventId("s1")).toBe("3");
+    // Different surface has its own counter
+    expect(sse.nextEventId("s2")).toBe("1");
+  });
+});

--- a/packages/gateway/src/__tests__/canvas-store.test.ts
+++ b/packages/gateway/src/__tests__/canvas-store.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { computeContentHash, createInMemorySurfaceStore } from "../canvas-store.js";
+
+describe("computeContentHash", () => {
+  test("returns deterministic SHA-256 hex for same content", () => {
+    const hash1 = computeContentHash("hello world");
+    const hash2 = computeContentHash("hello world");
+    expect(hash1).toBe(hash2);
+    expect(hash1).toHaveLength(64); // SHA-256 hex = 64 chars
+  });
+
+  test("returns different hashes for different content", () => {
+    const hash1 = computeContentHash("hello");
+    const hash2 = computeContentHash("world");
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe("createInMemorySurfaceStore", () => {
+  test("create → get returns entry with correct hash", async () => {
+    const store = createInMemorySurfaceStore();
+    const result = await store.create("s1", "content-1", { key: "val" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.surfaceId).toBe("s1");
+    expect(result.value.content).toBe("content-1");
+    expect(result.value.contentHash).toBe(computeContentHash("content-1"));
+    expect(result.value.metadata).toEqual({ key: "val" });
+
+    const getResult = await store.get("s1");
+    expect(getResult.ok).toBe(true);
+    if (!getResult.ok) return;
+    expect(getResult.value.content).toBe("content-1");
+  });
+
+  test("create duplicate surfaceId → CONFLICT", async () => {
+    const store = createInMemorySurfaceStore();
+    await store.create("s1", "content-1");
+    const dup = await store.create("s1", "content-2");
+    expect(dup.ok).toBe(false);
+    if (dup.ok) return;
+    expect(dup.error.code).toBe("CONFLICT");
+  });
+
+  test("get nonexistent → NOT_FOUND", async () => {
+    const store = createInMemorySurfaceStore();
+    const result = await store.get("nope");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("update with matching expectedHash → success + new hash", async () => {
+    const store = createInMemorySurfaceStore();
+    const created = await store.create("s1", "v1");
+    if (!created.ok) throw new Error("setup failed");
+    const oldHash = created.value.contentHash;
+
+    const updated = await store.update("s1", "v2", oldHash);
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) return;
+    expect(updated.value.content).toBe("v2");
+    expect(updated.value.contentHash).toBe(computeContentHash("v2"));
+    expect(updated.value.contentHash).not.toBe(oldHash);
+  });
+
+  test("update with stale expectedHash → CONFLICT", async () => {
+    const store = createInMemorySurfaceStore();
+    await store.create("s1", "v1");
+
+    const result = await store.update("s1", "v2", "stale-hash");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("CONFLICT");
+  });
+
+  test("update without expectedHash → unconditional success", async () => {
+    const store = createInMemorySurfaceStore();
+    await store.create("s1", "v1");
+
+    const result = await store.update("s1", "v2", undefined);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.content).toBe("v2");
+  });
+
+  test("update nonexistent → NOT_FOUND", async () => {
+    const store = createInMemorySurfaceStore();
+    const result = await store.update("nope", "v1", undefined);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("delete existing → true, subsequent get → NOT_FOUND", async () => {
+    const store = createInMemorySurfaceStore();
+    await store.create("s1", "v1");
+
+    const delResult = await store.delete("s1");
+    expect(delResult.ok).toBe(true);
+    if (!delResult.ok) return;
+    expect(delResult.value).toBe(true);
+
+    const getResult = await store.get("s1");
+    expect(getResult.ok).toBe(false);
+  });
+
+  test("delete nonexistent → false", async () => {
+    const store = createInMemorySurfaceStore();
+    const result = await store.delete("nope");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(false);
+  });
+
+  test("has returns true for existing, false for nonexistent", async () => {
+    const store = createInMemorySurfaceStore();
+    await store.create("s1", "v1");
+
+    const exists = await store.has("s1");
+    expect(exists.ok).toBe(true);
+    if (exists.ok) expect(exists.value).toBe(true);
+
+    const missing = await store.has("nope");
+    expect(missing.ok).toBe(true);
+    if (missing.ok) expect(missing.value).toBe(false);
+  });
+
+  test("size tracks entries", async () => {
+    const store = createInMemorySurfaceStore();
+    expect(store.size()).toBe(0);
+    await store.create("s1", "v1");
+    expect(store.size()).toBe(1);
+    await store.create("s2", "v2");
+    expect(store.size()).toBe(2);
+    await store.delete("s1");
+    expect(store.size()).toBe(1);
+  });
+
+  test("LRU eviction: oldest-accessed entry evicted when maxSurfaces reached", async () => {
+    const store = createInMemorySurfaceStore({ maxSurfaces: 3 });
+    await store.create("s1", "v1");
+    await store.create("s2", "v2");
+    await store.create("s3", "v3");
+
+    // Access s1 to make it more recent than s2
+    await store.get("s1");
+
+    // Adding s4 should evict s2 (oldest lastAccessedAt)
+    await store.create("s4", "v4");
+
+    expect(store.size()).toBe(3);
+    const s2 = await store.has("s2");
+    expect(s2).toEqual({ ok: true, value: false });
+    const s1 = await store.has("s1");
+    expect(s1).toEqual({ ok: true, value: true });
+    const s3 = await store.has("s3");
+    expect(s3).toEqual({ ok: true, value: true });
+    const s4 = await store.has("s4");
+    expect(s4).toEqual({ ok: true, value: true });
+  });
+
+  test("get updates lastAccessedAt preventing LRU eviction", async () => {
+    const store = createInMemorySurfaceStore({ maxSurfaces: 2 });
+    await store.create("s1", "v1");
+    await store.create("s2", "v2");
+
+    // Access s1 to refresh its timestamp
+    await store.get("s1");
+
+    // Adding s3 should evict s2 (s1 was accessed more recently)
+    await store.create("s3", "v3");
+
+    const s1 = await store.has("s1");
+    expect(s1).toEqual({ ok: true, value: true });
+    const s2 = await store.has("s2");
+    expect(s2).toEqual({ ok: true, value: false });
+    const s3 = await store.has("s3");
+    expect(s3).toEqual({ ok: true, value: true });
+  });
+
+  test("create without metadata omits metadata field", async () => {
+    const store = createInMemorySurfaceStore();
+    const result = await store.create("s1", "v1");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.metadata).toBeUndefined();
+  });
+});

--- a/packages/gateway/src/__tests__/canvas.full-stack.e2e.test.ts
+++ b/packages/gateway/src/__tests__/canvas.full-stack.e2e.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Canvas full-stack E2E test: createKoi + createPiAdapter + Canvas Server + SSE.
+ *
+ * Validates the complete canvas rendering pipeline with real LLM calls:
+ *   1. Agent generates HTML via the full Koi runtime (createKoi + Pi adapter)
+ *   2. Content stored via canvas HTTP REST API (POST/GET/PATCH/DELETE)
+ *   3. SSE delivers real-time update/deleted events to subscribers
+ *   4. ETag / If-Match CAS prevents stale overwrites
+ *   5. Middleware chain is exercised during LLM calls
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/canvas.full-stack.e2e.test.ts
+ *
+ * Or with .env at repo root:
+ *   bun test --env-file=../../.env src/__tests__/canvas.full-stack.e2e.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { AgentManifest, EngineEvent, KoiMiddleware, Result } from "@koi/core";
+import type { KoiRuntime } from "@koi/engine";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import type { CanvasAuthenticator, CanvasAuthResult, CanvasServer } from "../canvas-routes.js";
+import { createCanvasServer } from "../canvas-routes.js";
+import type { CanvasSseManager } from "../canvas-sse.js";
+import { createCanvasSseManager } from "../canvas-sse.js";
+import type { SurfaceStore } from "../canvas-store.js";
+import { createInMemorySurfaceStore } from "../canvas-store.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeE2E = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 90_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const PREFIX = "/gateway/canvas";
+
+const MANIFEST: AgentManifest = {
+  name: "canvas-e2e-agent",
+  version: "1.0.0",
+  model: { name: "claude-haiku" },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const acceptAllAuth: CanvasAuthenticator = async (
+  request: Request,
+): Promise<Result<CanvasAuthResult>> => {
+  const header = request.headers.get("Authorization");
+  if (header === null || !header.startsWith("Bearer ")) {
+    return { ok: false, error: { code: "PERMISSION", message: "Unauthorized", retryable: false } };
+  }
+  return { ok: true, value: { agentId: "e2e-agent" } };
+};
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: "Bearer e2e-token", "Content-Type": "application/json" };
+}
+
+/** Collect all events from an async iterable. */
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Extract concatenated text from text_delta events. */
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+/** Run a Koi runtime with a prompt and return the text response. */
+async function askLlm(prompt: string, systemPrompt?: string): Promise<string> {
+  const piAdapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: systemPrompt ?? "You are a helpful assistant that generates HTML content.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const runtime: KoiRuntime = await createKoi({
+    manifest: MANIFEST,
+    adapter: piAdapter,
+    loopDetection: false,
+    limits: { maxTurns: 1, maxDurationMs: 60_000, maxTokens: 2_000 },
+  });
+
+  const events = await collectEvents(runtime.run({ kind: "text", text: prompt }));
+  const text = extractText(events);
+  await runtime.dispose();
+  return text;
+}
+
+interface SseEventParsed {
+  readonly id?: string;
+  readonly event?: string;
+  readonly data?: string;
+}
+
+/**
+ * Collect SSE events from a streaming response.
+ * Reads chunks from the body, parses SSE wire format, returns parsed events.
+ */
+async function collectSseEvents(
+  response: Response,
+  maxEvents: number,
+  timeoutMs = 5000,
+): Promise<readonly SseEventParsed[]> {
+  const events: SseEventParsed[] = [];
+  if (response.body === null) return [];
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  // let: accumulates partial SSE data between reads
+  let buffer = "";
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (events.length < maxEvents && Date.now() < deadline) {
+    const { done, value } = await Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), deadline - Date.now()),
+      ),
+    ]);
+
+    if (done) break;
+    if (value === undefined) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // Parse SSE events from buffer
+    const parts = buffer.split("\n\n");
+    // Last part is incomplete (no trailing \n\n yet)
+    buffer = parts.pop() ?? "";
+
+    for (const part of parts) {
+      const lines = part.split("\n");
+      const event: Record<string, string> = {};
+      for (const line of lines) {
+        if (line.startsWith(":")) continue; // comment
+        const colonIdx = line.indexOf(": ");
+        if (colonIdx === -1) continue;
+        const field = line.slice(0, colonIdx);
+        const val = line.slice(colonIdx + 2);
+        event[field] = val;
+      }
+      if (Object.keys(event).length > 0) {
+        events.push(event as SseEventParsed);
+      }
+    }
+  }
+
+  reader.cancel();
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("canvas full-stack e2e: createKoi + Pi adapter + Canvas server + SSE", () => {
+  // let: assigned in beforeAll, cleaned up in afterAll
+  let store: SurfaceStore;
+  let sse: CanvasSseManager;
+  let server: CanvasServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    store = createInMemorySurfaceStore();
+    sse = createCanvasSseManager({ keepAliveIntervalMs: 60_000 });
+    server = createCanvasServer({ port: 0, pathPrefix: PREFIX }, store, sse, acceptAllAuth);
+    await server.start();
+    baseUrl = `http://localhost:${server.port()}${PREFIX}`;
+  });
+
+  afterAll(() => {
+    server.stop();
+    sse.dispose();
+  });
+
+  // -----------------------------------------------------------------
+  // Test 1: LLM generates HTML → stored in canvas → read back
+  // -----------------------------------------------------------------
+
+  test(
+    "LLM-generated content round-trips through canvas CRUD",
+    async () => {
+      // 1. Ask LLM to generate HTML via full Koi runtime
+      const html = await askLlm(
+        "Generate a simple HTML snippet with a <div> containing the text 'Hello from Koi'. " +
+          "Return ONLY the HTML, no markdown fences, no explanation.",
+      );
+      expect(html.length).toBeGreaterThan(0);
+      expect(html.toLowerCase()).toContain("hello");
+
+      // 2. POST the LLM-generated content to canvas server
+      const createRes = await fetch(`${baseUrl}/llm-surface-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: html }),
+      });
+      expect(createRes.status).toBe(201);
+      const createBody = (await createRes.json()) as { ok: boolean; surfaceId: string };
+      expect(createBody.ok).toBe(true);
+      expect(createBody.surfaceId).toBe("llm-surface-1");
+
+      // 3. Verify ETag was returned
+      const etag = createRes.headers.get("ETag");
+      expect(etag).toBeTruthy();
+
+      // 4. GET the surface and verify content round-tripped
+      const getRes = await fetch(`${baseUrl}/llm-surface-1`);
+      expect(getRes.status).toBe(200);
+      const getBody = (await getRes.json()) as {
+        ok: boolean;
+        surface: { content: string; surfaceId: string };
+      };
+      expect(getBody.ok).toBe(true);
+      expect(getBody.surface.content).toBe(html);
+      expect(getBody.surface.surfaceId).toBe("llm-surface-1");
+
+      // 5. Verify If-None-Match caching works with real content hash
+      const cachedRes = await fetch(`${baseUrl}/llm-surface-1`, {
+        headers: { "If-None-Match": etag ?? "" },
+      });
+      expect(cachedRes.status).toBe(304);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 2: SSE delivers real-time events from LLM content updates
+  // -----------------------------------------------------------------
+
+  test(
+    "SSE delivers update events when LLM content is patched",
+    async () => {
+      // 1. Create initial surface
+      const initialHtml = "<div>Initial content</div>";
+      await fetch(`${baseUrl}/sse-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: initialHtml }),
+      });
+
+      // 2. Open SSE connection
+      const sseRes = await fetch(`${baseUrl}/sse-e2e-1/events`);
+      expect(sseRes.status).toBe(200);
+      expect(sseRes.headers.get("Content-Type")).toBe("text/event-stream");
+
+      // 3. Ask LLM to generate updated content via full Koi runtime
+      const updatedHtml = await askLlm(
+        "Generate a simple HTML snippet with a <div> containing 'Updated by Koi Agent'. " +
+          "Return ONLY the HTML, no markdown fences, no explanation.",
+      );
+      expect(updatedHtml.length).toBeGreaterThan(0);
+
+      // 4. PATCH with LLM-generated content
+      const patchRes = await fetch(`${baseUrl}/sse-e2e-1`, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: updatedHtml }),
+      });
+      expect(patchRes.status).toBe(200);
+
+      // 5. Collect SSE events — should have "updated" event with new content
+      const events = await collectSseEvents(sseRes, 2, 3000);
+      const updatedEvent = events.find((e) => e.event === "updated");
+      expect(updatedEvent).toBeDefined();
+
+      if (updatedEvent?.data !== undefined) {
+        const data = JSON.parse(updatedEvent.data) as {
+          surfaceId: string;
+          content: string;
+        };
+        expect(data.surfaceId).toBe("sse-e2e-1");
+        expect(data.content).toBe(updatedHtml);
+      }
+
+      // 6. Verify GET returns updated content
+      const getRes = await fetch(`${baseUrl}/sse-e2e-1`);
+      const getBody = (await getRes.json()) as { surface: { content: string } };
+      expect(getBody.surface.content).toBe(updatedHtml);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 3: CAS prevents stale overwrites with real content hashes
+  // -----------------------------------------------------------------
+
+  test(
+    "ETag CAS prevents stale overwrites across LLM-generated versions",
+    async () => {
+      // 1. Create surface with v1 content
+      const createRes = await fetch(`${baseUrl}/cas-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<p>Version 1</p>" }),
+      });
+      const originalEtag = createRes.headers.get("ETag") ?? "";
+      expect(originalEtag).toBeTruthy();
+
+      // 2. Ask LLM to generate v2 content
+      const v2Html = await askLlm(
+        "Generate HTML: <p>Version 2 by LLM</p>. Return ONLY the HTML, nothing else.",
+      );
+
+      // 3. PATCH with correct ETag succeeds
+      const patch1 = await fetch(`${baseUrl}/cas-e2e-1`, {
+        method: "PATCH",
+        headers: { ...authHeaders(), "If-Match": originalEtag },
+        body: JSON.stringify({ content: v2Html }),
+      });
+      expect(patch1.status).toBe(200);
+      const newEtag = patch1.headers.get("ETag") ?? "";
+      expect(newEtag).not.toBe(originalEtag);
+
+      // 4. PATCH with stale ETag fails (412)
+      const patch2 = await fetch(`${baseUrl}/cas-e2e-1`, {
+        method: "PATCH",
+        headers: { ...authHeaders(), "If-Match": originalEtag },
+        body: JSON.stringify({ content: "<p>Version 3 - should fail</p>" }),
+      });
+      expect(patch2.status).toBe(412);
+
+      // 5. PATCH with fresh ETag succeeds
+      const patch3 = await fetch(`${baseUrl}/cas-e2e-1`, {
+        method: "PATCH",
+        headers: { ...authHeaders(), "If-Match": newEtag },
+        body: JSON.stringify({ content: "<p>Version 3 - correct</p>" }),
+      });
+      expect(patch3.status).toBe(200);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 4: Middleware chain exercises during LLM call
+  // -----------------------------------------------------------------
+
+  test(
+    "Koi middleware chain is exercised during canvas content generation",
+    async () => {
+      // let: tracks middleware interceptions
+      let modelStreamHit = false;
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Return exactly: <div>middleware-test</div>",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const observerMiddleware: KoiMiddleware = {
+        name: "e2e:canvas-observer",
+        priority: 500,
+        async *wrapModelStream(_ctx, req, next) {
+          modelStreamHit = true;
+          yield* next(req);
+        },
+      };
+
+      const runtime = await createKoi({
+        manifest: MANIFEST,
+        adapter: piAdapter,
+        middleware: [observerMiddleware],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 1_000 },
+      });
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Generate: <div>middleware-test</div>" }),
+      );
+      const html = extractText(events);
+      await runtime.dispose();
+
+      // Middleware was exercised
+      expect(modelStreamHit).toBe(true);
+      expect(html.length).toBeGreaterThan(0);
+
+      // Store the middleware-generated content in canvas
+      const res = await fetch(`${baseUrl}/middleware-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: html }),
+      });
+      expect(res.status).toBe(201);
+
+      // Verify it was stored correctly
+      const getRes = await fetch(`${baseUrl}/middleware-e2e-1`);
+      const body = (await getRes.json()) as { surface: { content: string } };
+      expect(body.surface.content).toBe(html);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 5: Full lifecycle with SSE — create → subscribe → update → delete
+  // -----------------------------------------------------------------
+
+  test(
+    "full lifecycle: LLM create → SSE subscribe → LLM update → delete → SSE closed",
+    async () => {
+      // 1. LLM generates initial content
+      const v1 = await askLlm(
+        "Return exactly this HTML: <h1>Canvas E2E v1</h1>. " +
+          "No markdown, no explanation, just the HTML tag.",
+      );
+      expect(v1).toContain("Canvas E2E");
+
+      // 2. Create surface
+      const createRes = await fetch(`${baseUrl}/lifecycle-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: v1, metadata: { author: "e2e-agent", version: 1 } }),
+      });
+      expect(createRes.status).toBe(201);
+
+      // 3. Open SSE
+      const sseRes = await fetch(`${baseUrl}/lifecycle-e2e-1/events`);
+      expect(sseRes.status).toBe(200);
+
+      // 4. LLM generates updated content
+      const v2 = await askLlm(
+        "Return exactly this HTML: <h1>Canvas E2E v2</h1>. " +
+          "No markdown, no explanation, just the HTML tag.",
+      );
+
+      // 5. PATCH with v2
+      const patchRes = await fetch(`${baseUrl}/lifecycle-e2e-1`, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: v2 }),
+      });
+      expect(patchRes.status).toBe(200);
+
+      // 6. DELETE surface
+      const deleteRes = await fetch(`${baseUrl}/lifecycle-e2e-1`, {
+        method: "DELETE",
+        headers: { Authorization: "Bearer e2e-token" },
+      });
+      expect(deleteRes.status).toBe(204);
+
+      // 7. Collect SSE events — should have "updated" and "deleted"
+      const events = await collectSseEvents(sseRes, 3, 3000);
+      const eventTypes = events.map((e) => e.event);
+      expect(eventTypes).toContain("updated");
+      expect(eventTypes).toContain("deleted");
+
+      // 8. Verify surface is gone
+      const goneRes = await fetch(`${baseUrl}/lifecycle-e2e-1`);
+      expect(goneRes.status).toBe(404);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 6: Auth boundary — public reads, gated writes
+  // -----------------------------------------------------------------
+
+  test(
+    "auth boundary: public GET/SSE, 401 on writes without token",
+    async () => {
+      // Create a surface (with auth)
+      await fetch(`${baseUrl}/auth-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<div>public</div>" }),
+      });
+
+      // Public GET — no auth required
+      const getRes = await fetch(`${baseUrl}/auth-e2e-1`);
+      expect(getRes.status).toBe(200);
+
+      // Public SSE — no auth required
+      const controller = new AbortController();
+      const sseRes = await fetch(`${baseUrl}/auth-e2e-1/events`, {
+        signal: controller.signal,
+      });
+      expect(sseRes.status).toBe(200);
+      controller.abort();
+
+      // Write without auth → 401
+      const patchRes = await fetch(`${baseUrl}/auth-e2e-1`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "hacked" }),
+      });
+      expect(patchRes.status).toBe(401);
+
+      const deleteRes = await fetch(`${baseUrl}/auth-e2e-1`, {
+        method: "DELETE",
+      });
+      expect(deleteRes.status).toBe(401);
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 7: Metadata preserved through LLM content cycle
+  // -----------------------------------------------------------------
+
+  test(
+    "metadata preserved alongside LLM-generated content",
+    async () => {
+      const html = await askLlm("Return: <p>metadata test</p>. Just the HTML tag, nothing else.");
+
+      // Create with metadata
+      await fetch(`${baseUrl}/meta-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          content: html,
+          metadata: {
+            author: "e2e-agent",
+            generatedBy: "claude-haiku",
+            timestamp: Date.now(),
+          },
+        }),
+      });
+
+      // Verify metadata round-trips
+      const getRes = await fetch(`${baseUrl}/meta-e2e-1`);
+      const body = (await getRes.json()) as {
+        surface: {
+          content: string;
+          metadata: { author: string; generatedBy: string; timestamp: number };
+        };
+      };
+      expect(body.surface.content).toBe(html);
+      expect(body.surface.metadata.author).toBe("e2e-agent");
+      expect(body.surface.metadata.generatedBy).toBe("claude-haiku");
+      expect(typeof body.surface.metadata.timestamp).toBe("number");
+    },
+    TIMEOUT_MS,
+  );
+
+  // -----------------------------------------------------------------
+  // Test 8: Multiple surfaces concurrently
+  // -----------------------------------------------------------------
+
+  test(
+    "multiple surfaces managed concurrently with SSE isolation",
+    async () => {
+      // Create two surfaces
+      await fetch(`${baseUrl}/multi-e2e-1`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<div>Surface A</div>" }),
+      });
+      await fetch(`${baseUrl}/multi-e2e-2`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<div>Surface B</div>" }),
+      });
+
+      // Subscribe to SSE on surface 1 only
+      const sseRes = await fetch(`${baseUrl}/multi-e2e-1/events`);
+      expect(sseRes.status).toBe(200);
+
+      // Update surface 2 (should NOT appear in surface 1's SSE)
+      await fetch(`${baseUrl}/multi-e2e-2`, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<div>Surface B updated</div>" }),
+      });
+
+      // Update surface 1 (should appear in SSE)
+      await fetch(`${baseUrl}/multi-e2e-1`, {
+        method: "PATCH",
+        headers: authHeaders(),
+        body: JSON.stringify({ content: "<div>Surface A updated</div>" }),
+      });
+
+      // Collect SSE — should only have surface 1's update
+      const events = await collectSseEvents(sseRes, 1, 2000);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.event).toBe("updated");
+      if (events[0]?.data !== undefined) {
+        const data = JSON.parse(events[0].data) as { surfaceId: string };
+        expect(data.surfaceId).toBe("multi-e2e-1");
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/gateway/src/__tests__/canvas.integration.test.ts
+++ b/packages/gateway/src/__tests__/canvas.integration.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Canvas rendering integration test: full lifecycle via HTTP.
+ *
+ * Starts a real canvas server, exercises CRUD + SSE live updates,
+ * and verifies end-to-end correctness through fetch().
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { Result } from "@koi/core";
+import type { CanvasAuthenticator, CanvasAuthResult, CanvasServer } from "../canvas-routes.js";
+import { createCanvasServer } from "../canvas-routes.js";
+import type { CanvasSseManager } from "../canvas-sse.js";
+import { createCanvasSseManager } from "../canvas-sse.js";
+import type { SurfaceStore } from "../canvas-store.js";
+import { createInMemorySurfaceStore } from "../canvas-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PREFIX = "/gateway/canvas";
+
+const acceptAllAuth: CanvasAuthenticator = async (
+  request: Request,
+): Promise<Result<CanvasAuthResult>> => {
+  const header = request.headers.get("Authorization");
+  if (header === null || !header.startsWith("Bearer ")) {
+    return { ok: false, error: { code: "PERMISSION", message: "Unauthorized", retryable: false } };
+  }
+  return { ok: true, value: { agentId: "integration-agent" } };
+};
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: "Bearer integration-token", "Content-Type": "application/json" };
+}
+
+interface SseEventParsed {
+  readonly id?: string;
+  readonly event?: string;
+  readonly data?: string;
+}
+
+/**
+ * Collect SSE events from a streaming response.
+ * Reads chunks from the body, parses SSE wire format, and returns parsed events.
+ */
+async function collectSseEvents(
+  response: Response,
+  maxEvents: number,
+  timeoutMs = 3000,
+): Promise<readonly SseEventParsed[]> {
+  const events: SseEventParsed[] = [];
+  if (response.body === null) return [];
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const deadline = Date.now() + timeoutMs;
+
+  while (events.length < maxEvents && Date.now() < deadline) {
+    const { done, value } = await Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), deadline - Date.now()),
+      ),
+    ]);
+
+    if (done) break;
+    if (value === undefined) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // Parse SSE events from buffer
+    const parts = buffer.split("\n\n");
+    // Last part is incomplete (no trailing \n\n yet)
+    buffer = parts.pop() ?? "";
+
+    for (const part of parts) {
+      const lines = part.split("\n");
+      const event: Record<string, string> = {};
+      for (const line of lines) {
+        if (line.startsWith(":")) continue; // comment
+        const colonIdx = line.indexOf(": ");
+        if (colonIdx === -1) continue;
+        const field = line.slice(0, colonIdx);
+        const value = line.slice(colonIdx + 2);
+        event[field] = value;
+      }
+      if (Object.keys(event).length > 0) {
+        events.push(event as SseEventParsed);
+      }
+    }
+  }
+
+  reader.cancel();
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Integration test
+// ---------------------------------------------------------------------------
+
+describe("canvas integration", () => {
+  let store: SurfaceStore;
+  let sse: CanvasSseManager;
+  let server: CanvasServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    store = createInMemorySurfaceStore();
+    sse = createCanvasSseManager({ keepAliveIntervalMs: 60_000 });
+    server = createCanvasServer({ port: 0, pathPrefix: PREFIX }, store, sse, acceptAllAuth);
+    await server.start();
+    baseUrl = `http://localhost:${server.port()}${PREFIX}`;
+  });
+
+  afterAll(() => {
+    server.stop();
+    sse.dispose();
+  });
+
+  test("full lifecycle: create → SSE subscribe → update → delete", async () => {
+    // 1. POST create surface
+    const createRes = await fetch(`${baseUrl}/lifecycle-1`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "<div>Hello</div>" }),
+    });
+    expect(createRes.status).toBe(201);
+    const createBody = (await createRes.json()) as { ok: boolean; surfaceId: string };
+    expect(createBody.ok).toBe(true);
+    expect(createBody.surfaceId).toBe("lifecycle-1");
+
+    // 2. Open SSE connection
+    const sseRes = await fetch(`${baseUrl}/lifecycle-1/events`);
+    expect(sseRes.status).toBe(200);
+    expect(sseRes.headers.get("Content-Type")).toBe("text/event-stream");
+
+    // 3. PATCH update surface
+    const patchRes = await fetch(`${baseUrl}/lifecycle-1`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "<div>Updated</div>" }),
+    });
+    expect(patchRes.status).toBe(200);
+    const newEtag = patchRes.headers.get("ETag");
+    expect(newEtag).toBeTruthy();
+
+    // 4. Verify GET returns updated content
+    const getRes = await fetch(`${baseUrl}/lifecycle-1`);
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { surface: { content: string } };
+    expect(getBody.surface.content).toBe("<div>Updated</div>");
+
+    // 5. Collect SSE events (should have "updated" event)
+    const events = await collectSseEvents(sseRes, 2, 1000);
+    const updatedEvent = events.find((e) => e.event === "updated");
+    expect(updatedEvent).toBeDefined();
+    if (updatedEvent?.data !== undefined) {
+      const data = JSON.parse(updatedEvent.data) as { surfaceId: string; content: string };
+      expect(data.surfaceId).toBe("lifecycle-1");
+      expect(data.content).toBe("<div>Updated</div>");
+    }
+  });
+
+  test("delete surface triggers SSE deleted event", async () => {
+    // Setup: create surface + open SSE
+    await fetch(`${baseUrl}/delete-sse-1`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "to-be-deleted" }),
+    });
+
+    const sseRes = await fetch(`${baseUrl}/delete-sse-1/events`);
+    expect(sseRes.status).toBe(200);
+
+    // Delete the surface
+    const delRes = await fetch(`${baseUrl}/delete-sse-1`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer integration-token" },
+    });
+    expect(delRes.status).toBe(204);
+
+    // Collect SSE events — should have "deleted" event
+    const events = await collectSseEvents(sseRes, 1, 1000);
+    const deletedEvent = events.find((e) => e.event === "deleted");
+    expect(deletedEvent).toBeDefined();
+  });
+
+  test("SSE subscribe to nonexistent surface → 404", async () => {
+    const res = await fetch(`${baseUrl}/nonexistent/events`);
+    expect(res.status).toBe(404);
+  });
+
+  test("ETag caching: If-None-Match returns 304", async () => {
+    await fetch(`${baseUrl}/etag-test`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "cached" }),
+    });
+
+    // Get the ETag
+    const getRes = await fetch(`${baseUrl}/etag-test`);
+    const etag = getRes.headers.get("ETag") ?? "";
+    await getRes.text(); // consume body
+
+    // Request with matching ETag
+    const cachedRes = await fetch(`${baseUrl}/etag-test`, {
+      headers: { "If-None-Match": etag },
+    });
+    expect(cachedRes.status).toBe(304);
+  });
+
+  test("CAS update: If-Match prevents stale overwrites", async () => {
+    const createRes = await fetch(`${baseUrl}/cas-test`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ content: "v1" }),
+    });
+    const originalEtag = createRes.headers.get("ETag") ?? "";
+
+    // First update succeeds with correct ETag
+    const patch1 = await fetch(`${baseUrl}/cas-test`, {
+      method: "PATCH",
+      headers: { ...authHeaders(), "If-Match": originalEtag },
+      body: JSON.stringify({ content: "v2" }),
+    });
+    expect(patch1.status).toBe(200);
+
+    // Second update with stale ETag fails
+    const patch2 = await fetch(`${baseUrl}/cas-test`, {
+      method: "PATCH",
+      headers: { ...authHeaders(), "If-Match": originalEtag },
+      body: JSON.stringify({ content: "v3" }),
+    });
+    expect(patch2.status).toBe(412);
+  });
+});

--- a/packages/gateway/src/canvas-routes.ts
+++ b/packages/gateway/src/canvas-routes.ts
@@ -1,0 +1,379 @@
+/**
+ * HTTP route handler for canvas surface CRUD + SSE streaming.
+ *
+ * Routes:
+ *   POST   {prefix}/{surfaceId}         Create surface (auth required)
+ *   GET    {prefix}/{surfaceId}         Fetch surface (public)
+ *   PATCH  {prefix}/{surfaceId}         Update surface (auth required)
+ *   DELETE {prefix}/{surfaceId}         Delete surface (auth required)
+ *   GET    {prefix}/{surfaceId}/events  SSE stream (public)
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import type { CanvasSseManager, SseEvent } from "./canvas-sse.js";
+import type { SurfaceStore } from "./canvas-store.js";
+import { jsonResponse, matchPath, parseJsonBody } from "./http-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CanvasRouteConfig {
+  /** URL path prefix. Default: "/gateway/canvas". */
+  readonly pathPrefix: string;
+  /** Maximum request body size in bytes. Default: 1_048_576 (1MB). */
+  readonly maxBodyBytes: number;
+}
+
+export interface CanvasServer {
+  readonly start: () => Promise<void>;
+  readonly stop: () => void;
+  readonly port: () => number;
+}
+
+export type CanvasAuthenticator = (request: Request) => Promise<Result<CanvasAuthResult, KoiError>>;
+
+export interface CanvasAuthResult {
+  readonly agentId: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+const DEFAULT_CANVAS_ROUTE_CONFIG: CanvasRouteConfig = {
+  pathPrefix: "/gateway/canvas",
+  maxBodyBytes: 1_048_576,
+} as const;
+
+const textEncoder = new TextEncoder();
+
+/** Surface ID: 1-128 alphanumeric chars, hyphens, underscores. */
+const SURFACE_ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+function isValidSurfaceId(id: string): boolean {
+  return SURFACE_ID_PATTERN.test(id);
+}
+
+/** Type guard: value is a non-null, non-array object usable as Record<string, unknown>. */
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+async function requireAuth(
+  request: Request,
+  authenticator: CanvasAuthenticator | undefined,
+): Promise<Result<CanvasAuthResult, "unauthorized">> {
+  if (authenticator === undefined) {
+    return { ok: false, error: "unauthorized" };
+  }
+  const result = await authenticator(request);
+  if (!result.ok) {
+    return { ok: false, error: "unauthorized" };
+  }
+  return { ok: true, value: result.value };
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+async function handlePost(
+  request: Request,
+  surfaceId: string,
+  store: SurfaceStore,
+  config: CanvasRouteConfig,
+  authenticator: CanvasAuthenticator | undefined,
+): Promise<Response> {
+  const auth = await requireAuth(request, authenticator);
+  if (!auth.ok) return jsonResponse(401, { ok: false, error: "Unauthorized" });
+
+  const bodyResult = await parseJsonBody(request, config.maxBodyBytes);
+  if (!bodyResult.ok) {
+    return jsonResponse(bodyResult.status, { ok: false, error: bodyResult.message });
+  }
+
+  const parsed = bodyResult.parsed;
+  if (!isRecord(parsed) || typeof parsed.content !== "string") {
+    return jsonResponse(400, { ok: false, error: "Body must include a string 'content' field" });
+  }
+
+  const metadata = isRecord(parsed.metadata) ? parsed.metadata : undefined;
+
+  const result = await store.create(surfaceId, parsed.content, metadata);
+  if (!result.ok) {
+    if (result.error.code === "CONFLICT") {
+      return jsonResponse(409, { ok: false, error: result.error.message });
+    }
+    return jsonResponse(500, { ok: false, error: "Internal error" });
+  }
+
+  return new Response(JSON.stringify({ ok: true, surfaceId }), {
+    status: 201,
+    headers: {
+      "Content-Type": "application/json",
+      ETag: `"${result.value.contentHash}"`,
+      Location: `${config.pathPrefix}/${surfaceId}`,
+    },
+  });
+}
+
+async function handleGet(
+  request: Request,
+  surfaceId: string,
+  store: SurfaceStore,
+): Promise<Response> {
+  const result = await store.get(surfaceId);
+  if (!result.ok) {
+    return jsonResponse(404, { ok: false, error: "Surface not found" });
+  }
+
+  const etag = `"${result.value.contentHash}"`;
+  const ifNoneMatch = request.headers.get("If-None-Match");
+  if (ifNoneMatch === etag) {
+    return new Response(null, { status: 304, headers: { ETag: etag } });
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      surface: {
+        surfaceId: result.value.surfaceId,
+        content: result.value.content,
+        createdAt: result.value.createdAt,
+        updatedAt: result.value.updatedAt,
+        ...(result.value.metadata !== undefined ? { metadata: result.value.metadata } : {}),
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json", ETag: etag },
+    },
+  );
+}
+
+async function handlePatch(
+  request: Request,
+  surfaceId: string,
+  store: SurfaceStore,
+  sse: CanvasSseManager,
+  config: CanvasRouteConfig,
+  authenticator: CanvasAuthenticator | undefined,
+): Promise<Response> {
+  const auth = await requireAuth(request, authenticator);
+  if (!auth.ok) return jsonResponse(401, { ok: false, error: "Unauthorized" });
+
+  const bodyResult = await parseJsonBody(request, config.maxBodyBytes);
+  if (!bodyResult.ok) {
+    return jsonResponse(bodyResult.status, { ok: false, error: bodyResult.message });
+  }
+
+  const parsed = bodyResult.parsed;
+  if (!isRecord(parsed) || typeof parsed.content !== "string") {
+    return jsonResponse(400, { ok: false, error: "Body must include a string 'content' field" });
+  }
+
+  // CAS via If-Match header
+  const ifMatch = request.headers.get("If-Match");
+  const expectedHash = ifMatch !== null ? ifMatch.replace(/^"|"$/g, "") : undefined;
+
+  const result = await store.update(surfaceId, parsed.content, expectedHash);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") {
+      return jsonResponse(404, { ok: false, error: "Surface not found" });
+    }
+    if (result.error.code === "CONFLICT") {
+      return jsonResponse(412, { ok: false, error: "Precondition failed: content hash mismatch" });
+    }
+    return jsonResponse(500, { ok: false, error: "Internal error" });
+  }
+
+  // Publish SSE update
+  const sseEvent: SseEvent = {
+    id: sse.nextEventId(surfaceId),
+    event: "updated",
+    data: JSON.stringify({ surfaceId, content: parsed.content }),
+  };
+  sse.publish(surfaceId, sseEvent);
+
+  const etag = `"${result.value.contentHash}"`;
+  return new Response(JSON.stringify({ ok: true, surfaceId }), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ETag: etag },
+  });
+}
+
+async function handleDelete(
+  request: Request,
+  surfaceId: string,
+  store: SurfaceStore,
+  sse: CanvasSseManager,
+  authenticator: CanvasAuthenticator | undefined,
+): Promise<Response> {
+  const auth = await requireAuth(request, authenticator);
+  if (!auth.ok) return jsonResponse(401, { ok: false, error: "Unauthorized" });
+
+  const result = await store.delete(surfaceId);
+  if (!result.ok) {
+    return jsonResponse(500, { ok: false, error: "Internal error" });
+  }
+  if (!result.value) {
+    return jsonResponse(404, { ok: false, error: "Surface not found" });
+  }
+
+  // Notify SSE subscribers and close their streams
+  sse.close(surfaceId);
+
+  return new Response(null, { status: 204 });
+}
+
+async function handleSseSubscribe(
+  request: Request,
+  surfaceId: string,
+  store: SurfaceStore,
+  sse: CanvasSseManager,
+): Promise<Response> {
+  const exists = await store.has(surfaceId);
+  if (!exists.ok || !exists.value) {
+    return jsonResponse(404, { ok: false, error: "Surface not found" });
+  }
+
+  // let: assigned inside ReadableStream.start(), read in cancel() and abort handler
+  let unsubscribe: (() => void) | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Send initial SSE comment to flush response headers
+      controller.enqueue(textEncoder.encode(": connected\n\n"));
+
+      const result = sse.subscribe(surfaceId, (data: Uint8Array) => {
+        try {
+          controller.enqueue(data);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      if (!result.ok) {
+        // Capacity exceeded — send error event and close
+        controller.enqueue(
+          textEncoder.encode(
+            `event: error\ndata: ${JSON.stringify({ error: result.error.message })}\n\n`,
+          ),
+        );
+        controller.close();
+        return;
+      }
+      unsubscribe = result.value;
+    },
+    cancel() {
+      unsubscribe?.();
+    },
+  });
+
+  // Unsubscribe when client disconnects
+  request.signal.addEventListener("abort", () => {
+    unsubscribe?.();
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createCanvasServer(
+  config: Partial<CanvasRouteConfig> & { readonly port: number },
+  store: SurfaceStore,
+  sse: CanvasSseManager,
+  authenticator?: CanvasAuthenticator,
+): CanvasServer {
+  // let: server lifecycle — assigned in start(), cleared in stop()
+  let server: ReturnType<typeof Bun.serve> | undefined;
+  // let: resolved after Bun.serve() picks an ephemeral port (port: 0)
+  let resolvedPort: number = config.port;
+
+  const routeConfig: CanvasRouteConfig = {
+    pathPrefix: config.pathPrefix ?? DEFAULT_CANVAS_ROUTE_CONFIG.pathPrefix,
+    maxBodyBytes: config.maxBodyBytes ?? DEFAULT_CANVAS_ROUTE_CONFIG.maxBodyBytes,
+  };
+
+  const prefix = routeConfig.pathPrefix.endsWith("/")
+    ? routeConfig.pathPrefix.slice(0, -1)
+    : routeConfig.pathPrefix;
+
+  return {
+    async start(): Promise<void> {
+      server = Bun.serve({
+        port: config.port,
+        async fetch(request: Request): Promise<Response> {
+          const url = new URL(request.url);
+          const pathResult = matchPath(url.pathname, prefix);
+          if (!pathResult.match) {
+            return jsonResponse(404, { ok: false, error: "Not found" });
+          }
+
+          const segments = pathResult.segments;
+          if (segments.length === 0) {
+            return jsonResponse(404, { ok: false, error: "Surface ID required" });
+          }
+
+          const firstSegment = segments[0];
+          if (firstSegment === undefined) {
+            return jsonResponse(404, { ok: false, error: "Surface ID required" });
+          }
+          const surfaceId = firstSegment;
+
+          if (!isValidSurfaceId(surfaceId)) {
+            return jsonResponse(400, { ok: false, error: "Invalid surface ID" });
+          }
+
+          // SSE endpoint: {prefix}/{surfaceId}/events
+          if (segments.length === 2 && segments[1] === "events") {
+            if (request.method !== "GET") {
+              return jsonResponse(405, { ok: false, error: "Method not allowed" });
+            }
+            return handleSseSubscribe(request, surfaceId, store, sse);
+          }
+
+          // CRUD routes: {prefix}/{surfaceId}
+          if (segments.length !== 1) {
+            return jsonResponse(404, { ok: false, error: "Not found" });
+          }
+
+          switch (request.method) {
+            case "POST":
+              return handlePost(request, surfaceId, store, routeConfig, authenticator);
+            case "GET":
+              return handleGet(request, surfaceId, store);
+            case "PATCH":
+              return handlePatch(request, surfaceId, store, sse, routeConfig, authenticator);
+            case "DELETE":
+              return handleDelete(request, surfaceId, store, sse, authenticator);
+            default:
+              return jsonResponse(405, { ok: false, error: "Method not allowed" });
+          }
+        },
+      });
+      resolvedPort = server.port ?? config.port;
+    },
+
+    stop(): void {
+      server?.stop(true);
+      server = undefined;
+    },
+
+    port(): number {
+      return resolvedPort;
+    },
+  };
+}

--- a/packages/gateway/src/canvas-sse.ts
+++ b/packages/gateway/src/canvas-sse.ts
@@ -1,0 +1,219 @@
+/**
+ * SSE (Server-Sent Events) subscriber registry for canvas surfaces.
+ *
+ * Manages per-surface fan-out, keep-alive pings, connection limits,
+ * and automatic dead-subscriber cleanup.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SseEvent {
+  /** Monotonic event ID for Last-Event-ID reconnection. */
+  readonly id: string;
+  /** Event type: "updated" | "deleted". */
+  readonly event: string;
+  /** JSON payload string. */
+  readonly data: string;
+}
+
+/**
+ * Callback that receives raw SSE bytes.
+ * Returns false if the subscriber is dead (connection closed).
+ */
+export type SseSubscriber = (data: Uint8Array) => boolean;
+
+export interface CanvasSseManager {
+  /**
+   * Register a subscriber for a surface's event stream.
+   * Returns an unsubscribe function on success.
+   * Fails with RATE_LIMIT if per-surface or global limit reached.
+   */
+  readonly subscribe: (
+    surfaceId: string,
+    subscriber: SseSubscriber,
+  ) => Result<() => void, KoiError>;
+  /** Fan out an event to all subscribers for a surface. */
+  readonly publish: (surfaceId: string, event: SseEvent) => void;
+  /** Send "deleted" event and remove all subscribers for a surface. */
+  readonly close: (surfaceId: string) => void;
+  /** Stop keep-alive timer and clear all subscribers. */
+  readonly dispose: () => void;
+  /** Get the next monotonic event ID for a surface. */
+  readonly nextEventId: (surfaceId: string) => string;
+  readonly subscriberCount: (surfaceId: string) => number;
+  readonly totalSubscribers: () => number;
+}
+
+export interface CanvasSseConfig {
+  /** Max subscribers per surface. Default: 100. */
+  readonly maxSubscribersPerSurface: number;
+  /** Max total subscribers across all surfaces. Default: 10_000. */
+  readonly maxTotalSubscribers: number;
+  /** Keep-alive interval in ms. Default: 15_000. */
+  readonly keepAliveIntervalMs: number;
+}
+
+const DEFAULT_CANVAS_SSE_CONFIG: CanvasSseConfig = {
+  maxSubscribersPerSurface: 100,
+  maxTotalSubscribers: 10_000,
+  keepAliveIntervalMs: 15_000,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const encoder = new TextEncoder();
+
+/** Strip newlines from SSE field values to prevent injection. */
+function sanitizeSseField(value: string): string {
+  return value.replace(/[\r\n]/g, "");
+}
+
+/** Format an SSE event to wire format bytes. */
+export function formatSseEvent(event: SseEvent): Uint8Array {
+  const id = sanitizeSseField(event.id);
+  const eventType = sanitizeSseField(event.event);
+  // Data may contain newlines — each line must be prefixed with "data: " per SSE spec
+  const dataLines = event.data
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  return encoder.encode(`id: ${id}\nevent: ${eventType}\n${dataLines}\n\n`);
+}
+
+const KEEP_ALIVE_BYTES = encoder.encode(": keep-alive\n\n");
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createCanvasSseManager(
+  configOverrides?: Partial<CanvasSseConfig>,
+): CanvasSseManager {
+  const config: CanvasSseConfig = { ...DEFAULT_CANVAS_SSE_CONFIG, ...configOverrides };
+  const registry = new Map<string, Set<SseSubscriber>>();
+  const eventCounters = new Map<string, number>();
+  // let: mutable counter tracking total subscribers across all surfaces
+  let total = 0;
+
+  function nextEventId(surfaceId: string): string {
+    const counter = (eventCounters.get(surfaceId) ?? 0) + 1;
+    eventCounters.set(surfaceId, counter);
+    return String(counter);
+  }
+
+  function removeSubscriber(surfaceId: string, subscriber: SseSubscriber): void {
+    const subscribers = registry.get(surfaceId);
+    if (subscribers === undefined) return;
+    if (subscribers.delete(subscriber)) {
+      total--;
+      if (subscribers.size === 0) {
+        registry.delete(surfaceId);
+      }
+    }
+  }
+
+  /** Send data to all subscribers for a surface, removing dead ones. */
+  function fanOut(surfaceId: string, data: Uint8Array): void {
+    const subscribers = registry.get(surfaceId);
+    if (subscribers === undefined) return;
+    const dead = [...subscribers].filter((subscriber) => !subscriber(data));
+    for (const subscriber of dead) {
+      removeSubscriber(surfaceId, subscriber);
+    }
+  }
+
+  // Keep-alive: send comment to all subscribers periodically
+  const keepAliveTimer = setInterval(() => {
+    for (const surfaceId of [...registry.keys()]) {
+      fanOut(surfaceId, KEEP_ALIVE_BYTES);
+    }
+  }, config.keepAliveIntervalMs);
+
+  return {
+    subscribe(surfaceId: string, subscriber: SseSubscriber): Result<() => void, KoiError> {
+      // Check global limit
+      if (total >= config.maxTotalSubscribers) {
+        return {
+          ok: false,
+          error: {
+            code: "RATE_LIMIT",
+            message: `Global SSE subscriber limit reached (${config.maxTotalSubscribers})`,
+            retryable: true,
+          },
+        };
+      }
+
+      // let: reassigned on cache miss when creating a new subscriber set
+      let subscribers = registry.get(surfaceId);
+      if (subscribers === undefined) {
+        subscribers = new Set();
+        registry.set(surfaceId, subscribers);
+      }
+
+      // Check per-surface limit
+      if (subscribers.size >= config.maxSubscribersPerSurface) {
+        return {
+          ok: false,
+          error: {
+            code: "RATE_LIMIT",
+            message: `Per-surface SSE subscriber limit reached (${config.maxSubscribersPerSurface})`,
+            retryable: true,
+          },
+        };
+      }
+
+      subscribers.add(subscriber);
+      total++;
+
+      const unsubscribe = (): void => {
+        removeSubscriber(surfaceId, subscriber);
+      };
+
+      return { ok: true, value: unsubscribe };
+    },
+
+    publish(surfaceId: string, event: SseEvent): void {
+      fanOut(surfaceId, formatSseEvent(event));
+    },
+
+    close(surfaceId: string): void {
+      const subscribers = registry.get(surfaceId);
+      if (subscribers === undefined) return;
+      const deletedEvent = formatSseEvent({
+        id: nextEventId(surfaceId),
+        event: "deleted",
+        data: JSON.stringify({ surfaceId }),
+      });
+      // Send deleted event to all (ignore dead status since we're removing anyway)
+      for (const subscriber of subscribers) {
+        subscriber(deletedEvent);
+      }
+      total -= subscribers.size;
+      registry.delete(surfaceId);
+      eventCounters.delete(surfaceId);
+    },
+
+    dispose(): void {
+      clearInterval(keepAliveTimer);
+      total = 0;
+      registry.clear();
+      eventCounters.clear();
+    },
+
+    nextEventId,
+
+    subscriberCount(surfaceId: string): number {
+      return registry.get(surfaceId)?.size ?? 0;
+    },
+
+    totalSubscribers(): number {
+      return total;
+    },
+  };
+}

--- a/packages/gateway/src/canvas-store.ts
+++ b/packages/gateway/src/canvas-store.ts
@@ -1,0 +1,189 @@
+/**
+ * SurfaceStore: pluggable surface persistence for canvas rendering.
+ *
+ * Surfaces are opaque blobs — the store does not understand A2UI structure.
+ * Default in-memory implementation with LRU eviction provided.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { conflict, notFound } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SurfaceEntry {
+  readonly surfaceId: string;
+  /** Opaque serialized surface content. */
+  readonly content: string;
+  /** SHA-256 hex digest of content — used as ETag. */
+  readonly contentHash: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  /** Tracks access time for LRU eviction. */
+  readonly lastAccessedAt: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface SurfaceStore {
+  readonly get: (
+    id: string,
+  ) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+  readonly create: (
+    id: string,
+    content: string,
+    metadata?: Readonly<Record<string, unknown>>,
+  ) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+  /**
+   * Update surface content.
+   * If expectedHash is provided and doesn't match current hash → CONFLICT error (CAS).
+   * If expectedHash is undefined → unconditional update.
+   */
+  readonly update: (
+    id: string,
+    content: string,
+    expectedHash: string | undefined,
+  ) => Result<SurfaceEntry, KoiError> | Promise<Result<SurfaceEntry, KoiError>>;
+  readonly delete: (id: string) => Result<boolean, KoiError> | Promise<Result<boolean, KoiError>>;
+  readonly has: (id: string) => Result<boolean, KoiError> | Promise<Result<boolean, KoiError>>;
+  readonly size: () => number;
+}
+
+export interface SurfaceStoreConfig {
+  /** Maximum number of surfaces before LRU eviction. Default: 10_000. */
+  readonly maxSurfaces: number;
+}
+
+const DEFAULT_SURFACE_STORE_CONFIG: SurfaceStoreConfig = {
+  maxSurfaces: 10_000,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Content hashing
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 hex digest of content using Bun native crypto. */
+export function computeContentHash(content: string): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(content);
+  return hasher.digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation with LRU eviction
+// ---------------------------------------------------------------------------
+
+export function createInMemorySurfaceStore(
+  configOverrides?: Partial<SurfaceStoreConfig>,
+): SurfaceStore {
+  const config: SurfaceStoreConfig = { ...DEFAULT_SURFACE_STORE_CONFIG, ...configOverrides };
+  const map = new Map<string, SurfaceEntry>();
+  // Monotonic counter for LRU ordering (Date.now() can repeat within same ms)
+  let accessCounter = 0;
+  const accessOrder = new Map<string, number>();
+
+  function touchAccess(id: string): void {
+    accessOrder.set(id, ++accessCounter);
+  }
+
+  function evictLru(): void {
+    if (map.size < config.maxSurfaces) return;
+
+    let oldestKey: string | undefined;
+    let oldestOrder = Infinity;
+    for (const [key] of map) {
+      const order = accessOrder.get(key) ?? 0;
+      if (order < oldestOrder) {
+        oldestOrder = order;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey !== undefined) {
+      map.delete(oldestKey);
+      accessOrder.delete(oldestKey);
+    }
+  }
+
+  return {
+    get(id: string): Result<SurfaceEntry, KoiError> {
+      const entry = map.get(id);
+      if (entry === undefined) {
+        return { ok: false, error: notFound(id, `Surface not found: ${id}`) };
+      }
+      // Update lastAccessedAt for LRU tracking (new object, not mutation)
+      const accessed: SurfaceEntry = { ...entry, lastAccessedAt: Date.now() };
+      map.set(id, accessed);
+      touchAccess(id);
+      return { ok: true, value: accessed };
+    },
+
+    create(
+      id: string,
+      content: string,
+      metadata?: Readonly<Record<string, unknown>>,
+    ): Result<SurfaceEntry, KoiError> {
+      if (map.has(id)) {
+        return { ok: false, error: conflict(id, `Surface already exists: ${id}`) };
+      }
+      evictLru();
+      const now = Date.now();
+      const entry: SurfaceEntry = {
+        surfaceId: id,
+        content,
+        contentHash: computeContentHash(content),
+        createdAt: now,
+        updatedAt: now,
+        lastAccessedAt: now,
+        ...(metadata !== undefined ? { metadata } : {}),
+      };
+      map.set(id, entry);
+      touchAccess(id);
+      return { ok: true, value: entry };
+    },
+
+    update(
+      id: string,
+      content: string,
+      expectedHash: string | undefined,
+    ): Result<SurfaceEntry, KoiError> {
+      const existing = map.get(id);
+      if (existing === undefined) {
+        return { ok: false, error: notFound(id, `Surface not found: ${id}`) };
+      }
+      // CAS check: if expectedHash provided, must match current
+      if (expectedHash !== undefined && expectedHash !== existing.contentHash) {
+        return {
+          ok: false,
+          error: conflict(
+            id,
+            `Content hash mismatch: expected ${expectedHash}, got ${existing.contentHash}`,
+          ),
+        };
+      }
+      const now = Date.now();
+      const updated: SurfaceEntry = {
+        ...existing,
+        content,
+        contentHash: computeContentHash(content),
+        updatedAt: now,
+        lastAccessedAt: now,
+      };
+      map.set(id, updated);
+      touchAccess(id);
+      return { ok: true, value: updated };
+    },
+
+    delete(id: string): Result<boolean, KoiError> {
+      accessOrder.delete(id);
+      return { ok: true, value: map.delete(id) };
+    },
+
+    has(id: string): Result<boolean, KoiError> {
+      return { ok: true, value: map.has(id) };
+    },
+
+    size(): number {
+      return map.size;
+    },
+  };
+}

--- a/packages/gateway/src/canvas-wiring.ts
+++ b/packages/gateway/src/canvas-wiring.ts
@@ -1,0 +1,69 @@
+/**
+ * Canvas server wiring — creates and configures canvas store, SSE manager,
+ * and HTTP server from GatewayConfig.
+ *
+ * Internal helper used by gateway.ts to keep it under the 800-line limit.
+ */
+
+import type { CanvasAuthenticator, CanvasServer } from "./canvas-routes.js";
+import { createCanvasServer } from "./canvas-routes.js";
+import type { CanvasSseManager } from "./canvas-sse.js";
+import { createCanvasSseManager } from "./canvas-sse.js";
+import type { SurfaceStore } from "./canvas-store.js";
+import { createInMemorySurfaceStore } from "./canvas-store.js";
+import type { GatewayConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CanvasWiring {
+  readonly server: CanvasServer;
+  readonly sse: CanvasSseManager;
+  readonly store: SurfaceStore;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createCanvasWiring(
+  config: GatewayConfig,
+  authenticator?: CanvasAuthenticator,
+): CanvasWiring {
+  const canvasPort = config.canvasPort;
+  if (canvasPort === undefined) {
+    throw new Error("canvasPort must be defined to create canvas wiring");
+  }
+
+  const store = createInMemorySurfaceStore(
+    config.canvasMaxSurfaces !== undefined ? { maxSurfaces: config.canvasMaxSurfaces } : {},
+  );
+
+  const sse = createCanvasSseManager({
+    ...(config.canvasMaxSsePerSurface !== undefined
+      ? { maxSubscribersPerSurface: config.canvasMaxSsePerSurface }
+      : {}),
+    ...(config.canvasMaxSseTotal !== undefined
+      ? { maxTotalSubscribers: config.canvasMaxSseTotal }
+      : {}),
+    ...(config.canvasSseKeepAliveMs !== undefined
+      ? { keepAliveIntervalMs: config.canvasSseKeepAliveMs }
+      : {}),
+  });
+
+  const server = createCanvasServer(
+    {
+      port: canvasPort,
+      pathPrefix: config.canvasPath ?? "/gateway/canvas",
+      ...(config.canvasMaxBodyBytes !== undefined
+        ? { maxBodyBytes: config.canvasMaxBodyBytes }
+        : {}),
+    },
+    store,
+    sse,
+    authenticator,
+  );
+
+  return { server, sse, store };
+}

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -9,6 +9,10 @@ import { swallowError } from "@koi/errors";
 import type { GatewayAuthenticator, HandshakeOptions } from "./auth.js";
 import { handleHandshake, startHeartbeatSweep } from "./auth.js";
 import { createBackpressureMonitor } from "./backpressure.js";
+import type { CanvasAuthenticator, CanvasServer } from "./canvas-routes.js";
+import type { CanvasSseManager } from "./canvas-sse.js";
+import type { SurfaceStore } from "./canvas-store.js";
+import { createCanvasWiring } from "./canvas-wiring.js";
 import { createNodeConnectionHandler } from "./node-connection.js";
 import type { NodeFrame } from "./node-handler.js";
 import { peekFrameKind } from "./node-handler.js";
@@ -77,6 +81,10 @@ export interface Gateway {
   readonly channelBindings: () => ReadonlyMap<string, string>;
   /** Send a NodeFrame to a connected compute node. */
   readonly sendToNode: (nodeId: string, frame: NodeFrame) => Result<number, KoiError>;
+  /** Returns the canvas server port, or undefined if canvas is not configured. */
+  readonly canvasPort: () => number | undefined;
+  /** Access the surface store for external use. Undefined if canvas is not configured. */
+  readonly surfaceStore: () => SurfaceStore | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -88,6 +96,7 @@ export interface GatewayDeps {
   readonly auth: GatewayAuthenticator;
   readonly store?: SessionStore;
   readonly webhookAuth?: WebhookAuthenticator;
+  readonly canvasAuth?: CanvasAuthenticator;
 }
 
 /** Maximum frames buffered per disconnected session to prevent memory exhaustion. */
@@ -135,6 +144,9 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
   let stopNodeSweep: (() => void) | undefined;
   let webhookServer: WebhookServer | undefined;
   let scheduler: GatewayScheduler | undefined;
+  let canvasServer: CanvasServer | undefined;
+  let canvasSseManager: CanvasSseManager | undefined;
+  let canvasSurfaceStore: SurfaceStore | undefined;
 
   // Populate static channel bindings from config
   if (config.channelBindings !== undefined) {
@@ -579,6 +591,15 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
         await webhookServer.start();
       }
 
+      // Start canvas server if configured
+      if (config.canvasPort !== undefined) {
+        const wiring = createCanvasWiring(config, deps.canvasAuth);
+        canvasSurfaceStore = wiring.store;
+        canvasSseManager = wiring.sse;
+        canvasServer = wiring.server;
+        await canvasServer.start();
+      }
+
       // Start schedulers if configured
       if (config.schedulers !== undefined && config.schedulers.length > 0) {
         scheduler = createScheduler(config.schedulers, resolveAndDispatch);
@@ -590,6 +611,11 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
       toolRouter?.dispose();
       toolRouter = undefined;
       scheduler?.stop();
+      canvasSseManager?.dispose();
+      canvasSseManager = undefined;
+      canvasServer?.stop();
+      canvasServer = undefined;
+      canvasSurfaceStore = undefined;
       webhookServer?.stop();
       stopSweep?.();
       stopNodeSweep?.();
@@ -748,6 +774,14 @@ export function createGateway(configOverrides: Partial<GatewayConfig>, deps: Gat
 
     sendToNode(nodeId: string, frame: NodeFrame): Result<number, KoiError> {
       return nodeHandler.sendToNode(nodeId, frame, connMap);
+    },
+
+    canvasPort(): number | undefined {
+      return canvasServer?.port();
+    },
+
+    surfaceStore(): SurfaceStore | undefined {
+      return canvasSurfaceStore;
     },
   };
 }

--- a/packages/gateway/src/http-helpers.ts
+++ b/packages/gateway/src/http-helpers.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared HTTP utilities for gateway HTTP servers (webhook, canvas, etc.).
+ */
+
+// ---------------------------------------------------------------------------
+// JSON response
+// ---------------------------------------------------------------------------
+
+/** Create a JSON Response with the given status code and body. */
+export function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Body parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedBody {
+  readonly ok: true;
+  readonly raw: string;
+  readonly parsed: unknown;
+}
+
+interface ParseBodyError {
+  readonly ok: false;
+  readonly status: number;
+  readonly message: string;
+}
+
+type ParseBodyResult = ParsedBody | ParseBodyError;
+
+/**
+ * Read and parse a JSON request body with streaming size enforcement.
+ *
+ * Returns the raw string (useful for HMAC verification) and the parsed JSON.
+ * Returns a typed error with HTTP status code on failure.
+ */
+export async function parseJsonBody(request: Request, maxBytes: number): Promise<ParseBodyResult> {
+  // Reject bodies that declare a too-large Content-Length early
+  const declaredLength = request.headers.get("Content-Length");
+  if (declaredLength !== null && parseInt(declaredLength, 10) > maxBytes) {
+    return { ok: false, status: 413, message: "Payload too large" };
+  }
+
+  let raw = "";
+  try {
+    if (request.body !== null) {
+      const reader = request.body.getReader();
+      const decoder = new TextDecoder();
+      let totalBytes = 0;
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          reader.cancel();
+          return { ok: false, status: 413, message: "Payload too large" };
+        }
+        raw += decoder.decode(value, { stream: true });
+      }
+      // Flush the decoder for multi-byte sequences
+      raw += decoder.decode();
+    }
+  } catch {
+    return { ok: false, status: 400, message: "Failed to read request body" };
+  }
+
+  // Parse JSON
+  let parsed: unknown = null;
+  if (raw.length > 0) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { ok: false, status: 400, message: "Invalid JSON body" };
+    }
+  }
+
+  return { ok: true, raw, parsed };
+}
+
+// ---------------------------------------------------------------------------
+// Path matching
+// ---------------------------------------------------------------------------
+
+interface PathMatch {
+  readonly match: true;
+  readonly segments: readonly string[];
+}
+
+interface PathNoMatch {
+  readonly match: false;
+}
+
+type PathMatchResult = PathMatch | PathNoMatch;
+
+/**
+ * Match a URL pathname against a prefix with boundary safety.
+ *
+ * Prevents "/webhook" from matching "/webhookadmin" by requiring
+ * an exact match or a "/" boundary after the prefix.
+ * Returns the path segments after the prefix.
+ */
+export function matchPath(pathname: string, prefix: string): PathMatchResult {
+  if (pathname !== prefix && !pathname.startsWith(`${prefix}/`)) {
+    return { match: false };
+  }
+  const pathAfterPrefix = pathname.slice(prefix.length);
+  const segments = pathAfterPrefix.split("/").filter((s) => s.length > 0);
+  return { match: true, segments };
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -18,9 +18,34 @@ export { handleHandshake, startHeartbeatSweep } from "./auth.js";
 // backpressure
 export type { BackpressureMonitor } from "./backpressure.js";
 export { createBackpressureMonitor } from "./backpressure.js";
+// canvas routes
+export type {
+  CanvasAuthenticator,
+  CanvasAuthResult,
+  CanvasRouteConfig,
+  CanvasServer,
+} from "./canvas-routes.js";
+export { createCanvasServer } from "./canvas-routes.js";
+// canvas SSE
+export type {
+  CanvasSseConfig,
+  CanvasSseManager,
+  SseEvent,
+  SseSubscriber,
+} from "./canvas-sse.js";
+export { createCanvasSseManager, formatSseEvent } from "./canvas-sse.js";
+// canvas store
+export type {
+  SurfaceEntry,
+  SurfaceStore,
+  SurfaceStoreConfig,
+} from "./canvas-store.js";
+export { computeContentHash, createInMemorySurfaceStore } from "./canvas-store.js";
 // gateway
 export type { Gateway, GatewayDeps, SessionEvent } from "./gateway.js";
 export { createGateway } from "./gateway.js";
+// http helpers
+export { jsonResponse, matchPath, parseJsonBody } from "./http-helpers.js";
 // node handler
 export type {
   CapabilitiesPayload,

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -208,6 +208,20 @@ export interface GatewayConfig {
   readonly channelBindings?: readonly ChannelBinding[];
   /** Tool routing configuration. Undefined = tool routing disabled (backward compatible). Partial fields are merged with DEFAULT_TOOL_ROUTING_CONFIG. */
   readonly toolRouting?: Partial<ToolRoutingConfig> | undefined;
+  /** Port for canvas HTTP server. Undefined = disabled. */
+  readonly canvasPort?: number;
+  /** URL path prefix for canvas endpoints. Default: "/gateway/canvas". */
+  readonly canvasPath?: string;
+  /** Maximum canvas request body size in bytes. Default: 1_048_576 (1MB). */
+  readonly canvasMaxBodyBytes?: number;
+  /** Maximum number of stored surfaces. Default: 10_000. */
+  readonly canvasMaxSurfaces?: number;
+  /** Maximum SSE subscribers per surface. Default: 100. */
+  readonly canvasMaxSsePerSurface?: number;
+  /** Maximum total SSE subscribers across all surfaces. Default: 10_000. */
+  readonly canvasMaxSseTotal?: number;
+  /** SSE keep-alive interval in ms. Default: 15_000. */
+  readonly canvasSseKeepAliveMs?: number;
 }
 
 export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {

--- a/packages/gateway/src/webhook.ts
+++ b/packages/gateway/src/webhook.ts
@@ -4,6 +4,7 @@
  */
 
 import type { KoiError, Result } from "@koi/core";
+import { jsonResponse, matchPath, parseJsonBody } from "./http-helpers.js";
 import type { GatewayFrame, RoutingContext, Session } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -37,17 +38,6 @@ export interface WebhookAuthResult {
   readonly agentId: string;
   readonly routing?: RoutingContext;
   readonly metadata?: Readonly<Record<string, unknown>>;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function jsonResponse(status: number, body: Record<string, unknown>): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -86,60 +76,25 @@ export function createWebhookServer(
           // Path check — require exact match or "/" boundary to avoid
           // "/webhook" matching "/webhookadmin"
           const url = new URL(request.url);
-          if (url.pathname !== prefix && !url.pathname.startsWith(`${prefix}/`)) {
+          const pathResult = matchPath(url.pathname, prefix);
+          if (!pathResult.match) {
             return jsonResponse(404, { ok: false, error: "Not found" });
           }
 
-          // Reject bodies that declare a too-large Content-Length early
-          const declaredLength = request.headers.get("Content-Length");
-          if (declaredLength !== null && parseInt(declaredLength, 10) > maxBodyBytes) {
-            return jsonResponse(413, { ok: false, error: "Payload too large" });
-          }
-
           // Extract channel/account from path: {prefix}/{channel}/{account?}
-          const pathAfterPrefix = url.pathname.slice(prefix.length);
-          const segments = pathAfterPrefix.split("/").filter((s) => s.length > 0);
-          const channel = segments[0] ?? undefined;
-          const account = segments[1] ?? undefined;
+          const channel = pathResult.segments[0] ?? undefined;
+          const account = pathResult.segments[1] ?? undefined;
 
           // Extract peer from header
           const peer = request.headers.get("X-Webhook-Peer") ?? "webhook";
 
-          // Read body with streaming size enforcement to prevent
-          // unbounded memory consumption when Content-Length is absent
-          let rawBody = "";
-          try {
-            if (request.body !== null) {
-              const reader = request.body.getReader();
-              const decoder = new TextDecoder();
-              let totalBytes = 0;
-
-              for (;;) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                totalBytes += value.byteLength;
-                if (totalBytes > maxBodyBytes) {
-                  reader.cancel();
-                  return jsonResponse(413, { ok: false, error: "Payload too large" });
-                }
-                rawBody += decoder.decode(value, { stream: true });
-              }
-              // Flush the decoder
-              rawBody += decoder.decode();
-            }
-          } catch {
-            return jsonResponse(400, { ok: false, error: "Failed to read request body" });
+          // Read and parse JSON body with streaming size enforcement
+          const bodyResult = await parseJsonBody(request, maxBodyBytes);
+          if (!bodyResult.ok) {
+            return jsonResponse(bodyResult.status, { ok: false, error: bodyResult.message });
           }
-
-          // Parse JSON body
-          let payload: unknown = null;
-          if (rawBody.length > 0) {
-            try {
-              payload = JSON.parse(rawBody);
-            } catch {
-              return jsonResponse(400, { ok: false, error: "Invalid JSON body" });
-            }
-          }
+          const rawBody = bodyResult.raw;
+          const payload = bodyResult.parsed;
 
           // Authenticate if authenticator provided — receives raw body
           // so it can verify HMAC signatures

--- a/scripts/demo-canvas-viewer.ts
+++ b/scripts/demo-canvas-viewer.ts
@@ -1,0 +1,731 @@
+#!/usr/bin/env bun
+
+/**
+ * Live Canvas Demo — starts a canvas API server + A2UI HTML viewer.
+ *
+ * Two servers:
+ *   1. Canvas API on port 3100 — REST CRUD + SSE streaming
+ *   2. Viewer on port 3101 — renders A2UI component trees as HTML
+ *
+ * Creates 3 demo surfaces (hello-world, dashboard, form) and prints
+ * clickable URLs. The viewer auto-refreshes via SSE when surfaces
+ * are updated through the API.
+ *
+ * Usage:
+ *   bun scripts/demo-canvas-viewer.ts
+ */
+
+import {
+  applySurfaceUpdate,
+  componentId,
+  createCanvasSurface,
+  serializeSurface,
+  surfaceId,
+} from "../packages/canvas/src/index.js";
+import type { KoiError, Result } from "../packages/core/src/index.js";
+import type {
+  CanvasAuthenticator,
+  CanvasAuthResult,
+} from "../packages/gateway/src/canvas-routes.js";
+import { createCanvasServer } from "../packages/gateway/src/canvas-routes.js";
+import { createCanvasSseManager } from "../packages/gateway/src/canvas-sse.js";
+import { createInMemorySurfaceStore } from "../packages/gateway/src/canvas-store.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CANVAS_PORT = 3100;
+const VIEWER_PORT = 3101;
+const PREFIX = "/gateway/canvas";
+
+// ---------------------------------------------------------------------------
+// Accept-all authenticator (demo only)
+// ---------------------------------------------------------------------------
+
+const acceptAllAuth: CanvasAuthenticator = async (
+  request: Request,
+): Promise<Result<CanvasAuthResult, KoiError>> => {
+  const header = request.headers.get("Authorization");
+  if (header === null || !header.startsWith("Bearer ")) {
+    return { ok: false, error: { code: "PERMISSION", message: "Unauthorized", retryable: false } };
+  }
+  return { ok: true, value: { agentId: "demo-agent" } };
+};
+
+// ---------------------------------------------------------------------------
+// A2UI component tree -> HTML renderer
+// ---------------------------------------------------------------------------
+
+// Subset of SerializedSurface from @koi/canvas/serialize.ts
+// (not exported — redeclared here for demo rendering)
+interface SerializedComponent {
+  readonly id: string;
+  readonly type: string;
+  readonly properties: Readonly<Record<string, unknown>>;
+  readonly children: readonly string[];
+  readonly dataBinding?: string;
+}
+
+interface SerializedSurface {
+  readonly id: string;
+  readonly title?: string;
+  readonly components: readonly SerializedComponent[];
+  readonly dataModel: Readonly<Record<string, unknown>>;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// escapeHtml covers all attribute contexts (& < > " ')
+const escapeAttr = escapeHtml;
+
+// ---------------------------------------------------------------------------
+// Per-component renderers (dispatch map keeps renderComponent < 50 lines)
+// ---------------------------------------------------------------------------
+
+type Props = Readonly<Record<string, unknown>>;
+
+function renderText(props: Props): string {
+  const text = typeof props.text === "string" ? escapeHtml(props.text) : "";
+  const style = typeof props.style === "string" ? props.style : "body";
+  if (style === "heading" || style === "title") return `<h2>${text}</h2>`;
+  if (style === "subtitle") return `<h3>${text}</h3>`;
+  if (style === "caption") return `<small>${text}</small>`;
+  return `<p>${text}</p>`;
+}
+
+function renderImage(props: Props): string {
+  const rawSrc = typeof props.src === "string" ? props.src : "";
+  const src =
+    rawSrc.startsWith("http://") || rawSrc.startsWith("https://") ? escapeAttr(rawSrc) : "";
+  const alt = typeof props.alt === "string" ? escapeAttr(props.alt) : "";
+  return `<img src="${src}" alt="${alt}" style="max-width:100%;border-radius:8px">`;
+}
+
+function renderButton(props: Props): string {
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "Button";
+  const variant = typeof props.variant === "string" ? props.variant : "primary";
+  return `<button class="btn btn-${escapeAttr(variant)}">${label}</button>`;
+}
+
+function renderTextField(props: Props): string {
+  const placeholder = typeof props.placeholder === "string" ? escapeAttr(props.placeholder) : "";
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "";
+  return label.length > 0
+    ? `<label>${label}<br><input type="text" placeholder="${placeholder}" class="text-field"></label>`
+    : `<input type="text" placeholder="${placeholder}" class="text-field">`;
+}
+
+function renderCheckBox(props: Props): string {
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "";
+  const checked = props.checked === true ? " checked" : "";
+  return `<label class="checkbox"><input type="checkbox"${checked}> ${label}</label>`;
+}
+
+function renderSlider(props: Props): string {
+  const min = typeof props.min === "number" ? props.min : 0;
+  const max = typeof props.max === "number" ? props.max : 100;
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "";
+  return `<label>${label} <input type="range" min="${min}" max="${max}"></label>`;
+}
+
+function renderChoicePicker(props: Props): string {
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "";
+  const options = Array.isArray(props.options) ? props.options : [];
+  const optionsHtml = options
+    .map((o) => `<option>${typeof o === "string" ? escapeHtml(o) : ""}</option>`)
+    .join("");
+  return `<label>${label}<br><select>${optionsHtml}</select></label>`;
+}
+
+function renderDateTimeInput(props: Props): string {
+  const label = typeof props.label === "string" ? escapeHtml(props.label) : "";
+  return `<label>${label}<br><input type="datetime-local" class="text-field"></label>`;
+}
+
+type ComponentRenderer = (props: Props, childrenHtml: string) => string;
+
+const RENDERERS: Readonly<Record<string, ComponentRenderer>> = {
+  Row: (_p, ch) => `<div style="display:flex;gap:16px;align-items:flex-start">${ch}</div>`,
+  Column: (_p, ch) => `<div style="display:flex;flex-direction:column;gap:12px">${ch}</div>`,
+  Card: (_p, ch) => `<div class="card">${ch}</div>`,
+  List: (_p, ch) => `<ul>${ch}</ul>`,
+  Tabs: (_p, ch) => `<div class="tabs">${ch}</div>`,
+  Modal: (_p, ch) => `<div class="modal">${ch}</div>`,
+  Text: (p) => renderText(p),
+  Image: (p) => renderImage(p),
+  Icon: (p) =>
+    `<span class="icon">[${typeof p.name === "string" ? escapeHtml(p.name) : "icon"}]</span>`,
+  Divider: () => "<hr>",
+  Button: (p) => renderButton(p),
+  TextField: (p) => renderTextField(p),
+  CheckBox: (p) => renderCheckBox(p),
+  Slider: (p) => renderSlider(p),
+  ChoicePicker: (p) => renderChoicePicker(p),
+  DateTimeInput: (p) => renderDateTimeInput(p),
+};
+
+// ---------------------------------------------------------------------------
+// Tree rendering
+// ---------------------------------------------------------------------------
+
+function renderComponent(
+  comp: SerializedComponent,
+  lookup: ReadonlyMap<string, SerializedComponent>,
+  visited: ReadonlySet<string> = new Set(),
+): string {
+  if (visited.has(comp.id)) return `<!-- cycle: ${escapeHtml(comp.id)} -->`;
+  const nextVisited = new Set([...visited, comp.id]);
+  const childrenHtml = comp.children
+    .map((childId) => {
+      const child = lookup.get(childId);
+      return child !== undefined ? renderComponent(child, lookup, nextVisited) : "";
+    })
+    .join("\n");
+
+  const renderer = RENDERERS[comp.type];
+  if (renderer !== undefined) return renderer(comp.properties, childrenHtml);
+  return `<div class="unknown">[${escapeHtml(comp.type)}: ${escapeHtml(comp.id)}]</div>`;
+}
+
+function renderSurface(surface: SerializedSurface): string {
+  const lookup = new Map(surface.components.map((c) => [c.id, c]));
+  const roots = findRoots(surface.components);
+  return roots.map((root) => renderComponent(root, lookup)).join("\n");
+}
+
+/** Find root components (those not referenced as children by any other component). */
+function findRoots(components: readonly SerializedComponent[]): readonly SerializedComponent[] {
+  const childIds = new Set<string>();
+  for (const comp of components) {
+    for (const childId of comp.children) {
+      childIds.add(childId);
+    }
+  }
+  return components.filter((c) => !childIds.has(c.id));
+}
+
+// ---------------------------------------------------------------------------
+// HTML templates
+// ---------------------------------------------------------------------------
+
+const PAGE_CSS = `
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         max-width: 900px; margin: 40px auto; padding: 0 20px; color: #1a1a2e;
+         background: #f8f9fa; line-height: 1.6; }
+  h1 { margin-bottom: 8px; }
+  h2 { margin: 16px 0 8px; font-size: 1.3em; }
+  h3 { margin: 12px 0 6px; font-size: 1.1em; color: #555; }
+  p { margin: 6px 0; }
+  hr { border: none; border-top: 1px solid #ddd; margin: 16px 0; }
+  .card { border: 1px solid #e0e0e0; border-radius: 12px; padding: 20px;
+          background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.06); margin: 8px 0; }
+  .btn { padding: 10px 20px; border: none; border-radius: 8px; cursor: pointer;
+         font-size: 14px; font-weight: 500; transition: background 0.2s; }
+  .btn-primary { background: #4f46e5; color: white; }
+  .btn-primary:hover { background: #4338ca; }
+  .btn-secondary { background: #e5e7eb; color: #374151; }
+  .btn-secondary:hover { background: #d1d5db; }
+  .btn-danger { background: #ef4444; color: white; }
+  .btn-danger:hover { background: #dc2626; }
+  .text-field { padding: 10px 14px; border: 1px solid #d1d5db; border-radius: 8px;
+                font-size: 14px; width: 100%; margin-top: 4px; }
+  .text-field:focus { outline: none; border-color: #4f46e5; box-shadow: 0 0 0 3px rgba(79,70,229,0.1); }
+  .checkbox { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+  .checkbox input { width: 18px; height: 18px; }
+  label { display: block; margin: 8px 0; font-weight: 500; }
+  select { padding: 10px 14px; border: 1px solid #d1d5db; border-radius: 8px;
+           font-size: 14px; width: 100%; margin-top: 4px; }
+  .unknown { color: #888; font-style: italic; padding: 8px; border: 1px dashed #ccc; border-radius: 4px; }
+  a { color: #4f46e5; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .surface-link { display: block; padding: 16px 20px; border: 1px solid #e0e0e0;
+                  border-radius: 12px; background: white; margin: 8px 0;
+                  box-shadow: 0 1px 4px rgba(0,0,0,0.04); transition: box-shadow 0.2s; }
+  .surface-link:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.1); text-decoration: none; }
+  .surface-link .name { font-weight: 600; font-size: 1.1em; }
+  .surface-link .desc { color: #666; font-size: 0.9em; margin-top: 4px; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 999px;
+           background: #dbeafe; color: #1e40af; font-size: 0.75em; font-weight: 500; margin-left: 8px; }
+  .sse-status { position: fixed; top: 12px; right: 16px; padding: 6px 12px; border-radius: 8px;
+                font-size: 12px; font-weight: 500; }
+  .sse-connected { background: #dcfce7; color: #166534; }
+  .sse-disconnected { background: #fef2f2; color: #991b1b; }
+`;
+
+function indexPage(
+  surfaces: readonly { readonly id: string; readonly description: string }[],
+): string {
+  const links = surfaces
+    .map(
+      (s) =>
+        `<a href="/${s.id}" class="surface-link">
+          <div class="name">${escapeHtml(s.id)} <span class="badge">A2UI</span></div>
+          <div class="desc">${escapeHtml(s.description)}</div>
+        </a>`,
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Koi Canvas Viewer</title><style>${PAGE_CSS}</style></head>
+<body>
+<h1>Koi Canvas Viewer</h1>
+<p>A2UI surfaces rendered as HTML. Click a surface to view it.</p>
+<p style="color:#666;font-size:0.9em">Canvas API: <code>http://localhost:${CANVAS_PORT}${PREFIX}</code></p>
+<hr>
+${links}
+</body></html>`;
+}
+
+function surfacePage(sid: string, renderedHtml: string, viewerPort: number): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(sid)} — Koi Canvas</title><style>${PAGE_CSS}</style></head>
+<body>
+<div style="margin-bottom:16px"><a href="/">&larr; Back to index</a></div>
+<h1>${escapeHtml(sid)}</h1>
+<div class="sse-status sse-disconnected" id="sse-badge">SSE: connecting...</div>
+<hr>
+<div id="surface-content">${renderedHtml}</div>
+<script>
+(function() {
+  var badge = document.getElementById("sse-badge");
+  var content = document.getElementById("surface-content");
+  var surfaceId = ${JSON.stringify(sid)};
+  var sseBase = "http://localhost:${viewerPort}/_sse";
+  var es = new EventSource(sseBase + "/" + surfaceId);
+
+  es.addEventListener("open", function() {
+    badge.textContent = "SSE: connected";
+    badge.className = "sse-status sse-connected";
+  });
+
+  es.addEventListener("updated", function() {
+    fetch("/" + surfaceId + "?fragment=1")
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        var doc = new DOMParser().parseFromString(html, "text/html");
+        var frag = document.createDocumentFragment();
+        while (doc.body.firstChild) frag.appendChild(doc.body.firstChild);
+        content.replaceChildren(frag);
+      });
+  });
+
+  es.addEventListener("deleted", function() {
+    content.textContent = "Surface deleted.";
+    badge.textContent = "SSE: surface deleted";
+    badge.className = "sse-status sse-disconnected";
+    es.close();
+  });
+
+  es.addEventListener("error", function() {
+    badge.textContent = "SSE: disconnected";
+    badge.className = "sse-status sse-disconnected";
+  });
+})();
+</script>
+</body></html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Demo surface definitions
+// ---------------------------------------------------------------------------
+
+function createHelloWorldSurface(): string {
+  const surface = applySurfaceUpdate(createCanvasSurface(surfaceId("hello-world"), "Hello World"), [
+    {
+      id: componentId("card"),
+      type: "Card",
+      properties: {},
+      children: [componentId("heading"), componentId("body")],
+    },
+    {
+      id: componentId("heading"),
+      type: "Text",
+      properties: { text: "Hello, Canvas!", style: "heading" },
+      children: [],
+    },
+    {
+      id: componentId("body"),
+      type: "Text",
+      properties: {
+        text: "This is a live A2UI surface rendered from the Koi canvas API. Edit it via PATCH and watch it update in real time.",
+      },
+      children: [],
+    },
+  ]);
+  return serializeSurface(surface);
+}
+
+function createDashboardSurface(): string {
+  const surface = applySurfaceUpdate(createCanvasSurface(surfaceId("dashboard"), "Dashboard"), [
+    {
+      id: componentId("row"),
+      type: "Row",
+      properties: {},
+      children: [componentId("c1"), componentId("c2"), componentId("c3")],
+    },
+    {
+      id: componentId("c1"),
+      type: "Card",
+      properties: {},
+      children: [componentId("c1-title"), componentId("c1-value"), componentId("c1-btn")],
+    },
+    {
+      id: componentId("c1-title"),
+      type: "Text",
+      properties: { text: "Active Agents", style: "caption" },
+      children: [],
+    },
+    {
+      id: componentId("c1-value"),
+      type: "Text",
+      properties: { text: "12", style: "heading" },
+      children: [],
+    },
+    {
+      id: componentId("c1-btn"),
+      type: "Button",
+      properties: { label: "View All", variant: "secondary" },
+      children: [],
+    },
+    {
+      id: componentId("c2"),
+      type: "Card",
+      properties: {},
+      children: [componentId("c2-title"), componentId("c2-value"), componentId("c2-btn")],
+    },
+    {
+      id: componentId("c2-title"),
+      type: "Text",
+      properties: { text: "Tasks Today", style: "caption" },
+      children: [],
+    },
+    {
+      id: componentId("c2-value"),
+      type: "Text",
+      properties: { text: "47", style: "heading" },
+      children: [],
+    },
+    {
+      id: componentId("c2-btn"),
+      type: "Button",
+      properties: { label: "Details", variant: "secondary" },
+      children: [],
+    },
+    {
+      id: componentId("c3"),
+      type: "Card",
+      properties: {},
+      children: [componentId("c3-title"), componentId("c3-value"), componentId("c3-btn")],
+    },
+    {
+      id: componentId("c3-title"),
+      type: "Text",
+      properties: { text: "Success Rate", style: "caption" },
+      children: [],
+    },
+    {
+      id: componentId("c3-value"),
+      type: "Text",
+      properties: { text: "98.5%", style: "heading" },
+      children: [],
+    },
+    {
+      id: componentId("c3-btn"),
+      type: "Button",
+      properties: { label: "Report", variant: "primary" },
+      children: [],
+    },
+  ]);
+  return serializeSurface(surface);
+}
+
+function createFormSurface(): string {
+  const surface = applySurfaceUpdate(createCanvasSurface(surfaceId("form"), "Form"), [
+    {
+      id: componentId("col"),
+      type: "Column",
+      properties: {},
+      children: [
+        componentId("title"),
+        componentId("name"),
+        componentId("email"),
+        componentId("divider"),
+        componentId("notify"),
+        componentId("submit"),
+      ],
+    },
+    {
+      id: componentId("title"),
+      type: "Text",
+      properties: { text: "Create Agent", style: "heading" },
+      children: [],
+    },
+    {
+      id: componentId("name"),
+      type: "TextField",
+      properties: { label: "Agent Name", placeholder: "e.g. research-assistant" },
+      children: [],
+    },
+    {
+      id: componentId("email"),
+      type: "TextField",
+      properties: { label: "Owner Email", placeholder: "you@example.com" },
+      children: [],
+    },
+    { id: componentId("divider"), type: "Divider", properties: {}, children: [] },
+    {
+      id: componentId("notify"),
+      type: "CheckBox",
+      properties: { label: "Send notification on completion" },
+      children: [],
+    },
+    {
+      id: componentId("submit"),
+      type: "Button",
+      properties: { label: "Create Agent", variant: "primary" },
+      children: [],
+    },
+  ]);
+  return serializeSurface(surface);
+}
+
+interface DemoSurface {
+  readonly id: string;
+  readonly description: string;
+  readonly content: string;
+}
+
+function createDemoSurfaces(): readonly DemoSurface[] {
+  return [
+    {
+      id: "hello-world",
+      description: "Simple card with heading and text",
+      content: createHelloWorldSurface(),
+    },
+    {
+      id: "dashboard",
+      description: "Three-card dashboard layout with stats",
+      content: createDashboardSurface(),
+    },
+    {
+      id: "form",
+      description: "Interactive form with text fields and checkbox",
+      content: createFormSurface(),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Viewer request handler
+// ---------------------------------------------------------------------------
+
+function handleViewerRequest(
+  canvasBase: string,
+  demos: readonly DemoSurface[],
+  viewerPort: number,
+): (request: Request) => Promise<Response> {
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Index page
+    if (path === "/" || path === "") {
+      return new Response(indexPage(demos), {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // SSE proxy: /_sse/{surfaceId} → canvas API SSE (avoids CORS)
+    if (path.startsWith("/_sse/")) {
+      const sid = path.slice("/_sse/".length);
+      if (!/^[a-zA-Z0-9_-]{1,128}$/.test(sid)) {
+        return new Response("Invalid surface ID", {
+          status: 400,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      const upstream = await fetch(`${canvasBase}/${sid}/events`);
+      if (!upstream.ok) {
+        return new Response(`Upstream error: ${upstream.status}`, {
+          status: upstream.status,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+      return new Response(upstream.body, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    // Surface page: /{surfaceId}
+    const sid = path.slice(1);
+    if (sid.length === 0 || sid.includes("/")) {
+      return new Response("Not found", { status: 404, headers: { "Content-Type": "text/plain" } });
+    }
+
+    return handleSurfacePage(canvasBase, sid, url, viewerPort);
+  };
+}
+
+/** Type guard for the canvas API GET response shape. */
+function isCanvasApiResponse(
+  v: unknown,
+): v is { readonly ok: boolean; readonly surface?: { readonly content?: string } } {
+  if (typeof v !== "object" || v === null) return false;
+  const rec = v as Readonly<Record<string, unknown>>;
+  if (typeof rec.ok !== "boolean") return false;
+  if (rec.surface !== undefined) {
+    if (typeof rec.surface !== "object" || rec.surface === null) return false;
+    const surf = rec.surface as Readonly<Record<string, unknown>>;
+    if (surf.content !== undefined && typeof surf.content !== "string") return false;
+  }
+  return true;
+}
+
+async function handleSurfacePage(
+  canvasBase: string,
+  sid: string,
+  url: URL,
+  viewerPort: number,
+): Promise<Response> {
+  const apiRes = await fetch(`${canvasBase}/${sid}`);
+  if (!apiRes.ok) {
+    return new Response("Surface not found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  const json: unknown = await apiRes.json();
+  if (!isCanvasApiResponse(json) || !json.ok || json.surface?.content === undefined) {
+    return new Response("Invalid surface data", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  let parsed: SerializedSurface;
+  try {
+    parsed = JSON.parse(json.surface.content) as SerializedSurface;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "parse error";
+    return new Response(`Invalid surface JSON: ${msg}`, {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+
+  const rendered = renderSurface(parsed);
+
+  // Fragment mode: return just the rendered HTML (for SSE refresh)
+  if (url.searchParams.get("fragment") === "1") {
+    return new Response(rendered, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+  }
+
+  return new Response(surfacePage(sid, rendered, viewerPort), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Curl example generator
+// ---------------------------------------------------------------------------
+
+function generatePatchExample(): string {
+  const updated = applySurfaceUpdate(createCanvasSurface(surfaceId("hello-world"), "Hello World"), [
+    { id: componentId("card"), type: "Card", properties: {}, children: [componentId("heading")] },
+    {
+      id: componentId("heading"),
+      type: "Text",
+      properties: { text: "UPDATED via PATCH!", style: "heading" },
+      children: [],
+    },
+  ]);
+  return serializeSurface(updated).replace(/"/g, '\\"');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // 1. Start canvas API server
+  const store = createInMemorySurfaceStore();
+  const sse = createCanvasSseManager({ keepAliveIntervalMs: 30_000 });
+  const canvasServer = createCanvasServer(
+    { port: CANVAS_PORT, pathPrefix: PREFIX },
+    store,
+    sse,
+    acceptAllAuth,
+  );
+  await canvasServer.start();
+
+  // 2. Create demo surfaces via the API
+  const demos = createDemoSurfaces();
+  const canvasBase = `http://localhost:${canvasServer.port()}${PREFIX}`;
+
+  for (const demo of demos) {
+    const res = await fetch(`${canvasBase}/${demo.id}`, {
+      method: "POST",
+      headers: { Authorization: "Bearer demo", "Content-Type": "application/json" },
+      body: JSON.stringify({ content: demo.content }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to create surface '${demo.id}': ${res.status} ${body}`);
+    }
+  }
+
+  // 3. Start viewer server (proxies SSE to avoid CORS issues, localhost-only)
+  const viewerServer = Bun.serve({
+    port: VIEWER_PORT,
+    hostname: "127.0.0.1",
+    fetch: handleViewerRequest(canvasBase, demos, VIEWER_PORT),
+  });
+
+  // 4. Print URLs
+  console.log("\n  Canvas API:    http://localhost:%d%s", canvasServer.port(), PREFIX);
+  console.log("  Viewer:        http://localhost:%d\n", viewerServer.port);
+  console.log("  Surfaces:");
+  for (const demo of demos) {
+    console.log("    http://localhost:%d/%s  — %s", viewerServer.port, demo.id, demo.description);
+  }
+  console.log("\n  Try live-updating a surface:");
+  console.log('    curl -X PATCH -H "Authorization: Bearer demo" \\');
+  console.log('      -H "Content-Type: application/json" \\');
+  console.log('      -d \'{"content":"%s"}\' \\', generatePatchExample());
+  console.log("      http://localhost:%d%s/hello-world\n", canvasServer.port(), PREFIX);
+  console.log("  Press Ctrl+C to stop.\n");
+
+  // 5. Graceful shutdown
+  process.on("SIGINT", () => {
+    console.log("\n  Shutting down...");
+    viewerServer.stop(true);
+    canvasServer.stop();
+    sse.dispose();
+    process.exit(0);
+  });
+
+  // Keep alive
+  await new Promise(() => {});
+}
+
+main().catch((err: unknown) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/demo-canvas.html
+++ b/scripts/demo-canvas.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Koi Canvas — A2UI Demo</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         max-width: 960px; margin: 0 auto; padding: 32px 20px; color: #1a1a2e;
+         background: #f8f9fa; line-height: 1.6; }
+  h1 { margin-bottom: 4px; font-size: 1.8em; }
+  h2 { margin: 16px 0 8px; font-size: 1.3em; }
+  h3 { margin: 12px 0 6px; font-size: 1.1em; color: #555; }
+  p { margin: 6px 0; }
+  small { color: #888; }
+  hr { border: none; border-top: 1px solid #ddd; margin: 16px 0; }
+  .card { border: 1px solid #e0e0e0; border-radius: 12px; padding: 20px;
+          background: white; box-shadow: 0 2px 8px rgba(0,0,0,0.06); margin: 8px 0; }
+  .btn { padding: 10px 20px; border: none; border-radius: 8px; cursor: pointer;
+         font-size: 14px; font-weight: 500; transition: all 0.2s; }
+  .btn-primary { background: #4f46e5; color: white; }
+  .btn-primary:hover { background: #4338ca; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(79,70,229,0.3); }
+  .btn-secondary { background: #e5e7eb; color: #374151; }
+  .btn-secondary:hover { background: #d1d5db; }
+  .btn-danger { background: #ef4444; color: white; }
+  .btn-danger:hover { background: #dc2626; }
+  .text-field { padding: 10px 14px; border: 1px solid #d1d5db; border-radius: 8px;
+                font-size: 14px; width: 100%; margin-top: 4px; background: white; }
+  .text-field:focus { outline: none; border-color: #4f46e5; box-shadow: 0 0 0 3px rgba(79,70,229,0.1); }
+  .checkbox { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+  .checkbox input { width: 18px; height: 18px; accent-color: #4f46e5; }
+  label { display: block; margin: 8px 0; font-weight: 500; }
+  select { padding: 10px 14px; border: 1px solid #d1d5db; border-radius: 8px;
+           font-size: 14px; width: 100%; margin-top: 4px; }
+  .unknown { color: #888; font-style: italic; padding: 8px; border: 1px dashed #ccc; border-radius: 4px; }
+
+  /* Nav tabs */
+  .tabs { display: flex; gap: 0; border-bottom: 2px solid #e0e0e0; margin-bottom: 24px; }
+  .tab { padding: 10px 20px; cursor: pointer; font-weight: 500; color: #666;
+         border-bottom: 2px solid transparent; margin-bottom: -2px; transition: all 0.2s; user-select: none; }
+  .tab:hover { color: #4f46e5; }
+  .tab.active { color: #4f46e5; border-bottom-color: #4f46e5; }
+
+  /* Surface container */
+  .surface { display: none; animation: fadeIn 0.3s ease; }
+  .surface.active { display: block; }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+
+  /* Header */
+  .header { margin-bottom: 24px; }
+  .header .subtitle { color: #666; font-size: 0.95em; }
+  .badge { display: inline-block; padding: 2px 10px; border-radius: 999px;
+           background: #dbeafe; color: #1e40af; font-size: 0.75em; font-weight: 600; margin-left: 8px; vertical-align: middle; }
+  .badge-green { background: #dcfce7; color: #166534; }
+
+  /* JSON viewer */
+  .json-toggle { margin-top: 20px; }
+  .json-toggle summary { cursor: pointer; color: #4f46e5; font-size: 0.85em; font-weight: 500; }
+  .json-toggle pre { background: #1e1e2e; color: #cdd6f4; padding: 16px; border-radius: 8px;
+                     overflow-x: auto; font-size: 12px; line-height: 1.5; margin-top: 8px; }
+  .json-key { color: #89b4fa; }
+  .json-string { color: #a6e3a1; }
+  .json-number { color: #fab387; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Koi Canvas <span class="badge">A2UI v0.9</span></h1>
+  <p class="subtitle">Agent-generated UI surfaces rendered as HTML</p>
+</div>
+
+<div class="tabs">
+  <div class="tab active" data-surface="hello-world">Hello World</div>
+  <div class="tab" data-surface="dashboard">Dashboard</div>
+  <div class="tab" data-surface="form">Form</div>
+</div>
+
+<div id="surfaces"></div>
+
+<script>
+// ---------------------------------------------------------------------------
+// Embedded A2UI surface data (serialized from @koi/canvas)
+// ---------------------------------------------------------------------------
+var SURFACES = {"hello":{"id":"hello-world","title":"Hello World","components":[{"id":"card","type":"Card","properties":{},"children":["heading","body"]},{"id":"heading","type":"Text","properties":{"text":"Hello, Canvas!","style":"heading"},"children":[]},{"id":"body","type":"Text","properties":{"text":"This is a live A2UI surface rendered from the Koi canvas API. Edit it via PATCH and watch it update in real time."},"children":[]}],"dataModel":{}},"dashboard":{"id":"dashboard","title":"Dashboard","components":[{"id":"row","type":"Row","properties":{},"children":["c1","c2","c3"]},{"id":"c1","type":"Card","properties":{},"children":["c1-title","c1-value","c1-btn"]},{"id":"c1-title","type":"Text","properties":{"text":"Active Agents","style":"caption"},"children":[]},{"id":"c1-value","type":"Text","properties":{"text":"12","style":"heading"},"children":[]},{"id":"c1-btn","type":"Button","properties":{"label":"View All","variant":"secondary"},"children":[]},{"id":"c2","type":"Card","properties":{},"children":["c2-title","c2-value","c2-btn"]},{"id":"c2-title","type":"Text","properties":{"text":"Tasks Today","style":"caption"},"children":[]},{"id":"c2-value","type":"Text","properties":{"text":"47","style":"heading"},"children":[]},{"id":"c2-btn","type":"Button","properties":{"label":"Details","variant":"secondary"},"children":[]},{"id":"c3","type":"Card","properties":{},"children":["c3-title","c3-value","c3-btn"]},{"id":"c3-title","type":"Text","properties":{"text":"Success Rate","style":"caption"},"children":[]},{"id":"c3-value","type":"Text","properties":{"text":"98.5%","style":"heading"},"children":[]},{"id":"c3-btn","type":"Button","properties":{"label":"Report","variant":"primary"},"children":[]}],"dataModel":{}},"form":{"id":"form","title":"Form","components":[{"id":"col","type":"Column","properties":{},"children":["title","name","email","divider","notify","submit"]},{"id":"title","type":"Text","properties":{"text":"Create Agent","style":"heading"},"children":[]},{"id":"name","type":"TextField","properties":{"label":"Agent Name","placeholder":"e.g. research-assistant"},"children":[]},{"id":"email","type":"TextField","properties":{"label":"Owner Email","placeholder":"you@example.com"},"children":[]},{"id":"divider","type":"Divider","properties":{},"children":[]},{"id":"notify","type":"CheckBox","properties":{"label":"Send notification on completion"},"children":[]},{"id":"submit","type":"Button","properties":{"label":"Create Agent","variant":"primary"},"children":[]}],"dataModel":{}}};
+
+// ---------------------------------------------------------------------------
+// A2UI -> HTML renderer (client-side, matches server-side renderer)
+// ---------------------------------------------------------------------------
+function esc(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+function lookup(components) {
+  var map = {};
+  for (var i = 0; i < components.length; i++) map[components[i].id] = components[i];
+  return map;
+}
+
+function renderComp(comp, map, visited) {
+  if (!comp) return '';
+  if (visited[comp.id]) return '';
+  visited[comp.id] = true;
+  var ch = (comp.children || []).map(function(cid) { return renderComp(map[cid], map, visited); }).join('\n');
+  var p = comp.properties || {};
+
+  switch (comp.type) {
+    case 'Row': return '<div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap">' + ch + '</div>';
+    case 'Column': return '<div style="display:flex;flex-direction:column;gap:12px">' + ch + '</div>';
+    case 'Card': return '<div class="card">' + ch + '</div>';
+    case 'List': return '<ul>' + ch + '</ul>';
+    case 'Text':
+      var t = esc(p.text || '');
+      if (p.style === 'heading' || p.style === 'title') return '<h2>' + t + '</h2>';
+      if (p.style === 'subtitle') return '<h3>' + t + '</h3>';
+      if (p.style === 'caption') return '<small>' + t + '</small>';
+      return '<p>' + t + '</p>';
+    case 'Image':
+      var src = (p.src || '').match(/^https?:\/\//) ? esc(p.src) : '';
+      return '<img src="' + src + '" alt="' + esc(p.alt || '') + '" style="max-width:100%;border-radius:8px">';
+    case 'Divider': return '<hr>';
+    case 'Button':
+      var v = p.variant || 'primary';
+      return '<button class="btn btn-' + esc(v) + '">' + esc(p.label || 'Button') + '</button>';
+    case 'TextField':
+      var lbl = p.label ? '<label>' + esc(p.label) + '<br>' : '';
+      var end = p.label ? '</label>' : '';
+      return lbl + '<input type="text" placeholder="' + esc(p.placeholder || '') + '" class="text-field">' + end;
+    case 'CheckBox':
+      return '<label class="checkbox"><input type="checkbox"' + (p.checked ? ' checked' : '') + '> ' + esc(p.label || '') + '</label>';
+    case 'Slider':
+      return '<label>' + esc(p.label || '') + ' <input type="range" min="' + (p.min||0) + '" max="' + (p.max||100) + '"></label>';
+    case 'ChoicePicker':
+      var opts = (p.options || []).map(function(o) { return '<option>' + esc(o) + '</option>'; }).join('');
+      return '<label>' + esc(p.label || '') + '<br><select>' + opts + '</select></label>';
+    case 'DateTimeInput':
+      return '<label>' + esc(p.label || '') + '<br><input type="datetime-local" class="text-field"></label>';
+    default:
+      return '<div class="unknown">[' + esc(comp.type) + ': ' + esc(comp.id) + ']</div>';
+  }
+}
+
+function findRoots(components) {
+  var childSet = {};
+  components.forEach(function(c) { (c.children || []).forEach(function(id) { childSet[id] = true; }); });
+  return components.filter(function(c) { return !childSet[c.id]; });
+}
+
+function renderSurface(surface) {
+  var map = lookup(surface.components);
+  var roots = findRoots(surface.components);
+  return roots.map(function(r) { return renderComp(r, map, {}); }).join('\n');
+}
+
+function syntaxHighlight(json) {
+  return json.replace(/("(?:\\.|[^"\\])*")\s*:/g, '<span class="json-key">$1</span>:')
+             .replace(/:\s*("(?:\\.|[^"\\])*")/g, ': <span class="json-string">$1</span>')
+             .replace(/:\s*(\d+(?:\.\d+)?)/g, ': <span class="json-number">$1</span>');
+}
+
+// ---------------------------------------------------------------------------
+// Render all surfaces
+// ---------------------------------------------------------------------------
+var container = document.getElementById('surfaces');
+var entries = [
+  { key: 'hello', id: 'hello-world', desc: 'Simple card with heading and text' },
+  { key: 'dashboard', id: 'dashboard', desc: 'Three-card dashboard layout with stats' },
+  { key: 'form', id: 'form', desc: 'Interactive form with text fields and checkbox' },
+];
+
+entries.forEach(function(entry) {
+  var surface = SURFACES[entry.key];
+  var div = document.createElement('div');
+  div.className = 'surface' + (entry.id === 'hello-world' ? ' active' : '');
+  div.setAttribute('data-surface', entry.id);
+
+  var rendered = renderSurface(surface);
+  var jsonStr = JSON.stringify(surface, null, 2);
+
+  div.innerHTML = '<p style="color:#888;font-size:0.85em;margin-bottom:12px">' + esc(entry.desc) +
+    ' <span class="badge badge-green">' + surface.components.length + ' components</span></p>' +
+    rendered +
+    '<details class="json-toggle"><summary>View A2UI JSON</summary><pre>' +
+    syntaxHighlight(esc(jsonStr)) + '</pre></details>';
+  container.appendChild(div);
+});
+
+// ---------------------------------------------------------------------------
+// Tab switching
+// ---------------------------------------------------------------------------
+document.querySelectorAll('.tab').forEach(function(tab) {
+  tab.addEventListener('click', function() {
+    document.querySelectorAll('.tab').forEach(function(t) { t.classList.remove('active'); });
+    document.querySelectorAll('.surface').forEach(function(s) { s.classList.remove('active'); });
+    tab.classList.add('active');
+    var target = tab.getAttribute('data-surface');
+    document.querySelector('.surface[data-surface="' + target + '"]').classList.add('active');
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add canvas surface CRUD endpoints (`POST/GET/PATCH/DELETE`) to `@koi/gateway` with SSE live-update push for real-time browser refresh
- Implement in-memory LRU surface store with SHA-256 content hashing for ETag/CAS concurrency control
- Add standalone demo script (`bun scripts/demo-canvas-viewer.ts`) that starts a canvas API server + an A2UI→HTML viewer server, rendering component trees as interactive HTML with SSE auto-refresh

## New files

| File | Purpose |
|------|---------|
| `canvas-routes.ts` | HTTP route handler for canvas CRUD + SSE `/events` endpoint |
| `canvas-sse.ts` | Pub/sub SSE manager with keep-alive and per-surface channels |
| `canvas-store.ts` | In-memory LRU store with SHA-256 content hashing |
| `canvas-wiring.ts` | Factory composing store + SSE + server from `GatewayConfig` |
| `http-helpers.ts` | Shared JSON response, body parsing, path matching utilities |
| `scripts/demo-canvas-viewer.ts` | Live demo: canvas API (port 3100) + HTML viewer (port 3101) |
| `scripts/demo-canvas.html` | Standalone HTML viewer companion |

## Test plan

- [x] 58 unit tests across canvas-routes, canvas-sse, canvas-store (95%+ coverage)
- [x] 5 integration tests for cross-component workflows
- [x] 8 full-stack E2E tests (server lifecycle, CRUD, SSE streaming)
- [x] Manual verification: `bun scripts/demo-canvas-viewer.ts` → browser renders A2UI surfaces → PATCH updates auto-refresh via SSE
- [ ] Verify CI passes (typecheck + lint + test)

Closes #415, closes #417

Note: The demo script includes an inline A2UI→HTML renderer for visualization, but does **not** close #416 — that issue requires a proper exported `mapA2uiToHtml()` function in `@koi/canvas` with full component coverage, data binding, and dedicated unit tests.