### PR TITLE
feat: add @koi/handoff — structured context relay between agents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -496,6 +496,18 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/handoff": {
+      "name": "@koi/handoff",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-loop": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/hash": {
       "name": "@koi/hash",
       "version": "0.0.0",
@@ -1698,6 +1710,8 @@
     "@koi/gateway": ["@koi/gateway@workspace:packages/gateway"],
 
     "@koi/git-utils": ["@koi/git-utils@workspace:packages/git-utils"],
+
+    "@koi/handoff": ["@koi/handoff@workspace:packages/handoff"],
 
     "@koi/hash": ["@koi/hash@workspace:packages/hash"],
 

--- a/docs/L2/handoff.md
+++ b/docs/L2/handoff.md
@@ -1,0 +1,547 @@
+# @koi/handoff — Structured Context Relay Between Agents
+
+Typed baton-pass protocol for multi-agent pipelines. When Agent A finishes phase 1 and needs to hand off to Agent B for phase 2, this package provides a `HandoffEnvelope` that packages results, artifacts, decisions, and warnings into a typed contract — then auto-injects a summary into the receiving agent's first model call via middleware.
+
+---
+
+## Why It Exists
+
+Without structured handoff, agents communicate via chat messages. The receiving agent has no typed context — it must parse free text to understand what was done, what to do next, and what to watch out for.
+
+```
+  BEFORE                              AFTER
+  ──────                              ─────
+
+  Agent A ── "I'm done" ──▶ Agent B   Agent A ── HandoffEnvelope ──▶ Agent B
+                                                  │
+  ❌ No structured results             ✅ Typed results (JsonObject)
+  ❌ No artifact references            ✅ URI-based artifact refs
+  ❌ No decision trail                 ✅ DecisionRecord[] with reasoning
+  ❌ No warnings propagated            ✅ Warnings accumulate through pipeline
+  ❌ Agent B starts from scratch       ✅ Middleware auto-injects context
+```
+
+Benefits:
+
+- **Zero-effort context injection** — middleware prepends a summary to the LLM's first turn; no prompt engineering needed
+- **Full details on demand** — `accept_handoff` tool returns complete results, artifacts, decisions, and warnings
+- **Pipeline-ready** — warnings and artifacts accumulate through A → B → C chains
+- **Observable** — `HandoffEvent` union enables telemetry, UI, and orchestrator integration
+- **Backend-swappable** — in-memory store today, Nexus/SQLite planned (#447)
+
+---
+
+## Architecture
+
+`@koi/handoff` is an **L2 feature package** — it depends only on `@koi/core` (L0). No L1 or peer L2 imports.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  @koi/handoff  (L2)                                      │
+│                                                          │
+│  types.ts          ← Config types, tool descriptors      │
+│  store.ts          ← HandoffStore (Map wrapper + CAS)    │
+│  validate.ts       ← Input + artifact validation         │
+│  summary.ts        ← Generate prompt summary (~300 tok)  │
+│  prepare-tool.ts   ← prepare_handoff tool factory        │
+│  accept-tool.ts    ← accept_handoff tool factory         │
+│  middleware.ts     ← HandoffMiddleware (context inject)   │
+│  provider.ts       ← ComponentProvider (attaches tools)  │
+│  index.ts          ← public API surface                  │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│  Dependencies                                            │
+│                                                          │
+│  @koi/core  (L0)   HandoffEnvelope, AgentId, Tool, etc. │
+│  crypto     (rt)   randomUUID for HandoffId generation   │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## The Handoff Envelope
+
+Every handoff is packaged into a `HandoffEnvelope` — the core data type defined in `@koi/core`:
+
+```typescript
+interface HandoffEnvelope {
+  readonly id: HandoffId               // Branded string — unique per handoff
+  readonly from: AgentId               // Sender agent
+  readonly to: AgentId                 // Receiver agent
+  readonly status: HandoffStatus       // "pending" | "injected" | "accepted" | "expired"
+  readonly createdAt: number           // Unix timestamp (ms)
+  readonly phase: {
+    readonly completed: string         // What was done
+    readonly next: string              // What to do next
+  }
+  readonly context: {
+    readonly results: JsonObject       // Structured results (domain-specific)
+    readonly artifacts: readonly ArtifactRef[]    // URI-based references
+    readonly decisions: readonly DecisionRecord[] // Reasoning trail
+    readonly warnings: readonly string[]          // Pitfalls to avoid
+  }
+  readonly delegation?: DelegationGrant // Optional capability delegation
+  readonly metadata: JsonObject         // Extensible
+}
+```
+
+### Status Lifecycle
+
+```
+  pending ──────▶ injected ──────▶ accepted
+     │                                 │
+     │            (middleware           │
+     │             injects summary)    (agent calls
+     │                                  accept_handoff)
+     │
+     └──────────▶ expired
+                  (TTL — future #447)
+```
+
+| Transition | Triggered by | What happens |
+|-----------|-------------|-------------|
+| `pending → injected` | Middleware `wrapModelCall` | Summary prepended to first model request |
+| `injected → accepted` | `accept_handoff` tool | Full context returned to agent |
+| `pending → expired` | TTL (planned) | Envelope becomes unavailable |
+
+All transitions are **CAS (compare-and-swap)** — the transition only succeeds if the current status matches the expected `from` status.
+
+---
+
+## Three Integration Points
+
+```
+  ┌─────────────────────────────────────────────────────┐
+  │  createHandoffStore()   ← shared between agents      │
+  │         │                                            │
+  │         ├── createHandoffProvider()   → registers     │
+  │         │     tool:prepare_handoff                   │
+  │         │     tool:accept_handoff                    │
+  │         │                                            │
+  │         └── createHandoffMiddleware() → intercepts    │
+  │               wrapModelCall (1st turn: inject summary)│
+  │               onBeforeTurn  (every turn: set metadata)│
+  │               describeCapabilities (advertise handoff)│
+  └─────────────────────────────────────────────────────┘
+```
+
+### Store — Shared State
+
+The `HandoffStore` is the shared envelope registry. Both the sending and receiving agents reference the same store instance.
+
+```typescript
+interface HandoffStore {
+  put(envelope: HandoffEnvelope): void
+  get(id: HandoffId): HandoffEnvelope | undefined
+  transition(id: HandoffId, from: HandoffStatus, to: HandoffStatus): HandoffEnvelope | undefined
+  listByAgent(agentId: AgentId): readonly HandoffEnvelope[]
+  findPendingForAgent(agentId: AgentId): HandoffEnvelope | undefined
+  remove(id: HandoffId): boolean
+  removeByAgent(agentId: AgentId): void
+  bindRegistry(registry: AgentRegistry): void   // auto-cleanup on termination
+  dispose(): void
+}
+```
+
+Today this is in-memory (`Map`). SQLite and Nexus backends are planned (#447).
+
+### Provider — Tool Registration
+
+`createHandoffProvider` is a `ComponentProvider` that registers both tools on the agent entity during assembly:
+
+```
+  Agent Entity
+  ├── tool:prepare_handoff   ← sender packs an envelope
+  └── tool:accept_handoff    ← receiver unpacks full context
+```
+
+### Middleware — Automatic Context Injection
+
+`createHandoffMiddleware` returns a `KoiMiddleware` (priority 400) with three hooks:
+
+| Hook | When | What |
+|------|------|------|
+| `onBeforeTurn` | Every turn | Sets `ctx.metadata.handoffId` and `ctx.metadata.handoffPhase` |
+| `wrapModelCall` | First turn only | Prepends summary system message to model request |
+| `describeCapabilities` | On query | Returns capability fragment advertising the handoff |
+
+The middleware uses a **closure flag** for first-turn detection — after the first injection, subsequent model calls pass through unchanged.
+
+---
+
+## Tools
+
+### `prepare_handoff`
+
+Called by the **sending** agent to package work into an envelope.
+
+```
+  Input (JSON Schema):
+  ┌────────────────────────────────────────────────────────┐
+  │  to          string  (required)  Target agent ID       │
+  │  completed   string  (required)  What was done         │
+  │  next        string  (required)  Instructions for next │
+  │  results     object  (optional)  Structured results    │
+  │  artifacts   array   (optional)  Artifact references   │
+  │  decisions   array   (optional)  Decision records      │
+  │  warnings    array   (optional)  Pitfalls to avoid     │
+  └────────────────────────────────────────────────────────┘
+
+  Output:
+  { handoffId: "hoff-abc123", status: "pending" }
+```
+
+Validation:
+- `to`, `completed`, `next` are required non-empty strings
+- Artifact URIs are validated (unsupported schemes → warnings, not errors)
+- `HandoffId` generated via `crypto.randomUUID()`
+
+### `accept_handoff`
+
+Called by the **receiving** agent to unpack the full envelope.
+
+```
+  Input:
+  ┌────────────────────────────────────────────────────────┐
+  │  handoff_id  string  (required)  The envelope ID       │
+  └────────────────────────────────────────────────────────┘
+
+  Output (success):
+  {
+    handoffId: "hoff-abc123",
+    from: "agent-a",
+    completed: "...",
+    next: "...",
+    results: { ... },
+    artifacts: [ ... ],
+    decisions: [ ... ],
+    warnings: [ ... ]
+  }
+```
+
+Error responses:
+
+| Code | When | Retryable |
+|------|------|-----------|
+| `NOT_FOUND` | Envelope doesn't exist | No |
+| `ALREADY_ACCEPTED` | Status is already `accepted` | No |
+| `TARGET_MISMATCH` | `envelope.to` doesn't match current agent | No |
+| `EXPIRED` | Envelope has expired | No |
+
+---
+
+## Context Injection
+
+When middleware injects a summary, the receiving agent's LLM sees this prepended to its first model request:
+
+```
+## Handoff Context
+You are continuing work from agent `agent-a`.
+
+### Completed Phase
+Analyzed 500 research papers on distributed systems
+
+### Your Task
+Write a survey paper covering the top 5 themes
+
+### Warnings
+- Source X has been retracted — do not cite
+- Budget constraint: keep under 10 pages
+
+### Available Context
+- 3 artifacts available
+- 2 decision records
+- Use `accept_handoff` tool with id="hoff-abc123" to retrieve full results and artifacts.
+```
+
+This summary is ~200-400 tokens — enough for the LLM to understand its task without overloading context. Full details (results, artifacts, decisions) are available on demand via `accept_handoff`.
+
+---
+
+## Events
+
+All state transitions emit typed `HandoffEvent` values via the `onEvent` callback:
+
+```typescript
+type HandoffEvent =
+  | { kind: "handoff:prepared"; envelope: HandoffEnvelope }
+  | { kind: "handoff:injected"; handoffId: HandoffId }
+  | { kind: "handoff:accepted"; handoffId: HandoffId; warnings: readonly string[] }
+  | { kind: "handoff:expired";  handoffId: HandoffId }
+```
+
+Event sequence for a typical A → B handoff:
+
+```
+  Agent A calls prepare_handoff     → handoff:prepared
+  Agent B's middleware injects       → handoff:injected
+  Agent B calls accept_handoff      → handoff:accepted
+```
+
+For a 3-agent pipeline (A → B → C):
+
+```
+  handoff:prepared   (A prepares for B)
+  handoff:injected   (B's middleware injects)
+  handoff:accepted   (B accepts)
+  handoff:prepared   (B prepares for C)
+  handoff:injected   (C's middleware injects)
+  handoff:accepted   (C accepts)
+```
+
+---
+
+## Error Handling
+
+Tools return typed error objects — never throw on expected failures:
+
+```
+  ┌────────────────────┐     ┌──────────────────┐     ┌──────────┐
+  │ Expected error     │     │ Error code       │     │ Retryable│
+  ├────────────────────┤     ├──────────────────┤     ├──────────┤
+  │ Missing to/next    │ ──> │ (validation msg) │ ──> │ No       │
+  │ Envelope not found │ ──> │ NOT_FOUND        │ ──> │ No       │
+  │ Already accepted   │ ──> │ ALREADY_ACCEPTED │ ──> │ No       │
+  │ Wrong target agent │ ──> │ TARGET_MISMATCH  │ ──> │ No       │
+  │ Envelope expired   │ ──> │ EXPIRED          │ ──> │ No       │
+  │ Bad artifact URI   │ ──> │ (warning only)   │ ──> │ N/A      │
+  └────────────────────┘     └──────────────────┘     └──────────┘
+```
+
+Artifact validation produces **warnings, not errors** — an unsupported URI scheme doesn't block the handoff, it's surfaced in the warnings array.
+
+---
+
+## API Reference
+
+### Factory Functions
+
+#### `createHandoffStore()`
+
+Returns `HandoffStore`. In-memory `Map`-based. Process-lifetime only.
+
+#### `createHandoffProvider(config)`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config.store` | `HandoffStore` | Shared envelope store |
+| `config.agentId` | `AgentId` | This agent's ID |
+| `config.registry` | `AgentRegistry` | Optional — auto-cleanup on termination |
+| `config.onEvent` | `(e: HandoffEvent) => void` | Optional event listener |
+
+Returns `ComponentProvider`. Registers `tool:prepare_handoff` and `tool:accept_handoff`.
+
+#### `createHandoffMiddleware(config)`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config.store` | `HandoffStore` | Shared envelope store |
+| `config.agentId` | `AgentId` | This agent's ID |
+| `config.onEvent` | `(e: HandoffEvent) => void` | Optional event listener |
+
+Returns `KoiMiddleware` (name: `koi:handoff`, priority: 400).
+
+#### `createPrepareTool(config)` / `createAcceptTool(config)`
+
+Lower-level factories — use `createHandoffProvider` unless you need manual tool registration.
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `HandoffStore` | Envelope registry with CAS transitions and agent-scoped queries |
+| `HandoffConfig` | Config for `createHandoffProvider` |
+| `HandoffMiddlewareConfig` | Config for `createHandoffMiddleware` |
+| `PREPARE_HANDOFF_DESCRIPTOR` | JSON Schema tool descriptor for `prepare_handoff` |
+| `ACCEPT_HANDOFF_DESCRIPTOR` | JSON Schema tool descriptor for `accept_handoff` |
+
+L0 types (from `@koi/core`):
+
+| Type | Description |
+|------|-------------|
+| `HandoffId` | Branded `string` — unique envelope identifier |
+| `HandoffEnvelope` | The typed baton — status, phase, context, artifacts, decisions, warnings |
+| `HandoffStatus` | `"pending" \| "injected" \| "accepted" \| "expired"` |
+| `HandoffEvent` | Discriminated union of lifecycle events |
+| `DecisionRecord` | Agent reasoning trace (agentId, action, reasoning, timestamp) |
+| `ArtifactRef` | URI-based artifact reference (id, kind, uri, mimeType) |
+| `HandoffAcceptResult` | Discriminated union: success with warnings, or typed error |
+| `HandoffAcceptError` | `NOT_FOUND \| ALREADY_ACCEPTED \| TARGET_MISMATCH \| EXPIRED` |
+| `HandoffComponent` | ECS component interface for the handoff subsystem |
+
+---
+
+## Examples
+
+### 1. Basic Two-Agent Handoff
+
+```typescript
+import { agentId } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import {
+  createHandoffStore,
+  createHandoffProvider,
+  createHandoffMiddleware,
+} from "@koi/handoff";
+
+// Shared store — the link between agents
+const store = createHandoffStore();
+
+// Agent A: can prepare handoffs (sender)
+const runtimeA = await createKoi({
+  manifest: { name: "researcher", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: createLoopAdapter({ modelCall, maxTurns: 10 }),
+  providers: [
+    createHandoffProvider({ store, agentId: agentId("researcher") }),
+  ],
+});
+
+// Agent B: receives handoffs via middleware + accepts via tool
+const runtimeB = await createKoi({
+  manifest: { name: "writer", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: createLoopAdapter({ modelCall, maxTurns: 10 }),
+  providers: [
+    createHandoffProvider({ store, agentId: agentId("writer") }),
+  ],
+  middleware: [
+    createHandoffMiddleware({ store, agentId: agentId("writer") }),
+  ],
+});
+
+// Run Agent A — LLM calls prepare_handoff
+await collectEvents(runtimeA.run({ kind: "text", text: "Analyze the data and hand off to writer" }));
+
+// Run Agent B — middleware auto-injects context, LLM calls accept_handoff
+await collectEvents(runtimeB.run({ kind: "text", text: "Continue the work from the handoff" }));
+```
+
+### 2. With Event Listening
+
+```typescript
+import type { HandoffEvent } from "@koi/core";
+
+function onHandoffEvent(event: HandoffEvent): void {
+  switch (event.kind) {
+    case "handoff:prepared":
+      console.log(`📦 ${event.envelope.from} → ${event.envelope.to}`);
+      break;
+    case "handoff:injected":
+      console.log(`💉 Context injected for ${event.handoffId}`);
+      break;
+    case "handoff:accepted":
+      console.log(`✅ Accepted ${event.handoffId} (${event.warnings.length} warnings)`);
+      break;
+  }
+}
+
+const store = createHandoffStore();
+
+createHandoffProvider({ store, agentId: id, onEvent: onHandoffEvent });
+createHandoffMiddleware({ store, agentId: id, onEvent: onHandoffEvent });
+```
+
+### 3. Three-Agent Pipeline
+
+```typescript
+const store = createHandoffStore();
+const onEvent = (e: HandoffEvent) => console.log(e.kind);
+
+// Agent A: Researcher → prepares for Architect
+const runtimeA = await createKoi({
+  manifest: { name: "researcher", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: createLoopAdapter({ modelCall, maxTurns: 5 }),
+  providers: [createHandoffProvider({ store, agentId: agentId("researcher"), onEvent })],
+});
+
+// Agent B: Architect → accepts from A, prepares for Builder
+const runtimeB = await createKoi({
+  manifest: { name: "architect", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: createLoopAdapter({ modelCall, maxTurns: 5 }),
+  providers: [createHandoffProvider({ store, agentId: agentId("architect"), onEvent })],
+  middleware: [createHandoffMiddleware({ store, agentId: agentId("architect"), onEvent })],
+});
+
+// Agent C: Builder → accepts from B
+const runtimeC = await createKoi({
+  manifest: { name: "builder", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: createLoopAdapter({ modelCall, maxTurns: 5 }),
+  providers: [createHandoffProvider({ store, agentId: agentId("builder"), onEvent })],
+  middleware: [createHandoffMiddleware({ store, agentId: agentId("builder"), onEvent })],
+});
+
+// Run pipeline sequentially
+await collectEvents(runtimeA.run({ kind: "text", text: "Research and hand off to architect" }));
+await collectEvents(runtimeB.run({ kind: "text", text: "Design and hand off to builder" }));
+await collectEvents(runtimeC.run({ kind: "text", text: "Build based on the architecture" }));
+
+// Events emitted: prepared → injected → accepted → prepared → injected → accepted
+// Warnings accumulate: A's warnings flow through B into C
+```
+
+### 4. With Registry Cleanup (Production)
+
+```typescript
+createHandoffProvider({
+  store,
+  agentId: id,
+  registry: myAgentRegistry, // watches for agent termination
+  onEvent,
+});
+
+// When an agent terminates, all its envelopes are automatically removed
+// from the store via registry.watch() → removeByAgent()
+```
+
+---
+
+## Store Backends
+
+```
+                  ┌─────────────────┐
+                  │  Which store?   │
+                  └────────┬────────┘
+                           │
+               ┌───────────┼───────────┐
+               ▼           ▼           ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │ InMemory │ │  SQLite  │ │  Nexus   │
+        │          │ │          │ │          │
+        │ Tests &  │ │ Local    │ │ Remote   │
+        │ same     │ │ dev &    │ │ prod &   │
+        │ process  │ │ single   │ │ multi    │
+        │          │ │ node     │ │ node     │
+        │ ✅ Today  │ │ 🔜 #447  │ │ 🔜 #447  │
+        └──────────┘ └──────────┘ └──────────┘
+```
+
+| Concern | InMemory | SQLite (planned) | Nexus (planned) |
+|---------|----------|-----------------|-----------------|
+| Persistence | None (process lifetime) | Disk file | Remote server |
+| Setup | Zero config | File path | URL + API key |
+| Concurrency | Single process | WAL mode | Multi-node via HTTP |
+| Best for | Tests, same-process agents | Local dev, CLI | Multi-node, shared state |
+
+See #447 for persistent backend tracking.
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    HandoffEnvelope, HandoffEvent, AgentId, Tool, etc.   │
+                                                         │
+L2  @koi/handoff ◄───────────────────────────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✓ crypto.randomUUID() is a runtime built-in
+```
+
+- [x] `@koi/core/handoff.ts` has zero imports from other `@koi/*` packages
+- [x] `@koi/core/handoff.ts` has no function bodies (except branded `handoffId()` cast)
+- [x] No vendor types (LangGraph, OpenAI, etc.) in any file
+- [x] Runtime source imports from `@koi/core` only — `@koi/engine` and `@koi/engine-loop` are devDependencies (E2E tests)
+- [x] All interface properties are `readonly`
+- [x] All array parameters are `readonly T[]`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/ecs.d.ts",
       "import": "./dist/ecs.js"
     },
+    "./handoff": {
+      "types": "./dist/handoff.d.ts",
+      "import": "./dist/handoff.js"
+    },
     "./engine": {
       "types": "./dist/engine.d.ts",
       "import": "./dist/engine.js"

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -4,7 +4,7 @@ exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { B as BrickRef, a as BrickKind } from './brick-snapshot-HASH.js';
 export { A as ALL_BRICK_KINDS, b as BrickId, c as BrickLifecycle, d as BrickSnapshot, e as BrickSource, F as ForgeScope, M as MIN_TRUST_BY_KIND, S as SnapshotEvent, f as SnapshotId, g as SnapshotQuery, h as SnapshotStore, V as VALID_LIFECYCLE_TRANSITIONS, i as brickId, s as snapshotId } from './brick-snapshot-HASH.js';
 import { A as AgentId, E as EngineState, P as ProcessState, T as Tool, S as SkillComponent, a as AgentDescriptor, b as Agent, K as KoiMiddleware, c as SessionId, d as ToolCallId } from './ecs-HASH.js';
-export { e as AbortReason, f as ApprovalDecision, g as ApprovalHandler, h as ApprovalRequest, B as BROWSER, i as BrowserActionOptions, j as BrowserConsoleEntry, k as BrowserConsoleLevel, l as BrowserConsoleOptions, m as BrowserConsoleResult, n as BrowserDriver, o as BrowserEvaluateOptions, p as BrowserEvaluateResult, q as BrowserFormField, r as BrowserNavigateOptions, s as BrowserNavigateResult, t as BrowserRefInfo, u as BrowserScreenshotOptions, v as BrowserScreenshotResult, w as BrowserScrollOptions, x as BrowserSnapshotOptions, y as BrowserSnapshotResult, z as BrowserTabCloseOptions, C as BrowserTabFocusOptions, D as BrowserTabInfo, F as BrowserTabNewOptions, G as BrowserTraceOptions, H as BrowserTraceResult, I as BrowserTypeOptions, J as BrowserUploadFile, L as BrowserUploadOptions, M as BrowserWaitOptions, N as BrowserWaitUntil, O as COMPONENT_PRIORITY, Q as CREDENTIALS, R as CapabilityFragment, U as ChildHandle, V as ChildLifecycleEvent, W as ComponentEvent, X as ComponentEventKind, Y as ComponentProvider, Z as ComposedCallHandlers, _ as CorrelationIds, $ as CredentialComponent, a0 as CronSchedule, a1 as DEFAULT_SCHEDULER_CONFIG, a2 as DELEGATION, a3 as EVENTS, a4 as EngineAdapter, a5 as EngineEvent, a6 as EngineInput, a7 as EngineInputBase, a8 as EngineMetrics, a9 as EngineOutput, aa as EngineStopReason, ab as EventComponent, ac as FILESYSTEM, ad as GOVERNANCE, ae as GOVERNANCE_VARIABLES, af as GovernanceCheck, ag as GovernanceController, ah as GovernanceEvent, ai as GovernanceSnapshot, aj as GovernanceVariable, ak as GovernanceVariableContributor, al as MEMORY, am as MemoryComponent, an as MemoryRecallOptions, ao as MemoryResult, ap as MemoryStoreOptions, aq as ModelChunk, ar as ModelHandler, as as ModelRequest, at as ModelResponse, au as ModelStreamHandler, av as ProcessAccounter, aw as ProcessId, ax as RunId, ay as SCHEDULER, az as ScheduleId, aA as ScheduleStore, aB as ScheduledTask, aC as SchedulerComponent, aD as SchedulerConfig, aE as SchedulerEvent, aF as SchedulerStats, aG as SensorReading, aH as SessionContext, aI as SkillMetadata, aJ as SpawnLedger, aK as SubsystemToken, aL as TaskFilter, aM as TaskHistoryFilter, aN as TaskId, aO as TaskOptions, aP as TaskRunRecord, aQ as TaskScheduler, aR as TaskStatus, aS as TaskStore, aT as ToolDescriptor, aU as ToolExecuteOptions, aV as ToolHandler, aW as ToolRequest, aX as ToolResponse, aY as TrustTier, aZ as TurnContext, a_ as TurnId, a$ as WEBHOOK, b0 as WORKSPACE, b1 as WorkspaceComponent, b2 as agentId, b3 as agentToken, b4 as channelToken, b5 as governanceContributorToken, b6 as middlewareToken, b7 as runId, b8 as scheduleId, b9 as sessionId, ba as skillToken, bb as taskId, bc as token, bd as toolCallId, be as toolToken, bf as turnId } from './ecs-HASH.js';
+export { e as AbortReason, f as ApprovalDecision, g as ApprovalHandler, h as ApprovalRequest, i as ArtifactRef, B as BROWSER, j as BrowserActionOptions, k as BrowserConsoleEntry, l as BrowserConsoleLevel, m as BrowserConsoleOptions, n as BrowserConsoleResult, o as BrowserDriver, p as BrowserEvaluateOptions, q as BrowserEvaluateResult, r as BrowserFormField, s as BrowserNavigateOptions, t as BrowserNavigateResult, u as BrowserRefInfo, v as BrowserScreenshotOptions, w as BrowserScreenshotResult, x as BrowserScrollOptions, y as BrowserSnapshotOptions, z as BrowserSnapshotResult, C as BrowserTabCloseOptions, D as BrowserTabFocusOptions, F as BrowserTabInfo, G as BrowserTabNewOptions, H as BrowserTraceOptions, I as BrowserTraceResult, J as BrowserTypeOptions, L as BrowserUploadFile, M as BrowserUploadOptions, N as BrowserWaitOptions, O as BrowserWaitUntil, Q as COMPONENT_PRIORITY, R as CREDENTIALS, U as CapabilityFragment, V as ChildHandle, W as ChildLifecycleEvent, X as ComponentEvent, Y as ComponentEventKind, Z as ComponentProvider, _ as ComposedCallHandlers, $ as CorrelationIds, a0 as CredentialComponent, a1 as CronSchedule, a2 as DEFAULT_SCHEDULER_CONFIG, a3 as DELEGATION, a4 as DecisionRecord, a5 as EVENTS, a6 as EngineAdapter, a7 as EngineEvent, a8 as EngineInput, a9 as EngineInputBase, aa as EngineMetrics, ab as EngineOutput, ac as EngineStopReason, ad as EventComponent, ae as FILESYSTEM, af as GOVERNANCE, ag as GOVERNANCE_VARIABLES, ah as GovernanceCheck, ai as GovernanceController, aj as GovernanceEvent, ak as GovernanceSnapshot, al as GovernanceVariable, am as GovernanceVariableContributor, an as HANDOFF, ao as HandoffAcceptError, ap as HandoffAcceptResult, aq as HandoffComponent, ar as HandoffEnvelope, as as HandoffEvent, at as HandoffId, au as HandoffStatus, av as MEMORY, aw as MemoryComponent, ax as MemoryRecallOptions, ay as MemoryResult, az as MemoryStoreOptions, aA as ModelChunk, aB as ModelHandler, aC as ModelRequest, aD as ModelResponse, aE as ModelStreamHandler, aF as ProcessAccounter, aG as ProcessId, aH as RunId, aI as SCHEDULER, aJ as ScheduleId, aK as ScheduleStore, aL as ScheduledTask, aM as SchedulerComponent, aN as SchedulerConfig, aO as SchedulerEvent, aP as SchedulerStats, aQ as SensorReading, aR as SessionContext, aS as SkillMetadata, aT as SpawnLedger, aU as SubsystemToken, aV as TaskFilter, aW as TaskHistoryFilter, aX as TaskId, aY as TaskOptions, aZ as TaskRunRecord, a_ as TaskScheduler, a$ as TaskStatus, b0 as TaskStore, b1 as ToolDescriptor, b2 as ToolExecuteOptions, b3 as ToolHandler, b4 as ToolRequest, b5 as ToolResponse, b6 as TrustTier, b7 as TurnContext, b8 as TurnId, b9 as WEBHOOK, ba as WORKSPACE, bb as WorkspaceComponent, bc as agentId, bd as agentToken, be as channelToken, bf as governanceContributorToken, bg as handoffId, bh as middlewareToken, bi as runId, bj as scheduleId, bk as sessionId, bl as skillToken, bm as taskId, bn as token, bo as toolCallId, bp as toolToken, bq as turnId } from './ecs-HASH.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { TransitionReason, AgentCondition, AgentStatus, RegistryEntry, AgentRegistry } from './lifecycle.js';
@@ -1577,7 +1577,7 @@ import './webhook.js';
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
 "import './assembly-HASH.js';
-export { b as Agent, a as AgentDescriptor, A as AgentId, B as BROWSER, O as COMPONENT_PRIORITY, Q as CREDENTIALS, U as ChildHandle, V as ChildLifecycleEvent, W as ComponentEvent, X as ComponentEventKind, Y as ComponentProvider, $ as CredentialComponent, a2 as DELEGATION, a3 as EVENTS, ab as EventComponent, ac as FILESYSTEM, ad as GOVERNANCE, al as MEMORY, am as MemoryComponent, an as MemoryRecallOptions, ao as MemoryResult, ap as MemoryStoreOptions, av as ProcessAccounter, aw as ProcessId, P as ProcessState, ax as RunId, ay as SCHEDULER, c as SessionId, S as SkillComponent, aI as SkillMetadata, aJ as SpawnLedger, aK as SubsystemToken, T as Tool, d as ToolCallId, aT as ToolDescriptor, aU as ToolExecuteOptions, aY as TrustTier, a_ as TurnId, a$ as WEBHOOK, b0 as WORKSPACE, b1 as WorkspaceComponent, b2 as agentId, b3 as agentToken, b4 as channelToken, b6 as middlewareToken, b7 as runId, b9 as sessionId, ba as skillToken, bc as token, bd as toolCallId, be as toolToken, bf as turnId } from './ecs-HASH.js';
+export { b as Agent, a as AgentDescriptor, A as AgentId, B as BROWSER, Q as COMPONENT_PRIORITY, R as CREDENTIALS, V as ChildHandle, W as ChildLifecycleEvent, X as ComponentEvent, Y as ComponentEventKind, Z as ComponentProvider, a0 as CredentialComponent, a3 as DELEGATION, a5 as EVENTS, ad as EventComponent, ae as FILESYSTEM, af as GOVERNANCE, an as HANDOFF, av as MEMORY, aw as MemoryComponent, ax as MemoryRecallOptions, ay as MemoryResult, az as MemoryStoreOptions, aF as ProcessAccounter, aG as ProcessId, P as ProcessState, aH as RunId, aI as SCHEDULER, c as SessionId, S as SkillComponent, aS as SkillMetadata, aT as SpawnLedger, aU as SubsystemToken, T as Tool, d as ToolCallId, b1 as ToolDescriptor, b2 as ToolExecuteOptions, b6 as TrustTier, b8 as TurnId, b9 as WEBHOOK, ba as WORKSPACE, bb as WorkspaceComponent, bc as agentId, bd as agentToken, be as channelToken, bh as middlewareToken, bi as runId, bk as sessionId, bl as skillToken, bn as token, bo as toolCallId, bp as toolToken, bq as turnId } from './ecs-HASH.js';
 import './channel.js';
 import './common.js';
 import './filesystem-HASH.js';
@@ -1587,9 +1587,21 @@ import './message.js';
 "
 `;
 
+exports[`@koi/core API surface ./handoff has stable type surface 1`] = `
+"import './common.js';
+import './assembly-HASH.js';
+export { i as ArtifactRef, a4 as DecisionRecord, ao as HandoffAcceptError, ap as HandoffAcceptResult, aq as HandoffComponent, ar as HandoffEnvelope, as as HandoffEvent, at as HandoffId, au as HandoffStatus, bg as handoffId } from './ecs-HASH.js';
+import './webhook.js';
+import './errors.js';
+import './channel.js';
+import './message.js';
+import './filesystem-HASH.js';
+"
+`;
+
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { e as AbortReason, Z as ComposedCallHandlers, a4 as EngineAdapter, a5 as EngineEvent, a6 as EngineInput, a7 as EngineInputBase, a8 as EngineMetrics, a9 as EngineOutput, E as EngineState, aa as EngineStopReason } from './ecs-HASH.js';
+export { e as AbortReason, _ as ComposedCallHandlers, a6 as EngineAdapter, a7 as EngineEvent, a8 as EngineInput, a9 as EngineInputBase, aa as EngineMetrics, ab as EngineOutput, E as EngineState, ac as EngineStopReason } from './ecs-HASH.js';
 import './message.js';
 import './assembly-HASH.js';
 import './webhook.js';
@@ -1875,7 +1887,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import './channel.js';
 import './common.js';
-export { f as ApprovalDecision, g as ApprovalHandler, h as ApprovalRequest, R as CapabilityFragment, K as KoiMiddleware, aq as ModelChunk, ar as ModelHandler, as as ModelRequest, at as ModelResponse, au as ModelStreamHandler, aH as SessionContext, aV as ToolHandler, aW as ToolRequest, aX as ToolResponse, aZ as TurnContext } from './ecs-HASH.js';
+export { f as ApprovalDecision, g as ApprovalHandler, h as ApprovalRequest, U as CapabilityFragment, K as KoiMiddleware, aA as ModelChunk, aB as ModelHandler, aC as ModelRequest, aD as ModelResponse, aE as ModelStreamHandler, aR as SessionContext, b3 as ToolHandler, b4 as ToolRequest, b5 as ToolResponse, b7 as TurnContext } from './ecs-HASH.js';
 import './message.js';
 import './assembly-HASH.js';
 import './webhook.js';
@@ -2348,7 +2360,7 @@ export type { SandboxAdapter, SandboxAdapterResult, SandboxExecOptions, SandboxI
 `;
 
 exports[`@koi/core API surface ./sandbox-executor has stable type surface 1`] = `
-"import { aY as TrustTier } from './ecs-HASH.js';
+"import { b6 as TrustTier } from './ecs-HASH.js';
 import './assembly-HASH.js';
 import './common.js';
 import './webhook.js';
@@ -2429,7 +2441,7 @@ export type { ExecutionContext, SandboxError, SandboxErrorCode, SandboxExecutor,
 `;
 
 exports[`@koi/core API surface ./sandbox-profile has stable type surface 1`] = `
-"import { aY as TrustTier } from './ecs-HASH.js';
+"import { b6 as TrustTier } from './ecs-HASH.js';
 import './assembly-HASH.js';
 import './common.js';
 import './webhook.js';

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -14,6 +14,7 @@ import type { JsonObject } from "./common.js";
 import type { DelegationComponent } from "./delegation.js";
 import type { FileSystemBackend } from "./filesystem-backend.js";
 import type { GovernanceController } from "./governance.js";
+import type { HandoffComponent } from "./handoff.js";
 import type { SchedulerComponent } from "./scheduler.js";
 import type { WebhookComponent } from "./webhook.js";
 
@@ -388,6 +389,7 @@ export const CREDENTIALS: SubsystemToken<CredentialComponent> =
 export const EVENTS: SubsystemToken<EventComponent> = token<EventComponent>("events");
 export const DELEGATION: SubsystemToken<DelegationComponent> =
   token<DelegationComponent>("delegation");
+export const HANDOFF: SubsystemToken<HandoffComponent> = token<HandoffComponent>("handoff");
 export const FILESYSTEM: SubsystemToken<FileSystemBackend> = token<FileSystemBackend>("filesystem");
 export const BROWSER: SubsystemToken<BrowserDriver> = token<BrowserDriver>("browser");
 export const WORKSPACE: SubsystemToken<WorkspaceComponent> = token<WorkspaceComponent>("workspace");

--- a/packages/core/src/handoff.ts
+++ b/packages/core/src/handoff.ts
@@ -1,0 +1,136 @@
+/**
+ * Handoff types — structured context relay for agent-to-agent baton passing.
+ *
+ * All types are immutable (readonly). No runtime code except the branded
+ * type constructor for HandoffId.
+ */
+
+import type { JsonObject } from "./common.js";
+import type { DelegationGrant } from "./delegation.js";
+import type { AgentId, ToolCallId } from "./ecs.js";
+
+// ---------------------------------------------------------------------------
+// Branded handoff ID
+// ---------------------------------------------------------------------------
+
+declare const __handoffBrand: unique symbol;
+
+/**
+ * Branded string type for handoff envelope identifiers.
+ * Prevents accidental mixing with other string IDs at compile time.
+ */
+export type HandoffId = string & { readonly [__handoffBrand]: "HandoffId" };
+
+/** Create a branded HandoffId from a plain string. */
+export function handoffId(raw: string): HandoffId {
+  return raw as HandoffId;
+}
+
+// ---------------------------------------------------------------------------
+// Decision record — agent reasoning trace
+// ---------------------------------------------------------------------------
+
+/** A single decision record capturing agent reasoning during a phase. */
+export interface DecisionRecord {
+  readonly agentId: AgentId;
+  readonly action: string;
+  readonly reasoning: string;
+  readonly timestamp: number;
+  readonly toolCallId?: ToolCallId | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Artifact reference — URI-based, storage-agnostic
+// ---------------------------------------------------------------------------
+
+/** URI-based reference to an artifact produced during a phase. */
+export interface ArtifactRef {
+  readonly id: string;
+  /** Artifact kind: "file" | "data" | "analysis" | custom. */
+  readonly kind: string;
+  /** URI pointing to the artifact (e.g., "file:///workspace/output.json"). */
+  readonly uri: string;
+  readonly mimeType?: string | undefined;
+  readonly metadata?: JsonObject | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Handoff envelope status
+// ---------------------------------------------------------------------------
+
+/** Lifecycle status of a handoff envelope. */
+export type HandoffStatus = "pending" | "injected" | "accepted" | "expired";
+
+// ---------------------------------------------------------------------------
+// Handoff envelope
+// ---------------------------------------------------------------------------
+
+/** Typed envelope for agent-to-agent context relay. */
+export interface HandoffEnvelope {
+  readonly id: HandoffId;
+  readonly from: AgentId;
+  readonly to: AgentId;
+  readonly status: HandoffStatus;
+  readonly createdAt: number;
+  readonly phase: {
+    readonly completed: string;
+    readonly next: string;
+  };
+  readonly context: {
+    readonly results: JsonObject;
+    readonly artifacts: readonly ArtifactRef[];
+    readonly decisions: readonly DecisionRecord[];
+    readonly warnings: readonly string[];
+  };
+  readonly delegation?: DelegationGrant | undefined;
+  readonly metadata: JsonObject;
+}
+
+// ---------------------------------------------------------------------------
+// Handoff events (discriminated union)
+// ---------------------------------------------------------------------------
+
+/** Events emitted during handoff lifecycle operations. */
+export type HandoffEvent =
+  | { readonly kind: "handoff:prepared"; readonly envelope: HandoffEnvelope }
+  | { readonly kind: "handoff:injected"; readonly handoffId: HandoffId }
+  | {
+      readonly kind: "handoff:accepted";
+      readonly handoffId: HandoffId;
+      readonly warnings: readonly string[];
+    }
+  | { readonly kind: "handoff:expired"; readonly handoffId: HandoffId };
+
+// ---------------------------------------------------------------------------
+// Handoff accept result
+// ---------------------------------------------------------------------------
+
+/** Error codes for handoff acceptance failures. */
+export type HandoffAcceptError =
+  | { readonly code: "NOT_FOUND"; readonly handoffId: string }
+  | { readonly code: "ALREADY_ACCEPTED"; readonly handoffId: string }
+  | { readonly code: "TARGET_MISMATCH"; readonly expected: string; readonly actual: string }
+  | { readonly code: "EXPIRED"; readonly handoffId: string };
+
+/** Result of accepting a handoff envelope. */
+export type HandoffAcceptResult =
+  | {
+      readonly ok: true;
+      readonly envelope: HandoffEnvelope;
+      readonly warnings: readonly string[];
+    }
+  | { readonly ok: false; readonly error: HandoffAcceptError };
+
+// ---------------------------------------------------------------------------
+// Handoff component (ECS singleton)
+// ---------------------------------------------------------------------------
+
+/** ECS component interface for handoff operations on an agent. */
+export interface HandoffComponent {
+  readonly prepare: (
+    envelope: Omit<HandoffEnvelope, "id" | "status" | "createdAt">,
+  ) => Promise<HandoffEnvelope>;
+  readonly accept: (handoffId: HandoffId) => Promise<HandoffAcceptResult>;
+  readonly get: (handoffId: HandoffId) => HandoffEnvelope | undefined;
+  readonly list: () => readonly HandoffEnvelope[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,6 +216,7 @@ export {
   EVENTS,
   FILESYSTEM,
   GOVERNANCE,
+  HANDOFF,
   MEMORY,
   middlewareToken,
   runId,
@@ -313,6 +314,20 @@ export type {
 } from "./governance.js";
 // governance — runtime values
 export { GOVERNANCE_VARIABLES, governanceContributorToken } from "./governance.js";
+// handoff — types
+export type {
+  ArtifactRef,
+  DecisionRecord,
+  HandoffAcceptError,
+  HandoffAcceptResult,
+  HandoffComponent,
+  HandoffEnvelope,
+  HandoffEvent,
+  HandoffId,
+  HandoffStatus,
+} from "./handoff.js";
+// handoff — runtime values
+export { handoffId } from "./handoff.js";
 // health
 export type {
   HealthMonitor,

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     "src/context.ts",
     "src/delegation.ts",
     "src/ecs.ts",
+    "src/handoff.ts",
     "src/engine.ts",
     "src/event-backend.ts",
     "src/errors.ts",

--- a/packages/handoff/package.json
+++ b/packages/handoff/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/handoff",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-loop": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/handoff/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/handoff/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,161 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/handoff API surface . has stable type surface 1`] = `
+"import { HandoffEnvelope, HandoffId, HandoffStatus, AgentId, AgentRegistry, HandoffEvent, Tool, ToolDescriptor, KoiMiddleware, ComponentProvider, JsonObject, ArtifactRef } from '@koi/core';
+
+/**
+ * HandoffStore — thin wrapper around Map<HandoffId, HandoffEnvelope>
+ * with CAS status transitions and registry-bound cleanup.
+ */
+
+interface HandoffStore {
+    readonly put: (envelope: HandoffEnvelope) => void;
+    readonly get: (id: HandoffId) => HandoffEnvelope | undefined;
+    /** CAS status transition. Returns updated envelope or undefined on mismatch. */
+    readonly transition: (id: HandoffId, from: HandoffStatus, to: HandoffStatus) => HandoffEnvelope | undefined;
+    readonly listByAgent: (agentId: AgentId) => readonly HandoffEnvelope[];
+    readonly remove: (id: HandoffId) => boolean;
+    readonly removeByAgent: (agentId: AgentId) => void;
+    readonly findPendingForAgent: (agentId: AgentId) => HandoffEnvelope | undefined;
+    /** Bind to AgentRegistry — removes envelopes when agents terminate. */
+    readonly bindRegistry: (registry: AgentRegistry) => void;
+    readonly dispose: () => void;
+}
+declare function createHandoffStore(): HandoffStore;
+
+/**
+ * accept_handoff tool factory — creates a Tool that accepts and
+ * unpacks a HandoffEnvelope, returning full context to the agent.
+ */
+
+interface CreateAcceptToolConfig {
+    readonly store: HandoffStore;
+    readonly agentId: AgentId;
+    readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+declare function createAcceptTool(config: CreateAcceptToolConfig): Tool;
+
+/**
+ * Configuration types and tool descriptors for @koi/handoff.
+ */
+
+/** Configuration for the handoff provider and its tools/middleware. */
+interface HandoffConfig {
+    readonly store: HandoffStore;
+    /** Current agent's ID (used for target matching on accept). */
+    readonly agentId: AgentId;
+    /** Optional registry for cleanup on agent termination. */
+    readonly registry?: AgentRegistry | undefined;
+    /** Optional event listener for handoff lifecycle events. */
+    readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+/** Configuration for the handoff middleware. */
+interface HandoffMiddlewareConfig {
+    readonly store: HandoffStore;
+    /** Current agent's ID (used to find pending envelopes). */
+    readonly agentId: AgentId;
+    /** Optional event listener for injection events. */
+    readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+declare const PREPARE_HANDOFF_DESCRIPTOR: ToolDescriptor;
+declare const ACCEPT_HANDOFF_DESCRIPTOR: ToolDescriptor;
+
+/**
+ * HandoffMiddleware — injects handoff context into the first model call
+ * and attaches metadata on every turn.
+ */
+
+/**
+ * Creates middleware that:
+ * 1. Injects handoffId + handoffPhase into turn metadata (every turn)
+ * 2. Prepends a summary system message on the first model call (once)
+ * 3. Transitions envelope status from pending → injected
+ */
+declare function createHandoffMiddleware(config: HandoffMiddlewareConfig): KoiMiddleware;
+
+/**
+ * prepare_handoff tool factory — creates a Tool that packages work
+ * into a typed HandoffEnvelope for the next agent.
+ */
+
+interface CreatePrepareToolConfig {
+    readonly store: HandoffStore;
+    readonly agentId: AgentId;
+    readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+declare function createPrepareTool(config: CreatePrepareToolConfig): Tool;
+
+/**
+ * ComponentProvider that attaches handoff tools to an agent.
+ */
+
+/**
+ * Creates a ComponentProvider that attaches prepare_handoff and
+ * accept_handoff tools. Optionally binds the store to the registry
+ * for cleanup on agent termination.
+ *
+ * Tools are created once and cached — subsequent attach() calls
+ * return the same instances.
+ */
+declare function createHandoffProvider(config: HandoffConfig): ComponentProvider;
+
+/**
+ * Generate concise prompt summaries from handoff envelopes.
+ */
+
+/**
+ * Generate a system prompt summary from a handoff envelope.
+ * Designed to be ~200-400 tokens — enough context for the agent
+ * to understand its task without overloading the context window.
+ * Full details are available via the accept_handoff tool.
+ */
+declare function generateHandoffSummary(envelope: HandoffEnvelope): string;
+
+/**
+ * Validation functions for handoff envelope input and artifact references.
+ */
+
+interface PrepareInput {
+    readonly to: string;
+    readonly completed: string;
+    readonly next: string;
+    readonly results?: JsonObject | undefined;
+    readonly artifacts?: readonly ArtifactRef[] | undefined;
+    readonly decisions?: readonly {
+        readonly agentId: string;
+        readonly action: string;
+        readonly reasoning: string;
+        readonly timestamp: number;
+        readonly toolCallId?: string | undefined;
+    }[] | undefined;
+    readonly warnings?: readonly string[] | undefined;
+    readonly delegation?: unknown | undefined;
+    readonly metadata?: JsonObject | undefined;
+}
+type ValidatePrepareResult = {
+    readonly ok: true;
+    readonly value: PrepareInput;
+} | {
+    readonly ok: false;
+    readonly message: string;
+};
+/** Validate and extract prepare_handoff tool input. */
+declare function validatePrepareInput(args: JsonObject): ValidatePrepareResult;
+type ValidateAcceptResult = {
+    readonly ok: true;
+    readonly handoffId: string;
+} | {
+    readonly ok: false;
+    readonly message: string;
+};
+/** Validate accept_handoff tool input. */
+declare function validateAcceptInput(args: JsonObject): ValidateAcceptResult;
+/**
+ * Validate artifact references. Returns warnings for unsupported or
+ * inaccessible URIs — does not hard-fail (Decision #14).
+ */
+declare function validateArtifactRefs(refs: readonly ArtifactRef[]): readonly string[];
+
+export { ACCEPT_HANDOFF_DESCRIPTOR, type CreateAcceptToolConfig, type CreatePrepareToolConfig, type HandoffConfig, type HandoffMiddlewareConfig, type HandoffStore, PREPARE_HANDOFF_DESCRIPTOR, type PrepareInput, type ValidateAcceptResult, type ValidatePrepareResult, createAcceptTool, createHandoffMiddleware, createHandoffProvider, createHandoffStore, createPrepareTool, generateHandoffSummary, validateAcceptInput, validateArtifactRefs, validatePrepareInput };
+"
+`;

--- a/packages/handoff/src/__tests__/api-surface.test.ts
+++ b/packages/handoff/src/__tests__/api-surface.test.ts
@@ -1,0 +1,42 @@
+/**
+ * API surface stability tests for @koi/handoff.
+ *
+ * Reads every subpath export from package.json, loads the corresponding
+ * .d.ts file from dist/, and snapshots it. Any unintended type signature
+ * change will cause a snapshot diff.
+ *
+ * Requires a prior `turbo build` so dist/ is populated.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe("@koi/handoff API surface", () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/handoff/src/__tests__/e2e-real-llm.test.ts
+++ b/packages/handoff/src/__tests__/e2e-real-llm.test.ts
@@ -1,0 +1,634 @@
+/**
+ * Real-LLM E2E test for @koi/handoff.
+ *
+ * Goes through the full createKoi + createLoopAdapter path with a custom
+ * modelCall that passes tool schemas to the Anthropic API and parses
+ * tool_use responses — proving the handoff tools + middleware chain work
+ * end-to-end with a real LLM.
+ *
+ * Test scenario: Agent A prepares handoff → Agent B receives injected
+ * context via middleware → Agent B accepts handoff via tool call.
+ *
+ * Gated on ANTHROPIC_API_KEY + E2E_TESTS=1.
+ *
+ * Run: E2E_TESTS=1 bun --env-file=/path/to/.env test e2e-real-llm
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  EngineEvent,
+  EngineOutput,
+  HandoffEvent,
+  JsonObject,
+  ModelRequest,
+  ModelResponse,
+  ToolDescriptor,
+} from "@koi/core";
+import { agentId, handoffId } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { createHandoffMiddleware } from "../middleware.js";
+import { createHandoffProvider } from "../provider.js";
+import { createHandoffStore, type HandoffStore } from "../store.js";
+
+// ---------------------------------------------------------------------------
+// Gate on API key + E2E_TESTS env var
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+
+// ---------------------------------------------------------------------------
+// Anthropic API types (tool calling)
+// ---------------------------------------------------------------------------
+
+interface AnthropicToolParam {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: JsonObject;
+}
+
+interface AnthropicTextBlock {
+  readonly type: "text";
+  readonly text: string;
+}
+
+interface AnthropicToolUseBlock {
+  readonly type: "tool_use";
+  readonly id: string;
+  readonly name: string;
+  readonly input: JsonObject;
+}
+
+type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+interface AnthropicToolResultBlock {
+  readonly type: "tool_result";
+  readonly tool_use_id: string;
+  readonly content: string;
+}
+
+type AnthropicMessageContent =
+  | string
+  | readonly (AnthropicContentBlock | AnthropicToolResultBlock)[];
+
+interface AnthropicMessage {
+  readonly role: "user" | "assistant";
+  readonly content: AnthropicMessageContent;
+}
+
+interface AnthropicApiResponse {
+  readonly id: string;
+  readonly model: string;
+  readonly content: readonly AnthropicContentBlock[];
+  readonly stop_reason: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
+  readonly usage: { readonly input_tokens: number; readonly output_tokens: number };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic API bridge (tool-aware modelCall)
+// ---------------------------------------------------------------------------
+
+function createAnthropicModelCall(
+  apiKey: string,
+  toolDescriptors: readonly ToolDescriptor[],
+): (request: ModelRequest) => Promise<ModelResponse> {
+  const tools: readonly AnthropicToolParam[] = toolDescriptors.map((t) => ({
+    name: t.name,
+    description: t.description ?? "",
+    input_schema: t.inputSchema ?? ({ type: "object", properties: {} } as JsonObject),
+  }));
+
+  return async (request: ModelRequest): Promise<ModelResponse> => {
+    const messages = mapMessagesToAnthropic(request.messages);
+
+    const body = {
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 4096,
+      messages,
+      tools,
+    };
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(`Anthropic API ${String(response.status)}: ${errorText}`);
+    }
+
+    const json = (await response.json()) as AnthropicApiResponse;
+    return mapAnthropicToModelResponse(json);
+  };
+}
+
+/**
+ * Convert Koi InboundMessage[] to Anthropic message format.
+ * Handles user, assistant (with tool_use), tool result, and system messages.
+ */
+function mapMessagesToAnthropic(
+  messages: readonly {
+    readonly content: readonly { readonly kind: string; readonly text?: string }[];
+    readonly senderId?: string;
+    readonly metadata?: JsonObject;
+  }[],
+): readonly AnthropicMessage[] {
+  const result: AnthropicMessage[] = [];
+
+  for (const msg of messages) {
+    const text = msg.content
+      .filter((b) => b.kind === "text" && typeof b.text === "string")
+      .map((b) => b.text ?? "")
+      .join("");
+
+    if (msg.senderId === "tool") {
+      // Tool result — pair with preceding assistant message
+      const callId = (msg.metadata?.callId as string) ?? "";
+      const toolResult: AnthropicToolResultBlock = {
+        type: "tool_result",
+        tool_use_id: callId,
+        content: text,
+      };
+
+      const last = result[result.length - 1];
+      if (last !== undefined && last.role === "user" && Array.isArray(last.content)) {
+        result[result.length - 1] = {
+          role: "user",
+          content: [...(last.content as readonly AnthropicToolResultBlock[]), toolResult],
+        };
+      } else {
+        result.push({ role: "user", content: [toolResult] });
+      }
+    } else if (msg.senderId === "assistant") {
+      // Assistant — check for tool calls in metadata
+      const toolCalls = msg.metadata?.toolCalls as
+        | readonly {
+            readonly toolName: string;
+            readonly callId: string;
+            readonly input: JsonObject;
+          }[]
+        | undefined;
+
+      if (toolCalls !== undefined && toolCalls.length > 0) {
+        const content: AnthropicContentBlock[] = [];
+        if (text.length > 0) {
+          content.push({ type: "text", text });
+        }
+        for (const tc of toolCalls) {
+          content.push({
+            type: "tool_use",
+            id: tc.callId,
+            name: tc.toolName,
+            input: tc.input,
+          });
+        }
+        result.push({ role: "assistant", content });
+      } else {
+        result.push({ role: "assistant", content: text });
+      }
+    } else {
+      // User or system message — both go as "user" role
+      result.push({ role: "user", content: text });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert Anthropic API response to Koi ModelResponse.
+ * Extracts tool_use blocks into metadata.toolCalls.
+ */
+function mapAnthropicToModelResponse(response: AnthropicApiResponse): ModelResponse {
+  const textParts: string[] = [];
+  const toolCalls: {
+    readonly toolName: string;
+    readonly callId: string;
+    readonly input: JsonObject;
+  }[] = [];
+
+  for (const block of response.content) {
+    if (block.type === "text") {
+      textParts.push(block.text);
+    } else if (block.type === "tool_use") {
+      toolCalls.push({
+        toolName: block.name,
+        callId: block.id,
+        input: block.input,
+      });
+    }
+  }
+
+  return {
+    content: textParts.join(""),
+    model: response.model,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+    ...(toolCalls.length > 0
+      ? { metadata: { toolCalls: toolCalls as unknown as JsonObject[] } as JsonObject }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function findToolCallStarts(
+  events: readonly EngineEvent[],
+): readonly (EngineEvent & { readonly kind: "tool_call_start" })[] {
+  return events.filter(
+    (e): e is EngineEvent & { readonly kind: "tool_call_start" } => e.kind === "tool_call_start",
+  );
+}
+
+function findToolCallEnds(
+  events: readonly EngineEvent[],
+): readonly (EngineEvent & { readonly kind: "tool_call_end" })[] {
+  return events.filter(
+    (e): e is EngineEvent & { readonly kind: "tool_call_end" } => e.kind === "tool_call_end",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Two-phase assembly helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a real-LLM runtime with handoff tools (and optionally middleware).
+ *
+ * Phase 1: Discover tool descriptors via dummy assembly.
+ * Phase 2: Create real runtime with tool-aware Anthropic model call.
+ */
+async function createHandoffRuntime(opts: {
+  readonly agentIdStr: string;
+  readonly store: HandoffStore;
+  readonly onEvent: (e: HandoffEvent) => void;
+  readonly withMiddleware: boolean;
+  readonly maxTurns: number;
+}): Promise<Awaited<ReturnType<typeof createKoi>>> {
+  const id = agentId(opts.agentIdStr);
+
+  // Phase 1: Assemble to discover tool descriptors
+  const discoveryProvider = createHandoffProvider({
+    store: opts.store,
+    agentId: id,
+    onEvent: opts.onEvent,
+  });
+
+  const discoveryAdapter = createLoopAdapter({
+    modelCall: async () => ({ content: "noop", model: "discovery" }),
+    maxTurns: 1,
+  });
+
+  const discoveryRuntime = await createKoi({
+    manifest: { name: "discovery", version: "0.0.0", model: { name: "discovery" } },
+    adapter: discoveryAdapter,
+    providers: [discoveryProvider],
+    loopDetection: false,
+  });
+
+  // Extract tool descriptors from the assembled agent
+  const toolDescriptors: ToolDescriptor[] = [];
+  for (const [key, value] of discoveryRuntime.agent.components()) {
+    if (key.startsWith("tool:")) {
+      const tool = value as { readonly descriptor: ToolDescriptor };
+      toolDescriptors.push(tool.descriptor);
+    }
+  }
+
+  await discoveryRuntime.dispose();
+
+  // Phase 2: Create real runtime with tool-aware model call
+  const modelCall = createAnthropicModelCall(ANTHROPIC_KEY, toolDescriptors);
+  const adapter = createLoopAdapter({ modelCall, maxTurns: opts.maxTurns });
+
+  // Fresh provider for the real runtime
+  const realProvider = createHandoffProvider({
+    store: opts.store,
+    agentId: id,
+    onEvent: opts.onEvent,
+  });
+
+  // Optionally add handoff middleware
+  const middleware = opts.withMiddleware
+    ? [
+        createHandoffMiddleware({
+          store: opts.store,
+          agentId: id,
+          onEvent: opts.onEvent,
+        }),
+      ]
+    : [];
+
+  const runtime = await createKoi({
+    manifest: { name: opts.agentIdStr, version: "1.0.0", model: { name: "claude-haiku" } },
+    adapter,
+    providers: [realProvider],
+    middleware,
+    loopDetection: false,
+  });
+
+  return runtime;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: handoff pipeline with real Anthropic LLM", () => {
+  test(
+    "Agent A prepares handoff → Agent B receives context injection + accepts",
+    async () => {
+      const store = createHandoffStore();
+      const events: HandoffEvent[] = [];
+      const onEvent = (e: HandoffEvent): void => {
+        events.push(e);
+      };
+
+      // -----------------------------------------------------------------
+      // Agent A: prepare_handoff via real LLM tool call
+      // -----------------------------------------------------------------
+      const runtimeA = await createHandoffRuntime({
+        agentIdStr: "agent-a",
+        store,
+        onEvent,
+        withMiddleware: false,
+        maxTurns: 3,
+      });
+
+      const eventsA = await collectEvents(
+        runtimeA.run({
+          kind: "text",
+          text: [
+            "You have a prepare_handoff tool. Call it immediately with these exact parameters:",
+            '- to: "agent-b"',
+            '- completed: "Analyzed user data and identified key patterns"',
+            '- next: "Generate the final report based on the analysis results"',
+            '- results: {"summary": "data analyzed", "count": 42}',
+            '- warnings: ["Watch out for edge cases in date parsing"]',
+            "Do NOT explain. Just call the tool.",
+          ].join("\n"),
+        }),
+      );
+
+      const outputA = findDoneOutput(eventsA);
+      expect(outputA).toBeDefined();
+
+      // Verify prepare_handoff was called (toolName is on tool_call_start, not tool_call_end)
+      const toolStartsA = findToolCallStarts(eventsA);
+      const prepareCall = toolStartsA.find((e) => e.toolName === "prepare_handoff");
+      expect(prepareCall).toBeDefined();
+      expect(findToolCallEnds(eventsA).length).toBeGreaterThanOrEqual(1);
+
+      // Verify envelope was created in the store
+      const allEnvelopes = store.listByAgent(agentId("agent-a"));
+      expect(allEnvelopes.length).toBeGreaterThanOrEqual(1);
+
+      // Find the pending envelope for agent-b
+      const pendingEnvelope = store.findPendingForAgent(agentId("agent-b"));
+      expect(pendingEnvelope).toBeDefined();
+      if (pendingEnvelope === undefined) throw new Error("No pending envelope found");
+
+      expect(pendingEnvelope.from).toBe(agentId("agent-a"));
+      expect(pendingEnvelope.to).toBe(agentId("agent-b"));
+      expect(pendingEnvelope.status).toBe("pending");
+      expect(pendingEnvelope.phase.next).toContain("report");
+
+      // Verify handoff:prepared event was emitted
+      const preparedEvents = events.filter((e) => e.kind === "handoff:prepared");
+      expect(preparedEvents.length).toBeGreaterThanOrEqual(1);
+
+      await runtimeA.dispose();
+
+      // -----------------------------------------------------------------
+      // Agent B: middleware injects context + accept_handoff via LLM
+      // -----------------------------------------------------------------
+      const runtimeB = await createHandoffRuntime({
+        agentIdStr: "agent-b",
+        store,
+        onEvent,
+        withMiddleware: true, // HandoffMiddleware will inject context
+        maxTurns: 3,
+      });
+
+      const eventsB = await collectEvents(
+        runtimeB.run({
+          kind: "text",
+          text: [
+            "You have an accept_handoff tool.",
+            "You should see a Handoff Context in this conversation.",
+            "Call accept_handoff with the handoff_id shown in that context.",
+            "Do NOT explain. Just call the tool.",
+          ].join("\n"),
+        }),
+      );
+
+      const outputB = findDoneOutput(eventsB);
+      expect(outputB).toBeDefined();
+
+      // Verify accept_handoff was called (toolName is on tool_call_start)
+      const toolStartsB = findToolCallStarts(eventsB);
+      const acceptCall = toolStartsB.find((e) => e.toolName === "accept_handoff");
+      expect(acceptCall).toBeDefined();
+      expect(findToolCallEnds(eventsB).length).toBeGreaterThanOrEqual(1);
+
+      // Verify envelope status transitioned to accepted
+      const finalEnvelope = store.get(pendingEnvelope.id);
+      expect(finalEnvelope).toBeDefined();
+      expect(finalEnvelope?.status).toBe("accepted");
+
+      // Verify full event lifecycle
+      const eventKinds = events.map((e) => e.kind);
+      expect(eventKinds).toContain("handoff:prepared");
+      expect(eventKinds).toContain("handoff:injected");
+      expect(eventKinds).toContain("handoff:accepted");
+
+      // Verify ordering: prepared → injected → accepted
+      const preparedIdx = eventKinds.indexOf("handoff:prepared");
+      const injectedIdx = eventKinds.indexOf("handoff:injected");
+      const acceptedIdx = eventKinds.indexOf("handoff:accepted");
+      expect(preparedIdx).toBeLessThan(injectedIdx);
+      expect(injectedIdx).toBeLessThan(acceptedIdx);
+
+      // Verify metrics — both agents consumed tokens (proves real LLM)
+      if (outputA !== undefined) {
+        expect(outputA.metrics.inputTokens).toBeGreaterThan(0);
+        expect(outputA.metrics.outputTokens).toBeGreaterThan(0);
+      }
+      if (outputB !== undefined) {
+        expect(outputB.metrics.inputTokens).toBeGreaterThan(0);
+        expect(outputB.metrics.outputTokens).toBeGreaterThan(0);
+      }
+
+      await runtimeB.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "Agent B receives injected context summary even without tool call",
+    async () => {
+      const store = createHandoffStore();
+      const events: HandoffEvent[] = [];
+      const onEvent = (e: HandoffEvent): void => {
+        events.push(e);
+      };
+
+      // Manually create an envelope in the store (simulating Agent A's prepare)
+      const envelopeId = handoffId(crypto.randomUUID());
+      store.put({
+        id: envelopeId,
+        from: agentId("agent-a"),
+        to: agentId("agent-b"),
+        status: "pending",
+        createdAt: Date.now(),
+        phase: {
+          completed: "Collected all user requirements",
+          next: "Design the system architecture",
+        },
+        context: {
+          results: { requirements: ["auth", "api", "ui"] },
+          artifacts: [],
+          decisions: [],
+          warnings: ["Budget constraint: keep infrastructure costs low"],
+        },
+        metadata: {},
+      });
+
+      // Agent B with middleware — the LLM should see the injected context
+      const runtimeB = await createHandoffRuntime({
+        agentIdStr: "agent-b",
+        store,
+        onEvent,
+        withMiddleware: true,
+        maxTurns: 2,
+      });
+
+      const eventsB = await collectEvents(
+        runtimeB.run({
+          kind: "text",
+          text: [
+            "Look at the context you have been given.",
+            "If you see a handoff context mentioning architecture design,",
+            'reply with exactly: "HANDOFF_RECEIVED"',
+            'If you do NOT see handoff context, reply with: "NO_HANDOFF"',
+            "Do NOT call any tools. Just reply with the text.",
+          ].join("\n"),
+        }),
+      );
+
+      const outputB = findDoneOutput(eventsB);
+      expect(outputB).toBeDefined();
+
+      // The middleware should have injected context and emitted handoff:injected
+      const injectedEvents = events.filter((e) => e.kind === "handoff:injected");
+      expect(injectedEvents.length).toBe(1);
+
+      // Verify envelope was transitioned (LLM may also call accept_handoff proactively)
+      const envelope = store.get(envelopeId);
+      const status = envelope?.status;
+      expect(status === "injected" || status === "accepted").toBe(true);
+
+      // The LLM should have seen the handoff context (check text response)
+      const textDeltas = eventsB
+        .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+        .map((e) => e.delta)
+        .join("");
+
+      // The LLM should respond acknowledging the handoff context
+      expect(textDeltas.toUpperCase()).toContain("HANDOFF_RECEIVED");
+
+      await runtimeB.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "middleware injects metadata (handoffId + handoffPhase) into turn context",
+    async () => {
+      const store = createHandoffStore();
+      const events: HandoffEvent[] = [];
+      const onEvent = (e: HandoffEvent): void => {
+        events.push(e);
+      };
+
+      // Create pending envelope
+      const envelopeId = handoffId(crypto.randomUUID());
+      store.put({
+        id: envelopeId,
+        from: agentId("agent-a"),
+        to: agentId("agent-b"),
+        status: "pending",
+        createdAt: Date.now(),
+        phase: {
+          completed: "Phase 1 done",
+          next: "Execute phase 2",
+        },
+        context: {
+          results: {},
+          artifacts: [],
+          decisions: [],
+          warnings: [],
+        },
+        metadata: {},
+      });
+
+      const runtimeB = await createHandoffRuntime({
+        agentIdStr: "agent-b",
+        store,
+        onEvent,
+        withMiddleware: true,
+        maxTurns: 2,
+      });
+
+      const engineEvents = await collectEvents(
+        runtimeB.run({
+          kind: "text",
+          text: "Reply with exactly: OK",
+        }),
+      );
+
+      const output = findDoneOutput(engineEvents);
+      expect(output).toBeDefined();
+
+      // Verify middleware emitted handoff:injected
+      expect(events.some((e) => e.kind === "handoff:injected")).toBe(true);
+
+      // Verify envelope was transitioned (LLM may also call accept_handoff proactively)
+      const finalStatus = store.get(envelopeId)?.status;
+      expect(finalStatus === "injected" || finalStatus === "accepted").toBe(true);
+
+      await runtimeB.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/handoff/src/__tests__/pipeline.test.ts
+++ b/packages/handoff/src/__tests__/pipeline.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration test — simulates a 3-agent pipeline with handoff envelopes.
+ *
+ * Agent A → prepare_handoff → Agent B → accept + prepare → Agent C → accept
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { HandoffEvent, JsonObject, ModelResponse } from "@koi/core";
+import { agentId, handoffId } from "@koi/core";
+import { createMockTurnContext } from "@koi/test-utils";
+import { createAcceptTool } from "../accept-tool.js";
+import { createHandoffMiddleware } from "../middleware.js";
+import { createPrepareTool } from "../prepare-tool.js";
+import { createHandoffStore } from "../store.js";
+
+const MOCK_RESPONSE: ModelResponse = { content: "ok", model: "test" };
+
+describe("3-agent pipeline integration", () => {
+  test("envelopes flow through A → B → C with correct status transitions", async () => {
+    const store = createHandoffStore();
+    const events: HandoffEvent[] = [];
+    const onEvent = (e: HandoffEvent): void => {
+      events.push(e);
+    };
+
+    // -----------------------------------------------------------------------
+    // Agent A: prepare handoff for B
+    // -----------------------------------------------------------------------
+    const prepareA = createPrepareTool({
+      store,
+      agentId: agentId("agent-a"),
+      onEvent,
+    });
+
+    const prepareResult = await prepareA.execute({
+      to: "agent-b",
+      completed: "Collected user requirements",
+      next: "Design the architecture based on requirements",
+      results: { requirements: ["auth", "api", "ui"] },
+      artifacts: [{ id: "req-doc", kind: "file", uri: "file:///workspace/requirements.md" }],
+      decisions: [
+        {
+          agentId: "agent-a",
+          action: "chose_framework",
+          reasoning: "React is best for this use case",
+          timestamp: Date.now(),
+        },
+      ],
+      warnings: ["Budget constraint: keep it simple"],
+    } as JsonObject);
+
+    const envelopeIdAB = (prepareResult as { handoffId: string }).handoffId;
+    expect(envelopeIdAB).toBeDefined();
+    expect(events[0]?.kind).toBe("handoff:prepared");
+
+    // -----------------------------------------------------------------------
+    // Agent B: middleware injects summary, then accept + prepare for C
+    // -----------------------------------------------------------------------
+    const middlewareB = createHandoffMiddleware({
+      store,
+      agentId: agentId("agent-b"),
+      onEvent,
+    });
+
+    // Simulate first model call — middleware injects summary
+    const ctxB = createMockTurnContext();
+    await middlewareB.onBeforeTurn?.(ctxB);
+
+    const metaB = ctxB.metadata as Record<string, unknown>;
+    expect(metaB.handoffId).toBe(envelopeIdAB);
+    expect(metaB.handoffPhase).toBe("Design the architecture based on requirements");
+
+    // wrapModelCall injects summary
+    let injectedRequest: { messages: readonly unknown[] } | undefined;
+    await middlewareB.wrapModelCall?.(ctxB, { messages: [], model: "test" }, async (req) => {
+      injectedRequest = req;
+      return MOCK_RESPONSE;
+    });
+
+    expect(injectedRequest?.messages.length).toBe(1); // system message prepended
+    expect(store.get(handoffId(envelopeIdAB))?.status).toBe("injected");
+
+    // Agent B accepts the handoff
+    const acceptB = createAcceptTool({
+      store,
+      agentId: agentId("agent-b"),
+      onEvent,
+    });
+
+    const acceptResultB = (await acceptB.execute({
+      handoff_id: envelopeIdAB,
+    } as JsonObject)) as Record<string, unknown>;
+    expect(acceptResultB.handoffId).toBe(envelopeIdAB);
+    expect(acceptResultB.results).toEqual({ requirements: ["auth", "api", "ui"] });
+    expect(store.get(handoffId(envelopeIdAB))?.status).toBe("accepted");
+
+    // Agent B prepares handoff for C
+    const prepareB = createPrepareTool({
+      store,
+      agentId: agentId("agent-b"),
+      onEvent,
+    });
+
+    const prepareResultBC = await prepareB.execute({
+      to: "agent-c",
+      completed: "Designed architecture: microservices with API gateway",
+      next: "Implement the architecture",
+      results: {
+        architecture: "microservices",
+        services: ["auth-service", "api-gateway", "ui-service"],
+      },
+      warnings: [
+        "Budget constraint: keep it simple",
+        "Use existing auth library, don't build from scratch",
+      ],
+    } as JsonObject);
+
+    const envelopeIdBC = (prepareResultBC as { handoffId: string }).handoffId;
+    expect(envelopeIdBC).toBeDefined();
+
+    // -----------------------------------------------------------------------
+    // Agent C: middleware injects, then accept
+    // -----------------------------------------------------------------------
+    const middlewareC = createHandoffMiddleware({
+      store,
+      agentId: agentId("agent-c"),
+      onEvent,
+    });
+
+    const ctxC = createMockTurnContext();
+    await middlewareC.onBeforeTurn?.(ctxC);
+
+    const metaC = ctxC.metadata as Record<string, unknown>;
+    expect(metaC.handoffId).toBe(envelopeIdBC);
+
+    // wrapModelCall injects summary
+    await middlewareC.wrapModelCall?.(
+      ctxC,
+      { messages: [], model: "test" },
+      async () => MOCK_RESPONSE,
+    );
+
+    expect(store.get(handoffId(envelopeIdBC))?.status).toBe("injected");
+
+    // Agent C accepts
+    const acceptC = createAcceptTool({
+      store,
+      agentId: agentId("agent-c"),
+      onEvent,
+    });
+
+    const acceptResultC = (await acceptC.execute({
+      handoff_id: envelopeIdBC,
+    } as JsonObject)) as Record<string, unknown>;
+    expect(acceptResultC.handoffId).toBe(envelopeIdBC);
+    expect(acceptResultC.results).toEqual({
+      architecture: "microservices",
+      services: ["auth-service", "api-gateway", "ui-service"],
+    });
+    expect(store.get(handoffId(envelopeIdBC))?.status).toBe("accepted");
+
+    // -----------------------------------------------------------------------
+    // Verify event sequence
+    // -----------------------------------------------------------------------
+    const eventKinds = events.map((e) => e.kind);
+    expect(eventKinds).toEqual([
+      "handoff:prepared", // A prepares for B
+      "handoff:injected", // B's middleware injects
+      "handoff:accepted", // B accepts
+      "handoff:prepared", // B prepares for C
+      "handoff:injected", // C's middleware injects
+      "handoff:accepted", // C accepts
+    ]);
+
+    // Verify warnings accumulated through pipeline
+    const _cWarnings = (acceptResultC.warnings as readonly string[]) ?? [];
+    // Agent B forwarded budget constraint + added its own warning
+    const bEnvelope = store.get(handoffId(envelopeIdBC));
+    expect(bEnvelope).toBeDefined();
+    expect(bEnvelope?.context.warnings).toContain("Budget constraint: keep it simple");
+    expect(bEnvelope?.context.warnings).toContain(
+      "Use existing auth library, don't build from scratch",
+    );
+  });
+});

--- a/packages/handoff/src/accept-tool.test.ts
+++ b/packages/handoff/src/accept-tool.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { HandoffEnvelope, HandoffEvent, JsonObject } from "@koi/core";
+import { agentId, handoffId } from "@koi/core";
+import { createAcceptTool } from "./accept-tool.js";
+import { createHandoffStore, type HandoffStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestEnvelope(overrides?: Partial<HandoffEnvelope>): HandoffEnvelope {
+  return {
+    id: handoffId("hoff-1"),
+    from: agentId("agent-a"),
+    to: agentId("agent-b"),
+    status: "pending",
+    createdAt: Date.now(),
+    phase: { completed: "phase 1 done", next: "do phase 2" },
+    context: {
+      results: { answer: 42 },
+      artifacts: [],
+      decisions: [],
+      warnings: [],
+    },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("accept_handoff tool", () => {
+  let store: HandoffStore;
+  const events: HandoffEvent[] = [];
+
+  beforeEach(() => {
+    store = createHandoffStore();
+    events.length = 0;
+  });
+
+  function makeTool(targetAgentId = "agent-b"): ReturnType<typeof createAcceptTool> {
+    return createAcceptTool({
+      store,
+      agentId: agentId(targetAgentId),
+      onEvent: (e) => {
+        events.push(e);
+      },
+    });
+  }
+
+  test("accepts pending envelope and returns full context", async () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.handoffId).toBe("hoff-1");
+    expect(result.from).toBe("agent-a");
+    expect(result.results).toEqual({ answer: 42 });
+    expect(result.phase).toEqual({ completed: "phase 1 done", next: "do phase 2" });
+
+    // Verify status transitioned
+    const stored = store.get(handoffId("hoff-1"));
+    expect(stored?.status).toBe("accepted");
+  });
+
+  test("emits handoff:accepted event", async () => {
+    store.put(createTestEnvelope());
+
+    const tool = makeTool();
+    await tool.execute({ handoff_id: "hoff-1" } as JsonObject);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("handoff:accepted");
+  });
+
+  test("returns NOT_FOUND for missing envelope", async () => {
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "nonexistent" } as JsonObject)) as {
+      output: null;
+      metadata: { error: { code: string } };
+    };
+
+    expect(result.output).toBeNull();
+    expect(result.metadata.error.code).toBe("NOT_FOUND");
+  });
+
+  test("returns ALREADY_ACCEPTED for accepted envelope", async () => {
+    store.put(createTestEnvelope({ status: "accepted" }));
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as {
+      output: null;
+      metadata: { error: { code: string } };
+    };
+
+    expect(result.output).toBeNull();
+    expect(result.metadata.error.code).toBe("ALREADY_ACCEPTED");
+  });
+
+  test("returns TARGET_MISMATCH for wrong agent", async () => {
+    store.put(createTestEnvelope({ to: agentId("agent-c") }));
+
+    const tool = makeTool("agent-b");
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as {
+      output: null;
+      metadata: { error: { code: string } };
+    };
+
+    expect(result.output).toBeNull();
+    expect(result.metadata.error.code).toBe("TARGET_MISMATCH");
+  });
+
+  test("returns EXPIRED for expired envelope", async () => {
+    store.put(createTestEnvelope({ status: "expired" }));
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as {
+      output: null;
+      metadata: { error: { code: string } };
+    };
+
+    expect(result.output).toBeNull();
+    expect(result.metadata.error.code).toBe("EXPIRED");
+  });
+
+  test("returns validation error for missing handoff_id", async () => {
+    const tool = makeTool();
+    const result = (await tool.execute({} as JsonObject)) as {
+      output: null;
+      metadata: { error: { code: string } };
+    };
+
+    expect(result.output).toBeNull();
+    expect(result.metadata.error.code).toBe("VALIDATION");
+  });
+
+  test("includes artifact warnings in result", async () => {
+    const envelope = createTestEnvelope({
+      context: {
+        results: {},
+        artifacts: [{ id: "a1", kind: "data", uri: "s3://bucket/key" }],
+        decisions: [],
+        warnings: [],
+      },
+    });
+    store.put(envelope);
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as Record<
+      string,
+      unknown
+    >;
+
+    const warnings = result.warnings as readonly string[];
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("unsupported URI scheme");
+  });
+
+  test("accepts injected envelope (pending → injected → accepted)", async () => {
+    store.put(createTestEnvelope({ status: "injected" }));
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.handoffId).toBe("hoff-1");
+    expect(store.get(handoffId("hoff-1"))?.status).toBe("accepted");
+  });
+
+  test("returns delegation grant if present", async () => {
+    const mockGrant = {
+      id: "del-1",
+      issuerId: "agent-a",
+      delegateeId: "agent-b",
+      scope: { permissions: {} },
+      chainDepth: 0,
+      maxChainDepth: 3,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 3600000,
+      signature: "test-sig",
+    };
+    store.put(
+      createTestEnvelope({ delegation: mockGrant as unknown as HandoffEnvelope["delegation"] }),
+    );
+
+    const tool = makeTool();
+    const result = (await tool.execute({ handoff_id: "hoff-1" } as JsonObject)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.delegation).toBeDefined();
+  });
+});

--- a/packages/handoff/src/accept-tool.ts
+++ b/packages/handoff/src/accept-tool.ts
@@ -1,0 +1,133 @@
+/**
+ * accept_handoff tool factory — creates a Tool that accepts and
+ * unpacks a HandoffEnvelope, returning full context to the agent.
+ */
+
+import type {
+  AgentId,
+  HandoffAcceptResult,
+  HandoffEvent,
+  HandoffId,
+  JsonObject,
+  Tool,
+} from "@koi/core";
+import { handoffId } from "@koi/core";
+import type { HandoffStore } from "./store.js";
+import { ACCEPT_HANDOFF_DESCRIPTOR } from "./types.js";
+import { validateAcceptInput, validateArtifactRefs } from "./validate.js";
+
+export interface CreateAcceptToolConfig {
+  readonly store: HandoffStore;
+  readonly agentId: AgentId;
+  readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+
+export function createAcceptTool(config: CreateAcceptToolConfig): Tool {
+  return {
+    descriptor: ACCEPT_HANDOFF_DESCRIPTOR,
+    trustTier: "verified",
+
+    async execute(args: JsonObject): Promise<unknown> {
+      const validation = validateAcceptInput(args);
+      if (!validation.ok) {
+        return makeError("VALIDATION", validation.message);
+      }
+
+      const id: HandoffId = handoffId(validation.handoffId);
+      const result = accept(config, id);
+
+      if (!result.ok) {
+        const err = result.error;
+        switch (err.code) {
+          case "NOT_FOUND":
+            return makeError("NOT_FOUND", `Handoff envelope not found: ${err.handoffId}`);
+          case "ALREADY_ACCEPTED":
+            return makeError("ALREADY_ACCEPTED", `Handoff already accepted: ${err.handoffId}`);
+          case "TARGET_MISMATCH":
+            return makeError(
+              "TARGET_MISMATCH",
+              `Target mismatch: expected ${err.expected}, got ${err.actual}`,
+            );
+          case "EXPIRED":
+            return makeError("EXPIRED", `Handoff expired: ${err.handoffId}`);
+        }
+      }
+
+      config.onEvent?.({
+        kind: "handoff:accepted",
+        handoffId: id,
+        warnings: result.warnings,
+      });
+
+      return {
+        handoffId: result.envelope.id,
+        from: result.envelope.from,
+        phase: result.envelope.phase,
+        results: result.envelope.context.results,
+        artifacts: result.envelope.context.artifacts,
+        decisions: result.envelope.context.decisions,
+        warnings: result.warnings,
+        delegation: result.envelope.delegation,
+        metadata: result.envelope.metadata,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core accept logic (pure, testable)
+// ---------------------------------------------------------------------------
+
+function accept(config: CreateAcceptToolConfig, id: HandoffId): HandoffAcceptResult {
+  const envelope = config.store.get(id);
+  if (envelope === undefined) {
+    return { ok: false, error: { code: "NOT_FOUND", handoffId: id } };
+  }
+
+  if (envelope.status === "accepted") {
+    return { ok: false, error: { code: "ALREADY_ACCEPTED", handoffId: id } };
+  }
+
+  if (envelope.status === "expired") {
+    return { ok: false, error: { code: "EXPIRED", handoffId: id } };
+  }
+
+  if (envelope.to !== config.agentId) {
+    return {
+      ok: false,
+      error: {
+        code: "TARGET_MISMATCH",
+        expected: envelope.to,
+        actual: config.agentId,
+      },
+    };
+  }
+
+  // Validate artifact refs — collect warnings (not hard fail)
+  const artifactWarnings = validateArtifactRefs(envelope.context.artifacts);
+
+  // Transition: pending|injected → accepted
+  const updated = config.store.transition(envelope.id, envelope.status, "accepted");
+  if (updated === undefined) {
+    // CAS conflict — envelope changed between get and transition
+    return { ok: false, error: { code: "NOT_FOUND", handoffId: id } };
+  }
+
+  return {
+    ok: true,
+    envelope: updated,
+    warnings: artifactWarnings,
+  };
+}
+
+function makeError(
+  code: string,
+  message: string,
+): { readonly output: null; readonly metadata: JsonObject } {
+  return {
+    output: null,
+    metadata: {
+      error: { code, message, retryable: false },
+    },
+  };
+}

--- a/packages/handoff/src/index.ts
+++ b/packages/handoff/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @koi/handoff — Structured context relay for agent-to-agent baton passing (Layer 2)
+ *
+ * Provides tools (prepare_handoff, accept_handoff) and middleware for
+ * packaging and injecting typed handoff envelopes between pipeline agents.
+ *
+ * Depends on @koi/core only.
+ */
+
+// accept tool
+export type { CreateAcceptToolConfig } from "./accept-tool.js";
+export { createAcceptTool } from "./accept-tool.js";
+// middleware
+export { createHandoffMiddleware } from "./middleware.js";
+// prepare tool
+export type { CreatePrepareToolConfig } from "./prepare-tool.js";
+export { createPrepareTool } from "./prepare-tool.js";
+// provider
+export { createHandoffProvider } from "./provider.js";
+// store
+export type { HandoffStore } from "./store.js";
+export { createHandoffStore } from "./store.js";
+// summary
+export { generateHandoffSummary } from "./summary.js";
+// types
+export type { HandoffConfig, HandoffMiddlewareConfig } from "./types.js";
+export { ACCEPT_HANDOFF_DESCRIPTOR, PREPARE_HANDOFF_DESCRIPTOR } from "./types.js";
+export type { PrepareInput, ValidateAcceptResult, ValidatePrepareResult } from "./validate.js";
+// validation
+export { validateAcceptInput, validateArtifactRefs, validatePrepareInput } from "./validate.js";

--- a/packages/handoff/src/middleware.test.ts
+++ b/packages/handoff/src/middleware.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { HandoffEnvelope, HandoffEvent, ModelRequest, ModelResponse } from "@koi/core";
+import { agentId, handoffId } from "@koi/core";
+import { createMockTurnContext } from "@koi/test-utils";
+import { createHandoffMiddleware } from "./middleware.js";
+import { createHandoffStore, type HandoffStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestEnvelope(overrides?: Partial<HandoffEnvelope>): HandoffEnvelope {
+  return {
+    id: handoffId("hoff-1"),
+    from: agentId("agent-a"),
+    to: agentId("agent-b"),
+    status: "pending",
+    createdAt: Date.now(),
+    phase: { completed: "Analyzed data", next: "Generate report" },
+    context: {
+      results: { answer: 42 },
+      artifacts: [{ id: "a1", kind: "file", uri: "file:///out.json" }],
+      decisions: [],
+      warnings: ["Watch out for X"],
+    },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function createMockModelRequest(): ModelRequest {
+  return {
+    messages: [
+      {
+        senderId: "user-1",
+        timestamp: Date.now(),
+        content: [{ kind: "text", text: "Hello" }],
+      },
+    ],
+    model: "test-model",
+  };
+}
+
+const MOCK_RESPONSE: ModelResponse = {
+  content: "test response",
+  model: "test-model",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HandoffMiddleware", () => {
+  let store: HandoffStore;
+  const events: HandoffEvent[] = [];
+
+  beforeEach(() => {
+    store = createHandoffStore();
+    events.length = 0;
+  });
+
+  function makeMiddleware(targetAgentId = "agent-b"): ReturnType<typeof createHandoffMiddleware> {
+    return createHandoffMiddleware({
+      store,
+      agentId: agentId(targetAgentId),
+      onEvent: (e) => {
+        events.push(e);
+      },
+    });
+  }
+
+  describe("onBeforeTurn", () => {
+    test("injects handoffId and handoffPhase into turn metadata", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      await mw.onBeforeTurn?.(ctx);
+
+      const meta = ctx.metadata as Record<string, unknown>;
+      expect(meta.handoffId).toBe("hoff-1");
+      expect(meta.handoffPhase).toBe("Generate report");
+    });
+
+    test("does nothing when no pending envelope", async () => {
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      await mw.onBeforeTurn?.(ctx);
+
+      const meta = ctx.metadata as Record<string, unknown>;
+      expect(meta.handoffId).toBeUndefined();
+    });
+  });
+
+  describe("wrapModelCall", () => {
+    test("injects summary into first model call", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+      const request = createMockModelRequest();
+
+      // let justified: tracking passed request
+      let passedRequest: ModelRequest | undefined;
+      const next = async (req: ModelRequest): Promise<ModelResponse> => {
+        passedRequest = req;
+        return MOCK_RESPONSE;
+      };
+
+      await mw.wrapModelCall?.(ctx, request, next);
+
+      // Should have prepended system message
+      expect(passedRequest?.messages.length).toBe(2);
+      const systemMsg = passedRequest?.messages[0];
+      expect(systemMsg?.senderId).toBe("system");
+      const text = systemMsg?.content[0];
+      expect(text?.kind).toBe("text");
+      expect((text as { text: string } | undefined)?.text).toContain("Handoff Context");
+      expect((text as { text: string } | undefined)?.text).toContain("Generate report");
+      expect((text as { text: string }).text).toContain("accept_handoff");
+    });
+
+    test("transitions envelope to injected status", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      await mw.wrapModelCall?.(ctx, createMockModelRequest(), async () => MOCK_RESPONSE);
+
+      expect(store.get(handoffId("hoff-1"))?.status).toBe("injected");
+    });
+
+    test("emits handoff:injected event", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      await mw.wrapModelCall?.(ctx, createMockModelRequest(), async () => MOCK_RESPONSE);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.kind).toBe("handoff:injected");
+    });
+
+    test("does not inject on second call (closure flag)", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      // First call — injects
+      await mw.wrapModelCall?.(ctx, createMockModelRequest(), async () => MOCK_RESPONSE);
+
+      // Second call — passes through
+      let passedRequest: ModelRequest | undefined;
+      const request2 = createMockModelRequest();
+      await mw.wrapModelCall?.(ctx, request2, async (req) => {
+        passedRequest = req;
+        return MOCK_RESPONSE;
+      });
+
+      expect(passedRequest?.messages.length).toBe(1); // No system message prepended
+    });
+
+    test("passes through when no pending envelope", async () => {
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+      const request = createMockModelRequest();
+
+      let passedRequest: ModelRequest | undefined;
+      await mw.wrapModelCall?.(ctx, request, async (req) => {
+        passedRequest = req;
+        return MOCK_RESPONSE;
+      });
+
+      expect(passedRequest).toBe(request); // Same reference — no modification
+    });
+  });
+
+  describe("wrapModelStream", () => {
+    test("injects summary into first streaming call", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+      const request = createMockModelRequest();
+
+      let passedRequest: ModelRequest | undefined;
+      const next = async function* (req: ModelRequest) {
+        passedRequest = req;
+        yield { kind: "done" as const, response: MOCK_RESPONSE };
+      };
+
+      const chunks = [];
+      const stream = mw.wrapModelStream;
+      if (stream === undefined) throw new Error("wrapModelStream must be defined");
+      for await (const chunk of stream(ctx, request, next)) {
+        chunks.push(chunk);
+      }
+
+      expect(passedRequest?.messages.length).toBe(2);
+      expect(chunks).toHaveLength(1);
+    });
+
+    test("passes through on second streaming call", async () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      const stream = mw.wrapModelStream;
+      if (stream === undefined) throw new Error("wrapModelStream must be defined");
+
+      // First call
+      for await (const _ of stream(ctx, createMockModelRequest(), async function* () {
+        yield { kind: "done" as const, response: MOCK_RESPONSE };
+      })) {
+        /* drain */
+      }
+
+      // Second call
+      let passedRequest: ModelRequest | undefined;
+      const request2 = createMockModelRequest();
+      for await (const _ of stream(ctx, request2, async function* (req) {
+        passedRequest = req;
+        yield { kind: "done" as const, response: MOCK_RESPONSE };
+      })) {
+        /* drain */
+      }
+
+      expect(passedRequest?.messages.length).toBe(1); // No injection
+    });
+  });
+
+  describe("describeCapabilities", () => {
+    test("returns capability fragment when envelope exists", () => {
+      store.put(createTestEnvelope());
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      const fragment = mw.describeCapabilities?.(ctx);
+      expect(fragment).toBeDefined();
+      expect(fragment?.label).toBe("handoff");
+      expect(fragment?.description).toContain("Generate report");
+      expect(fragment?.description).toContain("accept_handoff");
+    });
+
+    test("returns undefined when no envelope", () => {
+      const mw = makeMiddleware();
+      const ctx = createMockTurnContext();
+
+      expect(mw.describeCapabilities?.(ctx)).toBeUndefined();
+    });
+  });
+
+  test("middleware has correct name and priority", () => {
+    const mw = makeMiddleware();
+    expect(mw.name).toBe("koi:handoff");
+    expect(mw.priority).toBe(400);
+  });
+});

--- a/packages/handoff/src/middleware.ts
+++ b/packages/handoff/src/middleware.ts
@@ -1,0 +1,115 @@
+/**
+ * HandoffMiddleware — injects handoff context into the first model call
+ * and attaches metadata on every turn.
+ */
+
+import type {
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelStreamHandler,
+  TurnContext,
+} from "@koi/core";
+import { generateHandoffSummary } from "./summary.js";
+import type { HandoffMiddlewareConfig } from "./types.js";
+
+/**
+ * Creates middleware that:
+ * 1. Injects handoffId + handoffPhase into turn metadata (every turn)
+ * 2. Prepends a summary system message on the first model call (once)
+ * 3. Transitions envelope status from pending → injected
+ */
+export function createHandoffMiddleware(config: HandoffMiddlewareConfig): KoiMiddleware {
+  // let justified: mutable closure flag for first-turn detection (Decision #7)
+  let injected = false;
+
+  return {
+    name: "koi:handoff",
+    priority: 400,
+
+    onBeforeTurn: async (ctx: TurnContext): Promise<void> => {
+      const envelope = config.store.findPendingForAgent(config.agentId);
+      if (envelope === undefined) return;
+
+      // Inject metadata for programmatic access
+      const meta = ctx.metadata as Record<string, unknown>;
+      meta.handoffId = envelope.id;
+      meta.handoffPhase = envelope.phase.next;
+    },
+
+    wrapModelCall: async (_ctx: TurnContext, request: ModelRequest, next: ModelHandler) => {
+      if (injected) return next(request);
+
+      const envelope = config.store.findPendingForAgent(config.agentId);
+      if (envelope === undefined) return next(request);
+
+      // First model call: inject summary
+      injected = true;
+      config.store.transition(envelope.id, envelope.status, "injected");
+
+      config.onEvent?.({ kind: "handoff:injected", handoffId: envelope.id });
+
+      const summary = generateHandoffSummary(envelope);
+      const augmented = prependSystemMessage(request, summary);
+      return next(augmented);
+    },
+
+    wrapModelStream: async function* (
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      if (injected) {
+        yield* next(request);
+        return;
+      }
+
+      const envelope = config.store.findPendingForAgent(config.agentId);
+      if (envelope === undefined) {
+        yield* next(request);
+        return;
+      }
+
+      // First model call: inject summary (streaming path)
+      injected = true;
+      config.store.transition(envelope.id, envelope.status, "injected");
+
+      config.onEvent?.({ kind: "handoff:injected", handoffId: envelope.id });
+
+      const summary = generateHandoffSummary(envelope);
+      const augmented = prependSystemMessage(request, summary);
+      yield* next(augmented);
+    },
+
+    describeCapabilities: (_ctx: TurnContext) => {
+      const envelope = config.store.findPendingForAgent(config.agentId);
+      if (envelope === undefined) return undefined;
+
+      return {
+        label: "handoff",
+        description:
+          `Handoff from ${envelope.from}: "${envelope.phase.next}". ` +
+          `Use accept_handoff tool with id="${envelope.id}" to get full context.`,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Prepend a system message to the model request's messages. */
+function prependSystemMessage(request: ModelRequest, content: string): ModelRequest {
+  const systemMessage = {
+    senderId: "system",
+    timestamp: Date.now(),
+    content: [{ kind: "text" as const, text: content }],
+  };
+
+  return {
+    ...request,
+    messages: [systemMessage, ...request.messages],
+  };
+}

--- a/packages/handoff/src/prepare-tool.test.ts
+++ b/packages/handoff/src/prepare-tool.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { HandoffEvent, JsonObject } from "@koi/core";
+import { agentId } from "@koi/core";
+import { createPrepareTool } from "./prepare-tool.js";
+import { createHandoffStore, type HandoffStore } from "./store.js";
+
+describe("prepare_handoff tool", () => {
+  let store: HandoffStore;
+  const events: HandoffEvent[] = [];
+
+  beforeEach(() => {
+    store = createHandoffStore();
+    events.length = 0;
+  });
+
+  function makeTool(): ReturnType<typeof createPrepareTool> {
+    return createPrepareTool({
+      store,
+      agentId: agentId("agent-a"),
+      onEvent: (e) => {
+        events.push(e);
+      },
+    });
+  }
+
+  test("creates envelope with valid input", async () => {
+    const tool = makeTool();
+    const result = await tool.execute({
+      to: "agent-b",
+      completed: "Analyzed the data",
+      next: "Generate report from analysis",
+    } as JsonObject);
+
+    const output = result as { handoffId: string; status: string };
+    expect(output.handoffId).toBeDefined();
+    expect(output.status).toBe("pending");
+
+    // Verify stored
+    const stored = [...store.listByAgent(agentId("agent-a"))];
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.from).toBe(agentId("agent-a"));
+    expect(stored[0]?.to).toBe(agentId("agent-b"));
+    expect(stored[0]?.status).toBe("pending");
+    expect(stored[0]?.phase.completed).toBe("Analyzed the data");
+    expect(stored[0]?.phase.next).toBe("Generate report from analysis");
+  });
+
+  test("emits handoff:prepared event", async () => {
+    const tool = makeTool();
+    await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+      next: "Continue",
+    } as JsonObject);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("handoff:prepared");
+  });
+
+  test("returns error when 'to' is missing", async () => {
+    const tool = makeTool();
+    const result = await tool.execute({
+      completed: "Done",
+      next: "Continue",
+    } as JsonObject);
+
+    expect(result).toEqual({ error: "'to' is required and must be a non-empty string" });
+  });
+
+  test("returns error when 'completed' is missing", async () => {
+    const tool = makeTool();
+    const result = await tool.execute({
+      to: "agent-b",
+      next: "Continue",
+    } as JsonObject);
+
+    expect(result).toEqual({ error: "'completed' is required and must be a non-empty string" });
+  });
+
+  test("returns error when 'next' is missing", async () => {
+    const tool = makeTool();
+    const result = await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+    } as JsonObject);
+
+    expect(result).toEqual({ error: "'next' is required and must be a non-empty string" });
+  });
+
+  test("includes artifacts and warnings in envelope", async () => {
+    const tool = makeTool();
+    await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+      next: "Continue",
+      artifacts: [{ id: "a1", kind: "file", uri: "file:///workspace/out.json" }],
+      warnings: ["Watch out for edge case X"],
+    } as JsonObject);
+
+    const stored = store.listByAgent(agentId("agent-a"));
+    expect(stored[0]?.context.artifacts).toHaveLength(1);
+    expect(stored[0]?.context.warnings).toContain("Watch out for edge case X");
+  });
+
+  test("adds artifact validation warnings", async () => {
+    const tool = makeTool();
+    await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+      next: "Continue",
+      artifacts: [{ id: "a1", kind: "data", uri: "s3://bucket/key" }],
+    } as JsonObject);
+
+    const stored = store.listByAgent(agentId("agent-a"));
+    expect(stored[0]?.context.warnings.length).toBeGreaterThan(0);
+    expect(stored[0]?.context.warnings[0]).toContain("unsupported URI scheme");
+  });
+
+  test("concurrent calls produce unique IDs", async () => {
+    const tool = makeTool();
+    const [r1, r2] = await Promise.all([
+      tool.execute({ to: "b", completed: "D1", next: "N1" } as JsonObject),
+      tool.execute({ to: "b", completed: "D2", next: "N2" } as JsonObject),
+    ]);
+
+    const id1 = (r1 as { handoffId: string }).handoffId;
+    const id2 = (r2 as { handoffId: string }).handoffId;
+    expect(id1).not.toBe(id2);
+  });
+
+  test("includes decisions in envelope", async () => {
+    const tool = makeTool();
+    await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+      next: "Continue",
+      decisions: [
+        {
+          agentId: "agent-a",
+          action: "chose_strategy",
+          reasoning: "BFS is better for this graph",
+          timestamp: Date.now(),
+        },
+      ],
+    } as JsonObject);
+
+    const stored = store.listByAgent(agentId("agent-a"));
+    expect(stored[0]?.context.decisions).toHaveLength(1);
+    expect(stored[0]?.context.decisions[0]?.action).toBe("chose_strategy");
+  });
+
+  test("includes metadata in envelope", async () => {
+    const tool = makeTool();
+    await tool.execute({
+      to: "agent-b",
+      completed: "Done",
+      next: "Continue",
+      metadata: { priority: "high" },
+    } as JsonObject);
+
+    const stored = store.listByAgent(agentId("agent-a"));
+    expect(stored[0]?.metadata).toEqual({ priority: "high" });
+  });
+});

--- a/packages/handoff/src/prepare-tool.ts
+++ b/packages/handoff/src/prepare-tool.ts
@@ -1,0 +1,86 @@
+/**
+ * prepare_handoff tool factory — creates a Tool that packages work
+ * into a typed HandoffEnvelope for the next agent.
+ */
+
+import type {
+  AgentId,
+  ArtifactRef,
+  DecisionRecord,
+  DelegationGrant,
+  HandoffEnvelope,
+  HandoffEvent,
+  HandoffId,
+  JsonObject,
+  Tool,
+} from "@koi/core";
+import { agentId, handoffId, toolCallId } from "@koi/core";
+import type { HandoffStore } from "./store.js";
+import { PREPARE_HANDOFF_DESCRIPTOR } from "./types.js";
+import { validateArtifactRefs, validatePrepareInput } from "./validate.js";
+
+export interface CreatePrepareToolConfig {
+  readonly store: HandoffStore;
+  readonly agentId: AgentId;
+  readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+
+export function createPrepareTool(config: CreatePrepareToolConfig): Tool {
+  return {
+    descriptor: PREPARE_HANDOFF_DESCRIPTOR,
+    trustTier: "verified",
+
+    async execute(args: JsonObject): Promise<unknown> {
+      const validation = validatePrepareInput(args);
+      if (!validation.ok) {
+        return { error: validation.message };
+      }
+
+      const input = validation.value;
+
+      // Validate artifact refs — collect warnings
+      const artifacts: readonly ArtifactRef[] = input.artifacts ?? [];
+      const artifactWarnings = validateArtifactRefs(artifacts);
+
+      // Map decision records to branded types
+      const decisions: readonly DecisionRecord[] = (input.decisions ?? []).map((d) => ({
+        agentId: agentId(d.agentId),
+        action: d.action,
+        reasoning: d.reasoning,
+        timestamp: d.timestamp,
+        toolCallId: d.toolCallId !== undefined ? toolCallId(d.toolCallId) : undefined,
+      }));
+
+      // Merge artifact warnings into context warnings
+      const allWarnings = [...(input.warnings ?? []), ...artifactWarnings];
+
+      const id: HandoffId = handoffId(crypto.randomUUID());
+
+      const envelope: HandoffEnvelope = {
+        id,
+        from: config.agentId,
+        to: agentId(input.to),
+        status: "pending",
+        createdAt: Date.now(),
+        phase: {
+          completed: input.completed,
+          next: input.next,
+        },
+        context: {
+          results: input.results ?? {},
+          artifacts,
+          decisions,
+          warnings: allWarnings,
+        },
+        delegation: input.delegation as DelegationGrant | undefined,
+        metadata: input.metadata ?? {},
+      };
+
+      config.store.put(envelope);
+
+      config.onEvent?.({ kind: "handoff:prepared", envelope });
+
+      return { handoffId: id, status: "pending" };
+    },
+  };
+}

--- a/packages/handoff/src/provider.ts
+++ b/packages/handoff/src/provider.ts
@@ -1,0 +1,52 @@
+/**
+ * ComponentProvider that attaches handoff tools to an agent.
+ */
+
+import type { ComponentProvider } from "@koi/core";
+import { createAcceptTool } from "./accept-tool.js";
+import { createPrepareTool } from "./prepare-tool.js";
+import type { HandoffConfig } from "./types.js";
+
+/**
+ * Creates a ComponentProvider that attaches prepare_handoff and
+ * accept_handoff tools. Optionally binds the store to the registry
+ * for cleanup on agent termination.
+ *
+ * Tools are created once and cached — subsequent attach() calls
+ * return the same instances.
+ */
+export function createHandoffProvider(config: HandoffConfig): ComponentProvider {
+  // let justified: mutable cache (set once on first attach)
+  let cached: ReadonlyMap<string, unknown> | undefined;
+
+  // Bind registry if provided (Decision #15)
+  if (config.registry !== undefined) {
+    config.store.bindRegistry(config.registry);
+  }
+
+  return {
+    name: "handoff",
+
+    async attach(): Promise<ReadonlyMap<string, unknown>> {
+      if (cached !== undefined) return cached;
+
+      const prepareTool = createPrepareTool({
+        store: config.store,
+        agentId: config.agentId,
+        onEvent: config.onEvent,
+      });
+
+      const acceptTool = createAcceptTool({
+        store: config.store,
+        agentId: config.agentId,
+        onEvent: config.onEvent,
+      });
+
+      const components = new Map<string, unknown>();
+      components.set("tool:prepare_handoff", prepareTool);
+      components.set("tool:accept_handoff", acceptTool);
+      cached = components;
+      return cached;
+    },
+  };
+}

--- a/packages/handoff/src/store.test.ts
+++ b/packages/handoff/src/store.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { HandoffEnvelope, RegistryEvent } from "@koi/core";
+import { agentId, handoffId } from "@koi/core";
+import { createHandoffStore, type HandoffStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestEnvelope(overrides?: Partial<HandoffEnvelope>): HandoffEnvelope {
+  return {
+    id: handoffId("hoff-1"),
+    from: agentId("agent-a"),
+    to: agentId("agent-b"),
+    status: "pending",
+    createdAt: Date.now(),
+    phase: { completed: "phase 1 done", next: "do phase 2" },
+    context: {
+      results: { answer: 42 },
+      artifacts: [],
+      decisions: [],
+      warnings: [],
+    },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HandoffStore", () => {
+  let store: HandoffStore;
+
+  beforeEach(() => {
+    store = createHandoffStore();
+  });
+
+  test("put and get round-trip", () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+    expect(store.get(envelope.id)).toEqual(envelope);
+  });
+
+  test("get returns undefined for unknown ID", () => {
+    expect(store.get(handoffId("nonexistent"))).toBeUndefined();
+  });
+
+  test("transition updates status immutably", () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+
+    const updated = store.transition(envelope.id, "pending", "injected");
+    expect(updated).toBeDefined();
+    expect(updated?.status).toBe("injected");
+    expect(updated?.id).toBe(envelope.id);
+
+    // Original properties preserved
+    expect(updated?.from).toBe(envelope.from);
+    expect(updated?.phase).toEqual(envelope.phase);
+  });
+
+  test("transition returns undefined on status mismatch", () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+
+    const result = store.transition(envelope.id, "accepted", "expired");
+    expect(result).toBeUndefined();
+  });
+
+  test("transition returns undefined for unknown ID", () => {
+    const result = store.transition(handoffId("nonexistent"), "pending", "injected");
+    expect(result).toBeUndefined();
+  });
+
+  test("listByAgent returns envelopes for agent", () => {
+    const e1 = createTestEnvelope({ id: handoffId("h-1"), from: agentId("a"), to: agentId("b") });
+    const e2 = createTestEnvelope({ id: handoffId("h-2"), from: agentId("b"), to: agentId("c") });
+    const e3 = createTestEnvelope({ id: handoffId("h-3"), from: agentId("x"), to: agentId("y") });
+    store.put(e1);
+    store.put(e2);
+    store.put(e3);
+
+    const results = store.listByAgent(agentId("b"));
+    expect(results).toHaveLength(2);
+    expect(results.map((e) => e.id)).toContain(handoffId("h-1"));
+    expect(results.map((e) => e.id)).toContain(handoffId("h-2"));
+  });
+
+  test("remove deletes envelope", () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+    expect(store.remove(envelope.id)).toBe(true);
+    expect(store.get(envelope.id)).toBeUndefined();
+  });
+
+  test("remove returns false for unknown ID", () => {
+    expect(store.remove(handoffId("nonexistent"))).toBe(false);
+  });
+
+  test("removeByAgent cleans up all agent envelopes", () => {
+    const e1 = createTestEnvelope({ id: handoffId("h-1"), from: agentId("a"), to: agentId("b") });
+    const e2 = createTestEnvelope({ id: handoffId("h-2"), from: agentId("b"), to: agentId("c") });
+    const e3 = createTestEnvelope({ id: handoffId("h-3"), from: agentId("x"), to: agentId("y") });
+    store.put(e1);
+    store.put(e2);
+    store.put(e3);
+
+    store.removeByAgent(agentId("b"));
+    expect(store.get(handoffId("h-1"))).toBeUndefined();
+    expect(store.get(handoffId("h-2"))).toBeUndefined();
+    expect(store.get(handoffId("h-3"))).toBeDefined();
+  });
+
+  test("findPendingForAgent finds pending envelope", () => {
+    const envelope = createTestEnvelope({ to: agentId("target") });
+    store.put(envelope);
+
+    expect(store.findPendingForAgent(agentId("target"))).toEqual(envelope);
+  });
+
+  test("findPendingForAgent finds injected envelope", () => {
+    const envelope = createTestEnvelope({ to: agentId("target"), status: "injected" });
+    store.put(envelope);
+
+    expect(store.findPendingForAgent(agentId("target"))).toEqual(envelope);
+  });
+
+  test("findPendingForAgent ignores accepted envelopes", () => {
+    const envelope = createTestEnvelope({ to: agentId("target"), status: "accepted" });
+    store.put(envelope);
+
+    expect(store.findPendingForAgent(agentId("target"))).toBeUndefined();
+  });
+
+  test("findPendingForAgent returns undefined for wrong agent", () => {
+    const envelope = createTestEnvelope({ to: agentId("other") });
+    store.put(envelope);
+
+    expect(store.findPendingForAgent(agentId("target"))).toBeUndefined();
+  });
+
+  test("bindRegistry cleans up on agent termination", () => {
+    // let justified: mutable listener tracking
+    let listener: ((event: RegistryEvent) => void) | undefined;
+    const mockRegistry = {
+      watch: (l: (event: RegistryEvent) => void) => {
+        listener = l;
+        return () => {
+          listener = undefined;
+        };
+      },
+      register: () => {
+        throw new Error("not used");
+      },
+      deregister: () => {
+        throw new Error("not used");
+      },
+      lookup: () => {
+        throw new Error("not used");
+      },
+      list: () => {
+        throw new Error("not used");
+      },
+      transition: () => {
+        throw new Error("not used");
+      },
+      [Symbol.asyncDispose]: async () => {},
+    };
+
+    store.bindRegistry(mockRegistry);
+
+    const envelope = createTestEnvelope({ from: agentId("dying-agent") });
+    store.put(envelope);
+
+    // Simulate termination
+    listener?.({
+      kind: "transitioned",
+      agentId: agentId("dying-agent"),
+      from: "running",
+      to: "terminated",
+      generation: 1,
+      reason: { kind: "completed" },
+    });
+
+    expect(store.get(envelope.id)).toBeUndefined();
+  });
+
+  test("dispose clears all state", () => {
+    const envelope = createTestEnvelope();
+    store.put(envelope);
+    store.dispose();
+    expect(store.get(envelope.id)).toBeUndefined();
+  });
+});

--- a/packages/handoff/src/store.ts
+++ b/packages/handoff/src/store.ts
@@ -1,0 +1,124 @@
+/**
+ * HandoffStore — thin wrapper around Map<HandoffId, HandoffEnvelope>
+ * with CAS status transitions and registry-bound cleanup.
+ */
+
+import type {
+  AgentId,
+  AgentRegistry,
+  HandoffEnvelope,
+  HandoffId,
+  HandoffStatus,
+  RegistryEvent,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface HandoffStore {
+  readonly put: (envelope: HandoffEnvelope) => void;
+  readonly get: (id: HandoffId) => HandoffEnvelope | undefined;
+  /** CAS status transition. Returns updated envelope or undefined on mismatch. */
+  readonly transition: (
+    id: HandoffId,
+    from: HandoffStatus,
+    to: HandoffStatus,
+  ) => HandoffEnvelope | undefined;
+  readonly listByAgent: (agentId: AgentId) => readonly HandoffEnvelope[];
+  readonly remove: (id: HandoffId) => boolean;
+  readonly removeByAgent: (agentId: AgentId) => void;
+  readonly findPendingForAgent: (agentId: AgentId) => HandoffEnvelope | undefined;
+  /** Bind to AgentRegistry — removes envelopes when agents terminate. */
+  readonly bindRegistry: (registry: AgentRegistry) => void;
+  readonly dispose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createHandoffStore(): HandoffStore {
+  const envelopes = new Map<HandoffId, HandoffEnvelope>();
+
+  // let justified: mutable registry unsubscribe callback
+  let registryUnsubscribe: (() => void) | undefined;
+
+  function put(envelope: HandoffEnvelope): void {
+    envelopes.set(envelope.id, envelope);
+  }
+
+  function get(id: HandoffId): HandoffEnvelope | undefined {
+    return envelopes.get(id);
+  }
+
+  function transition(
+    id: HandoffId,
+    from: HandoffStatus,
+    to: HandoffStatus,
+  ): HandoffEnvelope | undefined {
+    const existing = envelopes.get(id);
+    if (existing === undefined || existing.status !== from) return undefined;
+
+    const updated: HandoffEnvelope = { ...existing, status: to };
+    envelopes.set(id, updated);
+    return updated;
+  }
+
+  function listByAgent(agentId: AgentId): readonly HandoffEnvelope[] {
+    return [...envelopes.values()].filter((e) => e.from === agentId || e.to === agentId);
+  }
+
+  function remove(id: HandoffId): boolean {
+    return envelopes.delete(id);
+  }
+
+  function removeByAgent(agentId: AgentId): void {
+    for (const [id, envelope] of envelopes) {
+      if (envelope.from === agentId || envelope.to === agentId) {
+        envelopes.delete(id);
+      }
+    }
+  }
+
+  function findPendingForAgent(agentId: AgentId): HandoffEnvelope | undefined {
+    for (const envelope of envelopes.values()) {
+      if (
+        envelope.to === agentId &&
+        (envelope.status === "pending" || envelope.status === "injected")
+      ) {
+        return envelope;
+      }
+    }
+    return undefined;
+  }
+
+  function bindRegistry(registry: AgentRegistry): void {
+    registryUnsubscribe?.();
+    registryUnsubscribe = registry.watch((event: RegistryEvent) => {
+      if (event.kind === "transitioned" && event.to === "terminated") {
+        removeByAgent(event.agentId);
+      } else if (event.kind === "deregistered") {
+        removeByAgent(event.agentId);
+      }
+    });
+  }
+
+  function dispose(): void {
+    registryUnsubscribe?.();
+    registryUnsubscribe = undefined;
+    envelopes.clear();
+  }
+
+  return {
+    put,
+    get,
+    transition,
+    listByAgent,
+    remove,
+    removeByAgent,
+    findPendingForAgent,
+    bindRegistry,
+    dispose,
+  };
+}

--- a/packages/handoff/src/summary.ts
+++ b/packages/handoff/src/summary.ts
@@ -1,0 +1,47 @@
+/**
+ * Generate concise prompt summaries from handoff envelopes.
+ */
+
+import type { HandoffEnvelope } from "@koi/core";
+
+/**
+ * Generate a system prompt summary from a handoff envelope.
+ * Designed to be ~200-400 tokens — enough context for the agent
+ * to understand its task without overloading the context window.
+ * Full details are available via the accept_handoff tool.
+ */
+export function generateHandoffSummary(envelope: HandoffEnvelope): string {
+  const lines: string[] = [
+    "## Handoff Context",
+    `You are continuing work from agent \`${envelope.from}\`.`,
+    "",
+    "### Completed Phase",
+    envelope.phase.completed,
+    "",
+    "### Your Task",
+    envelope.phase.next,
+  ];
+
+  if (envelope.context.warnings.length > 0) {
+    lines.push("", "### Warnings");
+    for (const warning of envelope.context.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  const artifactCount = envelope.context.artifacts.length;
+  const decisionCount = envelope.context.decisions.length;
+
+  lines.push("", "### Available Context");
+  if (artifactCount > 0) {
+    lines.push(`- ${String(artifactCount)} artifact${artifactCount === 1 ? "" : "s"} available`);
+  }
+  if (decisionCount > 0) {
+    lines.push(`- ${String(decisionCount)} decision record${decisionCount === 1 ? "" : "s"}`);
+  }
+  lines.push(
+    `- Use \`accept_handoff\` tool with id="${envelope.id}" to retrieve full results and artifacts.`,
+  );
+
+  return lines.join("\n");
+}

--- a/packages/handoff/src/types.ts
+++ b/packages/handoff/src/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Configuration types and tool descriptors for @koi/handoff.
+ */
+
+import type { AgentId, AgentRegistry, HandoffEvent, ToolDescriptor } from "@koi/core";
+import type { HandoffStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Configuration for the handoff provider and its tools/middleware. */
+export interface HandoffConfig {
+  readonly store: HandoffStore;
+  /** Current agent's ID (used for target matching on accept). */
+  readonly agentId: AgentId;
+  /** Optional registry for cleanup on agent termination. */
+  readonly registry?: AgentRegistry | undefined;
+  /** Optional event listener for handoff lifecycle events. */
+  readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+
+/** Configuration for the handoff middleware. */
+export interface HandoffMiddlewareConfig {
+  readonly store: HandoffStore;
+  /** Current agent's ID (used to find pending envelopes). */
+  readonly agentId: AgentId;
+  /** Optional event listener for injection events. */
+  readonly onEvent?: ((event: HandoffEvent) => void) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tool descriptors
+// ---------------------------------------------------------------------------
+
+export const PREPARE_HANDOFF_DESCRIPTOR: ToolDescriptor = {
+  name: "prepare_handoff",
+  description:
+    "Package current work into a typed envelope for the next agent in a pipeline. " +
+    "Returns the envelope ID for the target agent to accept.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      to: { type: "string", description: "Target agent ID" },
+      completed: { type: "string", description: "Summary of what was accomplished" },
+      next: { type: "string", description: "Instructions for the next agent" },
+      results: { type: "object", description: "Structured results (JSON object)" },
+      artifacts: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            kind: { type: "string" },
+            uri: { type: "string" },
+            mimeType: { type: "string" },
+            metadata: { type: "object" },
+          },
+          required: ["id", "kind", "uri"],
+        },
+        description: "Artifact references (URI-based)",
+      },
+      decisions: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            agentId: { type: "string" },
+            action: { type: "string" },
+            reasoning: { type: "string" },
+            timestamp: { type: "number" },
+            toolCallId: { type: "string" },
+          },
+          required: ["agentId", "action", "reasoning", "timestamp"],
+        },
+        description: "Decision records with agent reasoning",
+      },
+      warnings: {
+        type: "array",
+        items: { type: "string" },
+        description: "Pitfalls or caveats for the next agent",
+      },
+      delegation: { type: "object", description: "Optional delegation grant to forward" },
+      metadata: { type: "object", description: "Arbitrary metadata" },
+    },
+    required: ["to", "completed", "next"],
+  },
+};
+
+export const ACCEPT_HANDOFF_DESCRIPTOR: ToolDescriptor = {
+  name: "accept_handoff",
+  description:
+    "Accept and unpack a handoff envelope. Returns full context including results, " +
+    "artifacts, decisions, and any warnings.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      handoff_id: { type: "string", description: "The handoff envelope ID to accept" },
+    },
+    required: ["handoff_id"],
+  },
+};

--- a/packages/handoff/src/validate.ts
+++ b/packages/handoff/src/validate.ts
@@ -1,0 +1,123 @@
+/**
+ * Validation functions for handoff envelope input and artifact references.
+ */
+
+import type { ArtifactRef, JsonObject } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Prepare input validation
+// ---------------------------------------------------------------------------
+
+export interface PrepareInput {
+  readonly to: string;
+  readonly completed: string;
+  readonly next: string;
+  readonly results?: JsonObject | undefined;
+  readonly artifacts?: readonly ArtifactRef[] | undefined;
+  readonly decisions?:
+    | readonly {
+        readonly agentId: string;
+        readonly action: string;
+        readonly reasoning: string;
+        readonly timestamp: number;
+        readonly toolCallId?: string | undefined;
+      }[]
+    | undefined;
+  readonly warnings?: readonly string[] | undefined;
+  readonly delegation?: unknown | undefined;
+  readonly metadata?: JsonObject | undefined;
+}
+
+export type ValidatePrepareResult =
+  | { readonly ok: true; readonly value: PrepareInput }
+  | { readonly ok: false; readonly message: string };
+
+/** Validate and extract prepare_handoff tool input. */
+export function validatePrepareInput(args: JsonObject): ValidatePrepareResult {
+  const to = args.to;
+  if (typeof to !== "string" || to.length === 0) {
+    return { ok: false, message: "'to' is required and must be a non-empty string" };
+  }
+
+  const completed = args.completed;
+  if (typeof completed !== "string" || completed.length === 0) {
+    return { ok: false, message: "'completed' is required and must be a non-empty string" };
+  }
+
+  const next = args.next;
+  if (typeof next !== "string" || next.length === 0) {
+    return { ok: false, message: "'next' is required and must be a non-empty string" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      to,
+      completed,
+      next,
+      results:
+        typeof args.results === "object" && args.results !== null
+          ? (args.results as JsonObject)
+          : undefined,
+      artifacts: Array.isArray(args.artifacts)
+        ? (args.artifacts as readonly ArtifactRef[])
+        : undefined,
+      decisions: Array.isArray(args.decisions)
+        ? (args.decisions as PrepareInput["decisions"])
+        : undefined,
+      warnings: Array.isArray(args.warnings) ? (args.warnings as readonly string[]) : undefined,
+      delegation: args.delegation,
+      metadata:
+        typeof args.metadata === "object" && args.metadata !== null
+          ? (args.metadata as JsonObject)
+          : undefined,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Accept input validation
+// ---------------------------------------------------------------------------
+
+export type ValidateAcceptResult =
+  | { readonly ok: true; readonly handoffId: string }
+  | { readonly ok: false; readonly message: string };
+
+/** Validate accept_handoff tool input. */
+export function validateAcceptInput(args: JsonObject): ValidateAcceptResult {
+  const handoffId = args.handoff_id;
+  if (typeof handoffId !== "string" || handoffId.length === 0) {
+    return { ok: false, message: "'handoff_id' is required and must be a non-empty string" };
+  }
+  return { ok: true, handoffId };
+}
+
+// ---------------------------------------------------------------------------
+// Artifact validation
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_SCHEMES = ["file://"] as const;
+
+/**
+ * Validate artifact references. Returns warnings for unsupported or
+ * inaccessible URIs — does not hard-fail (Decision #14).
+ */
+export function validateArtifactRefs(refs: readonly ArtifactRef[]): readonly string[] {
+  const warnings: string[] = [];
+
+  for (const ref of refs) {
+    if (typeof ref.uri !== "string" || ref.uri.length === 0) {
+      warnings.push(`Artifact "${ref.id}" has empty or missing URI`);
+      continue;
+    }
+
+    const hasSupported = SUPPORTED_SCHEMES.some((scheme) => ref.uri.startsWith(scheme));
+    if (!hasSupported) {
+      warnings.push(
+        `Artifact "${ref.id}" uses unsupported URI scheme: ${ref.uri.split(":")[0] ?? "unknown"}. Supported: ${SUPPORTED_SCHEMES.join(", ")}`,
+      );
+    }
+  }
+
+  return warnings;
+}

--- a/packages/handoff/tsconfig.json
+++ b/packages/handoff/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/handoff/tsup.config.ts
+++ b/packages/handoff/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements `@koi/handoff` (closes #382) — a structured context relay protocol for passing typed envelopes between agents in a pipeline.

- **L0 types** in `@koi/core`: `HandoffId`, `HandoffEnvelope`, `HandoffEvent`, `HandoffComponent`, `HandoffAcceptResult`, `HandoffAcceptError`, `DecisionRecord`, `ArtifactRef`
- **L2 package** `@koi/handoff`: store, tools (`prepare_handoff` + `accept_handoff`), middleware (priority 400, first-turn context injection), provider, validation
- **50 unit/integration tests** + 3 real-LLM E2E tests (gated behind `ANTHROPIC_API_KEY` + `E2E_TESTS=1`)
- **Comprehensive docs** at `docs/L2/handoff.md`

### How it works

```
Agent A                          HandoffStore                        Agent B
   │                                 │                                  │
   ├── prepare_handoff ──────────────▶│ status: pending                 │
   │                                 │                                  │
   │                                 │◀── middleware: onBeforeTurn ──────┤
   │                                 │    (injects metadata)            │
   │                                 │                                  │
   │                                 │◀── middleware: wrapModelCall ─────┤
   │                                 │    (prepends summary prompt)     │
   │                                 │    status: injected              │
   │                                 │                                  │
   │                                 │◀── accept_handoff ───────────────┤
   │                                 │    status: accepted              │
   │                                 │    (returns full context)        │
```

### Key design decisions

| # | Decision |
|---|----------|
| 1 | L0 types + L2 runtime (mirrors delegation pattern) |
| 2 | Summary-only prompt injection + `accept_handoff` tool for full details |
| 3 | URI-based, storage-agnostic artifact refs (`file://` for V1) |
| 4 | Closure flag + store status for first-turn detection |
| 5 | In-memory store (persistent backends tracked in #447) |

Related: #447 (persistent HandoffStore backends — Nexus + SQLite)

## Test plan

- [x] 50 unit/integration tests pass (`bun test packages/handoff/src/`)
- [x] 86.83% line coverage (exceeds 80% threshold)
- [x] Core API surface snapshot updated
- [x] Handoff API surface snapshot test
- [x] Anti-leak checklist verified (zero L0 imports, all `readonly`, L2→L0 only)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (biome, 0 issues)
- [ ] CI passes