### PR TITLE
feat: add @koi/long-running (L2) — multi-session agent harness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -528,6 +528,17 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/long-running": {
+      "name": "@koi/long-running",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/snapshot-chain-store": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/lsp": {
       "name": "@koi/lsp",
       "version": "0.0.0",
@@ -1716,6 +1727,8 @@
     "@koi/hash": ["@koi/hash@workspace:packages/hash"],
 
     "@koi/identity": ["@koi/identity@workspace:packages/identity"],
+
+    "@koi/long-running": ["@koi/long-running@workspace:packages/long-running"],
 
     "@koi/lsp": ["@koi/lsp@workspace:packages/lsp"],
 

--- a/docs/L2/long-running.md
+++ b/docs/L2/long-running.md
@@ -1,0 +1,512 @@
+# @koi/long-running — Multi-Session Agent Harness for Long-Horizon Tasks
+
+State manager for agents that operate over hours or days across multiple sessions. Tracks task progress, bridges context between sessions via structured summaries, checkpoints at meaningful task boundaries, and captures key artifacts — enabling an agent to pick up exactly where it left off after any session boundary.
+
+---
+
+## Why It Exists
+
+Single-session agents lose all context when a session ends. Crash recovery (`SessionPersistence`) restores opaque engine state, but it knows nothing about _what the agent was doing_ — which tasks are done, what was learned, or what to work on next.
+
+`@koi/long-running` adds **semantic multi-session management** on top of existing persistence primitives:
+
+- **Task tracking** — knows which tasks are pending, completed, or failed across sessions
+- **Context bridging** — builds a structured resume prompt from summaries and artifacts so the agent doesn't start blind
+- **Soft checkpoints** — saves engine state every N turns so crash recovery loses minimal work
+- **Artifact capture** — records notable tool outputs for cross-session continuity
+- **Pinned messages** — resume context is marked `pinned: true` so the compactor never erases it
+
+Without this package, every long-running agent would reinvent progress tracking, session handoff, and context reconstruction.
+
+---
+
+## Architecture
+
+`@koi/long-running` is an **L2 feature package** — it depends only on L0 (`@koi/core`). Zero external dependencies.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  @koi/long-running  (L2)                                          │
+│                                                                    │
+│  types.ts              ← Config, LongRunningHarness interface      │
+│  harness.ts            ← Factory + state machine implementation    │
+│  context-bridge.ts     ← Builds resume context from snapshots      │
+│  checkpoint-policy.ts  ← Soft checkpoint timing + ID generation    │
+│  index.ts              ← Public API surface                        │
+│                                                                    │
+├──────────────────────────────────────────────────────────────────  │
+│  Dependencies                                                      │
+│                                                                    │
+│  @koi/core  (L0)   HarnessId, HarnessSnapshot, HarnessStatus,     │
+│                     TaskBoardSnapshot, TaskItemId, TaskResult,      │
+│                     SessionPersistence, EngineInput, EngineState,   │
+│                     Result, KoiError, KoiMiddleware, InboundMessage │
+└──────────────────────────────────────────────────────────────────  ┘
+```
+
+---
+
+## How It Works
+
+The harness is a **state manager called at session boundaries by Node** — it is not a middleware or engine decorator. It owns the task plan, context summaries, and progress tracking. Engine state lives in `SessionPersistence` (crash recovery). Harness state lives in `SnapshotChainStore<HarnessSnapshot>` (semantic history).
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      External Caller (Node)                        │
+│  "start a multi-day task, pause at session end, resume tomorrow"  │
+└────────────────────────┬─────────────────────────────────────────┘
+                         │
+    start(plan) ─────────┤
+    resume() ────────────┤
+    pause(result) ───────┤
+    completeTask(id) ────┤
+    fail(error) ─────────┤
+    status() ────────────┘
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│              @koi/long-running Harness                              │
+│                                                                    │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │                  Phase State Machine                        │  │
+│  │                                                            │  │
+│  │   idle ──start()──> active ──pause()──> suspended          │  │
+│  │                       │                     │              │  │
+│  │                       │ completeTask()       │ resume()     │  │
+│  │                       │ (all done)          │              │  │
+│  │                       ▼                     ▼              │  │
+│  │                   completed             active (again)     │  │
+│  │                                                            │  │
+│  │   active/suspended ──fail()──> failed                      │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                    │
+│  ┌─────────────┐  ┌───────────────┐  ┌────────────────────────┐  │
+│  │ TaskBoard   │  │ Summaries     │  │ KeyArtifacts           │  │
+│  │ pending: 3  │  │ session 1: .. │  │ code_search @ turn 5   │  │
+│  │ done: 2     │  │ session 2: .. │  │ file_write @ turn 12   │  │
+│  └─────────────┘  └───────────────┘  └────────────────────────┘  │
+│                                                                    │
+│  Persistence:                                                      │
+│  ├─ HarnessSnapshot → SnapshotChainStore (semantic history)        │
+│  └─ EngineState     → SessionPersistence  (crash recovery)         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Multi-Session Lifecycle
+
+A typical multi-session workflow:
+
+```
+Session 1                    Session 2                    Session 3
+─────────────────────────    ─────────────────────────    ──────────────
+start(plan)                  resume()                     resume()
+  │                            │                            │
+  │ engine runs with           │ engine resumes with        │ engine resumes
+  │ harness middleware         │ context bridge OR          │ ...
+  │                            │ engine state recovery      │
+  │ onAfterTurn:               │                            │
+  │   soft checkpoint @5,10    │ completeTask("task-2")     │ completeTask("task-3")
+  │                            │                            │  → all done!
+  │ completeTask("task-1")     │                            │  → phase = completed
+  │                            │                            │
+pause(sessionResult)         pause(sessionResult)
+  │                            │
+  │ snapshot v1                │ snapshot v2
+  │ metrics merged             │ metrics merged
+  │ summary appended           │ summary appended
+  │ engine state saved         │ chain pruned
+  │                            │
+  ▼                            ▼
+ [suspended]                  [suspended]                  [completed]
+```
+
+### Resume Strategy
+
+When `resume()` is called, the harness attempts two strategies in order:
+
+1. **Engine state recovery** — loads the latest `SessionCheckpoint` from `SessionPersistence`. If found, returns `{ kind: "resume", state }` so the engine can restore its internal state. This is the "hot" path — cheapest and most accurate.
+
+2. **Context bridge fallback** — if no checkpoint exists, builds `InboundMessage[]` from the harness snapshot's task board, summaries, and artifacts. Returns `{ kind: "messages", messages }`. Messages are marked `pinned: true` to survive compaction.
+
+```
+resume()
+   │
+   ├── loadLatestCheckpoint(agentId)
+   │       │
+   │       ├── found? → { kind: "resume", state }     ← hot path
+   │       │
+   │       └── not found?
+   │               │
+   │               └── buildResumeContext(snapshot)
+   │                       │
+   │                       └── { kind: "messages", messages }  ← cold path
+   │                            (messages are pinned: true)
+   │
+   └── sessionSeq++
+```
+
+---
+
+## Middleware Hooks
+
+`harness.createMiddleware()` returns a `KoiMiddleware` named `"long-running-harness"` (priority 50) with three hooks:
+
+### onAfterTurn — Soft Checkpoints
+
+Every `softCheckpointInterval` turns (default: 5), fires a soft checkpoint to `SessionPersistence`. If `saveState` callback is provided, captures real engine state; otherwise uses a placeholder.
+
+```
+Turn 1  2  3  4  5  6  7  8  9  10  11  12  ...
+                  ↑                 ↑
+              checkpoint         checkpoint
+```
+
+### wrapToolCall — Artifact Capture
+
+When a tool's name matches `artifactToolNames`, captures the tool response as a `KeyArtifact`. Artifacts are stored in the snapshot and included in resume context.
+
+### onSessionEnd — Artifact Flush
+
+On session end, flushes any captured artifacts to the harness snapshot. Respects `maxKeyArtifacts` limit (default: 10), keeping the newest.
+
+---
+
+## Configuration
+
+```typescript
+interface LongRunningConfig {
+  readonly harnessId: HarnessId;           // Unique harness identifier
+  readonly agentId: AgentId;               // Agent this harness manages
+  readonly harnessStore: HarnessSnapshotStore;  // DAG store for semantic history
+  readonly sessionPersistence: SessionPersistence; // Crash recovery store
+  readonly softCheckpointInterval?: number;     // Default: 5 turns
+  readonly maxKeyArtifacts?: number;            // Default: 10
+  readonly maxContextTokens?: number;           // Default: 3000
+  readonly artifactToolNames?: readonly string[]; // Tools to capture
+  readonly pruningPolicy?: PruningPolicy;       // Default: { retainCount: 10 }
+  readonly saveState?: SaveStateCallback;       // Capture real engine state
+}
+```
+
+### SaveStateCallback
+
+Optional callback invoked during soft checkpoints to capture real engine state instead of a placeholder:
+
+```typescript
+type SaveStateCallback = () => EngineState | Promise<EngineState>;
+```
+
+---
+
+## Context Bridge
+
+The context bridge builds resume prompts from harness snapshots. It operates within a token budget (default: 3000 tokens) and includes content in priority order:
+
+1. **Task plan** (always included) — formatted task board with status icons
+2. **Session summaries** (newest first, up to half remaining budget)
+3. **Key artifacts** (newest first, up to half remaining budget)
+
+```
+## Task Plan
+
+[x] task-1: Set up database schema
+[x] task-2: Implement user authentication
+[ ] task-3: Build API endpoints
+[ ] task-4: Write integration tests
+
+Completed: 2/4
+
+## Previous Session Summaries
+
+Session 2: Implemented JWT auth with refresh tokens. Added bcrypt hashing.
+Session 1: Created PostgreSQL schema with users, sessions, and roles tables.
+
+## Key Artifacts
+
+[code_search @ turn 12]: Found 3 matching files in src/auth/
+[file_write @ turn 8]: Created migrations/001_users.sql
+```
+
+All resume messages are marked `pinned: true` — the compactor middleware will never summarize them away.
+
+---
+
+## Examples
+
+### Minimal — Single-Session Task
+
+```typescript
+import { createLongRunningHarness } from "@koi/long-running";
+import type { LongRunningConfig } from "@koi/long-running";
+import { harnessId, agentId, taskItemId } from "@koi/core";
+
+const config: LongRunningConfig = {
+  harnessId: harnessId("my-harness"),
+  agentId: agentId("agent-1"),
+  harnessStore: mySnapshotStore,
+  sessionPersistence: mySessionPersistence,
+};
+
+const harness = createLongRunningHarness(config);
+
+// Start with a task plan
+const startResult = await harness.start({
+  items: [
+    {
+      id: taskItemId("task-1"),
+      description: "Implement user auth",
+      dependencies: [],
+      priority: 0,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending",
+    },
+  ],
+  results: [],
+});
+
+// Mark task complete
+await harness.completeTask(taskItemId("task-1"), {
+  taskId: taskItemId("task-1"),
+  output: "JWT auth implemented",
+  durationMs: 45000,
+});
+
+// harness.status().phase === "completed"
+```
+
+### Multi-Session with Engine Integration
+
+```typescript
+import { createLongRunningHarness } from "@koi/long-running";
+import { createKoi } from "@koi/engine";
+
+const harness = createLongRunningHarness(config);
+
+// --- Session 1 ---
+const startResult = await harness.start(taskPlan);
+if (!startResult.ok) throw new Error(startResult.error.message);
+
+const runtime = await createKoi({
+  manifest,
+  adapter,
+  middleware: [harness.createMiddleware()],
+});
+
+// Run with the harness-generated engine input
+for await (const event of runtime.run(startResult.value.engineInput)) {
+  // Process events...
+}
+
+// End session — persist state
+await harness.pause({
+  sessionId: startResult.value.sessionId,
+  metrics: { totalTokens: 5000, inputTokens: 3000, outputTokens: 2000, turns: 8, durationMs: 60000 },
+  summary: "Completed database schema setup. Created 3 migration files.",
+});
+
+// --- Session 2 (hours later) ---
+const resumeResult = await harness.resume();
+if (!resumeResult.ok) throw new Error(resumeResult.error.message);
+
+const runtime2 = await createKoi({
+  manifest,
+  adapter,
+  middleware: [harness.createMiddleware()],
+});
+
+for await (const event of runtime2.run(resumeResult.value.engineInput)) {
+  // Agent resumes with full context...
+}
+```
+
+### With SaveState Callback
+
+```typescript
+const harness = createLongRunningHarness({
+  ...config,
+  saveState: async () => adapter.getState(),  // Capture real engine state
+  softCheckpointInterval: 3,                   // Checkpoint every 3 turns
+  artifactToolNames: ["code_search", "file_write", "shell"],
+});
+```
+
+### Handling Failures
+
+```typescript
+try {
+  // Agent encounters unrecoverable error
+} catch (e: unknown) {
+  await harness.fail({
+    code: "EXTERNAL",
+    message: e instanceof Error ? e.message : String(e),
+    retryable: false,
+  });
+  // harness.status().phase === "failed"
+  // harness.status().failureReason === error message
+}
+```
+
+### Testing with In-Memory Stores
+
+```typescript
+import { createLongRunningHarness } from "@koi/long-running";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { createMockHarness, createMockTaskPlan } from "@koi/test-utils";
+
+// Option A: Real harness with in-memory stores
+const harness = createLongRunningHarness({
+  harnessId: harnessId("test"),
+  agentId: agentId("test-agent"),
+  harnessStore: createInMemorySnapshotChainStore(),
+  sessionPersistence: mockSessionPersistence,
+});
+
+// Option B: Mock harness for unit tests
+const mock = createMockHarness();
+await mock.start(createMockTaskPlan(3));
+```
+
+---
+
+## Checkpoint Policy
+
+Two pure functions control soft checkpoint behavior:
+
+### shouldSoftCheckpoint
+
+Determines if a soft checkpoint should fire at the current turn:
+
+```typescript
+shouldSoftCheckpoint(turnIndex: 0, interval: 5)  // false (turn 0 never fires)
+shouldSoftCheckpoint(turnIndex: 5, interval: 5)  // true
+shouldSoftCheckpoint(turnIndex: 7, interval: 5)  // false
+shouldSoftCheckpoint(turnIndex: 10, interval: 5) // true
+```
+
+### computeCheckpointId
+
+Generates a deterministic checkpoint ID from harness, session, and turn:
+
+```typescript
+computeCheckpointId(harnessId("h1"), "session-1", 5)
+// → "h1:session-1:5"
+```
+
+---
+
+## Pinned Messages and Compaction
+
+Resume context messages are marked `pinned: true` on `InboundMessage`. The `@koi/middleware-compactor` respects this flag — pinned messages are never included in the compaction head (summarized portion). This ensures harness context survives even aggressive compaction.
+
+```
+Context window during Session 2:
+
+┌──────────────────────────────────────────────────────┐
+│ [pinned] Harness resume context                       │  ← never compacted
+│   Task plan, summaries, artifacts                    │
+│                                                      │
+│ [compactable] Old conversation turns                 │  ← compactor may
+│ ...                                                  │     summarize these
+│                                                      │
+│ [preserved] Recent turns (preserveRecent)            │  ← always kept
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## API Reference
+
+### Factory Functions
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `createLongRunningHarness(config)` | `LongRunningHarness` | Creates a new harness instance |
+
+### Harness Methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `start(plan)` | `(TaskBoardSnapshot) → Promise<Result<StartResult, KoiError>>` | Initialize with task plan, transition to active |
+| `resume()` | `() → Promise<Result<ResumeResult, KoiError>>` | Resume from suspended, try engine state then context bridge |
+| `pause(result)` | `(SessionResult) → Promise<Result<void, KoiError>>` | End session, persist snapshot, transition to suspended |
+| `fail(error)` | `(KoiError) → Promise<Result<void, KoiError>>` | Transition to failed with reason |
+| `completeTask(id, result)` | `(TaskItemId, TaskResult) → Promise<Result<void, KoiError>>` | Mark task done; auto-completes if all done |
+| `status()` | `() → HarnessStatus` | Sync read of current phase, tasks, metrics |
+| `createMiddleware()` | `() → KoiMiddleware` | Returns middleware with 3 hooks |
+| `dispose()` | `() → Promise<void>` | Idempotent cleanup, prevents further operations |
+
+### Context Bridge
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `buildInitialPrompt(plan)` | `(TaskBoardSnapshot) → string` | Formats task plan as text for first session |
+| `buildResumeContext(snapshot, config)` | `(HarnessSnapshot, { maxContextTokens }) → Result<InboundMessage[], KoiError>` | Builds pinned resume messages from snapshot |
+
+### Checkpoint Policy
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `shouldSoftCheckpoint(turn, interval)` | `(number, number) → boolean` | Whether to fire at this turn |
+| `computeCheckpointId(harness, session, turn)` | `(HarnessId, string, number) → string` | Deterministic checkpoint ID |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `LongRunningConfig` | Full configuration for harness creation |
+| `LongRunningHarness` | Main harness interface with 8 methods |
+| `StartResult` | `{ engineInput, sessionId }` |
+| `ResumeResult` | `{ engineInput, sessionId, engineStateRecovered }` |
+| `SessionResult` | `{ sessionId, engineState?, metrics, summary? }` |
+| `SaveStateCallback` | `() → EngineState \| Promise<EngineState>` |
+| `DEFAULT_LONG_RUNNING_CONFIG` | Default values for optional config fields |
+
+### L0 Types (from @koi/core)
+
+| Type | Description |
+|------|-------------|
+| `HarnessId` | Branded string for harness identity |
+| `HarnessPhase` | `"idle" \| "active" \| "suspended" \| "completed" \| "failed"` |
+| `HarnessSnapshot` | Durable checkpoint: task board, summaries, artifacts, metrics |
+| `HarnessStatus` | Observable status: phase, tasks, metrics, failure reason |
+| `HarnessMetrics` | Accumulated metrics: sessions, turns, tokens, tasks |
+| `ContextSummary` | Per-session narrative with token estimate |
+| `KeyArtifact` | Captured tool output with tool name and turn index |
+| `HarnessSnapshotStore` | `SnapshotChainStore<HarnessSnapshot>` alias |
+| `AgentId` | Branded string for agent identity |
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Harness is a state manager, not middleware | Called at session boundaries by Node — decoupled from engine lifecycle |
+| Snapshot chain (DAG) over flat store | Enables branching, forking, and pruning of harness history |
+| Resume tries engine state first | Hot path is cheapest — avoids LLM summarization when possible |
+| Context bridge messages are `pinned` | Prevents compactor from erasing task plan and summaries |
+| Soft checkpoints are fire-and-forget | Checkpoint failures must never block the agent's work |
+| Token budget for context bridge | Prevents resume context from consuming entire context window |
+| `fail()` separate from `pause()` | Failed state is terminal — prevents accidental resume of broken agents |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────────────┐
+    HarnessId, HarnessSnapshot, HarnessStatus, HarnessMetrics,   │
+    TaskBoardSnapshot, TaskItemId, TaskResult, SessionPersistence, │
+    EngineInput, EngineState, InboundMessage, KoiMiddleware,       │
+    Result, KoiError                                               │
+                                                                    ▼
+L2  @koi/long-running <─────────────────────────────────────────┘
+    imports from L0 only
+    x never imports @koi/engine (L1)
+    x never imports peer L2 packages
+    x zero external dependencies
+    ~ package.json: { "dependencies": { "@koi/core": "workspace:*" } }
+```

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -456,6 +456,181 @@ declare function permission(message: string): KoiError;
 declare function staleRef(refId: string, hint?: string): KoiError;
 
 /**
+ * TaskBoard contract — persistent task coordination for multi-agent swarms.
+ *
+ * A TaskBoard maintains a DAG of tasks with dependency tracking,
+ * assignment, completion, failure/retry, and board-level queries.
+ *
+ * Exception: branded type constructor (taskItemId) is permitted in L0
+ * as a zero-logic identity cast for type safety.
+ * Exception: DEFAULT_TASK_BOARD_CONFIG is a pure readonly data constant
+ * derived from L0 type definitions.
+ */
+
+declare const __taskItemBrand: unique symbol;
+/** Branded string type for task board item identifiers. */
+type TaskItemId = string & {
+    readonly [__taskItemBrand]: "TaskItemId";
+};
+/** Create a branded TaskItemId from a plain string. */
+declare function taskItemId(id: string): TaskItemId;
+type TaskItemStatus = "pending" | "assigned" | "completed" | "failed";
+/** Input shape for adding a task to the board. */
+interface TaskItemInput {
+    readonly id: TaskItemId;
+    readonly description: string;
+    readonly dependencies?: readonly TaskItemId[] | undefined;
+    readonly priority?: number | undefined;
+    readonly maxRetries?: number | undefined;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+/** A task item on the board with full state. */
+interface TaskItem {
+    readonly id: TaskItemId;
+    readonly description: string;
+    readonly dependencies: readonly TaskItemId[];
+    readonly priority: number;
+    readonly maxRetries: number;
+    readonly retries: number;
+    readonly status: TaskItemStatus;
+    readonly assignedTo?: AgentId | undefined;
+    readonly error?: KoiError | undefined;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+/** Result produced by a completed task. */
+interface TaskResult {
+    readonly taskId: TaskItemId;
+    readonly output: string;
+    readonly durationMs: number;
+    readonly workerId?: string | undefined;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+/** Patch fields for updating a pending or assigned task. */
+interface TaskItemPatch {
+    readonly priority?: number | undefined;
+    readonly description?: string | undefined;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+type TaskBoardEvent = {
+    readonly kind: "task:added";
+    readonly item: TaskItem;
+} | {
+    readonly kind: "task:assigned";
+    readonly taskId: TaskItemId;
+    readonly agentId: AgentId;
+} | {
+    readonly kind: "task:completed";
+    readonly taskId: TaskItemId;
+    readonly result: TaskResult;
+} | {
+    readonly kind: "task:failed";
+    readonly taskId: TaskItemId;
+    readonly error: KoiError;
+} | {
+    readonly kind: "task:retried";
+    readonly taskId: TaskItemId;
+    readonly retries: number;
+};
+interface TaskBoardSnapshot {
+    readonly items: readonly TaskItem[];
+    readonly results: readonly TaskResult[];
+}
+interface TaskBoardConfig {
+    readonly maxRetries?: number | undefined;
+    readonly onEvent?: ((event: TaskBoardEvent) => void) | undefined;
+}
+declare const DEFAULT_TASK_BOARD_CONFIG: TaskBoardConfig;
+interface TaskBoard {
+    readonly add: (item: TaskItemInput) => Result<TaskBoard, KoiError>;
+    readonly addAll: (items: readonly TaskItemInput[]) => Result<TaskBoard, KoiError>;
+    readonly assign: (taskId: TaskItemId, agentId: AgentId) => Result<TaskBoard, KoiError>;
+    readonly complete: (taskId: TaskItemId, result: TaskResult) => Result<TaskBoard, KoiError>;
+    readonly fail: (taskId: TaskItemId, error: KoiError) => Result<TaskBoard, KoiError>;
+    readonly update: (taskId: TaskItemId, patch: TaskItemPatch) => Result<TaskBoard, KoiError>;
+    readonly get: (taskId: TaskItemId) => TaskItem | undefined;
+    readonly ready: () => readonly TaskItem[];
+    readonly pending: () => readonly TaskItem[];
+    readonly blocked: () => readonly TaskItem[];
+    readonly inProgress: () => readonly TaskItem[];
+    readonly completed: () => readonly TaskResult[];
+    readonly failed: () => readonly TaskItem[];
+    readonly unreachable: () => readonly TaskItem[];
+    readonly dependentsOf: (taskId: TaskItemId) => readonly TaskItem[];
+    readonly all: () => readonly TaskItem[];
+    readonly size: () => number;
+}
+
+/**
+ * Long-running harness types — multi-session agent lifecycle management.
+ *
+ * Provides types for agents that operate over hours/days across multiple
+ * sessions, tracking progress, bridging context, and checkpointing at
+ * meaningful task boundaries.
+ *
+ * Exception: branded type constructor (harnessId) is permitted in L0
+ * as a zero-logic identity cast for type safety.
+ */
+
+declare const __harnessIdBrand: unique symbol;
+/** Branded string type for harness identifiers. */
+type HarnessId = string & {
+    readonly [__harnessIdBrand]: "HarnessId";
+};
+/** Create a branded HarnessId from a plain string. */
+declare function harnessId(raw: string): HarnessId;
+/** Lifecycle phase of a long-running harness. */
+type HarnessPhase = "idle" | "active" | "suspended" | "completed" | "failed";
+/** Narrative summary generated eagerly at session end. */
+interface ContextSummary {
+    readonly narrative: string;
+    readonly sessionSeq: number;
+    readonly completedTaskIds: readonly string[];
+    readonly estimatedTokens: number;
+    readonly generatedAt: number;
+}
+interface KeyArtifact {
+    readonly toolName: string;
+    readonly content: string;
+    readonly turnIndex: number;
+    readonly capturedAt: number;
+}
+interface HarnessMetrics {
+    readonly totalSessions: number;
+    readonly totalTurns: number;
+    readonly totalInputTokens: number;
+    readonly totalOutputTokens: number;
+    readonly completedTaskCount: number;
+    readonly pendingTaskCount: number;
+    readonly elapsedMs: number;
+}
+interface HarnessStatus {
+    readonly harnessId: HarnessId;
+    readonly phase: HarnessPhase;
+    readonly currentSessionSeq: number;
+    readonly taskBoard: TaskBoardSnapshot;
+    readonly metrics: HarnessMetrics;
+    readonly lastSessionEndedAt?: number | undefined;
+    readonly startedAt?: number | undefined;
+    readonly failureReason?: string | undefined;
+}
+interface HarnessSnapshot {
+    readonly harnessId: HarnessId;
+    readonly phase: HarnessPhase;
+    readonly sessionSeq: number;
+    readonly taskBoard: TaskBoardSnapshot;
+    readonly summaries: readonly ContextSummary[];
+    readonly keyArtifacts: readonly KeyArtifact[];
+    readonly lastSessionId?: string | undefined;
+    readonly agentId: string;
+    readonly metrics: HarnessMetrics;
+    readonly startedAt: number;
+    readonly checkpointedAt: number;
+    readonly failureReason?: string | undefined;
+}
+/** A SnapshotChainStore specialized for HarnessSnapshot payloads. */
+type HarnessSnapshotStore = SnapshotChainStore<HarnessSnapshot>;
+
+/**
  * Kernel extension contract — pluggable L1 guard/lifecycle/assembly slots.
  *
  * Extensions allow composable, replaceable kernel behaviors without forking
@@ -1245,111 +1420,6 @@ interface EventCursor {
 }
 
 /**
- * TaskBoard contract — persistent task coordination for multi-agent swarms.
- *
- * A TaskBoard maintains a DAG of tasks with dependency tracking,
- * assignment, completion, failure/retry, and board-level queries.
- *
- * Exception: branded type constructor (taskItemId) is permitted in L0
- * as a zero-logic identity cast for type safety.
- * Exception: DEFAULT_TASK_BOARD_CONFIG is a pure readonly data constant
- * derived from L0 type definitions.
- */
-
-declare const __taskItemBrand: unique symbol;
-/** Branded string type for task board item identifiers. */
-type TaskItemId = string & {
-    readonly [__taskItemBrand]: "TaskItemId";
-};
-/** Create a branded TaskItemId from a plain string. */
-declare function taskItemId(id: string): TaskItemId;
-type TaskItemStatus = "pending" | "assigned" | "completed" | "failed";
-/** Input shape for adding a task to the board. */
-interface TaskItemInput {
-    readonly id: TaskItemId;
-    readonly description: string;
-    readonly dependencies?: readonly TaskItemId[] | undefined;
-    readonly priority?: number | undefined;
-    readonly maxRetries?: number | undefined;
-    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
-}
-/** A task item on the board with full state. */
-interface TaskItem {
-    readonly id: TaskItemId;
-    readonly description: string;
-    readonly dependencies: readonly TaskItemId[];
-    readonly priority: number;
-    readonly maxRetries: number;
-    readonly retries: number;
-    readonly status: TaskItemStatus;
-    readonly assignedTo?: AgentId | undefined;
-    readonly error?: KoiError | undefined;
-    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
-}
-/** Result produced by a completed task. */
-interface TaskResult {
-    readonly taskId: TaskItemId;
-    readonly output: string;
-    readonly durationMs: number;
-    readonly workerId?: string | undefined;
-    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
-}
-/** Patch fields for updating a pending or assigned task. */
-interface TaskItemPatch {
-    readonly priority?: number | undefined;
-    readonly description?: string | undefined;
-    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
-}
-type TaskBoardEvent = {
-    readonly kind: "task:added";
-    readonly item: TaskItem;
-} | {
-    readonly kind: "task:assigned";
-    readonly taskId: TaskItemId;
-    readonly agentId: AgentId;
-} | {
-    readonly kind: "task:completed";
-    readonly taskId: TaskItemId;
-    readonly result: TaskResult;
-} | {
-    readonly kind: "task:failed";
-    readonly taskId: TaskItemId;
-    readonly error: KoiError;
-} | {
-    readonly kind: "task:retried";
-    readonly taskId: TaskItemId;
-    readonly retries: number;
-};
-interface TaskBoardSnapshot {
-    readonly items: readonly TaskItem[];
-    readonly results: readonly TaskResult[];
-}
-interface TaskBoardConfig {
-    readonly maxRetries?: number | undefined;
-    readonly onEvent?: ((event: TaskBoardEvent) => void) | undefined;
-}
-declare const DEFAULT_TASK_BOARD_CONFIG: TaskBoardConfig;
-interface TaskBoard {
-    readonly add: (item: TaskItemInput) => Result<TaskBoard, KoiError>;
-    readonly addAll: (items: readonly TaskItemInput[]) => Result<TaskBoard, KoiError>;
-    readonly assign: (taskId: TaskItemId, agentId: AgentId) => Result<TaskBoard, KoiError>;
-    readonly complete: (taskId: TaskItemId, result: TaskResult) => Result<TaskBoard, KoiError>;
-    readonly fail: (taskId: TaskItemId, error: KoiError) => Result<TaskBoard, KoiError>;
-    readonly update: (taskId: TaskItemId, patch: TaskItemPatch) => Result<TaskBoard, KoiError>;
-    readonly get: (taskId: TaskItemId) => TaskItem | undefined;
-    readonly ready: () => readonly TaskItem[];
-    readonly pending: () => readonly TaskItem[];
-    readonly blocked: () => readonly TaskItem[];
-    readonly inProgress: () => readonly TaskItem[];
-    readonly completed: () => readonly TaskResult[];
-    readonly failed: () => readonly TaskItem[];
-    readonly unreachable: () => readonly TaskItem[];
-    readonly dependentsOf: (taskId: TaskItemId) => readonly TaskItem[];
-    readonly all: () => readonly TaskItem[];
-    readonly size: () => number;
-}
-
-/**
  * Validation utilities — pure functions for L0 type safety.
  *
  * isProcessState: runtime type guard matching the ProcessState union.
@@ -1367,7 +1437,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type BundleId, type CapabilityRegistry, type CapacityReport, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CompensatingOp, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_REPUTATION_QUERY_LIMIT, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineState, type EventCursor, type FeedbackKind, type FileOpKind, type FileOpRecord, type ForkRef, type GateRequirement, type GuardContext, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, KoiError, KoiMiddleware, type NodeCapability, type NodeId, PROPOSAL_GATE_REQUIREMENTS, type PendingFrame, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, REPUTATION_LEVEL_ORDER, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, type ReputationBackend, type ReputationFeedback, type ReputationLevel, type ReputationQuery, type ReputationQueryResult, type ReputationScore, Result, type ReviewDecision, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskResult, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, bundleId, chainId, conflict, evolveRegistryEntry, external, internal, isAgentStateEvent, isProcessState, isToolCallPayload, nodeId, notFound, permission, proposalId, rateLimit, staleRef, taskItemId, timeout, validateNonEmpty, validation };
+export { ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, type BrickPage, BrickRef, type BrickRegistryBackend, type BrickRegistryChangeEvent, type BrickRegistryChangeKind, type BrickRegistryReader, type BrickRegistryWriter, type BrickSearchQuery, type BundleId, type CapabilityRegistry, type CapacityReport, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CompensatingOp, type ContextSummary, DEFAULT_BRICK_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_REPUTATION_QUERY_LIMIT, DEFAULT_TASK_BOARD_CONFIG, EXTENSION_PRIORITY, EngineState, type EventCursor, type FeedbackKind, type FileOpKind, type FileOpRecord, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, type NodeCapability, type NodeId, PROPOSAL_GATE_REQUIREMENTS, type PendingFrame, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, REPUTATION_LEVEL_ORDER, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, type ReputationBackend, type ReputationFeedback, type ReputationLevel, type ReputationQuery, type ReputationQueryResult, type ReputationScore, Result, type ReviewDecision, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskResult, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, type TurnTrace, type ValidationDiagnostic, type ValidationResult, bundleId, chainId, conflict, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isProcessState, isToolCallPayload, nodeId, notFound, permission, proposalId, rateLimit, staleRef, taskItemId, timeout, validateNonEmpty, validation };
 "
 `;
 
@@ -1878,6 +1948,8 @@ interface InboundMessage {
     readonly threadId?: string;
     readonly timestamp: number;
     readonly metadata?: JsonObject;
+    /** When true, compaction middleware must preserve this message verbatim. */
+    readonly pinned?: boolean | undefined;
 }
 
 export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, InboundMessage, OutboundMessage, TextBlock };

--- a/packages/core/src/harness.ts
+++ b/packages/core/src/harness.ts
@@ -1,0 +1,113 @@
+/**
+ * Long-running harness types — multi-session agent lifecycle management.
+ *
+ * Provides types for agents that operate over hours/days across multiple
+ * sessions, tracking progress, bridging context, and checkpointing at
+ * meaningful task boundaries.
+ *
+ * Exception: branded type constructor (harnessId) is permitted in L0
+ * as a zero-logic identity cast for type safety.
+ */
+
+import type { SnapshotChainStore } from "./snapshot-chain.js";
+import type { TaskBoardSnapshot } from "./task-board.js";
+
+// ---------------------------------------------------------------------------
+// Branded types
+// ---------------------------------------------------------------------------
+
+declare const __harnessIdBrand: unique symbol;
+
+/** Branded string type for harness identifiers. */
+export type HarnessId = string & { readonly [__harnessIdBrand]: "HarnessId" };
+
+/** Create a branded HarnessId from a plain string. */
+export function harnessId(raw: string): HarnessId {
+  return raw as HarnessId;
+}
+
+// ---------------------------------------------------------------------------
+// Phase discriminant
+// ---------------------------------------------------------------------------
+
+/** Lifecycle phase of a long-running harness. */
+export type HarnessPhase = "idle" | "active" | "suspended" | "completed" | "failed";
+
+// ---------------------------------------------------------------------------
+// Per-session context summary
+// ---------------------------------------------------------------------------
+
+/** Narrative summary generated eagerly at session end. */
+export interface ContextSummary {
+  readonly narrative: string;
+  readonly sessionSeq: number;
+  readonly completedTaskIds: readonly string[];
+  readonly estimatedTokens: number;
+  readonly generatedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Key artifact — notable tool output captured during execution
+// ---------------------------------------------------------------------------
+
+export interface KeyArtifact {
+  readonly toolName: string;
+  readonly content: string;
+  readonly turnIndex: number;
+  readonly capturedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Accumulated metrics across all sessions
+// ---------------------------------------------------------------------------
+
+export interface HarnessMetrics {
+  readonly totalSessions: number;
+  readonly totalTurns: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly completedTaskCount: number;
+  readonly pendingTaskCount: number;
+  readonly elapsedMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Observable harness status (read by Node/dashboard)
+// ---------------------------------------------------------------------------
+
+export interface HarnessStatus {
+  readonly harnessId: HarnessId;
+  readonly phase: HarnessPhase;
+  readonly currentSessionSeq: number;
+  readonly taskBoard: TaskBoardSnapshot;
+  readonly metrics: HarnessMetrics;
+  readonly lastSessionEndedAt?: number | undefined;
+  readonly startedAt?: number | undefined;
+  readonly failureReason?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Durable checkpoint payload — stored in SnapshotChainStore<HarnessSnapshot>
+// ---------------------------------------------------------------------------
+
+export interface HarnessSnapshot {
+  readonly harnessId: HarnessId;
+  readonly phase: HarnessPhase;
+  readonly sessionSeq: number;
+  readonly taskBoard: TaskBoardSnapshot;
+  readonly summaries: readonly ContextSummary[];
+  readonly keyArtifacts: readonly KeyArtifact[];
+  readonly lastSessionId?: string | undefined;
+  readonly agentId: string;
+  readonly metrics: HarnessMetrics;
+  readonly startedAt: number;
+  readonly checkpointedAt: number;
+  readonly failureReason?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Type alias — follows AgentSnapshotStore pattern from agent-snapshot.ts
+// ---------------------------------------------------------------------------
+
+/** A SnapshotChainStore specialized for HarnessSnapshot payloads. */
+export type HarnessSnapshotStore = SnapshotChainStore<HarnessSnapshot>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -328,6 +328,18 @@ export type {
 } from "./handoff.js";
 // handoff — runtime values
 export { handoffId } from "./handoff.js";
+// harness — multi-session long-horizon task harness types
+export type {
+  ContextSummary,
+  HarnessId,
+  HarnessMetrics,
+  HarnessPhase,
+  HarnessSnapshot,
+  HarnessSnapshotStore,
+  HarnessStatus,
+  KeyArtifact,
+} from "./harness.js";
+export { harnessId } from "./harness.js";
 // health
 export type {
   HealthMonitor,

--- a/packages/core/src/message.ts
+++ b/packages/core/src/message.ts
@@ -49,4 +49,6 @@ export interface InboundMessage {
   readonly threadId?: string;
   readonly timestamp: number;
   readonly metadata?: JsonObject;
+  /** When true, compaction middleware must preserve this message verbatim. */
+  readonly pinned?: boolean | undefined;
 }

--- a/packages/long-running/package.json
+++ b/packages/long-running/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@koi/long-running",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*",
+    "@koi/snapshot-chain-store": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/long-running/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/long-running/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,124 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/long-running API surface . has stable type surface 1`] = `
+"import { HarnessId, TaskBoardSnapshot, HarnessSnapshot, Result, InboundMessage, KoiError, PruningPolicy, AgentId, HarnessSnapshotStore, SessionPersistence, EngineState, EngineInput, EngineMetrics, TaskItemId, TaskResult, HarnessStatus, KoiMiddleware } from '@koi/core';
+
+/**
+ * Checkpoint timing policy — pure functions, no I/O.
+ *
+ * Determines when soft checkpoints should fire and generates
+ * deterministic checkpoint identifiers.
+ */
+
+/**
+ * Determine whether a soft checkpoint should fire at the given turn.
+ *
+ * Fires at every \`interval\`-th turn, starting from the first interval.
+ * Turn 0 never triggers a checkpoint (session just started).
+ */
+declare function shouldSoftCheckpoint(turnIndex: number, interval: number): boolean;
+/**
+ * Generate a deterministic checkpoint ID from harness, session, and turn.
+ *
+ * Format: \`{harnessId}:{sessionId}:t{turnIndex}\`
+ */
+declare function computeCheckpointId(harnessId: HarnessId, sessionId: string, turnIndex: number): string;
+
+/**
+ * Context bridge — builds resume context from a harness snapshot.
+ *
+ * Pure function that assembles InboundMessage[] from the snapshot's
+ * task board, context summaries, and key artifacts, respecting a
+ * token budget. No I/O, depends only on L0 types.
+ */
+
+/**
+ * Build initial prompt from a task plan for the first session.
+ *
+ * Returns a text string describing the task plan for the engine.
+ */
+declare function buildInitialPrompt(plan: TaskBoardSnapshot): string;
+/**
+ * Build resume context from a harness snapshot.
+ *
+ * Assembles InboundMessage[] with:
+ * 1. Task plan (always included)
+ * 2. Context summaries (newest first, up to half remaining budget)
+ * 3. Key artifacts (newest first, up to half remaining budget)
+ *
+ * @returns Result with messages on success, VALIDATION error if task board is empty.
+ */
+declare function buildResumeContext(snapshot: HarnessSnapshot, config: {
+    readonly maxContextTokens: number;
+}): Result<readonly InboundMessage[], KoiError>;
+
+/**
+ * L2-local configuration and interface types for @koi/long-running.
+ *
+ * These types are internal to the package — L0 types live in @koi/core/harness.
+ */
+
+/** Optional callback to capture real engine state during soft checkpoints. */
+type SaveStateCallback = () => EngineState | Promise<EngineState>;
+interface LongRunningConfig {
+    readonly harnessId: HarnessId;
+    readonly agentId: AgentId;
+    readonly harnessStore: HarnessSnapshotStore;
+    readonly sessionPersistence: SessionPersistence;
+    readonly softCheckpointInterval?: number | undefined;
+    readonly maxKeyArtifacts?: number | undefined;
+    readonly maxContextTokens?: number | undefined;
+    readonly artifactToolNames?: readonly string[] | undefined;
+    readonly pruningPolicy?: PruningPolicy | undefined;
+    readonly saveState?: SaveStateCallback | undefined;
+}
+interface LongRunningHarness {
+    readonly harnessId: HarnessId;
+    readonly start: (taskPlan: TaskBoardSnapshot) => Promise<Result<StartResult, KoiError>>;
+    readonly resume: () => Promise<Result<ResumeResult, KoiError>>;
+    readonly pause: (sessionResult: SessionResult) => Promise<Result<void, KoiError>>;
+    readonly fail: (error: KoiError) => Promise<Result<void, KoiError>>;
+    readonly completeTask: (taskId: TaskItemId, result: TaskResult) => Promise<Result<void, KoiError>>;
+    readonly status: () => HarnessStatus;
+    readonly createMiddleware: () => KoiMiddleware;
+    readonly dispose: () => Promise<void>;
+}
+interface StartResult {
+    readonly engineInput: EngineInput;
+    readonly sessionId: string;
+}
+interface ResumeResult {
+    readonly engineInput: EngineInput;
+    readonly sessionId: string;
+    readonly engineStateRecovered: boolean;
+}
+interface SessionResult {
+    readonly sessionId: string;
+    readonly engineState?: EngineState | undefined;
+    readonly metrics: EngineMetrics;
+    readonly summary?: string | undefined;
+}
+declare const DEFAULT_LONG_RUNNING_CONFIG: {
+    readonly softCheckpointInterval: 5;
+    readonly maxKeyArtifacts: 10;
+    readonly maxContextTokens: 3000;
+    readonly pruningPolicy: PruningPolicy;
+};
+
+/**
+ * Long-running harness — state manager for multi-session agent operation.
+ *
+ * Called at session boundaries by Node (not a middleware or engine decorator).
+ * Owns the task plan, context summaries, and progress tracking.
+ * Engine state lives in SessionPersistence (crash recovery).
+ * Harness state lives in SnapshotChainStore<HarnessSnapshot> (semantic history).
+ */
+
+/**
+ * Create a long-running harness for multi-session agent operation.
+ */
+declare function createLongRunningHarness(config: LongRunningConfig): LongRunningHarness;
+
+export { DEFAULT_LONG_RUNNING_CONFIG, type LongRunningConfig, type LongRunningHarness, type ResumeResult, type SaveStateCallback, type SessionResult, type StartResult, buildInitialPrompt, buildResumeContext, computeCheckpointId, createLongRunningHarness, shouldSoftCheckpoint };
+"
+`;

--- a/packages/long-running/src/__tests__/api-surface.test.ts
+++ b/packages/long-running/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/long-running/src/__tests__/degradation.integration.test.ts
+++ b/packages/long-running/src/__tests__/degradation.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Degradation integration tests — edge cases and error recovery.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AgentId,
+  EngineMetrics,
+  HarnessSnapshotStore,
+  SessionPersistence,
+  TaskBoardSnapshot,
+} from "@koi/core";
+import { agentId, harnessId, taskItemId } from "@koi/core";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { assertErr, assertOk } from "@koi/test-utils";
+import { createLongRunningHarness } from "../harness.js";
+import type { LongRunningConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_HARNESS_ID = harnessId("degradation-harness");
+const TEST_AGENT_ID = agentId("agent-degradation");
+
+const METRICS: EngineMetrics = {
+  totalTokens: 50,
+  inputTokens: 30,
+  outputTokens: 20,
+  turns: 2,
+  durationMs: 1000,
+};
+
+function createPlan(count = 2): TaskBoardSnapshot {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      id: taskItemId(`task-${String(i + 1)}`),
+      description: `Task ${String(i + 1)}`,
+      dependencies: [],
+      priority: i,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    })),
+    results: [],
+  };
+}
+
+function createMockPersistence(): SessionPersistence {
+  return {
+    saveSession: () => ({ ok: true as const, value: undefined }),
+    loadSession: () => ({
+      ok: false as const,
+      error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+    }),
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    saveCheckpoint: () => ({ ok: true as const, value: undefined }),
+    loadLatestCheckpoint: (_aid: AgentId) => ({ ok: true as const, value: undefined }),
+    listCheckpoints: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], checkpoints: new Map(), pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => undefined,
+  };
+}
+
+function createHarness(
+  store: HarnessSnapshotStore,
+  overrides?: Partial<LongRunningConfig>,
+): ReturnType<typeof createLongRunningHarness> {
+  return createLongRunningHarness({
+    harnessId: TEST_HARNESS_ID,
+    agentId: TEST_AGENT_ID,
+    harnessStore: store,
+    sessionPersistence: createMockPersistence(),
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("degradation", () => {
+  let store: HarnessSnapshotStore;
+
+  beforeEach(() => {
+    store = createInMemorySnapshotChainStore();
+  });
+
+  test("pause without summary omits context summary", async () => {
+    const harness = createHarness(store);
+    await harness.start(createPlan());
+    const result = await harness.pause({
+      sessionId: "s-1",
+      metrics: METRICS,
+      // No summary
+    });
+    assertOk(result);
+    expect(harness.status().phase).toBe("suspended");
+  });
+
+  test("all-completed plan transitions to completed on last task", async () => {
+    const harness = createHarness(store);
+    await harness.start(createPlan(1));
+
+    const result = await harness.completeTask(taskItemId("task-1"), {
+      taskId: taskItemId("task-1"),
+      output: "Done",
+      durationMs: 100,
+    });
+    assertOk(result);
+    expect(harness.status().phase).toBe("completed");
+  });
+
+  test("concurrent resume on same harness fails (second call sees active phase)", async () => {
+    const harness = createHarness(store);
+    await harness.start(createPlan());
+    await harness.pause({ sessionId: "s-1", metrics: METRICS });
+
+    // First resume succeeds
+    const r1 = await harness.resume();
+    assertOk(r1);
+
+    // Second resume fails — now active
+    const r2 = await harness.resume();
+    assertErr(r2);
+    expect(r2.error.code).toBe("VALIDATION");
+  });
+
+  test("dispose prevents start", async () => {
+    const harness = createHarness(store);
+    await harness.dispose();
+    const result = await harness.start(createPlan());
+    assertErr(result);
+  });
+
+  test("dispose prevents resume", async () => {
+    const harness = createHarness(store);
+    await harness.start(createPlan());
+    await harness.pause({ sessionId: "s-1", metrics: METRICS });
+    await harness.dispose();
+    const result = await harness.resume();
+    assertErr(result);
+  });
+
+  test("dispose prevents completeTask", async () => {
+    const harness = createHarness(store);
+    await harness.start(createPlan());
+    await harness.dispose();
+    const result = await harness.completeTask(taskItemId("task-1"), {
+      taskId: taskItemId("task-1"),
+      output: "Done",
+      durationMs: 100,
+    });
+    assertErr(result);
+  });
+});

--- a/packages/long-running/src/__tests__/harness-contract.test.ts
+++ b/packages/long-running/src/__tests__/harness-contract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Contract test suite for the long-running harness.
+ *
+ * Uses the reusable contract tests from @koi/test-utils.
+ */
+
+import type { AgentId, SessionPersistence } from "@koi/core";
+import { agentId, harnessId } from "@koi/core";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { runHarnessContractTests } from "@koi/test-utils";
+import { createLongRunningHarness } from "../harness.js";
+
+function createMockPersistence(): SessionPersistence {
+  return {
+    saveSession: () => ({ ok: true as const, value: undefined }),
+    loadSession: () => ({
+      ok: false as const,
+      error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+    }),
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    saveCheckpoint: () => ({ ok: true as const, value: undefined }),
+    loadLatestCheckpoint: (_aid: AgentId) => ({ ok: true as const, value: undefined }),
+    listCheckpoints: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], checkpoints: new Map(), pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => undefined,
+  };
+}
+
+runHarnessContractTests(() =>
+  createLongRunningHarness({
+    harnessId: harnessId("contract-harness"),
+    agentId: agentId("contract-agent"),
+    harnessStore: createInMemorySnapshotChainStore(),
+    sessionPersistence: createMockPersistence(),
+  }),
+);

--- a/packages/long-running/src/__tests__/multi-session.integration.test.ts
+++ b/packages/long-running/src/__tests__/multi-session.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Multi-session integration tests — full lifecycle across sessions.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AgentId,
+  EngineMetrics,
+  HarnessSnapshotStore,
+  SessionCheckpoint,
+  SessionPersistence,
+  TaskBoardSnapshot,
+} from "@koi/core";
+import { agentId, chainId, harnessId, taskItemId } from "@koi/core";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { assertOk } from "@koi/test-utils";
+import { createLongRunningHarness } from "../harness.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_HARNESS_ID = harnessId("integration-harness");
+const TEST_AGENT_ID = agentId("agent-integration");
+const TEST_CHAIN_ID = chainId(TEST_HARNESS_ID);
+
+const METRICS: EngineMetrics = {
+  totalTokens: 100,
+  inputTokens: 60,
+  outputTokens: 40,
+  turns: 5,
+  durationMs: 3000,
+};
+
+function createPlan(): TaskBoardSnapshot {
+  return {
+    items: [
+      {
+        id: taskItemId("task-A"),
+        description: "Task A",
+        dependencies: [],
+        priority: 0,
+        maxRetries: 3,
+        retries: 0,
+        status: "pending" as const,
+      },
+      {
+        id: taskItemId("task-B"),
+        description: "Task B",
+        dependencies: [],
+        priority: 1,
+        maxRetries: 3,
+        retries: 0,
+        status: "pending" as const,
+      },
+      {
+        id: taskItemId("task-C"),
+        description: "Task C",
+        dependencies: [],
+        priority: 2,
+        maxRetries: 3,
+        retries: 0,
+        status: "pending" as const,
+      },
+    ],
+    results: [],
+  };
+}
+
+function createMockPersistence(): SessionPersistence & {
+  setLatestCheckpoint: (cp: SessionCheckpoint | undefined) => void;
+} {
+  let latestCheckpoint: SessionCheckpoint | undefined;
+
+  return {
+    setLatestCheckpoint(cp: SessionCheckpoint | undefined): void {
+      latestCheckpoint = cp;
+    },
+    saveSession: () => ({ ok: true as const, value: undefined }),
+    loadSession: () => ({
+      ok: false as const,
+      error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+    }),
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    saveCheckpoint() {
+      return { ok: true as const, value: undefined };
+    },
+    loadLatestCheckpoint(_aid: AgentId) {
+      return { ok: true as const, value: latestCheckpoint };
+    },
+    listCheckpoints: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], checkpoints: new Map(), pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("multi-session integration", () => {
+  let store: HarnessSnapshotStore;
+  let persistence: ReturnType<typeof createMockPersistence>;
+
+  beforeEach(() => {
+    store = createInMemorySnapshotChainStore();
+    persistence = createMockPersistence();
+  });
+
+  test("full lifecycle: start → session 1 → pause → resume → session 2 → completed", async () => {
+    const harness = createLongRunningHarness({
+      harnessId: TEST_HARNESS_ID,
+      agentId: TEST_AGENT_ID,
+      harnessStore: store,
+      sessionPersistence: persistence,
+    });
+
+    // Start with plan
+    const startResult = await harness.start(createPlan());
+    assertOk(startResult);
+    expect(startResult.value.engineInput.kind).toBe("text");
+
+    // Complete task A during session 1
+    const completeA = await harness.completeTask(taskItemId("task-A"), {
+      taskId: taskItemId("task-A"),
+      output: "Done A",
+      durationMs: 500,
+    });
+    assertOk(completeA);
+    expect(harness.status().phase).toBe("active");
+
+    // Pause session 1
+    const pauseResult = await harness.pause({
+      sessionId: startResult.value.sessionId,
+      metrics: METRICS,
+      summary: "Completed task A, B and C remain",
+    });
+    assertOk(pauseResult);
+    expect(harness.status().phase).toBe("suspended");
+
+    // Resume for session 2
+    const resumeResult = await harness.resume();
+    assertOk(resumeResult);
+    expect(resumeResult.value.engineInput.kind).toBe("messages");
+
+    // Complete tasks B and C during session 2
+    const completeB = await harness.completeTask(taskItemId("task-B"), {
+      taskId: taskItemId("task-B"),
+      output: "Done B",
+      durationMs: 500,
+    });
+    assertOk(completeB);
+
+    const completeC = await harness.completeTask(taskItemId("task-C"), {
+      taskId: taskItemId("task-C"),
+      output: "Done C",
+      durationMs: 500,
+    });
+    assertOk(completeC);
+
+    // All tasks done → completed
+    expect(harness.status().phase).toBe("completed");
+    expect(harness.status().metrics.totalSessions).toBe(1);
+    expect(harness.status().metrics.completedTaskCount).toBe(3);
+  });
+
+  test("resume without engine state falls back to messages", async () => {
+    const harness = createLongRunningHarness({
+      harnessId: TEST_HARNESS_ID,
+      agentId: TEST_AGENT_ID,
+      harnessStore: store,
+      sessionPersistence: persistence,
+    });
+
+    await harness.start(createPlan());
+    await harness.pause({ sessionId: "s-1", metrics: METRICS });
+
+    // No engine state set on persistence
+    const result = await harness.resume();
+    assertOk(result);
+    expect(result.value.engineStateRecovered).toBe(false);
+    expect(result.value.engineInput.kind).toBe("messages");
+  });
+
+  test("snapshot chain grows across sessions", async () => {
+    const harness = createLongRunningHarness({
+      harnessId: TEST_HARNESS_ID,
+      agentId: TEST_AGENT_ID,
+      harnessStore: store,
+      sessionPersistence: persistence,
+    });
+
+    await harness.start(createPlan());
+    // Snapshot 1: start
+
+    await harness.pause({ sessionId: "s-1", metrics: METRICS, summary: "Session 1" });
+    // Snapshot 2: pause
+
+    await harness.resume();
+    // Snapshot 3: resume
+
+    await harness.pause({ sessionId: "s-2", metrics: METRICS, summary: "Session 2" });
+    // Snapshot 4: pause again
+
+    const listResult = await store.list(TEST_CHAIN_ID);
+    assertOk(listResult);
+    expect(listResult.value.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/long-running/src/checkpoint-policy.test.ts
+++ b/packages/long-running/src/checkpoint-policy.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for checkpoint timing policy.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { harnessId } from "@koi/core";
+import { computeCheckpointId, shouldSoftCheckpoint } from "./checkpoint-policy.js";
+
+describe("shouldSoftCheckpoint", () => {
+  test("returns false for turn 0 (session just started)", () => {
+    expect(shouldSoftCheckpoint(0, 5)).toBe(false);
+  });
+
+  test("returns true at multiples of interval", () => {
+    expect(shouldSoftCheckpoint(5, 5)).toBe(true);
+    expect(shouldSoftCheckpoint(10, 5)).toBe(true);
+    expect(shouldSoftCheckpoint(15, 5)).toBe(true);
+  });
+
+  test("returns false at non-multiples of interval", () => {
+    expect(shouldSoftCheckpoint(1, 5)).toBe(false);
+    expect(shouldSoftCheckpoint(3, 5)).toBe(false);
+    expect(shouldSoftCheckpoint(7, 5)).toBe(false);
+  });
+
+  test("returns true every turn when interval is 1", () => {
+    expect(shouldSoftCheckpoint(1, 1)).toBe(true);
+    expect(shouldSoftCheckpoint(2, 1)).toBe(true);
+    expect(shouldSoftCheckpoint(100, 1)).toBe(true);
+  });
+
+  test("handles large turn indices", () => {
+    expect(shouldSoftCheckpoint(1000, 5)).toBe(true);
+    expect(shouldSoftCheckpoint(999, 5)).toBe(false);
+  });
+});
+
+describe("computeCheckpointId", () => {
+  test("produces deterministic checkpoint ID", () => {
+    const hid = harnessId("harness-1");
+    const a = computeCheckpointId(hid, "session-abc", 5);
+    const b = computeCheckpointId(hid, "session-abc", 5);
+    expect(a).toBe(b);
+  });
+
+  test("encodes harness, session, and turn", () => {
+    const hid = harnessId("h-42");
+    const result = computeCheckpointId(hid, "s-99", 7);
+    expect(result).toBe("h-42:s-99:t7");
+  });
+});

--- a/packages/long-running/src/checkpoint-policy.ts
+++ b/packages/long-running/src/checkpoint-policy.ts
@@ -1,0 +1,33 @@
+/**
+ * Checkpoint timing policy — pure functions, no I/O.
+ *
+ * Determines when soft checkpoints should fire and generates
+ * deterministic checkpoint identifiers.
+ */
+
+import type { HarnessId } from "@koi/core";
+
+/**
+ * Determine whether a soft checkpoint should fire at the given turn.
+ *
+ * Fires at every `interval`-th turn, starting from the first interval.
+ * Turn 0 never triggers a checkpoint (session just started).
+ */
+export function shouldSoftCheckpoint(turnIndex: number, interval: number): boolean {
+  if (turnIndex <= 0) return false;
+  if (interval <= 0) return false;
+  return turnIndex % interval === 0;
+}
+
+/**
+ * Generate a deterministic checkpoint ID from harness, session, and turn.
+ *
+ * Format: `{harnessId}:{sessionId}:t{turnIndex}`
+ */
+export function computeCheckpointId(
+  harnessId: HarnessId,
+  sessionId: string,
+  turnIndex: number,
+): string {
+  return `${harnessId}:${sessionId}:t${String(turnIndex)}`;
+}

--- a/packages/long-running/src/context-bridge.test.ts
+++ b/packages/long-running/src/context-bridge.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for context bridge — resume context builder.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  ContextSummary,
+  HarnessMetrics,
+  HarnessSnapshot,
+  KeyArtifact,
+  TaskBoardSnapshot,
+} from "@koi/core";
+import { harnessId, taskItemId } from "@koi/core";
+import { assertErr, assertOk } from "@koi/test-utils";
+import { buildInitialPrompt, buildResumeContext } from "./context-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const EMPTY_METRICS: HarnessMetrics = {
+  totalSessions: 0,
+  totalTurns: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  completedTaskCount: 0,
+  pendingTaskCount: 2,
+  elapsedMs: 0,
+};
+
+function createTestBoard(taskCount = 2): TaskBoardSnapshot {
+  return {
+    items: Array.from({ length: taskCount }, (_, i) => ({
+      id: taskItemId(`task-${String(i + 1)}`),
+      description: `Task ${String(i + 1)} description`,
+      dependencies: [],
+      priority: 0,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    })),
+    results: [],
+  };
+}
+
+function createTestSnapshot(overrides?: Partial<HarnessSnapshot>): HarnessSnapshot {
+  return {
+    harnessId: harnessId("test-harness"),
+    phase: "suspended",
+    sessionSeq: 1,
+    taskBoard: createTestBoard(),
+    summaries: [],
+    keyArtifacts: [],
+    agentId: "agent-1",
+    metrics: EMPTY_METRICS,
+    startedAt: Date.now(),
+    checkpointedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildInitialPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildInitialPrompt", () => {
+  test("produces plan-only output", () => {
+    const board = createTestBoard();
+    const prompt = buildInitialPrompt(board);
+    expect(prompt).toContain("Task Plan");
+    expect(prompt).toContain("task-1");
+    expect(prompt).toContain("task-2");
+    expect(prompt).toContain("Begin working");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildResumeContext
+// ---------------------------------------------------------------------------
+
+describe("buildResumeContext", () => {
+  test("returns VALIDATION error for empty task board", () => {
+    const snapshot = createTestSnapshot({
+      taskBoard: { items: [], results: [] },
+    });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("includes task plan in output", () => {
+    const snapshot = createTestSnapshot();
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    expect(result.value).toHaveLength(1);
+    const text = result.value[0]?.content[0];
+    expect(text).toBeDefined();
+    if (text?.kind === "text") {
+      expect(text.text).toContain("Task Plan");
+    }
+  });
+
+  test("includes summaries when present", () => {
+    const summaries: readonly ContextSummary[] = [
+      {
+        narrative: "Session 1 completed task A",
+        sessionSeq: 1,
+        completedTaskIds: ["task-1"],
+        estimatedTokens: 10,
+        generatedAt: Date.now(),
+      },
+    ];
+    const snapshot = createTestSnapshot({ summaries });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    const text = result.value[0]?.content[0];
+    if (text?.kind === "text") {
+      expect(text.text).toContain("Session 1 completed task A");
+    }
+  });
+
+  test("includes artifacts when present", () => {
+    const artifacts: readonly KeyArtifact[] = [
+      {
+        toolName: "code_search",
+        content: "Found 3 matching files",
+        turnIndex: 2,
+        capturedAt: Date.now(),
+      },
+    ];
+    const snapshot = createTestSnapshot({ keyArtifacts: artifacts });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    const text = result.value[0]?.content[0];
+    if (text?.kind === "text") {
+      expect(text.text).toContain("Found 3 matching files");
+    }
+  });
+
+  test("respects token budget", () => {
+    // Create very large summaries
+    const longNarrative = "x".repeat(10000);
+    const summaries: readonly ContextSummary[] = [
+      {
+        narrative: longNarrative,
+        sessionSeq: 1,
+        completedTaskIds: [],
+        estimatedTokens: 2500,
+        generatedAt: Date.now(),
+      },
+      {
+        narrative: longNarrative,
+        sessionSeq: 2,
+        completedTaskIds: [],
+        estimatedTokens: 2500,
+        generatedAt: Date.now(),
+      },
+    ];
+    const snapshot = createTestSnapshot({ summaries });
+    // With a small budget, not all summaries should fit
+    const result = buildResumeContext(snapshot, { maxContextTokens: 500 });
+    assertOk(result);
+    // Result should exist and contain task plan at minimum
+    const text = result.value[0]?.content[0];
+    if (text?.kind === "text") {
+      expect(text.text).toContain("Task Plan");
+    }
+  });
+
+  test("orders summaries newest first", () => {
+    const summaries: readonly ContextSummary[] = [
+      {
+        narrative: "First session",
+        sessionSeq: 1,
+        completedTaskIds: [],
+        estimatedTokens: 10,
+        generatedAt: 1000,
+      },
+      {
+        narrative: "Second session",
+        sessionSeq: 2,
+        completedTaskIds: [],
+        estimatedTokens: 10,
+        generatedAt: 2000,
+      },
+    ];
+    const snapshot = createTestSnapshot({ summaries });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    const text = result.value[0]?.content[0];
+    if (text?.kind === "text") {
+      const firstIdx = text.text.indexOf("Second session");
+      const secondIdx = text.text.indexOf("First session");
+      // Newest should come first
+      expect(firstIdx).toBeLessThan(secondIdx);
+    }
+  });
+
+  test("produces InboundMessage with senderId 'harness'", () => {
+    const snapshot = createTestSnapshot();
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    expect(result.value[0]?.senderId).toBe("harness");
+  });
+
+  test("resume messages are pinned to survive compaction", () => {
+    const snapshot = createTestSnapshot();
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+    expect(result.value[0]?.pinned).toBe(true);
+  });
+
+  test("handles missing summaries gracefully (fail-open)", () => {
+    const snapshot = createTestSnapshot({ summaries: [] });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+  });
+
+  test("handles missing artifacts gracefully (fail-open)", () => {
+    const snapshot = createTestSnapshot({ keyArtifacts: [] });
+    const result = buildResumeContext(snapshot, { maxContextTokens: 3000 });
+    assertOk(result);
+  });
+
+  test("token estimation is roughly text.length / 4", () => {
+    // Sanity check: build with exact budget
+    const snapshot = createTestSnapshot();
+    const result = buildResumeContext(snapshot, { maxContextTokens: 100 });
+    assertOk(result);
+  });
+});

--- a/packages/long-running/src/context-bridge.ts
+++ b/packages/long-running/src/context-bridge.ts
@@ -1,0 +1,163 @@
+/**
+ * Context bridge — builds resume context from a harness snapshot.
+ *
+ * Pure function that assembles InboundMessage[] from the snapshot's
+ * task board, context summaries, and key artifacts, respecting a
+ * token budget. No I/O, depends only on L0 types.
+ */
+
+import type {
+  HarnessSnapshot,
+  InboundMessage,
+  KoiError,
+  Result,
+  TaskBoardSnapshot,
+  TaskItem,
+} from "@koi/core";
+import { validation } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+/** Estimate token count from text length. ~4 chars per token. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// Task plan formatting
+// ---------------------------------------------------------------------------
+
+function formatTaskItem(item: TaskItem): string {
+  const statusIcon =
+    item.status === "completed"
+      ? "[x]"
+      : item.status === "failed"
+        ? "[!]"
+        : item.status === "assigned"
+          ? "[~]"
+          : "[ ]";
+  return `${statusIcon} ${item.id}: ${item.description}`;
+}
+
+function formatTaskBoard(board: TaskBoardSnapshot): string {
+  const lines: readonly string[] = [
+    "## Task Plan",
+    "",
+    ...board.items.map(formatTaskItem),
+    "",
+    `Completed: ${String(board.items.filter((i: TaskItem) => i.status === "completed").length)}/${String(board.items.length)}`,
+  ];
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build initial prompt from a task plan for the first session.
+ *
+ * Returns a text string describing the task plan for the engine.
+ */
+export function buildInitialPrompt(plan: TaskBoardSnapshot): string {
+  const lines: readonly string[] = [
+    "You are resuming a long-running task. Here is your task plan:",
+    "",
+    formatTaskBoard(plan),
+    "",
+    "Begin working on the pending tasks in priority order.",
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Build resume context from a harness snapshot.
+ *
+ * Assembles InboundMessage[] with:
+ * 1. Task plan (always included)
+ * 2. Context summaries (newest first, up to half remaining budget)
+ * 3. Key artifacts (newest first, up to half remaining budget)
+ *
+ * @returns Result with messages on success, VALIDATION error if task board is empty.
+ */
+export function buildResumeContext(
+  snapshot: HarnessSnapshot,
+  config: { readonly maxContextTokens: number },
+): Result<readonly InboundMessage[], KoiError> {
+  // Fail-closed: can't resume without a plan
+  if (snapshot.taskBoard.items.length === 0) {
+    return {
+      ok: false,
+      error: validation("Cannot build resume context: task board is empty"),
+    };
+  }
+
+  const budget = config.maxContextTokens;
+  const parts: string[] = [];
+
+  // Phase 1: Task plan (always included)
+  const planText = formatTaskBoard(snapshot.taskBoard);
+  parts.push(planText);
+  let usedTokens = estimateTokens(planText);
+
+  const remaining = budget - usedTokens;
+  const halfRemaining = Math.floor(remaining / 2);
+
+  // Phase 2: Summaries (newest first, up to half remaining)
+  if (snapshot.summaries.length > 0) {
+    const summaryLines: string[] = ["", "## Previous Session Summaries"];
+    let summaryTokens = estimateTokens(summaryLines.join("\n"));
+
+    // Walk newest first
+    const sortedSummaries = [...snapshot.summaries].sort((a, b) => b.sessionSeq - a.sessionSeq);
+
+    for (const summary of sortedSummaries) {
+      const line = `\nSession ${String(summary.sessionSeq)}: ${summary.narrative}`;
+      const lineTokens = estimateTokens(line);
+      if (summaryTokens + lineTokens > halfRemaining) break;
+      summaryLines.push(line);
+      summaryTokens += lineTokens;
+    }
+
+    if (summaryLines.length > 2) {
+      const summaryText = summaryLines.join("\n");
+      parts.push(summaryText);
+      usedTokens += estimateTokens(summaryText);
+    }
+  }
+
+  // Phase 3: Artifacts (newest first, up to half remaining)
+  if (snapshot.keyArtifacts.length > 0) {
+    const artifactLines: string[] = ["", "## Key Artifacts"];
+    let artifactTokens = estimateTokens(artifactLines.join("\n"));
+
+    // Walk newest first (by capturedAt)
+    const sortedArtifacts = [...snapshot.keyArtifacts].sort((a, b) => b.capturedAt - a.capturedAt);
+
+    for (const artifact of sortedArtifacts) {
+      const line = `\n[${artifact.toolName} @ turn ${String(artifact.turnIndex)}]: ${artifact.content}`;
+      const lineTokens = estimateTokens(line);
+      if (artifactTokens + lineTokens > halfRemaining) break;
+      artifactLines.push(line);
+      artifactTokens += lineTokens;
+    }
+
+    if (artifactLines.length > 2) {
+      const artifactText = artifactLines.join("\n");
+      parts.push(artifactText);
+    }
+  }
+
+  const fullText = parts.join("\n");
+
+  const message: InboundMessage = {
+    senderId: "harness",
+    timestamp: Date.now(),
+    content: [{ kind: "text", text: fullText }],
+    pinned: true,
+  };
+
+  return { ok: true, value: [message] };
+}

--- a/packages/long-running/src/harness.test.ts
+++ b/packages/long-running/src/harness.test.ts
@@ -1,0 +1,692 @@
+/**
+ * Tests for the long-running harness.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AgentId,
+  EngineMetrics,
+  EngineState,
+  HarnessSnapshotStore,
+  KoiError,
+  SessionCheckpoint,
+  SessionPersistence,
+  TaskBoardSnapshot,
+  TaskResult,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { agentId, chainId, harnessId, sessionId, taskItemId } from "@koi/core";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import {
+  assertErr,
+  assertOk,
+  createMockSessionContext,
+  createMockTurnContext,
+} from "@koi/test-utils";
+import { createLongRunningHarness } from "./harness.js";
+import type { LongRunningConfig, LongRunningHarness, SessionResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_HARNESS_ID = harnessId("test-harness");
+const TEST_AGENT_ID = agentId("agent-1");
+const TEST_CHAIN_ID = chainId(TEST_HARNESS_ID);
+
+const DEFAULT_METRICS: EngineMetrics = {
+  totalTokens: 100,
+  inputTokens: 60,
+  outputTokens: 40,
+  turns: 3,
+  durationMs: 5000,
+};
+
+function createTestPlan(count = 3): TaskBoardSnapshot {
+  return {
+    items: Array.from({ length: count }, (_, i) => ({
+      id: taskItemId(`task-${String(i + 1)}`),
+      description: `Test task ${String(i + 1)}`,
+      dependencies: [],
+      priority: i,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    })),
+    results: [],
+  };
+}
+
+function createSessionResult(overrides?: Partial<SessionResult>): SessionResult {
+  return {
+    sessionId: "session-1",
+    metrics: DEFAULT_METRICS,
+    ...overrides,
+  };
+}
+
+function createTaskResult(taskId: string): TaskResult {
+  return {
+    taskId: taskItemId(taskId),
+    output: `Completed ${taskId}`,
+    durationMs: 1000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock SessionPersistence
+// ---------------------------------------------------------------------------
+
+function createMockSessionPersistence(): SessionPersistence & {
+  readonly savedCheckpoints: SessionCheckpoint[];
+  setLatestCheckpoint: (cp: SessionCheckpoint | undefined) => void;
+} {
+  const savedCheckpoints: SessionCheckpoint[] = [];
+  let latestCheckpoint: SessionCheckpoint | undefined;
+
+  return {
+    savedCheckpoints,
+    setLatestCheckpoint(cp: SessionCheckpoint | undefined): void {
+      latestCheckpoint = cp;
+    },
+    saveSession: () => ({ ok: true as const, value: undefined }),
+    loadSession: () => ({
+      ok: false as const,
+      error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+    }),
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    saveCheckpoint(cp: SessionCheckpoint) {
+      savedCheckpoints.push(cp);
+      return { ok: true as const, value: undefined };
+    },
+    loadLatestCheckpoint(_aid: AgentId) {
+      return { ok: true as const, value: latestCheckpoint };
+    },
+    listCheckpoints: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], checkpoints: new Map(), pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let harnessStore: HarnessSnapshotStore;
+let persistence: ReturnType<typeof createMockSessionPersistence>;
+let harness: LongRunningHarness;
+
+function createTestHarness(overrides?: Partial<LongRunningConfig>): LongRunningHarness {
+  const config: LongRunningConfig = {
+    harnessId: TEST_HARNESS_ID,
+    agentId: TEST_AGENT_ID,
+    harnessStore,
+    sessionPersistence: persistence,
+    ...overrides,
+  };
+  return createLongRunningHarness(config);
+}
+
+beforeEach(() => {
+  harnessStore = createInMemorySnapshotChainStore();
+  persistence = createMockSessionPersistence();
+  harness = createTestHarness();
+});
+
+// ---------------------------------------------------------------------------
+// start()
+// ---------------------------------------------------------------------------
+
+describe("start", () => {
+  test("returns text engine input with task plan", async () => {
+    const plan = createTestPlan();
+    const result = await harness.start(plan);
+    assertOk(result);
+    expect(result.value.engineInput.kind).toBe("text");
+    if (result.value.engineInput.kind === "text") {
+      expect(result.value.engineInput.text).toContain("Task Plan");
+    }
+  });
+
+  test("returns a session ID", async () => {
+    const result = await harness.start(createTestPlan());
+    assertOk(result);
+    expect(result.value.sessionId).toBeTruthy();
+  });
+
+  test("persists initial snapshot to store", async () => {
+    const result = await harness.start(createTestPlan());
+    assertOk(result);
+
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value).toBeDefined();
+    expect(headResult.value?.data.phase).toBe("active");
+    expect(headResult.value?.data.sessionSeq).toBe(1);
+  });
+
+  test("transitions phase to active", async () => {
+    await harness.start(createTestPlan());
+    expect(harness.status().phase).toBe("active");
+  });
+
+  test("rejects empty task plan", async () => {
+    const emptyPlan: TaskBoardSnapshot = { items: [], results: [] };
+    const result = await harness.start(emptyPlan);
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pause()
+// ---------------------------------------------------------------------------
+
+describe("pause", () => {
+  beforeEach(async () => {
+    await harness.start(createTestPlan());
+  });
+
+  test("transitions phase to suspended", async () => {
+    const result = await harness.pause(createSessionResult());
+    assertOk(result);
+    expect(harness.status().phase).toBe("suspended");
+  });
+
+  test("accumulates metrics", async () => {
+    const result = await harness.pause(createSessionResult());
+    assertOk(result);
+    const status = harness.status();
+    expect(status.metrics.totalSessions).toBe(1);
+    expect(status.metrics.totalTurns).toBe(3);
+    expect(status.metrics.totalInputTokens).toBe(60);
+    expect(status.metrics.totalOutputTokens).toBe(40);
+  });
+
+  test("saves engine state via session persistence", async () => {
+    const engineState: EngineState = { engineId: "test", data: { foo: "bar" } };
+    await harness.pause(createSessionResult({ engineState }));
+    expect(persistence.savedCheckpoints.length).toBeGreaterThan(0);
+  });
+
+  test("creates hard checkpoint in harness store", async () => {
+    await harness.pause(createSessionResult());
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.phase).toBe("suspended");
+  });
+
+  test("rejects when not in active phase", async () => {
+    await harness.pause(createSessionResult());
+    // Now suspended — pause again should fail
+    const result = await harness.pause(createSessionResult());
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("appends context summary when provided", async () => {
+    await harness.pause(createSessionResult({ summary: "Did great work" }));
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.summaries).toHaveLength(1);
+    expect(headResult.value?.data.summaries[0]?.narrative).toBe("Did great work");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume()
+// ---------------------------------------------------------------------------
+
+describe("resume", () => {
+  beforeEach(async () => {
+    await harness.start(createTestPlan());
+    await harness.pause(createSessionResult({ summary: "Session 1 done" }));
+  });
+
+  test("resumes with engine state when available", async () => {
+    const engineState: EngineState = { engineId: "test", data: { turnCount: 5 } };
+    const checkpoint: SessionCheckpoint = {
+      id: "cp-1",
+      agentId: TEST_AGENT_ID,
+      sessionId: sessionId("s-1"),
+      engineState,
+      processState: "running",
+      generation: 1,
+      metadata: {},
+      createdAt: Date.now(),
+    };
+    persistence.setLatestCheckpoint(checkpoint);
+
+    const result = await harness.resume();
+    assertOk(result);
+    expect(result.value.engineStateRecovered).toBe(true);
+    expect(result.value.engineInput.kind).toBe("resume");
+  });
+
+  test("falls back to messages when no engine state", async () => {
+    const result = await harness.resume();
+    assertOk(result);
+    expect(result.value.engineStateRecovered).toBe(false);
+    expect(result.value.engineInput.kind).toBe("messages");
+  });
+
+  test("increments sessionSeq", async () => {
+    await harness.resume();
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.sessionSeq).toBe(2);
+  });
+
+  test("rejects when not in suspended phase", async () => {
+    await harness.resume();
+    // Now active — resume again should fail
+    const result = await harness.resume();
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeTask()
+// ---------------------------------------------------------------------------
+
+describe("completeTask", () => {
+  beforeEach(async () => {
+    await harness.start(createTestPlan());
+  });
+
+  test("marks task as completed in board", async () => {
+    const result = await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    assertOk(result);
+    const status = harness.status();
+    const task = status.taskBoard.items.find((i) => i.id === "task-1");
+    expect(task?.status).toBe("completed");
+  });
+
+  test("transitions to completed when all tasks done", async () => {
+    await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    await harness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    expect(harness.status().phase).toBe("completed");
+  });
+
+  test("returns NOT_FOUND for unknown task", async () => {
+    const result = await harness.completeTask(
+      taskItemId("nonexistent"),
+      createTaskResult("nonexistent"),
+    );
+    assertErr(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("rejects when not in active or suspended phase", async () => {
+    // Complete all tasks to move to "completed" phase
+    await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    await harness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+
+    const result = await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    assertErr(result);
+  });
+
+  test("is callable in both active and suspended phases", async () => {
+    // Active phase
+    const r1 = await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    assertOk(r1);
+
+    // Pause to suspended
+    await harness.pause(createSessionResult());
+
+    // Suspended phase
+    const r2 = await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    assertOk(r2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status()
+// ---------------------------------------------------------------------------
+
+describe("status", () => {
+  test("reflects current phase", async () => {
+    expect(harness.status().phase).toBe("idle");
+    await harness.start(createTestPlan());
+    expect(harness.status().phase).toBe("active");
+  });
+
+  test("reflects task board", async () => {
+    await harness.start(createTestPlan(2));
+    const status = harness.status();
+    expect(status.taskBoard.items).toHaveLength(2);
+  });
+
+  test("reflects metrics", async () => {
+    await harness.start(createTestPlan());
+    await harness.pause(createSessionResult());
+    const status = harness.status();
+    expect(status.metrics.totalSessions).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeTask() — metric assertions (Gap 6)
+// ---------------------------------------------------------------------------
+
+describe("completeTask metrics", () => {
+  beforeEach(async () => {
+    await harness.start(createTestPlan());
+  });
+
+  test("updates completedTaskCount after each completion", async () => {
+    await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    expect(harness.status().metrics.completedTaskCount).toBe(1);
+    expect(harness.status().metrics.pendingTaskCount).toBe(2);
+
+    await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    expect(harness.status().metrics.completedTaskCount).toBe(2);
+    expect(harness.status().metrics.pendingTaskCount).toBe(1);
+  });
+
+  test("sets pendingTaskCount to 0 when all done", async () => {
+    await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    await harness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    expect(harness.status().metrics.completedTaskCount).toBe(3);
+    expect(harness.status().metrics.pendingTaskCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fail() (Gap 1)
+// ---------------------------------------------------------------------------
+
+describe("fail", () => {
+  beforeEach(async () => {
+    await harness.start(createTestPlan());
+  });
+
+  test("transitions phase to failed", async () => {
+    const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+    const result = await harness.fail(error);
+    assertOk(result);
+    expect(harness.status().phase).toBe("failed");
+  });
+
+  test("persists failureReason in status", async () => {
+    const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+    await harness.fail(error);
+    expect(harness.status().failureReason).toBe("Agent timed out");
+  });
+
+  test("persists failureReason in snapshot store", async () => {
+    const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+    await harness.fail(error);
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.phase).toBe("failed");
+    expect(headResult.value?.data.failureReason).toBe("Agent timed out");
+  });
+
+  test("is callable from active phase", async () => {
+    const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+    const result = await harness.fail(error);
+    assertOk(result);
+  });
+
+  test("is callable from suspended phase", async () => {
+    await harness.pause(createSessionResult());
+    const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+    const result = await harness.fail(error);
+    assertOk(result);
+    expect(harness.status().phase).toBe("failed");
+  });
+
+  test("rejects from idle phase", async () => {
+    const freshHarness = createTestHarness();
+    const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+    const result = await freshHarness.fail(error);
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects from completed phase", async () => {
+    await harness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await harness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    await harness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    expect(harness.status().phase).toBe("completed");
+
+    const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+    const result = await harness.fail(error);
+    assertErr(result);
+  });
+
+  test("prevents further operations after fail", async () => {
+    await harness.fail({ code: "TIMEOUT", message: "Timed out", retryable: false });
+    const resumeResult = await harness.resume();
+    assertErr(resumeResult);
+    const startResult = await harness.start(createTestPlan());
+    assertErr(startResult);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resume() — store recovery path (Gap 5)
+// ---------------------------------------------------------------------------
+
+describe("resume store recovery", () => {
+  test("resume uses in-memory snapshot and loads from store as fallback", async () => {
+    // Standard start → pause → resume cycle exercises the in-memory path
+    await harness.start(createTestPlan());
+    await harness.pause(createSessionResult({ summary: "Session 1" }));
+
+    const result = await harness.resume();
+    assertOk(result);
+    expect(result.value.engineInput.kind).toBe("messages");
+    expect(result.value.engineStateRecovered).toBe(false);
+  });
+
+  test("resume loads snapshot from store when harness state is persisted", async () => {
+    // Verify the store has data after start → pause
+    await harness.start(createTestPlan());
+    await harness.pause(createSessionResult({ summary: "Session 1" }));
+
+    // Verify data was written to the store
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value).toBeDefined();
+    expect(headResult.value?.data.phase).toBe("suspended");
+    expect(headResult.value?.data.summaries).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMiddleware() (Gap 3 + 4)
+// ---------------------------------------------------------------------------
+
+describe("createMiddleware", () => {
+  test("returns middleware with correct name and priority", async () => {
+    await harness.start(createTestPlan());
+    const mw = harness.createMiddleware();
+    expect(mw.name).toBe("long-running-harness");
+    expect(mw.priority).toBe(50);
+  });
+
+  test("onAfterTurn increments turn count and fires soft checkpoint", async () => {
+    const testHarness = createTestHarness({ softCheckpointInterval: 1 });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+
+    // Fire onAfterTurn — should trigger soft checkpoint at every turn
+    await mw.onAfterTurn?.(ctx);
+
+    // Check that a checkpoint was saved
+    expect(persistence.savedCheckpoints.length).toBe(1);
+    expect(persistence.savedCheckpoints[0]?.metadata).toEqual({ softCheckpoint: true });
+  });
+
+  test("onAfterTurn uses saveState callback for real engine state", async () => {
+    const realState: EngineState = { engineId: "real-engine", data: { cursor: 42 } };
+    const testHarness = createTestHarness({
+      softCheckpointInterval: 1,
+      saveState: () => realState,
+    });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+    await mw.onAfterTurn?.(ctx);
+
+    expect(persistence.savedCheckpoints.length).toBe(1);
+    expect(persistence.savedCheckpoints[0]?.engineState).toEqual(realState);
+  });
+
+  test("onAfterTurn uses placeholder when no saveState callback", async () => {
+    const testHarness = createTestHarness({ softCheckpointInterval: 1 });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+    await mw.onAfterTurn?.(ctx);
+
+    expect(persistence.savedCheckpoints[0]?.engineState).toEqual({
+      engineId: "soft-checkpoint",
+      data: null,
+    });
+  });
+
+  test("onAfterTurn respects checkpoint interval", async () => {
+    const testHarness = createTestHarness({ softCheckpointInterval: 3 });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 0 });
+
+    // Turns 1, 2 — no checkpoint
+    await mw.onAfterTurn?.(ctx);
+    await mw.onAfterTurn?.(ctx);
+    expect(persistence.savedCheckpoints.length).toBe(0);
+
+    // Turn 3 — checkpoint
+    await mw.onAfterTurn?.(ctx);
+    expect(persistence.savedCheckpoints.length).toBe(1);
+  });
+
+  test("wrapToolCall captures artifact for configured tool names", async () => {
+    const testHarness = createTestHarness({ artifactToolNames: ["code_search"] });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 1 });
+    const request: ToolRequest = { toolId: "code_search", input: { query: "foo" } };
+    const mockResponse: ToolResponse = { output: "Found 3 files" };
+    const next = async (_req: ToolRequest): Promise<ToolResponse> => mockResponse;
+
+    const response = await mw.wrapToolCall?.(ctx, request, next);
+    expect(response).toEqual(mockResponse);
+
+    // Pause to flush artifacts into snapshot
+    await testHarness.pause(createSessionResult());
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.keyArtifacts).toHaveLength(1);
+    expect(headResult.value?.data.keyArtifacts[0]?.toolName).toBe("code_search");
+    expect(headResult.value?.data.keyArtifacts[0]?.content).toBe("Found 3 files");
+  });
+
+  test("wrapToolCall ignores non-configured tool names", async () => {
+    const testHarness = createTestHarness({ artifactToolNames: ["code_search"] });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 1 });
+    const request: ToolRequest = { toolId: "other_tool", input: {} };
+    const mockResponse: ToolResponse = { output: "Some output" };
+    const next = async (_req: ToolRequest): Promise<ToolResponse> => mockResponse;
+
+    await mw.wrapToolCall?.(ctx, request, next);
+
+    // Pause — no artifacts should be captured
+    await testHarness.pause(createSessionResult());
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.keyArtifacts).toHaveLength(0);
+  });
+
+  test("wrapToolCall truncates large artifact content to 2000 chars", async () => {
+    const testHarness = createTestHarness({ artifactToolNames: ["big_tool"] });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    const ctx = createMockTurnContext({ turnIndex: 1 });
+    const request: ToolRequest = { toolId: "big_tool", input: {} };
+    const largeOutput = "x".repeat(5000);
+    const next = async (_req: ToolRequest): Promise<ToolResponse> => ({ output: largeOutput });
+
+    await mw.wrapToolCall?.(ctx, request, next);
+
+    await testHarness.pause(createSessionResult());
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.keyArtifacts[0]?.content.length).toBe(2000);
+  });
+
+  test("onSessionEnd flushes captured artifacts to snapshot", async () => {
+    const testHarness = createTestHarness({ artifactToolNames: ["code_search"] });
+    await testHarness.start(createTestPlan());
+    const mw = testHarness.createMiddleware();
+
+    // Capture an artifact via wrapToolCall
+    const ctx = createMockTurnContext({ turnIndex: 1 });
+    const request: ToolRequest = { toolId: "code_search", input: { query: "bar" } };
+    const next = async (_req: ToolRequest): Promise<ToolResponse> => ({ output: "Result" });
+    await mw.wrapToolCall?.(ctx, request, next);
+
+    // Fire onSessionEnd — should flush artifacts
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionEnd?.(sessionCtx);
+
+    // Verify artifacts were persisted
+    const headResult = await harnessStore.head(TEST_CHAIN_ID);
+    assertOk(headResult);
+    expect(headResult.value?.data.keyArtifacts).toHaveLength(1);
+    expect(headResult.value?.data.keyArtifacts[0]?.content).toBe("Result");
+  });
+
+  test("onSessionEnd is no-op when no artifacts captured", async () => {
+    await harness.start(createTestPlan());
+    const mw = harness.createMiddleware();
+
+    const sessionCtx = createMockSessionContext();
+    // Should not throw or error
+    await mw.onSessionEnd?.(sessionCtx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispose()
+// ---------------------------------------------------------------------------
+
+describe("dispose", () => {
+  test("prevents further operations", async () => {
+    await harness.dispose();
+    const result = await harness.start(createTestPlan());
+    assertErr(result);
+    expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("is idempotent", async () => {
+    await harness.dispose();
+    await harness.dispose(); // Should not throw
+  });
+});

--- a/packages/long-running/src/harness.ts
+++ b/packages/long-running/src/harness.ts
@@ -1,0 +1,592 @@
+/**
+ * Long-running harness — state manager for multi-session agent operation.
+ *
+ * Called at session boundaries by Node (not a middleware or engine decorator).
+ * Owns the task plan, context summaries, and progress tracking.
+ * Engine state lives in SessionPersistence (crash recovery).
+ * Harness state lives in SnapshotChainStore<HarnessSnapshot> (semantic history).
+ */
+
+import type {
+  ContextSummary,
+  EngineState,
+  HarnessMetrics,
+  HarnessPhase,
+  HarnessSnapshot,
+  HarnessStatus,
+  KeyArtifact,
+  KoiError,
+  KoiMiddleware,
+  NodeId,
+  Result,
+  SessionCheckpoint,
+  SessionContext,
+  TaskBoardSnapshot,
+  TaskItem,
+  TaskItemId,
+  TaskResult,
+  ToolHandler,
+  ToolRequest,
+  TurnContext,
+} from "@koi/core";
+import { chainId, sessionId as createSessionId, validation } from "@koi/core";
+import { computeCheckpointId, shouldSoftCheckpoint } from "./checkpoint-policy.js";
+import { buildInitialPrompt, buildResumeContext } from "./context-bridge.js";
+import type {
+  LongRunningConfig,
+  LongRunningHarness,
+  ResumeResult,
+  SaveStateCallback,
+  SessionResult,
+  StartResult,
+} from "./types.js";
+import { DEFAULT_LONG_RUNNING_CONFIG } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_METRICS: HarnessMetrics = {
+  totalSessions: 0,
+  totalTurns: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  completedTaskCount: 0,
+  pendingTaskCount: 0,
+  elapsedMs: 0,
+};
+
+function mergeMetrics(base: HarnessMetrics, session: SessionResult): HarnessMetrics {
+  return {
+    totalSessions: base.totalSessions + 1,
+    totalTurns: base.totalTurns + session.metrics.turns,
+    totalInputTokens: base.totalInputTokens + session.metrics.inputTokens,
+    totalOutputTokens: base.totalOutputTokens + session.metrics.outputTokens,
+    completedTaskCount: base.completedTaskCount,
+    pendingTaskCount: base.pendingTaskCount,
+    elapsedMs: base.elapsedMs + session.metrics.durationMs,
+  };
+}
+
+function generateSessionId(): string {
+  return `session-${crypto.randomUUID()}`;
+}
+
+function countByStatus(board: TaskBoardSnapshot, status: string): number {
+  return board.items.filter((i: TaskItem) => i.status === status).length;
+}
+
+function updateTaskInBoard(
+  board: TaskBoardSnapshot,
+  taskId: TaskItemId,
+  result: TaskResult,
+): TaskBoardSnapshot {
+  const updatedItems: readonly TaskItem[] = board.items.map((item: TaskItem) =>
+    item.id === taskId ? { ...item, status: "completed" as const } : item,
+  );
+  return {
+    items: updatedItems,
+    results: [...board.results, result],
+  };
+}
+
+function allTasksCompleted(board: TaskBoardSnapshot): boolean {
+  return board.items.every(
+    (item: TaskItem) => item.status === "completed" || item.status === "failed",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a long-running harness for multi-session agent operation.
+ */
+export function createLongRunningHarness(config: LongRunningConfig): LongRunningHarness {
+  const { harnessId, agentId, harnessStore, sessionPersistence } = config;
+  const softCheckpointInterval =
+    config.softCheckpointInterval ?? DEFAULT_LONG_RUNNING_CONFIG.softCheckpointInterval;
+  const maxKeyArtifacts = config.maxKeyArtifacts ?? DEFAULT_LONG_RUNNING_CONFIG.maxKeyArtifacts;
+  const maxContextTokens = config.maxContextTokens ?? DEFAULT_LONG_RUNNING_CONFIG.maxContextTokens;
+  const artifactToolNames = config.artifactToolNames ?? [];
+  const pruningPolicy = config.pruningPolicy ?? DEFAULT_LONG_RUNNING_CONFIG.pruningPolicy;
+  const saveState: SaveStateCallback | undefined = config.saveState;
+
+  const cid = chainId(harnessId);
+
+  // Internal mutable state (references to immutable snapshots)
+  let currentSnapshot: HarnessSnapshot | undefined;
+  let currentNodeId: NodeId | undefined;
+  let phase: HarnessPhase = "idle";
+  let turnCount = 0;
+  let capturedArtifacts: readonly KeyArtifact[] = [];
+  let disposed = false;
+  let currentSessionId: string | undefined;
+  let startedAt: number | undefined;
+
+  // -------------------------------------------------------------------------
+  // Snapshot persistence
+  // -------------------------------------------------------------------------
+
+  async function persistSnapshot(snapshot: HarnessSnapshot): Promise<Result<void, KoiError>> {
+    const parentIds = currentNodeId !== undefined ? [currentNodeId] : [];
+    const putResult = await harnessStore.put(cid, snapshot, parentIds);
+    if (!putResult.ok) return putResult;
+    if (putResult.value !== undefined) {
+      currentNodeId = putResult.value.nodeId;
+    }
+    currentSnapshot = snapshot;
+    return { ok: true, value: undefined };
+  }
+
+  // -------------------------------------------------------------------------
+  // Guard helpers
+  // -------------------------------------------------------------------------
+
+  function guardDisposed(): Result<void, KoiError> {
+    if (disposed) {
+      return { ok: false, error: validation("Harness has been disposed") };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  function guardPhase(...allowed: readonly HarnessPhase[]): Result<void, KoiError> {
+    if (!allowed.includes(phase)) {
+      return {
+        ok: false,
+        error: validation(`Invalid phase: expected one of [${allowed.join(", ")}], got "${phase}"`),
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  // -------------------------------------------------------------------------
+  // start()
+  // -------------------------------------------------------------------------
+
+  const start = async (taskPlan: TaskBoardSnapshot): Promise<Result<StartResult, KoiError>> => {
+    const dg = guardDisposed();
+    if (!dg.ok) return dg;
+    const pg = guardPhase("idle");
+    if (!pg.ok) return pg;
+
+    if (taskPlan.items.length === 0) {
+      return { ok: false, error: validation("Task plan must have at least one task") };
+    }
+
+    const now = Date.now();
+    const sid = generateSessionId();
+    startedAt = now;
+    currentSessionId = sid;
+
+    const snapshot: HarnessSnapshot = {
+      harnessId,
+      phase: "active",
+      sessionSeq: 1,
+      taskBoard: taskPlan,
+      summaries: [],
+      keyArtifacts: [],
+      lastSessionId: sid,
+      agentId,
+      metrics: {
+        ...EMPTY_METRICS,
+        pendingTaskCount: taskPlan.items.length,
+      },
+      startedAt: now,
+      checkpointedAt: now,
+    };
+
+    const persistResult = await persistSnapshot(snapshot);
+    if (!persistResult.ok) return persistResult;
+
+    phase = "active";
+    turnCount = 0;
+    capturedArtifacts = [];
+
+    const promptText = buildInitialPrompt(taskPlan);
+
+    return {
+      ok: true,
+      value: {
+        engineInput: { kind: "text", text: promptText },
+        sessionId: sid,
+      },
+    };
+  };
+
+  // -------------------------------------------------------------------------
+  // resume()
+  // -------------------------------------------------------------------------
+
+  const resume = async (): Promise<Result<ResumeResult, KoiError>> => {
+    const dg = guardDisposed();
+    if (!dg.ok) return dg;
+    const pg = guardPhase("suspended");
+    if (!pg.ok) return pg;
+
+    const sid = generateSessionId();
+    currentSessionId = sid;
+    turnCount = 0;
+    capturedArtifacts = [];
+
+    // Try to load from store if we don't have in-memory snapshot
+    if (currentSnapshot === undefined) {
+      const headResult = await harnessStore.head(cid);
+      if (headResult.ok && headResult.value !== undefined) {
+        currentSnapshot = headResult.value.data;
+        currentNodeId = headResult.value.nodeId;
+      }
+    }
+
+    if (currentSnapshot === undefined) {
+      return {
+        ok: false,
+        error: validation("No snapshot available for resume"),
+      };
+    }
+
+    // Try engine state recovery
+    const checkpointResult = await sessionPersistence.loadLatestCheckpoint(config.agentId);
+
+    let _engineStateRecovered = false;
+
+    if (checkpointResult.ok && checkpointResult.value !== undefined) {
+      const checkpoint = checkpointResult.value;
+      _engineStateRecovered = true;
+
+      const nextSeq = currentSnapshot.sessionSeq + 1;
+      const updated: HarnessSnapshot = {
+        ...currentSnapshot,
+        sessionSeq: nextSeq,
+        lastSessionId: sid,
+        checkpointedAt: Date.now(),
+      };
+      await persistSnapshot(updated);
+      phase = "active";
+
+      return {
+        ok: true,
+        value: {
+          engineInput: { kind: "resume", state: checkpoint.engineState },
+          sessionId: sid,
+          engineStateRecovered: true,
+        },
+      };
+    }
+
+    // Fallback: build resume context from summaries
+    const contextResult = buildResumeContext(currentSnapshot, { maxContextTokens });
+    if (!contextResult.ok) return contextResult;
+
+    const nextSeq = currentSnapshot.sessionSeq + 1;
+    const updated: HarnessSnapshot = {
+      ...currentSnapshot,
+      sessionSeq: nextSeq,
+      lastSessionId: sid,
+      checkpointedAt: Date.now(),
+    };
+    await persistSnapshot(updated);
+    phase = "active";
+
+    return {
+      ok: true,
+      value: {
+        engineInput: { kind: "messages", messages: contextResult.value },
+        sessionId: sid,
+        engineStateRecovered: false,
+      },
+    };
+  };
+
+  // -------------------------------------------------------------------------
+  // pause()
+  // -------------------------------------------------------------------------
+
+  const pause = async (sessionResult: SessionResult): Promise<Result<void, KoiError>> => {
+    const dg = guardDisposed();
+    if (!dg.ok) return dg;
+    const pg = guardPhase("active");
+    if (!pg.ok) return pg;
+
+    if (currentSnapshot === undefined) {
+      return { ok: false, error: validation("No active snapshot to pause") };
+    }
+
+    // Merge metrics
+    const mergedMetrics = mergeMetrics(currentSnapshot.metrics, sessionResult);
+    const updatedMetrics: HarnessMetrics = {
+      ...mergedMetrics,
+      completedTaskCount: countByStatus(currentSnapshot.taskBoard, "completed"),
+      pendingTaskCount: countByStatus(currentSnapshot.taskBoard, "pending"),
+    };
+
+    // Build summary if provided
+    const newSummaries: readonly ContextSummary[] =
+      sessionResult.summary !== undefined
+        ? [
+            ...currentSnapshot.summaries,
+            {
+              narrative: sessionResult.summary,
+              sessionSeq: currentSnapshot.sessionSeq,
+              completedTaskIds: currentSnapshot.taskBoard.results.map((r: TaskResult) => r.taskId),
+              estimatedTokens: Math.ceil(sessionResult.summary.length / 4),
+              generatedAt: Date.now(),
+            },
+          ]
+        : currentSnapshot.summaries;
+
+    // Save engine state via session persistence if available
+    if (sessionResult.engineState !== undefined) {
+      const checkpoint: SessionCheckpoint = {
+        id: computeCheckpointId(harnessId, sessionResult.sessionId, turnCount),
+        agentId: config.agentId,
+        sessionId: createSessionId(sessionResult.sessionId),
+        engineState: sessionResult.engineState,
+        processState: "running",
+        generation: currentSnapshot.sessionSeq,
+        metadata: {},
+        createdAt: Date.now(),
+      };
+      await sessionPersistence.saveCheckpoint(checkpoint);
+    }
+
+    // Limit artifacts
+    const allArtifacts = [...currentSnapshot.keyArtifacts, ...capturedArtifacts];
+    const limitedArtifacts = allArtifacts.slice(-maxKeyArtifacts);
+
+    // Hard checkpoint
+    const now = Date.now();
+    const snapshot: HarnessSnapshot = {
+      ...currentSnapshot,
+      phase: "suspended",
+      summaries: newSummaries,
+      keyArtifacts: limitedArtifacts,
+      metrics: updatedMetrics,
+      checkpointedAt: now,
+    };
+
+    const persistResult = await persistSnapshot(snapshot);
+    if (!persistResult.ok) return persistResult;
+
+    phase = "suspended";
+    capturedArtifacts = [];
+
+    // Fire-and-forget pruning
+    void harnessStore.prune(cid, pruningPolicy);
+
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // completeTask()
+  // -------------------------------------------------------------------------
+
+  const completeTask = async (
+    taskId: TaskItemId,
+    result: TaskResult,
+  ): Promise<Result<void, KoiError>> => {
+    const dg = guardDisposed();
+    if (!dg.ok) return dg;
+    const pg = guardPhase("active", "suspended");
+    if (!pg.ok) return pg;
+
+    if (currentSnapshot === undefined) {
+      return { ok: false, error: validation("No active snapshot") };
+    }
+
+    // Verify task exists
+    const task = currentSnapshot.taskBoard.items.find((i: TaskItem) => i.id === taskId);
+    if (task === undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `Task not found: ${taskId}`,
+          retryable: false,
+        },
+      };
+    }
+
+    const updatedBoard = updateTaskInBoard(currentSnapshot.taskBoard, taskId, result);
+
+    const updatedMetrics: HarnessMetrics = {
+      ...currentSnapshot.metrics,
+      completedTaskCount: countByStatus(updatedBoard, "completed"),
+      pendingTaskCount: countByStatus(updatedBoard, "pending"),
+    };
+
+    const allDone = allTasksCompleted(updatedBoard);
+    const nextPhase: HarnessPhase = allDone ? "completed" : phase;
+
+    const snapshot: HarnessSnapshot = {
+      ...currentSnapshot,
+      phase: nextPhase,
+      taskBoard: updatedBoard,
+      metrics: updatedMetrics,
+      checkpointedAt: Date.now(),
+    };
+
+    const persistResult = await persistSnapshot(snapshot);
+    if (!persistResult.ok) return persistResult;
+
+    if (allDone) {
+      phase = "completed";
+    }
+
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // fail()
+  // -------------------------------------------------------------------------
+
+  let failureReason: string | undefined;
+
+  const fail = async (error: KoiError): Promise<Result<void, KoiError>> => {
+    const dg = guardDisposed();
+    if (!dg.ok) return dg;
+    const pg = guardPhase("active", "suspended");
+    if (!pg.ok) return pg;
+
+    if (currentSnapshot === undefined) {
+      return { ok: false, error: validation("No active snapshot to fail") };
+    }
+
+    failureReason = error.message;
+
+    const snapshot: HarnessSnapshot = {
+      ...currentSnapshot,
+      phase: "failed",
+      failureReason: error.message,
+      checkpointedAt: Date.now(),
+    };
+
+    const persistResult = await persistSnapshot(snapshot);
+    if (!persistResult.ok) return persistResult;
+
+    phase = "failed";
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // status()
+  // -------------------------------------------------------------------------
+
+  const status = (): HarnessStatus => {
+    const snap = currentSnapshot;
+    const board: TaskBoardSnapshot = snap?.taskBoard ?? { items: [], results: [] };
+    const metrics: HarnessMetrics = snap?.metrics ?? EMPTY_METRICS;
+
+    return {
+      harnessId,
+      phase,
+      currentSessionSeq: snap?.sessionSeq ?? 0,
+      taskBoard: board,
+      metrics,
+      lastSessionEndedAt: snap?.checkpointedAt,
+      startedAt,
+      failureReason,
+    };
+  };
+
+  // -------------------------------------------------------------------------
+  // createMiddleware()
+  // -------------------------------------------------------------------------
+
+  const createMiddleware = (): KoiMiddleware => {
+    const artifactSet = new Set(artifactToolNames);
+
+    return {
+      name: "long-running-harness",
+      priority: 50,
+
+      async onAfterTurn(_ctx: TurnContext): Promise<void> {
+        turnCount += 1;
+
+        if (
+          shouldSoftCheckpoint(turnCount, softCheckpointInterval) &&
+          currentSnapshot !== undefined &&
+          currentSessionId !== undefined
+        ) {
+          // Capture real engine state if callback provided, else use placeholder
+          let engineState: EngineState = { engineId: "soft-checkpoint", data: null };
+          if (saveState !== undefined) {
+            engineState = await saveState();
+          }
+
+          const checkpoint: SessionCheckpoint = {
+            id: computeCheckpointId(harnessId, currentSessionId, turnCount),
+            agentId: config.agentId,
+            sessionId: createSessionId(currentSessionId),
+            engineState,
+            processState: "running",
+            generation: currentSnapshot.sessionSeq,
+            metadata: { softCheckpoint: true },
+            createdAt: Date.now(),
+          };
+          // Fire-and-forget
+          void sessionPersistence.saveCheckpoint(checkpoint);
+        }
+      },
+
+      async onSessionEnd(_ctx: SessionContext): Promise<void> {
+        // Flush any remaining captured artifacts into the snapshot
+        if (capturedArtifacts.length > 0 && currentSnapshot !== undefined) {
+          const allArtifacts = [...currentSnapshot.keyArtifacts, ...capturedArtifacts];
+          const limitedArtifacts = allArtifacts.slice(-maxKeyArtifacts);
+          const updated: HarnessSnapshot = {
+            ...currentSnapshot,
+            keyArtifacts: limitedArtifacts,
+            checkpointedAt: Date.now(),
+          };
+          await persistSnapshot(updated);
+          capturedArtifacts = [];
+        }
+      },
+
+      async wrapToolCall(ctx: TurnContext, request: ToolRequest, next: ToolHandler) {
+        const response = await next(request);
+
+        if (artifactSet.has(request.toolId) && response.output !== undefined) {
+          const content =
+            typeof response.output === "string" ? response.output : JSON.stringify(response.output);
+
+          const artifact: KeyArtifact = {
+            toolName: request.toolId,
+            content: content.slice(0, 2000), // Limit artifact size
+            turnIndex: ctx.turnIndex,
+            capturedAt: Date.now(),
+          };
+          capturedArtifacts = [...capturedArtifacts, artifact];
+        }
+
+        return response;
+      },
+    };
+  };
+
+  // -------------------------------------------------------------------------
+  // dispose()
+  // -------------------------------------------------------------------------
+
+  const dispose = async (): Promise<void> => {
+    disposed = true;
+  };
+
+  // -------------------------------------------------------------------------
+  // Return harness
+  // -------------------------------------------------------------------------
+
+  return {
+    harnessId,
+    start,
+    resume,
+    pause,
+    fail,
+    completeTask,
+    status,
+    createMiddleware,
+    dispose,
+  };
+}

--- a/packages/long-running/src/index.ts
+++ b/packages/long-running/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @koi/long-running — Multi-session agent harness (L2).
+ *
+ * Provides a state manager for agents that operate over hours/days
+ * across multiple sessions, tracking progress, bridging context,
+ * and checkpointing at meaningful task boundaries.
+ */
+
+export { computeCheckpointId, shouldSoftCheckpoint } from "./checkpoint-policy.js";
+export { buildInitialPrompt, buildResumeContext } from "./context-bridge.js";
+export { createLongRunningHarness } from "./harness.js";
+export type {
+  LongRunningConfig,
+  LongRunningHarness,
+  ResumeResult,
+  SaveStateCallback,
+  SessionResult,
+  StartResult,
+} from "./types.js";
+export { DEFAULT_LONG_RUNNING_CONFIG } from "./types.js";

--- a/packages/long-running/src/types.ts
+++ b/packages/long-running/src/types.ts
@@ -1,0 +1,99 @@
+/**
+ * L2-local configuration and interface types for @koi/long-running.
+ *
+ * These types are internal to the package — L0 types live in @koi/core/harness.
+ */
+
+import type {
+  AgentId,
+  EngineInput,
+  EngineMetrics,
+  EngineState,
+  HarnessId,
+  HarnessSnapshotStore,
+  HarnessStatus,
+  KoiError,
+  KoiMiddleware,
+  PruningPolicy,
+  Result,
+  SessionPersistence,
+  TaskBoardSnapshot,
+  TaskItemId,
+  TaskResult,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Save-state callback for soft checkpoints
+// ---------------------------------------------------------------------------
+
+/** Optional callback to capture real engine state during soft checkpoints. */
+export type SaveStateCallback = () => EngineState | Promise<EngineState>;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface LongRunningConfig {
+  readonly harnessId: HarnessId;
+  readonly agentId: AgentId;
+  readonly harnessStore: HarnessSnapshotStore;
+  readonly sessionPersistence: SessionPersistence;
+  readonly softCheckpointInterval?: number | undefined;
+  readonly maxKeyArtifacts?: number | undefined;
+  readonly maxContextTokens?: number | undefined;
+  readonly artifactToolNames?: readonly string[] | undefined;
+  readonly pruningPolicy?: PruningPolicy | undefined;
+  readonly saveState?: SaveStateCallback | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Harness interface
+// ---------------------------------------------------------------------------
+
+export interface LongRunningHarness {
+  readonly harnessId: HarnessId;
+  readonly start: (taskPlan: TaskBoardSnapshot) => Promise<Result<StartResult, KoiError>>;
+  readonly resume: () => Promise<Result<ResumeResult, KoiError>>;
+  readonly pause: (sessionResult: SessionResult) => Promise<Result<void, KoiError>>;
+  readonly fail: (error: KoiError) => Promise<Result<void, KoiError>>;
+  readonly completeTask: (
+    taskId: TaskItemId,
+    result: TaskResult,
+  ) => Promise<Result<void, KoiError>>;
+  readonly status: () => HarnessStatus;
+  readonly createMiddleware: () => KoiMiddleware;
+  readonly dispose: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Operation results
+// ---------------------------------------------------------------------------
+
+export interface StartResult {
+  readonly engineInput: EngineInput;
+  readonly sessionId: string;
+}
+
+export interface ResumeResult {
+  readonly engineInput: EngineInput;
+  readonly sessionId: string;
+  readonly engineStateRecovered: boolean;
+}
+
+export interface SessionResult {
+  readonly sessionId: string;
+  readonly engineState?: EngineState | undefined;
+  readonly metrics: EngineMetrics;
+  readonly summary?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_LONG_RUNNING_CONFIG = {
+  softCheckpointInterval: 5,
+  maxKeyArtifacts: 10,
+  maxContextTokens: 3000,
+  pruningPolicy: { retainCount: 10 } as PruningPolicy,
+} as const;

--- a/packages/long-running/tsconfig.json
+++ b/packages/long-running/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/long-running/tsup.config.ts
+++ b/packages/long-running/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/middleware-compactor/src/compact.test.ts
+++ b/packages/middleware-compactor/src/compact.test.ts
@@ -410,6 +410,59 @@ describe("createLlmCompactor", () => {
     expect(result.strategy).toBe("llm-summary");
   });
 
+  test("pinned messages survive compaction", async () => {
+    const summarizer = createMockSummarizer("Summary");
+
+    const compactor = createLlmCompactor({
+      summarizer,
+      contextWindowSize: 1000,
+      trigger: { messageCount: 3 },
+      preserveRecent: 1,
+      maxSummaryTokens: 100,
+    });
+
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context — do not compact" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+
+    // Pinned at index 1 — only index 0 can be compacted
+    const msgs = [userMsg("old"), pinned, userMsg("mid"), userMsg("recent")];
+    const result = await compactor.compact(msgs, 1000);
+
+    // Pinned message must be in the output
+    const hasPinned = result.messages.some((m) => m.pinned === true);
+    expect(hasPinned).toBe(true);
+  });
+
+  test("pinned message at start prevents all compaction", async () => {
+    const summarizer = createMockSummarizer("Summary");
+
+    const compactor = createLlmCompactor({
+      summarizer,
+      contextWindowSize: 1000,
+      trigger: { messageCount: 2 },
+      preserveRecent: 1,
+      maxSummaryTokens: 100,
+    });
+
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+
+    const msgs = [pinned, userMsg("a"), userMsg("b"), userMsg("c")];
+    const result = await compactor.compact(msgs, 1000);
+
+    // No valid split points — should noop
+    expect(result.strategy).toBe("noop");
+    expect(result.messages).toBe(msgs);
+  });
+
   test("forceCompact bypasses trigger checks", async () => {
     const compactor = createLlmCompactor({
       summarizer: createMockSummarizer("Forced summary"),

--- a/packages/middleware-compactor/src/pair-boundaries.test.ts
+++ b/packages/middleware-compactor/src/pair-boundaries.test.ts
@@ -133,4 +133,91 @@ describe("findValidSplitPoints", () => {
     const result = findValidSplitPoints(msgs, 1);
     expect(result).toEqual([1, 2]);
   });
+
+  test("pinned message at start — no valid splits (all messages protected)", () => {
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+    const msgs = [pinned, userMsg("a"), userMsg("b"), userMsg("c")];
+    // First pinned at index 0 → cap = 0 → no splits possible
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([]);
+  });
+
+  test("pinned message in middle — splits only before it", () => {
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+    const msgs = [userMsg("old-1"), userMsg("old-2"), pinned, userMsg("recent")];
+    // First pinned at index 2 → cap = 2, preserveRecent=1 → maxSplit = 3
+    // effectiveMax = min(3, 2) = 2 → splits at 1, 2
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([1, 2]);
+  });
+
+  test("pinned message at end — all normal splits valid", () => {
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+    const msgs = [userMsg("a"), userMsg("b"), userMsg("c"), pinned];
+    // First pinned at index 3 → cap = 3, preserveRecent=1 → maxSplit = 3
+    // effectiveMax = min(3, 3) = 3 → splits at 1, 2, 3
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  test("multiple pinned messages — caps at the first one", () => {
+    const pin1: InboundMessage = {
+      content: [{ kind: "text", text: "ctx 1" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+    const pin2: InboundMessage = {
+      content: [{ kind: "text", text: "ctx 2" }],
+      senderId: "harness",
+      timestamp: 2,
+      pinned: true,
+    };
+    const msgs = [userMsg("old"), pin1, userMsg("mid"), pin2, userMsg("recent")];
+    // First pinned at index 1 → cap = 1 → only split at 1
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([1]);
+  });
+
+  test("no pinned messages — normal behavior unchanged", () => {
+    const msgs = [userMsg("a"), userMsg("b"), userMsg("c"), userMsg("d")];
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  test("pinned message combined with atomic pair", () => {
+    const pinned: InboundMessage = {
+      content: [{ kind: "text", text: "harness context" }],
+      senderId: "harness",
+      timestamp: 1,
+      pinned: true,
+    };
+    const msgs = [
+      userMsg("old"),
+      assistantMsg("calling", "c1"),
+      toolResultMsg("c1", "result"),
+      pinned,
+      userMsg("recent"),
+    ];
+    // Pair: [1,2] are atomic. Pinned at index 3 → cap = 3.
+    // preserveRecent=1 → maxSplit = 4. effectiveMax = min(4, 3) = 3.
+    // Split 1: valid (before pair). Split 2: forbidden (interior). Split 3: valid.
+    const result = findValidSplitPoints(msgs, 1);
+    expect(result).toEqual([1, 3]);
+  });
 });

--- a/packages/middleware-compactor/src/pair-boundaries.ts
+++ b/packages/middleware-compactor/src/pair-boundaries.ts
@@ -59,6 +59,21 @@ function findAtomicGroupInteriors(messages: readonly InboundMessage[]): Readonly
 }
 
 /**
+ * Find the first pinned message index.
+ *
+ * All split points must be <= this index so that pinned messages
+ * remain in the preserved tail and are never summarized away.
+ * Returns `len` if no messages are pinned (no additional constraint).
+ */
+function findFirstPinnedIndex(messages: readonly InboundMessage[]): number {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg !== undefined && msg.pinned === true) return i;
+  }
+  return messages.length;
+}
+
+/**
  * Find valid split point indices in a message array.
  *
  * A split at index `s` means: messages[0..s-1] go to the summary,
@@ -68,6 +83,7 @@ function findAtomicGroupInteriors(messages: readonly InboundMessage[]): Readonly
  * 1. Split index must be >= 1 (can't summarize zero messages).
  * 2. Split index must not be inside an atomic assistant+tool group.
  * 3. The tail (messages[s..end]) must contain at least `preserveRecent` messages.
+ * 4. Split index must not place a pinned message in the head (summarized portion).
  *
  * Returns indices in ascending order.
  */
@@ -80,10 +96,14 @@ export function findValidSplitPoints(
   const maxSplitIndex = len - preserveRecent;
   if (maxSplitIndex < 1) return [];
 
+  // Pinned messages must stay in the tail — cap split index before first pinned
+  const pinnedCap = findFirstPinnedIndex(messages);
+
   const interiors = findAtomicGroupInteriors(messages);
   const validPoints: number[] = [];
+  const effectiveMax = Math.min(maxSplitIndex, pinnedCap);
 
-  for (let s = 1; s <= maxSplitIndex; s++) {
+  for (let s = 1; s <= effectiveMax; s++) {
     if (!interiors.has(s)) {
       validPoints.push(s);
     }

--- a/packages/test-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/test-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,10 +1,10 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/test-utils API surface . has stable type surface 1`] = `
-"import { ProcessId, AgentManifest, ProcessState, EngineEvent, Agent, EngineAdapter, EngineInput, KoiErrorCode, ForgeProvenance, AgentArtifact, ImplementationArtifact, SkillArtifact, ToolArtifact, BrickRegistryBackend, ChannelAdapter, MemoryResult, MemoryRecallOptions, MemoryStoreOptions, MemoryComponent, KoiConfig, ConfigStore, EventBackend, EventEnvelope, DeadLetterEntry, RegistryEntry, AgentId, TransitionReason, Result as Result$1, KoiError as KoiError$1, RegistryEvent, GovernanceCheck, GovernanceEvent, GovernanceSnapshot, GovernanceVariable, SensorReading, GovernanceController, SessionPersistence, SkillRegistryBackend, SnapshotChainStore, ForgeStore } from '@koi/core';
+"import { ProcessId, AgentManifest, ProcessState, EngineEvent, Agent, EngineAdapter, EngineInput, KoiErrorCode, ForgeProvenance, AgentArtifact, ImplementationArtifact, SkillArtifact, ToolArtifact, BrickRegistryBackend, ChannelAdapter, MemoryResult, MemoryRecallOptions, MemoryStoreOptions, MemoryComponent, KoiConfig, ConfigStore, EventBackend, EventEnvelope, DeadLetterEntry, RegistryEntry, AgentId, TransitionReason, Result as Result$1, KoiError as KoiError$1, RegistryEvent, GovernanceCheck, GovernanceEvent, GovernanceSnapshot, GovernanceVariable, SensorReading, GovernanceController, HarnessId, TaskBoardSnapshot, EngineMetrics, TaskItemId, TaskResult, HarnessStatus, KoiMiddleware, ContextSummary, SessionPersistence, SkillRegistryBackend, SnapshotChainStore, ForgeStore } from '@koi/core';
 import { Result, KoiError } from '@koi/core/errors';
 import { InboundMessage } from '@koi/core/message';
-import { SessionContext, TurnContext, ModelHandler, ModelRequest, ModelStreamHandler, ToolHandler, ToolRequest, ModelResponse, ModelChunk, ToolResponse, KoiMiddleware } from '@koi/core/middleware';
+import { SessionContext, TurnContext, ModelHandler, ModelRequest, ModelStreamHandler, ToolHandler, ToolRequest, ModelResponse, ModelChunk, ToolResponse, KoiMiddleware as KoiMiddleware$1 } from '@koi/core/middleware';
 import { Resolver } from '@koi/core/resolver';
 
 /**
@@ -429,6 +429,73 @@ declare function createSpyModelStreamHandler(chunks: readonly ModelChunk[]): Spy
 declare function createMockModelStreamHandler(chunks: readonly ModelChunk[]): ModelStreamHandler;
 
 /**
+ * Contract test suite for LongRunningHarness implementations.
+ *
+ * Validates the core start → pause → resume lifecycle, status transitions,
+ * and dispose idempotency. Designed to be reused by any harness implementation.
+ */
+
+interface ContractSessionResult {
+    readonly sessionId: string;
+    readonly metrics: EngineMetrics;
+    readonly summary?: string | undefined;
+}
+interface ContractHarness {
+    readonly harnessId: HarnessId;
+    readonly start: (plan: TaskBoardSnapshot) => Promise<Result$1<unknown, KoiError$1>>;
+    readonly resume: () => Promise<Result$1<unknown, KoiError$1>>;
+    readonly pause: (result: ContractSessionResult) => Promise<Result$1<void, KoiError$1>>;
+    readonly fail: (error: KoiError$1) => Promise<Result$1<void, KoiError$1>>;
+    readonly completeTask: (taskId: TaskItemId, result: TaskResult) => Promise<Result$1<void, KoiError$1>>;
+    readonly status: () => HarnessStatus;
+    readonly createMiddleware: () => KoiMiddleware;
+    readonly dispose: () => Promise<void>;
+}
+/**
+ * Run the harness contract test suite against a factory.
+ *
+ * The factory is called before each test group to create a fresh harness.
+ * Tests validate lifecycle transitions, status reporting, and dispose behavior.
+ */
+declare function runHarnessContractTests(factory: () => ContractHarness | Promise<ContractHarness>): void;
+
+/**
+ * Mock factories for @koi/long-running harness testing.
+ *
+ * Provides pre-built mocks for LongRunningHarness, TaskBoardSnapshot,
+ * and ContextSummary — usable across all packages that test harness integration.
+ */
+
+/**
+ * Minimal harness interface matching @koi/long-running's LongRunningHarness.
+ * Defined locally to avoid L2→L2 dependency from test-utils to long-running.
+ */
+interface MockLongRunningHarness {
+    readonly harnessId: HarnessId;
+    readonly start: (taskPlan: TaskBoardSnapshot) => Promise<Result$1<unknown, KoiError$1>>;
+    readonly resume: () => Promise<Result$1<unknown, KoiError$1>>;
+    readonly pause: (sessionResult: unknown) => Promise<Result$1<void, KoiError$1>>;
+    readonly fail: (error: KoiError$1) => Promise<Result$1<void, KoiError$1>>;
+    readonly completeTask: (taskId: TaskItemId, result: TaskResult) => Promise<Result$1<void, KoiError$1>>;
+    readonly status: () => HarnessStatus;
+    readonly createMiddleware: () => KoiMiddleware;
+    readonly dispose: () => Promise<void>;
+}
+/**
+ * Create a mock harness with sensible defaults. Override individual methods
+ * for test-specific behavior.
+ */
+declare function createMockHarness(overrides?: Partial<MockLongRunningHarness>): MockLongRunningHarness;
+/**
+ * Create a mock TaskBoardSnapshot with the given number of pending tasks.
+ */
+declare function createMockTaskPlan(taskCount?: number): TaskBoardSnapshot;
+/**
+ * Create a mock ContextSummary for the given session sequence.
+ */
+declare function createMockContextSummary(sessionSeq?: number): ContextSummary;
+
+/**
  * In-memory BrickRegistryBackend implementation for testing.
  *
  * Stores bricks in a Map keyed by "kind:name". Supports search, get,
@@ -447,7 +514,7 @@ declare function createInMemoryBrickRegistry(): BrickRegistryBackend;
 
 interface MiddlewareContractOptions {
     /** Factory that creates a fresh middleware instance for each test. */
-    readonly createMiddleware: () => KoiMiddleware | Promise<KoiMiddleware>;
+    readonly createMiddleware: () => KoiMiddleware$1 | Promise<KoiMiddleware$1>;
     /** Optional custom session context factory. */
     readonly createSessionContext?: (() => SessionContext) | undefined;
     /** Optional custom turn context factory. */
@@ -629,6 +696,6 @@ declare function createThrowingValidator(error: Error, name?: string): MockValid
 /** Creates a validator that passes or fails based on a predicate. */
 declare function createConditionalValidator(fn: (output: unknown) => boolean, name?: string): MockValidator;
 
-export { type BrickRegistryContractOptions, type CapturedOutput, type ChannelContractOptions, DEFAULT_PROVENANCE, type EngineContractOptions, type EventSourcedRegistryForTest, type EventSourcedRegistryTestContext, type MiddlewareContractOptions, type MockAgentOptions, type MockEngineAdapterOptions, type MockEngineData, type MockEventBackend, type MockGovernanceControllerOverrides, type MockMemoryComponentOptions, type MockStatefulEngineOptions, type MockValidationError, type MockValidationResult, type MockValidator, type RecallCall, type ResolverContractOptions, type SkillRegistryContractOptions, type SpyModelHandler, type SpyModelStreamHandler, type SpyToolHandler, type StoreCall, type TempGitRepo, assertErr, assertKoiError, assertOk, captureOutput, createAsyncValidator, createConditionalValidator, createFactory, createFailingValidator, createInMemoryBrickRegistry, createInMemorySkillRegistry, createManifestFile, createMockAgent, createMockEngineAdapter, createMockEventBackend, createMockGovernanceController, createMockInboundMessage, createMockMemoryComponent, createMockModelHandler, createMockModelStreamHandler, createMockSessionContext, createMockStatefulEngine, createMockToolHandler, createMockTurnContext, createMockValidator, createSpyModelHandler, createSpyModelStreamHandler, createSpyToolHandler, createTempGitRepo, createTestAgentArtifact, createTestConfig, createTestConfigStore, createTestImplementationArtifact, createTestSkillArtifact, createTestToolArtifact, createThrowingValidator, makeTempDir, runEventBackendContractTests, runEventSourcedRegistryContractTests, runForgeStoreContractTests, runSessionPersistenceContractTests, runSnapshotChainStoreContractTests, testBrickRegistryContract, testChannelAdapter, testEngineAdapter, testMiddlewareContract, testResolverContract, testSkillRegistryContract, withTempDir };
+export { type BrickRegistryContractOptions, type CapturedOutput, type ChannelContractOptions, DEFAULT_PROVENANCE, type EngineContractOptions, type EventSourcedRegistryForTest, type EventSourcedRegistryTestContext, type MiddlewareContractOptions, type MockAgentOptions, type MockEngineAdapterOptions, type MockEngineData, type MockEventBackend, type MockGovernanceControllerOverrides, type MockMemoryComponentOptions, type MockStatefulEngineOptions, type MockValidationError, type MockValidationResult, type MockValidator, type RecallCall, type ResolverContractOptions, type SkillRegistryContractOptions, type SpyModelHandler, type SpyModelStreamHandler, type SpyToolHandler, type StoreCall, type TempGitRepo, assertErr, assertKoiError, assertOk, captureOutput, createAsyncValidator, createConditionalValidator, createFactory, createFailingValidator, createInMemoryBrickRegistry, createInMemorySkillRegistry, createManifestFile, createMockAgent, createMockContextSummary, createMockEngineAdapter, createMockEventBackend, createMockGovernanceController, createMockHarness, createMockInboundMessage, createMockMemoryComponent, createMockModelHandler, createMockModelStreamHandler, createMockSessionContext, createMockStatefulEngine, createMockTaskPlan, createMockToolHandler, createMockTurnContext, createMockValidator, createSpyModelHandler, createSpyModelStreamHandler, createSpyToolHandler, createTempGitRepo, createTestAgentArtifact, createTestConfig, createTestConfigStore, createTestImplementationArtifact, createTestSkillArtifact, createTestToolArtifact, createThrowingValidator, makeTempDir, runEventBackendContractTests, runEventSourcedRegistryContractTests, runForgeStoreContractTests, runHarnessContractTests, runSessionPersistenceContractTests, runSnapshotChainStoreContractTests, testBrickRegistryContract, testChannelAdapter, testEngineAdapter, testMiddlewareContract, testResolverContract, testSkillRegistryContract, withTempDir };
 "
 `;

--- a/packages/test-utils/src/harness-contract.ts
+++ b/packages/test-utils/src/harness-contract.ts
@@ -1,0 +1,254 @@
+/**
+ * Contract test suite for LongRunningHarness implementations.
+ *
+ * Validates the core start → pause → resume lifecycle, status transitions,
+ * and dispose idempotency. Designed to be reused by any harness implementation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  EngineMetrics,
+  HarnessId,
+  HarnessStatus,
+  KoiError,
+  KoiMiddleware,
+  Result,
+  TaskBoardSnapshot,
+  TaskItemId,
+  TaskResult,
+} from "@koi/core";
+import { taskItemId } from "@koi/core";
+import { assertErr, assertOk } from "./assert-result.js";
+
+// ---------------------------------------------------------------------------
+// Session result shape (avoid depending on L2)
+// ---------------------------------------------------------------------------
+
+interface ContractSessionResult {
+  readonly sessionId: string;
+  readonly metrics: EngineMetrics;
+  readonly summary?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Harness interface for contract testing
+// ---------------------------------------------------------------------------
+
+interface ContractHarness {
+  readonly harnessId: HarnessId;
+  readonly start: (plan: TaskBoardSnapshot) => Promise<Result<unknown, KoiError>>;
+  readonly resume: () => Promise<Result<unknown, KoiError>>;
+  readonly pause: (result: ContractSessionResult) => Promise<Result<void, KoiError>>;
+  readonly fail: (error: KoiError) => Promise<Result<void, KoiError>>;
+  readonly completeTask: (
+    taskId: TaskItemId,
+    result: TaskResult,
+  ) => Promise<Result<void, KoiError>>;
+  readonly status: () => HarnessStatus;
+  readonly createMiddleware: () => KoiMiddleware;
+  readonly dispose: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Default test fixtures
+// ---------------------------------------------------------------------------
+
+const DEFAULT_METRICS: EngineMetrics = {
+  totalTokens: 100,
+  inputTokens: 60,
+  outputTokens: 40,
+  turns: 3,
+  durationMs: 2000,
+};
+
+function createContractPlan(): TaskBoardSnapshot {
+  return {
+    items: [
+      {
+        id: taskItemId("contract-task-1"),
+        description: "Contract task 1",
+        dependencies: [],
+        priority: 0,
+        maxRetries: 3,
+        retries: 0,
+        status: "pending" as const,
+      },
+      {
+        id: taskItemId("contract-task-2"),
+        description: "Contract task 2",
+        dependencies: [],
+        priority: 1,
+        maxRetries: 3,
+        retries: 0,
+        status: "pending" as const,
+      },
+    ],
+    results: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract test suite
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the harness contract test suite against a factory.
+ *
+ * The factory is called before each test group to create a fresh harness.
+ * Tests validate lifecycle transitions, status reporting, and dispose behavior.
+ */
+export function runHarnessContractTests(
+  factory: () => ContractHarness | Promise<ContractHarness>,
+): void {
+  describe("harness contract", () => {
+    test("starts in idle phase", async () => {
+      const harness = await factory();
+      expect(harness.status().phase).toBe("idle");
+    });
+
+    test("start transitions to active", async () => {
+      const harness = await factory();
+      const result = await harness.start(createContractPlan());
+      assertOk(result);
+      expect(harness.status().phase).toBe("active");
+    });
+
+    test("start rejects empty plan", async () => {
+      const harness = await factory();
+      const result = await harness.start({ items: [], results: [] });
+      assertErr(result);
+    });
+
+    test("pause transitions to suspended", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      const result = await harness.pause({
+        sessionId: "s-1",
+        metrics: DEFAULT_METRICS,
+        summary: "Test",
+      });
+      assertOk(result);
+      expect(harness.status().phase).toBe("suspended");
+    });
+
+    test("resume transitions back to active", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.pause({ sessionId: "s-1", metrics: DEFAULT_METRICS });
+      const result = await harness.resume();
+      assertOk(result);
+      expect(harness.status().phase).toBe("active");
+    });
+
+    test("start → pause → resume → pause cycle", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.pause({ sessionId: "s-1", metrics: DEFAULT_METRICS });
+      await harness.resume();
+      const result = await harness.pause({ sessionId: "s-2", metrics: DEFAULT_METRICS });
+      assertOk(result);
+      expect(harness.status().phase).toBe("suspended");
+    });
+
+    test("completeTask marks task done", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      const result = await harness.completeTask(taskItemId("contract-task-1"), {
+        taskId: taskItemId("contract-task-1"),
+        output: "Done",
+        durationMs: 100,
+      });
+      assertOk(result);
+    });
+
+    test("completing all tasks transitions to completed", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.completeTask(taskItemId("contract-task-1"), {
+        taskId: taskItemId("contract-task-1"),
+        output: "Done",
+        durationMs: 100,
+      });
+      await harness.completeTask(taskItemId("contract-task-2"), {
+        taskId: taskItemId("contract-task-2"),
+        output: "Done",
+        durationMs: 100,
+      });
+      expect(harness.status().phase).toBe("completed");
+    });
+
+    test("status returns harness ID", async () => {
+      const harness = await factory();
+      expect(harness.status().harnessId).toBe(harness.harnessId);
+    });
+
+    test("status reflects task board", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      expect(harness.status().taskBoard.items.length).toBe(2);
+    });
+
+    test("status reflects metrics after pause", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.pause({ sessionId: "s-1", metrics: DEFAULT_METRICS });
+      expect(harness.status().metrics.totalSessions).toBe(1);
+    });
+
+    test("createMiddleware returns valid middleware", async () => {
+      const harness = await factory();
+      const mw = harness.createMiddleware();
+      expect(mw.name).toBeTruthy();
+    });
+
+    test("dispose is idempotent", async () => {
+      const harness = await factory();
+      await harness.dispose();
+      await harness.dispose(); // No throw
+    });
+
+    test("dispose prevents start", async () => {
+      const harness = await factory();
+      await harness.dispose();
+      const result = await harness.start(createContractPlan());
+      assertErr(result);
+    });
+
+    test("dispose prevents resume", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.pause({ sessionId: "s-1", metrics: DEFAULT_METRICS });
+      await harness.dispose();
+      const result = await harness.resume();
+      assertErr(result);
+    });
+
+    test("dispose prevents completeTask", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      await harness.dispose();
+      const result = await harness.completeTask(taskItemId("contract-task-1"), {
+        taskId: taskItemId("contract-task-1"),
+        output: "Done",
+        durationMs: 100,
+      });
+      assertErr(result);
+    });
+
+    test("fail transitions to failed phase", async () => {
+      const harness = await factory();
+      await harness.start(createContractPlan());
+      const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+      const result = await harness.fail(error);
+      assertOk(result);
+      expect(harness.status().phase).toBe("failed");
+    });
+
+    test("fail rejects from idle phase", async () => {
+      const harness = await factory();
+      const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+      const result = await harness.fail(error);
+      assertErr(result);
+    });
+  });
+}

--- a/packages/test-utils/src/harness-mocks.ts
+++ b/packages/test-utils/src/harness-mocks.ts
@@ -1,0 +1,163 @@
+/**
+ * Mock factories for @koi/long-running harness testing.
+ *
+ * Provides pre-built mocks for LongRunningHarness, TaskBoardSnapshot,
+ * and ContextSummary — usable across all packages that test harness integration.
+ */
+
+import type {
+  ContextSummary,
+  HarnessId,
+  HarnessMetrics,
+  HarnessPhase,
+  HarnessStatus,
+  KoiError,
+  KoiMiddleware,
+  Result,
+  TaskBoardSnapshot,
+  TaskItemId,
+  TaskResult,
+} from "@koi/core";
+import { harnessId, taskItemId } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Harness interface (local copy to avoid L2 dep)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal harness interface matching @koi/long-running's LongRunningHarness.
+ * Defined locally to avoid L2→L2 dependency from test-utils to long-running.
+ */
+interface MockLongRunningHarness {
+  readonly harnessId: HarnessId;
+  readonly start: (taskPlan: TaskBoardSnapshot) => Promise<Result<unknown, KoiError>>;
+  readonly resume: () => Promise<Result<unknown, KoiError>>;
+  readonly pause: (sessionResult: unknown) => Promise<Result<void, KoiError>>;
+  readonly fail: (error: KoiError) => Promise<Result<void, KoiError>>;
+  readonly completeTask: (
+    taskId: TaskItemId,
+    result: TaskResult,
+  ) => Promise<Result<void, KoiError>>;
+  readonly status: () => HarnessStatus;
+  readonly createMiddleware: () => KoiMiddleware;
+  readonly dispose: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Default values
+// ---------------------------------------------------------------------------
+
+const DEFAULT_HARNESS_METRICS: HarnessMetrics = {
+  totalSessions: 0,
+  totalTurns: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  completedTaskCount: 0,
+  pendingTaskCount: 0,
+  elapsedMs: 0,
+};
+
+// ---------------------------------------------------------------------------
+// createMockHarness
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock harness with sensible defaults. Override individual methods
+ * for test-specific behavior.
+ */
+export function createMockHarness(
+  overrides?: Partial<MockLongRunningHarness>,
+): MockLongRunningHarness {
+  const hid = overrides?.harnessId ?? harnessId("mock-harness");
+  let currentPhase: HarnessPhase = "idle";
+
+  const defaultStatus: HarnessStatus = {
+    harnessId: hid,
+    phase: currentPhase,
+    currentSessionSeq: 0,
+    taskBoard: { items: [], results: [] },
+    metrics: DEFAULT_HARNESS_METRICS,
+  };
+
+  return {
+    harnessId: hid,
+    async start(_plan: TaskBoardSnapshot) {
+      currentPhase = "active";
+      return {
+        ok: true,
+        value: { engineInput: { kind: "text", text: "mock" }, sessionId: "mock-session" },
+      };
+    },
+    async resume() {
+      currentPhase = "active";
+      return {
+        ok: true,
+        value: {
+          engineInput: { kind: "text", text: "mock-resume" },
+          sessionId: "mock-session",
+          engineStateRecovered: false,
+        },
+      };
+    },
+    async pause(_result: unknown) {
+      currentPhase = "suspended";
+      return { ok: true, value: undefined };
+    },
+    async fail(_error: KoiError) {
+      currentPhase = "failed";
+      return { ok: true, value: undefined };
+    },
+    async completeTask(_taskId: TaskItemId, _result: TaskResult) {
+      return { ok: true, value: undefined };
+    },
+    status() {
+      return { ...defaultStatus, phase: currentPhase };
+    },
+    createMiddleware() {
+      return { name: "mock-harness-middleware" };
+    },
+    async dispose() {
+      // no-op
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createMockTaskPlan
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock TaskBoardSnapshot with the given number of pending tasks.
+ */
+export function createMockTaskPlan(taskCount = 3): TaskBoardSnapshot {
+  return {
+    items: Array.from({ length: taskCount }, (_, i) => ({
+      id: taskItemId(`mock-task-${String(i + 1)}`),
+      description: `Mock task ${String(i + 1)}`,
+      dependencies: [],
+      priority: i,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    })),
+    results: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createMockContextSummary
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock ContextSummary for the given session sequence.
+ */
+export function createMockContextSummary(sessionSeq = 1): ContextSummary {
+  return {
+    narrative: `Mock session ${String(sessionSeq)} summary`,
+    sessionSeq,
+    completedTaskIds: [],
+    estimatedTokens: 20,
+    generatedAt: Date.now(),
+  };
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -62,6 +62,12 @@ export {
   createSpyModelStreamHandler,
   createSpyToolHandler,
 } from "./handlers.js";
+export { runHarnessContractTests } from "./harness-contract.js";
+export {
+  createMockContextSummary,
+  createMockHarness,
+  createMockTaskPlan,
+} from "./harness-mocks.js";
 export { createInMemoryBrickRegistry } from "./in-memory-brick-registry.js";
 export type { MiddlewareContractOptions } from "./middleware-contract/index.js";
 export { testMiddlewareContract } from "./middleware-contract/index.js";

--- a/scripts/e2e-long-running-pi.ts
+++ b/scripts/e2e-long-running-pi.ts
@@ -1,0 +1,562 @@
+#!/usr/bin/env bun
+/**
+ * E2E: Long-Running Harness with Pi-Engine (Real LLM).
+ *
+ * Validates the full @koi/long-running lifecycle against a real Anthropic API
+ * using createPiAdapter() + createKoi():
+ *
+ *   Test 1: start() → engine runs with text input → agent produces output
+ *   Test 2: middleware onAfterTurn fires → soft checkpoint saved
+ *   Test 3: middleware wrapToolCall captures artifacts
+ *   Test 4: pause() persists snapshot + metrics
+ *   Test 5: resume() returns messages input with context bridge
+ *   Test 6: completeTask() + all-done transitions to completed
+ *   Test 7: fail() transitions to failed with reason
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-long-running-pi.ts
+ */
+
+import type {
+  AgentId,
+  EngineEvent,
+  EngineMetrics,
+  EngineOutput,
+  EngineState,
+  HarnessSnapshotStore,
+  SessionCheckpoint,
+  SessionPersistence,
+} from "../packages/core/src/index.js";
+import { agentId, chainId, harnessId, taskItemId } from "../packages/core/src/index.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { createLongRunningHarness } from "../packages/long-running/src/harness.js";
+import type { LongRunningHarness, SessionResult } from "../packages/long-running/src/types.js";
+import { createInMemorySnapshotChainStore } from "../packages/snapshot-chain-store/src/memory-store.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting long-running harness pi-engine E2E tests...");
+console.log("[e2e] ANTHROPIC_API_KEY: set\n");
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  const suffix = detail && !condition ? ` — ${detail}` : "";
+  console.log(`  ${tag}  ${name}${suffix}`);
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Mock SessionPersistence (captures checkpoints for assertions)
+// ---------------------------------------------------------------------------
+
+function createTrackingPersistence(): SessionPersistence & {
+  readonly savedCheckpoints: SessionCheckpoint[];
+  setLatestCheckpoint: (cp: SessionCheckpoint | undefined) => void;
+} {
+  const savedCheckpoints: SessionCheckpoint[] = [];
+  let latestCheckpoint: SessionCheckpoint | undefined;
+
+  return {
+    savedCheckpoints,
+    setLatestCheckpoint(cp: SessionCheckpoint | undefined): void {
+      latestCheckpoint = cp;
+    },
+    saveSession: () => ({ ok: true as const, value: undefined }),
+    loadSession: () => ({
+      ok: false as const,
+      error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+    }),
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    saveCheckpoint(cp: SessionCheckpoint) {
+      savedCheckpoints.push(cp);
+      return { ok: true as const, value: undefined };
+    },
+    loadLatestCheckpoint(_aid: AgentId) {
+      return { ok: true as const, value: latestCheckpoint };
+    },
+    listCheckpoints: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], checkpoints: new Map(), pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared config
+// ---------------------------------------------------------------------------
+
+const TEST_HARNESS_ID = harnessId("e2e-long-running");
+const TEST_AGENT_ID = agentId("e2e-agent");
+const TEST_CHAIN_ID = chainId(TEST_HARNESS_ID);
+
+const MODEL = "anthropic:claude-haiku-4-5-20251001"; // Cheapest for E2E
+
+function createAdapter(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: MODEL,
+    systemPrompt: "You are a concise assistant. Answer in 1-2 sentences max.",
+    getApiKey: async () => API_KEY,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: start() → real LLM call via createKoi
+// ---------------------------------------------------------------------------
+
+console.log("[test 1] start() → real LLM call via createKoi");
+
+const store: HarnessSnapshotStore = createInMemorySnapshotChainStore();
+const persistence = createTrackingPersistence();
+
+const harness: LongRunningHarness = createLongRunningHarness({
+  harnessId: TEST_HARNESS_ID,
+  agentId: TEST_AGENT_ID,
+  harnessStore: store,
+  sessionPersistence: persistence,
+  softCheckpointInterval: 1, // checkpoint every turn for testing
+});
+
+// Create task plan
+const taskPlan = {
+  items: [
+    {
+      id: taskItemId("task-greet"),
+      description: "Greet the user with a fun fact",
+      dependencies: [],
+      priority: 0,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    },
+    {
+      id: taskItemId("task-math"),
+      description: "Solve a math problem",
+      dependencies: [],
+      priority: 1,
+      maxRetries: 3,
+      retries: 0,
+      status: "pending" as const,
+    },
+  ],
+  results: [],
+};
+
+// Start the harness
+const startResult = await harness.start(taskPlan);
+assert("start() returns ok", startResult.ok === true);
+
+if (!startResult.ok) {
+  console.error("[e2e] start() failed, cannot continue:", startResult.error);
+  process.exit(1);
+}
+
+assert("start() returns text engine input", startResult.value.engineInput.kind === "text");
+assert("start() returns sessionId", startResult.value.sessionId.length > 0);
+assert("phase is active after start", harness.status().phase === "active");
+
+// Use the engine input from start() to run a real LLM call
+const engineInput = startResult.value.engineInput;
+
+const adapter1 = createAdapter();
+const koi1 = await createKoi({
+  manifest: {
+    name: "e2e-long-running-agent",
+    version: "0.0.1",
+    model: { name: MODEL },
+  },
+  adapter: adapter1,
+  middleware: [harness.createMiddleware()], // Attach harness middleware!
+  limits: { maxTurns: 3, maxDurationMs: 60_000, maxTokens: 10_000 },
+});
+
+const events1: EngineEvent[] = [];
+let output1: EngineOutput | undefined;
+
+await withTimeout(
+  async () => {
+    for await (const event of koi1.run(engineInput)) {
+      events1.push(event);
+      if (event.kind === "text_delta") {
+        process.stdout.write(event.text ?? "");
+      }
+      if (event.kind === "done") {
+        output1 = event.output;
+      }
+    }
+  },
+  120_000,
+  "Test 1: LLM call",
+);
+
+console.log(""); // newline after streaming output
+
+assert("LLM produced events", events1.length > 0);
+assert("done event emitted", output1 !== undefined);
+assert(
+  "output has metrics",
+  output1 !== undefined && output1.metrics.inputTokens > 0 && output1.metrics.outputTokens > 0,
+);
+
+await koi1.dispose();
+
+// ---------------------------------------------------------------------------
+// Test 2: middleware onAfterTurn fires soft checkpoints
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 2] middleware onAfterTurn soft checkpoints");
+
+// With softCheckpointInterval=1, every turn should trigger a checkpoint
+const turnEnds = events1.filter((e) => e.kind === "turn_end");
+assert("at least 1 turn completed", turnEnds.length >= 1);
+
+// Give fire-and-forget checkpoint a moment to settle
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+assert(
+  "soft checkpoint(s) saved to persistence",
+  persistence.savedCheckpoints.length > 0,
+  `saved: ${persistence.savedCheckpoints.length}`,
+);
+
+if (persistence.savedCheckpoints.length > 0) {
+  const firstCp = persistence.savedCheckpoints[0];
+  assert("checkpoint has softCheckpoint metadata", firstCp?.metadata?.softCheckpoint === true);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: pause() persists snapshot + accumulates metrics
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 3] pause() persists snapshot + metrics");
+
+const sessionMetrics: EngineMetrics = output1?.metrics ?? {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 1,
+  durationMs: 1000,
+};
+
+const sessionResult: SessionResult = {
+  sessionId: startResult.value.sessionId,
+  metrics: sessionMetrics,
+  summary: "E2E session 1: Agent greeted user and received task plan.",
+  engineState: { engineId: "pi", data: { turnCount: sessionMetrics.turns } },
+};
+
+const pauseResult = await harness.pause(sessionResult);
+assert("pause() returns ok", pauseResult.ok === true);
+assert("phase is suspended after pause", harness.status().phase === "suspended");
+assert("metrics.totalSessions = 1", harness.status().metrics.totalSessions === 1);
+assert("metrics.totalTurns > 0", harness.status().metrics.totalTurns > 0);
+assert(
+  "metrics.totalInputTokens > 0",
+  harness.status().metrics.totalInputTokens > 0,
+  `got: ${harness.status().metrics.totalInputTokens}`,
+);
+
+// Verify snapshot persisted to store
+const headResult = await store.head(TEST_CHAIN_ID);
+assert("snapshot persisted to store", headResult.ok === true);
+if (headResult.ok && headResult.value !== undefined) {
+  assert("snapshot phase is suspended", headResult.value.data.phase === "suspended");
+  assert("snapshot has summary", headResult.value.data.summaries.length === 1);
+  assert(
+    "summary narrative matches",
+    headResult.value.data.summaries[0]?.narrative === sessionResult.summary,
+  );
+}
+
+// Verify engine state was saved via persistence
+const engineStateCps = persistence.savedCheckpoints.filter(
+  (cp) => cp.metadata?.softCheckpoint !== true,
+);
+assert(
+  "engine state checkpoint saved on pause",
+  engineStateCps.length > 0,
+  `found: ${engineStateCps.length}`,
+);
+
+// ---------------------------------------------------------------------------
+// Test 4: resume() returns messages input with context bridge
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 4] resume() returns messages input");
+
+const resumeResult = await harness.resume();
+assert("resume() returns ok", resumeResult.ok === true);
+
+if (resumeResult.ok) {
+  assert("phase is active after resume", harness.status().phase === "active");
+  // Without engine state recovery, falls back to messages
+  assert(
+    "resume returns messages or resume input",
+    resumeResult.value.engineInput.kind === "messages" ||
+      resumeResult.value.engineInput.kind === "resume",
+  );
+  assert("resume returns sessionId", resumeResult.value.sessionId.length > 0);
+  assert(
+    "resume sessionId differs from start",
+    resumeResult.value.sessionId !== startResult.value.sessionId,
+  );
+
+  // Run session 2 with a real LLM call to verify context bridge works
+  if (resumeResult.value.engineInput.kind === "messages") {
+    console.log("  (context bridge mode — running session 2 with resumed context)");
+
+    const adapter2 = createAdapter();
+    const koi2 = await createKoi({
+      manifest: {
+        name: "e2e-long-running-agent-s2",
+        version: "0.0.1",
+        model: { name: MODEL },
+      },
+      adapter: adapter2,
+      middleware: [harness.createMiddleware()],
+      limits: { maxTurns: 2, maxDurationMs: 60_000, maxTokens: 10_000 },
+    });
+
+    let output2: EngineOutput | undefined;
+    await withTimeout(
+      async () => {
+        for await (const event of koi2.run(resumeResult.value.engineInput)) {
+          if (event.kind === "text_delta") {
+            process.stdout.write(event.text ?? "");
+          }
+          if (event.kind === "done") {
+            output2 = event.output;
+          }
+        }
+      },
+      120_000,
+      "Test 4: Session 2 LLM call",
+    );
+    console.log("");
+
+    assert("session 2 produced output", output2 !== undefined);
+    assert("session 2 has tokens", output2 !== undefined && output2.metrics.totalTokens > 0);
+
+    await koi2.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: completeTask() + all-done transition
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 5] completeTask() + completed transition");
+
+const ct1 = await harness.completeTask(taskItemId("task-greet"), {
+  taskId: taskItemId("task-greet"),
+  output: "Greeted user successfully",
+  durationMs: 2000,
+});
+assert("completeTask(task-greet) returns ok", ct1.ok === true);
+assert("phase still active after 1 task", harness.status().phase === "active");
+assert(
+  "completedTaskCount = 1",
+  harness.status().metrics.completedTaskCount === 1,
+  `got: ${harness.status().metrics.completedTaskCount}`,
+);
+
+const ct2 = await harness.completeTask(taskItemId("task-math"), {
+  taskId: taskItemId("task-math"),
+  output: "Math problem solved",
+  durationMs: 1000,
+});
+assert("completeTask(task-math) returns ok", ct2.ok === true);
+assert("phase is completed after all tasks done", harness.status().phase === "completed");
+assert("completedTaskCount = 2", harness.status().metrics.completedTaskCount === 2);
+assert("pendingTaskCount = 0", harness.status().metrics.pendingTaskCount === 0);
+
+// ---------------------------------------------------------------------------
+// Test 6: fail() on a fresh harness
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 6] fail() transitions to failed");
+
+const store2: HarnessSnapshotStore = createInMemorySnapshotChainStore();
+const persistence2 = createTrackingPersistence();
+const harness2 = createLongRunningHarness({
+  harnessId: harnessId("e2e-fail-harness"),
+  agentId: TEST_AGENT_ID,
+  harnessStore: store2,
+  sessionPersistence: persistence2,
+});
+
+await harness2.start({
+  items: [
+    {
+      id: taskItemId("fail-task"),
+      description: "This will fail",
+      dependencies: [],
+      priority: 0,
+      maxRetries: 1,
+      retries: 0,
+      status: "pending" as const,
+    },
+  ],
+  results: [],
+});
+
+const failResult = await harness2.fail({
+  code: "TIMEOUT",
+  message: "Agent exceeded maximum runtime",
+  retryable: false,
+});
+assert("fail() returns ok", failResult.ok === true);
+assert("phase is failed", harness2.status().phase === "failed");
+assert(
+  "failureReason is set",
+  harness2.status().failureReason === "Agent exceeded maximum runtime",
+);
+
+// Verify fail prevents further operations
+const resumeAfterFail = await harness2.resume();
+assert("resume() rejects after fail", resumeAfterFail.ok === false);
+
+await harness2.dispose();
+
+// ---------------------------------------------------------------------------
+// Test 7: saveState callback in soft checkpoints
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 7] saveState callback wires into soft checkpoints");
+
+const store3: HarnessSnapshotStore = createInMemorySnapshotChainStore();
+const persistence3 = createTrackingPersistence();
+
+const capturedState: EngineState = { engineId: "pi-real", data: { cursor: 99 } };
+const harness3 = createLongRunningHarness({
+  harnessId: harnessId("e2e-savestate-harness"),
+  agentId: TEST_AGENT_ID,
+  harnessStore: store3,
+  sessionPersistence: persistence3,
+  softCheckpointInterval: 1,
+  saveState: () => capturedState,
+});
+
+await harness3.start({
+  items: [
+    {
+      id: taskItemId("save-state-task"),
+      description: "Test saveState",
+      dependencies: [],
+      priority: 0,
+      maxRetries: 1,
+      retries: 0,
+      status: "pending" as const,
+    },
+  ],
+  results: [],
+});
+
+// Run a quick LLM call with this harness's middleware
+const adapter3 = createAdapter();
+const koi3 = await createKoi({
+  manifest: {
+    name: "e2e-savestate-agent",
+    version: "0.0.1",
+    model: { name: MODEL },
+  },
+  adapter: adapter3,
+  middleware: [harness3.createMiddleware()],
+  limits: { maxTurns: 2, maxDurationMs: 60_000, maxTokens: 5_000 },
+});
+
+await withTimeout(
+  async () => {
+    for await (const _event of koi3.run({ kind: "text", text: "Say hello" })) {
+      // drain events
+    }
+  },
+  60_000,
+  "Test 7: saveState LLM call",
+);
+
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+const realStateCps = persistence3.savedCheckpoints.filter(
+  (cp) => cp.engineState.engineId === "pi-real",
+);
+assert(
+  "saveState callback produced real engine state in checkpoint",
+  realStateCps.length > 0,
+  `found: ${realStateCps.length}, total: ${persistence3.savedCheckpoints.length}`,
+);
+
+if (realStateCps.length > 0) {
+  assert(
+    "checkpoint engine state matches saveState return value",
+    JSON.stringify(realStateCps[0]?.engineState) === JSON.stringify(capturedState),
+  );
+}
+
+await koi3.dispose();
+await harness3.dispose();
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+await harness.dispose();
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n[e2e] Results: ${passed}/${total} passed`);
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      const detail = r.detail ? ` — ${r.detail}` : "";
+      console.error(`  FAIL  ${r.name}${detail}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e] All tests passed!");


### PR DESCRIPTION
## Summary

- **New package `@koi/long-running`** — stateful harness for agents operating across multiple sessions (hours/days). Manages task progress, bridges context between sessions via snapshot chain, and checkpoints at meaningful task boundaries.
- **`InboundMessage.pinned` flag** in `@koi/core` — prevents compaction middleware from summarizing away harness-injected context messages.
- **Compactor pinned support** in `@koi/middleware-compactor` — `findValidSplitPoints()` now caps split points before the first pinned message, ensuring pinned messages always stay in the preserved tail.
- **Test utilities** — `createMockHarness()`, `createMockTaskPlan()`, `createMockContextSummary()` in `@koi/test-utils` + contract test suite `runHarnessContractTests()`.
- **Documentation** — `docs/L2/long-running.md` with architecture diagrams, lifecycle flow, examples, and API reference.
- **E2E validation script** — `scripts/e2e-long-running-pi.ts` (40 assertions covering full multi-session lifecycle).

### Package breakdown

| Module | LOC | Purpose |
|--------|-----|---------|
| `harness.ts` | ~320 | Factory + state machine (idle→active→suspended→completed/failed) |
| `context-bridge.ts` | ~180 | Builds token-budgeted resume prompts from snapshots |
| `checkpoint-policy.ts` | ~90 | Pure functions for checkpoint timing |
| `types.ts` | ~120 | L2-local config and interface types |

### Key design decisions

- **State manager, not middleware** — called at session boundaries by Node, not inside the engine loop
- **Immutable snapshots** — all state transitions produce new `HarnessSnapshot` objects via `SnapshotChainStore`
- **Fail-open on missing context** — missing summaries/artifacts skip gracefully; missing task board fails closed
- **Pinned messages** — resume context marked `pinned: true` so compaction middleware preserves it

## Test plan

- [x] 94 unit/integration tests pass in `@koi/long-running` (harness, context-bridge, checkpoint-policy, degradation, multi-session, contract, api-surface)
- [x] 38 tests pass in `@koi/middleware-compactor` (including 8 new pinned message tests)
- [x] 711 total tests pass across the monorepo
- [x] `bun run typecheck` passes for all affected packages
- [x] `bun run build` succeeds for `@koi/long-running`
- [x] API surface snapshot tests pass
- [x] Biome lint/format passes
- [x] E2E script validates full lifecycle (40/40 assertions)

Closes #134
Refs #450