### PR TITLE
feat: add @koi/channel-chat-sdk — multi-platform channel adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,28 @@
         "@koi/errors": "workspace:*",
       },
     },
+    "packages/channel-chat-sdk": {
+      "name": "@koi/channel-chat-sdk",
+      "version": "0.0.0",
+      "dependencies": {
+        "@chat-adapter/discord": "4.14.0",
+        "@chat-adapter/gchat": "4.14.0",
+        "@chat-adapter/github": "4.14.0",
+        "@chat-adapter/linear": "4.14.0",
+        "@chat-adapter/slack": "4.14.0",
+        "@chat-adapter/state-memory": "4.14.0",
+        "@chat-adapter/teams": "4.14.0",
+        "@koi/channel-base": "workspace:*",
+        "@koi/core": "workspace:*",
+        "@koi/resolve": "workspace:*",
+        "chat": "4.14.0",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/channel-cli": {
       "name": "@koi/channel-cli",
       "version": "0.0.0",
@@ -1427,6 +1449,30 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
+    "@azure/abort-controller": ["@azure/abort-controller@2.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA=="],
+
+    "@azure/core-auth": ["@azure/core-auth@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-util": "^1.13.0", "tslib": "^2.6.2" } }, "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg=="],
+
+    "@azure/core-client": ["@azure/core-client@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "tslib": "^2.6.2" } }, "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w=="],
+
+    "@azure/core-http-compat": ["@azure/core-http-compat@2.3.2", "", { "dependencies": { "@azure/abort-controller": "^2.1.2" }, "peerDependencies": { "@azure/core-client": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0" } }, "sha512-Tf6ltdKzOJEgxZeWLCjMxrxbodB/ZeCbzzA1A2qHbhzAjzjHoBVSUeSl/baT/oHAxhc4qdqVaDKnc2+iE932gw=="],
+
+    "@azure/core-rest-pipeline": ["@azure/core-rest-pipeline@1.22.2", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg=="],
+
+    "@azure/core-tracing": ["@azure/core-tracing@1.3.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ=="],
+
+    "@azure/core-util": ["@azure/core-util@1.13.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A=="],
+
+    "@azure/identity": ["@azure/identity@4.13.0", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.2", "@azure/core-rest-pipeline": "^1.17.0", "@azure/core-tracing": "^1.0.0", "@azure/core-util": "^1.11.0", "@azure/logger": "^1.0.0", "@azure/msal-browser": "^4.2.0", "@azure/msal-node": "^3.5.0", "open": "^10.1.0", "tslib": "^2.2.0" } }, "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw=="],
+
+    "@azure/logger": ["@azure/logger@1.3.0", "", { "dependencies": { "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA=="],
+
+    "@azure/msal-browser": ["@azure/msal-browser@4.29.0", "", { "dependencies": { "@azure/msal-common": "15.15.0" } }, "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w=="],
+
+    "@azure/msal-common": ["@azure/msal-common@15.15.0", "", {}, "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw=="],
+
+    "@azure/msal-node": ["@azure/msal-node@3.8.8", "", { "dependencies": { "@azure/msal-common": "15.15.0", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -1487,6 +1533,22 @@
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
+    "@chat-adapter/discord": ["@chat-adapter/discord@4.14.0", "", { "dependencies": { "@chat-adapter/shared": "4.14.0", "chat": "4.14.0", "discord-api-types": "^0.37.119", "discord-interactions": "^4.4.0", "discord.js": "^14.25.1" } }, "sha512-qaBqonssVqroIeNYmgGv6nzWFES4BX24ox39LJkJhG3LvTTUXPPVbgGo8hJG3EH7+9JUEUIJXjSs974+pm14Zw=="],
+
+    "@chat-adapter/gchat": ["@chat-adapter/gchat@4.14.0", "", { "dependencies": { "@chat-adapter/shared": "4.14.0", "chat": "4.14.0", "googleapis": "^144.0.0" } }, "sha512-pztTAIBL7k/VqQ2PA0/3OfRJmTkR+SXA6tQgPA3scIukq7+a04Q1O5fU05YQY8lIDp3zuOPuId8PS7xm/mGnMg=="],
+
+    "@chat-adapter/github": ["@chat-adapter/github@4.14.0", "", { "dependencies": { "@chat-adapter/shared": "4.14.0", "@octokit/auth-app": "^7.1.1", "@octokit/rest": "^21.0.2", "chat": "4.14.0" } }, "sha512-Cf9mgZ24Uo+IQmyyqD1FDoSDdFov5gQhqX+l768RzQxyBxXXhgbYN74uVRNbhQ9BCMcJmrVNNYJbyD/EHnQEoA=="],
+
+    "@chat-adapter/linear": ["@chat-adapter/linear@4.14.0", "", { "dependencies": { "@chat-adapter/shared": "4.14.0", "@linear/sdk": "^37.0.0", "chat": "4.14.0" } }, "sha512-6iexDJHR8rWSHatJRHwqz15aGUQcmvz2vjatAqVYwpd17WH0T9tMrkfrps55fvt2AoY8M7qa+1dS0GsjKhTIyQ=="],
+
+    "@chat-adapter/shared": ["@chat-adapter/shared@4.14.0", "", { "dependencies": { "chat": "4.14.0" } }, "sha512-D6OCFlO7g8Tvq6YJ06c0KkEtR4XKFx0FLCGV93AtRrww9mE9MBKEgeQwJosFRMt7y21n6XJK1n/BPZDnTveNZg=="],
+
+    "@chat-adapter/slack": ["@chat-adapter/slack@4.14.0", "", { "dependencies": { "@chat-adapter/shared": "4.14.0", "@slack/web-api": "^7.11.0", "chat": "4.14.0" } }, "sha512-IJ0cJ3QC1f/inieA12VIhoJCap59kQbT4xovt52OU9WtTy4zGkxKIgEem7jA+KcbxeepoypmNIpTy8QSUMZBnQ=="],
+
+    "@chat-adapter/state-memory": ["@chat-adapter/state-memory@4.14.0", "", { "dependencies": { "chat": "4.14.0" } }, "sha512-6YWMok5/1tS81lXspXhObmXVN+Zaopdd4ZMMh3r2WVeCCLCvbRYz9X9tqA+QuI2XCWxUcAPuWavFATgn+PdkLw=="],
+
+    "@chat-adapter/teams": ["@chat-adapter/teams@4.14.0", "", { "dependencies": { "@azure/identity": "^4.13.0", "@chat-adapter/shared": "4.14.0", "@microsoft/microsoft-graph-client": "^3.0.7", "botbuilder": "^4.23.1", "chat": "4.14.0" } }, "sha512-Cq7skD9za7bz7S/BbZB04zim3tR4rhWiZajqKDXky0uzX4wy1+c+LNNEZ+sp4/JsiENXSR1+0vJ72QtR8BMRRA=="],
+
     "@clack/core": ["@clack/core@0.4.1", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA=="],
 
     "@clack/prompts": ["@clack/prompts@0.10.0", "", { "dependencies": { "@clack/core": "0.4.1", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-H3rCl6CwW1NdQt9rE3n373t7o5cthPv7yUoxF2ytZvyvlJv89C5RYMJu83Hed8ODgys5vpBU0GKxIRG83jd8NQ=="],
@@ -1496,6 +1558,18 @@
     "@connectrpc/connect-web": ["@connectrpc/connect-web@2.0.0-rc.3", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.2.0", "@connectrpc/connect": "2.0.0-rc.3" } }, "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw=="],
 
     "@datastructures-js/deque": ["@datastructures-js/deque@1.0.8", "", {}, "sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg=="],
+
+    "@discordjs/builders": ["@discordjs/builders@1.13.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.33", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.0", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.16", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1576,6 +1650,8 @@
     "@google/genai": ["@google/genai@1.42.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw=="],
 
     "@grammyjs/types": ["@grammyjs/types@3.24.0", "", {}, "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -1660,6 +1736,8 @@
     "@koi/canvas": ["@koi/canvas@workspace:packages/canvas"],
 
     "@koi/channel-base": ["@koi/channel-base@workspace:packages/channel-base"],
+
+    "@koi/channel-chat-sdk": ["@koi/channel-chat-sdk@workspace:packages/channel-chat-sdk"],
 
     "@koi/channel-cli": ["@koi/channel-cli@workspace:packages/channel-cli"],
 
@@ -1867,6 +1945,8 @@
 
     "@koi/worktree-merge": ["@koi/worktree-merge@workspace:packages/worktree-merge"],
 
+    "@linear/sdk": ["@linear/sdk@37.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.0", "graphql": "^15.4.0", "isomorphic-unfetch": "^3.1.0" } }, "sha512-EAZCXtV414Nwtvrwn7Ucu3E8BbYYKsc3HqZCGf1mHUE7FhZGtfISu295DOVv89WhhXlp2N344EMg3K0nnhLxtA=="],
+
     "@livekit/agents": ["@livekit/agents@1.0.47", "", { "dependencies": { "@ffmpeg-installer/ffmpeg": "^1.1.0", "@livekit/mutex": "^1.1.1", "@livekit/protocol": "^1.43.0", "@livekit/typed-emitter": "^3.0.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.54.0", "@opentelemetry/core": "^2.2.0", "@opentelemetry/exporter-logs-otlp-proto": "^0.54.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.54.0", "@opentelemetry/instrumentation-pino": "^0.43.0", "@opentelemetry/otlp-exporter-base": "^0.208.0", "@opentelemetry/resources": "^1.28.0", "@opentelemetry/sdk-logs": "^0.54.0", "@opentelemetry/sdk-trace-base": "^1.28.0", "@opentelemetry/sdk-trace-node": "^1.28.0", "@opentelemetry/semantic-conventions": "^1.28.0", "@types/pidusage": "^2.0.5", "commander": "^12.0.0", "fluent-ffmpeg": "^2.1.3", "form-data": "^4.0.5", "heap-js": "^2.6.0", "json-schema": "^0.4.0", "livekit-server-sdk": "^2.14.1", "openai": "^6.8.1", "pidusage": "^4.0.1", "pino": "^8.19.0", "pino-pretty": "^11.0.0", "sharp": "0.34.5", "uuid": "^11.1.0", "ws": "^8.18.0", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "@livekit/rtc-node": "^0.13.24", "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Iy995PAdObU2niimqYNvJxLGAvrTktrJAMd+vFOmMRmB1IRafcwEBIcSBM1N5csT7Snu6mwS9/3SmjkHgysXyg=="],
 
     "@livekit/agents-plugin-deepgram": ["@livekit/agents-plugin-deepgram@1.0.47", "", { "dependencies": { "ws": "^8.16.0" }, "peerDependencies": { "@livekit/agents": "1.0.47", "@livekit/rtc-node": "^0.13.24" } }, "sha512-b7aYQLNGw/+JUWJQdchCKr+InQV2MynJmp6HRT1jfKO/dr/uzpMWUQV+5tQGQuyfNo+u2WdAxgBnHS6pFEQqVw=="],
@@ -1895,11 +1975,49 @@
 
     "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.54.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-XHhMIbFFHCa4mbiYdttfhVg6r3VmFD5tAiW4tjnmf33FhLUCRd76bGMQRc4kLWXPKCi/U4nqAErvaGiZUY4B8A=="],
 
+    "@microsoft/microsoft-graph-client": ["@microsoft/microsoft-graph-client@3.0.7", "", { "dependencies": { "@babel/runtime": "^7.12.5", "tslib": "^2.2.0" } }, "sha512-/AazAV/F+HK4LIywF9C+NYHcJo038zEnWkteilcxC1FM/uK/4NVGDKGrxx7nNq1ybspAroRKT4I1FHfxQzxkUw=="],
+
     "@mistralai/mistralai": ["@mistralai/mistralai@1.10.0", "", { "dependencies": { "zod": "^3.20.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.12.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@octokit/auth-app": ["@octokit/auth-app@7.2.2", "", { "dependencies": { "@octokit/auth-oauth-app": "^8.1.4", "@octokit/auth-oauth-user": "^5.1.4", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw=="],
+
+    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@8.1.4", "", { "dependencies": { "@octokit/auth-oauth-device": "^7.1.5", "@octokit/auth-oauth-user": "^5.1.4", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ=="],
+
+    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@7.1.5", "", { "dependencies": { "@octokit/oauth-methods": "^5.1.5", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw=="],
+
+    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@5.1.6", "", { "dependencies": { "@octokit/auth-oauth-device": "^7.1.5", "@octokit/oauth-methods": "^5.1.5", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@5.1.2", "", {}, "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="],
+
+    "@octokit/core": ["@octokit/core@6.1.6", "", { "dependencies": { "@octokit/auth-token": "^5.0.0", "@octokit/graphql": "^8.2.2", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "before-after-hook": "^3.0.2", "universal-user-agent": "^7.0.0" } }, "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@10.1.4", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@8.2.2", "", { "dependencies": { "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA=="],
+
+    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@7.1.1", "", {}, "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="],
+
+    "@octokit/oauth-methods": ["@octokit/oauth-methods@5.1.5", "", { "dependencies": { "@octokit/oauth-authorization-url": "^7.0.0", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0" } }, "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@25.1.0", "", {}, "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@11.6.0", "", { "dependencies": { "@octokit/types": "^13.10.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@5.3.1", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@13.5.0", "", { "dependencies": { "@octokit/types": "^13.10.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw=="],
+
+    "@octokit/request": ["@octokit/request@9.2.4", "", { "dependencies": { "@octokit/endpoint": "^10.1.4", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^2.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@6.1.8", "", { "dependencies": { "@octokit/types": "^14.0.0" } }, "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ=="],
+
+    "@octokit/rest": ["@octokit/rest@21.1.1", "", { "dependencies": { "@octokit/core": "^6.1.4", "@octokit/plugin-paginate-rest": "^11.4.2", "@octokit/plugin-request-log": "^5.3.1", "@octokit/plugin-rest-endpoint-methods": "^13.3.0" } }, "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg=="],
+
+    "@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -2057,7 +2175,19 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.33", "", {}, "sha512-5HAV9exOMcXRUxo+9iYB5n09XxzCXnfy4VTNW4xnDv+FgjzAGY989C28BIdljKqmF+ZltUwujE3aossvcVtq6g=="],
+
+    "@slack/logger": ["@slack/logger@4.0.0", "", { "dependencies": { "@types/node": ">=18.0.0" } }, "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA=="],
+
+    "@slack/types": ["@slack/types@2.20.0", "", {}, "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA=="],
+
+    "@slack/web-api": ["@slack/web-api@7.14.1", "", { "dependencies": { "@slack/logger": "^4.0.0", "@slack/types": "^2.20.0", "@types/node": ">=18.0.0", "@types/retry": "0.12.0", "axios": "^1.13.5", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw=="],
 
@@ -2205,7 +2335,15 @@
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
@@ -2219,11 +2357,21 @@
 
     "@types/shimmer": ["@types/shimmer@1.2.0", "", {}, "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="],
 
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.3", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA=="],
+
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vercel/sandbox": ["@vercel/sandbox@1.7.1", "", { "dependencies": { "@vercel/oidc": "3.2.0", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-TI9InUQe7sqyO4/TIiGXC/3RHA0hTt5PpFaTWeWunkbKZae26nuPVsd+p10W/WN2THUKE+NPtTJ21dhp1Yw48w=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.5.2", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.11", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-QNVT3/Lxx99nMQWJWF7K4N6apUEuT0KlZA3mx/mVaoGj3smm/8rc8ezz15J1pcbcjDK0V15rpHetVfya08r76Q=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
+
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -2232,6 +2380,8 @@
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "adaptivecards": ["adaptivecards@1.2.3", "", {}, "sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -2257,7 +2407,11 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
+    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
+
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -2265,13 +2419,31 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
 
     "basic-ftp": ["basic-ftp@5.1.0", "", {}, "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw=="],
 
+    "before-after-hook": ["before-after-hook@3.0.2", "", {}, "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="],
+
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "botbuilder": ["botbuilder@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/msal-node": "^2.13.1", "axios": "^1.8.2", "botbuilder-core": "4.23.3", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "botframework-streaming": "4.23.3", "dayjs": "^1.11.13", "filenamify": "^6.0.0", "fs-extra": "^11.2.0", "htmlparser2": "^9.0.1", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-1gDIQHHYosYBHGXMjvZEJDrcp3NGy3lzHBml5wn9PFqVuIk/cbsCDZs3KJ3g+aH/GGh4CH/ij9iQ2KbQYHAYKA=="],
+
+    "botbuilder-core": ["botbuilder-core@4.23.3", "", { "dependencies": { "botbuilder-dialogs-adaptive-runtime-core": "4.23.3-preview", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-48iW739I24piBH683b/Unvlu1fSzjB69ViOwZ0PbTkN2yW5cTvHJWlW7bXntO8GSqJfssgPaVthKfyaCW457ig=="],
+
+    "botbuilder-dialogs-adaptive-runtime-core": ["botbuilder-dialogs-adaptive-runtime-core@4.23.3-preview", "", { "dependencies": { "dependency-graph": "^1.0.0" } }, "sha512-EssyvqK9MobX3gbnUe/jjhLuxpCEeyQeQsyUFMJ236U6vzSQdrAxNH7Jc5DyZw2KKelBdK1xPBdwTYQNM5S0Qw=="],
+
+    "botbuilder-stdlib": ["botbuilder-stdlib@4.23.3-internal", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.2", "@azure/core-http-compat": "^2.1.2", "@azure/core-rest-pipeline": "^1.18.1", "@azure/core-tracing": "^1.2.0" } }, "sha512-fwvIHnKU8sXo1gTww+m/k8wnuM5ktVBAV/3vWJ+ou40zapy1HYjWQuu6sVCRFgMUngpKwhdmoOQsTXsp58SNtA=="],
+
+    "botframework-connector": ["botframework-connector@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/identity": "^4.4.1", "@azure/msal-node": "^2.13.1", "@types/jsonwebtoken": "9.0.6", "axios": "^1.8.2", "base64url": "^3.0.0", "botbuilder-stdlib": "4.23.3-internal", "botframework-schema": "4.23.3", "buffer": "^6.0.3", "cross-fetch": "^4.0.0", "https-proxy-agent": "^7.0.5", "jsonwebtoken": "^9.0.2", "node-fetch": "^2.7.0", "openssl-wrapper": "^0.3.4", "rsa-pem-from-mod-exp": "^0.8.6", "zod": "^3.23.8" } }, "sha512-sChwCFJr3xhcMCYChaOxJoE8/YgdjOPWzGwz5JAxZDwhbQonwYX5O/6Z9EA+wB3TCFNEh642SGeC/rOitaTnGQ=="],
+
+    "botframework-schema": ["botframework-schema@4.23.3", "", { "dependencies": { "adaptivecards": "1.2.3", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-/W0uWxZ3fuPLAImZRLnPTbs49Z2xMpJSIzIBxSfvwO0aqv9GsM3bTk3zlNdJ1xr40SshQ7WiH2H1hgjBALwYJw=="],
+
+    "botframework-streaming": ["botframework-streaming@4.23.3", "", { "dependencies": { "@types/ws": "^6.0.3", "uuid": "^10.0.0", "ws": "^7.5.10" } }, "sha512-GMtciQGfZXtAW6syUqFpFJQ2vDyVbpxL3T1DqFzq/GmmkAu7KTZ1zvo7PTww6+IT1kMW0lmL/XZJVq3Rhg4PQA=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -2284,6 +2456,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -2301,7 +2475,13 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "chat": ["chat@4.14.0", "", { "dependencies": { "@workflow/serde": "4.1.0-beta.2", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.5" } }, "sha512-gVod4FBptr4ewPEdY2zo1GnegI8/O0aC5F+IvFMIjimqmQjW0txhQbgI/DgmD48pwXJhxUGpvNrqzMrChx8GWw=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -2339,6 +2519,8 @@
 
     "croner": ["croner@9.0.0", "", {}, "sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA=="],
 
+    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
@@ -2349,7 +2531,17 @@
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
+    "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
@@ -2357,13 +2549,31 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dependency-graph": ["dependency-graph@1.0.0", "", {}, "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "discord-api-types": ["discord-api-types@0.37.120", "", {}, "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="],
+
+    "discord-interactions": ["discord-interactions@4.4.0", "", {}, "sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA=="],
+
+    "discord.js": ["discord.js@14.25.1", "", { "dependencies": { "@discordjs/builders": "^1.13.0", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.33", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g=="],
+
     "dockerfile-ast": ["dockerfile-ast@0.7.1", "", { "dependencies": { "vscode-languageserver-textdocument": "^1.0.8", "vscode-languageserver-types": "^3.17.3" } }, "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -2385,6 +2595,8 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
@@ -2399,6 +2611,8 @@
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
@@ -2410,6 +2624,8 @@
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -2424,6 +2640,8 @@
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@2.0.1", "", {}, "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="],
 
     "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
 
@@ -2445,11 +2663,17 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
+    "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
+
+    "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "fluent-ffmpeg": ["fluent-ffmpeg@2.1.3", "", { "dependencies": { "async": "^0.2.9", "which": "^1.1.1" } }, "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q=="],
+
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -2461,13 +2685,15 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
+
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
 
-    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -2479,9 +2705,13 @@
 
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
-    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "googleapis": ["googleapis@144.0.0", "", { "dependencies": { "google-auth-library": "^9.0.0", "googleapis-common": "^7.0.0" } }, "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw=="],
+
+    "googleapis-common": ["googleapis-common@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^6.0.3", "google-auth-library": "^9.7.0", "qs": "^6.7.0", "url-template": "^2.0.8", "uuid": "^9.0.0" } }, "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -2489,7 +2719,9 @@
 
     "grammy": ["grammy@1.40.0", "", { "dependencies": { "@grammyjs/types": "3.24.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q=="],
 
-    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
+    "graphql": ["graphql@15.10.1", "", {}, "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2502,6 +2734,8 @@
     "heap-js": ["heap-js@2.7.1", "", {}, "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -2525,11 +2759,25 @@
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isomorphic-unfetch": ["isomorphic-unfetch@3.1.0", "", { "dependencies": { "node-fetch": "^2.6.1", "unfetch": "^4.2.0" } }, "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q=="],
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
@@ -2553,7 +2801,11 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
+
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -2613,21 +2865,121 @@
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
+
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "map-obj": ["map-obj@5.0.0", "", {}, "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -2673,17 +3025,27 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
     "openai": ["openai@6.10.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A=="],
 
     "openapi-fetch": ["openapi-fetch@0.14.1", "", { "dependencies": { "openapi-typescript-helpers": "^0.0.15" } }, "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A=="],
 
     "openapi-typescript-helpers": ["openapi-typescript-helpers@0.0.15", "", {}, "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="],
 
+    "openssl-wrapper": ["openssl-wrapper@0.3.4", "", {}, "sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ=="],
+
     "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
 
     "oxc-parser": ["oxc-parser@0.114.0", "", { "dependencies": { "@oxc-project/types": "^0.114.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.114.0", "@oxc-parser/binding-android-arm64": "0.114.0", "@oxc-parser/binding-darwin-arm64": "0.114.0", "@oxc-parser/binding-darwin-x64": "0.114.0", "@oxc-parser/binding-freebsd-x64": "0.114.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.114.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.114.0", "@oxc-parser/binding-linux-arm64-gnu": "0.114.0", "@oxc-parser/binding-linux-arm64-musl": "0.114.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.114.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.114.0", "@oxc-parser/binding-linux-riscv64-musl": "0.114.0", "@oxc-parser/binding-linux-s390x-gnu": "0.114.0", "@oxc-parser/binding-linux-x64-gnu": "0.114.0", "@oxc-parser/binding-linux-x64-musl": "0.114.0", "@oxc-parser/binding-openharmony-arm64": "0.114.0", "@oxc-parser/binding-wasm32-wasi": "0.114.0", "@oxc-parser/binding-win32-arm64-msvc": "0.114.0", "@oxc-parser/binding-win32-ia32-msvc": "0.114.0", "@oxc-parser/binding-win32-x64-msvc": "0.114.0" } }, "sha512-V+tATPyadb6MP51BpK2OMnB27Ln/pDwG7Uk5cAi5jPHRyZwdb72zacuPI6umafcV3VJjh9Jc9WWp0rwEM0AjSQ=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -2785,6 +3147,12 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "require-in-the-middle": ["require-in-the-middle@7.5.2", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3", "resolve": "^1.22.8" } }, "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ=="],
@@ -2800,6 +3168,10 @@
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "rsa-pem-from-mod-exp": ["rsa-pem-from-mod-exp@0.8.6", "", {}, "sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
 
@@ -2903,15 +3275,21 @@
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -2943,15 +3321,39 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "unfetch": ["unfetch@4.2.0", "", {}, "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
+
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
 
@@ -2975,6 +3377,8 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
     "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
     "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
@@ -2986,6 +3390,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zustand": ["zustand@5.0.5", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -3005,11 +3411,31 @@
 
     "@aws-sdk/middleware-user-agent/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.993.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw=="],
 
+    "@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@discordjs/builders/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "@discordjs/formatters/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "@discordjs/rest/undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
+
+    "@discordjs/util/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "@google/genai/google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
     "@livekit/agents/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
 
@@ -3030,6 +3456,10 @@
     "@modelcontextprotocol/sdk/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@1.27.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.27.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg=="],
 
@@ -3099,7 +3529,35 @@
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "botbuilder/@azure/msal-node": ["@azure/msal-node@2.16.3", "", { "dependencies": { "@azure/msal-common": "14.16.1", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw=="],
+
+    "botbuilder/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "botbuilder/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botbuilder-core/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "botbuilder-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-connector/@azure/msal-node": ["@azure/msal-node@2.16.3", "", { "dependencies": { "@azure/msal-common": "14.16.1", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw=="],
+
+    "botframework-connector/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-schema/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "botframework-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-streaming/@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
+
+    "botframework-streaming/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "botframework-streaming/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "discord.js/discord-api-types": ["discord-api-types@0.38.40", "", {}, "sha512-P/His8cotqZgQqrt+hzrocp9L8RhQQz1GkrCnC9TMJ8Uw2q0tg8YyqJyGULxhXn/8kxHETN4IppmOv+P2m82lQ=="],
+
+    "discord.js/undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -3107,9 +3565,15 @@
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "googleapis-common/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "livekit-server-sdk/@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.1", "", {}, "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
@@ -3159,6 +3623,12 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@google/genai/google-auth-library/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "@google/genai/google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "@google/genai/google-auth-library/gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
+
     "@livekit/agents/@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
 
     "@livekit/agents/@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
@@ -3188,6 +3658,10 @@
     "@livekit/rtc-node/pino-pretty/strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.27.0", "", {}, "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg=="],
 
@@ -3235,9 +3709,15 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "botbuilder/@azure/msal-node/@azure/msal-common": ["@azure/msal-common@14.16.1", "", {}, "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w=="],
 
-    "gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+    "botbuilder/@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
+    "botframework-connector/@azure/msal-node/@azure/msal-common": ["@azure/msal-common@14.16.1", "", {}, "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w=="],
+
+    "botframework-connector/@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
@@ -3309,10 +3789,14 @@
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers/@aws-sdk/nested-clients/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.993.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw=="],
 
+    "@google/genai/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "@livekit/agents/@opentelemetry/sdk-trace-node/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "rimraf/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@google/genai/google-auth-library/gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
   }
 }

--- a/docs/L2/channel-chat-sdk.md
+++ b/docs/L2/channel-chat-sdk.md
@@ -1,0 +1,718 @@
+# @koi/channel-chat-sdk — Multi-Platform Channel Adapter
+
+Wraps 6 chat platforms (Slack, Discord, Teams, Google Chat, GitHub, Linear) into Koi `ChannelAdapter` instances using a single shared [Vercel Chat SDK](https://github.com/vercel/chat) instance. One normalizer, one content mapper, 6 platforms — instead of building 6 separate channel adapter packages.
+
+---
+
+## Why It Exists
+
+Supporting 6 chat platforms individually would mean 6 packages, 6 normalizers, 6 content mappers, and ~1800 LOC of largely duplicated adapter code. The Vercel Chat SDK already normalizes these platforms into a unified `Message` type and provides a single `postMessage()` interface.
+
+`@koi/channel-chat-sdk` wraps the Chat SDK as a Koi L2 channel adapter. One factory call returns N ready-to-use `ChannelAdapter` instances — each backed by the same shared `Chat` instance for webhook handling, event normalization, and sending.
+
+---
+
+## What This Enables
+
+### One Agent, Six Platforms
+
+```
+                         ┌─────────────────────────────────────────────┐
+                         │           Your Koi Agent (YAML)             │
+                         │  name: "support-bot"                        │
+                         │  channels: [chat-sdk:slack, chat-sdk:discord]│
+                         │  tools: [search, ticket-create]             │
+                         └──────────────────┬──────────────────────────┘
+                                            │
+                     ┌──────────────────────▼──────────────────────┐
+                     │            createKoi() — L1 Engine           │
+                     │  ┌─────────────────────────────────────────┐ │
+                     │  │ Middleware Chain                         │ │
+                     │  │  audit → rate-limit → your-custom → ... │ │
+                     │  └─────────────────────────────────────────┘ │
+                     │  ┌─────────────────────────────────────────┐ │
+                     │  │ Engine Adapter (Pi / LangGraph / etc.)  │ │
+                     │  │  → real LLM calls (Anthropic, OpenAI)   │ │
+                     │  └─────────────────────────────────────────┘ │
+                     └──────────────────────┬──────────────────────┘
+                                            │
+               ┌────────────────────────────▼────────────────────────────┐
+               │          createChatSdkChannels() — THIS PACKAGE         │
+               │                                                         │
+               │  ONE factory → N channel adapters → ONE shared Chat SDK │
+               │                                                         │
+               │  ┌─────────┐  ┌─────────┐  ┌──────┐  ┌──────┐  ┌────┐ │
+               │  │  Slack   │  │ Discord │  │Teams │  │GChat │  │ ...│ │
+               │  └────┬────┘  └────┬────┘  └──┬───┘  └──┬───┘  └──┬─┘ │
+               │       │            │           │         │          │   │
+               │  ┌────▼────────────▼───────────▼─────────▼──────────▼─┐ │
+               │  │  Shared Chat SDK instance (webhook verify,         │ │
+               │  │  event normalize, signature check, send)           │ │
+               │  └────────────────────┬───────────────────────────────┘ │
+               └───────────────────────┼────────────────────────────────┘
+                                       │
+          ┌────────────────────────────▼────────────────────────────┐
+          │                    The Internet                          │
+          │                                                          │
+          │  ┌──────┐  ┌───────┐  ┌─────┐  ┌─────┐  ┌──────┐  ┌──┐│
+          │  │Slack │  │Discord│  │Teams│  │GChat│  │GitHub│  │LN││
+          │  │ API  │  │  API  │  │ API │  │ API │  │ API  │  │  ││
+          │  └──┬───┘  └──┬────┘  └──┬──┘  └──┬──┘  └──┬───┘  └┬─┘│
+          └─────┼─────────┼─────────┼────────┼────────┼────────┼───┘
+                │         │         │        │        │        │
+          ┌─────▼───┐ ┌───▼──┐ ┌───▼──┐ ┌───▼──┐ ┌───▼──┐ ┌──▼───┐
+          │ #general│ │      │ │      │ │      │ │ Issue│ │ Issue│
+          │ "hey    │ │"help │ │"file │ │"what │ │ #42  │ │ KOI- │
+          │  bot!"  │ │ me"  │ │ this"│ │ is X"│ │      │ │ 123  │
+          └─────────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘
+            Users on 6 platforms talk to the SAME agent
+```
+
+### Before vs After
+
+```
+WITHOUT channel-chat-sdk:  6 packages, 6 normalizers, 6 mappers
+═══════════════════════════════════════════════════════════════
+
+  @koi/channel-slack     @koi/channel-discord    @koi/channel-teams   ...
+  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+  │ Bolt SDK wrapper│    │ Discord.js      │    │ Bot Framework   │
+  │ normalizer      │    │ normalizer      │    │ normalizer      │
+  │ content mapper  │    │ content mapper  │    │ content mapper  │
+  │ webhook verify  │    │ interaction hdlr│    │ webhook verify  │
+  │ ~300 LOC each   │    │ ~300 LOC each   │    │ ~300 LOC each   │
+  └─────────────────┘    └─────────────────┘    └─────────────────┘
+        ~1800 LOC total          ~6 normalizers          ~6 mappers
+
+
+WITH channel-chat-sdk:  1 package, 1 normalizer, 1 mapper
+══════════════════════════════════════════════════════════
+
+                    @koi/channel-chat-sdk
+                ┌───────────────────────────────┐
+                │ createChatSdkChannels()        │
+                │ ● ONE normalizer (~95 LOC)     │
+                │ ● ONE content mapper (~55 LOC)  │
+                │ ● ONE factory (~340 LOC)        │
+                │ ● ONE config validator          │
+                │ ● Chat SDK handles:             │
+                │   - webhook verification        │
+                │   - platform normalization      │
+                │   - credential auto-detect      │
+                └────────┬──────────────────────┘
+           ┌─────────────┼───────────────┐
+           ▼             ▼               ▼
+    chat-sdk:slack  chat-sdk:discord  chat-sdk:teams  ...
+    (ChannelAdapter) (ChannelAdapter) (ChannelAdapter)
+
+        ~545 LOC total     1 normalizer     1 mapper
+```
+
+---
+
+## Inbound + Outbound Flow
+
+### Inbound: Platform Event → Agent
+
+```
+User types in Slack                  Webhook POST
+"hey bot, search for X"  ──────────►  /webhooks/slack
+                                            │
+                                     handleWebhook(request)
+                                            │
+                                    Chat SDK verifies Slack
+                                    signing secret, parses
+                                    event payload
+                                            │
+                                    onNewMention() fires
+                                            │
+                                    Event router dispatches
+                                    to "slack" handlers only
+                                            │
+                                     normalize()
+                                     Thread + Message →
+                                     InboundMessage {
+                                       content: [TextBlock("hey bot, search for X")],
+                                       senderId: "U12345",
+                                       threadId: "C01-1717000000",
+                                       timestamp: 1717000000000,
+                                       metadata: { isMention: true }
+                                     }
+                                            │
+                                     channel.onMessage() handlers
+                                            │
+                                     Koi middleware chain
+                                            │
+                                     LLM decides: call tool "search"
+                                     with query "X"
+                                            │
+                                     Tool returns results
+                                            │
+                                     LLM composes reply
+```
+
+### Outbound: Agent → Platform
+
+```
+                                     OutboundMessage {
+                                       content: [
+                                         TextBlock("Found 3 results..."),
+                                         ImageBlock(url: "chart.png"),
+                                       ],
+                                       threadId: "C01-1717000000"
+                                     }
+                                            │
+                                     renderBlocks()
+                                     (from @koi/channel-base)
+                                     Downgrades unsupported blocks
+                                            │
+                                     mapContentToPostable()
+                                     [Text, Image] →
+                                     { markdown: "Found 3 results...\n\n![image](chart.png)" }
+                                            │
+                                     adapter.postMessage(threadId, postable)
+                                            │
+                                     Chat SDK formats for
+                                     Slack API, sends via HTTPS
+                                            │
+User sees reply                      Slack API POST
+"Found 3 results..."  ◄───────────────────────┘
+```
+
+### Typing Indicator (sendStatus)
+
+```
+User sends message ──────► Agent starts processing
+                                    │
+                             sendStatus({
+                               kind: "processing",
+                               messageRef: "C01-1717000000"
+                             })
+                                    │
+                             adapter.startTyping(threadId)
+                                    │
+User sees                    Platform API call
+"bot is typing..."  ◄──────────────┘
+                                    │
+                             ... LLM thinks (2-3 sec) ...
+                                    │
+                             channel.send(response)
+                                    │
+User sees reply  ◄──────────────────┘
+```
+
+### Multi-Platform Event Routing
+
+```
+                    Shared Chat SDK Instance
+                    ┌──────────────────────────────┐
+                    │  onNewMention()               │
+                    │  onSubscribedMessage()         │
+                    └───────────┬───────────────────┘
+                                │
+                    Event Router (internal Map)
+                    ┌───────────▼───────────────────┐
+                    │ "slack"   → [handler₁, ...]   │
+                    │ "discord" → [handler₂, ...]   │
+                    │ "teams"   → [handler₃, ...]   │
+                    └───────────────────────────────┘
+                                │
+          Slack event comes in: thread.adapter.name = "slack"
+                                │
+               ┌────────────────┼──────────────────┐
+               ▼                ▼                  ▼
+          handler₁ (slack)   handler₂ (discord)  handler₃ (teams)
+             FIRES              skipped            skipped
+
+     Events route only to the correct platform's handlers.
+     Other platforms are completely unaffected.
+```
+
+---
+
+## Architecture
+
+`@koi/channel-chat-sdk` is an **L2 feature package** built on `@koi/channel-base` (L0u).
+
+```
+┌────────────────────────────────────────────────────────┐
+│  @koi/channel-chat-sdk  (L2)                           │
+│                                                        │
+│  config.ts                  ← config types + validator │
+│  capabilities.ts            ← per-platform caps        │
+│  normalize.ts               ← Chat SDK → InboundMsg    │
+│  map-content.ts             ← ContentBlock → markdown   │
+│  create-chat-sdk-channels.ts ← main factory            │
+│  types.ts                   ← ChatSdkEvent type        │
+│  descriptor.ts              ← BrickDescriptor          │
+│  index.ts                   ← public API surface       │
+│                                                        │
+├────────────────────────────────────────────────────────┤
+│  External deps (Chat SDK)                              │
+│  ● chat 4.14.0                                         │
+│  ● @chat-adapter/slack 4.14.0                         │
+│  ● @chat-adapter/discord 4.14.0                       │
+│  ● @chat-adapter/teams 4.14.0                         │
+│  ● @chat-adapter/gchat 4.14.0                         │
+│  ● @chat-adapter/github 4.14.0                        │
+│  ● @chat-adapter/linear 4.14.0                        │
+│  ● @chat-adapter/state-memory 4.14.0                  │
+│                                                        │
+├────────────────────────────────────────────────────────┤
+│  Internal deps                                         │
+│  ● @koi/core (L0) — ChannelAdapter, ContentBlock, etc │
+│  ● @koi/channel-base (L0u) — createChannelAdapter     │
+│  ● @koi/resolve (L0u) — BrickDescriptor               │
+└────────────────────────────────────────────────────────┘
+```
+
+### Layer Position
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    ChannelAdapter, ContentBlock, InboundMessage          │
+                                                          │
+L0u @koi/channel-base ──────────────────┐               │
+    createChannelAdapter<ChatSdkEvent>   │               │
+                                          │               │
+L0u @koi/resolve ────────────┐           │               │
+    BrickDescriptor           │           │               │
+                               ▼           ▼               ▼
+L2  @koi/channel-chat-sdk ◄──┴───────────┴───────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✓ Chat SDK types stay internal (never leak to public API)
+```
+
+**Dev-only:** `@koi/engine`, `@koi/engine-pi`, `@koi/test-utils` used in E2E tests but are not runtime imports.
+
+### Internal Structure
+
+```
+createChatSdkChannels(config)
+│
+├── createEventRouter(platforms)
+│   Routes events by adapter name → platform handlers
+│
+├── createSharedLifecycle(config, ...)
+│   ● Lazy Chat SDK initialization (promise guard)
+│   ● Ref-counted connect/disconnect
+│   ● Registers onNewMention + onSubscribedMessage
+│
+└── for each platform:
+    createPlatformChannelAdapter(platform, router, lifecycle)
+    │
+    └── createChannelAdapter<ChatSdkEvent>({
+          name: "chat-sdk:slack",
+          capabilities: { text, images, files, buttons, threads },
+          platformConnect:    → lifecycle.connect(),
+          platformDisconnect: → lifecycle.disconnect(),
+          platformSend:       → mapContentToPostable() → adapter.postMessage(),
+          platformSendStatus: → adapter.startTyping(),
+          onPlatformEvent:    → router.add(platform, handler),
+          normalize:          → normalizeChatSdkEvent(),
+        })
+```
+
+---
+
+## Platform Capabilities
+
+Each platform declares what content types it supports natively. Unsupported blocks are downgraded to text fallbacks by `renderBlocks()` from `@koi/channel-base`.
+
+```
+╔═══════════╦══════╦════════╦═══════╦═════════╦═══════╦═══════╦═════════╗
+║ Platform  ║ text ║ images ║ files ║ buttons ║ audio ║ video ║ threads ║
+╠═══════════╬══════╬════════╬═══════╬═════════╬═══════╬═══════╬═════════╣
+║ Slack     ║  ✓   ║   ✓    ║   ✓   ║    ✓    ║   ✗   ║   ✗   ║    ✓    ║
+║ Discord   ║  ✓   ║   ✓    ║   ✓   ║    ✓    ║   ✗   ║   ✗   ║    ✓    ║
+║ Teams     ║  ✓   ║   ✓    ║   ✓   ║    ✓    ║   ✗   ║   ✗   ║    ✓    ║
+║ GChat     ║  ✓   ║   ✓    ║   ✗   ║    ✓    ║   ✗   ║   ✗   ║    ✓    ║
+║ GitHub    ║  ✓   ║   ✓    ║   ✗   ║    ✗    ║   ✗   ║   ✗   ║    ✓    ║
+║ Linear    ║  ✓   ║   ✓    ║   ✗   ║    ✗    ║   ✗   ║   ✗   ║    ✓    ║
+╚═══════════╩══════╩════════╩═══════╩═════════╩═══════╩═══════╩═════════╝
+
+When sending to a platform that lacks support:
+  ImageBlock on GitHub → "![alt](url)" markdown (images: true, native)
+  FileBlock on GitHub  → "[filename](url)" text fallback (files: false)
+  ButtonBlock on Linear → "[label]" text fallback (buttons: false)
+```
+
+---
+
+## Content Mapping
+
+### Outbound: Koi ContentBlock → Chat SDK Markdown
+
+```
+mapContentToPostable(content) → { markdown: string }
+
+╔═══════════════════════╦══════════════════════════════════╗
+║ Koi ContentBlock      ║ Chat SDK markdown                ║
+╠═══════════════════════╬══════════════════════════════════╣
+║ TextBlock("hello")    ║ "hello"                          ║
+║ ImageBlock(url, alt)  ║ "![alt](url)"                    ║
+║ FileBlock(url, name)  ║ "[name](url)"                    ║
+║ ButtonBlock(label)    ║ "[label]"                         ║
+║ CustomBlock(...)      ║ (skipped — not mappable)          ║
+╚═══════════════════════╩══════════════════════════════════╝
+
+Multiple blocks joined with "\n\n":
+  [TextBlock("Report"), ImageBlock("chart.png")] →
+  { markdown: "Report\n\n![image](chart.png)" }
+```
+
+### Inbound: Chat SDK Message → Koi InboundMessage
+
+```
+normalize(ChatSdkEvent) → InboundMessage | null
+
+╔══════════════════════════════╦════════════════════════════════╗
+║ Chat SDK input               ║ Koi output                     ║
+╠══════════════════════════════╬════════════════════════════════╣
+║ message.text = "hello"       ║ [TextBlock("hello")]           ║
+║ attachment type "image"      ║ [ImageBlock(url, alt)]         ║
+║ attachment type "file"       ║ [FileBlock(url, mimeType)]     ║
+║ message.author.isMe = true   ║ null (bot echo — filtered)     ║
+║ empty text + no attachments  ║ null (ignored)                 ║
+║ message.isMention = true     ║ metadata: { isMention: true }  ║
+╚══════════════════════════════╩════════════════════════════════╝
+
+Thread ID comes from thread.id, sender ID from message.author.userId.
+```
+
+---
+
+## Configuration
+
+### ChatSdkChannelConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `platforms` | `readonly PlatformConfig[]` | **required** | One or more platform configs |
+| `userName` | `string` | `"koi-bot"` | Bot display name for the Chat SDK |
+
+### Per-Platform Config (discriminated union on `platform`)
+
+```
+╔═══════════╦═══════════════════════════════════════════════════════════╗
+║ Platform  ║ Optional credentials (auto-detected from env if omitted) ║
+╠═══════════╬═══════════════════════════════════════════════════════════╣
+║ slack     ║ botToken, signingSecret                                  ║
+║ discord   ║ botToken, publicKey, applicationId                       ║
+║ teams     ║ appId, appPassword                                       ║
+║ gchat     ║ credentials: { client_email, private_key, project_id? }  ║
+║ github    ║ token, webhookSecret, userName                           ║
+║ linear    ║ apiKey, webhookSecret, userName                          ║
+╚═══════════╩═══════════════════════════════════════════════════════════╝
+
+All credentials are optional — Chat SDK adapters auto-detect from
+environment variables when not provided explicitly.
+```
+
+### Validation
+
+```
+validateChatSdkChannelConfig(input: unknown): Result<ChatSdkChannelConfig, KoiError>
+
+Validates:
+  ● input is an object
+  ● platforms is a non-empty array
+  ● each platform has a valid "platform" discriminant
+  ● no duplicate platforms
+  ● returns Result (never throws)
+```
+
+---
+
+## Usage
+
+### Standalone (without L1 engine)
+
+```typescript
+import { createChatSdkChannels } from "@koi/channel-chat-sdk";
+
+const adapters = createChatSdkChannels({
+  platforms: [
+    { platform: "slack" },    // credentials from SLACK_BOT_TOKEN env
+    { platform: "discord" },  // credentials from DISCORD_BOT_TOKEN env
+  ],
+});
+
+// Connect all adapters
+for (const adapter of adapters) {
+  await adapter.connect();
+
+  // Register message handler
+  adapter.onMessage(async (msg) => {
+    console.log(`[${adapter.platform}] ${msg.senderId}: ${msg.content}`);
+    await adapter.send({
+      content: [{ kind: "text", text: "Got it!" }],
+      threadId: msg.threadId,
+    });
+  });
+}
+
+// Route webhooks (e.g., in a Bun.serve handler)
+const slackAdapter = adapters.find((a) => a.platform === "slack")!;
+const response = await slackAdapter.handleWebhook(request);
+```
+
+### With Full L1 Runtime (createKoi)
+
+```typescript
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createChatSdkChannels } from "@koi/channel-chat-sdk";
+
+// 1. Create channel adapters
+const [channel] = createChatSdkChannels({
+  platforms: [{ platform: "slack" }],
+});
+
+// 2. Create engine adapter (real LLM)
+const adapter = createPiAdapter({
+  model: "anthropic:claude-haiku-4-5-20251001",
+  systemPrompt: "You are a helpful Slack bot.",
+  getApiKey: async () => process.env.ANTHROPIC_API_KEY!,
+});
+
+// 3. Assemble L1 runtime
+const runtime = await createKoi({
+  manifest: {
+    name: "SlackBot",
+    version: "1.0.0",
+    model: { name: "anthropic:claude-haiku-4-5-20251001" },
+  },
+  adapter,
+  channelId: "@koi/channel-chat-sdk",
+  // Wire typing indicators
+  ...(channel.sendStatus !== undefined ? { sendStatus: channel.sendStatus } : {}),
+});
+
+// 4. Connect and wire message handler
+await channel.connect();
+channel.onMessage(async (msg) => {
+  for await (const event of runtime.run({ kind: "messages", messages: [msg] })) {
+    // process engine events
+  }
+});
+```
+
+### Webhook Routing (Bun.serve)
+
+```typescript
+Bun.serve({
+  port: 3000,
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    // Route by platform prefix
+    if (url.pathname === "/webhooks/slack") {
+      return slackAdapter.handleWebhook(request);
+    }
+    if (url.pathname === "/webhooks/discord") {
+      return discordAdapter.handleWebhook(request);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+});
+```
+
+### Auto-Resolution via BrickDescriptor
+
+```yaml
+# agent-manifest.yaml
+name: support-bot
+channels:
+  - id: "@koi/channel-chat-sdk"
+    options:
+      platforms:
+        - platform: slack
+        - platform: discord
+```
+
+The `descriptor` export enables the Koi resolver to discover and instantiate the channel adapter from a manifest.
+
+---
+
+## Shared Lifecycle
+
+The Chat SDK instance is shared across all platform adapters. Lifecycle is ref-counted:
+
+```
+createChatSdkChannels({
+  platforms: [slack, discord, teams]
+})
+       │
+       ▼
+┌──────────────────────────────────────────────┐
+│  SharedLifecycle                              │
+│                                               │
+│  Chat instance: null (lazy — created on       │
+│                        first connect)         │
+│  connectedCount: 0                            │
+│                                               │
+│  ensureInitialized()                          │
+│   ● Promise guard prevents concurrent init    │
+│   ● Creates Chat instance with all adapters   │
+│   ● Registers onNewMention + onSubscribedMsg  │
+│   ● Calls chat.initialize()                   │
+│                                               │
+│  connect()                                    │
+│   ● Initializes if needed                     │
+│   ● connectedCount++                          │
+│                                               │
+│  disconnect()                                 │
+│   ● connectedCount--                          │
+│   ● When count reaches 0: chat.shutdown()     │
+│                                               │
+│  shutdown()                                   │
+│   ● Force shutdown regardless of count        │
+└──────────────────────────────────────────────┘
+
+Timeline:
+  slackAdapter.connect()   → connectedCount = 1 (Chat initialized)
+  discordAdapter.connect() → connectedCount = 2 (no-op, already init)
+  slackAdapter.disconnect()→ connectedCount = 1 (Chat stays alive)
+  discordAdapter.disconnect()→ connectedCount = 0 (Chat shutdown)
+```
+
+---
+
+## API Reference
+
+### Factory Functions
+
+| Function | Returns | Purpose |
+|----------|---------|---------|
+| `createChatSdkChannels(config, overrides?)` | `readonly ChatSdkChannelAdapter[]` | Create N adapters from config |
+| `validateChatSdkChannelConfig(input)` | `Result<ChatSdkChannelConfig, KoiError>` | Validate config (never throws) |
+
+### ChatSdkChannelAdapter (extends ChannelAdapter)
+
+| Method / Property | Returns | Purpose |
+|-------------------|---------|---------|
+| `connect()` | `Promise<void>` | Initialize shared Chat SDK + platform adapter |
+| `disconnect()` | `Promise<void>` | Ref-counted; shuts down Chat on last disconnect |
+| `send(message)` | `Promise<void>` | Map content → markdown → `adapter.postMessage()` |
+| `onMessage(handler)` | `() => void` | Register handler (returns unsubscribe) |
+| `sendStatus(status)` | `Promise<void>` | Typing indicator via `adapter.startTyping()` |
+| `handleWebhook(request, options?)` | `Promise<Response>` | Delegate to Chat SDK webhook handler |
+| `platform` | `string` | Platform name (`"slack"`, `"discord"`, etc.) |
+| `name` | `string` | Adapter name (`"chat-sdk:slack"`, etc.) |
+| `capabilities` | `ChannelCapabilities` | Per-platform capability flags |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `ChatSdkChannelConfig` | `{ platforms: PlatformConfig[], userName?: string }` |
+| `PlatformConfig` | Discriminated union on `platform` field |
+| `PlatformName` | `"slack" \| "discord" \| "teams" \| "gchat" \| "github" \| "linear"` |
+| `ChatSdkChannelAdapter` | Extended `ChannelAdapter` with `handleWebhook` + `platform` |
+| `SlackPlatformConfig` | Slack-specific: `botToken?`, `signingSecret?` |
+| `DiscordPlatformConfig` | Discord-specific: `botToken?`, `publicKey?`, `applicationId?` |
+| `TeamsPlatformConfig` | Teams-specific: `appId?`, `appPassword?` |
+| `GchatPlatformConfig` | Google Chat-specific: `credentials?` |
+| `GithubPlatformConfig` | GitHub-specific: `token?`, `webhookSecret?`, `userName?` |
+| `LinearPlatformConfig` | Linear-specific: `apiKey?`, `webhookSecret?`, `userName?` |
+
+### BrickDescriptor
+
+| Field | Value |
+|-------|-------|
+| `kind` | `"channel"` |
+| `name` | `"@koi/channel-chat-sdk"` |
+| `aliases` | `["chat-sdk"]` |
+| `factory` | Returns first adapter from `createChatSdkChannels()` |
+
+---
+
+## Testing
+
+### Test Structure
+
+```
+packages/channel-chat-sdk/src/
+  config.test.ts                     Config validation (valid, invalid, edge cases)
+  capabilities.test.ts               Per-platform capability constants
+  normalize.test.ts                  Inbound normalization (text, attachments, bot echo)
+  map-content.test.ts                Outbound content mapping (markdown generation)
+  create-chat-sdk-channels.test.ts   Factory, lifecycle, send, status, error paths
+  __tests__/
+    integration.test.ts              Full webhook → normalize → send flow
+    api-surface.test.ts              .d.ts snapshot stability
+    e2e-full-stack.test.ts           Real LLM calls through full L1 runtime
+```
+
+### Coverage
+
+77 tests, 0 failures, 90.86% coverage across 8 test files.
+
+### E2E Tests (Real LLM)
+
+Gated behind `E2E_TESTS=1` environment variable + `ANTHROPIC_API_KEY` presence:
+
+```bash
+# Run unit + integration tests only
+bun test packages/channel-chat-sdk/
+
+# Run everything including E2E with real Anthropic API calls
+E2E_TESTS=1 bun test packages/channel-chat-sdk/
+```
+
+E2E tests validate the full pipeline:
+- Channel adapter creation + properties
+- Inbound → real LLM (Anthropic) → outbound through `createKoi`
+- Tool calls through full stack (LLM invokes tool, result flows back)
+- `sendStatus` typing indicators
+- Multi-platform event isolation
+- Middleware lifecycle hooks (`session_start` → `after_turn` → `session_end`)
+- Rich content block mapping
+- Bot echo prevention
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Chat SDK as internal infra | Chat SDK handles webhook verification, platform normalization, credential detection. Koi owns routing, state, and lifecycle |
+| In-memory state only | `@chat-adapter/state-memory` — no Redis dependency. Koi handles persistence at higher layers |
+| One normalizer for all platforms | Chat SDK already normalizes to unified `Message` type — platform differences are handled internally |
+| One content mapper (markdown) | All Chat SDK adapters accept `{ markdown: string }` natively. Rich cards can be added in v2 |
+| Lazy initialization | Chat SDK instance created on first `connect()`, not at factory call time. Saves resources for unused adapters |
+| Ref-counted lifecycle | Multiple adapters share one Chat instance. Last disconnect triggers shutdown |
+| Promise guard on init | Prevents concurrent initialization when multiple adapters call `connect()` simultaneously |
+| `handleWebhook` on each adapter | Consumer routes HTTP to the right platform; adapter delegates to Chat SDK's verified webhook handler |
+| Credentials optional | Chat SDK adapters auto-detect from env vars (`SLACK_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, etc.) |
+| `@ts-expect-error` for adapter types | Chat SDK's `botUserId: string \| undefined` doesn't match `Adapter`'s `string?` under `exactOptionalPropertyTypes` |
+| `sendStatus` → `startTyping` | Simple delegation. Chat SDK adapters handle platform-specific typing API internally |
+| Event router via `Map` | O(1) lookup by adapter name. Immutable updates (new arrays on add/remove) |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    ChannelAdapter, ContentBlock, InboundMessage,         │
+    OutboundMessage, ChannelStatus, KoiError              │
+                                                          │
+L0u @koi/channel-base ──────────────────┐               │
+    createChannelAdapter<ChatSdkEvent>   │               │
+                                          │               │
+L0u @koi/resolve ────────────┐           │               │
+    BrickDescriptor           │           │               │
+                               ▼           ▼               ▼
+L2  @koi/channel-chat-sdk ◄──┴───────────┴───────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✓ Chat SDK types stay internal (never leak to public API)
+    ✓ All interface properties readonly
+    ✓ No vendor types in public API surface
+```

--- a/packages/channel-chat-sdk/package.json
+++ b/packages/channel-chat-sdk/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@koi/channel-chat-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@chat-adapter/discord": "4.14.0",
+    "@chat-adapter/gchat": "4.14.0",
+    "@chat-adapter/github": "4.14.0",
+    "@chat-adapter/linear": "4.14.0",
+    "@chat-adapter/slack": "4.14.0",
+    "@chat-adapter/state-memory": "4.14.0",
+    "@chat-adapter/teams": "4.14.0",
+    "@koi/channel-base": "workspace:*",
+    "@koi/core": "workspace:*",
+    "@koi/resolve": "workspace:*",
+    "chat": "4.14.0"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/channel-chat-sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/channel-chat-sdk/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,109 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/channel-chat-sdk API surface . has stable type surface 1`] = `
+"import { Result, KoiError, ChannelAdapter } from '@koi/core';
+import { BrickDescriptor } from '@koi/resolve';
+
+/**
+ * Configuration types and validation for @koi/channel-chat-sdk.
+ *
+ * Each platform uses a discriminated union on the \`platform\` field.
+ * Credentials are optional — the Chat SDK adapters auto-detect from
+ * environment variables when not provided explicitly.
+ */
+
+declare const VALID_PLATFORMS: readonly ["slack", "discord", "teams", "gchat", "github", "linear"];
+type PlatformName = (typeof VALID_PLATFORMS)[number];
+interface SlackPlatformConfig {
+    readonly platform: "slack";
+    readonly botToken?: string;
+    readonly signingSecret?: string;
+}
+interface DiscordPlatformConfig {
+    readonly platform: "discord";
+    readonly botToken?: string;
+    readonly publicKey?: string;
+    readonly applicationId?: string;
+}
+interface TeamsPlatformConfig {
+    readonly platform: "teams";
+    readonly appId?: string;
+    readonly appPassword?: string;
+}
+interface GchatPlatformConfig {
+    readonly platform: "gchat";
+    readonly credentials?: {
+        readonly client_email: string;
+        readonly private_key: string;
+        readonly project_id?: string;
+    };
+}
+interface GithubPlatformConfig {
+    readonly platform: "github";
+    readonly token?: string;
+    readonly webhookSecret?: string;
+    readonly userName?: string;
+}
+interface LinearPlatformConfig {
+    readonly platform: "linear";
+    readonly apiKey?: string;
+    readonly webhookSecret?: string;
+    readonly userName?: string;
+}
+type PlatformConfig = SlackPlatformConfig | DiscordPlatformConfig | TeamsPlatformConfig | GchatPlatformConfig | GithubPlatformConfig | LinearPlatformConfig;
+interface ChatSdkChannelConfig {
+    readonly platforms: readonly PlatformConfig[];
+    readonly userName?: string;
+}
+declare function validateChatSdkChannelConfig(input: unknown): Result<ChatSdkChannelConfig, KoiError>;
+
+/**
+ * Main factory for @koi/channel-chat-sdk.
+ *
+ * Creates a shared Chat SDK instance and returns one ChannelAdapter
+ * per configured platform. Each adapter routes through the shared
+ * Chat instance for webhook handling, event normalization, and sending.
+ */
+
+interface ChatSdkChannelAdapter extends ChannelAdapter {
+    readonly handleWebhook: (request: Request, options?: {
+        readonly waitUntil?: (p: Promise<unknown>) => void;
+    }) => Promise<Response>;
+    readonly platform: string;
+}
+/**
+ * Internal test overrides. Not part of the public API.
+ */
+interface ChatSdkTestOverrides {
+    /** Injected Chat instance for testing. Typed as unknown to accept partial mocks. */
+    readonly _chat?: unknown;
+    /** Injected platform adapters for testing. Typed as unknown to accept partial mocks. */
+    readonly _adapters?: Readonly<Record<string, unknown>>;
+}
+/**
+ * Creates N ChannelAdapters backed by a shared Chat SDK instance.
+ *
+ * @param config - Validated ChatSdkChannelConfig with platforms array.
+ * @param overrides - Test-only overrides for the Chat instance and adapters.
+ * @returns One ChatSdkChannelAdapter per configured platform.
+ */
+declare function createChatSdkChannels(config: ChatSdkChannelConfig, overrides?: ChatSdkTestOverrides): readonly ChatSdkChannelAdapter[];
+
+/**
+ * BrickDescriptor for @koi/channel-chat-sdk.
+ *
+ * Enables manifest auto-resolution for the Chat SDK multi-platform
+ * channel adapter. Each platform in the config gets its own ChannelAdapter.
+ */
+
+/**
+ * Descriptor for Chat SDK multi-platform channel adapter.
+ *
+ * The factory returns the first channel adapter from the configured
+ * platforms. For multiple platforms, use createChatSdkChannels() directly.
+ */
+declare const descriptor: BrickDescriptor<ChannelAdapter>;
+
+export { type ChatSdkChannelAdapter, type ChatSdkChannelConfig, type DiscordPlatformConfig, type GchatPlatformConfig, type GithubPlatformConfig, type LinearPlatformConfig, type PlatformConfig, type PlatformName, type SlackPlatformConfig, type TeamsPlatformConfig, createChatSdkChannels, descriptor, validateChatSdkChannelConfig };
+"
+`;

--- a/packages/channel-chat-sdk/src/__tests__/api-surface.test.ts
+++ b/packages/channel-chat-sdk/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/channel-chat-sdk/src/__tests__/e2e-full-stack.test.ts
+++ b/packages/channel-chat-sdk/src/__tests__/e2e-full-stack.test.ts
@@ -1,0 +1,875 @@
+/**
+ * Full-stack E2E: createKoi + createPiAdapter + channel-chat-sdk adapters.
+ *
+ * Validates the entire pipeline with a real LLM call:
+ *   - Channel adapter creation + lifecycle (connect/disconnect)
+ *   - Inbound message normalization through the channel
+ *   - Full L1 runtime assembly (createKoi + middleware chain)
+ *   - Real Anthropic LLM call via createPiAdapter
+ *   - Tool registration + tool call + result integration
+ *   - Outbound message mapping (ContentBlock[] → markdown → postMessage)
+ *   - sendStatus typing indicator wiring
+ *   - Multi-platform adapter isolation
+ *   - Middleware hook observation (session/turn lifecycle, tool interception)
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test src/__tests__/e2e-full-stack.test.ts
+ *
+ * Requires ANTHROPIC_API_KEY in .env (auto-loaded by Bun).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  AgentManifest,
+  ChannelStatus,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  InboundMessage,
+  KoiMiddleware,
+  Tool,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import type { ChatSdkChannelConfig } from "../config.js";
+import { createChatSdkChannels } from "../create-chat-sdk-channels.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function testManifest(): AgentManifest {
+  return {
+    name: "E2E Chat SDK Agent",
+    version: "0.1.0",
+    model: { name: "claude-haiku-4-5" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock Chat SDK adapter factory (simulates a real platform adapter)
+// ---------------------------------------------------------------------------
+
+function makeMockChatSdkAdapter(name: string): Record<string, unknown> {
+  return {
+    name,
+    userName: "test-bot",
+    botUserId: "BOT001",
+    initialize: mock(async () => {}),
+    handleWebhook: mock(async () => new Response("ok")),
+    postMessage: mock(async (_threadId: string, _msg: unknown) => ({
+      id: "sent-1",
+      raw: {},
+      threadId: `${name}:C1:T1`,
+    })),
+    editMessage: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+    deleteMessage: mock(async () => {}),
+    fetchMessages: mock(async () => ({ messages: [] })),
+    fetchThread: mock(async () => ({ id: `${name}:C1:T1`, channelId: "C1", metadata: {} })),
+    parseMessage: mock((raw: unknown) => raw),
+    startTyping: mock(async () => {}),
+    addReaction: mock(async () => {}),
+    removeReaction: mock(async () => {}),
+    encodeThreadId: mock((data: unknown) => String(data)),
+    decodeThreadId: mock((id: string) => id),
+    renderFormatted: mock(() => ""),
+    channelIdFromThreadId: mock((id: string) => id.split(":")[1] ?? id),
+    stream: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+  };
+}
+
+function makeMockChat(): {
+  readonly instance: Record<string, unknown>;
+  readonly handlers: {
+    readonly mentions: Array<(thread: unknown, message: unknown) => void>;
+    readonly subscribed: Array<(thread: unknown, message: unknown) => void>;
+  };
+} {
+  const handlers = {
+    mentions: [] as Array<(thread: unknown, message: unknown) => void>,
+    subscribed: [] as Array<(thread: unknown, message: unknown) => void>,
+  };
+
+  return {
+    instance: {
+      initialize: mock(async () => {}),
+      shutdown: mock(async () => {}),
+      onNewMention: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.mentions.push(handler);
+      }),
+      onSubscribedMessage: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.subscribed.push(handler);
+      }),
+      webhooks: {},
+      getAdapter: mock((adapterName: string) => makeMockChatSdkAdapter(adapterName)),
+    },
+    handlers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+const MULTIPLY_TOOL: Tool = {
+  descriptor: {
+    name: "multiply",
+    description: "Multiplies two numbers together and returns the product.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First number" },
+        b: { type: "number", description: "Second number" },
+      },
+      required: ["a", "b"],
+    },
+  },
+  trustTier: "sandbox",
+  execute: async (input: Readonly<Record<string, unknown>>) => {
+    const a = Number(input.a ?? 0);
+    const b = Number(input.b ?? 0);
+    return String(a * b);
+  },
+};
+
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-tool-provider",
+    attach: async () => new Map(tools.map((t) => [toolToken(t.descriptor.name) as string, t])),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: channel-chat-sdk + createKoi + createPiAdapter full stack", () => {
+  // ── Test 1: Channel adapter creation + properties ──────────────────
+
+  test("channel adapters created with correct properties", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "discord" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        discord: makeMockChatSdkAdapter("discord"),
+      },
+    });
+
+    expect(adapters).toHaveLength(2);
+    expect(adapters[0]?.name).toBe("chat-sdk:slack");
+    expect(adapters[0]?.platform).toBe("slack");
+    expect(adapters[1]?.name).toBe("chat-sdk:discord");
+    expect(adapters[1]?.platform).toBe("discord");
+
+    // Capabilities are platform-specific
+    expect(adapters[0]?.capabilities.files).toBe(true);
+    expect(adapters[0]?.capabilities.buttons).toBe(true);
+
+    // sendStatus is present
+    expect(typeof adapters[0]?.sendStatus).toBe("function");
+    expect(typeof adapters[1]?.sendStatus).toBe("function");
+  });
+
+  // ── Test 2: Full inbound → LLM → outbound through channel + runtime ──
+
+  test(
+    "inbound message through channel → createKoi runtime → real LLM → outbound via postMessage",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockChat = makeMockChat();
+      mockChat.instance.getAdapter = mock(() => mockSlackAdapter);
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: { slack: mockSlackAdapter },
+      });
+
+      const channel = adapters[0];
+      if (channel === undefined) throw new Error("No adapter created");
+
+      await channel.connect();
+
+      // Wire up channel to collect inbound messages
+      const received: InboundMessage[] = [];
+      channel.onMessage(async (msg) => {
+        received.push(msg);
+      });
+
+      // Simulate a Chat SDK mention event (as if Slack webhook arrived)
+      const fakeThread = {
+        id: "slack:C123:ts456",
+        channelId: "C123",
+        isDM: false,
+        adapter: { name: "slack" },
+        subscribe: mock(async () => {}),
+      };
+      const fakeMessage = {
+        id: "msg-1",
+        threadId: "slack:C123:ts456",
+        text: "Reply with exactly: pong",
+        author: {
+          userId: "U001",
+          userName: "alice",
+          fullName: "Alice",
+          isBot: false,
+          isMe: false,
+        },
+        metadata: { dateSent: new Date(), edited: false },
+        attachments: [],
+        formatted: { type: "root", children: [] },
+        raw: {},
+        isMention: true,
+      };
+
+      for (const handler of mockChat.handlers.mentions) {
+        handler(fakeThread, fakeMessage);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify inbound normalization worked
+      expect(received).toHaveLength(1);
+      const inbound = received[0];
+      if (inbound === undefined) throw new Error("No inbound message");
+      expect(inbound.content[0]).toEqual({ kind: "text", text: "Reply with exactly: pong" });
+      expect(inbound.senderId).toBe("U001");
+      expect(inbound.threadId).toBe("slack:C123:ts456");
+
+      // Now run the inbound message through the full L1 runtime with a real LLM call
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise assistant. Reply briefly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        channelId: "chat-sdk:slack",
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "messages",
+          messages: [inbound],
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // LLM should have responded with "pong"
+      const text = extractText(events);
+      expect(text.toLowerCase()).toContain("pong");
+
+      // Now send the LLM response back through the channel
+      await channel.send({
+        content: [{ kind: "text", text }],
+        ...(inbound.threadId !== undefined ? { threadId: inbound.threadId } : {}),
+      });
+
+      // Verify postMessage was called on the mock adapter
+      expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+      const [threadId, postable] = (mockSlackAdapter.postMessage as ReturnType<typeof mock>).mock
+        .calls[0] as [string, { readonly markdown: string }];
+      expect(threadId).toBe("slack:C123:ts456");
+      expect(postable.markdown.toLowerCase()).toContain("pong");
+
+      await runtime.dispose();
+      await channel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Tool call through channel + middleware chain ────────────
+
+  test(
+    "LLM tool call through full stack: channel inbound → middleware → tool → LLM → channel outbound",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockChat = makeMockChat();
+      mockChat.instance.getAdapter = mock(() => mockSlackAdapter);
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: { slack: mockSlackAdapter },
+      });
+
+      const channel = adapters[0];
+      if (channel === undefined) throw new Error("No adapter created");
+
+      await channel.connect();
+
+      // Collect inbound via channel
+      const received: InboundMessage[] = [];
+      channel.onMessage(async (msg) => {
+        received.push(msg);
+      });
+
+      // Simulate mention event
+      const fakeThread = {
+        id: "slack:C1:ts1",
+        channelId: "C1",
+        isDM: false,
+        adapter: { name: "slack" },
+        subscribe: mock(async () => {}),
+      };
+      const fakeMessage = {
+        id: "msg-1",
+        threadId: "slack:C1:ts1",
+        text: "Use the multiply tool to compute 7 * 8. Report the result number only.",
+        author: {
+          userId: "U002",
+          userName: "bob",
+          fullName: "Bob",
+          isBot: false,
+          isMe: false,
+        },
+        metadata: { dateSent: new Date(), edited: false },
+        attachments: [],
+        formatted: { type: "root", children: [] },
+        raw: {},
+        isMention: true,
+      };
+
+      for (const handler of mockChat.handlers.mentions) {
+        handler(fakeThread, fakeMessage);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const inbound = received[0];
+      if (inbound === undefined) throw new Error("No inbound message");
+
+      // Middleware that observes tool calls
+      const toolCalls: string[] = [];
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-tool-observer",
+        wrapToolCall: async (
+          _ctx: unknown,
+          request: ToolRequest,
+          next: (r: ToolRequest) => Promise<ToolResponse>,
+        ) => {
+          toolCalls.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      // Create runtime with tool + middleware
+      const engineAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the multiply tool for math. Never compute in your head. Always use tools.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: engineAdapter,
+        middleware: [toolObserver],
+        providers: [createToolProvider([MULTIPLY_TOOL])],
+        channelId: "chat-sdk:slack",
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "messages", messages: [inbound] }));
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Tool should have been called through middleware
+      expect(toolCalls).toContain("multiply");
+
+      // tool_call_start and tool_call_end events should exist
+      const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+      const toolEnds = events.filter((e) => e.kind === "tool_call_end");
+      expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+      expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+      // Response should contain 56
+      const text = extractText(events);
+      expect(text).toContain("56");
+
+      // Send back through channel
+      await channel.send({
+        content: [{ kind: "text", text }],
+        ...(inbound.threadId !== undefined ? { threadId: inbound.threadId } : {}),
+      });
+
+      expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+      const [, postable] = (mockSlackAdapter.postMessage as ReturnType<typeof mock>).mock
+        .calls[0] as [string, { readonly markdown: string }];
+      expect(postable.markdown).toContain("56");
+
+      await runtime.dispose();
+      await channel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: sendStatus typing indicator wiring ─────────────────────
+
+  test(
+    "sendStatus fires startTyping during real LLM processing",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockChat = makeMockChat();
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: { slack: mockSlackAdapter },
+      });
+
+      const channel = adapters[0];
+      if (channel === undefined) throw new Error("No adapter created");
+
+      await channel.connect();
+
+      // Manually invoke sendStatus (as L1 runtime would during a turn)
+      const status: ChannelStatus = {
+        kind: "processing",
+        turnIndex: 0,
+        messageRef: "slack:C123:ts456",
+      };
+      await channel.sendStatus?.(status);
+
+      expect(mockSlackAdapter.startTyping).toHaveBeenCalledTimes(1);
+      expect((mockSlackAdapter.startTyping as ReturnType<typeof mock>).mock.calls[0]).toEqual([
+        "slack:C123:ts456",
+      ]);
+
+      // Idle status should not trigger typing
+      const idleStatus: ChannelStatus = { kind: "idle", turnIndex: 0 };
+      await channel.sendStatus?.(idleStatus);
+      expect(mockSlackAdapter.startTyping).toHaveBeenCalledTimes(1); // Still 1
+
+      await channel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Multi-platform isolation with real LLM ─────────────────
+
+  test(
+    "multi-platform: Slack and Discord channels independently process the same LLM response",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }, { platform: "discord" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockDiscordAdapter = makeMockChatSdkAdapter("discord");
+      const mockChat = makeMockChat();
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: {
+          slack: mockSlackAdapter,
+          discord: mockDiscordAdapter,
+        },
+      });
+
+      const slackChannel = adapters[0];
+      const discordChannel = adapters[1];
+      if (slackChannel === undefined || discordChannel === undefined) {
+        throw new Error("Missing adapters");
+      }
+
+      await slackChannel.connect();
+      await discordChannel.connect();
+
+      // Collect inbound from both channels
+      const slackMsgs: InboundMessage[] = [];
+      const discordMsgs: InboundMessage[] = [];
+      slackChannel.onMessage(async (msg) => {
+        slackMsgs.push(msg);
+      });
+      discordChannel.onMessage(async (msg) => {
+        discordMsgs.push(msg);
+      });
+
+      // Simulate Slack event only
+      const slackThread = {
+        id: "slack:C1:ts1",
+        channelId: "C1",
+        isDM: false,
+        adapter: { name: "slack" },
+        subscribe: mock(async () => {}),
+      };
+      const slackMsg = {
+        id: "msg-1",
+        threadId: "slack:C1:ts1",
+        text: "Say hello",
+        author: { userId: "U1", userName: "a", fullName: "A", isBot: false, isMe: false },
+        metadata: { dateSent: new Date(), edited: false },
+        attachments: [],
+        formatted: { type: "root", children: [] },
+        raw: {},
+        isMention: true,
+      };
+
+      for (const handler of mockChat.handlers.mentions) {
+        handler(slackThread, slackMsg);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Slack gets the message, Discord does not
+      expect(slackMsgs).toHaveLength(1);
+      expect(discordMsgs).toHaveLength(0);
+
+      // Run through LLM with Slack's inbound
+      const inbound = slackMsgs[0];
+      if (inbound === undefined) throw new Error("No inbound");
+
+      const engineAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with one word.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: engineAdapter,
+        channelId: "chat-sdk:slack",
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "messages", messages: [inbound] }));
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+      expect(output?.metrics.inputTokens).toBeGreaterThan(0);
+
+      const text = extractText(events);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Send response through Slack channel only
+      await slackChannel.send({
+        content: [{ kind: "text", text }],
+        ...(inbound.threadId !== undefined ? { threadId: inbound.threadId } : {}),
+      });
+
+      // Slack adapter got the message
+      expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+      // Discord adapter did NOT
+      expect(mockDiscordAdapter.postMessage).toHaveBeenCalledTimes(0);
+
+      await runtime.dispose();
+      await slackChannel.disconnect();
+      await discordChannel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Middleware lifecycle hooks fire through channel-sourced messages ──
+
+  test(
+    "session + turn lifecycle hooks fire for channel-sourced inbound messages",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockChat = makeMockChat();
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: { slack: mockSlackAdapter },
+      });
+
+      const channel = adapters[0];
+      if (channel === undefined) throw new Error("No adapter");
+
+      await channel.connect();
+
+      const received: InboundMessage[] = [];
+      channel.onMessage(async (msg) => {
+        received.push(msg);
+      });
+
+      // Simulate event
+      const fakeThread = {
+        id: "slack:C1:ts1",
+        channelId: "C1",
+        isDM: false,
+        adapter: { name: "slack" },
+        subscribe: mock(async () => {}),
+      };
+      const fakeMessage = {
+        id: "msg-1",
+        threadId: "slack:C1:ts1",
+        text: "Say OK",
+        author: { userId: "U1", userName: "a", fullName: "A", isBot: false, isMe: false },
+        metadata: { dateSent: new Date(), edited: false },
+        attachments: [],
+        formatted: { type: "root", children: [] },
+        raw: {},
+        isMention: true,
+      };
+
+      for (const handler of mockChat.handlers.mentions) {
+        handler(fakeThread, fakeMessage);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const inbound = received[0];
+      if (inbound === undefined) throw new Error("No inbound");
+
+      // Track lifecycle hooks
+      const hookOrder: string[] = [];
+      const lifecycleObserver: KoiMiddleware = {
+        name: "lifecycle-observer",
+        onSessionStart: async () => {
+          hookOrder.push("session_start");
+        },
+        onSessionEnd: async () => {
+          hookOrder.push("session_end");
+        },
+        onAfterTurn: async () => {
+          hookOrder.push("after_turn");
+        },
+      };
+
+      const engineAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with one word only.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: engineAdapter,
+        middleware: [lifecycleObserver],
+        channelId: "chat-sdk:slack",
+        loopDetection: false,
+      });
+
+      await collectEvents(runtime.run({ kind: "messages", messages: [inbound] }));
+
+      // Session lifecycle must be correct
+      expect(hookOrder[0]).toBe("session_start");
+      expect(hookOrder[hookOrder.length - 1]).toBe("session_end");
+      expect(hookOrder).toContain("after_turn");
+
+      await runtime.dispose();
+      await channel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Content block mapping — rich outbound ──────────────────
+
+  test("outbound with mixed content blocks maps to markdown correctly", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    const channel = adapters[0];
+    if (channel === undefined) throw new Error("No adapter");
+
+    await channel.connect();
+
+    // Send rich content through the channel
+    await channel.send({
+      content: [
+        { kind: "text", text: "Here is the report:" },
+        { kind: "image", url: "https://example.com/chart.png", alt: "Sales chart" },
+        {
+          kind: "file",
+          url: "https://example.com/report.pdf",
+          mimeType: "application/pdf",
+          name: "Q4 Report",
+        },
+      ],
+      threadId: "slack:C1:ts1",
+    });
+
+    expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+    const [threadId, postable] = (mockSlackAdapter.postMessage as ReturnType<typeof mock>).mock
+      .calls[0] as [string, { readonly markdown: string }];
+
+    expect(threadId).toBe("slack:C1:ts1");
+    expect(postable.markdown).toContain("Here is the report:");
+    expect(postable.markdown).toContain("![Sales chart](https://example.com/chart.png)");
+    expect(postable.markdown).toContain("[Q4 Report](https://example.com/report.pdf)");
+
+    await channel.disconnect();
+  });
+
+  // ── Test 8: Bot echo prevention — end-to-end ──────────────────────
+
+  test("bot's own messages are filtered at normalization layer", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    const channel = adapters[0];
+    if (channel === undefined) throw new Error("No adapter");
+
+    await channel.connect();
+
+    const received: InboundMessage[] = [];
+    channel.onMessage(async (msg) => {
+      received.push(msg);
+    });
+
+    // Simulate bot's own message (isMe: true)
+    const botThread = {
+      id: "slack:C1:ts1",
+      channelId: "C1",
+      isDM: false,
+      adapter: { name: "slack" },
+      subscribe: mock(async () => {}),
+    };
+    const botMessage = {
+      id: "msg-bot",
+      threadId: "slack:C1:ts1",
+      text: "I already replied",
+      author: { userId: "BOT001", userName: "koi-bot", fullName: "Koi", isBot: true, isMe: true },
+      metadata: { dateSent: new Date(), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: false,
+    };
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(botThread, botMessage);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Bot messages must be filtered out — never reach the handler
+    expect(received).toHaveLength(0);
+
+    await channel.disconnect();
+  });
+
+  // ── Test 9: sendStatus + real LLM flow integration ─────────────────
+
+  test(
+    "sendStatus wired through createKoi runtime options",
+    async () => {
+      const config: ChatSdkChannelConfig = {
+        platforms: [{ platform: "slack" }],
+      };
+
+      const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+      const mockChat = makeMockChat();
+
+      const adapters = createChatSdkChannels(config, {
+        _chat: mockChat.instance,
+        _adapters: { slack: mockSlackAdapter },
+      });
+
+      const channel = adapters[0];
+      if (channel === undefined) throw new Error("No adapter");
+
+      await channel.connect();
+
+      // Create runtime with sendStatus wired to channel
+      const engineAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with one word.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: engineAdapter,
+        channelId: "chat-sdk:slack",
+        ...(channel.sendStatus !== undefined ? { sendStatus: channel.sendStatus } : {}),
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say: OK" }));
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // The runtime should have called sendStatus, which triggers startTyping
+      // Note: whether L1 actually calls sendStatus depends on the engine adapter
+      // emitting the right events. We verify the wiring works, not that L1 calls it
+      // at specific points — that's L1's concern.
+
+      await runtime.dispose();
+      await channel.disconnect();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/channel-chat-sdk/src/__tests__/integration.test.ts
+++ b/packages/channel-chat-sdk/src/__tests__/integration.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Integration tests for @koi/channel-chat-sdk.
+ *
+ * Tests the full webhook → normalize → onMessage → send → postMessage flow
+ * using mock Chat SDK adapters (no real platform connections).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { InboundMessage } from "@koi/core";
+import type { ChatSdkChannelConfig } from "../config.js";
+import { createChatSdkChannels } from "../create-chat-sdk-channels.js";
+
+function makeMockChatSdkAdapter(name: string): Record<string, unknown> {
+  return {
+    name,
+    userName: "test-bot",
+    botUserId: "BOT001",
+    initialize: mock(async () => {}),
+    handleWebhook: mock(async () => new Response("ok")),
+    postMessage: mock(async (_threadId: string, _msg: unknown) => ({
+      id: "sent-1",
+      raw: {},
+      threadId: `${name}:C1:T1`,
+    })),
+    editMessage: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+    deleteMessage: mock(async () => {}),
+    fetchMessages: mock(async () => ({ messages: [] })),
+    fetchThread: mock(async () => ({ id: `${name}:C1:T1`, channelId: "C1", metadata: {} })),
+    parseMessage: mock((raw: unknown) => raw),
+    startTyping: mock(async () => {}),
+    addReaction: mock(async () => {}),
+    removeReaction: mock(async () => {}),
+    encodeThreadId: mock((data: unknown) => String(data)),
+    decodeThreadId: mock((id: string) => id),
+    renderFormatted: mock(() => ""),
+    channelIdFromThreadId: mock((id: string) => id.split(":")[1] ?? id),
+    stream: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+  };
+}
+
+function makeMockChat(): {
+  readonly instance: Record<string, unknown>;
+  readonly handlers: {
+    mentions: Array<(thread: unknown, message: unknown) => void>;
+    subscribed: Array<(thread: unknown, message: unknown) => void>;
+  };
+} {
+  const handlers = {
+    mentions: [] as Array<(thread: unknown, message: unknown) => void>,
+    subscribed: [] as Array<(thread: unknown, message: unknown) => void>,
+  };
+
+  return {
+    instance: {
+      initialize: mock(async () => {}),
+      shutdown: mock(async () => {}),
+      onNewMention: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.mentions.push(handler);
+      }),
+      onSubscribedMessage: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.subscribed.push(handler);
+      }),
+      webhooks: {},
+      getAdapter: mock((name: string) => makeMockChatSdkAdapter(name)),
+    },
+    handlers,
+  };
+}
+
+function makeFakeEvent(
+  platform: string,
+  text: string,
+  overrides?: { readonly isMe?: boolean; readonly isMention?: boolean },
+): { readonly thread: Record<string, unknown>; readonly message: Record<string, unknown> } {
+  return {
+    thread: {
+      id: `${platform}:C123:ts456`,
+      channelId: "C123",
+      isDM: false,
+      adapter: { name: platform },
+      subscribe: mock(async () => {}),
+    },
+    message: {
+      id: "msg-1",
+      threadId: `${platform}:C123:ts456`,
+      text,
+      author: {
+        userId: "U001",
+        userName: "alice",
+        fullName: "Alice",
+        isBot: false,
+        isMe: overrides?.isMe ?? false,
+      },
+      metadata: { dateSent: new Date("2024-01-15T12:00:00Z"), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: overrides?.isMention ?? true,
+    },
+  };
+}
+
+describe("integration — full webhook→normalize→send flow", () => {
+  test("Slack: mention → normalize → handler → send → postMessage", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    mockChat.instance.getAdapter = mock(() => mockSlackAdapter);
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    const adapter = adapters[0];
+    if (adapter === undefined) throw new Error("No adapter");
+
+    await adapter.connect();
+
+    // Wire handler that echoes back
+    const received: InboundMessage[] = [];
+    adapter.onMessage(async (msg) => {
+      received.push(msg);
+      await adapter.send({
+        content: [
+          {
+            kind: "text",
+            text: `Echo: ${msg.content[0]?.kind === "text" ? msg.content[0].text : ""}`,
+          },
+        ],
+        ...(msg.threadId !== undefined ? { threadId: msg.threadId } : {}),
+      });
+    });
+
+    // Simulate mention event
+    const event = makeFakeEvent("slack", "hello bot");
+    for (const handler of mockChat.handlers.mentions) {
+      handler(event.thread, event.message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify inbound was received
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content[0]).toEqual({ kind: "text", text: "hello bot" });
+
+    // Verify outbound was sent via Chat SDK
+    expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+    const [threadId, postable] = (mockSlackAdapter.postMessage as ReturnType<typeof mock>).mock
+      .calls[0] as [string, { markdown: string }];
+    expect(threadId).toBe("slack:C123:ts456");
+    expect(postable.markdown).toBe("Echo: hello bot");
+  });
+
+  test("Discord: subscribed message flow", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "discord" }],
+    };
+
+    const mockDiscordAdapter = makeMockChatSdkAdapter("discord");
+    const mockChat = makeMockChat();
+    mockChat.instance.getAdapter = mock(() => mockDiscordAdapter);
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { discord: mockDiscordAdapter },
+    });
+
+    await adapters[0]?.connect();
+
+    const received: InboundMessage[] = [];
+    adapters[0]?.onMessage(async (msg) => {
+      received.push(msg);
+    });
+
+    // Simulate subscribed message (not a mention)
+    const event = makeFakeEvent("discord", "follow up message", { isMention: false });
+    for (const handler of mockChat.handlers.subscribed) {
+      handler(event.thread, event.message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content[0]).toEqual({ kind: "text", text: "follow up message" });
+  });
+
+  test("multi-platform: routes to correct adapter only", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "discord" }, { platform: "github" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        discord: makeMockChatSdkAdapter("discord"),
+        github: makeMockChatSdkAdapter("github"),
+      },
+    });
+
+    for (const adapter of adapters) {
+      await adapter.connect();
+    }
+
+    const slackMsgs: InboundMessage[] = [];
+    const discordMsgs: InboundMessage[] = [];
+    const githubMsgs: InboundMessage[] = [];
+
+    adapters[0]?.onMessage(async (msg) => {
+      slackMsgs.push(msg);
+    });
+    adapters[1]?.onMessage(async (msg) => {
+      discordMsgs.push(msg);
+    });
+    adapters[2]?.onMessage(async (msg) => {
+      githubMsgs.push(msg);
+    });
+
+    // Send event for each platform
+    const slackEvent = makeFakeEvent("slack", "slack msg");
+    const discordEvent = makeFakeEvent("discord", "discord msg");
+    const githubEvent = makeFakeEvent("github", "github msg");
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(slackEvent.thread, slackEvent.message);
+      handler(discordEvent.thread, discordEvent.message);
+      handler(githubEvent.thread, githubEvent.message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(slackMsgs).toHaveLength(1);
+    expect(slackMsgs[0]?.content[0]).toEqual({ kind: "text", text: "slack msg" });
+
+    expect(discordMsgs).toHaveLength(1);
+    expect(discordMsgs[0]?.content[0]).toEqual({ kind: "text", text: "discord msg" });
+
+    expect(githubMsgs).toHaveLength(1);
+    expect(githubMsgs[0]?.content[0]).toEqual({ kind: "text", text: "github msg" });
+  });
+
+  test("error isolation: one platform error does not affect others", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "discord" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        discord: makeMockChatSdkAdapter("discord"),
+      },
+    });
+
+    for (const adapter of adapters) {
+      await adapter.connect();
+    }
+
+    // Slack handler throws
+    adapters[0]?.onMessage(async () => {
+      throw new Error("Slack handler crashed");
+    });
+
+    const discordMsgs: InboundMessage[] = [];
+    adapters[1]?.onMessage(async (msg) => {
+      discordMsgs.push(msg);
+    });
+
+    // Send events to both platforms
+    const slackEvent = makeFakeEvent("slack", "slack msg");
+    const discordEvent = makeFakeEvent("discord", "discord msg");
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(slackEvent.thread, slackEvent.message);
+      handler(discordEvent.thread, discordEvent.message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Discord should still receive its message despite Slack handler error
+    expect(discordMsgs).toHaveLength(1);
+    expect(discordMsgs[0]?.content[0]).toEqual({ kind: "text", text: "discord msg" });
+  });
+
+  test("bot's own messages are filtered out", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+
+    const received: InboundMessage[] = [];
+    adapters[0]?.onMessage(async (msg) => {
+      received.push(msg);
+    });
+
+    // Simulate bot's own message
+    const event = makeFakeEvent("slack", "bot reply", { isMe: true });
+    for (const handler of mockChat.handlers.mentions) {
+      handler(event.thread, event.message);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(received).toHaveLength(0);
+  });
+});

--- a/packages/channel-chat-sdk/src/capabilities.test.ts
+++ b/packages/channel-chat-sdk/src/capabilities.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { capabilitiesForPlatform } from "./capabilities.js";
+import type { PlatformName } from "./config.js";
+
+const ALL_PLATFORMS: readonly PlatformName[] = [
+  "slack",
+  "discord",
+  "teams",
+  "gchat",
+  "github",
+  "linear",
+];
+
+describe("capabilitiesForPlatform", () => {
+  test("returns capabilities for all platforms", () => {
+    for (const platform of ALL_PLATFORMS) {
+      const caps = capabilitiesForPlatform(platform);
+      expect(caps).toBeDefined();
+      expect(caps.text).toBe(true);
+      expect(caps.threads).toBe(true);
+    }
+  });
+
+  test("slack supports images, files, and buttons", () => {
+    const caps = capabilitiesForPlatform("slack");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(true);
+    expect(caps.buttons).toBe(true);
+    expect(caps.audio).toBe(false);
+    expect(caps.video).toBe(false);
+  });
+
+  test("discord supports images, files, and buttons", () => {
+    const caps = capabilitiesForPlatform("discord");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(true);
+    expect(caps.buttons).toBe(true);
+  });
+
+  test("teams supports images, files, and buttons", () => {
+    const caps = capabilitiesForPlatform("teams");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(true);
+    expect(caps.buttons).toBe(true);
+  });
+
+  test("gchat supports images and buttons but not files", () => {
+    const caps = capabilitiesForPlatform("gchat");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(false);
+    expect(caps.buttons).toBe(true);
+  });
+
+  test("github supports images but not files or buttons", () => {
+    const caps = capabilitiesForPlatform("github");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(false);
+    expect(caps.buttons).toBe(false);
+  });
+
+  test("linear supports images but not files or buttons", () => {
+    const caps = capabilitiesForPlatform("linear");
+    expect(caps.images).toBe(true);
+    expect(caps.files).toBe(false);
+    expect(caps.buttons).toBe(false);
+  });
+
+  test("no platform supports audio or video", () => {
+    for (const platform of ALL_PLATFORMS) {
+      const caps = capabilitiesForPlatform(platform);
+      expect(caps.audio).toBe(false);
+      expect(caps.video).toBe(false);
+    }
+  });
+});

--- a/packages/channel-chat-sdk/src/capabilities.ts
+++ b/packages/channel-chat-sdk/src/capabilities.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-platform ChannelCapabilities constants.
+ *
+ * Each platform declares what content block types it supports natively.
+ * Unsupported blocks are downgraded by renderBlocks() from @koi/channel-base.
+ */
+
+import type { ChannelCapabilities } from "@koi/core";
+import type { PlatformName } from "./config.js";
+
+const SLACK_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: true,
+  buttons: true,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const DISCORD_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: true,
+  buttons: true,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const TEAMS_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: true,
+  buttons: true,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const GCHAT_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: false,
+  buttons: true,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const GITHUB_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: false,
+  buttons: false,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const LINEAR_CAPABILITIES: ChannelCapabilities = {
+  text: true,
+  images: true,
+  files: false,
+  buttons: false,
+  audio: false,
+  video: false,
+  threads: true,
+} as const satisfies ChannelCapabilities;
+
+const CAPABILITIES_MAP: Readonly<Record<PlatformName, ChannelCapabilities>> = {
+  slack: SLACK_CAPABILITIES,
+  discord: DISCORD_CAPABILITIES,
+  teams: TEAMS_CAPABILITIES,
+  gchat: GCHAT_CAPABILITIES,
+  github: GITHUB_CAPABILITIES,
+  linear: LINEAR_CAPABILITIES,
+} as const;
+
+export function capabilitiesForPlatform(platform: PlatformName): ChannelCapabilities {
+  return CAPABILITIES_MAP[platform];
+}

--- a/packages/channel-chat-sdk/src/config.test.ts
+++ b/packages/channel-chat-sdk/src/config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { validateChatSdkChannelConfig } from "./config.js";
+
+describe("validateChatSdkChannelConfig", () => {
+  test("accepts config with one platform", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [{ platform: "slack" }],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.platforms).toHaveLength(1);
+      expect(result.value.platforms[0]?.platform).toBe("slack");
+    }
+  });
+
+  test("accepts config with all 6 platforms", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [
+        { platform: "slack" },
+        { platform: "discord" },
+        { platform: "teams" },
+        { platform: "gchat" },
+        { platform: "github" },
+        { platform: "linear" },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.platforms).toHaveLength(6);
+    }
+  });
+
+  test("accepts config with explicit credentials", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [{ platform: "slack", botToken: "xoxb-123", signingSecret: "secret" }],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const slack = result.value.platforms[0];
+      expect(slack?.platform).toBe("slack");
+      if (slack?.platform === "slack") {
+        expect(slack.botToken).toBe("xoxb-123");
+        expect(slack.signingSecret).toBe("secret");
+      }
+    }
+  });
+
+  test("accepts config with userName", () => {
+    const result = validateChatSdkChannelConfig({
+      userName: "mybot",
+      platforms: [{ platform: "slack" }],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.userName).toBe("mybot");
+    }
+  });
+
+  test("rejects empty platforms array", () => {
+    const result = validateChatSdkChannelConfig({ platforms: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("at least one platform");
+    }
+  });
+
+  test("rejects missing platforms field", () => {
+    const result = validateChatSdkChannelConfig({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects non-object input", () => {
+    const result = validateChatSdkChannelConfig("not-an-object");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects unknown platform name", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [{ platform: "whatsapp" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("whatsapp");
+    }
+  });
+
+  test("rejects duplicate platforms", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [{ platform: "slack" }, { platform: "slack" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("Duplicate");
+    }
+  });
+
+  test("rejects platform entry without platform field", () => {
+    const result = validateChatSdkChannelConfig({
+      platforms: [{}],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+});

--- a/packages/channel-chat-sdk/src/config.ts
+++ b/packages/channel-chat-sdk/src/config.ts
@@ -1,0 +1,159 @@
+/**
+ * Configuration types and validation for @koi/channel-chat-sdk.
+ *
+ * Each platform uses a discriminated union on the `platform` field.
+ * Credentials are optional — the Chat SDK adapters auto-detect from
+ * environment variables when not provided explicitly.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+
+const VALID_PLATFORMS = ["slack", "discord", "teams", "gchat", "github", "linear"] as const;
+
+export type PlatformName = (typeof VALID_PLATFORMS)[number];
+
+export interface SlackPlatformConfig {
+  readonly platform: "slack";
+  readonly botToken?: string;
+  readonly signingSecret?: string;
+}
+
+export interface DiscordPlatformConfig {
+  readonly platform: "discord";
+  readonly botToken?: string;
+  readonly publicKey?: string;
+  readonly applicationId?: string;
+}
+
+export interface TeamsPlatformConfig {
+  readonly platform: "teams";
+  readonly appId?: string;
+  readonly appPassword?: string;
+}
+
+export interface GchatPlatformConfig {
+  readonly platform: "gchat";
+  readonly credentials?: {
+    readonly client_email: string;
+    readonly private_key: string;
+    readonly project_id?: string;
+  };
+}
+
+export interface GithubPlatformConfig {
+  readonly platform: "github";
+  readonly token?: string;
+  readonly webhookSecret?: string;
+  readonly userName?: string;
+}
+
+export interface LinearPlatformConfig {
+  readonly platform: "linear";
+  readonly apiKey?: string;
+  readonly webhookSecret?: string;
+  readonly userName?: string;
+}
+
+export type PlatformConfig =
+  | SlackPlatformConfig
+  | DiscordPlatformConfig
+  | TeamsPlatformConfig
+  | GchatPlatformConfig
+  | GithubPlatformConfig
+  | LinearPlatformConfig;
+
+export interface ChatSdkChannelConfig {
+  readonly platforms: readonly PlatformConfig[];
+  readonly userName?: string;
+}
+
+function isPlatformName(value: unknown): value is PlatformName {
+  return typeof value === "string" && VALID_PLATFORMS.includes(value as PlatformName);
+}
+
+export function validateChatSdkChannelConfig(
+  input: unknown,
+): Result<ChatSdkChannelConfig, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Chat SDK channel config must be an object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const raw = input as Readonly<Record<string, unknown>>;
+
+  if (!Array.isArray(raw.platforms)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Chat SDK channel config requires a 'platforms' array",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (raw.platforms.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Chat SDK channel config requires at least one platform",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const seen = new Set<string>();
+  for (const entry of raw.platforms) {
+    if (entry === null || entry === undefined || typeof entry !== "object") {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "Each platform entry must be an object with a 'platform' field",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+
+    const platformEntry = entry as Readonly<Record<string, unknown>>;
+    const platform = platformEntry.platform;
+
+    if (!isPlatformName(platform)) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `Unknown platform: "${String(platform)}". Valid platforms: ${VALID_PLATFORMS.join(", ")}`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+
+    if (seen.has(platform)) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `Duplicate platform "${platform}" — each platform may only appear once`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+    seen.add(platform);
+  }
+
+  const config: ChatSdkChannelConfig = {
+    platforms: raw.platforms as readonly PlatformConfig[],
+    ...(typeof raw.userName === "string" ? { userName: raw.userName } : {}),
+  };
+
+  return { ok: true, value: config };
+}

--- a/packages/channel-chat-sdk/src/create-chat-sdk-channels.test.ts
+++ b/packages/channel-chat-sdk/src/create-chat-sdk-channels.test.ts
@@ -1,0 +1,544 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ChannelStatus, InboundMessage } from "@koi/core";
+import type { ChatSdkChannelConfig } from "./config.js";
+import { createChatSdkChannels } from "./create-chat-sdk-channels.js";
+
+/**
+ * Creates a mock Chat SDK adapter with spied methods.
+ * The factory accepts these via _adapters for testing.
+ */
+function makeMockChatSdkAdapter(name: string): Record<string, unknown> {
+  return {
+    name,
+    userName: "test-bot",
+    botUserId: "BOT001",
+    initialize: mock(async () => {}),
+    handleWebhook: mock(async () => new Response("ok")),
+    postMessage: mock(async (_threadId: string, _msg: unknown) => ({
+      id: "sent-1",
+      raw: {},
+      threadId: `${name}:C1:T1`,
+    })),
+    editMessage: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+    deleteMessage: mock(async () => {}),
+    fetchMessages: mock(async () => ({ messages: [] })),
+    fetchThread: mock(async () => ({ id: `${name}:C1:T1`, channelId: "C1", metadata: {} })),
+    parseMessage: mock((raw: unknown) => raw),
+    startTyping: mock(async () => {}),
+    addReaction: mock(async () => {}),
+    removeReaction: mock(async () => {}),
+    encodeThreadId: mock((data: unknown) => String(data)),
+    decodeThreadId: mock((id: string) => id),
+    renderFormatted: mock(() => ""),
+    channelIdFromThreadId: mock((id: string) => id.split(":")[1] ?? id),
+    stream: mock(async () => ({ id: "sent-1", raw: {}, threadId: `${name}:C1:T1` })),
+  };
+}
+
+/**
+ * Creates a mock Chat instance that records handler registrations.
+ */
+function makeMockChat(): {
+  readonly instance: Record<string, unknown>;
+  readonly handlers: {
+    // let justification: accumulates registered handlers during test setup
+    mentions: Array<(thread: unknown, message: unknown) => void>;
+    subscribed: Array<(thread: unknown, message: unknown) => void>;
+  };
+} {
+  const handlers = {
+    mentions: [] as Array<(thread: unknown, message: unknown) => void>,
+    subscribed: [] as Array<(thread: unknown, message: unknown) => void>,
+  };
+
+  return {
+    instance: {
+      initialize: mock(async () => {}),
+      shutdown: mock(async () => {}),
+      onNewMention: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.mentions.push(handler);
+      }),
+      onSubscribedMessage: mock((handler: (thread: unknown, message: unknown) => void) => {
+        handlers.subscribed.push(handler);
+      }),
+      webhooks: {},
+      getAdapter: mock((name: string) => makeMockChatSdkAdapter(name)),
+    },
+    handlers,
+  };
+}
+
+describe("createChatSdkChannels", () => {
+  test("returns one adapter per configured platform", () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "discord" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        discord: makeMockChatSdkAdapter("discord"),
+      },
+    });
+
+    expect(adapters).toHaveLength(2);
+  });
+
+  test("each adapter has correct name with chat-sdk prefix", () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "github" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        github: makeMockChatSdkAdapter("github"),
+      },
+    });
+
+    const names = adapters.map((a) => a.name);
+    expect(names).toContain("chat-sdk:slack");
+    expect(names).toContain("chat-sdk:github");
+  });
+
+  test("each adapter has correct capabilities per platform", () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "github" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        github: makeMockChatSdkAdapter("github"),
+      },
+    });
+
+    const slack = adapters.find((a) => a.name === "chat-sdk:slack");
+    expect(slack?.capabilities.files).toBe(true);
+    expect(slack?.capabilities.buttons).toBe(true);
+
+    const github = adapters.find((a) => a.name === "chat-sdk:github");
+    expect(github?.capabilities.files).toBe(false);
+    expect(github?.capabilities.buttons).toBe(false);
+  });
+
+  test("each adapter exposes platform property", () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "linear" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { linear: makeMockChatSdkAdapter("linear") },
+    });
+
+    expect(adapters[0]?.platform).toBe("linear");
+  });
+
+  test("connect() initializes the Chat instance", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+    expect(mockChat.instance.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  test("disconnect() shuts down the Chat instance", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+    await adapters[0]?.disconnect();
+    expect(mockChat.instance.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  test("handleWebhook delegates to Chat SDK webhook handler", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    mockChat.instance.webhooks = {
+      slack: mock(async () => new Response("ack")),
+    };
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    await adapters[0]?.connect();
+    const req = new Request("https://example.com/webhook", { method: "POST" });
+    const resp = await adapters[0]?.handleWebhook(req);
+
+    expect(resp?.status).toBe(200);
+  });
+
+  test("onMessage receives normalized messages", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+
+    const received: InboundMessage[] = [];
+    adapters[0]?.onMessage(async (msg) => {
+      received.push(msg);
+    });
+
+    // Simulate a Chat SDK event via the registered mention handler
+    const fakeThread = {
+      id: "slack:C123:ts456",
+      channelId: "C123",
+      isDM: false,
+      adapter: { name: "slack" },
+      subscribe: mock(async () => {}),
+    };
+    const fakeMessage = {
+      id: "msg-1",
+      threadId: "slack:C123:ts456",
+      text: "hello bot",
+      author: {
+        userId: "U001",
+        userName: "alice",
+        fullName: "Alice",
+        isBot: false,
+        isMe: false,
+      },
+      metadata: { dateSent: new Date("2024-01-15T12:00:00Z"), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: true,
+    };
+
+    // Trigger the mention handler
+    for (const handler of mockChat.handlers.mentions) {
+      handler(fakeThread, fakeMessage);
+    }
+
+    // Wait for async dispatch
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.content[0]).toEqual({ kind: "text", text: "hello bot" });
+    expect(received[0]?.senderId).toBe("U001");
+  });
+
+  test("auto-subscribes threads on new mention", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+    adapters[0]?.onMessage(async () => {});
+
+    const subscribeMock = mock(async () => {});
+    const fakeThread = {
+      id: "slack:C123:ts456",
+      channelId: "C123",
+      isDM: false,
+      adapter: { name: "slack" },
+      subscribe: subscribeMock,
+    };
+    const fakeMessage = {
+      id: "msg-1",
+      threadId: "slack:C123:ts456",
+      text: "hey",
+      author: { userId: "U001", userName: "alice", fullName: "Alice", isBot: false, isMe: false },
+      metadata: { dateSent: new Date(), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: true,
+    };
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(fakeThread, fakeMessage);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("send() maps content and calls Chat SDK adapter postMessage", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    mockChat.instance.getAdapter = mock(() => mockSlackAdapter);
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    await adapters[0]?.connect();
+    await adapters[0]?.send({
+      content: [{ kind: "text", text: "hello from koi" }],
+      threadId: "slack:C123:ts456",
+    });
+
+    expect(mockSlackAdapter.postMessage).toHaveBeenCalledTimes(1);
+    const [threadId, message] = (mockSlackAdapter.postMessage as ReturnType<typeof mock>).mock
+      .calls[0] as [string, { markdown: string }];
+    expect(threadId).toBe("slack:C123:ts456");
+    expect(message.markdown).toBe("hello from koi");
+  });
+
+  test("routes events to correct platform adapter only", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }, { platform: "discord" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: {
+        slack: makeMockChatSdkAdapter("slack"),
+        discord: makeMockChatSdkAdapter("discord"),
+      },
+    });
+
+    await adapters[0]?.connect();
+    await adapters[1]?.connect();
+
+    const slackMessages: InboundMessage[] = [];
+    const discordMessages: InboundMessage[] = [];
+    adapters[0]?.onMessage(async (msg) => {
+      slackMessages.push(msg);
+    });
+    adapters[1]?.onMessage(async (msg) => {
+      discordMessages.push(msg);
+    });
+
+    // Send Slack event
+    const slackThread = {
+      id: "slack:C1:ts1",
+      channelId: "C1",
+      isDM: false,
+      adapter: { name: "slack" },
+      subscribe: mock(async () => {}),
+    };
+    const slackMsg = {
+      id: "msg-1",
+      threadId: "slack:C1:ts1",
+      text: "slack msg",
+      author: { userId: "U1", userName: "a", fullName: "A", isBot: false, isMe: false },
+      metadata: { dateSent: new Date(), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: true,
+    };
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(slackThread, slackMsg);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(slackMessages).toHaveLength(1);
+    expect(discordMessages).toHaveLength(0);
+  });
+
+  test("event from unconfigured adapter is silently ignored", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+
+    const received: InboundMessage[] = [];
+    adapters[0]?.onMessage(async (msg) => {
+      received.push(msg);
+    });
+
+    // Send event from a platform that wasn't configured
+    const unknownThread = {
+      id: "teams:C1:T1",
+      channelId: "C1",
+      isDM: false,
+      adapter: { name: "teams" },
+      subscribe: mock(async () => {}),
+    };
+    const unknownMsg = {
+      id: "msg-1",
+      threadId: "teams:C1:T1",
+      text: "teams msg",
+      author: { userId: "U1", userName: "a", fullName: "A", isBot: false, isMe: false },
+      metadata: { dateSent: new Date(), edited: false },
+      attachments: [],
+      formatted: { type: "root", children: [] },
+      raw: {},
+      isMention: true,
+    };
+
+    for (const handler of mockChat.handlers.mentions) {
+      handler(unknownThread, unknownMsg);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Slack adapter should not receive the teams event
+    expect(received).toHaveLength(0);
+  });
+
+  test("handleWebhook returns 404 when no handler for platform", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    // webhooks map doesn't include "slack"
+    mockChat.instance.webhooks = {};
+
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+    const req = new Request("https://example.com/webhook", { method: "POST" });
+    const resp = await adapters[0]?.handleWebhook(req);
+
+    expect(resp?.status).toBe(404);
+  });
+
+  test("send throws when threadId is missing", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    await adapters[0]?.connect();
+
+    await expect(adapters[0]?.send({ content: [{ kind: "text", text: "hello" }] })).rejects.toThrow(
+      "threadId",
+    );
+  });
+
+  test("sendStatus is present on adapters", () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: makeMockChatSdkAdapter("slack") },
+    });
+
+    expect(typeof adapters[0]?.sendStatus).toBe("function");
+  });
+
+  test("sendStatus 'processing' calls startTyping on adapter", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    await adapters[0]?.connect();
+
+    const status: ChannelStatus = { kind: "processing", turnIndex: 0, messageRef: "slack:C1:ts1" };
+    await adapters[0]?.sendStatus?.(status);
+
+    expect(mockSlackAdapter.startTyping).toHaveBeenCalledTimes(1);
+    expect((mockSlackAdapter.startTyping as ReturnType<typeof mock>).mock.calls[0]).toEqual([
+      "slack:C1:ts1",
+    ]);
+  });
+
+  test("sendStatus 'idle' does not call startTyping", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    await adapters[0]?.connect();
+
+    const status: ChannelStatus = { kind: "idle", turnIndex: 0 };
+    await adapters[0]?.sendStatus?.(status);
+
+    expect(mockSlackAdapter.startTyping).toHaveBeenCalledTimes(0);
+  });
+
+  test("sendStatus without messageRef is silently ignored", async () => {
+    const config: ChatSdkChannelConfig = {
+      platforms: [{ platform: "slack" }],
+    };
+
+    const mockSlackAdapter = makeMockChatSdkAdapter("slack");
+    const mockChat = makeMockChat();
+    const adapters = createChatSdkChannels(config, {
+      _chat: mockChat.instance,
+      _adapters: { slack: mockSlackAdapter },
+    });
+
+    await adapters[0]?.connect();
+
+    const status: ChannelStatus = { kind: "processing", turnIndex: 0 };
+    await adapters[0]?.sendStatus?.(status);
+
+    expect(mockSlackAdapter.startTyping).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/channel-chat-sdk/src/create-chat-sdk-channels.ts
+++ b/packages/channel-chat-sdk/src/create-chat-sdk-channels.ts
@@ -1,0 +1,340 @@
+/**
+ * Main factory for @koi/channel-chat-sdk.
+ *
+ * Creates a shared Chat SDK instance and returns one ChannelAdapter
+ * per configured platform. Each adapter routes through the shared
+ * Chat instance for webhook handling, event normalization, and sending.
+ */
+
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createChannelAdapter } from "@koi/channel-base";
+import type { ChannelAdapter, ChannelStatus, OutboundMessage } from "@koi/core";
+import type { Adapter, Message, Thread } from "chat";
+import { Chat } from "chat";
+import { capabilitiesForPlatform } from "./capabilities.js";
+import type { ChatSdkChannelConfig, PlatformConfig, PlatformName } from "./config.js";
+import { mapContentToPostable } from "./map-content.js";
+import { normalize } from "./normalize.js";
+import type { ChatSdkEvent } from "./types.js";
+
+const DEFAULT_USER_NAME = "koi-bot";
+
+export interface ChatSdkChannelAdapter extends ChannelAdapter {
+  readonly handleWebhook: (
+    request: Request,
+    options?: { readonly waitUntil?: (p: Promise<unknown>) => void },
+  ) => Promise<Response>;
+  readonly platform: string;
+}
+
+/**
+ * Internal test overrides. Not part of the public API.
+ */
+export interface ChatSdkTestOverrides {
+  /** Injected Chat instance for testing. Typed as unknown to accept partial mocks. */
+  readonly _chat?: unknown;
+  /** Injected platform adapters for testing. Typed as unknown to accept partial mocks. */
+  readonly _adapters?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Creates a Chat SDK platform adapter from a PlatformConfig.
+ * Each adapter factory auto-detects credentials from env when not provided.
+ */
+async function createPlatformAdapter(config: PlatformConfig): Promise<Adapter> {
+  switch (config.platform) {
+    case "slack": {
+      const { createSlackAdapter } = await import("@chat-adapter/slack");
+      // @ts-expect-error — SlackAdapter.botUserId is `string | undefined` vs Adapter's optional `string` (Chat SDK type bug under exactOptionalPropertyTypes)
+      return createSlackAdapter({
+        ...(config.botToken !== undefined ? { botToken: config.botToken } : {}),
+        ...(config.signingSecret !== undefined ? { signingSecret: config.signingSecret } : {}),
+      });
+    }
+    case "discord": {
+      const { createDiscordAdapter } = await import("@chat-adapter/discord");
+      return createDiscordAdapter({
+        ...(config.botToken !== undefined ? { botToken: config.botToken } : {}),
+        ...(config.publicKey !== undefined ? { publicKey: config.publicKey } : {}),
+        ...(config.applicationId !== undefined ? { applicationId: config.applicationId } : {}),
+      });
+    }
+    case "teams": {
+      const { createTeamsAdapter } = await import("@chat-adapter/teams");
+      return createTeamsAdapter({
+        ...(config.appId !== undefined ? { appId: config.appId } : {}),
+        ...(config.appPassword !== undefined ? { appPassword: config.appPassword } : {}),
+      });
+    }
+    case "gchat": {
+      const { createGoogleChatAdapter } = await import("@chat-adapter/gchat");
+      return createGoogleChatAdapter({
+        ...(config.credentials !== undefined ? { credentials: config.credentials } : {}),
+      });
+    }
+    case "github": {
+      const { createGitHubAdapter } = await import("@chat-adapter/github");
+      // @ts-expect-error — GitHubAdapter.botUserId is `string | undefined` vs Adapter's optional `string` (Chat SDK type bug under exactOptionalPropertyTypes)
+      return createGitHubAdapter({
+        ...(config.token !== undefined ? { token: config.token } : {}),
+        ...(config.webhookSecret !== undefined ? { webhookSecret: config.webhookSecret } : {}),
+        ...(config.userName !== undefined ? { userName: config.userName } : {}),
+      });
+    }
+    case "linear": {
+      const { createLinearAdapter } = await import("@chat-adapter/linear");
+      // @ts-expect-error — LinearAdapter.botUserId is `string | undefined` vs Adapter's optional `string` (Chat SDK type bug under exactOptionalPropertyTypes)
+      return createLinearAdapter({
+        ...(config.apiKey !== undefined ? { apiKey: config.apiKey } : {}),
+        ...(config.webhookSecret !== undefined ? { webhookSecret: config.webhookSecret } : {}),
+        ...(config.userName !== undefined ? { userName: config.userName } : {}),
+      });
+    }
+  }
+}
+
+/**
+ * Event router state: maps adapter name → event handler list.
+ * Immutable updates via Map.set with new arrays.
+ */
+interface EventRouter {
+  readonly get: (name: string) => readonly ((event: ChatSdkEvent) => void)[];
+  readonly add: (name: string, handler: (event: ChatSdkEvent) => void) => void;
+  readonly remove: (name: string, handler: (event: ChatSdkEvent) => void) => void;
+}
+
+function createEventRouter(platforms: readonly PlatformConfig[]): EventRouter {
+  const routes = new Map<string, readonly ((event: ChatSdkEvent) => void)[]>();
+
+  for (const platformConfig of platforms) {
+    routes.set(platformConfig.platform, []);
+  }
+
+  return {
+    get: (name: string) => routes.get(name) ?? [],
+    add: (name: string, handler: (event: ChatSdkEvent) => void) => {
+      routes.set(name, [...(routes.get(name) ?? []), handler]);
+    },
+    remove: (name: string, handler: (event: ChatSdkEvent) => void) => {
+      const current = routes.get(name) ?? [];
+      routes.set(
+        name,
+        current.filter((h) => h !== handler),
+      );
+    },
+  };
+}
+
+/**
+ * Shared lifecycle state for the Chat SDK instance.
+ * Uses a promise guard to prevent concurrent initialization.
+ */
+interface SharedLifecycle {
+  readonly ensureInitialized: () => Promise<void>;
+  readonly shutdown: () => Promise<void>;
+  readonly getChatInstance: () => Chat | null;
+  readonly connect: () => Promise<void>;
+  readonly disconnect: () => Promise<void>;
+}
+
+function createSharedLifecycle(
+  config: ChatSdkChannelConfig,
+  injectedChat: unknown,
+  injectedAdapters: Readonly<Record<string, unknown>>,
+  onReady: (chat: Chat) => void,
+): SharedLifecycle {
+  const userName = config.userName ?? DEFAULT_USER_NAME;
+
+  // let justification: Chat instance is created lazily, or injected for tests
+  let chatInstance = (injectedChat ?? null) as Chat | null;
+  // let justification: promise guard for concurrent init
+  let initPromise: Promise<void> | null = null;
+  // let justification: tracks connected adapter count for ref-counted shutdown
+  let connectedCount = 0;
+
+  async function doInitialize(): Promise<void> {
+    if (chatInstance === null) {
+      const adapterMap: Record<string, Adapter> = {};
+      for (const platformConfig of config.platforms) {
+        const existing = injectedAdapters[platformConfig.platform] as Adapter | undefined;
+        adapterMap[platformConfig.platform] =
+          existing ?? (await createPlatformAdapter(platformConfig));
+      }
+
+      chatInstance = new Chat({
+        userName,
+        adapters: adapterMap,
+        state: createMemoryState(),
+      });
+    }
+
+    onReady(chatInstance);
+    await chatInstance.initialize();
+  }
+
+  return {
+    ensureInitialized: (): Promise<void> => {
+      if (initPromise !== null) {
+        return initPromise;
+      }
+      initPromise = doInitialize();
+      return initPromise;
+    },
+
+    shutdown: async (): Promise<void> => {
+      if (chatInstance !== null) {
+        await chatInstance.shutdown();
+        chatInstance = null;
+        initPromise = null;
+      }
+    },
+
+    getChatInstance: (): Chat | null => chatInstance,
+
+    connect: async (): Promise<void> => {
+      if (initPromise === null) {
+        initPromise = doInitialize();
+      }
+      await initPromise;
+      connectedCount++;
+    },
+
+    disconnect: async (): Promise<void> => {
+      connectedCount = Math.max(0, connectedCount - 1);
+      if (connectedCount === 0 && chatInstance !== null) {
+        await chatInstance.shutdown();
+        chatInstance = null;
+        initPromise = null;
+      }
+    },
+  };
+}
+
+/**
+ * Builds a single ChatSdkChannelAdapter for one platform.
+ */
+function createPlatformChannelAdapter(
+  platform: PlatformName,
+  router: EventRouter,
+  lifecycle: SharedLifecycle,
+  injectedAdapters: Readonly<Record<string, unknown>>,
+): ChatSdkChannelAdapter {
+  const adapterName = `chat-sdk:${platform}`;
+  const capabilities = capabilitiesForPlatform(platform);
+
+  const resolveAdapter = (): Adapter => {
+    const injected = injectedAdapters[platform] as Adapter | undefined;
+    if (injected !== undefined) {
+      return injected;
+    }
+    const chat = lifecycle.getChatInstance();
+    if (chat !== null) {
+      return chat.getAdapter(platform);
+    }
+    throw new Error(`Chat SDK adapter for "${platform}" not found`);
+  };
+
+  const base = createChannelAdapter<ChatSdkEvent>({
+    name: adapterName,
+    capabilities,
+    platformConnect: lifecycle.connect,
+    platformDisconnect: lifecycle.disconnect,
+
+    platformSend: async (message: OutboundMessage): Promise<void> => {
+      if (message.threadId === undefined) {
+        throw new Error(`[${adapterName}] threadId is required to send a message`);
+      }
+      const postable = mapContentToPostable(message.content);
+      const adapter = resolveAdapter();
+      await adapter.postMessage(message.threadId, postable);
+    },
+
+    onPlatformEvent: (handler: (event: ChatSdkEvent) => void): (() => void) => {
+      router.add(platform, handler);
+      return (): void => {
+        router.remove(platform, handler);
+      };
+    },
+
+    normalize,
+
+    platformSendStatus: async (status: ChannelStatus): Promise<void> => {
+      if (status.kind !== "processing" || status.messageRef === undefined) {
+        return;
+      }
+      const adapter = resolveAdapter();
+      await adapter.startTyping(status.messageRef);
+    },
+  });
+
+  return {
+    ...base,
+    platform,
+
+    handleWebhook: async (
+      request: Request,
+      options?: { readonly waitUntil?: (p: Promise<unknown>) => void },
+    ): Promise<Response> => {
+      await lifecycle.ensureInitialized();
+
+      const chat = lifecycle.getChatInstance();
+      if (chat === null) {
+        return new Response("Chat instance not initialized", { status: 503 });
+      }
+
+      const webhooks = chat.webhooks;
+      const handler = (
+        webhooks as Readonly<Record<string, (req: Request, opts?: unknown) => Promise<Response>>>
+      )[platform];
+      if (handler === undefined) {
+        return new Response(`No webhook handler for platform "${platform}"`, { status: 404 });
+      }
+
+      return handler(request, options);
+    },
+  };
+}
+
+/**
+ * Creates N ChannelAdapters backed by a shared Chat SDK instance.
+ *
+ * @param config - Validated ChatSdkChannelConfig with platforms array.
+ * @param overrides - Test-only overrides for the Chat instance and adapters.
+ * @returns One ChatSdkChannelAdapter per configured platform.
+ */
+export function createChatSdkChannels(
+  config: ChatSdkChannelConfig,
+  overrides?: ChatSdkTestOverrides,
+): readonly ChatSdkChannelAdapter[] {
+  const injectedAdapters = overrides?._adapters ?? {};
+  const injectedChat = overrides?._chat ?? null;
+
+  const router = createEventRouter(config.platforms);
+
+  function dispatchChatEvent(thread: Thread, message: Message): void {
+    const adapterName = thread.adapter.name;
+    const handlers = router.get(adapterName);
+    if (handlers.length === 0) {
+      return;
+    }
+
+    const event: ChatSdkEvent = { thread, message, adapterName };
+    for (const handler of handlers) {
+      handler(event);
+    }
+  }
+
+  function handleNewMention(thread: Thread, message: Message): void {
+    void thread.subscribe();
+    dispatchChatEvent(thread, message);
+  }
+
+  const lifecycle = createSharedLifecycle(config, injectedChat, injectedAdapters, (chat) => {
+    chat.onNewMention(handleNewMention);
+    chat.onSubscribedMessage(dispatchChatEvent);
+  });
+
+  return config.platforms.map((platformConfig) =>
+    createPlatformChannelAdapter(platformConfig.platform, router, lifecycle, injectedAdapters),
+  );
+}

--- a/packages/channel-chat-sdk/src/descriptor.ts
+++ b/packages/channel-chat-sdk/src/descriptor.ts
@@ -1,0 +1,54 @@
+/**
+ * BrickDescriptor for @koi/channel-chat-sdk.
+ *
+ * Enables manifest auto-resolution for the Chat SDK multi-platform
+ * channel adapter. Each platform in the config gets its own ChannelAdapter.
+ */
+
+import type { ChannelAdapter, KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateChatSdkChannelConfig } from "./config.js";
+import { createChatSdkChannels } from "./create-chat-sdk-channels.js";
+
+function validateChatSdkChannelOptions(input: unknown): Result<unknown, KoiError> {
+  if (input !== null && input !== undefined && typeof input !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Chat SDK channel options must be an object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+  return { ok: true, value: input ?? {} };
+}
+
+/**
+ * Descriptor for Chat SDK multi-platform channel adapter.
+ *
+ * The factory returns the first channel adapter from the configured
+ * platforms. For multiple platforms, use createChatSdkChannels() directly.
+ */
+export const descriptor: BrickDescriptor<ChannelAdapter> = {
+  kind: "channel",
+  name: "@koi/channel-chat-sdk",
+  aliases: ["chat-sdk"],
+  optionsValidator: validateChatSdkChannelOptions,
+  factory(options: unknown, _context: ResolutionContext): ChannelAdapter {
+    const raw = (options ?? {}) as Record<string, unknown>;
+
+    const configResult = validateChatSdkChannelConfig(raw);
+    if (!configResult.ok) {
+      throw new Error(configResult.error.message);
+    }
+
+    const adapters = createChatSdkChannels(configResult.value);
+    const first = adapters[0];
+    if (first === undefined) {
+      throw new Error("No channel adapters created — check your platform configuration");
+    }
+    return first;
+  },
+};

--- a/packages/channel-chat-sdk/src/index.ts
+++ b/packages/channel-chat-sdk/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * @koi/channel-chat-sdk — Multi-platform channel adapter via Vercel Chat SDK.
+ *
+ * Wraps Slack, Discord, Teams, Google Chat, GitHub, and Linear into
+ * Koi ChannelAdapters using a single shared Chat SDK instance.
+ *
+ * @example
+ * ```typescript
+ * import { createChatSdkChannels } from "@koi/channel-chat-sdk";
+ *
+ * const adapters = createChatSdkChannels({
+ *   platforms: [
+ *     { platform: "slack" },
+ *     { platform: "discord" },
+ *   ],
+ * });
+ *
+ * for (const adapter of adapters) {
+ *   await adapter.connect();
+ * }
+ * ```
+ */
+
+export type {
+  ChatSdkChannelConfig,
+  DiscordPlatformConfig,
+  GchatPlatformConfig,
+  GithubPlatformConfig,
+  LinearPlatformConfig,
+  PlatformConfig,
+  PlatformName,
+  SlackPlatformConfig,
+  TeamsPlatformConfig,
+} from "./config.js";
+export { validateChatSdkChannelConfig } from "./config.js";
+export type { ChatSdkChannelAdapter } from "./create-chat-sdk-channels.js";
+export { createChatSdkChannels } from "./create-chat-sdk-channels.js";
+export { descriptor } from "./descriptor.js";

--- a/packages/channel-chat-sdk/src/map-content.test.ts
+++ b/packages/channel-chat-sdk/src/map-content.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { ContentBlock } from "@koi/core";
+import { mapContentToPostable } from "./map-content.js";
+
+describe("mapContentToPostable", () => {
+  test("maps single TextBlock to markdown", () => {
+    const blocks: readonly ContentBlock[] = [{ kind: "text", text: "hello" }];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({ markdown: "hello" });
+  });
+
+  test("maps TextBlock with markdown formatting", () => {
+    const blocks: readonly ContentBlock[] = [{ kind: "text", text: "**bold** and _italic_" }];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({ markdown: "**bold** and _italic_" });
+  });
+
+  test("maps multiple TextBlocks by joining with newlines", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "text", text: "first" },
+      { kind: "text", text: "second" },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({ markdown: "first\n\nsecond" });
+  });
+
+  test("maps TextBlock + ImageBlock", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "text", text: "check this" },
+      { kind: "image", url: "https://example.com/img.png", alt: "a photo" },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({
+      markdown: "check this\n\n![a photo](https://example.com/img.png)",
+    });
+  });
+
+  test("maps ImageBlock without alt text", () => {
+    const blocks: readonly ContentBlock[] = [{ kind: "image", url: "https://example.com/img.png" }];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({
+      markdown: "![image](https://example.com/img.png)",
+    });
+  });
+
+  test("maps TextBlock + FileBlock", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "text", text: "here's the doc" },
+      {
+        kind: "file",
+        url: "https://example.com/doc.pdf",
+        mimeType: "application/pdf",
+        name: "doc.pdf",
+      },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({
+      markdown: "here's the doc\n\n[doc.pdf](https://example.com/doc.pdf)",
+    });
+  });
+
+  test("maps FileBlock without name", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "file", url: "https://example.com/data.bin", mimeType: "application/octet-stream" },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({
+      markdown: "[file](https://example.com/data.bin)",
+    });
+  });
+
+  test("maps ButtonBlock as text fallback", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "text", text: "Choose one:" },
+      { kind: "button", label: "Option A", action: "select_a" },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({
+      markdown: "Choose one:\n\n[Option A]",
+    });
+  });
+
+  test("skips CustomBlock", () => {
+    const blocks: readonly ContentBlock[] = [
+      { kind: "text", text: "hello" },
+      { kind: "custom", type: "my-widget", data: { foo: 1 } },
+    ];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({ markdown: "hello" });
+  });
+
+  test("returns empty markdown for empty content", () => {
+    const result = mapContentToPostable([]);
+    expect(result).toEqual({ markdown: "" });
+  });
+
+  test("returns empty markdown for only custom blocks", () => {
+    const blocks: readonly ContentBlock[] = [{ kind: "custom", type: "widget", data: null }];
+    const result = mapContentToPostable(blocks);
+    expect(result).toEqual({ markdown: "" });
+  });
+});

--- a/packages/channel-chat-sdk/src/map-content.ts
+++ b/packages/channel-chat-sdk/src/map-content.ts
@@ -1,0 +1,54 @@
+/**
+ * Content mapper: Koi ContentBlock[] → Chat SDK AdapterPostableMessage.
+ *
+ * Converts Koi's rich content blocks into a markdown string suitable
+ * for the Chat SDK's `postMessage()`. Images and files are embedded
+ * as markdown links; buttons degrade to `[label]` text; custom blocks
+ * are silently skipped (no platform mapping).
+ */
+
+import type { ContentBlock } from "@koi/core";
+
+/**
+ * Maps a single ContentBlock to its markdown representation, or null
+ * for unmappable blocks (custom).
+ */
+function blockToMarkdown(block: ContentBlock): string | null {
+  switch (block.kind) {
+    case "text":
+      return block.text;
+    case "image": {
+      const alt = block.alt ?? "image";
+      return `![${alt}](${block.url})`;
+    }
+    case "file": {
+      const name = block.name ?? "file";
+      return `[${name}](${block.url})`;
+    }
+    case "button":
+      return `[${block.label}]`;
+    case "custom":
+      return null;
+  }
+}
+
+/**
+ * Maps Koi ContentBlock[] to a Chat SDK AdapterPostableMessage.
+ *
+ * Returns a `{ markdown: string }` object that all Chat SDK adapters
+ * accept natively. In v2, this may return richer card-based messages.
+ */
+export function mapContentToPostable(content: readonly ContentBlock[]): {
+  readonly markdown: string;
+} {
+  const parts: string[] = [];
+
+  for (const block of content) {
+    const md = blockToMarkdown(block);
+    if (md !== null) {
+      parts.push(md);
+    }
+  }
+
+  return { markdown: parts.join("\n\n") };
+}

--- a/packages/channel-chat-sdk/src/normalize.test.ts
+++ b/packages/channel-chat-sdk/src/normalize.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import type { Message, Thread } from "chat";
+import { normalizeChatSdkEvent as normalize } from "./normalize.js";
+import type { ChatSdkEvent } from "./types.js";
+
+/**
+ * Creates a minimal Chat SDK Message stub for testing.
+ */
+function makeMessage(overrides: {
+  readonly text?: string;
+  readonly userId?: string;
+  readonly userName?: string;
+  readonly threadId?: string;
+  readonly isMention?: boolean;
+  readonly isBot?: boolean;
+  readonly isMe?: boolean;
+  readonly dateSent?: Date;
+  readonly attachments?: ReadonlyArray<{
+    readonly type: string;
+    readonly url?: string;
+    readonly name?: string;
+    readonly mimeType?: string;
+  }>;
+}): Message {
+  return {
+    id: "msg-1",
+    threadId: overrides.threadId ?? "slack:C123:ts456",
+    text: overrides.text ?? "",
+    isMention: overrides.isMention ?? false,
+    author: {
+      userId: overrides.userId ?? "U001",
+      userName: overrides.userName ?? "testuser",
+      fullName: "Test User",
+      isBot: overrides.isBot ?? false,
+      isMe: overrides.isMe ?? false,
+    },
+    metadata: {
+      dateSent: overrides.dateSent ?? new Date("2024-01-15T12:00:00Z"),
+      edited: false,
+    },
+    attachments: (overrides.attachments as Message["attachments"]) ?? [],
+    formatted: { type: "root", children: [] },
+    raw: {},
+  } as unknown as Message;
+}
+
+function makeThread(overrides?: { readonly id?: string; readonly adapterName?: string }): Thread {
+  return {
+    id: overrides?.id ?? "slack:C123:ts456",
+    channelId: "C123",
+    isDM: false,
+    adapter: { name: overrides?.adapterName ?? "slack" },
+  } as unknown as Thread;
+}
+
+function makeEvent(overrides?: {
+  readonly text?: string;
+  readonly userId?: string;
+  readonly isMention?: boolean;
+  readonly isBot?: boolean;
+  readonly isMe?: boolean;
+  readonly threadId?: string;
+  readonly adapterName?: string;
+  readonly dateSent?: Date;
+  readonly attachments?: ReadonlyArray<{
+    readonly type: string;
+    readonly url?: string;
+    readonly name?: string;
+    readonly mimeType?: string;
+  }>;
+}): ChatSdkEvent {
+  const adapterName = overrides?.adapterName ?? "slack";
+  const threadId = overrides?.threadId ?? `${adapterName}:C123:ts456`;
+  return {
+    thread: makeThread({ id: threadId, adapterName }),
+    message: makeMessage({ ...overrides, threadId }),
+    adapterName,
+  };
+}
+
+describe("normalize", () => {
+  test("returns InboundMessage for text message", () => {
+    const result = normalize(makeEvent({ text: "hello world" }));
+    expect(result).not.toBeNull();
+    expect(result?.content).toEqual([{ kind: "text", text: "hello world" }]);
+    expect(result?.senderId).toBe("U001");
+    expect(result?.threadId).toBe("slack:C123:ts456");
+  });
+
+  test("extracts timestamp from message metadata", () => {
+    const date = new Date("2024-06-15T10:30:00Z");
+    const result = normalize(makeEvent({ text: "hi", dateSent: date }));
+    expect(result).not.toBeNull();
+    expect(result?.timestamp).toBe(date.getTime());
+  });
+
+  test("returns null for bot's own messages", () => {
+    const result = normalize(makeEvent({ text: "bot reply", isMe: true }));
+    expect(result).toBeNull();
+  });
+
+  test("returns null for empty text without attachments", () => {
+    const result = normalize(makeEvent({ text: "" }));
+    expect(result).toBeNull();
+  });
+
+  test("returns InboundMessage for message with image attachment", () => {
+    const result = normalize(
+      makeEvent({
+        text: "check this",
+        attachments: [{ type: "image", url: "https://example.com/img.png", name: "img.png" }],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toHaveLength(2);
+    expect(result?.content[0]).toEqual({ kind: "text", text: "check this" });
+    expect(result?.content[1]).toEqual({
+      kind: "image",
+      url: "https://example.com/img.png",
+      alt: "img.png",
+    });
+  });
+
+  test("returns InboundMessage for message with file attachment", () => {
+    const result = normalize(
+      makeEvent({
+        text: "here's the doc",
+        attachments: [
+          {
+            type: "file",
+            url: "https://example.com/doc.pdf",
+            name: "doc.pdf",
+            mimeType: "application/pdf",
+          },
+        ],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toHaveLength(2);
+    expect(result?.content[1]).toEqual({
+      kind: "file",
+      url: "https://example.com/doc.pdf",
+      mimeType: "application/pdf",
+      name: "doc.pdf",
+    });
+  });
+
+  test("handles attachment without URL gracefully", () => {
+    const result = normalize(
+      makeEvent({
+        text: "file attached",
+        attachments: [{ type: "file", name: "secret.pdf" }],
+      }),
+    );
+    expect(result).not.toBeNull();
+    // Attachment without URL is skipped, only text block remains
+    expect(result?.content).toEqual([{ kind: "text", text: "file attached" }]);
+  });
+
+  test("returns InboundMessage for attachment-only message (no text)", () => {
+    const result = normalize(
+      makeEvent({
+        text: "",
+        attachments: [{ type: "image", url: "https://example.com/img.png", name: "photo" }],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toHaveLength(1);
+    expect(result?.content[0]).toEqual({
+      kind: "image",
+      url: "https://example.com/img.png",
+      alt: "photo",
+    });
+  });
+
+  test("sets correct threadId from thread.id", () => {
+    const result = normalize(
+      makeEvent({
+        text: "hello",
+        threadId: "discord:G789:T111",
+        adapterName: "discord",
+      }),
+    );
+    expect(result?.threadId).toBe("discord:G789:T111");
+  });
+
+  test("sets correct senderId from message author", () => {
+    const result = normalize(makeEvent({ text: "hi", userId: "U999" }));
+    expect(result?.senderId).toBe("U999");
+  });
+
+  test("handles image attachment without name", () => {
+    const result = normalize(
+      makeEvent({
+        text: "",
+        attachments: [{ type: "image", url: "https://example.com/img.png" }],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toEqual([{ kind: "image", url: "https://example.com/img.png" }]);
+  });
+
+  test("handles file attachment without name", () => {
+    const result = normalize(
+      makeEvent({
+        text: "",
+        attachments: [
+          {
+            type: "file",
+            url: "https://example.com/data.bin",
+            mimeType: "application/octet-stream",
+          },
+        ],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toEqual([
+      { kind: "file", url: "https://example.com/data.bin", mimeType: "application/octet-stream" },
+    ]);
+  });
+
+  test("handles video attachment as file block", () => {
+    const result = normalize(
+      makeEvent({
+        text: "",
+        attachments: [
+          {
+            type: "video",
+            url: "https://example.com/video.mp4",
+            name: "clip.mp4",
+            mimeType: "video/mp4",
+          },
+        ],
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.content).toEqual([
+      {
+        kind: "file",
+        url: "https://example.com/video.mp4",
+        mimeType: "video/mp4",
+        name: "clip.mp4",
+      },
+    ]);
+  });
+
+  test("includes isMention in metadata when true", () => {
+    const result = normalize(makeEvent({ text: "@bot help", isMention: true }));
+    expect(result).not.toBeNull();
+    expect(result?.metadata?.isMention).toBe(true);
+  });
+});

--- a/packages/channel-chat-sdk/src/normalize.ts
+++ b/packages/channel-chat-sdk/src/normalize.ts
@@ -1,0 +1,95 @@
+/**
+ * Normalizer: Chat SDK Message + Thread → Koi InboundMessage.
+ *
+ * One normalizer handles all 6 platforms because the Chat SDK
+ * already normalizes platform events into a unified Message type.
+ */
+
+import type { MessageNormalizer } from "@koi/channel-base";
+import type { ContentBlock, InboundMessage } from "@koi/core";
+import type { ChatSdkEvent } from "./types.js";
+
+/**
+ * Maps a Chat SDK attachment to a Koi ContentBlock, or null if unmappable.
+ */
+function mapAttachment(
+  attachment: Readonly<{
+    type: string;
+    url?: string;
+    name?: string;
+    mimeType?: string;
+  }>,
+): ContentBlock | null {
+  if (attachment.url === undefined) {
+    return null;
+  }
+
+  if (attachment.type === "image") {
+    const base: ContentBlock = { kind: "image", url: attachment.url };
+    if (attachment.name !== undefined) {
+      return { kind: "image", url: attachment.url, alt: attachment.name };
+    }
+    return base;
+  }
+
+  if (attachment.type === "file" || attachment.type === "video" || attachment.type === "audio") {
+    const mimeType = attachment.mimeType ?? "application/octet-stream";
+    if (attachment.name !== undefined) {
+      return { kind: "file", url: attachment.url, mimeType, name: attachment.name };
+    }
+    return { kind: "file", url: attachment.url, mimeType };
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes a Chat SDK event (Thread + Message) into a Koi InboundMessage.
+ *
+ * Returns null for:
+ * - Bot's own messages (author.isMe === true)
+ * - Empty messages (no text and no attachments)
+ */
+export function normalizeChatSdkEvent(event: ChatSdkEvent): InboundMessage | null {
+  const { thread, message } = event;
+
+  // Skip bot's own messages to prevent echo loops
+  if (message.author.isMe) {
+    return null;
+  }
+
+  const textBlocks: readonly ContentBlock[] =
+    message.text.length > 0 ? [{ kind: "text", text: message.text }] : [];
+
+  const attachmentBlocks: readonly ContentBlock[] = message.attachments
+    .map(mapAttachment)
+    .filter((b): b is ContentBlock => b !== null);
+
+  const content: readonly ContentBlock[] = [...textBlocks, ...attachmentBlocks];
+
+  // Skip completely empty messages
+  if (content.length === 0) {
+    return null;
+  }
+
+  const timestamp =
+    message.metadata.dateSent instanceof Date ? message.metadata.dateSent.getTime() : Date.now();
+
+  const base: InboundMessage = {
+    content,
+    senderId: message.author.userId,
+    threadId: thread.id,
+    timestamp,
+  };
+
+  if (message.isMention === true) {
+    return { ...base, metadata: { isMention: true } };
+  }
+
+  return base;
+}
+
+/**
+ * MessageNormalizer-typed reference for use in createChannelAdapter config.
+ */
+export const normalize: MessageNormalizer<ChatSdkEvent> = normalizeChatSdkEvent;

--- a/packages/channel-chat-sdk/src/types.ts
+++ b/packages/channel-chat-sdk/src/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal shared types for @koi/channel-chat-sdk.
+ *
+ * ChatSdkEvent wraps the Thread + Message pair delivered by
+ * the Chat SDK's onNewMention / onSubscribedMessage handlers.
+ * This is the event type E for createChannelAdapter<E>().
+ */
+
+import type { Message, Thread } from "chat";
+
+export interface ChatSdkEvent {
+  readonly thread: Thread;
+  readonly message: Message;
+  readonly adapterName: string;
+}

--- a/packages/channel-chat-sdk/tsconfig.json
+++ b/packages/channel-chat-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../resolve" }]
+}

--- a/packages/channel-chat-sdk/tsup.config.ts
+++ b/packages/channel-chat-sdk/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Adds `@koi/channel-chat-sdk` (L2) — wraps 6 chat platforms (Slack, Discord, Teams, Google Chat, GitHub, Linear) into Koi `ChannelAdapter` instances via a single shared [Vercel Chat SDK](https://github.com/vercel/chat) instance
- One normalizer, one content mapper, one factory → N ready-to-use channel adapters (~545 LOC source vs ~1800 LOC for 6 separate packages)
- Includes `sendStatus` typing indicators, `BrickDescriptor` for manifest auto-resolution, per-platform capability flags, and lazy ref-counted lifecycle
- 77 tests (68 unit/integration + 9 E2E with real Anthropic API calls), 90.86% coverage
- Comprehensive documentation with ASCII architecture diagrams at `docs/L2/channel-chat-sdk.md`

## What's included

| File | Purpose |
|------|---------|
| `config.ts` | Discriminated union per-platform config + `validateChatSdkChannelConfig()` |
| `capabilities.ts` | Per-platform `ChannelCapabilities` constants |
| `normalize.ts` | Chat SDK `Message+Thread` → Koi `InboundMessage` (bot echo filtered) |
| `map-content.ts` | Koi `ContentBlock[]` → Chat SDK `{ markdown }` |
| `create-chat-sdk-channels.ts` | Main factory: shared `Chat` instance + N `ChannelAdapter`s |
| `descriptor.ts` | `BrickDescriptor` for manifest auto-resolution |
| `docs/L2/channel-chat-sdk.md` | Full documentation with architecture diagrams |

## Architecture

```
createChatSdkChannels({ platforms: [slack, discord, teams] })
  │
  ├── Shared Chat SDK instance (webhook verify, event normalize, send)
  │
  ├── chat-sdk:slack   (ChannelAdapter)
  ├── chat-sdk:discord (ChannelAdapter)
  └── chat-sdk:teams   (ChannelAdapter)
      │
      All share one normalizer + one content mapper
      Ref-counted lifecycle (last disconnect shuts down Chat)
```

## Test plan

- [x] Unit tests: config validation, capabilities, normalizer, content mapper, factory lifecycle
- [x] Integration tests: full webhook → normalize → send flow with mock adapters
- [x] API surface snapshot test (`.d.ts` stability)
- [x] E2E tests with real Anthropic API calls through `createKoi` + `createPiAdapter`
- [x] `bun run build` clean, `bun run typecheck` clean, `bun run lint` clean
- [x] 90.86% coverage (exceeds 80% threshold)
- [ ] Anti-leak checklist verified (L2 imports from L0 + L0u only, no vendor types in public API)

Closes #333
Supersedes #18, #26, #47 for basic coverage