### PR TITLE
feat: add @koi/tools-github — GitHub CLI tools for PR lifecycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1259,6 +1259,17 @@
         "@koi/scope": "workspace:*",
       },
     },
+    "packages/tools-github": {
+      "name": "@koi/tools-github",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-loop": "workspace:*",
+      },
+    },
     "packages/tracing": {
       "name": "@koi/tracing",
       "version": "0.0.0",
@@ -1934,6 +1945,8 @@
     "@koi/test-utils": ["@koi/test-utils@workspace:packages/test-utils"],
 
     "@koi/tool-browser": ["@koi/tool-browser@workspace:packages/tool-browser"],
+
+    "@koi/tools-github": ["@koi/tools-github@workspace:packages/tools-github"],
 
     "@koi/tracing": ["@koi/tracing@workspace:packages/tracing"],
 

--- a/docs/L2/tools-github.md
+++ b/docs/L2/tools-github.md
@@ -1,0 +1,549 @@
+# @koi/tools-github — GitHub PR Lifecycle Tools
+
+Wraps the GitHub CLI (`gh`) as 5 Koi Tool components for PR lifecycle management: create, status, review, merge, and CI wait. One factory call attaches all tools to any agent via ECS — engines discover them with zero engine changes.
+
+---
+
+## Why It Exists
+
+Agents that manage code need to interact with GitHub pull requests: check CI status, read reviews, merge when ready. Raw `gh` CLI output is unstructured, error handling is inconsistent, and there's no standard way to plug GitHub operations into the Koi middleware chain.
+
+`@koi/tools-github` solves this by wrapping `gh` behind a typed `GhExecutor` interface, mapping CLI failures to `KoiError` codes, and exposing each operation as a Koi `Tool` component. The `ComponentProvider` pattern means any engine adapter (loop, Pi, LangGraph) discovers these tools automatically.
+
+---
+
+## What This Enables
+
+### Agent-Driven PR Lifecycle
+
+```
+                      ┌──────────────────────────────────────────────┐
+                      │           Your Koi Agent (YAML)              │
+                      │  name: "pr-bot"                              │
+                      │  model: anthropic:claude-sonnet              │
+                      │  tools: [github_pr_*]                        │
+                      └──────────────────┬───────────────────────────┘
+                                         │
+                    ┌────────────────────▼─────────────────────────┐
+                    │           createKoi() — L1 Engine             │
+                    │  ┌──────────────────────────────────────────┐ │
+                    │  │ Middleware Chain                          │ │
+                    │  │  audit → rate-limit → permissions → ...  │ │
+                    │  └──────────────────────────────────────────┘ │
+                    │  ┌──────────────────────────────────────────┐ │
+                    │  │ Engine Adapter (Loop / Pi / LangGraph)   │ │
+                    │  │  → real LLM calls (Anthropic, OpenAI)    │ │
+                    │  └──────────────────────────────────────────┘ │
+                    └────────────────────┬─────────────────────────┘
+                                         │
+              ┌──────────────────────────▼──────────────────────────────┐
+              │         createGithubProvider() — THIS PACKAGE           │
+              │                                                         │
+              │  ONE factory → 5 Tool components → ECS-attached         │
+              │                                                         │
+              │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+              │  │pr_create │ │pr_status │ │pr_review │ │pr_merge  │  │
+              │  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘  │
+              │       │            │             │             │        │
+              │  ┌────▼────────────▼─────────────▼─────────────▼─────┐ │
+              │  │  ci_wait                                          │ │
+              │  └───────────────────────┬───────────────────────────┘ │
+              │                          │                             │
+              │  ┌───────────────────────▼───────────────────────────┐ │
+              │  │  GhExecutor (abstraction over `gh` CLI)           │ │
+              │  │  ● Spawns `gh` with structured args               │ │
+              │  │  ● Returns Result<string, KoiError>               │ │
+              │  │  ● Mockable for tests (inject via interface)      │ │
+              │  └───────────────────────┬───────────────────────────┘ │
+              └──────────────────────────┼─────────────────────────────┘
+                                         │
+                                         ▼
+                                    GitHub CLI (`gh`)
+                                         │
+                                    GitHub REST API
+```
+
+### Before vs After
+
+```
+WITHOUT tools-github:  raw gh calls, ad-hoc error handling
+══════════════════════════════════════════════════════════
+
+  Agent code:
+  ┌─────────────────────────────────────────────────────┐
+  │ const proc = Bun.spawn(["gh", "pr", "view", ...])  │
+  │ const stdout = await new Response(proc.stdout).text()│
+  │ const json = JSON.parse(stdout) // may throw        │
+  │ if (exitCode !== 0) { ... } // ad-hoc error parsing │
+  │ // No middleware interception                        │
+  │ // No trust tier enforcement                         │
+  │ // No structured error codes                         │
+  └─────────────────────────────────────────────────────┘
+
+
+WITH tools-github:  typed tools, middleware chain, structured errors
+═══════════════════════════════════════════════════════════════════
+
+  Agent YAML:
+  ┌─────────────────────────────────────────────────────┐
+  │ tools: [github_pr_status, github_pr_merge, ...]     │
+  │                                                     │
+  │ LLM calls tools naturally:                          │
+  │   "Check PR #42 status" → github_pr_status          │
+  │   "Merge if approved"   → github_pr_merge           │
+  │                                                     │
+  │ ● Middleware intercepts every tool call              │
+  │ ● Trust tiers: reads = verified, writes = promoted  │
+  │ ● Structured KoiError codes (NOT_FOUND, RATE_LIMIT) │
+  │ ● Errors flow back to model as tool results         │
+  └─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tool Execution Flow
+
+### Happy Path: LLM calls `github_pr_status`
+
+```
+LLM decides: "call github_pr_status
+              with { pr_number: 42 }"
+        │
+        ▼
+  ┌────────────────┐
+  │ Middleware Chain│
+  │ wrapToolCall() │──── audit, rate-limit, permissions...
+  └───────┬────────┘
+          │
+          ▼
+  ┌────────────────────┐
+  │ tool.execute(args)  │
+  │ pr-status.ts        │
+  └───────┬────────────┘
+          │
+    parsePrNumber(args)
+    validate input ✓
+          │
+          ▼
+  ┌────────────────────────────────────┐
+  │ executor.execute(                  │
+  │   ["pr", "view", "42", "--json",  │
+  │    "state,isDraft,mergeable,..."]  │
+  │ )                                  │
+  └───────┬────────────────────────────┘
+          │
+     gh CLI returns JSON
+          │
+          ▼
+  ┌────────────────────┐
+  │ parseGhJson(stdout)│
+  │ → structured object│
+  └───────┬────────────┘
+          │
+          ▼
+  tool_call_end event
+  result: {
+    state: "OPEN",
+    reviewDecision: "APPROVED",
+    mergeable: "MERGEABLE",
+    ...
+  }
+          │
+          ▼
+  LLM receives result
+  in next turn's messages[]
+```
+
+### Error Path: `RATE_LIMIT` flows back to model
+
+```
+LLM calls github_pr_status
+        │
+        ▼
+  Middleware chain (wrapToolCall)
+        │
+        ▼
+  executor.execute([...])
+        │
+  GitHub API returns 429
+  gh stderr: "API rate limit exceeded"
+        │
+        ▼
+  parseGhError(stderr, exitCode, args)
+  → KoiError {
+      code: "RATE_LIMIT",
+      message: "API rate limit exceeded",
+      retryable: true
+    }
+        │
+        ▼
+  mapErrorResult(error)
+  → { code: "RATE_LIMIT", error: "API rate limit exceeded" }
+        │
+        ▼
+  tool_call_end event
+  result: { code: "RATE_LIMIT", error: "..." }
+        │
+        ▼
+  LLM receives error in messages[]
+  LLM decides: "Rate limited, I'll wait and retry"
+```
+
+### Pre-Validation: `github_pr_merge` checks before merging
+
+```
+LLM calls github_pr_merge
+  { pr_number: 42, strategy: "squash" }
+        │
+        ▼
+  validateMergeReadiness()
+  ├── executor: gh pr view 42 --json state,isDraft,...
+  │
+  ├── isDraft? → { code: "VALIDATION", error: "PR is a draft" }
+  ├── state !== "OPEN"? → { code: "VALIDATION", error: "not open" }
+  ├── mergeable === "CONFLICTING"? → { code: "CONFLICT", error: "..." }
+  ├── failing CI checks? → { code: "VALIDATION", error: "N failing checks" }
+  │
+  └── All clear ✓
+        │
+        ▼
+  executor: gh pr merge 42 --squash
+        │
+        ▼
+  { merged: true }
+```
+
+---
+
+## Architecture
+
+`@koi/tools-github` is an **L2 feature package** that depends only on `@koi/core`.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  @koi/tools-github  (L2)                              │
+│                                                       │
+│  constants.ts              ← operations, field lists  │
+│  gh-executor.ts            ← GhExecutor interface     │
+│  parse-args.ts             ← input validation helpers │
+│  parse-gh-error.ts         ← stderr → KoiError mapper │
+│  github-component-provider.ts ← ComponentProvider     │
+│  test-helpers.ts           ← mock executor + helpers  │
+│  index.ts                  ← public API surface       │
+│                                                       │
+│  tools/                                               │
+│    pr-create.ts            ← github_pr_create         │
+│    pr-status.ts            ← github_pr_status         │
+│    pr-review.ts            ← github_pr_review         │
+│    pr-merge.ts             ← github_pr_merge          │
+│    ci-wait.ts              ← github_ci_wait           │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  External deps: NONE (gh CLI accessed via Bun.spawn)  │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  Internal deps                                        │
+│  ● @koi/core (L0) — Tool, ComponentProvider, KoiError │
+│                                                       │
+│  Dev-only                                             │
+│  ● @koi/engine (L1) — createKoi (E2E tests only)     │
+│  ● @koi/engine-loop — createLoopAdapter (tests only)  │
+└───────────────────────────────────────────────────────┘
+```
+
+### Layer Position
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    Tool, ToolDescriptor, ComponentProvider,            │
+    KoiError, Result, JsonObject, TrustTier             │
+                                                        │
+                                                        ▼
+L2  @koi/tools-github ◄────────────────────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ gh CLI types stay internal (never leak to public API)
+    ✓ All interface properties readonly
+```
+
+### Internal Structure
+
+```
+createGithubProvider(config)
+│
+├── config.executor      → GhExecutor (injected)
+├── config.prefix        → "github" (default)
+├── config.trustTier     → "verified" (default)
+├── config.operations    → all 5 (default)
+│
+└── attach(agent) → Map<SubsystemToken, Tool>
+    │
+    ├── toolToken("github_pr_create")  → createGithubPrCreateTool(executor, prefix, "promoted")
+    ├── toolToken("github_pr_status")  → createGithubPrStatusTool(executor, prefix, "verified")
+    ├── toolToken("github_pr_review")  → createGithubPrReviewTool(executor, prefix, "promoted")
+    ├── toolToken("github_pr_merge")   → createGithubPrMergeTool(executor, prefix, "promoted")
+    └── toolToken("github_ci_wait")    → createGithubCiWaitTool(executor, prefix, "verified")
+
+Trust tiers:
+  Read operations  (pr_status, ci_wait)   → configTier (default: "verified")
+  Write operations (pr_create, pr_review, pr_merge) → "promoted"
+```
+
+---
+
+## Tools Reference
+
+### 5 Tools
+
+```
+╔════════════════════╦═══════════╦═════════════════════════════════════════════╗
+║ Tool               ║ Trust     ║ Purpose                                     ║
+╠════════════════════╬═══════════╬═════════════════════════════════════════════╣
+║ github_pr_create   ║ promoted  ║ Create a new PR (title, body, base, draft) ║
+║ github_pr_status   ║ verified  ║ Get PR state, CI, reviews, merge readiness ║
+║ github_pr_review   ║ promoted  ║ Read reviews or post a new review          ║
+║ github_pr_merge    ║ promoted  ║ Merge PR (merge/squash/rebase strategy)    ║
+║ github_ci_wait     ║ verified  ║ Poll CI checks until done or timeout       ║
+╚════════════════════╩═══════════╩═════════════════════════════════════════════╝
+```
+
+### Input Schemas
+
+```
+github_pr_create
+  ├── title?        string    PR title (auto-generated from commits if omitted)
+  ├── body?         string    PR description
+  ├── base?         string    Base branch (default: repo default)
+  ├── head?         string    Head branch (default: current)
+  └── draft?        boolean   Create as draft (default: false)
+
+github_pr_status
+  └── pr_number     number    (required) Pull request number
+
+github_pr_review
+  ├── pr_number     number    (required) Pull request number
+  ├── action        string    (required) "read" | "post"
+  ├── body?         string    Review body (required for REQUEST_CHANGES)
+  └── event?        string    "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
+
+github_pr_merge
+  ├── pr_number     number    (required) Pull request number
+  ├── strategy?     string    "merge" | "squash" | "rebase" (default: "merge")
+  └── delete_branch? boolean  Delete head branch after merge (default: false)
+
+github_ci_wait
+  ├── pr_number     number    (required) Pull request number
+  ├── timeout_ms?   number    Max wait (default: 600000, max: 1800000)
+  ├── poll_interval_ms? number  Poll interval (default: 10000, min: 5000)
+  └── fail_fast?    boolean   Stop on first failure (default: false)
+```
+
+---
+
+## Error Handling
+
+All tool errors return structured `{ code, error }` objects — never throw.
+
+```
+╔══════════════╦═══════════════════════════════╦═══════════╦═══════════════════════╗
+║ Code         ║ Meaning                       ║ Retryable ║ Agent action          ║
+╠══════════════╬═══════════════════════════════╬═══════════╬═══════════════════════╣
+║ VALIDATION   ║ Bad argument or precondition  ║ No        ║ Fix args and retry    ║
+║ NOT_FOUND    ║ PR or resource doesn't exist  ║ No        ║ Check PR number       ║
+║ PERMISSION   ║ Insufficient gh permissions   ║ No        ║ Check gh auth status  ║
+║ CONFLICT     ║ PR exists / merge conflict    ║ No        ║ Resolve conflicts     ║
+║ RATE_LIMIT   ║ GitHub API rate limit         ║ Yes       ║ Wait and retry        ║
+║ EXTERNAL     ║ CLI or network failure        ║ No        ║ Check connectivity    ║
+╚══════════════╩═══════════════════════════════╩═══════════╩═══════════════════════╝
+
+Error mapping pipeline:
+  gh stderr → parseGhError() → KoiError → mapErrorResult() → { code, error }
+```
+
+---
+
+## Usage
+
+### With Full L1 Runtime (createKoi)
+
+```typescript
+import { createGhExecutor, createGithubProvider } from "@koi/tools-github";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+
+// 1. Create executor (validates gh is installed)
+const executor = await createGhExecutor({ cwd: "/path/to/repo" });
+
+// 2. Create component provider
+const provider = createGithubProvider({ executor });
+
+// 3. Assemble runtime — tools are attached via ECS
+const runtime = await createKoi({
+  manifest: {
+    name: "pr-bot",
+    version: "1.0.0",
+    model: { name: "anthropic:claude-sonnet" },
+  },
+  adapter,
+  providers: [provider],
+});
+
+// 4. Tools are now discoverable
+runtime.agent.has(toolToken("github_pr_status")); // true
+runtime.agent.has(toolToken("github_pr_merge"));  // true
+
+// 5. Run — LLM discovers and calls tools through middleware chain
+for await (const event of runtime.run({ kind: "text", text: "Check PR #42" })) {
+  // tool_call_start, tool_call_end, text_delta, done...
+}
+```
+
+### Standalone Tool Usage
+
+```typescript
+import { createGhExecutor, createGithubPrStatusTool } from "@koi/tools-github";
+
+const executor = await createGhExecutor();
+const tool = createGithubPrStatusTool(executor, "github", "verified");
+
+const result = await tool.execute({ pr_number: 42 });
+// → { state: "OPEN", reviewDecision: "APPROVED", ... }
+```
+
+### Custom Operation Subset
+
+```typescript
+const provider = createGithubProvider({
+  executor,
+  operations: ["pr_status", "ci_wait"],  // read-only tools only
+  prefix: "gh",                            // → gh_pr_status, gh_ci_wait
+  trustTier: "promoted",                   // override default trust
+});
+```
+
+### Mock Executor for Tests
+
+```typescript
+import {
+  createMockGhExecutor,
+  mockSuccess,
+  mockError,
+} from "@koi/tools-github";
+
+const executor = createMockGhExecutor([
+  mockSuccess({ state: "OPEN", reviewDecision: "APPROVED" }),
+  mockError("RATE_LIMIT", "API rate limit exceeded"),
+]);
+
+// First call returns success, second returns rate limit error
+```
+
+---
+
+## Testing
+
+### Test Structure
+
+```
+packages/tools-github/src/
+  tools/
+    pr-create.test.ts            Happy path, validation errors, executor errors
+    pr-status.test.ts            Happy path, validation, JSON parse errors
+    pr-review.test.ts            Read + post actions, REQUEST_CHANGES body check
+    pr-merge.test.ts             Pre-validation, draft PR, merge conflicts
+    ci-wait.test.ts              Polling, timeout, fail_fast, abort signal
+  parse-gh-error.test.ts         stderr → KoiError mapping (all 6 codes)
+  __tests__/
+    github-component-provider.test.ts  Provider attach, operation subset, prefix
+    e2e-full-stack.test.ts             CI-safe: scripted model through full L1
+    e2e-real-llm.test.ts               Real Anthropic API through full L1
+```
+
+### Test Tiers
+
+```
+Tier 1: Unit tests (always run in CI)
+═══════════════════════════════════════
+  93 tests across 8 files
+  ● Per-tool: happy path + validation errors + executor errors
+  ● Error mapping: stderr patterns → KoiError codes
+  ● Provider: ECS attachment, operation filtering, prefix override
+
+Tier 2: CI-safe E2E (always run in CI, no API key)
+═══════════════════════════════════════════════════
+  9 tests in e2e-full-stack.test.ts
+  ● Scripted model call → deterministic tool calls
+  ● Full pipeline: createKoi → middleware → tool execute → event stream
+  ● Error paths: RATE_LIMIT, NOT_FOUND, PERMISSION flow through chain
+  ● Multi-tool: status → merge with pre-validation
+
+Tier 3: Real LLM E2E (opt-in, needs ANTHROPIC_API_KEY)
+═══════════════════════════════════════════════════════
+  8 tests in e2e-real-llm.test.ts
+  ● Real Claude Haiku calls with tool schemas
+  ● LLM discovers tools, calls correct tool, uses results
+  ● Multi-tool reasoning: status → merge decision
+  ● Middleware wrapToolCall fires for real LLM calls
+
+  Run: E2E_TESTS=1 bun --env-file=.env test e2e-real-llm
+```
+
+### Coverage
+
+110 tests total, 0 failures. Unit + CI-safe E2E run on every build. Real LLM tests gated behind `E2E_TESTS=1`.
+
+```bash
+# Unit + CI-safe E2E (default)
+bun --cwd packages/tools-github test
+
+# Everything including real LLM
+E2E_TESTS=1 bun --env-file=.env --cwd packages/tools-github test
+
+# Full pipeline (build + typecheck + lint + test)
+bun turbo run build typecheck lint test --filter=@koi/tools-github
+```
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `GhExecutor` interface (not direct `Bun.spawn`) | Enables mock injection in tests; same interface for real CLI and test doubles |
+| ComponentProvider pattern | Tools attach via ECS — any engine adapter discovers them with zero engine changes |
+| Trust tiers: reads verified, writes promoted | Reads are safe to auto-approve; writes (create, review, merge) need explicit permission |
+| Pre-validation in `pr_merge` | Checks draft status, CI, merge conflicts BEFORE attempting merge — avoids partial failures |
+| `parseGhError` maps stderr patterns | Structured `KoiError` codes enable LLM-driven error handling ("rate limited → wait and retry") |
+| No external dependencies | `gh` CLI is the only external dependency; zero npm packages beyond `@koi/core` |
+| `GITHUB_SYSTEM_PROMPT` exported | Agents can include PR lifecycle best practices in their system prompt |
+| Configurable prefix and operation subset | Same provider works for `github_*`, `gh_*`, or read-only subsets |
+| CI-safe E2E via scripted model | Validates full assembly pipeline without API keys — catches integration regressions in CI |
+| Sequential mock executor (queue) | Deterministic test ordering; routing executor for non-deterministic LLM tests |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    Tool, ToolDescriptor, ComponentProvider,            │
+    KoiError, Result, JsonObject, TrustTier,            │
+    toolToken, agentId                                  │
+                                                        │
+                                                        ▼
+L2  @koi/tools-github ◄────────────────────────────────┘
+    imports from L0 only (runtime)
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ GhExecutor is a plain interface (no vendor types)
+    ✓ All interface properties readonly
+    ✓ Tool execute returns Result-shaped objects (never throws)
+    ✓ Engine adapter agnostic (works with loop, Pi, LangGraph)
+
+Dev-only imports (test files only):
+    @koi/engine      — createKoi (E2E assembly)
+    @koi/engine-loop — createLoopAdapter (scripted model)
+```

--- a/packages/tools-github/package.json
+++ b/packages/tools-github/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/tools-github",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-loop": "workspace:*"
+  }
+}

--- a/packages/tools-github/src/__tests__/e2e-full-stack.test.ts
+++ b/packages/tools-github/src/__tests__/e2e-full-stack.test.ts
@@ -1,0 +1,397 @@
+/**
+ * CI-safe end-to-end tests for @koi/tools-github through the full L1 runtime.
+ *
+ * Uses a scripted model call (queue of ModelResponse objects) so no API key
+ * is needed — runs in every CI build.
+ *
+ * Validates:
+ * 1. All 5 GitHub tools are discoverable through ECS assembly
+ * 2. Scripted tool calls flow through the middleware chain
+ * 3. Error paths (RATE_LIMIT, NOT_FOUND, PERMISSION) flow back to the model
+ * 4. Multi-tool scripted sequences work end-to-end
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  EngineEvent,
+  EngineOutput,
+  JsonObject,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  ToolDescriptor,
+  ToolHandler,
+  ToolRequest,
+  TurnContext,
+} from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import type { GhExecutor } from "../gh-executor.js";
+import { createGithubProvider } from "../github-component-provider.js";
+import { createMockGhExecutor, mockError, mockSuccess, mockSuccessRaw } from "../test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Scripted model helpers (same pattern as code-mode e2e-full-stack)
+// ---------------------------------------------------------------------------
+
+function createScriptedModelCall(
+  script: readonly ModelResponse[],
+): (request: ModelRequest) => Promise<ModelResponse> {
+  /* let justified: mutable turn counter for scripted sequence */
+  let callIndex = 0;
+  return async (_request: ModelRequest): Promise<ModelResponse> => {
+    const response = script[callIndex];
+    if (response === undefined) {
+      return { content: "Script exhausted", model: "scripted" };
+    }
+    callIndex++;
+    return response;
+  };
+}
+
+function toolCallResponse(toolName: string, input: JsonObject, callId?: string): ModelResponse {
+  return {
+    content: "",
+    model: "scripted",
+    metadata: {
+      toolCalls: [
+        {
+          toolName,
+          callId: callId ?? `call-${toolName}-${Date.now()}`,
+          input,
+        },
+      ],
+    },
+  };
+}
+
+function textResponse(text: string): ModelResponse {
+  return { content: text, model: "scripted" };
+}
+
+// ---------------------------------------------------------------------------
+// Event collection helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function findToolCallEnds(
+  events: readonly EngineEvent[],
+): readonly (EngineEvent & { readonly kind: "tool_call_end" })[] {
+  return events.filter(
+    (e): e is EngineEvent & { readonly kind: "tool_call_end" } => e.kind === "tool_call_end",
+  );
+}
+
+/** Parse the result from a tool_call_end event (may be stringified JSON or object). */
+function parseToolResult(
+  event: (EngineEvent & { readonly kind: "tool_call_end" }) | undefined,
+): unknown {
+  if (event === undefined) return undefined;
+  return typeof event.result === "string" ? JSON.parse(event.result) : event.result;
+}
+
+// ---------------------------------------------------------------------------
+// Mock runtime factory
+// ---------------------------------------------------------------------------
+
+async function createMockRuntime(
+  executor: GhExecutor,
+  script: readonly ModelResponse[],
+  middleware?: readonly KoiMiddleware[],
+): Promise<Awaited<ReturnType<typeof createKoi>>> {
+  const provider = createGithubProvider({ executor });
+  const modelCall = createScriptedModelCall(script);
+  const adapter = createLoopAdapter({ modelCall, maxTurns: 10 });
+
+  const runtime = await createKoi({
+    manifest: { name: "gh-e2e-mock", version: "1.0.0", model: { name: "scripted" } },
+    adapter,
+    providers: [provider],
+    middleware: middleware !== undefined ? [...middleware] : [],
+    // Scripted model cannot loop — disable to avoid false positives
+    loopDetection: false,
+  });
+
+  return runtime;
+}
+
+// ---------------------------------------------------------------------------
+// Canned response data
+// ---------------------------------------------------------------------------
+
+const CANNED_PR_STATUS = {
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "APPROVED",
+  statusCheckRollup: [{ name: "CI", status: "COMPLETED", conclusion: "SUCCESS" }],
+  headRefName: "feat/awesome",
+  baseRefName: "main",
+  title: "Add awesome feature",
+  additions: 42,
+  deletions: 7,
+  changedFiles: 3,
+};
+
+const CANNED_PR_CREATE = {
+  number: 99,
+  url: "https://github.com/test/repo/pull/99",
+  headRefName: "feat/new-feature",
+};
+
+// ---------------------------------------------------------------------------
+// Group 1: Assembly & Discovery
+// ---------------------------------------------------------------------------
+
+describe("e2e: CI-safe full-stack — tools-github through createKoi + createLoopAdapter", () => {
+  test("all 5 GitHub tools are discoverable through ECS assembly", async () => {
+    const executor = createMockGhExecutor([]);
+    const runtime = await createMockRuntime(executor, [textResponse("OK")]);
+
+    expect(runtime.agent.has(toolToken("github_pr_create"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_status"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_review"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_merge"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_ci_wait"))).toBe(true);
+
+    const tools = runtime.agent.query<{ readonly descriptor: ToolDescriptor }>("tool:");
+    const names = [...tools.values()].map((t) => t.descriptor.name);
+    expect(names).toContain("github_pr_status");
+    expect(names).toContain("github_pr_create");
+    expect(names).toContain("github_pr_review");
+    expect(names).toContain("github_pr_merge");
+    expect(names).toContain("github_ci_wait");
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("scripted model calls github_pr_status and receives structured result", async () => {
+    const executor = createMockGhExecutor([mockSuccess(CANNED_PR_STATUS)]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 42 }),
+      textResponse("Got the PR status"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR #42 status" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("state", "OPEN");
+    expect(result).toHaveProperty("title", "Add awesome feature");
+    expect(result).toHaveProperty("reviewDecision", "APPROVED");
+
+    expect(executor.calls.length).toBe(1);
+    expect(executor.calls[0]?.args[0]).toBe("pr");
+    expect(executor.calls[0]?.args[1]).toBe("view");
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("scripted model calls github_pr_create and receives PR number", async () => {
+    const executor = createMockGhExecutor([mockSuccess(CANNED_PR_CREATE)]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_create", {
+        title: "Add login",
+        body: "Implements OAuth",
+      }),
+      textResponse("PR created"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Create a PR" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("number", 99);
+    expect(result).toHaveProperty("url", expect.stringContaining("pull/99"));
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("middleware wrapToolCall intercepts scripted GitHub tool calls", async () => {
+    /* let justified: mutable spy array collecting tool IDs during wrapToolCall */
+    const observedToolIds: string[] = [];
+
+    const observerMiddleware: KoiMiddleware = {
+      name: "tool-call-observer",
+      wrapToolCall: async (_ctx: TurnContext, request: ToolRequest, next: ToolHandler) => {
+        observedToolIds.push(request.toolId);
+        return next(request);
+      },
+    };
+
+    const executor = createMockGhExecutor([mockSuccess(CANNED_PR_STATUS)]);
+    const runtime = await createMockRuntime(
+      executor,
+      [toolCallResponse("github_pr_status", { pr_number: 10 }), textResponse("Done")],
+      [observerMiddleware],
+    );
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    expect(observedToolIds.length).toBeGreaterThanOrEqual(1);
+    expect(observedToolIds).toContain("github_pr_status");
+
+    await runtime.dispose();
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: Error Paths
+// ---------------------------------------------------------------------------
+
+describe("e2e: error paths — tools-github through full pipeline", () => {
+  test("RATE_LIMIT error flows through middleware chain as tool result", async () => {
+    const executor = createMockGhExecutor([mockError("RATE_LIMIT", "API rate limit exceeded")]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 42 }),
+      textResponse("Got rate limit error"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("code", "RATE_LIMIT");
+    expect(result).toHaveProperty("error", expect.stringContaining("rate limit"));
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("NOT_FOUND error flows through middleware chain as tool result", async () => {
+    const executor = createMockGhExecutor([mockError("NOT_FOUND", "Pull request not found")]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 9999 }),
+      textResponse("PR not found"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR" }));
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("code", "NOT_FOUND");
+    expect(result).toHaveProperty("error", expect.stringContaining("not found"));
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("PERMISSION error flows through middleware chain as tool result", async () => {
+    const executor = createMockGhExecutor([
+      mockError("PERMISSION", "Resource not accessible by integration"),
+    ]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 42 }),
+      textResponse("Permission denied"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR" }));
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("code", "PERMISSION");
+    expect(result).toHaveProperty("error", expect.stringContaining("not accessible"));
+
+    await runtime.dispose();
+  }, 30_000);
+
+  test("tool execution error is captured in tool_call_end event result", async () => {
+    const executor = createMockGhExecutor([mockError("EXTERNAL", "gh CLI network timeout")]);
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 1 }),
+      textResponse("Error noted"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check PR" }));
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(1);
+
+    const result = parseToolResult(toolEnds[0]);
+    expect(result).toHaveProperty("code", "EXTERNAL");
+    expect(result).toHaveProperty("error", expect.stringContaining("network timeout"));
+
+    await runtime.dispose();
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Group 3: Multi-tool Scripted Sequence
+// ---------------------------------------------------------------------------
+
+describe("e2e: multi-tool scripted sequence — tools-github", () => {
+  test("scripted status → merge flows through full pipeline", async () => {
+    // Provide all 3 executor calls: (1) status, (2) merge pre-validation, (3) merge
+    const executor = createMockGhExecutor([
+      mockSuccess(CANNED_PR_STATUS), // for github_pr_status
+      mockSuccess(CANNED_PR_STATUS), // for github_pr_merge pre-validation (pr view)
+      mockSuccessRaw("merged"), // for github_pr_merge actual merge
+    ]);
+
+    const runtime = await createMockRuntime(executor, [
+      toolCallResponse("github_pr_status", { pr_number: 42 }),
+      toolCallResponse("github_pr_merge", { pr_number: 42 }),
+      textResponse("Status checked and PR merged"),
+    ]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Check then merge" }));
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBe(2);
+
+    const statusResult = parseToolResult(toolEnds[0]);
+    expect(statusResult).toHaveProperty("state", "OPEN");
+
+    const mergeResult = parseToolResult(toolEnds[1]);
+    expect(mergeResult).toHaveProperty("merged", true);
+
+    // Verify all 3 executor calls happened
+    expect(executor.calls.length).toBe(3);
+    expect(executor.calls[0]?.args.slice(0, 2)).toEqual(["pr", "view"]); // status
+    expect(executor.calls[1]?.args.slice(0, 2)).toEqual(["pr", "view"]); // merge pre-validation
+    expect(executor.calls[2]?.args.slice(0, 2)).toEqual(["pr", "merge"]); // actual merge
+
+    await runtime.dispose();
+  }, 30_000);
+});

--- a/packages/tools-github/src/__tests__/e2e-real-llm.test.ts
+++ b/packages/tools-github/src/__tests__/e2e-real-llm.test.ts
@@ -1,0 +1,737 @@
+/**
+ * E2E test — @koi/tools-github through the full Koi runtime.
+ *
+ * Proves that:
+ *   1. Claude discovers all 5 GitHub tools from the agent entity
+ *   2. Claude calls tools with correct arguments
+ *   3. Tool results flow back through the middleware chain to the model
+ *   4. The model uses tool results in its response
+ *   5. Full lifecycle (session start → tool calls → session end) works
+ *
+ * Uses createMockGhExecutor so tools return canned responses instead of
+ * calling the real `gh` CLI — but the LLM call, tool discovery, middleware
+ * chain, and event pipeline are all real.
+ *
+ * Gated on ANTHROPIC_API_KEY + E2E_TESTS=1.
+ *
+ * Run: E2E_TESTS=1 bun --env-file=/Users/taofeng/koi/.env test e2e-real-llm
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  EngineEvent,
+  EngineOutput,
+  JsonObject,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  Tool,
+  ToolDescriptor,
+  ToolHandler,
+  ToolRequest,
+  TurnContext,
+} from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import type { GhExecuteOptions, GhExecutor } from "../gh-executor.js";
+import { createGithubProvider } from "../github-component-provider.js";
+import type { MockGhResponse } from "../test-helpers.js";
+import { mockSuccess, mockSuccessRaw } from "../test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Gate on API key + E2E_TESTS env var
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const HAIKU_MODEL_ID = "claude-haiku-4-5-20251001" as const;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeReal = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
+// Anthropic API types (tool calling)
+// ---------------------------------------------------------------------------
+
+interface AnthropicToolParam {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: JsonObject;
+}
+
+interface AnthropicTextBlock {
+  readonly type: "text";
+  readonly text: string;
+}
+
+interface AnthropicToolUseBlock {
+  readonly type: "tool_use";
+  readonly id: string;
+  readonly name: string;
+  readonly input: JsonObject;
+}
+
+type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+interface AnthropicToolResultBlock {
+  readonly type: "tool_result";
+  readonly tool_use_id: string;
+  readonly content: string;
+}
+
+type AnthropicMessageContent =
+  | string
+  | readonly (AnthropicContentBlock | AnthropicToolResultBlock)[];
+
+interface AnthropicMessage {
+  readonly role: "user" | "assistant";
+  readonly content: AnthropicMessageContent;
+}
+
+interface AnthropicApiResponse {
+  readonly id: string;
+  readonly model: string;
+  readonly content: readonly AnthropicContentBlock[];
+  readonly stop_reason: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
+  readonly usage: { readonly input_tokens: number; readonly output_tokens: number };
+}
+
+// ---------------------------------------------------------------------------
+// Custom modelCall that bridges to Anthropic API WITH tool schemas
+// ---------------------------------------------------------------------------
+
+function createAnthropicModelCall(
+  apiKey: string,
+  toolDescriptors: readonly ToolDescriptor[],
+): (request: ModelRequest) => Promise<ModelResponse> {
+  const tools: readonly AnthropicToolParam[] = toolDescriptors.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.inputSchema,
+  }));
+
+  return async (request: ModelRequest): Promise<ModelResponse> => {
+    const messages = mapMessagesToAnthropic(request.messages);
+
+    const body = {
+      model: HAIKU_MODEL_ID,
+      max_tokens: 4096,
+      messages,
+      tools,
+    };
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(`Anthropic API ${response.status}: ${errorText}`);
+    }
+
+    const json = (await response.json()) as AnthropicApiResponse;
+    return mapAnthropicToModelResponse(json);
+  };
+}
+
+/**
+ * Convert Koi InboundMessage[] to Anthropic message format.
+ *
+ * Handles three cases:
+ * - User messages (senderId !== "assistant" and !== "tool")
+ * - Assistant messages (may contain tool_use metadata)
+ * - Tool result messages (senderId === "tool", has callId in metadata)
+ */
+function mapMessagesToAnthropic(
+  messages: readonly {
+    readonly content: readonly { readonly kind: string; readonly text?: string }[];
+    readonly senderId?: string;
+    readonly metadata?: JsonObject;
+  }[],
+): readonly AnthropicMessage[] {
+  const result: AnthropicMessage[] = [];
+
+  for (const msg of messages) {
+    const text = msg.content
+      .filter((b) => b.kind === "text" && typeof b.text === "string")
+      .map((b) => b.text ?? "")
+      .join("");
+
+    if (msg.senderId === "tool") {
+      const callId = (msg.metadata?.callId as string) ?? "";
+      const toolResult: AnthropicToolResultBlock = {
+        type: "tool_result",
+        tool_use_id: callId,
+        content: text,
+      };
+
+      const last = result[result.length - 1];
+      if (last !== undefined && last.role === "user" && Array.isArray(last.content)) {
+        result[result.length - 1] = {
+          role: "user",
+          content: [...(last.content as readonly AnthropicToolResultBlock[]), toolResult],
+        };
+      } else {
+        result.push({ role: "user", content: [toolResult] });
+      }
+    } else if (msg.senderId === "assistant") {
+      const toolCalls = msg.metadata?.toolCalls as
+        | readonly {
+            readonly toolName: string;
+            readonly callId: string;
+            readonly input: JsonObject;
+          }[]
+        | undefined;
+
+      if (toolCalls !== undefined && toolCalls.length > 0) {
+        const content: AnthropicContentBlock[] = [];
+        if (text.length > 0) {
+          content.push({ type: "text", text });
+        }
+        for (const tc of toolCalls) {
+          content.push({
+            type: "tool_use",
+            id: tc.callId,
+            name: tc.toolName,
+            input: tc.input,
+          });
+        }
+        result.push({ role: "assistant", content });
+      } else {
+        result.push({ role: "assistant", content: text });
+      }
+    } else {
+      result.push({ role: "user", content: text });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert Anthropic API response to Koi ModelResponse.
+ * Extracts tool_use blocks into metadata.toolCalls.
+ */
+function mapAnthropicToModelResponse(response: AnthropicApiResponse): ModelResponse {
+  const textParts: string[] = [];
+  const toolCalls: JsonObject[] = [];
+
+  for (const block of response.content) {
+    if (block.type === "text") {
+      textParts.push(block.text);
+    } else if (block.type === "tool_use") {
+      toolCalls.push({
+        toolName: block.name,
+        callId: block.id,
+        input: block.input,
+      } satisfies JsonObject);
+    }
+  }
+
+  const metadata: JsonObject | undefined = toolCalls.length > 0 ? { toolCalls } : undefined;
+
+  return {
+    content: textParts.join(""),
+    model: response.model,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+    },
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Routing mock executor — dispatches on gh subcommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a routing mock executor that returns canned responses based on
+ * the `gh` subcommand pattern in args. This handles LLM non-determinism
+ * (tools may be called in any order).
+ */
+function createRoutingMockExecutor(
+  routes: ReadonlyMap<string, MockGhResponse>,
+  fallback?: MockGhResponse,
+): GhExecutor & {
+  readonly calls: ReadonlyArray<{
+    readonly args: readonly string[];
+    readonly options: GhExecuteOptions | undefined;
+  }>;
+} {
+  const calls: Array<{
+    readonly args: readonly string[];
+    readonly options: GhExecuteOptions | undefined;
+  }> = [];
+
+  return {
+    calls,
+    execute: async (args: readonly string[], options?: GhExecuteOptions) => {
+      calls.push({ args, options });
+
+      // Build a route key from the first 2-3 args (e.g. "pr view", "pr create", "pr merge")
+      const key = args.slice(0, 2).join(" ");
+
+      const route = routes.get(key);
+      if (route !== undefined) {
+        return route.result;
+      }
+
+      if (fallback !== undefined) {
+        return fallback.result;
+      }
+
+      return {
+        ok: false as const,
+        error: {
+          code: "EXTERNAL" as const,
+          message: `Routing mock: no route for "${key}" (args: ${JSON.stringify(args)})`,
+          retryable: false,
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event collection helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function findToolCallEnds(
+  events: readonly EngineEvent[],
+): readonly (EngineEvent & { readonly kind: "tool_call_end" })[] {
+  return events.filter(
+    (e): e is EngineEvent & { readonly kind: "tool_call_end" } => e.kind === "tool_call_end",
+  );
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// Two-phase assembly factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a runtime with a real Anthropic model call that includes tool schemas.
+ *
+ * Phase 1 (Discovery): Assemble a throwaway createKoi runtime with a noop
+ *   model call to discover tool descriptors from the agent entity.
+ * Phase 2 (Real): Create a real createAnthropicModelCall with those tool
+ *   schemas, wire through createLoopAdapter, and run the full pipeline.
+ */
+async function createRealLLMRuntime(
+  executor: GhExecutor,
+  maxTurns: number,
+  middleware?: readonly KoiMiddleware[],
+): Promise<{
+  readonly runtime: Awaited<ReturnType<typeof createKoi>>;
+}> {
+  const provider = createGithubProvider({ executor });
+
+  // Phase 1: Assemble to discover tool descriptors
+  const discoveryAdapter = createLoopAdapter({
+    modelCall: async () => ({ content: "noop", model: "discovery" }),
+    maxTurns: 1,
+  });
+
+  const discoveryRuntime = await createKoi({
+    manifest: { name: "discovery", version: "0.0.0", model: { name: "discovery" } },
+    adapter: discoveryAdapter,
+    providers: [provider],
+    loopDetection: false,
+  });
+
+  // Extract tool descriptors using the typed query accessor
+  const toolDescriptors: ToolDescriptor[] = [];
+  for (const tool of discoveryRuntime.agent.query<Tool>("tool:").values()) {
+    toolDescriptors.push(tool.descriptor);
+  }
+
+  await discoveryRuntime.dispose();
+
+  // Phase 2: Create real runtime with tool-aware model call
+  const modelCall = createAnthropicModelCall(ANTHROPIC_KEY, toolDescriptors);
+  const adapter = createLoopAdapter({ modelCall, maxTurns });
+
+  // Re-create the provider since the executor is stateless across runtimes
+  const realProvider = createGithubProvider({ executor });
+
+  const runtime = await createKoi({
+    manifest: { name: "github-e2e", version: "1.0.0", model: { name: "claude-haiku" } },
+    adapter,
+    providers: [realProvider],
+    middleware: middleware !== undefined ? [...middleware] : [],
+    loopDetection: false,
+  });
+
+  return { runtime };
+}
+
+// ---------------------------------------------------------------------------
+// Canned response data
+// ---------------------------------------------------------------------------
+
+const CANNED_PR_STATUS = {
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "APPROVED",
+  statusCheckRollup: [
+    { name: "CI", status: "COMPLETED", conclusion: "SUCCESS" },
+    { name: "Lint", status: "COMPLETED", conclusion: "SUCCESS" },
+  ],
+  headRefName: "feat/awesome",
+  baseRefName: "main",
+  title: "Add awesome feature",
+  additions: 42,
+  deletions: 7,
+  changedFiles: 3,
+};
+
+const CANNED_PR_CREATE = {
+  number: 123,
+  url: "https://github.com/test/repo/pull/123",
+  headRefName: "feat/new-feature",
+};
+
+const CANNED_PR_REVIEW_READ = {
+  reviews: [{ author: { login: "reviewer1" }, state: "APPROVED", body: "LGTM!" }],
+  latestReviews: [{ author: { login: "reviewer1" }, state: "APPROVED", body: "LGTM!" }],
+  reviewDecision: "APPROVED",
+};
+
+const CANNED_DRAFT_PR_STATUS = {
+  state: "OPEN",
+  isDraft: true,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "BLOCKED",
+  reviewDecision: "",
+  statusCheckRollup: [],
+  headRefName: "feat/wip",
+  baseRefName: "main",
+  title: "WIP: Draft feature",
+  additions: 10,
+  deletions: 0,
+  changedFiles: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeReal("e2e: real Anthropic LLM — @koi/tools-github through full Koi runtime", () => {
+  // ── Test 1: Tool discovery ─────────────────────────────────────────────
+
+  test("tool discovery: all 5 GitHub tools are registered on the agent", async () => {
+    const executor = createRoutingMockExecutor(new Map());
+    const { runtime } = await createRealLLMRuntime(executor, 1);
+
+    expect(runtime.agent.has(toolToken("github_pr_create"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_status"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_review"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_pr_merge"))).toBe(true);
+    expect(runtime.agent.has(toolToken("github_ci_wait"))).toBe(true);
+
+    await runtime.dispose();
+  }, 30_000);
+
+  // ── Test 2: LLM calls github_pr_status ─────────────────────────────────
+
+  test("LLM calls github_pr_status to check a PR", async () => {
+    const routes = new Map<string, MockGhResponse>([["pr view", mockSuccess(CANNED_PR_STATUS)]]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          "Use the github_pr_status tool to check the status of PR #42.",
+          "Report the title, state, and review decision from the result.",
+          "Do NOT explain your reasoning, just call the tool and report.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+    // Verify the executor was called with pr view args
+    expect(executor.calls.length).toBeGreaterThanOrEqual(1);
+    const prViewCall = executor.calls.find((c) => c.args[0] === "pr" && c.args[1] === "view");
+    expect(prViewCall).toBeDefined();
+
+    // Response should reference the canned data
+    const text = extractText(events);
+    const lower = text.toLowerCase();
+    expect(
+      lower.includes("awesome") ||
+        lower.includes("open") ||
+        lower.includes("approved") ||
+        lower.includes("42"),
+    ).toBe(true);
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 3: LLM calls github_pr_create ─────────────────────────────────
+
+  test("LLM calls github_pr_create to create a PR", async () => {
+    const routes = new Map<string, MockGhResponse>([["pr create", mockSuccess(CANNED_PR_CREATE)]]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          'Use the github_pr_create tool to create a PR with title "Add login feature" and body "Implements OAuth login".',
+          "Report the PR number and URL from the result.",
+          "Do NOT explain your reasoning, just call the tool and report.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+    // Verify executor was called with pr create args
+    const prCreateCall = executor.calls.find((c) => c.args[0] === "pr" && c.args[1] === "create");
+    expect(prCreateCall).toBeDefined();
+
+    // Response should reference the canned PR number or URL
+    const text = extractText(events);
+    expect(text.includes("123") || text.includes("pull/123")).toBe(true);
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 4: LLM calls github_pr_review ─────────────────────────────────
+
+  test("LLM calls github_pr_review to read reviews", async () => {
+    const routes = new Map<string, MockGhResponse>([
+      ["pr view", mockSuccess(CANNED_PR_REVIEW_READ)],
+    ]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          'Use the github_pr_review tool with action="read" to read reviews on PR #42.',
+          "Report the review decision and reviewer names.",
+          "Do NOT explain your reasoning, just call the tool and report.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+    const text = extractText(events);
+    const lower = text.toLowerCase();
+    expect(
+      lower.includes("approved") || lower.includes("reviewer1") || lower.includes("lgtm"),
+    ).toBe(true);
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 5: LLM calls github_pr_merge and gets pre-validation error ────
+
+  test("LLM calls github_pr_merge and gets pre-validation error for draft PR", async () => {
+    // pr_merge pre-validates by calling pr view first, which returns a draft PR
+    const routes = new Map<string, MockGhResponse>([
+      ["pr view", mockSuccess(CANNED_DRAFT_PR_STATUS)],
+    ]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          "Use the github_pr_merge tool to merge PR #42.",
+          "Report what happened — whether it succeeded or failed and why.",
+          "Do NOT explain your reasoning, just call the tool and report.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+    // The tool should have returned an error about draft PR
+    const text = extractText(events);
+    const lower = text.toLowerCase();
+    expect(
+      lower.includes("draft") ||
+        lower.includes("cannot") ||
+        lower.includes("error") ||
+        lower.includes("fail"),
+    ).toBe(true);
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 6: LLM calls github_ci_wait and gets immediate success ────────
+
+  test("LLM calls github_ci_wait and gets immediate success for no checks", async () => {
+    // A PR with no statusCheckRollup returns success immediately
+    const prWithNoChecks = {
+      statusCheckRollup: [],
+    };
+    const routes = new Map<string, MockGhResponse>([["pr view", mockSuccess(prWithNoChecks)]]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          "Use the github_ci_wait tool to wait for CI checks on PR #42.",
+          "Report the final status.",
+          "Do NOT explain your reasoning, just call the tool and report.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+
+    const text = extractText(events);
+    const lower = text.toLowerCase();
+    expect(
+      lower.includes("success") ||
+        lower.includes("pass") ||
+        lower.includes("no checks") ||
+        lower.includes("complete"),
+    ).toBe(true);
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 7: Middleware wrapToolCall fires ───────────────────────────────
+
+  test("middleware wrapToolCall fires for GitHub tool calls", async () => {
+    const observedToolIds: string[] = [];
+
+    const observerMiddleware: KoiMiddleware = {
+      name: "tool-call-observer",
+      wrapToolCall: async (_ctx: TurnContext, request: ToolRequest, next: ToolHandler) => {
+        observedToolIds.push(request.toolId);
+        return next(request);
+      },
+    };
+
+    const routes = new Map<string, MockGhResponse>([["pr view", mockSuccess(CANNED_PR_STATUS)]]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 5, [observerMiddleware]);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools available.",
+          "Use the github_pr_status tool to check PR #10.",
+          "Report the result briefly. Do NOT explain, just call the tool.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    // Middleware must have intercepted the tool call
+    expect(observedToolIds.length).toBeGreaterThanOrEqual(1);
+    expect(observedToolIds).toContain("github_pr_status");
+
+    await runtime.dispose();
+  }, 120_000);
+
+  // ── Test 8: Multi-tool scenario ────────────────────────────────────────
+
+  test("LLM checks status then decides based on tool result", async () => {
+    const routes = new Map<string, MockGhResponse>([
+      ["pr view", mockSuccess(CANNED_PR_STATUS)],
+      ["pr merge", mockSuccessRaw("merged")],
+    ]);
+    const executor = createRoutingMockExecutor(routes);
+    const { runtime } = await createRealLLMRuntime(executor, 8);
+
+    const events = await collectEvents(
+      runtime.run({
+        kind: "text",
+        text: [
+          "You have GitHub tools: github_pr_status and github_pr_merge.",
+          "First, use github_pr_status to check PR #42.",
+          "Then use github_pr_merge to merge it.",
+          "Report the final result. Do NOT explain your reasoning.",
+        ].join("\n"),
+      }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+
+    const toolEnds = findToolCallEnds(events);
+    // Should have at least 2 tool calls (status + merge)
+    expect(toolEnds.length).toBeGreaterThanOrEqual(2);
+
+    // Verify both commands were called
+    const statusCall = executor.calls.find((c) => c.args[0] === "pr" && c.args[1] === "view");
+    const mergeCall = executor.calls.find((c) => c.args[0] === "pr" && c.args[1] === "merge");
+    expect(statusCall).toBeDefined();
+    expect(mergeCall).toBeDefined();
+
+    await runtime.dispose();
+  }, 120_000);
+});

--- a/packages/tools-github/src/__tests__/github-component-provider.test.ts
+++ b/packages/tools-github/src/__tests__/github-component-provider.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import type { Tool } from "@koi/core";
+import { createGithubProvider } from "../github-component-provider.js";
+import { createMockAgent, createMockGhExecutor } from "../test-helpers.js";
+
+describe("createGithubProvider", () => {
+  test("attaches all 5 tools by default", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    expect(components.size).toBe(5);
+    const keys = [...components.keys()];
+    expect(keys).toContain("tool:github_pr_create");
+    expect(keys).toContain("tool:github_pr_status");
+    expect(keys).toContain("tool:github_pr_review");
+    expect(keys).toContain("tool:github_pr_merge");
+    expect(keys).toContain("tool:github_ci_wait");
+  });
+
+  test("uses custom prefix", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor, prefix: "gh" });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    const keys = [...components.keys()];
+    expect(keys).toContain("tool:gh_pr_create");
+    expect(keys).toContain("tool:gh_pr_status");
+  });
+
+  test("assigns promoted trust tier to write operations", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    const prCreate = components.get("tool:github_pr_create") as Tool;
+    const prMerge = components.get("tool:github_pr_merge") as Tool;
+    const prReview = components.get("tool:github_pr_review") as Tool;
+    expect(prCreate.trustTier).toBe("promoted");
+    expect(prMerge.trustTier).toBe("promoted");
+    expect(prReview.trustTier).toBe("promoted");
+  });
+
+  test("assigns configured trust tier to read operations", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor, trustTier: "sandbox" });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    const prStatus = components.get("tool:github_pr_status") as Tool;
+    const ciWait = components.get("tool:github_ci_wait") as Tool;
+    expect(prStatus.trustTier).toBe("sandbox");
+    expect(ciWait.trustTier).toBe("sandbox");
+  });
+
+  test("defaults read trust tier to verified", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    const prStatus = components.get("tool:github_pr_status") as Tool;
+    expect(prStatus.trustTier).toBe("verified");
+  });
+
+  test("limits operations when specified", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({
+      executor,
+      operations: ["pr_create", "pr_status"],
+    });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    expect(components.size).toBe(2);
+    const keys = [...components.keys()];
+    expect(keys).toContain("tool:github_pr_create");
+    expect(keys).toContain("tool:github_pr_status");
+    expect(keys).not.toContain("tool:github_pr_merge");
+  });
+
+  test("provider has correct name", () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    expect(provider.name).toBe("github:github");
+  });
+
+  test("provider name reflects custom prefix", () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor, prefix: "gh" });
+    expect(provider.name).toBe("github:gh");
+  });
+
+  test("each tool has a valid descriptor", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = await provider.attach(agent);
+
+    for (const [_key, value] of components) {
+      const tool = value as Tool;
+      expect(tool.descriptor.name).toBeTruthy();
+      expect(tool.descriptor.description).toBeTruthy();
+      expect(tool.descriptor.inputSchema).toBeTruthy();
+      expect(typeof tool.execute).toBe("function");
+    }
+  });
+});

--- a/packages/tools-github/src/constants.ts
+++ b/packages/tools-github/src/constants.ts
@@ -1,0 +1,97 @@
+/**
+ * Constants for @koi/tools-github — tool names, operations, trust tiers, and system prompt.
+ */
+
+import type { TrustTier } from "@koi/core";
+
+/** All GitHub operation names. */
+export const OPERATIONS = ["pr_create", "pr_status", "pr_review", "pr_merge", "ci_wait"] as const;
+
+export type GithubOperation = (typeof OPERATIONS)[number];
+
+/** Default tool name prefix for GitHub tools. */
+export const DEFAULT_PREFIX = "github" as const;
+
+/** Write operations require promoted trust tier. */
+export const WRITE_OPERATIONS: readonly GithubOperation[] = [
+  "pr_create",
+  "pr_review",
+  "pr_merge",
+] as const;
+
+/** Read operations use the configured trust tier (default: verified). */
+export const READ_OPERATIONS: readonly GithubOperation[] = ["pr_status", "ci_wait"] as const;
+
+/** Resolve the trust tier for an operation — write ops are always promoted. */
+export function trustTierForOperation(op: GithubOperation, configTier: TrustTier): TrustTier {
+  return (WRITE_OPERATIONS as readonly string[]).includes(op) ? "promoted" : configTier;
+}
+
+/** Merge strategies for PR merge. */
+export const MERGE_STRATEGIES = ["merge", "squash", "rebase"] as const;
+export type MergeStrategy = (typeof MERGE_STRATEGIES)[number];
+
+/** Review event types for PR review. */
+export const REVIEW_EVENTS = ["APPROVE", "REQUEST_CHANGES", "COMMENT"] as const;
+export type ReviewEvent = (typeof REVIEW_EVENTS)[number];
+
+/** Review action types — read or post. */
+export const REVIEW_ACTIONS = ["post", "read"] as const;
+export type ReviewAction = (typeof REVIEW_ACTIONS)[number];
+
+/** Default CI wait configuration. */
+export const DEFAULT_CI_TIMEOUT_MS = 600_000;
+export const MAX_CI_TIMEOUT_MS = 1_800_000;
+export const DEFAULT_CI_POLL_INTERVAL_MS = 10_000;
+export const MIN_CI_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * JSON fields requested per tool — minimal set to reduce spawn overhead.
+ */
+export const PR_CREATE_FIELDS = "number,url,headRefName" as const;
+export const PR_STATUS_FIELDS =
+  "state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,baseRefName,title,additions,deletions,changedFiles" as const;
+export const PR_REVIEW_READ_FIELDS = "reviews,latestReviews,reviewDecision" as const;
+export const CI_WAIT_FIELDS = "statusCheckRollup" as const;
+
+/**
+ * System prompt guidance for agents using GitHub tools.
+ *
+ * Include this in your agent's system prompt or koi.yaml `instructions` field
+ * to prime the agent with PR lifecycle best practices.
+ */
+export const GITHUB_SYSTEM_PROMPT: string = `
+## GitHub PR lifecycle — best practices
+
+When working with pull requests, follow this workflow:
+
+1. **Create PR** — use \`github_pr_create\` after pushing your branch.
+   Provide a clear title and body. Use \`--draft\` if the PR is not ready for review.
+
+2. **Check status** — use \`github_pr_status\` to inspect:
+   - CI check results (statusCheckRollup)
+   - Review decision (approved / changes_requested / review_required)
+   - Merge readiness (mergeable state)
+
+3. **Wait for CI** — use \`github_ci_wait\` to poll CI checks until completion.
+   Set \`fail_fast: true\` to stop on the first failing check.
+
+4. **Review** — use \`github_pr_review\` to read existing reviews or post a new one.
+   Always include a body when requesting changes.
+
+5. **Merge** — use \`github_pr_merge\` only when:
+   - All required checks pass
+   - Reviews are approved
+   - No merge conflicts
+
+## Error handling
+
+| Code        | Meaning                           | What to do                              |
+|-------------|-----------------------------------|-----------------------------------------|
+| VALIDATION  | Bad argument                      | Fix the argument and retry              |
+| NOT_FOUND   | PR or resource doesn't exist      | Check PR number, verify it exists       |
+| PERMISSION  | Insufficient permissions          | Check gh auth status                    |
+| CONFLICT    | PR already exists / merge conflict| Check existing PRs or resolve conflicts |
+| RATE_LIMIT  | GitHub API rate limit hit         | Wait and retry (retryable)              |
+| EXTERNAL    | CLI or network failure            | Check gh auth, network connectivity     |
+`.trim();

--- a/packages/tools-github/src/gh-executor.ts
+++ b/packages/tools-github/src/gh-executor.ts
@@ -1,0 +1,138 @@
+/**
+ * GhExecutor — interface + factory for running `gh` CLI commands.
+ *
+ * The interface enables mock injection in tests while the factory
+ * validates `gh` availability at construction time (fail fast).
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { parseGhError } from "./parse-gh-error.js";
+
+/** Options for a single `gh` invocation. */
+export interface GhExecuteOptions {
+  readonly cwd?: string;
+  readonly signal?: AbortSignal;
+}
+
+/** Injectable interface for executing `gh` CLI commands. */
+export interface GhExecutor {
+  readonly execute: (
+    args: readonly string[],
+    options?: GhExecuteOptions,
+  ) => Promise<Result<string, KoiError>>;
+}
+
+/** Configuration for the real GhExecutor. */
+export interface GhExecutorConfig {
+  readonly cwd?: string;
+}
+
+/**
+ * Create a real GhExecutor backed by Bun.spawn.
+ *
+ * Validates `gh --version` at creation time — throws if `gh` is not installed.
+ * Side-effect: spawns child processes for each execute() call.
+ */
+export async function createGhExecutor(config: GhExecutorConfig = {}): Promise<GhExecutor> {
+  // Validate gh availability at construction time
+  try {
+    const check = Bun.spawn(["gh", "--version"], { stdout: "pipe", stderr: "pipe" });
+    const exitCode = await check.exited;
+    if (exitCode !== 0) {
+      throw new Error("gh exited with non-zero status");
+    }
+  } catch (e: unknown) {
+    throw new Error(
+      "GitHub CLI (gh) is not installed or not in PATH. Install it: https://cli.github.com",
+      { cause: e },
+    );
+  }
+
+  return {
+    execute: async (
+      args: readonly string[],
+      options?: GhExecuteOptions,
+    ): Promise<Result<string, KoiError>> => {
+      const cwd = options?.cwd ?? config.cwd;
+
+      let proc: {
+        readonly exited: Promise<number>;
+        readonly stdout: ReadableStream;
+        readonly stderr: ReadableStream;
+        readonly kill: () => void;
+      };
+
+      try {
+        const spawnOpts = {
+          stdout: "pipe" as const,
+          stderr: "pipe" as const,
+          ...(cwd !== undefined && { cwd }),
+        };
+        const spawned = Bun.spawn(["gh", ...args], spawnOpts);
+        proc = {
+          exited: spawned.exited,
+          stdout: spawned.stdout as ReadableStream,
+          stderr: spawned.stderr as ReadableStream,
+          kill: () => spawned.kill(),
+        };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: `Failed to spawn gh: ${e instanceof Error ? e.message : String(e)}`,
+            retryable: false,
+            cause: e,
+          },
+        };
+      }
+
+      // Handle abort signal
+      const signal = options?.signal;
+      if (signal) {
+        const onAbort = (): void => {
+          proc.kill();
+        };
+        if (signal.aborted) {
+          proc.kill();
+          return {
+            ok: false,
+            error: {
+              code: "TIMEOUT",
+              message: "Operation aborted",
+              retryable: false,
+            },
+          };
+        }
+        signal.addEventListener("abort", onAbort, { once: true });
+
+        const [exitCode, stdout, stderr] = await Promise.all([
+          proc.exited,
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+
+        // Clean up listener to prevent leaks when the signal is reused
+        signal.removeEventListener("abort", onAbort);
+
+        if (exitCode !== 0) {
+          return { ok: false, error: parseGhError(stderr, exitCode, args) };
+        }
+
+        return { ok: true, value: stdout.trim() };
+      }
+
+      const [exitCode, stdout, stderr] = await Promise.all([
+        proc.exited,
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+
+      if (exitCode !== 0) {
+        return { ok: false, error: parseGhError(stderr, exitCode, args) };
+      }
+
+      return { ok: true, value: stdout.trim() };
+    },
+  };
+}

--- a/packages/tools-github/src/github-component-provider.ts
+++ b/packages/tools-github/src/github-component-provider.ts
@@ -1,0 +1,59 @@
+/**
+ * GitHub ComponentProvider — attaches GitHub Tool components to an agent.
+ *
+ * Engines discover tools via `agent.query<Tool>("tool:")`.
+ * This provider creates Tool components from a GhExecutor, making them
+ * available to any engine with zero engine changes.
+ */
+
+import type { Agent, ComponentProvider, Tool, TrustTier } from "@koi/core";
+import { toolToken } from "@koi/core";
+import { type GithubOperation, OPERATIONS, trustTierForOperation } from "./constants.js";
+import type { GhExecutor } from "./gh-executor.js";
+import { createGithubCiWaitTool } from "./tools/ci-wait.js";
+import { createGithubPrCreateTool } from "./tools/pr-create.js";
+import { createGithubPrMergeTool } from "./tools/pr-merge.js";
+import { createGithubPrReviewTool } from "./tools/pr-review.js";
+import { createGithubPrStatusTool } from "./tools/pr-status.js";
+
+export interface GithubProviderConfig {
+  readonly executor: GhExecutor;
+  /** Default trust tier for read operations (default: "verified"). */
+  readonly trustTier?: TrustTier;
+  /** Tool name prefix (default: "github"). */
+  readonly prefix?: string;
+  /** Operations to include (default: all 5). */
+  readonly operations?: readonly GithubOperation[];
+}
+
+type ToolFactory = (executor: GhExecutor, prefix: string, trustTier: TrustTier) => Tool;
+
+const TOOL_FACTORIES: Readonly<Record<GithubOperation, ToolFactory>> = {
+  pr_create: createGithubPrCreateTool,
+  pr_status: createGithubPrStatusTool,
+  pr_review: createGithubPrReviewTool,
+  pr_merge: createGithubPrMergeTool,
+  ci_wait: createGithubCiWaitTool,
+};
+
+export function createGithubProvider(config: GithubProviderConfig): ComponentProvider {
+  const { executor, trustTier = "verified", prefix = "github", operations = OPERATIONS } = config;
+
+  return {
+    name: `github:${prefix}`,
+
+    attach: async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
+      const entries: ReadonlyMap<string, unknown> = new Map(
+        operations.map((op) => {
+          const tier = trustTierForOperation(op, trustTier);
+          const factory = TOOL_FACTORIES[op];
+          const tool = factory(executor, prefix, tier);
+          // SubsystemToken<T> extends string — safe to use as Map key directly
+          const key: string = toolToken(tool.descriptor.name);
+          return [key, tool] as const;
+        }),
+      );
+      return entries;
+    },
+  };
+}

--- a/packages/tools-github/src/index.ts
+++ b/packages/tools-github/src/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @koi/tools-github — GitHub CLI tools for PR lifecycle management (Layer 2)
+ *
+ * Provides a ComponentProvider that wraps a GhExecutor as Tool components.
+ * Engines discover these tools via `agent.query<Tool>("tool:")` with zero
+ * engine changes.
+ *
+ * 5 tools: pr_create, pr_status, pr_review, pr_merge, ci_wait.
+ *
+ * Depends on @koi/core only — never on L1 or peer L2 packages.
+ *
+ * Usage:
+ * ```ts
+ * import { createGithubProvider, createGhExecutor } from "@koi/tools-github";
+ *
+ * const executor = await createGhExecutor({ cwd: "/path/to/repo" });
+ * const provider = createGithubProvider({ executor });
+ * ```
+ */
+
+// constants
+export type { GithubOperation, MergeStrategy, ReviewAction, ReviewEvent } from "./constants.js";
+export {
+  DEFAULT_CI_POLL_INTERVAL_MS,
+  DEFAULT_CI_TIMEOUT_MS,
+  DEFAULT_PREFIX,
+  GITHUB_SYSTEM_PROMPT,
+  MAX_CI_TIMEOUT_MS,
+  MERGE_STRATEGIES,
+  MIN_CI_POLL_INTERVAL_MS,
+  OPERATIONS,
+  READ_OPERATIONS,
+  REVIEW_ACTIONS,
+  REVIEW_EVENTS,
+  WRITE_OPERATIONS,
+} from "./constants.js";
+// executor
+export type { GhExecuteOptions, GhExecutor, GhExecutorConfig } from "./gh-executor.js";
+export { createGhExecutor } from "./gh-executor.js";
+// provider
+export type { GithubProviderConfig } from "./github-component-provider.js";
+export { createGithubProvider } from "./github-component-provider.js";
+// error mapping
+export { isRecord, mapErrorResult, parseGhError, parseGhJson } from "./parse-gh-error.js";
+export type { MockGhResponse } from "./test-helpers.js";
+// test helpers
+export {
+  createMockAgent,
+  createMockGhExecutor,
+  mockError,
+  mockSuccess,
+  mockSuccessRaw,
+} from "./test-helpers.js";
+// tool factories — for advanced usage (custom tool composition)
+export { createGithubCiWaitTool } from "./tools/ci-wait.js";
+export { createGithubPrCreateTool } from "./tools/pr-create.js";
+export { createGithubPrMergeTool } from "./tools/pr-merge.js";
+export { createGithubPrReviewTool } from "./tools/pr-review.js";
+export { createGithubPrStatusTool } from "./tools/pr-status.js";

--- a/packages/tools-github/src/parse-args.ts
+++ b/packages/tools-github/src/parse-args.ts
@@ -1,0 +1,149 @@
+/**
+ * Argument parsing utilities for GitHub tool factories.
+ *
+ * Generic parsers copied from @koi/tool-browser (parse-args.ts).
+ * GitHub-specific parsers added for PR numbers and enum values.
+ */
+
+import type { JsonObject } from "@koi/core";
+
+interface ValidationError {
+  readonly error: string;
+  readonly code: "VALIDATION";
+}
+
+export type ParseResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly err: ValidationError };
+
+// ---------------------------------------------------------------------------
+// Generic parsers (from tool-browser)
+// ---------------------------------------------------------------------------
+
+export function parseString(args: JsonObject, key: string): ParseResult<string> {
+  const value = args[key];
+  if (typeof value !== "string" || value.length === 0) {
+    return { ok: false, err: { error: `${key} must be a non-empty string`, code: "VALIDATION" } };
+  }
+  return { ok: true, value };
+}
+
+export function parseOptionalString(
+  args: JsonObject,
+  key: string,
+): ParseResult<string | undefined> {
+  const value = args[key];
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value !== "string") {
+    return { ok: false, err: { error: `${key} must be a string`, code: "VALIDATION" } };
+  }
+  return { ok: true, value };
+}
+
+export function parseOptionalNumber(
+  args: JsonObject,
+  key: string,
+): ParseResult<number | undefined> {
+  const value = args[key];
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value !== "number") {
+    return { ok: false, err: { error: `${key} must be a number`, code: "VALIDATION" } };
+  }
+  return { ok: true, value };
+}
+
+export function parseOptionalBoolean(
+  args: JsonObject,
+  key: string,
+): ParseResult<boolean | undefined> {
+  const value = args[key];
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value !== "boolean") {
+    return { ok: false, err: { error: `${key} must be a boolean`, code: "VALIDATION" } };
+  }
+  return { ok: true, value };
+}
+
+/** Parse a timeout in ms, validating it falls within [minMs, maxMs]. */
+export function parseOptionalTimeout(
+  args: JsonObject,
+  key: string,
+  minMs: number,
+  maxMs: number,
+): ParseResult<number | undefined> {
+  const value = args[key];
+  if (value === undefined) return { ok: true, value: undefined };
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return { ok: false, err: { error: `${key} must be a number`, code: "VALIDATION" } };
+  }
+  if (value < minMs || value > maxMs) {
+    return {
+      ok: false,
+      err: {
+        error: `${key} must be between ${minMs} and ${maxMs} ms`,
+        code: "VALIDATION",
+      },
+    };
+  }
+  return { ok: true, value };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub-specific parsers
+// ---------------------------------------------------------------------------
+
+/** Parse a required PR number (positive integer). */
+export function parsePrNumber(args: JsonObject, key: string): ParseResult<number> {
+  const value = args[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    return {
+      ok: false,
+      err: { error: `${key} must be a positive integer`, code: "VALIDATION" },
+    };
+  }
+  return { ok: true, value };
+}
+
+/** Type guard that narrows `unknown` to a member of a string literal union. */
+function memberOf<T extends string>(set: readonly T[], value: unknown): value is T {
+  return (set as readonly unknown[]).includes(value);
+}
+
+/** Parse a required enum value from a known set. */
+export function parseEnum<T extends string>(
+  args: JsonObject,
+  key: string,
+  values: readonly T[],
+): ParseResult<T> {
+  const value = args[key];
+  if (!memberOf(values, value)) {
+    return {
+      ok: false,
+      err: {
+        error: `${key} must be one of: ${values.join(", ")}`,
+        code: "VALIDATION",
+      },
+    };
+  }
+  return { ok: true, value };
+}
+
+/** Parse an optional enum value from a known set. */
+export function parseOptionalEnum<T extends string>(
+  args: JsonObject,
+  key: string,
+  values: readonly T[],
+): ParseResult<T | undefined> {
+  const value = args[key];
+  if (value === undefined) return { ok: true, value: undefined };
+  if (!memberOf(values, value)) {
+    return {
+      ok: false,
+      err: {
+        error: `${key} must be one of: ${values.join(", ")}`,
+        code: "VALIDATION",
+      },
+    };
+  }
+  return { ok: true, value };
+}

--- a/packages/tools-github/src/parse-gh-error.test.ts
+++ b/packages/tools-github/src/parse-gh-error.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { parseGhError, parseGhJson } from "./parse-gh-error.js";
+
+describe("parseGhError", () => {
+  test("maps exit code 4 to PERMISSION", () => {
+    const error = parseGhError("insufficient scope", 4, ["pr", "create"]);
+    expect(error.code).toBe("PERMISSION");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("maps rate limit stderr to RATE_LIMIT", () => {
+    const error = parseGhError("API rate limit exceeded", 1, ["pr", "view"]);
+    expect(error.code).toBe("RATE_LIMIT");
+    expect(error.retryable).toBe(true);
+  });
+
+  test("maps not found stderr to NOT_FOUND", () => {
+    const error = parseGhError("Could not resolve to a PullRequest: not found", 1, [
+      "pr",
+      "view",
+      "999",
+    ]);
+    expect(error.code).toBe("NOT_FOUND");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("maps already exists stderr to CONFLICT", () => {
+    const error = parseGhError("a pull request already exists for branch feature/x", 1, [
+      "pr",
+      "create",
+    ]);
+    expect(error.code).toBe("CONFLICT");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("maps merge conflict stderr to CONFLICT", () => {
+    const error = parseGhError("merge conflict detected", 1, ["pr", "merge", "42"]);
+    expect(error.code).toBe("CONFLICT");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("maps not mergeable stderr to VALIDATION", () => {
+    const error = parseGhError("Pull request is not mergeable", 1, ["pr", "merge", "42"]);
+    expect(error.code).toBe("VALIDATION");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("defaults to EXTERNAL for unknown errors", () => {
+    const error = parseGhError("something unexpected", 1, ["pr", "view"]);
+    expect(error.code).toBe("EXTERNAL");
+    expect(error.retryable).toBe(false);
+  });
+
+  test("includes command in context", () => {
+    const error = parseGhError("error", 1, ["pr", "view", "42"]);
+    expect(error.context).toMatchObject({ command: "gh pr view 42" });
+  });
+
+  test("handles empty stderr gracefully", () => {
+    const error = parseGhError("", 1, ["pr", "view"]);
+    expect(error.code).toBe("EXTERNAL");
+    expect(error.message).toContain("exit code 1");
+  });
+
+  test("exit code 4 takes precedence over stderr patterns", () => {
+    const error = parseGhError("not found", 4, ["pr", "view"]);
+    expect(error.code).toBe("PERMISSION");
+  });
+});
+
+describe("parseGhJson", () => {
+  test("parses valid JSON", () => {
+    const result = parseGhJson('{"number": 42}');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatchObject({ number: 42 });
+    }
+  });
+
+  test("returns error for invalid JSON", () => {
+    const result = parseGhJson("not json");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("EXTERNAL");
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+
+  test("parses empty object", () => {
+    const result = parseGhJson("{}");
+    expect(result.ok).toBe(true);
+  });
+
+  test("parses array", () => {
+    const result = parseGhJson("[1, 2, 3]");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual([1, 2, 3]);
+    }
+  });
+});

--- a/packages/tools-github/src/parse-gh-error.ts
+++ b/packages/tools-github/src/parse-gh-error.ts
@@ -1,0 +1,109 @@
+/**
+ * Map `gh` CLI failures to KoiError values.
+ *
+ * Pattern-matches stderr content and exit codes following
+ * the same approach as @koi/git-utils parseGitError.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+
+/**
+ * Parse stderr from a `gh` CLI invocation into a structured KoiError.
+ *
+ * Exit code 4 = insufficient permissions (GitHub CLI convention).
+ */
+export function parseGhError(stderr: string, exitCode: number, args: readonly string[]): KoiError {
+  const trimmed = stderr.trim();
+  const command = `gh ${args.join(" ")}`;
+
+  if (exitCode === 4) {
+    return {
+      code: "PERMISSION",
+      message: trimmed || "Insufficient permissions",
+      retryable: false,
+      context: { command },
+    };
+  }
+
+  if (/rate limit/i.test(trimmed)) {
+    return {
+      code: "RATE_LIMIT",
+      message: trimmed,
+      retryable: true,
+      context: { command },
+    };
+  }
+
+  if (/not found/i.test(trimmed)) {
+    return {
+      code: "NOT_FOUND",
+      message: trimmed,
+      retryable: false,
+      context: { command },
+    };
+  }
+
+  if (/already exists/i.test(trimmed)) {
+    return {
+      code: "CONFLICT",
+      message: trimmed,
+      retryable: false,
+      context: { command },
+    };
+  }
+
+  if (/merge conflict/i.test(trimmed)) {
+    return {
+      code: "CONFLICT",
+      message: trimmed,
+      retryable: false,
+      context: { command },
+    };
+  }
+
+  if (/not mergeable/i.test(trimmed)) {
+    return {
+      code: "VALIDATION",
+      message: trimmed,
+      retryable: false,
+      context: { command },
+    };
+  }
+
+  return {
+    code: "EXTERNAL",
+    message: `gh ${args[0] ?? ""} failed: ${trimmed || `exit code ${exitCode}`}`,
+    retryable: false,
+    context: { command },
+  };
+}
+
+/**
+ * Attempt to parse a JSON response from gh output.
+ * Returns a KoiError if parsing fails.
+ */
+export function parseGhJson(raw: string): Result<unknown, KoiError> {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      error: {
+        code: "EXTERNAL",
+        message: `Failed to parse gh JSON output: ${e instanceof Error ? e.message : String(e)}`,
+        retryable: false,
+        cause: e,
+      },
+    };
+  }
+}
+
+/** Type guard: checks whether a value is a non-null object (Record-like). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Map a KoiError to the standard tool error response shape. */
+export function mapErrorResult(error: KoiError): { readonly error: string; readonly code: string } {
+  return { error: error.message, code: error.code };
+}

--- a/packages/tools-github/src/test-helpers.ts
+++ b/packages/tools-github/src/test-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared test helpers for @koi/tools-github tests.
+ *
+ * Test convention — each tool test file MUST cover:
+ *   1. Happy path (success case)
+ *   2. Missing required arg (VALIDATION error)
+ *   3. Invalid arg type (VALIDATION error)
+ *   4. Tool-specific failure mode (executor error)
+ */
+
+import type { Agent, KoiError, KoiErrorCode, Result, SubsystemToken } from "@koi/core";
+import { agentId } from "@koi/core";
+import type { GhExecuteOptions, GhExecutor } from "./gh-executor.js";
+
+/** A canned response entry for the mock executor. */
+export interface MockGhResponse {
+  readonly result: Result<string, KoiError>;
+}
+
+/**
+ * Create a mock GhExecutor that returns canned responses in order.
+ *
+ * When all responses are consumed, returns an EXTERNAL error.
+ * Also tracks call history for assertions on args passed.
+ */
+export function createMockGhExecutor(responses: readonly MockGhResponse[]): GhExecutor & {
+  readonly calls: ReadonlyArray<{
+    readonly args: readonly string[];
+    readonly options: GhExecuteOptions | undefined;
+  }>;
+} {
+  const calls: Array<{
+    readonly args: readonly string[];
+    readonly options: GhExecuteOptions | undefined;
+  }> = [];
+  // let is justified: index is incremented on each call to track consumption
+  let callIndex = 0;
+
+  return {
+    calls,
+    execute: async (
+      args: readonly string[],
+      options?: GhExecuteOptions,
+    ): Promise<Result<string, KoiError>> => {
+      calls.push({ args, options });
+      const response = responses[callIndex];
+      callIndex += 1;
+
+      if (response === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: "Mock executor: no more canned responses",
+            retryable: false,
+          },
+        };
+      }
+
+      return response.result;
+    },
+  };
+}
+
+/** Shorthand to create a successful mock response with JSON output. */
+export function mockSuccess(json: unknown): MockGhResponse {
+  return { result: { ok: true, value: JSON.stringify(json) } };
+}
+
+/** Shorthand to create a successful mock response with raw string output. */
+export function mockSuccessRaw(output: string): MockGhResponse {
+  return { result: { ok: true, value: output } };
+}
+
+/** Shorthand to create a failed mock response. */
+export function mockError(code: KoiErrorCode, message: string): MockGhResponse {
+  return {
+    result: {
+      ok: false,
+      error: { code, message, retryable: code === "RATE_LIMIT" },
+    },
+  };
+}
+
+/** Create a minimal mock Agent for testing. */
+export function createMockAgent(): Agent {
+  const components = new Map<string, unknown>();
+  return {
+    pid: { id: agentId("test-agent"), name: "test", type: "worker", depth: 0 },
+    manifest: {
+      name: "test-agent",
+      version: "0.0.0",
+      model: { name: "test-model" },
+    },
+    state: "running",
+    component: <T>(token: { toString: () => string }): T | undefined =>
+      components.get(token.toString()) as T | undefined,
+    has: (token: { toString: () => string }): boolean => components.has(token.toString()),
+    hasAll: (...tokens: readonly { toString: () => string }[]): boolean =>
+      tokens.every((t) => components.has(t.toString())),
+    query: <T>(_prefix: string): ReadonlyMap<SubsystemToken<T>, T> => new Map(),
+    components: (): ReadonlyMap<string, unknown> => components,
+  };
+}

--- a/packages/tools-github/src/tools/ci-wait.test.ts
+++ b/packages/tools-github/src/tools/ci-wait.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { createMockGhExecutor, mockError, mockSuccess } from "../test-helpers.js";
+import { createGithubCiWaitTool } from "./ci-wait.js";
+
+const PENDING_CHECKS = {
+  statusCheckRollup: [{ name: "ci", status: "IN_PROGRESS", conclusion: null }],
+};
+
+const SUCCESS_CHECKS = {
+  statusCheckRollup: [
+    { name: "ci", status: "COMPLETED", conclusion: "SUCCESS" },
+    { name: "lint", status: "COMPLETED", conclusion: "SUCCESS" },
+  ],
+};
+
+const FAILURE_CHECKS = {
+  statusCheckRollup: [
+    { name: "ci", status: "COMPLETED", conclusion: "SUCCESS" },
+    { name: "lint", status: "COMPLETED", conclusion: "FAILURE" },
+  ],
+};
+
+const MIXED_CHECKS = {
+  statusCheckRollup: [
+    { name: "ci", status: "COMPLETED", conclusion: "FAILURE" },
+    { name: "lint", status: "IN_PROGRESS", conclusion: null },
+  ],
+};
+
+describe("github_ci_wait — happy paths", () => {
+  test("returns success when all checks pass immediately", async () => {
+    const executor = createMockGhExecutor([mockSuccess(SUCCESS_CHECKS)]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({ pr_number: 42, poll_interval_ms: 1 })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.status).toBe("success");
+    expect(result.elapsed_ms).toEqual(expect.any(Number));
+    expect(Array.isArray(result.checks)).toBe(true);
+  });
+
+  test("returns success when no checks configured", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ statusCheckRollup: [] })]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({ pr_number: 42, poll_interval_ms: 1 })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.status).toBe("success");
+  });
+
+  test("returns success when statusCheckRollup is missing", async () => {
+    const executor = createMockGhExecutor([mockSuccess({})]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({ pr_number: 42, poll_interval_ms: 1 })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.status).toBe("success");
+  });
+
+  test("returns failure when checks fail", async () => {
+    const executor = createMockGhExecutor([mockSuccess(FAILURE_CHECKS)]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({ pr_number: 42, poll_interval_ms: 1 })) as Record<
+      string,
+      unknown
+    >;
+    expect(result.status).toBe("failure");
+  });
+});
+
+describe("github_ci_wait — polling", () => {
+  test("polls until checks complete", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(PENDING_CHECKS),
+      mockSuccess(SUCCESS_CHECKS),
+    ]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({
+      pr_number: 42,
+      poll_interval_ms: 1,
+      timeout_ms: 60000,
+    })) as Record<string, unknown>;
+    expect(result.status).toBe("success");
+    expect(executor.calls.length).toBe(2);
+  });
+
+  test("returns timeout when deadline exceeded", async () => {
+    const executor = createMockGhExecutor([mockSuccess(PENDING_CHECKS)]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({
+      pr_number: 42,
+      timeout_ms: 1,
+      poll_interval_ms: 100,
+    })) as Record<string, unknown>;
+    expect(result.status).toBe("timeout");
+  });
+
+  test("fail_fast stops on first failure", async () => {
+    const executor = createMockGhExecutor([mockSuccess(MIXED_CHECKS)]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = (await tool.execute({
+      pr_number: 42,
+      fail_fast: true,
+      poll_interval_ms: 1,
+    })) as Record<string, unknown>;
+    expect(result.status).toBe("failure");
+    // Should stop after first poll since fail_fast is true
+    expect(executor.calls.length).toBe(1);
+  });
+});
+
+describe("github_ci_wait — argument validation", () => {
+  test("rejects missing pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-number pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: "42" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects timeout_ms below minimum", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42, timeout_ms: 0 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects timeout_ms above maximum", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42, timeout_ms: 99_999_999 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects poll_interval_ms below minimum", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42, poll_interval_ms: 0 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-boolean fail_fast", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42, fail_fast: "yes" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+});
+
+describe("github_ci_wait — error handling", () => {
+  test("returns error when PR not found", async () => {
+    const executor = createMockGhExecutor([mockError("NOT_FOUND", "PR not found")]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 9999, poll_interval_ms: 1 });
+    expect(result).toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("returns error on executor failure", async () => {
+    const executor = createMockGhExecutor([mockError("EXTERNAL", "network error")]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42, poll_interval_ms: 1 });
+    expect(result).toMatchObject({ code: "EXTERNAL" });
+  });
+
+  test("descriptor has correct name", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    expect(tool.descriptor.name).toBe("github_ci_wait");
+  });
+
+  test("trust tier is verified", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubCiWaitTool(executor, "github", "verified");
+    expect(tool.trustTier).toBe("verified");
+  });
+});

--- a/packages/tools-github/src/tools/ci-wait.ts
+++ b/packages/tools-github/src/tools/ci-wait.ts
@@ -1,0 +1,199 @@
+/**
+ * Tool factory for `github_ci_wait` — poll CI checks until completion or timeout.
+ */
+
+import type { JsonObject, Tool, ToolExecuteOptions, TrustTier } from "@koi/core";
+import {
+  CI_WAIT_FIELDS,
+  DEFAULT_CI_POLL_INTERVAL_MS,
+  DEFAULT_CI_TIMEOUT_MS,
+  MAX_CI_TIMEOUT_MS,
+  MIN_CI_POLL_INTERVAL_MS,
+} from "../constants.js";
+import type { GhExecutor } from "../gh-executor.js";
+import { parseOptionalBoolean, parseOptionalTimeout, parsePrNumber } from "../parse-args.js";
+import { isRecord, mapErrorResult, parseGhJson } from "../parse-gh-error.js";
+
+/** Statuses that indicate a check has finished running. */
+const COMPLETED_STATUSES = new Set([
+  "COMPLETED",
+  "SUCCESS",
+  "FAILURE",
+  "CANCELLED",
+  "ERROR",
+  "TIMED_OUT",
+]);
+
+/** Conclusions that indicate a check failed. */
+const FAILURE_CONCLUSIONS = new Set(["FAILURE", "CANCELLED", "TIMED_OUT", "ERROR"]);
+
+export function createGithubCiWaitTool(
+  executor: GhExecutor,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_ci_wait`,
+      description:
+        "Wait for CI checks on a PR to complete by polling. " +
+        "Returns the final status of all checks. Use fail_fast=true to stop on first failure.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pr_number: { type: "number", description: "Pull request number" },
+          timeout_ms: {
+            type: "number",
+            description: `Max wait time in ms (default: ${DEFAULT_CI_TIMEOUT_MS}, max: ${MAX_CI_TIMEOUT_MS})`,
+          },
+          poll_interval_ms: {
+            type: "number",
+            description: `Polling interval in ms (default: ${DEFAULT_CI_POLL_INTERVAL_MS}, min: ${MIN_CI_POLL_INTERVAL_MS})`,
+          },
+          fail_fast: {
+            type: "boolean",
+            description: "Stop on first failing check (default: false)",
+          },
+        },
+        required: ["pr_number"],
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject, options?: ToolExecuteOptions): Promise<unknown> => {
+      const prResult = parsePrNumber(args, "pr_number");
+      if (!prResult.ok) return prResult.err;
+
+      const timeoutResult = parseOptionalTimeout(args, "timeout_ms", 1, MAX_CI_TIMEOUT_MS);
+      if (!timeoutResult.ok) return timeoutResult.err;
+
+      const pollResult = parseOptionalTimeout(args, "poll_interval_ms", 1, MAX_CI_TIMEOUT_MS);
+      if (!pollResult.ok) return pollResult.err;
+
+      const failFastResult = parseOptionalBoolean(args, "fail_fast");
+      if (!failFastResult.ok) return failFastResult.err;
+
+      const timeoutMs = timeoutResult.value ?? DEFAULT_CI_TIMEOUT_MS;
+      const pollIntervalMs = pollResult.value ?? DEFAULT_CI_POLL_INTERVAL_MS;
+      const failFast = failFastResult.value ?? false;
+      const signal = options?.signal;
+
+      const startTime = Date.now();
+      const deadline = startTime + timeoutMs;
+
+      while (true) {
+        // Check abort signal at top of each iteration
+        if (signal?.aborted) {
+          return {
+            status: "timeout",
+            checks: [],
+            elapsed_ms: Date.now() - startTime,
+            message: "Operation aborted",
+          };
+        }
+
+        const outcome = await pollChecks(executor, prResult.value);
+        if (!outcome.ok) return outcome.error;
+
+        const { checks, allComplete, hasFailure } = outcome.value;
+
+        // Check for fail_fast
+        if (failFast && hasFailure) {
+          return {
+            status: "failure",
+            checks,
+            elapsed_ms: Date.now() - startTime,
+          };
+        }
+
+        // All checks complete
+        if (allComplete) {
+          return {
+            status: hasFailure ? "failure" : "success",
+            checks,
+            elapsed_ms: Date.now() - startTime,
+          };
+        }
+
+        // Check timeout
+        if (Date.now() + pollIntervalMs > deadline) {
+          return {
+            status: "timeout",
+            checks,
+            elapsed_ms: Date.now() - startTime,
+          };
+        }
+
+        // Wait before next poll
+        await sleep(pollIntervalMs);
+      }
+    },
+  };
+}
+
+interface PollResult {
+  readonly checks: readonly CheckInfo[];
+  readonly allComplete: boolean;
+  readonly hasFailure: boolean;
+}
+
+interface CheckInfo {
+  readonly name: string;
+  readonly status: string;
+  readonly conclusion: string | null;
+}
+
+/** Discriminated union for poll outcome — avoids `as Type` assertions. */
+type PollOutcome =
+  | { readonly ok: true; readonly value: PollResult }
+  | { readonly ok: false; readonly error: { readonly error: string; readonly code: string } };
+
+async function pollChecks(executor: GhExecutor, prNumber: number): Promise<PollOutcome> {
+  const result = await executor.execute(["pr", "view", String(prNumber), "--json", CI_WAIT_FIELDS]);
+
+  if (!result.ok) {
+    return { ok: false, error: mapErrorResult(result.error) };
+  }
+
+  const parsed = parseGhJson(result.value);
+  if (!parsed.ok) {
+    return { ok: false, error: mapErrorResult(parsed.error) };
+  }
+
+  if (!isRecord(parsed.value)) {
+    return { ok: false, error: { error: "Unexpected response format from gh", code: "EXTERNAL" } };
+  }
+
+  const data = parsed.value;
+  const rawChecks = data.statusCheckRollup;
+
+  // No checks configured — immediate success
+  if (!Array.isArray(rawChecks) || rawChecks.length === 0) {
+    return { ok: true, value: { checks: [], allComplete: true, hasFailure: false } };
+  }
+
+  const checks: readonly CheckInfo[] = rawChecks.map((c: unknown) => {
+    if (!isRecord(c)) {
+      return { name: "unknown", status: "UNKNOWN", conclusion: null };
+    }
+    return {
+      name: String(c.name ?? c.context ?? "unknown"),
+      status: String(c.status ?? "UNKNOWN"),
+      conclusion: c.conclusion != null ? String(c.conclusion) : null,
+    };
+  });
+
+  const allComplete = checks.every(
+    (c) => COMPLETED_STATUSES.has(c.status) || c.conclusion !== null,
+  );
+  const hasFailure = checks.some(
+    (c) => c.conclusion !== null && FAILURE_CONCLUSIONS.has(c.conclusion),
+  );
+
+  return { ok: true, value: { checks, allComplete, hasFailure } };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/tools-github/src/tools/pr-create.test.ts
+++ b/packages/tools-github/src/tools/pr-create.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { createMockGhExecutor, mockError, mockSuccess } from "../test-helpers.js";
+import { createGithubPrCreateTool } from "./pr-create.js";
+
+describe("github_pr_create", () => {
+  test("creates PR with title and body", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess({
+        number: 42,
+        url: "https://github.com/org/repo/pull/42",
+        headRefName: "feat/x",
+      }),
+    ]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ title: "Add feature X", body: "Description" });
+    expect(result).toMatchObject({ number: 42, url: expect.any(String), headRefName: "feat/x" });
+  });
+
+  test("passes --title and --body to gh", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({ title: "T", body: "B" });
+    expect(executor.calls[0]?.args).toContain("--title");
+    expect(executor.calls[0]?.args).toContain("T");
+    expect(executor.calls[0]?.args).toContain("--body");
+    expect(executor.calls[0]?.args).toContain("B");
+  });
+
+  test("uses --fill when no title provided", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({});
+    expect(executor.calls[0]?.args).toContain("--fill");
+    expect(executor.calls[0]?.args).not.toContain("--title");
+  });
+
+  test("passes --base when base specified", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({ title: "T", base: "develop" });
+    expect(executor.calls[0]?.args).toContain("--base");
+    expect(executor.calls[0]?.args).toContain("develop");
+  });
+
+  test("passes --head when head specified", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({ title: "T", head: "feature/y" });
+    expect(executor.calls[0]?.args).toContain("--head");
+    expect(executor.calls[0]?.args).toContain("feature/y");
+  });
+
+  test("passes --draft when draft=true", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({ title: "T", draft: true });
+    expect(executor.calls[0]?.args).toContain("--draft");
+  });
+
+  test("omits --draft when draft=false", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ number: 1, url: "u", headRefName: "b" })]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    await tool.execute({ title: "T", draft: false });
+    expect(executor.calls[0]?.args).not.toContain("--draft");
+  });
+
+  test("rejects non-string title", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ title: 123 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-boolean draft", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ draft: "yes" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("returns error when PR already exists", async () => {
+    const executor = createMockGhExecutor([mockError("CONFLICT", "a]pull request already exists")]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ title: "T" });
+    expect(result).toMatchObject({ code: "CONFLICT" });
+  });
+
+  test("returns error on executor failure", async () => {
+    const executor = createMockGhExecutor([mockError("EXTERNAL", "gh pr create failed")]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ title: "T" });
+    expect(result).toMatchObject({ code: "EXTERNAL" });
+  });
+
+  test("returns error on JSON parse failure", async () => {
+    const executor = createMockGhExecutor([{ result: { ok: true, value: "not json" } }]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    const result = await tool.execute({ title: "T" });
+    expect(result).toMatchObject({ code: "EXTERNAL" });
+  });
+
+  test("descriptor has correct name with custom prefix", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrCreateTool(executor, "gh", "promoted");
+    expect(tool.descriptor.name).toBe("gh_pr_create");
+  });
+
+  test("trust tier is set correctly", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrCreateTool(executor, "github", "promoted");
+    expect(tool.trustTier).toBe("promoted");
+  });
+});

--- a/packages/tools-github/src/tools/pr-create.ts
+++ b/packages/tools-github/src/tools/pr-create.ts
@@ -1,0 +1,73 @@
+/**
+ * Tool factory for `github_pr_create` — create a pull request.
+ */
+
+import type { JsonObject, Tool, TrustTier } from "@koi/core";
+import { PR_CREATE_FIELDS } from "../constants.js";
+import type { GhExecutor } from "../gh-executor.js";
+import { parseOptionalBoolean, parseOptionalString } from "../parse-args.js";
+import { mapErrorResult, parseGhJson } from "../parse-gh-error.js";
+
+export function createGithubPrCreateTool(
+  executor: GhExecutor,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_pr_create`,
+      description:
+        "Create a new pull request on GitHub. The current branch must be pushed to the remote first.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+            description: "PR title (auto-generated from commits if omitted)",
+          },
+          body: { type: "string", description: "PR body/description" },
+          base: {
+            type: "string",
+            description: "Base branch to merge into (default: repo default branch)",
+          },
+          head: { type: "string", description: "Head branch (default: current branch)" },
+          draft: { type: "boolean", description: "Create as draft PR (default: false)" },
+        },
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const titleResult = parseOptionalString(args, "title");
+      if (!titleResult.ok) return titleResult.err;
+      const bodyResult = parseOptionalString(args, "body");
+      if (!bodyResult.ok) return bodyResult.err;
+      const baseResult = parseOptionalString(args, "base");
+      if (!baseResult.ok) return baseResult.err;
+      const headResult = parseOptionalString(args, "head");
+      if (!headResult.ok) return headResult.err;
+      const draftResult = parseOptionalBoolean(args, "draft");
+      if (!draftResult.ok) return draftResult.err;
+
+      const ghArgs: readonly string[] = [
+        "pr",
+        "create",
+        ...(titleResult.value !== undefined ? ["--title", titleResult.value] : []),
+        ...(bodyResult.value !== undefined ? ["--body", bodyResult.value] : []),
+        ...(baseResult.value !== undefined ? ["--base", baseResult.value] : []),
+        ...(headResult.value !== undefined ? ["--head", headResult.value] : []),
+        ...(draftResult.value === true ? ["--draft"] : []),
+        ...(titleResult.value === undefined ? ["--fill"] : []),
+        "--json",
+        PR_CREATE_FIELDS,
+      ];
+
+      const result = await executor.execute(ghArgs);
+      if (!result.ok) return mapErrorResult(result.error);
+
+      const parsed = parseGhJson(result.value);
+      if (!parsed.ok) return mapErrorResult(parsed.error);
+
+      return parsed.value;
+    },
+  };
+}

--- a/packages/tools-github/src/tools/pr-merge.test.ts
+++ b/packages/tools-github/src/tools/pr-merge.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { createMockGhExecutor, mockError, mockSuccess, mockSuccessRaw } from "../test-helpers.js";
+import { createGithubPrMergeTool } from "./pr-merge.js";
+
+/** A valid PR status that is ready to merge. */
+const MERGEABLE_STATUS = {
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "APPROVED",
+  statusCheckRollup: [{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS" }],
+  headRefName: "feat/x",
+  baseRefName: "main",
+  title: "X",
+  additions: 1,
+  deletions: 0,
+  changedFiles: 1,
+};
+
+describe("github_pr_merge", () => {
+  test("merges PR successfully with default strategy", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(MERGEABLE_STATUS),
+      mockSuccessRaw("Merged"),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ merged: true });
+    // Second call should be the merge command
+    expect(executor.calls[1]?.args).toContain("merge");
+    expect(executor.calls[1]?.args).toContain("--merge");
+  });
+
+  test("uses squash strategy", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(MERGEABLE_STATUS),
+      mockSuccessRaw("Merged"),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 42, strategy: "squash" });
+    expect(executor.calls[1]?.args).toContain("--squash");
+  });
+
+  test("uses rebase strategy", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(MERGEABLE_STATUS),
+      mockSuccessRaw("Merged"),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 42, strategy: "rebase" });
+    expect(executor.calls[1]?.args).toContain("--rebase");
+  });
+
+  test("passes --delete-branch when requested", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(MERGEABLE_STATUS),
+      mockSuccessRaw("Merged"),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 42, delete_branch: true });
+    expect(executor.calls[1]?.args).toContain("--delete-branch");
+  });
+
+  test("omits --delete-branch when false", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess(MERGEABLE_STATUS),
+      mockSuccessRaw("Merged"),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 42, delete_branch: false });
+    expect(executor.calls[1]?.args).not.toContain("--delete-branch");
+  });
+});
+
+describe("github_pr_merge — pre-validation", () => {
+  test("rejects merge of closed PR", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ ...MERGEABLE_STATUS, state: "CLOSED" })]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects merge of draft PR", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ ...MERGEABLE_STATUS, isDraft: true })]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects merge with conflicts", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess({ ...MERGEABLE_STATUS, mergeable: "CONFLICTING" }),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ code: "CONFLICT" });
+  });
+
+  test("rejects merge with failing CI checks", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess({
+        ...MERGEABLE_STATUS,
+        statusCheckRollup: [{ name: "ci", status: "COMPLETED", conclusion: "FAILURE" }],
+      }),
+    ]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("returns error when status check fails", async () => {
+    const executor = createMockGhExecutor([mockError("NOT_FOUND", "PR not found")]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("github_pr_merge — argument validation", () => {
+  test("rejects missing pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects invalid strategy", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42, strategy: "fast-forward" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-boolean delete_branch", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 42, delete_branch: "yes" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("descriptor has correct name", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrMergeTool(executor, "github", "promoted");
+    expect(tool.descriptor.name).toBe("github_pr_merge");
+  });
+});

--- a/packages/tools-github/src/tools/pr-merge.ts
+++ b/packages/tools-github/src/tools/pr-merge.ts
@@ -1,0 +1,133 @@
+/**
+ * Tool factory for `github_pr_merge` — merge a pull request.
+ *
+ * Pre-validates merge readiness by checking PR state, CI, and reviews
+ * before attempting the merge.
+ */
+
+import type { JsonObject, Tool, TrustTier } from "@koi/core";
+import { MERGE_STRATEGIES, PR_STATUS_FIELDS } from "../constants.js";
+import type { GhExecutor } from "../gh-executor.js";
+import { parseOptionalBoolean, parseOptionalEnum, parsePrNumber } from "../parse-args.js";
+import { isRecord, mapErrorResult, parseGhJson } from "../parse-gh-error.js";
+
+export function createGithubPrMergeTool(
+  executor: GhExecutor,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_pr_merge`,
+      description:
+        "Merge a pull request. Pre-validates CI status, review decision, and merge readiness. " +
+        "Supports merge, squash, and rebase strategies.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pr_number: { type: "number", description: "Pull request number" },
+          strategy: {
+            type: "string",
+            enum: ["merge", "squash", "rebase"],
+            description: "Merge strategy (default: merge)",
+          },
+          delete_branch: {
+            type: "boolean",
+            description: "Delete the head branch after merge (default: false)",
+          },
+        },
+        required: ["pr_number"],
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const prResult = parsePrNumber(args, "pr_number");
+      if (!prResult.ok) return prResult.err;
+      const strategyResult = parseOptionalEnum(args, "strategy", MERGE_STRATEGIES);
+      if (!strategyResult.ok) return strategyResult.err;
+      const deleteBranchResult = parseOptionalBoolean(args, "delete_branch");
+      if (!deleteBranchResult.ok) return deleteBranchResult.err;
+
+      // Pre-validate merge readiness
+      const validationError = await validateMergeReadiness(executor, prResult.value);
+      if (validationError !== undefined) return validationError;
+
+      const strategy = strategyResult.value ?? "merge";
+      const strategyFlag =
+        strategy === "squash" ? "--squash" : strategy === "rebase" ? "--rebase" : "--merge";
+
+      const ghArgs: readonly string[] = [
+        "pr",
+        "merge",
+        String(prResult.value),
+        strategyFlag,
+        ...(deleteBranchResult.value === true ? ["--delete-branch"] : []),
+      ];
+
+      const result = await executor.execute(ghArgs);
+      if (!result.ok) return mapErrorResult(result.error);
+
+      return { merged: true };
+    },
+  };
+}
+
+/** Check PR state before merge — returns an error object if not ready, undefined if ok. */
+async function validateMergeReadiness(
+  executor: GhExecutor,
+  prNumber: number,
+): Promise<{ readonly error: string; readonly code: string } | undefined> {
+  const statusResult = await executor.execute([
+    "pr",
+    "view",
+    String(prNumber),
+    "--json",
+    PR_STATUS_FIELDS,
+  ]);
+
+  if (!statusResult.ok) return mapErrorResult(statusResult.error);
+
+  const parsed = parseGhJson(statusResult.value);
+  if (!parsed.ok) return mapErrorResult(parsed.error);
+
+  if (!isRecord(parsed.value)) {
+    return { error: "Unexpected response format from gh", code: "EXTERNAL" };
+  }
+
+  const status = parsed.value;
+
+  if (status.state !== "OPEN") {
+    return {
+      error: `PR #${prNumber} is not open (state: ${String(status.state)})`,
+      code: "VALIDATION",
+    };
+  }
+
+  if (status.isDraft === true) {
+    return {
+      error: `PR #${prNumber} is a draft and cannot be merged`,
+      code: "VALIDATION",
+    };
+  }
+
+  if (status.mergeable === "CONFLICTING") {
+    return {
+      error: `PR #${prNumber} has merge conflicts that must be resolved first`,
+      code: "CONFLICT",
+    };
+  }
+
+  // Check CI status — warn but don't block if checks haven't finished
+  const checks = status.statusCheckRollup;
+  if (Array.isArray(checks)) {
+    const failedChecks = checks.filter((c: unknown) => isRecord(c) && c.conclusion === "FAILURE");
+    if (failedChecks.length > 0) {
+      return {
+        error: `PR #${prNumber} has ${failedChecks.length} failing CI check(s)`,
+        code: "VALIDATION",
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/packages/tools-github/src/tools/pr-review.test.ts
+++ b/packages/tools-github/src/tools/pr-review.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { createMockGhExecutor, mockError, mockSuccess, mockSuccessRaw } from "../test-helpers.js";
+import { createGithubPrReviewTool } from "./pr-review.js";
+
+describe("github_pr_review — read", () => {
+  test("reads reviews for a PR", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess({
+        reviews: [{ author: { login: "reviewer" }, state: "APPROVED", body: "LGTM" }],
+        latestReviews: [{ author: { login: "reviewer" }, state: "APPROVED" }],
+        reviewDecision: "APPROVED",
+      }),
+    ]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10, action: "read" });
+    expect(result).toMatchObject({ reviewDecision: "APPROVED" });
+  });
+
+  test("passes correct args for read action", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ reviewDecision: "APPROVED" })]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 10, action: "read" });
+    expect(executor.calls[0]?.args).toContain("view");
+    expect(executor.calls[0]?.args).toContain("10");
+    expect(executor.calls[0]?.args).toContain("--json");
+  });
+
+  test("returns NOT_FOUND for unknown PR", async () => {
+    const executor = createMockGhExecutor([mockError("NOT_FOUND", "not found")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 9999, action: "read" });
+    expect(result).toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("github_pr_review — post", () => {
+  test("posts APPROVE review", async () => {
+    const executor = createMockGhExecutor([mockSuccessRaw("Approved")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10, action: "post", event: "APPROVE" });
+    expect(result).toMatchObject({ success: true });
+    expect(executor.calls[0]?.args).toContain("--approve");
+  });
+
+  test("posts REQUEST_CHANGES review with body", async () => {
+    const executor = createMockGhExecutor([mockSuccessRaw("Changes requested")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({
+      pr_number: 10,
+      action: "post",
+      event: "REQUEST_CHANGES",
+      body: "Please fix the tests",
+    });
+    expect(result).toMatchObject({ success: true });
+    expect(executor.calls[0]?.args).toContain("--request-changes");
+    expect(executor.calls[0]?.args).toContain("--body");
+  });
+
+  test("posts COMMENT review with body", async () => {
+    const executor = createMockGhExecutor([mockSuccessRaw("Commented")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({
+      pr_number: 10,
+      action: "post",
+      body: "Nice work!",
+    });
+    expect(result).toMatchObject({ success: true });
+    expect(executor.calls[0]?.args).toContain("--comment");
+    expect(executor.calls[0]?.args).toContain("--body");
+  });
+
+  test("defaults to COMMENT when no event specified", async () => {
+    const executor = createMockGhExecutor([mockSuccessRaw("Commented")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    await tool.execute({ pr_number: 10, action: "post", body: "Hello" });
+    expect(executor.calls[0]?.args).toContain("--comment");
+  });
+
+  test("rejects REQUEST_CHANGES without body", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({
+      pr_number: 10,
+      action: "post",
+      event: "REQUEST_CHANGES",
+    });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects REQUEST_CHANGES with empty body", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({
+      pr_number: 10,
+      action: "post",
+      event: "REQUEST_CHANGES",
+      body: "",
+    });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("returns error on executor failure", async () => {
+    const executor = createMockGhExecutor([mockError("PERMISSION", "no permission")]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10, action: "post", event: "APPROVE" });
+    expect(result).toMatchObject({ code: "PERMISSION" });
+  });
+});
+
+describe("github_pr_review — validation", () => {
+  test("rejects missing pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ action: "read" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects missing action", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects invalid action", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10, action: "delete" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects invalid event type", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    const result = await tool.execute({ pr_number: 10, action: "post", event: "REJECT" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("descriptor has correct name", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrReviewTool(executor, "github", "promoted");
+    expect(tool.descriptor.name).toBe("github_pr_review");
+  });
+});

--- a/packages/tools-github/src/tools/pr-review.ts
+++ b/packages/tools-github/src/tools/pr-review.ts
@@ -1,0 +1,111 @@
+/**
+ * Tool factory for `github_pr_review` — read existing reviews or post a new review.
+ */
+
+import type { JsonObject, Tool, TrustTier } from "@koi/core";
+import { PR_REVIEW_READ_FIELDS, REVIEW_ACTIONS, REVIEW_EVENTS } from "../constants.js";
+import type { GhExecutor } from "../gh-executor.js";
+import { parseEnum, parseOptionalEnum, parseOptionalString, parsePrNumber } from "../parse-args.js";
+import { mapErrorResult, parseGhJson } from "../parse-gh-error.js";
+
+export function createGithubPrReviewTool(
+  executor: GhExecutor,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_pr_review`,
+      description:
+        "Read existing reviews on a PR or post a new review. " +
+        'Use action="read" to see reviews, action="post" to submit one.',
+      inputSchema: {
+        type: "object",
+        properties: {
+          pr_number: { type: "number", description: "Pull request number" },
+          action: {
+            type: "string",
+            enum: ["post", "read"],
+            description: 'Action: "read" to view reviews, "post" to submit a review',
+          },
+          body: { type: "string", description: "Review body text (required for REQUEST_CHANGES)" },
+          event: {
+            type: "string",
+            enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+            description: 'Review event type (default: "COMMENT", only for action="post")',
+          },
+        },
+        required: ["pr_number", "action"],
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const prResult = parsePrNumber(args, "pr_number");
+      if (!prResult.ok) return prResult.err;
+      const actionResult = parseEnum(args, "action", REVIEW_ACTIONS);
+      if (!actionResult.ok) return actionResult.err;
+
+      if (actionResult.value === "read") {
+        return executeRead(executor, prResult.value);
+      }
+
+      return executePost(executor, args, prResult.value);
+    },
+  };
+}
+
+async function executeRead(executor: GhExecutor, prNumber: number): Promise<unknown> {
+  const ghArgs = ["pr", "view", String(prNumber), "--json", PR_REVIEW_READ_FIELDS] as const;
+
+  const result = await executor.execute(ghArgs);
+  if (!result.ok) return mapErrorResult(result.error);
+
+  const parsed = parseGhJson(result.value);
+  if (!parsed.ok) return mapErrorResult(parsed.error);
+
+  return parsed.value;
+}
+
+async function executePost(
+  executor: GhExecutor,
+  args: JsonObject,
+  prNumber: number,
+): Promise<unknown> {
+  const bodyResult = parseOptionalString(args, "body");
+  if (!bodyResult.ok) return bodyResult.err;
+  const eventResult = parseOptionalEnum(args, "event", REVIEW_EVENTS);
+  if (!eventResult.ok) return eventResult.err;
+
+  const event = eventResult.value ?? "COMMENT";
+
+  // REQUEST_CHANGES requires a body
+  if (
+    event === "REQUEST_CHANGES" &&
+    (bodyResult.value === undefined || bodyResult.value.length === 0)
+  ) {
+    return {
+      error: "body is required when event is REQUEST_CHANGES",
+      code: "VALIDATION",
+    };
+  }
+
+  const eventFlag =
+    event === "APPROVE"
+      ? "--approve"
+      : event === "REQUEST_CHANGES"
+        ? "--request-changes"
+        : "--comment";
+
+  const ghArgs: readonly string[] = [
+    "pr",
+    "review",
+    String(prNumber),
+    eventFlag,
+    ...(bodyResult.value !== undefined ? ["--body", bodyResult.value] : []),
+  ];
+
+  const result = await executor.execute(ghArgs);
+  if (!result.ok) return mapErrorResult(result.error);
+
+  return { success: true };
+}

--- a/packages/tools-github/src/tools/pr-status.test.ts
+++ b/packages/tools-github/src/tools/pr-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { createMockGhExecutor, mockError, mockSuccess } from "../test-helpers.js";
+import { createGithubPrStatusTool } from "./pr-status.js";
+
+describe("github_pr_status", () => {
+  test("returns PR status for a valid PR number", async () => {
+    const executor = createMockGhExecutor([
+      mockSuccess({
+        state: "OPEN",
+        isDraft: false,
+        mergeable: "MERGEABLE",
+        mergeStateStatus: "CLEAN",
+        reviewDecision: "APPROVED",
+        statusCheckRollup: [{ name: "ci", status: "COMPLETED", conclusion: "SUCCESS" }],
+        headRefName: "feat/x",
+        baseRefName: "main",
+        title: "Add X",
+        additions: 10,
+        deletions: 5,
+        changedFiles: 3,
+      }),
+    ]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 42 });
+    expect(result).toMatchObject({
+      state: "OPEN",
+      isDraft: false,
+      title: "Add X",
+      additions: 10,
+    });
+  });
+
+  test("passes correct PR number to gh", async () => {
+    const executor = createMockGhExecutor([mockSuccess({ state: "OPEN" })]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    await tool.execute({ pr_number: 99 });
+    expect(executor.calls[0]?.args).toContain("99");
+  });
+
+  test("rejects missing pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({});
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-number pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: "42" });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects negative pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: -1 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("rejects non-integer pr_number", async () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 4.5 });
+    expect(result).toMatchObject({ code: "VALIDATION" });
+  });
+
+  test("returns NOT_FOUND for unknown PR", async () => {
+    const executor = createMockGhExecutor([
+      mockError("NOT_FOUND", "Could not resolve to a PullRequest"),
+    ]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 9999 });
+    expect(result).toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("returns error on executor failure", async () => {
+    const executor = createMockGhExecutor([mockError("EXTERNAL", "network error")]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 1 });
+    expect(result).toMatchObject({ code: "EXTERNAL" });
+  });
+
+  test("returns error on JSON parse failure", async () => {
+    const executor = createMockGhExecutor([{ result: { ok: true, value: "not json" } }]);
+    const tool = createGithubPrStatusTool(executor, "github", "verified");
+    const result = await tool.execute({ pr_number: 1 });
+    expect(result).toMatchObject({ code: "EXTERNAL" });
+  });
+
+  test("descriptor has correct name with custom prefix", () => {
+    const executor = createMockGhExecutor([]);
+    const tool = createGithubPrStatusTool(executor, "gh", "verified");
+    expect(tool.descriptor.name).toBe("gh_pr_status");
+  });
+});

--- a/packages/tools-github/src/tools/pr-status.ts
+++ b/packages/tools-github/src/tools/pr-status.ts
@@ -1,0 +1,46 @@
+/**
+ * Tool factory for `github_pr_status` — get PR status including CI checks, reviews, and merge readiness.
+ */
+
+import type { JsonObject, Tool, TrustTier } from "@koi/core";
+import { PR_STATUS_FIELDS } from "../constants.js";
+import type { GhExecutor } from "../gh-executor.js";
+import { parsePrNumber } from "../parse-args.js";
+import { mapErrorResult, parseGhJson } from "../parse-gh-error.js";
+
+export function createGithubPrStatusTool(
+  executor: GhExecutor,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_pr_status`,
+      description:
+        "Get the current status of a pull request including CI checks, review decision, " +
+        "merge readiness, and diff statistics.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pr_number: { type: "number", description: "Pull request number" },
+        },
+        required: ["pr_number"],
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const prResult = parsePrNumber(args, "pr_number");
+      if (!prResult.ok) return prResult.err;
+
+      const ghArgs = ["pr", "view", String(prResult.value), "--json", PR_STATUS_FIELDS];
+
+      const result = await executor.execute(ghArgs);
+      if (!result.ok) return mapErrorResult(result.error);
+
+      const parsed = parseGhJson(result.value);
+      if (!parsed.ok) return mapErrorResult(parsed.error);
+
+      return parsed.value;
+    },
+  };
+}

--- a/packages/tools-github/tsconfig.json
+++ b/packages/tools-github/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/tools-github/tsup.config.ts
+++ b/packages/tools-github/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Add `@koi/tools-github` L2 package with 5 Koi Tool components wrapping the GitHub CLI (`gh`): `pr_create`, `pr_status`, `pr_review`, `pr_merge`, `ci_wait`
- GhExecutor interface abstracts CLI for test mock injection; ComponentProvider attaches tools via ECS
- Trust tiers: reads (status, ci_wait) = verified, writes (create, review, merge) = promoted
- Structured KoiError codes: NOT_FOUND, RATE_LIMIT, PERMISSION, CONFLICT, VALIDATION, EXTERNAL
- CI-safe E2E tests using scripted model calls through full createKoi + middleware pipeline
- Real LLM E2E tests (gated on API key) validate Claude discovers and calls tools correctly
- Package documentation at `docs/L2/tools-github.md`

## Test results

- **110 tests, 0 failures** across 9 test files
- 93 unit tests (per-tool happy/error paths, error mapping, provider)
- 9 CI-safe E2E tests (scripted model, no API key needed)
- 8 real LLM E2E tests (Claude Haiku with tool schemas, gated on `E2E_TESTS=1`)

## Test plan

- [x] `bun --cwd packages/tools-github test` — all 110 tests pass
- [x] `bun turbo run build typecheck lint test --filter=@koi/tools-github` — full pipeline green
- [x] `E2E_TESTS=1 bun --env-file=.env test e2e-real-llm` — real Anthropic API validated
- [x] Layer compliance: L2 imports only from @koi/core (L0), zero external deps
- [x] Anti-leak checklist: no vendor types, all properties readonly, no L1/L2 peer imports

Closes #326