### PR TITLE
feat: redesign GovernanceBackend with ISP-split sub-interfaces

### DIFF
--- a/docs/architecture/governance-backend.md
+++ b/docs/architecture/governance-backend.md
@@ -1,0 +1,671 @@
+# GovernanceBackend — Pluggable Rule-Based Policy Evaluation Contract (L0)
+
+A canonical L0 interface for evaluating policy requests, checking constraints, recording compliance, and querying violation history. Backend implementations are swappable — in-memory for dev/test, OPA or Cedar for production — with zero changes to consumers.
+
+**Layer**: L0 types (`@koi/core`)
+**Issue**: #265
+
+---
+
+## Why It Exists
+
+Koi already has a GovernanceController (#261) for numeric guardrails — turns, tokens, cost, spawn depth. But numeric gauges can't answer *policy* questions:
+
+```
+GovernanceController (numeric)       GovernanceBackend (rule-based)
+──────────────────────────────       ─────────────────────────────
+
+"Has this agent used 25 turns?"      "Can this agent call execute_sql?"
+"Is token budget exhausted?"         "Is this model call allowed by org policy?"
+"Is spawn depth too deep?"           "Should we block delegation to untrusted agents?"
+                                     "Log every allow/deny for SOC2 audit"
+                                     "Show all critical violations in the last hour"
+```
+
+They are **parallel peers** — both attached to the same agent, both active simultaneously, each handling a different governance dimension:
+
+| Dimension | GovernanceController | GovernanceBackend |
+|-----------|---------------------|-------------------|
+| What it checks | Numeric gauges (turns, tokens, cost) | Rule-based policies (tool access, model permissions) |
+| Decision type | Threshold comparison (current >= limit?) | Rich verdict (allow/deny with violations) |
+| Audit trail | Snapshot of sensor readings | Compliance records with policy fingerprint |
+| Extensibility | L2 contributes numeric variables | L2 implements policy engines (OPA, Cedar) |
+| ECS token | `GOVERNANCE` | `GOVERNANCE_BACKEND` |
+
+---
+
+## Layer Position
+
+```
+L0  @koi/core
+    └── GovernanceBackend            ← composite interface (this doc)
+        PolicyEvaluator              ← evaluate PolicyRequest → GovernanceVerdict
+        ConstraintChecker            ← check individual constraints
+        ComplianceRecorder           ← audit trail recording
+        ViolationStore               ← violation history queries
+        PolicyRequest                ← input shape
+        GovernanceVerdict            ← output shape (ok: true | ok: false + violations)
+        Violation                    ← rule + severity + message
+        ViolationSeverity            ← "info" | "warning" | "critical"
+        ComplianceRecord             ← request + verdict + policy fingerprint
+        GOVERNANCE_ALLOW             ← frozen singleton allow verdict
+        VIOLATION_SEVERITY_ORDER     ← frozen ordered array
+        DEFAULT_VIOLATION_QUERY_LIMIT ← 100
+        GOVERNANCE_BACKEND           ← ECS token (in ecs.ts)
+
+L2  @koi/governance-memory (future)
+    └── implements GovernanceBackend
+    └── in-memory rule engine, sync, dev/test
+
+L2  @koi/governance-opa (future)
+    └── implements GovernanceBackend
+    └── OPA Rego policies, async HTTP, production
+
+L2  @koi/governance-cedar (future)
+    └── implements GovernanceBackend
+    └── Cedar policies, local engine, production
+```
+
+`@koi/core` has zero dependencies. `GovernanceBackend` imports only from `./common.js` and `./ecs.js`.
+
+---
+
+## Architecture
+
+### The contract surface (ISP split)
+
+```
+GovernanceBackend
+│
+├── evaluator (required)     PolicyEvaluator
+│   ├── evaluate(request)    PolicyRequest → GovernanceVerdict
+│   └── scope?               PolicyRequestKind[] — hot-path filter
+│
+├── constraints? (optional)  ConstraintChecker
+│   └── checkConstraint(q)   ConstraintQuery → boolean
+│
+├── compliance? (optional)   ComplianceRecorder
+│   └── recordCompliance(r)  ComplianceRecord → ComplianceRecord
+│
+├── violations? (optional)   ViolationStore
+│   └── getViolations(f)     ViolationFilter → ViolationPage
+│
+└── dispose?()               optional cleanup
+```
+
+The interface follows the **Interface Segregation Principle** — only the evaluator is required. Backends that don't need compliance recording or violation history simply omit those sub-interfaces. Consumers check for presence before calling.
+
+### Fail-closed contract
+
+When `evaluate()` throws or returns an error, callers **must deny access**. A missing or errored backend means "deny all":
+
+```
+evaluate(request) → verdict.ok === true   → allow
+evaluate(request) → verdict.ok === false  → deny (violations attached)
+evaluate(request) → throws                → deny (fail-closed)
+backend is undefined                      → deny (fail-closed)
+```
+
+### PolicyRequest → GovernanceVerdict flow
+
+```
+  Middleware receives model/tool call
+      │
+      ▼
+  Construct PolicyRequest:
+  ┌──────────────────────────────────┐
+  │ kind: "model_call"               │
+  │ agentId: "agent-worker-42"       │
+  │ payload: { model: "claude-sonnet"│
+  │            prompt: "..." }       │
+  │ timestamp: 1709049600000         │
+  └──────────────────────────────────┘
+      │
+      ▼
+  Scope check: is "model_call" in evaluator.scope?
+      │
+      ├── scope defined and kind NOT in scope → skip (allow)
+      │
+      └── scope undefined OR kind in scope → evaluate
+          │
+          ▼
+  evaluator.evaluate(request)
+          │
+          ▼
+  ┌────────────────────────────────────┐
+  │ GovernanceVerdict                   │
+  │                                    │
+  │ ok: true                           │  → allow, proceed
+  │   diagnostics?: [{ info: "..." }]  │    (optional warnings)
+  │                                    │
+  │ ok: false                          │  → deny
+  │   violations: [                    │
+  │     { rule: "no-destructive-sql",  │
+  │       severity: "critical",        │
+  │       message: "DROP not allowed"  │
+  │       context: { table: "users" }  │
+  │     }                              │
+  │   ]                                │
+  └────────────────────────────────────┘
+```
+
+### Scope filter (hot-path optimization)
+
+The `evaluator.scope` field is a performance optimization. When present, the middleware chain can skip evaluating requests whose `kind` doesn't match:
+
+```
+evaluator.scope = ["tool_call", "spawn"]
+
+model_call request  → NOT in scope → skip evaluate() → allow  (saves ~1 RPC)
+tool_call request   → in scope     → evaluate()
+spawn request       → in scope     → evaluate()
+```
+
+When `scope` is absent or undefined, the evaluator handles all request kinds.
+
+---
+
+## Data Flow
+
+### Allow path (middleware integration)
+
+```
+  User prompt: "What's the weather?"
+      │
+      ▼
+  ┌──────────────────────────────────────────────────────────────┐
+  │  Governance Backend Middleware (wrapModelStream / wrapModelCall)
+  │                                                              │
+  │  1. Build PolicyRequest { kind: "model_call", agentId, ... } │
+  │                                                              │
+  │  2. Scope check — kind in evaluator.scope?                   │
+  │     yes: evaluate(request) → { ok: true } ✓                  │
+  │                                                              │
+  │  3. checkConstraint? { kind: "spawn_depth", value: 2 }       │
+  │     → true ✓                                                 │
+  │                                                              │
+  │  4. Forward to next middleware → model call executes          │
+  │                                                              │
+  │  5. recordCompliance? {                                      │
+  │       requestId: "req-abc123",                               │
+  │       request: <original PolicyRequest>,                     │
+  │       verdict: { ok: true },                                 │
+  │       evaluatedAt: 1709049600000,                            │
+  │       policyFingerprint: "sha256:abc..."                     │
+  │     }                                                        │
+  └──────────────────────────────────────────────────────────────┘
+      │
+      ▼
+  LLM response: "The weather is sunny..."
+```
+
+### Deny path (fail-closed enforcement)
+
+```
+  Agent "data-analyst" tries tool "execute_sql":
+      │
+      ▼
+  ┌──────────────────────────────────────────────────────────────┐
+  │  Governance Backend Middleware (wrapToolCall)                  │
+  │                                                              │
+  │  1. Build PolicyRequest:                                     │
+  │     kind: "tool_call"                                        │
+  │     agentId: "data-analyst"                                  │
+  │     payload: { tool: "execute_sql", args: { sql: "DROP.." }} │
+  │                                                              │
+  │  2. evaluate(request) →                                      │
+  │     {                                                        │
+  │       ok: false,                                             │
+  │       violations: [{                                         │
+  │         rule: "no-destructive-sql",                          │
+  │         severity: "critical",                                │
+  │         message: "DROP not allowed for non-admin agents"     │
+  │       }]                                                     │
+  │     }                                                        │
+  │                                                              │
+  │  3. DENY — throw KoiRuntimeError(PERMISSION, "...")          │
+  │     Tool never executes.                                     │
+  │     Violation recorded in compliance log.                    │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+### Both governance systems active simultaneously
+
+```
+  ┌─────────────────────────────────────────────────────────┐
+  │                    Agent (ECS Entity)                     │
+  │                                                          │
+  │  ┌──────────────────┐     ┌───────────────────────────┐  │
+  │  │   GOVERNANCE      │     │   GOVERNANCE_BACKEND       │  │
+  │  │   (Controller)    │     │   (Rule Engine)            │  │
+  │  │                   │     │                            │  │
+  │  │   turns: 3/25     │     │   evaluator ──► OPA/Cedar  │  │
+  │  │   tokens: 12k/100k│     │   constraints? ──► limits  │  │
+  │  │   cost: $0.02/$1  │     │   compliance? ──► audit    │  │
+  │  │   errors: 0.1/0.5 │     │   violations? ──► history  │  │
+  │  │   depth: 1/5      │     │                            │  │
+  │  └──────────────────┘     └───────────────────────────┘  │
+  │      │  parallel peers, both active  │                   │
+  └──────┼───────────────────────────────┼───────────────────┘
+         │                               │
+         ▼                               ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │                 Middleware Chain                           │
+  │                                                          │
+  │  governance-guard (p:0)      ← Controller: checkAll()    │
+  │  governance-backend-mw (p:X) ← Backend: evaluate()       │
+  │  ... other middleware ...                                │
+  └──────────────────────────────────────────────────────────┘
+         │
+         ▼
+  ┌──────────────────────┐
+  │   Engine Adapter      │
+  └──────────────────────┘
+```
+
+---
+
+## Wiring
+
+### Via ComponentProvider + createKoi
+
+GovernanceBackend is attached to the agent via a `ComponentProvider`, the same pattern as all ECS components:
+
+```typescript
+import type { ComponentProvider, GovernanceBackend } from "@koi/core";
+import { COMPONENT_PRIORITY, GOVERNANCE_BACKEND } from "@koi/core";
+
+// 1. Create the backend
+const backend: GovernanceBackend = createMyGovernanceBackend(config);
+
+// 2. Wrap it in a ComponentProvider
+const provider: ComponentProvider = {
+  name: "governance-backend-provider",
+  priority: COMPONENT_PRIORITY.BUNDLED,
+  attach: async () => new Map([[GOVERNANCE_BACKEND, backend]]),
+};
+
+// 3. Pass to createKoi
+const runtime = await createKoi({
+  manifest: { name: "my-agent", version: "1.0.0", model: { name: "claude-sonnet" } },
+  adapter: myAdapter,
+  providers: [provider],
+  middleware: [createGovernanceBackendMiddleware(backend)],
+});
+```
+
+### Middleware pattern (closure capture)
+
+The middleware receives the backend at construction time via closure — **not** from `TurnContext` (which doesn't carry the agent entity):
+
+```typescript
+function createGovernanceBackendMiddleware(
+  backend: GovernanceBackend,
+): KoiMiddleware {
+  return {
+    name: "governance-backend",
+    priority: 100,
+
+    // For streaming adapters (Pi adapter)
+    async *wrapModelStream(ctx, request, next) {
+      const policyRequest: PolicyRequest = {
+        kind: "model_call",
+        agentId: agentId(ctx.session.agentId),
+        payload: { model: request.model },
+        timestamp: Date.now(),
+      };
+
+      // Scope check
+      if (backend.evaluator.scope !== undefined) {
+        if (!backend.evaluator.scope.includes("model_call")) {
+          yield* next(request);
+          return;
+        }
+      }
+
+      // Evaluate
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+      if (!verdict.ok) {
+        throw new Error(`Policy denied: ${verdict.violations[0].message}`);
+      }
+
+      // Forward
+      try {
+        yield* next(request);
+      } finally {
+        // Record compliance (finally survives generator .return())
+        if (backend.compliance !== undefined) {
+          await backend.compliance.recordCompliance({
+            requestId: `req-${Date.now()}`,
+            request: policyRequest,
+            verdict,
+            evaluatedAt: Date.now(),
+            policyFingerprint: "sha256:...",
+          });
+        }
+      }
+    },
+
+    // For non-streaming adapters (Loop adapter)
+    async wrapModelCall(ctx, request, next) {
+      // Same pattern as wrapModelStream
+      const verdict = await backend.evaluator.evaluate(/* ... */);
+      if (!verdict.ok) throw new Error(/* ... */);
+      const response = await next(request);
+      // recordCompliance...
+      return response;
+    },
+  };
+}
+```
+
+---
+
+## Adapter-Specific Behavior
+
+### Loop adapter vs Pi adapter
+
+The governance middleware must handle both streaming and non-streaming adapters:
+
+| Aspect | Loop Adapter | Pi Adapter |
+|--------|-------------|------------|
+| Model call path | `wrapModelCall` | `wrapModelStream` |
+| Return type | `Promise<ModelResponse>` | `AsyncIterable<ModelChunk>` |
+| Deny enforcement | Throw in `wrapModelCall` | Throw in `onBeforeTurn` |
+| Compliance recording | After `await next()` | In `try/finally` block |
+
+### Pi adapter gotchas
+
+1. **Errors in `wrapModelStream` are non-fatal**: The stream bridge catches errors from async generators and converts them to pi-agent-core error events. The PiAgent completes with `stopReason: "completed"` despite the error. **Solution**: Use `onBeforeTurn` for deny enforcement — koi.ts properly propagates `KoiRuntimeError` to a done event with `stopReason: "error"`.
+
+2. **Generator early termination**: The stream bridge calls `.return()` on the async generator when it processes a `done` chunk. Code after `yield*` never executes. **Solution**: Use `try/finally` for compliance recording.
+
+3. **Async race on deny**: Pi adapter starts `piAgent.prompt()` asynchronously before `onBeforeTurn` fires, so `getApiKey` may be called even when deny blocks the turn. This is expected — the deny still prevents any model output.
+
+---
+
+## L0 Types (`@koi/core/governance-backend.ts`)
+
+### PolicyRequestKind
+
+```typescript
+type PolicyRequestKind =
+  | "tool_call"
+  | "model_call"
+  | "spawn"
+  | "delegation"
+  | "forge"
+  | "handoff"
+  | `custom:${string}`;  // domain-specific extensions
+```
+
+### PolicyRequest
+
+```typescript
+interface PolicyRequest {
+  readonly kind: PolicyRequestKind;
+  readonly agentId: AgentId;
+  readonly payload: JsonObject;
+  readonly timestamp: number;  // Unix ms
+}
+```
+
+### GovernanceVerdict
+
+Discriminated union on `ok`:
+
+```typescript
+type GovernanceVerdict =
+  | { readonly ok: true; readonly diagnostics?: readonly Violation[] }
+  | { readonly ok: false; readonly violations: readonly Violation[] };
+```
+
+`GOVERNANCE_ALLOW` is a frozen singleton for the common allow case — avoids allocating a new object per decision.
+
+### Violation
+
+```typescript
+interface Violation {
+  readonly rule: string;               // e.g., "no-destructive-sql"
+  readonly severity: ViolationSeverity; // "info" | "warning" | "critical"
+  readonly message: string;
+  readonly context?: JsonObject;
+}
+```
+
+### ViolationSeverity
+
+Three levels, ordered least to most severe:
+
+```
+VIOLATION_SEVERITY_ORDER = ["info", "warning", "critical"]
+```
+
+Use the array for comparisons:
+
+```typescript
+const idx = VIOLATION_SEVERITY_ORDER.indexOf(violation.severity);
+if (idx >= VIOLATION_SEVERITY_ORDER.indexOf("warning")) {
+  // warning or critical
+}
+```
+
+### ComplianceRecord
+
+Links a request to its verdict for audit:
+
+```typescript
+interface ComplianceRecord {
+  readonly requestId: string;
+  readonly request: PolicyRequest;
+  readonly verdict: GovernanceVerdict;
+  readonly evaluatedAt: number;           // Unix ms
+  readonly policyFingerprint: string;     // reproducibility
+}
+```
+
+### ViolationFilter + ViolationPage
+
+```typescript
+interface ViolationFilter {
+  readonly agentId?: AgentId;
+  readonly sessionId?: SessionId;
+  readonly severity?: ViolationSeverity;  // at or above this level
+  readonly rule?: string;
+  readonly since?: number;
+  readonly until?: number;
+  readonly limit?: number;      // default: DEFAULT_VIOLATION_QUERY_LIMIT (100)
+  readonly offset?: string;     // opaque pagination cursor
+}
+
+interface ViolationPage {
+  readonly items: readonly Violation[];
+  readonly cursor?: string;     // next page cursor
+  readonly total?: number;      // if backend supports it
+}
+```
+
+---
+
+## Sub-Interfaces (ISP)
+
+| Sub-Interface | Required | Methods | Purpose |
+|---------------|----------|---------|---------|
+| `PolicyEvaluator` | yes | `evaluate(request)`, `scope?` | Core policy decision |
+| `ConstraintChecker` | no | `checkConstraint(query)` | Individual limit checks |
+| `ComplianceRecorder` | no | `recordCompliance(record)` | Audit trail |
+| `ViolationStore` | no | `getViolations(filter)` | Violation history queries |
+
+All methods return `T | Promise<T>` — in-memory backends are sync, HTTP/database backends are async.
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| ISP split | 4 sub-interfaces | Backends implement only what they need. An OPA evaluator doesn't need violation storage |
+| Fail-closed | Callers must deny on error | Security-first — ambiguous state = deny |
+| `GOVERNANCE_ALLOW` singleton | Frozen, reused | Avoids allocation per decision on the hot path |
+| Scope filter | Optional `PolicyRequestKind[]` | Hot-path optimization — skip eval for irrelevant kinds |
+| Parallel to Controller | Separate ECS token | Each handles a different governance dimension without coupling |
+| `custom:${string}` kind | Template literal type | Domain extensions without modifying the core union |
+| Compliance fingerprint | String (opaque) | Reproducibility — tie verdict to exact policy version |
+| Violation severity | 3-level scale + ordered array | Simple, covers real needs, canonical ordering for comparisons |
+
+---
+
+## Comparison: GovernanceController vs GovernanceBackend
+
+```
+                  GovernanceController           GovernanceBackend
+                  ────────────────────           ─────────────────
+
+ECS token:        GOVERNANCE                     GOVERNANCE_BACKEND
+
+Question type:    "How much?"                    "Is this allowed?"
+                  (numeric gauges)               (rule-based policies)
+
+Input:            GovernanceEvent                PolicyRequest
+                  { kind: "turn" }               { kind: "tool_call",
+                  { kind: "token_usage",           agentId, payload }
+                    count: 1200 }
+
+Output:           GovernanceCheck                GovernanceVerdict
+                  { ok: false,                   { ok: false,
+                    variable: "turn_count",        violations: [
+                    reason: "limit reached" }        { rule: "no-sql-drop",
+                                                       severity: "critical",
+                                                       message: "..." }
+                                                   ] }
+
+Audit:            snapshot() → sensor readings   recordCompliance() → full record
+                                                 getViolations() → history
+
+Extensibility:    L2 contributes numeric vars    L2 implements policy engines
+                  via GovernanceVariableContributor  (OPA, Cedar, custom rules)
+
+Wiring:           Built into createKoi           Via ComponentProvider + middleware
+                  governance option               providers option + middleware option
+```
+
+Both are active simultaneously. Neither subsumes the other.
+
+---
+
+## Future Backend Implementations
+
+```
+@koi/core (L0)
+└── GovernanceBackend ← this contract
+
+@koi/governance-memory (L2, planned)
+└── in-memory rule engine
+└── configurable rule functions
+└── sync — zero async overhead
+└── use for: dev, test, single-node
+
+@koi/governance-opa (L2, planned)
+└── OPA Rego policies
+└── HTTP → OPA sidecar/service
+└── async — network I/O
+└── use for: production, Kubernetes
+
+@koi/governance-cedar (L2, planned)
+└── Cedar policies (AWS-style RBAC/ABAC)
+└── local WASM engine
+└── sync or async depending on policy store
+└── use for: production, fine-grained authz
+```
+
+Consumers code against `GovernanceBackend` — switching backends is a one-line change at the composition root.
+
+---
+
+## Testing
+
+### Core contract tests (no LLM)
+
+```bash
+bun test packages/core/src/governance-backend.test.ts
+```
+
+Covers: `PolicyRequest` shape, `GovernanceVerdict` discriminated union, `Violation` shape, `ViolationSeverity` values, `VIOLATION_SEVERITY_ORDER` ordering and immutability, `GOVERNANCE_ALLOW` singleton, `ComplianceRecord` shape, `ViolationFilter` and `ViolationPage` pagination, `GovernanceBackend` composite interface structural conformance, ISP sub-interface independence.
+
+### Mock factory (test-utils)
+
+```bash
+bun test packages/test-utils/src/governance-backend.test.ts
+```
+
+`createMockGovernanceBackend()` provides a configurable mock with all sub-interfaces for testing middleware and consumers.
+
+### E2E tests (real Anthropic API)
+
+```bash
+# Loop adapter E2E (wrapModelCall path)
+bun scripts/e2e-governance-backend.ts
+
+# Pi adapter E2E (wrapModelStream path)
+bun scripts/e2e-governance-backend-pi.ts
+```
+
+| Script | Adapter | Tests | Assertions | What it proves |
+|--------|---------|-------|------------|----------------|
+| `e2e-governance-backend.ts` | Loop | 7 | 36 | Full contract through `createKoi + createLoopAdapter` |
+| `e2e-governance-backend-pi.ts` | Pi | 7 | 36 | Full contract through `createKoi + createPiAdapter` |
+
+Both scripts test:
+
+1. ComponentProvider wiring under `GOVERNANCE_BACKEND` token
+2. PolicyEvaluator called through middleware on real LLM call
+3. Deny verdict blocks model call (fail-closed enforcement)
+4. ComplianceRecorder captures audit trail
+5. ConstraintChecker called per-request
+6. GovernanceBackend + GovernanceController coexist as parallel peers
+7. Scope-filtered evaluator skips non-matching kinds
+
+---
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `packages/core/src/governance-backend.ts` | L0 types: GovernanceBackend, PolicyEvaluator, GovernanceVerdict, Violation, ComplianceRecord |
+| `packages/core/src/ecs.ts` | `GOVERNANCE_BACKEND` ECS token |
+| `packages/core/src/index.ts` | Re-exports all types and constants |
+| `packages/test-utils/src/governance.ts` | `createMockGovernanceBackend()` factory |
+| `scripts/e2e-governance-backend.ts` | Loop adapter E2E test script |
+| `scripts/e2e-governance-backend-pi.ts` | Pi adapter E2E test script |
+
+---
+
+## API Reference
+
+### Types
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `GovernanceBackend` | interface | The main composite contract |
+| `PolicyEvaluator` | interface | Core policy evaluation sub-interface |
+| `ConstraintChecker` | interface | Individual constraint checking |
+| `ComplianceRecorder` | interface | Audit trail recording |
+| `ViolationStore` | interface | Violation history queries |
+| `PolicyRequest` | interface | Input to `evaluate()` |
+| `PolicyRequestKind` | type | `"tool_call" \| "model_call" \| "spawn" \| ...` |
+| `GovernanceVerdict` | type | Discriminated union: allow (with diagnostics) or deny (with violations) |
+| `Violation` | interface | Rule + severity + message |
+| `ViolationSeverity` | type | `"info" \| "warning" \| "critical"` |
+| `ConstraintQuery` | interface | Input to `checkConstraint()` |
+| `ComplianceRecord` | interface | Request + verdict + policy fingerprint |
+| `ViolationFilter` | interface | Filter for `getViolations()` |
+| `ViolationPage` | interface | Paginated violation results |
+
+### Runtime Values
+
+| Export | Type | Value |
+|--------|------|-------|
+| `GOVERNANCE_BACKEND` | `SubsystemToken<GovernanceBackend>` | ECS component key |
+| `GOVERNANCE_ALLOW` | `GovernanceVerdict` | Frozen singleton `{ ok: true }` |
+| `VIOLATION_SEVERITY_ORDER` | `readonly ViolationSeverity[]` | `["info", "warning", "critical"]` |
+| `DEFAULT_VIOLATION_QUERY_LIMIT` | `number` | `100` |

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -4,7 +4,7 @@ exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { B as BrickRef, a as BrickKind } from './brick-snapshot-HASH.js';
 export { A as ALL_BRICK_KINDS, b as BrickId, c as BrickLifecycle, d as BrickSnapshot, e as BrickSource, F as ForgeScope, M as MIN_TRUST_BY_KIND, S as SnapshotEvent, f as SnapshotId, g as SnapshotQuery, h as SnapshotStore, V as VALID_LIFECYCLE_TRANSITIONS, i as brickId, s as snapshotId } from './brick-snapshot-HASH.js';
 import { A as AgentId, E as EngineState, P as ProcessState, T as Tool, S as SkillComponent, a as AgentDescriptor, b as SubsystemToken, c as TrustTier, d as Agent, C as ComponentProvider, K as KoiMiddleware, e as SessionId, f as ToolCallId } from './ecs-HASH.js';
-export { g as AbortReason, h as ApprovalDecision, i as ApprovalHandler, j as ApprovalRequest, k as ArtifactRef, B as BROWSER, l as BrowserActionOptions, m as BrowserConsoleEntry, n as BrowserConsoleLevel, o as BrowserConsoleOptions, p as BrowserConsoleResult, q as BrowserDriver, r as BrowserEvaluateOptions, s as BrowserEvaluateResult, t as BrowserFormField, u as BrowserNavigateOptions, v as BrowserNavigateResult, w as BrowserRefInfo, x as BrowserScreenshotOptions, y as BrowserScreenshotResult, z as BrowserScrollOptions, D as BrowserSnapshotOptions, F as BrowserSnapshotResult, G as BrowserTabCloseOptions, H as BrowserTabFocusOptions, I as BrowserTabInfo, J as BrowserTabNewOptions, L as BrowserTraceOptions, M as BrowserTraceResult, N as BrowserTypeOptions, O as BrowserUploadFile, Q as BrowserUploadOptions, R as BrowserWaitOptions, U as BrowserWaitUntil, V as COMPONENT_PRIORITY, W as CREDENTIALS, X as CapabilityFragment, Y as ChildHandle, Z as ChildLifecycleEvent, _ as ComponentEvent, $ as ComponentEventKind, a0 as ComposedCallHandlers, a1 as CorrelationIds, a2 as CredentialComponent, a3 as CronSchedule, a4 as DEFAULT_SCHEDULER_CONFIG, a5 as DELEGATION, a6 as DecisionRecord, a7 as EVENTS, a8 as EngineAdapter, a9 as EngineEvent, aa as EngineInput, ab as EngineInputBase, ac as EngineMetrics, ad as EngineOutput, ae as EngineStopReason, af as EventComponent, ag as FILESYSTEM, ah as GOVERNANCE, ai as GOVERNANCE_VARIABLES, aj as GovernanceCheck, ak as GovernanceController, al as GovernanceEvent, am as GovernanceSnapshot, an as GovernanceVariable, ao as GovernanceVariableContributor, ap as HANDOFF, aq as HandoffAcceptError, ar as HandoffAcceptResult, as as HandoffComponent, at as HandoffEnvelope, au as HandoffEvent, av as HandoffId, aw as HandoffStatus, ax as MEMORY, ay as MemoryComponent, az as MemoryRecallOptions, aA as MemoryResult, aB as MemoryStoreOptions, aC as MemoryTier, aD as ModelChunk, aE as ModelHandler, aF as ModelRequest, aG as ModelResponse, aH as ModelStreamHandler, aI as ProcessAccounter, aJ as ProcessId, aK as RunId, aL as SCHEDULER, aM as ScheduleId, aN as ScheduleStore, aO as ScheduledTask, aP as SchedulerComponent, aQ as SchedulerConfig, aR as SchedulerEvent, aS as SchedulerStats, aT as SensorReading, aU as SessionContext, aV as SkillMetadata, aW as SpawnLedger, aX as TaskFilter, aY as TaskHistoryFilter, aZ as TaskId, a_ as TaskOptions, a$ as TaskRunRecord, b0 as TaskScheduler, b1 as TaskStatus, b2 as TaskStore, b3 as ToolDescriptor, b4 as ToolExecuteOptions, b5 as ToolHandler, b6 as ToolRequest, b7 as ToolResponse, b8 as TurnContext, b9 as TurnId, ba as WEBHOOK, bb as WORKSPACE, bc as WorkspaceComponent, bd as agentId, be as agentToken, bf as channelToken, bg as governanceContributorToken, bh as handoffId, bi as middlewareToken, bj as runId, bk as scheduleId, bl as sessionId, bm as skillToken, bn as taskId, bo as token, bp as toolCallId, bq as toolToken, br as turnId } from './ecs-HASH.js';
+export { g as AbortReason, h as ApprovalDecision, i as ApprovalHandler, j as ApprovalRequest, k as ArtifactRef, B as BROWSER, l as BrowserActionOptions, m as BrowserConsoleEntry, n as BrowserConsoleLevel, o as BrowserConsoleOptions, p as BrowserConsoleResult, q as BrowserDriver, r as BrowserEvaluateOptions, s as BrowserEvaluateResult, t as BrowserFormField, u as BrowserNavigateOptions, v as BrowserNavigateResult, w as BrowserRefInfo, x as BrowserScreenshotOptions, y as BrowserScreenshotResult, z as BrowserScrollOptions, D as BrowserSnapshotOptions, F as BrowserSnapshotResult, G as BrowserTabCloseOptions, H as BrowserTabFocusOptions, I as BrowserTabInfo, J as BrowserTabNewOptions, L as BrowserTraceOptions, M as BrowserTraceResult, N as BrowserTypeOptions, O as BrowserUploadFile, Q as BrowserUploadOptions, R as BrowserWaitOptions, U as BrowserWaitUntil, V as COMPONENT_PRIORITY, W as CREDENTIALS, X as CapabilityFragment, Y as ChildHandle, Z as ChildLifecycleEvent, _ as ComplianceRecord, $ as ComplianceRecorder, a0 as ComponentEvent, a1 as ComponentEventKind, a2 as ComposedCallHandlers, a3 as ConstraintChecker, a4 as ConstraintQuery, a5 as CorrelationIds, a6 as CredentialComponent, a7 as CronSchedule, a8 as DEFAULT_SCHEDULER_CONFIG, a9 as DEFAULT_VIOLATION_QUERY_LIMIT, aa as DELEGATION, ab as DecisionRecord, ac as EVENTS, ad as EngineAdapter, ae as EngineEvent, af as EngineInput, ag as EngineInputBase, ah as EngineMetrics, ai as EngineOutput, aj as EngineStopReason, ak as EventComponent, al as FILESYSTEM, am as GOVERNANCE, an as GOVERNANCE_ALLOW, ao as GOVERNANCE_BACKEND, ap as GOVERNANCE_VARIABLES, aq as GovernanceBackend, ar as GovernanceCheck, as as GovernanceController, at as GovernanceEvent, au as GovernanceSnapshot, av as GovernanceVariable, aw as GovernanceVariableContributor, ax as GovernanceVerdict, ay as HANDOFF, az as HandoffAcceptError, aA as HandoffAcceptResult, aB as HandoffComponent, aC as HandoffEnvelope, aD as HandoffEvent, aE as HandoffId, aF as HandoffStatus, aG as MEMORY, aH as MemoryComponent, aI as MemoryRecallOptions, aJ as MemoryResult, aK as MemoryStoreOptions, aL as MemoryTier, aM as ModelChunk, aN as ModelHandler, aO as ModelRequest, aP as ModelResponse, aQ as ModelStreamHandler, aR as PolicyEvaluator, aS as PolicyRequest, aT as PolicyRequestKind, aU as ProcessAccounter, aV as ProcessId, aW as RunId, aX as SCHEDULER, aY as ScheduleId, aZ as ScheduleStore, a_ as ScheduledTask, a$ as SchedulerComponent, b0 as SchedulerConfig, b1 as SchedulerEvent, b2 as SchedulerStats, b3 as SensorReading, b4 as SessionContext, b5 as SkillMetadata, b6 as SpawnLedger, b7 as TaskFilter, b8 as TaskHistoryFilter, b9 as TaskId, ba as TaskOptions, bb as TaskRunRecord, bc as TaskScheduler, bd as TaskStatus, be as TaskStore, bf as ToolDescriptor, bg as ToolExecuteOptions, bh as ToolHandler, bi as ToolRequest, bj as ToolResponse, bk as TurnContext, bl as TurnId, bm as VIOLATION_SEVERITY_ORDER, bn as Violation, bo as ViolationFilter, bp as ViolationPage, bq as ViolationSeverity, br as ViolationStore, bs as WEBHOOK, bt as WORKSPACE, bu as WorkspaceComponent, bv as agentId, bw as agentToken, bx as channelToken, by as governanceContributorToken, bz as handoffId, bA as middlewareToken, bB as runId, bC as scheduleId, bD as sessionId, bE as skillToken, bF as taskId, bG as token, bH as toolCallId, bI as toolToken, bJ as turnId } from './ecs-HASH.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { TransitionReason, AgentCondition, AgentStatus, RegistryEntry, AgentRegistry } from './lifecycle.js';
@@ -20,7 +20,6 @@ export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js
 export { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfig, EventEnvelope, EventInput, ReadOptions, ReadResult, SubscribeOptions, SubscriptionHandle } from './event-HASH.js';
 export { EvictionCandidate, EvictionPolicy, EvictionReason, EvictionResult } from './eviction.js';
 export { FileDeleteResult, FileEdit, FileEditOptions, FileEditResult, FileEntryKind, FileListEntry, FileListOptions, FileListResult, FileReadOptions, FileReadResult, FileRenameResult, FileSearchMatch, FileSearchOptions, FileSearchResult, FileSystemBackend, FileWriteOptions, FileWriteResult } from './filesystem-HASH.js';
-export { ConstraintQuery, DEFAULT_VIOLATION_QUERY_LIMIT, GovernanceAttestation, GovernanceAttestationId, GovernanceAttestationInput, GovernanceBackend, GovernanceBackendEvent, GovernanceVerdict, VIOLATION_SEVERITIES, Violation, ViolationQuery, ViolationSeverity, governanceAttestationId } from './governance-HASH.js';
 export { DEFAULT_HEALTH_MONITOR_CONFIG, HealthMonitor, HealthMonitorConfig, HealthMonitorStats, HealthSnapshot, HealthStatus } from './health.js';
 export { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, InboundMessage, OutboundMessage, TextBlock } from './message.js';
 export { ModelCapabilities, ModelProvider, ModelTarget } from './model-HASH.js';
@@ -1739,7 +1738,7 @@ import './webhook.js';
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
 "import './assembly-HASH.js';
-export { d as Agent, a as AgentDescriptor, A as AgentId, B as BROWSER, V as COMPONENT_PRIORITY, W as CREDENTIALS, Y as ChildHandle, Z as ChildLifecycleEvent, _ as ComponentEvent, $ as ComponentEventKind, C as ComponentProvider, a2 as CredentialComponent, a5 as DELEGATION, a7 as EVENTS, af as EventComponent, ag as FILESYSTEM, ah as GOVERNANCE, ap as HANDOFF, ax as MEMORY, ay as MemoryComponent, az as MemoryRecallOptions, aA as MemoryResult, aB as MemoryStoreOptions, aC as MemoryTier, aI as ProcessAccounter, aJ as ProcessId, P as ProcessState, aK as RunId, aL as SCHEDULER, e as SessionId, S as SkillComponent, aV as SkillMetadata, aW as SpawnLedger, b as SubsystemToken, T as Tool, f as ToolCallId, b3 as ToolDescriptor, b4 as ToolExecuteOptions, c as TrustTier, b9 as TurnId, ba as WEBHOOK, bb as WORKSPACE, bc as WorkspaceComponent, bd as agentId, be as agentToken, bf as channelToken, bi as middlewareToken, bj as runId, bl as sessionId, bm as skillToken, bo as token, bp as toolCallId, bq as toolToken, br as turnId } from './ecs-HASH.js';
+export { d as Agent, a as AgentDescriptor, A as AgentId, B as BROWSER, V as COMPONENT_PRIORITY, W as CREDENTIALS, Y as ChildHandle, Z as ChildLifecycleEvent, a0 as ComponentEvent, a1 as ComponentEventKind, C as ComponentProvider, a6 as CredentialComponent, aa as DELEGATION, ac as EVENTS, ak as EventComponent, al as FILESYSTEM, am as GOVERNANCE, ao as GOVERNANCE_BACKEND, ay as HANDOFF, aG as MEMORY, aH as MemoryComponent, aI as MemoryRecallOptions, aJ as MemoryResult, aK as MemoryStoreOptions, aL as MemoryTier, aU as ProcessAccounter, aV as ProcessId, P as ProcessState, aW as RunId, aX as SCHEDULER, e as SessionId, S as SkillComponent, b5 as SkillMetadata, b6 as SpawnLedger, b as SubsystemToken, T as Tool, f as ToolCallId, bf as ToolDescriptor, bg as ToolExecuteOptions, c as TrustTier, bl as TurnId, bs as WEBHOOK, bt as WORKSPACE, bu as WorkspaceComponent, bv as agentId, bw as agentToken, bx as channelToken, bA as middlewareToken, bB as runId, bD as sessionId, bE as skillToken, bG as token, bH as toolCallId, bI as toolToken, bJ as turnId } from './ecs-HASH.js';
 import './channel.js';
 import './common.js';
 import './filesystem-HASH.js';
@@ -1752,7 +1751,7 @@ import './message.js';
 exports[`@koi/core API surface ./handoff has stable type surface 1`] = `
 "import './common.js';
 import './assembly-HASH.js';
-export { k as ArtifactRef, a6 as DecisionRecord, aq as HandoffAcceptError, ar as HandoffAcceptResult, as as HandoffComponent, at as HandoffEnvelope, au as HandoffEvent, av as HandoffId, aw as HandoffStatus, bh as handoffId } from './ecs-HASH.js';
+export { k as ArtifactRef, ab as DecisionRecord, az as HandoffAcceptError, aA as HandoffAcceptResult, aB as HandoffComponent, aC as HandoffEnvelope, aD as HandoffEvent, aE as HandoffId, aF as HandoffStatus, bz as handoffId } from './ecs-HASH.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -1763,7 +1762,7 @@ import './filesystem-HASH.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { g as AbortReason, a0 as ComposedCallHandlers, a8 as EngineAdapter, a9 as EngineEvent, aa as EngineInput, ab as EngineInputBase, ac as EngineMetrics, ad as EngineOutput, E as EngineState, ae as EngineStopReason } from './ecs-HASH.js';
+export { g as AbortReason, a2 as ComposedCallHandlers, ad as EngineAdapter, ae as EngineEvent, af as EngineInput, ag as EngineInputBase, ah as EngineMetrics, ai as EngineOutput, E as EngineState, aj as EngineStopReason } from './ecs-HASH.js';
 import './message.js';
 import './assembly-HASH.js';
 import './webhook.js';
@@ -1924,267 +1923,14 @@ export type { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfi
 `;
 
 exports[`@koi/core API surface ./governance-backend has stable type surface 1`] = `
-"import { JsonObject } from './common.js';
-import { A as AgentId } from './ecs-HASH.js';
-import { Result, KoiError } from './errors.js';
+"import './common.js';
+export { _ as ComplianceRecord, $ as ComplianceRecorder, a3 as ConstraintChecker, a4 as ConstraintQuery, a9 as DEFAULT_VIOLATION_QUERY_LIMIT, an as GOVERNANCE_ALLOW, aq as GovernanceBackend, ax as GovernanceVerdict, aR as PolicyEvaluator, aS as PolicyRequest, aT as PolicyRequestKind, bm as VIOLATION_SEVERITY_ORDER, bn as Violation, bo as ViolationFilter, bp as ViolationPage, bq as ViolationSeverity, br as ViolationStore } from './ecs-HASH.js';
 import './assembly-HASH.js';
 import './webhook.js';
+import './errors.js';
 import './channel.js';
 import './message.js';
 import './filesystem-HASH.js';
-
-/**
- * GovernanceBackend — pluggable anomaly detection and constraint enforcement contract (Layer 0).
- *
- * Defines the interface for evaluating governance events against policy rules,
- * checking constraints, recording compliance attestations, and querying violations.
- *
- * L2 packages implement GovernanceBackend for specific backends:
- *   - @koi/governance: local in-process rule evaluation (default)
- *   - @koi/governance-nexus: Nexus governance brick (attestation, audit, compliance)
- *   - User-provided: any implementation of GovernanceBackend
- *
- * Consumed by: agent-monitor (#59), spawn governance, ProposalGate (#223),
- *              unified governance controller (#261).
- *
- * Fail-closed contract: if evaluate() or checkConstraint() throw, callers
- * MUST deny the operation. Infrastructure failures are not distinguished from
- * intentional denials — never treat a throwing backend as permissive.
- *
- * Exception: governanceAttestationId() is a branded type constructor (identity cast),
- * permitted in L0 as a zero-logic operation for type safety.
- *
- * Exception: DEFAULT_VIOLATION_QUERY_LIMIT and VIOLATION_SEVERITIES are pure readonly
- * data constants derived from L0 type definitions, codifying architecture-doc
- * invariants with zero logic.
- */
-
-/**
- * An event submitted to the governance backend for policy evaluation.
- *
- * Distinct from GovernanceEvent (governance.ts), which is the controller's
- * sensor-update event (a closed discriminated union for the sensor/setpoint model).
- * GovernanceBackendEvent uses an open string kind with an arbitrary payload,
- * supporting any event the backend needs to evaluate — including custom event kinds
- * from L2 packages.
- */
-interface GovernanceBackendEvent {
-    /**
-     * Semantic event type. Well-known kinds: "tool_call" | "spawn" | "forge" |
-     * "promotion" | "proposal". Backends may support additional kinds.
-     */
-    readonly kind: string;
-    /** The agent that produced this event. */
-    readonly agentId: AgentId;
-    /** Structured event payload — backend-specific content for rule evaluation. */
-    readonly payload: JsonObject;
-    /** Unix timestamp (ms) when the event occurred. */
-    readonly timestamp: number;
-}
-/**
- * Severity level for a policy violation. Ordered from lowest to highest impact.
- * Use VIOLATION_SEVERITIES for the canonical ordering and comparison.
- */
-type ViolationSeverity = "info" | "warning" | "critical";
-/**
- * Canonical ordering of ViolationSeverity values from lowest to highest impact.
- * Use for severity comparison:
- *
- * \`\`\`typescript
- * const infoIdx    = VIOLATION_SEVERITIES.indexOf("info");    // 0
- * const warningIdx = VIOLATION_SEVERITIES.indexOf("warning"); // 1
- * const critIdx    = VIOLATION_SEVERITIES.indexOf("critical"); // 2
- * if (VIOLATION_SEVERITIES.indexOf(v.severity) >= VIOLATION_SEVERITIES.indexOf("warning")) { ... }
- * \`\`\`
- */
-declare const VIOLATION_SEVERITIES: readonly ViolationSeverity[];
-/**
- * A single policy rule violation produced by a GovernanceBackend.evaluate() call.
- *
- * A GovernanceVerdict may contain multiple Violations — one per violated rule.
- * Backends SHOULD include all violated rules (not just the first) to enable
- * consumers to make fully informed decisions.
- */
-interface Violation {
-    /** The rule identifier that was violated (backend-defined). */
-    readonly rule: string;
-    /** Categorical impact level of this violation. */
-    readonly severity: ViolationSeverity;
-    /** Human-readable description of the violation. Answers: what happened + why. */
-    readonly message: string;
-    /** Optional structured context for this violation (threshold values, agent state, etc.). */
-    readonly context?: JsonObject | undefined;
-}
-/**
- * The outcome of a GovernanceBackend.evaluate() call.
- *
- * Distinct from GovernanceCheck (governance.ts), which is the controller's
- * per-sensor check result ("did this one variable exceed its limit?", single
- * variable, retryable flag). GovernanceVerdict is the backend's policy evaluation
- * result: zero or more violations across all applicable rules for a single event.
- */
-type GovernanceVerdict = {
-    readonly ok: true;
-} | {
-    readonly ok: false;
-    readonly violations: readonly Violation[];
-};
-/**
- * Input for a point-in-time constraint check against a specific agent.
- * The constraint is identified by ID; the backend resolves the rule definition.
- */
-interface ConstraintQuery {
-    /** The constraint identifier to check (backend-defined rule ID). */
-    readonly constraintId: string;
-    /** The agent to check the constraint against. */
-    readonly agentId: AgentId;
-    /** Optional structured context for evaluating the constraint. */
-    readonly context?: JsonObject | undefined;
-}
-/**
- * Default maximum number of violations returned by a single getViolations() call.
- * Implementations SHOULD apply this when the caller omits \`limit\`.
- */
-declare const DEFAULT_VIOLATION_QUERY_LIMIT = 100;
-/**
- * Filter for querying stored violation records.
- * All fields are optional — omitting a field means "no constraint on that dimension".
- * Providing no fields returns ALL violations up to \`limit\` — use with care.
- */
-interface ViolationQuery {
-    /** Filter to violations for a specific agent. */
-    readonly agentId?: AgentId | undefined;
-    /** Filter to violations matching any of these severity levels. */
-    readonly severity?: readonly ViolationSeverity[] | undefined;
-    /** Filter to violations from a specific rule. */
-    readonly ruleId?: string | undefined;
-    /** Include only violations at or after this Unix timestamp (ms). */
-    readonly after?: number | undefined;
-    /** Include only violations before this Unix timestamp (ms). */
-    readonly before?: number | undefined;
-    /**
-     * Maximum number of violations to return.
-     * Defaults to DEFAULT_VIOLATION_QUERY_LIMIT when omitted.
-     */
-    readonly limit?: number | undefined;
-}
-declare const __governanceAttestationBrand: unique symbol;
-/**
- * Branded string type for governance attestation identifiers.
- * Prevents accidental mixing with other string IDs (ProposalId, BrickId, etc.)
- * at compile time.
- */
-type GovernanceAttestationId = string & {
-    readonly [__governanceAttestationBrand]: "GovernanceAttestationId";
-};
-/** Create a branded GovernanceAttestationId from a plain string. */
-declare function governanceAttestationId(raw: string): GovernanceAttestationId;
-/**
- * Data provided by the caller when recording a compliance attestation.
- * The backend assigns id, attestedAt, and attestedBy — callers provide
- * the agentId, ruleId, verdict, and optional evidence.
- */
-interface GovernanceAttestationInput {
-    /** The agent this attestation is about. */
-    readonly agentId: AgentId;
-    /** The rule or policy this attestation covers (backend-defined rule ID). */
-    readonly ruleId: string;
-    /** The policy evaluation result being attested. */
-    readonly verdict: GovernanceVerdict;
-    /** Optional structured evidence supporting the attestation. */
-    readonly evidence?: JsonObject | undefined;
-}
-/**
- * A governance compliance attestation as stored and returned by the backend.
- * Immutable — each attestation is a point-in-time compliance claim.
- * Callers receive this from recordAttestation(); it is never mutated.
- */
-interface GovernanceAttestation {
-    /** Backend-assigned unique identifier for this attestation. */
-    readonly id: GovernanceAttestationId;
-    /** The agent this attestation is about. */
-    readonly agentId: AgentId;
-    /** The rule or policy this attestation covers. */
-    readonly ruleId: string;
-    /** The policy evaluation result being attested. */
-    readonly verdict: GovernanceVerdict;
-    /** Optional structured evidence supporting the attestation. */
-    readonly evidence?: JsonObject | undefined;
-    /** Unix timestamp (ms) when this attestation was recorded. Backend-assigned. */
-    readonly attestedAt: number;
-    /**
-     * Identity of the backend that recorded this attestation.
-     * Allows consumers to distinguish attestations from different backends
-     * (e.g., "local", "nexus", "custom").
-     */
-    readonly attestedBy: string;
-}
-/**
- * Pluggable anomaly detection and constraint enforcement backend.
- *
- * All methods return \`T | Promise<T>\` — in-memory implementations return sync
- * values, database/network implementations return Promises. Callers must always
- * \`await\` the result.
- *
- * **Fail-closed contract**: \`evaluate()\` and \`checkConstraint()\` do NOT use
- * \`Result<T, KoiError>\`. If they throw, callers MUST treat the operation as
- * denied. Infrastructure failures are indistinguishable from intentional denials
- * — never treat a throwing backend as permissive.
- *
- * \`recordAttestation()\` and \`getViolations()\` use \`Result<T, KoiError>\` because
- * their callers need structured error information (retry vs. permanent failure,
- * storage unavailable vs. invalid input).
- *
- * @see GovernanceController (governance.ts) — sensor/setpoint runtime model.
- * @see ProposalGate (proposal.ts) — structural layer change governance.
- * @see AuditSink (audit-backend.ts) — structured audit logging.
- */
-interface GovernanceBackend {
-    /**
-     * Evaluate a governance event against all applicable policy rules.
-     *
-     * Returns \`{ ok: true }\` if no rules are violated.
-     * Returns \`{ ok: false; violations }\` if one or more rules are violated.
-     * Backends SHOULD include all violated rules (not only the first).
-     *
-     * **Fail closed**: if this method throws, callers MUST deny the operation.
-     * Never treat a throwing backend as permissive.
-     */
-    readonly evaluate: (event: GovernanceBackendEvent) => GovernanceVerdict | Promise<GovernanceVerdict>;
-    /**
-     * Check whether a specific constraint is satisfied for the given agent.
-     *
-     * Returns \`true\` if the constraint is satisfied.
-     * Returns \`false\` if the constraint is violated.
-     *
-     * **Fail closed**: if this method throws, callers MUST deny the operation.
-     * Never treat a throwing backend as permissive.
-     */
-    readonly checkConstraint: (constraint: ConstraintQuery) => boolean | Promise<boolean>;
-    /**
-     * Record a compliance attestation for a governance evaluation result.
-     *
-     * The backend assigns \`id\`, \`attestedAt\`, and \`attestedBy\`.
-     * Returns the stored GovernanceAttestation on success.
-     * Returns a KoiError on validation failure or storage error.
-     *
-     * Implementations SHOULD be idempotent for identical
-     * (agentId, ruleId, verdict, timestamp) tuples to handle retry scenarios.
-     */
-    readonly recordAttestation: (input: GovernanceAttestationInput) => Result<GovernanceAttestation, KoiError> | Promise<Result<GovernanceAttestation, KoiError>>;
-    /**
-     * Query stored violation records matching the filter.
-     *
-     * Returns violations ordered by timestamp descending (most recent first).
-     * Applies DEFAULT_VIOLATION_QUERY_LIMIT when \`filter.limit\` is omitted.
-     * Check the returned array length against \`filter.limit\` to detect truncation.
-     */
-    readonly getViolations: (filter: ViolationQuery) => Result<readonly Violation[], KoiError> | Promise<Result<readonly Violation[], KoiError>>;
-    /** Close the backend and release resources (connections, timers, file handles). */
-    readonly dispose?: () => void | Promise<void>;
-}
-
-export { type ConstraintQuery, DEFAULT_VIOLATION_QUERY_LIMIT, type GovernanceAttestation, type GovernanceAttestationId, type GovernanceAttestationInput, type GovernanceBackend, type GovernanceBackendEvent, type GovernanceVerdict, VIOLATION_SEVERITIES, type Violation, type ViolationQuery, type ViolationSeverity, governanceAttestationId };
 "
 `;
 
@@ -2316,7 +2062,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import './channel.js';
 import './common.js';
-export { h as ApprovalDecision, i as ApprovalHandler, j as ApprovalRequest, X as CapabilityFragment, K as KoiMiddleware, aD as ModelChunk, aE as ModelHandler, aF as ModelRequest, aG as ModelResponse, aH as ModelStreamHandler, aU as SessionContext, b5 as ToolHandler, b6 as ToolRequest, b7 as ToolResponse, b8 as TurnContext } from './ecs-HASH.js';
+export { h as ApprovalDecision, i as ApprovalHandler, j as ApprovalRequest, X as CapabilityFragment, K as KoiMiddleware, aM as ModelChunk, aN as ModelHandler, aO as ModelRequest, aP as ModelResponse, aQ as ModelStreamHandler, b4 as SessionContext, bh as ToolHandler, bi as ToolRequest, bj as ToolResponse, bk as TurnContext } from './ecs-HASH.js';
 import './message.js';
 import './assembly-HASH.js';
 import './webhook.js';
@@ -3249,7 +2995,7 @@ export { type PublisherId, type ShadowWarning, type VersionChangeEvent, type Ver
 
 exports[`@koi/core API surface ./run-report has stable type surface 1`] = `
 "import { JsonObject } from './common.js';
-import { A as AgentId, e as SessionId, aK as RunId, k as ArtifactRef } from './ecs-HASH.js';
+import { A as AgentId, e as SessionId, aW as RunId, k as ArtifactRef } from './ecs-HASH.js';
 import './assembly-HASH.js';
 import './webhook.js';
 import './errors.js';

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -14,6 +14,7 @@ import type { JsonObject } from "./common.js";
 import type { DelegationComponent } from "./delegation.js";
 import type { FileSystemBackend } from "./filesystem-backend.js";
 import type { GovernanceController } from "./governance.js";
+import type { GovernanceBackend } from "./governance-backend.js";
 import type { HandoffComponent } from "./handoff.js";
 import type { SchedulerComponent } from "./scheduler.js";
 import type { WebhookComponent } from "./webhook.js";
@@ -401,6 +402,8 @@ export interface ChildHandle {
 export const MEMORY: SubsystemToken<MemoryComponent> = token<MemoryComponent>("memory");
 export const GOVERNANCE: SubsystemToken<GovernanceController> =
   token<GovernanceController>("governance");
+export const GOVERNANCE_BACKEND: SubsystemToken<GovernanceBackend> =
+  token<GovernanceBackend>("governance-backend");
 export const CREDENTIALS: SubsystemToken<CredentialComponent> =
   token<CredentialComponent>("credentials");
 export const EVENTS: SubsystemToken<EventComponent> = token<EventComponent>("events");

--- a/packages/core/src/governance-backend.test.ts
+++ b/packages/core/src/governance-backend.test.ts
@@ -1,53 +1,248 @@
-/**
- * governance-backend.test.ts
- *
- * Structural and invariant tests for @koi/core governance backend types.
- * Tests runtime values (branded constructors, constants) and structural
- * shapes that api-surface snapshot tests cannot catch (wrong constant values,
- * silent severity additions/removals).
- */
-
 import { describe, expect, test } from "bun:test";
+import { agentId } from "./ecs.js";
+import type {
+  ComplianceRecord,
+  ComplianceRecorder,
+  ConstraintChecker,
+  ConstraintQuery,
+  GovernanceBackend,
+  GovernanceVerdict,
+  PolicyEvaluator,
+  PolicyRequest,
+  PolicyRequestKind,
+  Violation,
+  ViolationFilter,
+  ViolationPage,
+  ViolationSeverity,
+  ViolationStore,
+} from "./governance-backend.js";
 import {
   DEFAULT_VIOLATION_QUERY_LIMIT,
-  type GovernanceAttestation,
-  type GovernanceAttestationInput,
-  type GovernanceBackend,
-  type GovernanceBackendEvent,
-  type GovernanceVerdict,
-  governanceAttestationId,
-  VIOLATION_SEVERITIES,
-  type Violation,
-  type ViolationQuery,
-  type ViolationSeverity,
+  GOVERNANCE_ALLOW,
+  VIOLATION_SEVERITY_ORDER,
 } from "./governance-backend.js";
 
-// ---------------------------------------------------------------------------
-// governanceAttestationId — branded constructor
-// ---------------------------------------------------------------------------
-
-describe("governanceAttestationId", () => {
-  test("is an identity cast — returns the input string unchanged", () => {
-    const id = governanceAttestationId("attest-abc-123");
-    expect(id).toBe(governanceAttestationId("attest-abc-123"));
+describe("PolicyRequestKind", () => {
+  test("accepts all standard kinds", () => {
+    const kinds: readonly PolicyRequestKind[] = [
+      "tool_call",
+      "model_call",
+      "spawn",
+      "delegation",
+      "forge",
+      "handoff",
+    ];
+    expect(kinds).toHaveLength(6);
   });
 
-  test("produces distinct values for distinct inputs", () => {
-    const a = governanceAttestationId("a");
-    const b = governanceAttestationId("b");
-    expect(a).not.toBe(b);
+  test("accepts custom: prefixed kinds", () => {
+    const customKind: PolicyRequestKind = "custom:my-domain-check";
+    expect(customKind).toBe("custom:my-domain-check");
   });
 
-  test("round-trips through string comparison", () => {
-    const raw = "governance-attest-xyz";
-    const id = governanceAttestationId(raw);
-    expect(String(id)).toBe(raw);
+  test("exhaustive switch covers all standard kinds", () => {
+    const toLabel = (kind: PolicyRequestKind): string => {
+      switch (kind) {
+        case "tool_call":
+          return "tool";
+        case "model_call":
+          return "model";
+        case "spawn":
+          return "spawn";
+        case "delegation":
+          return "delegation";
+        case "forge":
+          return "forge";
+        case "handoff":
+          return "handoff";
+        default: {
+          // custom:${string} falls through to default
+          const custom: `custom:${string}` = kind;
+          return `custom(${custom})`;
+        }
+      }
+    };
+    expect(toLabel("tool_call")).toBe("tool");
+    expect(toLabel("custom:foo")).toBe("custom(custom:foo)");
   });
 });
 
-// ---------------------------------------------------------------------------
-// DEFAULT_VIOLATION_QUERY_LIMIT — default page size constant
-// ---------------------------------------------------------------------------
+describe("PolicyRequest", () => {
+  test("conforms to interface shape", () => {
+    const request = {
+      kind: "tool_call" as PolicyRequestKind,
+      agentId: agentId("agent-a"),
+      payload: { toolName: "read_file" },
+      timestamp: 1_000_000,
+    } satisfies PolicyRequest;
+    expect(request.kind).toBe("tool_call");
+  });
+
+  test("accepts custom kind", () => {
+    const request = {
+      kind: "custom:domain-check" as PolicyRequestKind,
+      agentId: agentId("agent-b"),
+      payload: { domain: "example.com" },
+      timestamp: 2_000_000,
+    } satisfies PolicyRequest;
+    expect(request.kind).toBe("custom:domain-check");
+  });
+});
+
+describe("VIOLATION_SEVERITY_ORDER", () => {
+  test("has 3 ordered levels", () => {
+    expect(VIOLATION_SEVERITY_ORDER).toHaveLength(3);
+  });
+
+  test("starts with info and ends with critical", () => {
+    expect(VIOLATION_SEVERITY_ORDER[0]).toBe("info");
+    expect(VIOLATION_SEVERITY_ORDER[VIOLATION_SEVERITY_ORDER.length - 1]).toBe("critical");
+  });
+
+  test("is frozen at runtime", () => {
+    expect(Object.isFrozen(VIOLATION_SEVERITY_ORDER)).toBe(true);
+  });
+
+  test("contains all expected severities in order", () => {
+    expect(VIOLATION_SEVERITY_ORDER).toEqual(["info", "warning", "critical"]);
+  });
+
+  test("info index is lower than critical index", () => {
+    const infoIdx = VIOLATION_SEVERITY_ORDER.indexOf("info");
+    const criticalIdx = VIOLATION_SEVERITY_ORDER.indexOf("critical");
+    expect(infoIdx).toBeLessThan(criticalIdx);
+  });
+});
+
+describe("ViolationSeverity", () => {
+  test("all values are present in VIOLATION_SEVERITY_ORDER", () => {
+    const severities: readonly ViolationSeverity[] = ["info", "warning", "critical"];
+    for (const severity of severities) {
+      expect(VIOLATION_SEVERITY_ORDER).toContain(severity);
+    }
+  });
+});
+
+describe("Violation", () => {
+  test("conforms to interface shape", () => {
+    const violation = {
+      rule: "max-spawn-depth",
+      severity: "critical" as ViolationSeverity,
+      message: "Agent exceeded maximum spawn depth of 3",
+    } satisfies Violation;
+    expect(violation.rule).toBe("max-spawn-depth");
+  });
+
+  test("accepts optional context field", () => {
+    const violation = {
+      rule: "no-external-api",
+      severity: "warning" as ViolationSeverity,
+      message: "External API access is restricted",
+      context: { url: "https://example.com", method: "GET" },
+    } satisfies Violation;
+    expect(violation.context?.url).toBe("https://example.com");
+  });
+});
+
+describe("GovernanceVerdict", () => {
+  test("narrows to allow branch", () => {
+    const verdict: GovernanceVerdict = { ok: true };
+    if (verdict.ok) {
+      expect(verdict.diagnostics).toBeUndefined();
+    }
+  });
+
+  test("narrows to deny branch with violations", () => {
+    const verdict: GovernanceVerdict = {
+      ok: false,
+      violations: [{ rule: "test-rule", severity: "critical", message: "denied" }],
+    };
+    if (!verdict.ok) {
+      expect(verdict.violations).toHaveLength(1);
+      expect(verdict.violations[0]?.rule).toBe("test-rule");
+    }
+  });
+
+  test("allow branch accepts optional diagnostics", () => {
+    const verdict: GovernanceVerdict = {
+      ok: true,
+      diagnostics: [{ rule: "rate-limit", severity: "info", message: "Approaching rate limit" }],
+    };
+    if (verdict.ok) {
+      expect(verdict.diagnostics).toHaveLength(1);
+    }
+  });
+});
+
+describe("GOVERNANCE_ALLOW", () => {
+  test("is frozen at runtime", () => {
+    expect(Object.isFrozen(GOVERNANCE_ALLOW)).toBe(true);
+  });
+
+  test("has ok: true", () => {
+    expect(GOVERNANCE_ALLOW.ok).toBe(true);
+  });
+
+  test("has no diagnostics", () => {
+    if (GOVERNANCE_ALLOW.ok) {
+      expect(GOVERNANCE_ALLOW.diagnostics).toBeUndefined();
+    }
+  });
+
+  test("is a valid GovernanceVerdict", () => {
+    const verdict: GovernanceVerdict = GOVERNANCE_ALLOW;
+    expect(verdict.ok).toBe(true);
+  });
+});
+
+describe("ConstraintQuery", () => {
+  test("conforms to interface shape with all fields", () => {
+    const query = {
+      kind: "spawn_depth",
+      agentId: agentId("agent-a"),
+      value: 4,
+      context: { maxAllowed: 3 },
+    } satisfies ConstraintQuery;
+    expect(query.kind).toBe("spawn_depth");
+  });
+
+  test("value and context are optional", () => {
+    const query: ConstraintQuery = {
+      kind: "token_budget",
+      agentId: agentId("agent-b"),
+    };
+    expect(query.value).toBeUndefined();
+    expect(query.context).toBeUndefined();
+  });
+
+  test("value accepts string", () => {
+    const query = {
+      kind: "model_tier",
+      agentId: agentId("agent-c"),
+      value: "premium",
+    } satisfies ConstraintQuery;
+    expect(query.value).toBe("premium");
+  });
+});
+
+describe("ComplianceRecord", () => {
+  test("conforms to interface shape", () => {
+    const record = {
+      requestId: "req-001",
+      request: {
+        kind: "tool_call" as PolicyRequestKind,
+        agentId: agentId("agent-a"),
+        payload: { toolName: "read_file" },
+        timestamp: 1_000_000,
+      },
+      verdict: GOVERNANCE_ALLOW,
+      evaluatedAt: 1_000_001,
+      policyFingerprint: "sha256:abc123",
+    } satisfies ComplianceRecord;
+    expect(record.requestId).toBe("req-001");
+    expect(record.verdict.ok).toBe(true);
+  });
+});
 
 describe("DEFAULT_VIOLATION_QUERY_LIMIT", () => {
   test("is 100", () => {
@@ -55,260 +250,129 @@ describe("DEFAULT_VIOLATION_QUERY_LIMIT", () => {
   });
 
   test("is a positive integer", () => {
-    expect(Number.isInteger(DEFAULT_VIOLATION_QUERY_LIMIT)).toBe(true);
     expect(DEFAULT_VIOLATION_QUERY_LIMIT).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_VIOLATION_QUERY_LIMIT)).toBe(true);
   });
 });
 
-// ---------------------------------------------------------------------------
-// VIOLATION_SEVERITIES — exhaustiveness + ordering + immutability
-// ---------------------------------------------------------------------------
-
-describe("VIOLATION_SEVERITIES", () => {
-  test("contains exactly the three defined severity levels", () => {
-    expect(VIOLATION_SEVERITIES).toEqual(["info", "warning", "critical"]);
+describe("ViolationFilter", () => {
+  test("all fields are optional", () => {
+    const emptyFilter = {} satisfies ViolationFilter;
+    expect(emptyFilter).toBeDefined();
   });
 
-  test("is ordered from lowest to highest impact", () => {
-    const infoIdx = VIOLATION_SEVERITIES.indexOf("info");
-    const warningIdx = VIOLATION_SEVERITIES.indexOf("warning");
-    const criticalIdx = VIOLATION_SEVERITIES.indexOf("critical");
-
-    expect(infoIdx).toBeGreaterThanOrEqual(0);
-    expect(warningIdx).toBeGreaterThan(infoIdx);
-    expect(criticalIdx).toBeGreaterThan(warningIdx);
-  });
-
-  test("indexOf enables severity comparison", () => {
-    const atLeastWarning = (s: ViolationSeverity): boolean =>
-      VIOLATION_SEVERITIES.indexOf(s) >= VIOLATION_SEVERITIES.indexOf("warning");
-
-    expect(atLeastWarning("info")).toBe(false);
-    expect(atLeastWarning("warning")).toBe(true);
-    expect(atLeastWarning("critical")).toBe(true);
-  });
-
-  test("is frozen (immutable at runtime)", () => {
-    expect(Object.isFrozen(VIOLATION_SEVERITIES)).toBe(true);
-  });
-
-  test("every entry is a non-empty string", () => {
-    for (const s of VIOLATION_SEVERITIES) {
-      expect(typeof s).toBe("string");
-      expect(s.length).toBeGreaterThan(0);
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// GovernanceVerdict — discriminated union structural shape
-// ---------------------------------------------------------------------------
-
-describe("GovernanceVerdict structural shape", () => {
-  test("ok:true verdict has no violations field", () => {
-    const verdict: GovernanceVerdict = { ok: true };
-    expect(verdict.ok).toBe(true);
-    expect("violations" in verdict).toBe(false);
-  });
-
-  test("ok:false verdict carries a readonly violations array", () => {
-    const violation: Violation = {
+  test("supports full filter shape", () => {
+    const fullFilter = {
+      agentId: agentId("agent-a"),
+      sessionId: "session-1" as import("./ecs.js").SessionId,
+      severity: "warning" as ViolationSeverity,
       rule: "max-spawn-depth",
-      severity: "critical",
-      message: "Spawn depth 10 exceeds the limit of 5",
-    };
-    const verdict: GovernanceVerdict = { ok: false, violations: [violation] };
-
-    expect(verdict.ok).toBe(false);
-    if (!verdict.ok) {
-      expect(verdict.violations).toHaveLength(1);
-      expect(verdict.violations[0]?.rule).toBe("max-spawn-depth");
-      expect(verdict.violations[0]?.severity).toBe("critical");
-      expect(verdict.violations[0]?.message).toContain("5");
-    }
-  });
-
-  test("ok:false verdict may carry multiple violations (all rules reported)", () => {
-    const violations: Violation[] = [
-      { rule: "max-spawn-depth", severity: "critical", message: "depth exceeded" },
-      { rule: "max-token-usage", severity: "warning", message: "token budget low" },
-    ];
-    const verdict: GovernanceVerdict = { ok: false, violations };
-
-    expect(verdict.ok).toBe(false);
-    if (!verdict.ok) {
-      expect(verdict.violations).toHaveLength(2);
-    }
-  });
-
-  test("ok:false verdict with optional context field on violation", () => {
-    const violation: Violation = {
-      rule: "cost-limit",
-      severity: "warning",
-      message: "Cost $0.95 approaching limit $1.00",
-      context: { currentUsd: 0.95, limitUsd: 1.0 },
-    };
-    const verdict: GovernanceVerdict = { ok: false, violations: [violation] };
-
-    expect(verdict.ok).toBe(false);
-    if (!verdict.ok) {
-      expect(verdict.violations[0]?.context).toEqual({ currentUsd: 0.95, limitUsd: 1.0 });
-    }
+      since: 1_000_000,
+      until: 2_000_000,
+      limit: 50,
+      offset: "cursor-abc",
+    } satisfies ViolationFilter;
+    expect(fullFilter.limit).toBe(50);
   });
 });
 
-// ---------------------------------------------------------------------------
-// GovernanceBackendEvent — structural shape
-// ---------------------------------------------------------------------------
-
-describe("GovernanceBackendEvent structural shape", () => {
-  test("accepts well-known kinds", () => {
-    const kinds = ["tool_call", "spawn", "forge", "promotion", "proposal"];
-    for (const kind of kinds) {
-      const event: GovernanceBackendEvent = {
-        kind,
-        agentId: "agent-1" as ReturnType<typeof governanceAttestationId> extends never
-          ? never
-          : // biome-ignore lint/suspicious/noExplicitAny: cast for test only
-            any,
-        payload: {},
-        timestamp: Date.now(),
-      };
-      expect(event.kind).toBe(kind);
-    }
+describe("ViolationPage", () => {
+  test("conforms to interface shape", () => {
+    const page: ViolationPage = {
+      items: [],
+    };
+    expect(page.items).toHaveLength(0);
+    expect(page.cursor).toBeUndefined();
+    expect(page.total).toBeUndefined();
   });
 
-  test("accepts arbitrary custom kind (open string union)", () => {
-    const event: GovernanceBackendEvent = {
-      kind: "custom:my-domain-event",
-      // biome-ignore lint/suspicious/noExplicitAny: cast for test only
-      agentId: "agent-x" as any,
-      payload: { foo: "bar" },
-      timestamp: 1_700_000_000_000,
-    };
-    expect(event.kind).toBe("custom:my-domain-event");
-    expect(event.payload).toEqual({ foo: "bar" });
+  test("accepts cursor and total", () => {
+    const page = {
+      items: [{ rule: "test", severity: "info" as ViolationSeverity, message: "ok" }],
+      cursor: "next-page",
+      total: 42,
+    } satisfies ViolationPage;
+    expect(page.cursor).toBe("next-page");
+    expect(page.total).toBe(42);
   });
 });
 
-// ---------------------------------------------------------------------------
-// GovernanceAttestationInput / GovernanceAttestation — relationship
-// ---------------------------------------------------------------------------
-
-describe("GovernanceAttestation enrichment contract", () => {
-  test("GovernanceAttestation extends GovernanceAttestationInput with backend-assigned fields", () => {
-    const input: GovernanceAttestationInput = {
-      // biome-ignore lint/suspicious/noExplicitAny: cast for test only
-      agentId: "agent-1" as any,
-      ruleId: "no-exfiltration",
-      verdict: { ok: true },
+describe("PolicyEvaluator", () => {
+  test("scope field is optional", () => {
+    const evaluator: PolicyEvaluator = {
+      evaluate: () => GOVERNANCE_ALLOW,
     };
-
-    // Simulate what a backend would return after storing
-    const stored: GovernanceAttestation = {
-      id: governanceAttestationId("attest-001"),
-      agentId: input.agentId,
-      ruleId: input.ruleId,
-      verdict: input.verdict,
-      attestedAt: 1_700_000_000_000,
-      attestedBy: "local",
-    };
-
-    expect(stored.id).toBe(governanceAttestationId("attest-001"));
-    expect(stored.agentId).toBe(input.agentId);
-    expect(stored.ruleId).toBe(input.ruleId);
-    expect(stored.verdict.ok).toBe(true);
-    expect(stored.attestedAt).toBeGreaterThan(0);
-    expect(stored.attestedBy).toBe("local");
-    // evidence is optional and absent when not provided
-    expect("evidence" in stored).toBe(false);
+    expect(evaluator.scope).toBeUndefined();
   });
 
-  test("GovernanceAttestation with optional evidence field", () => {
-    const stored: GovernanceAttestation = {
-      id: governanceAttestationId("attest-002"),
-      // biome-ignore lint/suspicious/noExplicitAny: cast for test only
-      agentId: "agent-2" as any,
-      ruleId: "cost-limit",
-      verdict: {
-        ok: false,
-        violations: [{ rule: "cost-limit", severity: "warning", message: "high cost" }],
+  test("scope field accepts PolicyRequestKind array", () => {
+    const evaluator: PolicyEvaluator = {
+      evaluate: () => GOVERNANCE_ALLOW,
+      scope: ["tool_call", "spawn"],
+    };
+    expect(evaluator.scope).toHaveLength(2);
+  });
+});
+
+describe("GovernanceBackend interface", () => {
+  test("type-compatible minimal implementation compiles", () => {
+    const backend = {
+      evaluator: {
+        evaluate: (_request: PolicyRequest) => GOVERNANCE_ALLOW,
       },
-      evidence: { costUsd: 0.95, sessionId: "sess-xyz" },
-      attestedAt: 1_700_000_001_000,
-      attestedBy: "nexus",
+    } satisfies GovernanceBackend;
+    expect(backend.evaluator).toBeDefined();
+  });
+
+  test("optional sub-interfaces are not required", () => {
+    const minimalBackend: GovernanceBackend = {
+      evaluator: {
+        evaluate: () => GOVERNANCE_ALLOW,
+      },
     };
-
-    expect(stored.evidence).toEqual({ costUsd: 0.95, sessionId: "sess-xyz" });
-    expect(stored.attestedBy).toBe("nexus");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// ViolationQuery — default limit constant usage
-// ---------------------------------------------------------------------------
-
-describe("ViolationQuery with DEFAULT_VIOLATION_QUERY_LIMIT", () => {
-  test("empty query uses default limit", () => {
-    const query: ViolationQuery = {};
-    // When limit is omitted, backends apply DEFAULT_VIOLATION_QUERY_LIMIT
-    const effectiveLimit = query.limit ?? DEFAULT_VIOLATION_QUERY_LIMIT;
-    expect(effectiveLimit).toBe(100);
+    expect(minimalBackend.constraints).toBeUndefined();
+    expect(minimalBackend.compliance).toBeUndefined();
+    expect(minimalBackend.violations).toBeUndefined();
+    expect(minimalBackend.dispose).toBeUndefined();
   });
 
-  test("explicit limit overrides default", () => {
-    const query: ViolationQuery = { limit: 10 };
-    const effectiveLimit = query.limit ?? DEFAULT_VIOLATION_QUERY_LIMIT;
-    expect(effectiveLimit).toBe(10);
-  });
-
-  test("severity filter accepts subset of VIOLATION_SEVERITIES", () => {
-    const query: ViolationQuery = { severity: ["warning", "critical"] };
-    expect(query.severity).toEqual(["warning", "critical"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// GovernanceBackend interface shape (compile-time contract smoke test)
-// ---------------------------------------------------------------------------
-
-describe("GovernanceBackend interface contract", () => {
-  test("a minimal in-memory implementation satisfies the interface", () => {
-    // Structural check: verify a minimal object assignable to GovernanceBackend compiles
+  test("accepts all sub-interfaces", () => {
     const backend: GovernanceBackend = {
-      evaluate: (_event) => ({ ok: true }),
-      checkConstraint: (_query) => true,
-      recordAttestation: (_input) => ({
-        ok: true,
-        value: {
-          id: governanceAttestationId("test-id"),
-          // biome-ignore lint/suspicious/noExplicitAny: cast for test only
-          agentId: "agent-test" as any,
-          ruleId: "test-rule",
-          verdict: { ok: true },
-          attestedAt: Date.now(),
-          attestedBy: "test-backend",
-        },
-      }),
-      getViolations: (_filter) => ({ ok: true, value: [] }),
-    };
-
-    expect(typeof backend.evaluate).toBe("function");
-    expect(typeof backend.checkConstraint).toBe("function");
-    expect(typeof backend.recordAttestation).toBe("function");
-    expect(typeof backend.getViolations).toBe("function");
-    expect(backend.dispose).toBeUndefined();
-  });
-
-  test("dispose is optional on GovernanceBackend", () => {
-    const withDispose: GovernanceBackend = {
-      evaluate: (_event) => ({ ok: true }),
-      checkConstraint: (_query) => true,
-      recordAttestation: (_input) => ({ ok: true, value: {} as GovernanceAttestation }),
-      getViolations: (_filter) => ({ ok: true, value: [] }),
+      evaluator: {
+        evaluate: () => GOVERNANCE_ALLOW,
+        scope: ["tool_call"],
+      } satisfies PolicyEvaluator,
+      constraints: {
+        checkConstraint: () => true,
+      } satisfies ConstraintChecker,
+      compliance: {
+        recordCompliance: (record: ComplianceRecord) => record,
+      } satisfies ComplianceRecorder,
+      violations: {
+        getViolations: (_filter: ViolationFilter) => ({ items: [], total: 0 }),
+      } satisfies ViolationStore,
       dispose: () => {},
     };
+    expect(backend.evaluator).toBeDefined();
+    expect(backend.constraints).toBeDefined();
+    expect(backend.compliance).toBeDefined();
+    expect(backend.violations).toBeDefined();
+    expect(backend.dispose).toBeDefined();
+  });
 
-    expect(typeof withDispose.dispose).toBe("function");
+  test("sub-interfaces compose independently", () => {
+    // Evaluator + constraints only
+    const withConstraints: GovernanceBackend = {
+      evaluator: { evaluate: () => GOVERNANCE_ALLOW },
+      constraints: { checkConstraint: () => true },
+    };
+    expect(withConstraints.compliance).toBeUndefined();
+
+    // Evaluator + violations only
+    const withViolations: GovernanceBackend = {
+      evaluator: { evaluate: () => GOVERNANCE_ALLOW },
+      violations: { getViolations: () => ({ items: [] }) },
+    };
+    expect(withViolations.constraints).toBeUndefined();
   });
 });

--- a/packages/core/src/governance-backend.ts
+++ b/packages/core/src/governance-backend.ts
@@ -1,82 +1,91 @@
 /**
- * GovernanceBackend — pluggable anomaly detection and constraint enforcement contract (Layer 0).
+ * Governance backend — pluggable rule-based policy evaluation contract (Layer 0).
  *
- * Defines the interface for evaluating governance events against policy rules,
- * checking constraints, recording compliance attestations, and querying violations.
+ * Defines the shapes for evaluating policy requests, checking constraints,
+ * recording compliance, and querying violation history. L2 packages implement
+ * GovernanceBackend for specific backends (OPA, Cedar, in-memory rule engine, etc.).
  *
- * L2 packages implement GovernanceBackend for specific backends:
- *   - @koi/governance: local in-process rule evaluation (default)
- *   - @koi/governance-nexus: Nexus governance brick (attestation, audit, compliance)
- *   - User-provided: any implementation of GovernanceBackend
+ * Complementary to GovernanceController (governance.ts) which handles numeric
+ * sensor/setpoint governance (turns, tokens, spawn depth). GovernanceBackend
+ * handles rule-based policy evaluation, constraint checking, compliance recording,
+ * and violation tracking. Both are composed by the unified governance controller (#261).
  *
- * Consumed by: agent-monitor (#59), spawn governance, ProposalGate (#223),
- *              unified governance controller (#261).
+ * Relationship to ScopeEnforcer (scope-enforcement.ts): ScopeEnforcer handles
+ * subsystem access checks (filesystem, browser, credentials, memory) with a
+ * boolean allow/deny result. GovernanceBackend handles broader policy evaluation
+ * with rich verdicts, violation details, and compliance recording. They are
+ * independent contracts — ScopeEnforcer is not subsumed.
  *
- * Fail-closed contract: if evaluate() or checkConstraint() throw, callers
- * MUST deny the operation. Infrastructure failures are not distinguished from
- * intentional denials — never treat a throwing backend as permissive.
+ * Fail-closed contract: callers MUST deny access when evaluate() throws or
+ * returns an error. A missing or errored backend means "deny all".
  *
- * Exception: governanceAttestationId() is a branded type constructor (identity cast),
- * permitted in L0 as a zero-logic operation for type safety.
- *
- * Exception: DEFAULT_VIOLATION_QUERY_LIMIT and VIOLATION_SEVERITIES are pure readonly
- * data constants derived from L0 type definitions, codifying architecture-doc
- * invariants with zero logic.
+ * Exception: constants (VIOLATION_SEVERITY_ORDER, GOVERNANCE_ALLOW,
+ * DEFAULT_VIOLATION_QUERY_LIMIT) are pure readonly data derived from L0 type
+ * definitions, permitted in L0 per architecture rules.
  */
 
 import type { JsonObject } from "./common.js";
-import type { AgentId } from "./ecs.js";
-import type { KoiError, Result } from "./errors.js";
+import type { AgentId, SessionId } from "./ecs.js";
 
 // ---------------------------------------------------------------------------
-// GovernanceBackendEvent — input event for policy evaluation
+// PolicyRequestKind — what kind of action is being evaluated
 // ---------------------------------------------------------------------------
 
 /**
- * An event submitted to the governance backend for policy evaluation.
- *
- * Distinct from GovernanceEvent (governance.ts), which is the controller's
- * sensor-update event (a closed discriminated union for the sensor/setpoint model).
- * GovernanceBackendEvent uses an open string kind with an arbitrary payload,
- * supporting any event the backend needs to evaluate — including custom event kinds
- * from L2 packages.
+ * Categorical kind for policy evaluation requests.
+ * Covers the core agent lifecycle actions. Use `custom:${string}` for
+ * domain-specific extensions without modifying the core union.
  */
-export interface GovernanceBackendEvent {
-  /**
-   * Semantic event type. Well-known kinds: "tool_call" | "spawn" | "forge" |
-   * "promotion" | "proposal". Backends may support additional kinds.
-   */
-  readonly kind: string;
-  /** The agent that produced this event. */
+export type PolicyRequestKind =
+  | "tool_call"
+  | "model_call"
+  | "spawn"
+  | "delegation"
+  | "forge"
+  | "handoff"
+  | `custom:${string}`;
+
+// ---------------------------------------------------------------------------
+// PolicyRequest — the input to policy evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * A request to evaluate against governance policy.
+ * Follows the PEP-PDP (Policy Enforcement Point / Policy Decision Point) pattern:
+ * the caller (PEP) constructs a PolicyRequest, the backend (PDP) returns a verdict.
+ */
+export interface PolicyRequest {
+  /** The kind of action being evaluated. */
+  readonly kind: PolicyRequestKind;
+  /** The agent requesting the action. */
   readonly agentId: AgentId;
-  /** Structured event payload — backend-specific content for rule evaluation. */
+  /** Action-specific payload for policy evaluation. */
   readonly payload: JsonObject;
-  /** Unix timestamp (ms) when the event occurred. */
+  /** Unix timestamp (ms) when the request was created. */
   readonly timestamp: number;
 }
 
 // ---------------------------------------------------------------------------
-// ViolationSeverity — categorical severity for policy violations
+// ViolationSeverity — how serious a policy violation is
 // ---------------------------------------------------------------------------
 
 /**
- * Severity level for a policy violation. Ordered from lowest to highest impact.
- * Use VIOLATION_SEVERITIES for the canonical ordering and comparison.
+ * Severity level for policy violations.
+ * Ordered from least to most severe — see VIOLATION_SEVERITY_ORDER for
+ * the canonical sequence.
  */
 export type ViolationSeverity = "info" | "warning" | "critical";
 
 /**
- * Canonical ordering of ViolationSeverity values from lowest to highest impact.
- * Use for severity comparison:
+ * Canonical ordering of ViolationSeverity values from least to most severe.
+ * Use this to avoid hardcoding the sequence in consumers:
  *
  * ```typescript
- * const infoIdx    = VIOLATION_SEVERITIES.indexOf("info");    // 0
- * const warningIdx = VIOLATION_SEVERITIES.indexOf("warning"); // 1
- * const critIdx    = VIOLATION_SEVERITIES.indexOf("critical"); // 2
- * if (VIOLATION_SEVERITIES.indexOf(v.severity) >= VIOLATION_SEVERITIES.indexOf("warning")) { ... }
+ * const idx = VIOLATION_SEVERITY_ORDER.indexOf(violation.severity);
+ * if (idx >= VIOLATION_SEVERITY_ORDER.indexOf("warning")) { ... }
  * ```
  */
-export const VIOLATION_SEVERITIES: readonly ViolationSeverity[] = Object.freeze([
+export const VIOLATION_SEVERITY_ORDER: readonly ViolationSeverity[] = Object.freeze([
   "info",
   "warning",
   "critical",
@@ -86,227 +95,198 @@ export const VIOLATION_SEVERITIES: readonly ViolationSeverity[] = Object.freeze(
 // Violation — a single policy rule violation
 // ---------------------------------------------------------------------------
 
-/**
- * A single policy rule violation produced by a GovernanceBackend.evaluate() call.
- *
- * A GovernanceVerdict may contain multiple Violations — one per violated rule.
- * Backends SHOULD include all violated rules (not just the first) to enable
- * consumers to make fully informed decisions.
- */
+/** A single policy rule violation found during evaluation. */
 export interface Violation {
-  /** The rule identifier that was violated (backend-defined). */
+  /** The rule identifier that was violated (e.g., "max-spawn-depth", "no-external-api"). */
   readonly rule: string;
-  /** Categorical impact level of this violation. */
+  /** How severe this violation is. */
   readonly severity: ViolationSeverity;
-  /** Human-readable description of the violation. Answers: what happened + why. */
+  /** Human-readable description of the violation. */
   readonly message: string;
-  /** Optional structured context for this violation (threshold values, agent state, etc.). */
+  /** Optional structured context for diagnostics. */
   readonly context?: JsonObject | undefined;
 }
 
 // ---------------------------------------------------------------------------
-// GovernanceVerdict — result of a policy evaluation
+// GovernanceVerdict — the output of policy evaluation
 // ---------------------------------------------------------------------------
 
 /**
- * The outcome of a GovernanceBackend.evaluate() call.
- *
- * Distinct from GovernanceCheck (governance.ts), which is the controller's
- * per-sensor check result ("did this one variable exceed its limit?", single
- * variable, retryable flag). GovernanceVerdict is the backend's policy evaluation
- * result: zero or more violations across all applicable rules for a single event.
+ * Result of evaluating a PolicyRequest against governance rules.
+ * Discriminated union on `ok`:
+ * - `ok: true` — request is allowed, with optional diagnostics (info-level observations)
+ * - `ok: false` — request is denied, with one or more violations
  */
 export type GovernanceVerdict =
-  | { readonly ok: true }
-  | { readonly ok: false; readonly violations: readonly Violation[] };
+  | {
+      readonly ok: true;
+      /** Optional info-level observations (e.g., "approaching rate limit"). */
+      readonly diagnostics?: readonly Violation[] | undefined;
+    }
+  | {
+      readonly ok: false;
+      /** One or more violations that caused denial. Never empty when ok is false. */
+      readonly violations: readonly Violation[];
+    };
+
+/**
+ * Singleton allow verdict for the common case.
+ * Avoids allocating a new object on every allow decision.
+ * Frozen to prevent accidental mutation.
+ */
+export const GOVERNANCE_ALLOW: GovernanceVerdict = Object.freeze({
+  ok: true as const,
+});
 
 // ---------------------------------------------------------------------------
-// ConstraintQuery — input for a specific constraint check
+// ConstraintQuery — input to constraint checking
 // ---------------------------------------------------------------------------
 
 /**
- * Input for a point-in-time constraint check against a specific agent.
- * The constraint is identified by ID; the backend resolves the rule definition.
+ * Minimal query for checking a single constraint.
+ * Used by ConstraintChecker to evaluate numeric or boolean constraints
+ * (e.g., "can this agent spawn at depth 4?").
  */
 export interface ConstraintQuery {
-  /** The constraint identifier to check (backend-defined rule ID). */
-  readonly constraintId: string;
-  /** The agent to check the constraint against. */
+  /** The constraint kind to check (e.g., "spawn_depth", "token_budget"). */
+  readonly kind: string;
+  /** The agent the constraint applies to. */
   readonly agentId: AgentId;
-  /** Optional structured context for evaluating the constraint. */
+  /** Optional numeric or string value to check against the constraint limit. */
+  readonly value?: number | string | undefined;
+  /** Optional structured context for the check. */
   readonly context?: JsonObject | undefined;
 }
 
 // ---------------------------------------------------------------------------
-// ViolationQuery — filter for querying stored violation records
+// ComplianceRecord — lightweight attestation for audit trails
+// ---------------------------------------------------------------------------
+
+/** A recorded compliance event linking a request to its verdict. */
+export interface ComplianceRecord {
+  /** Unique identifier for this compliance record. */
+  readonly requestId: string;
+  /** The original policy request that was evaluated. */
+  readonly request: PolicyRequest;
+  /** The verdict returned by the evaluator. */
+  readonly verdict: GovernanceVerdict;
+  /** Unix timestamp (ms) when the evaluation occurred. */
+  readonly evaluatedAt: number;
+  /** Fingerprint of the policy version used for evaluation (for reproducibility). */
+  readonly policyFingerprint: string;
+}
+
+// ---------------------------------------------------------------------------
+// ViolationFilter + ViolationPage — querying violation history
 // ---------------------------------------------------------------------------
 
 /**
- * Default maximum number of violations returned by a single getViolations() call.
+ * Default maximum number of violation entries returned by a single getViolations() call.
  * Implementations SHOULD apply this when the caller omits `limit`.
  */
-export const DEFAULT_VIOLATION_QUERY_LIMIT = 100;
+export const DEFAULT_VIOLATION_QUERY_LIMIT: 100 = 100;
 
 /**
- * Filter for querying stored violation records.
+ * Filter for querying recorded violations.
  * All fields are optional — omitting a field means "no constraint on that dimension".
- * Providing no fields returns ALL violations up to `limit` — use with care.
  */
-export interface ViolationQuery {
-  /** Filter to violations for a specific agent. */
+export interface ViolationFilter {
+  /** Filter to violations for this agent. */
   readonly agentId?: AgentId | undefined;
-  /** Filter to violations matching any of these severity levels. */
-  readonly severity?: readonly ViolationSeverity[] | undefined;
-  /** Filter to violations from a specific rule. */
-  readonly ruleId?: string | undefined;
+  /** Filter to violations within this session. */
+  readonly sessionId?: SessionId | undefined;
+  /** Filter to violations at or above this severity. */
+  readonly severity?: ViolationSeverity | undefined;
+  /** Filter to violations matching this rule identifier. */
+  readonly rule?: string | undefined;
   /** Include only violations at or after this Unix timestamp (ms). */
-  readonly after?: number | undefined;
+  readonly since?: number | undefined;
   /** Include only violations before this Unix timestamp (ms). */
-  readonly before?: number | undefined;
-  /**
-   * Maximum number of violations to return.
-   * Defaults to DEFAULT_VIOLATION_QUERY_LIMIT when omitted.
-   */
+  readonly until?: number | undefined;
+  /** Maximum number of entries to return. Defaults to DEFAULT_VIOLATION_QUERY_LIMIT. */
   readonly limit?: number | undefined;
+  /** Opaque cursor for pagination (from a previous ViolationPage.cursor). */
+  readonly offset?: string | undefined;
+}
+
+/** Paginated result of a violation query. */
+export interface ViolationPage {
+  /** Violation entries matching the filter. */
+  readonly items: readonly Violation[];
+  /** Opaque cursor for fetching the next page. Absent when no more pages. */
+  readonly cursor?: string | undefined;
+  /** Total count of matching violations (if the backend supports it). */
+  readonly total?: number | undefined;
 }
 
 // ---------------------------------------------------------------------------
-// GovernanceAttestation — compliance claim recorded by the backend
+// Sub-interfaces (ISP split)
 // ---------------------------------------------------------------------------
 
-declare const __governanceAttestationBrand: unique symbol;
-
 /**
- * Branded string type for governance attestation identifiers.
- * Prevents accidental mixing with other string IDs (ProposalId, BrickId, etc.)
- * at compile time.
+ * Evaluates policy requests and returns verdicts.
+ *
+ * The `scope` field is a hot-path optimization: when present, the engine
+ * can skip invoking this evaluator for request kinds not in the scope set.
+ * When absent, the evaluator is invoked for all request kinds.
  */
-export type GovernanceAttestationId = string & {
-  readonly [__governanceAttestationBrand]: "GovernanceAttestationId";
-};
-
-/** Create a branded GovernanceAttestationId from a plain string. */
-export function governanceAttestationId(raw: string): GovernanceAttestationId {
-  return raw as GovernanceAttestationId;
-}
-
-/**
- * Data provided by the caller when recording a compliance attestation.
- * The backend assigns id, attestedAt, and attestedBy — callers provide
- * the agentId, ruleId, verdict, and optional evidence.
- */
-export interface GovernanceAttestationInput {
-  /** The agent this attestation is about. */
-  readonly agentId: AgentId;
-  /** The rule or policy this attestation covers (backend-defined rule ID). */
-  readonly ruleId: string;
-  /** The policy evaluation result being attested. */
-  readonly verdict: GovernanceVerdict;
-  /** Optional structured evidence supporting the attestation. */
-  readonly evidence?: JsonObject | undefined;
-}
-
-/**
- * A governance compliance attestation as stored and returned by the backend.
- * Immutable — each attestation is a point-in-time compliance claim.
- * Callers receive this from recordAttestation(); it is never mutated.
- */
-export interface GovernanceAttestation {
-  /** Backend-assigned unique identifier for this attestation. */
-  readonly id: GovernanceAttestationId;
-  /** The agent this attestation is about. */
-  readonly agentId: AgentId;
-  /** The rule or policy this attestation covers. */
-  readonly ruleId: string;
-  /** The policy evaluation result being attested. */
-  readonly verdict: GovernanceVerdict;
-  /** Optional structured evidence supporting the attestation. */
-  readonly evidence?: JsonObject | undefined;
-  /** Unix timestamp (ms) when this attestation was recorded. Backend-assigned. */
-  readonly attestedAt: number;
+export interface PolicyEvaluator {
+  /** Evaluate a policy request. Returns a verdict (allow/deny with details). */
+  readonly evaluate: (request: PolicyRequest) => GovernanceVerdict | Promise<GovernanceVerdict>;
   /**
-   * Identity of the backend that recorded this attestation.
-   * Allows consumers to distinguish attestations from different backends
-   * (e.g., "local", "nexus", "custom").
+   * Optional declarative scope filter. When present, this evaluator is only
+   * invoked for request kinds matching one of these values. When absent,
+   * the evaluator handles all request kinds.
    */
-  readonly attestedBy: string;
+  readonly scope?: readonly PolicyRequestKind[] | undefined;
+}
+
+/** Checks individual constraints (numeric/boolean limit checks). */
+export interface ConstraintChecker {
+  /** Check whether a constraint is satisfied. Returns true if the constraint passes. */
+  readonly checkConstraint: (query: ConstraintQuery) => boolean | Promise<boolean>;
+}
+
+/** Records compliance events for audit trails. */
+export interface ComplianceRecorder {
+  /** Record a compliance event. Returns the recorded entry. */
+  readonly recordCompliance: (
+    record: ComplianceRecord,
+  ) => ComplianceRecord | Promise<ComplianceRecord>;
+}
+
+/** Queries recorded violation history. */
+export interface ViolationStore {
+  /** Query recorded violations matching the filter. */
+  readonly getViolations: (filter: ViolationFilter) => ViolationPage | Promise<ViolationPage>;
 }
 
 // ---------------------------------------------------------------------------
-// GovernanceBackend — the main pluggable contract
+// GovernanceBackend — composite interface
 // ---------------------------------------------------------------------------
 
 /**
- * Pluggable anomaly detection and constraint enforcement backend.
+ * Pluggable governance backend for rule-based policy evaluation.
  *
- * All methods return `T | Promise<T>` — in-memory implementations return sync
- * values, database/network implementations return Promises. Callers must always
- * `await` the result.
+ * Composed of ISP-split sub-interfaces:
+ * - `evaluator` (required) — the core policy evaluation engine
+ * - `constraints` (optional) — individual constraint checks
+ * - `compliance` (optional) — compliance recording for audit
+ * - `violations` (optional) — violation history queries
  *
- * **Fail-closed contract**: `evaluate()` and `checkConstraint()` do NOT use
- * `Result<T, KoiError>`. If they throw, callers MUST treat the operation as
- * denied. Infrastructure failures are indistinguishable from intentional denials
- * — never treat a throwing backend as permissive.
- *
- * `recordAttestation()` and `getViolations()` use `Result<T, KoiError>` because
- * their callers need structured error information (retry vs. permanent failure,
- * storage unavailable vs. invalid input).
- *
- * @see GovernanceController (governance.ts) — sensor/setpoint runtime model.
- * @see ProposalGate (proposal.ts) — structural layer change governance.
- * @see AuditSink (audit-backend.ts) — structured audit logging.
+ * Fail-closed: if `evaluator.evaluate()` throws, callers MUST deny.
+ * Optional sub-interfaces degrade gracefully — constraint checks return
+ * true (allow) when no ConstraintChecker is configured, etc.
  */
 export interface GovernanceBackend {
-  /**
-   * Evaluate a governance event against all applicable policy rules.
-   *
-   * Returns `{ ok: true }` if no rules are violated.
-   * Returns `{ ok: false; violations }` if one or more rules are violated.
-   * Backends SHOULD include all violated rules (not only the first).
-   *
-   * **Fail closed**: if this method throws, callers MUST deny the operation.
-   * Never treat a throwing backend as permissive.
-   */
-  readonly evaluate: (
-    event: GovernanceBackendEvent,
-  ) => GovernanceVerdict | Promise<GovernanceVerdict>;
-
-  /**
-   * Check whether a specific constraint is satisfied for the given agent.
-   *
-   * Returns `true` if the constraint is satisfied.
-   * Returns `false` if the constraint is violated.
-   *
-   * **Fail closed**: if this method throws, callers MUST deny the operation.
-   * Never treat a throwing backend as permissive.
-   */
-  readonly checkConstraint: (constraint: ConstraintQuery) => boolean | Promise<boolean>;
-
-  /**
-   * Record a compliance attestation for a governance evaluation result.
-   *
-   * The backend assigns `id`, `attestedAt`, and `attestedBy`.
-   * Returns the stored GovernanceAttestation on success.
-   * Returns a KoiError on validation failure or storage error.
-   *
-   * Implementations SHOULD be idempotent for identical
-   * (agentId, ruleId, verdict, timestamp) tuples to handle retry scenarios.
-   */
-  readonly recordAttestation: (
-    input: GovernanceAttestationInput,
-  ) => Result<GovernanceAttestation, KoiError> | Promise<Result<GovernanceAttestation, KoiError>>;
-
-  /**
-   * Query stored violation records matching the filter.
-   *
-   * Returns violations ordered by timestamp descending (most recent first).
-   * Applies DEFAULT_VIOLATION_QUERY_LIMIT when `filter.limit` is omitted.
-   * Check the returned array length against `filter.limit` to detect truncation.
-   */
-  readonly getViolations: (
-    filter: ViolationQuery,
-  ) => Result<readonly Violation[], KoiError> | Promise<Result<readonly Violation[], KoiError>>;
-
-  /** Close the backend and release resources (connections, timers, file handles). */
+  /** The policy evaluator (required). */
+  readonly evaluator: PolicyEvaluator;
+  /** Optional constraint checker for individual limit checks. */
+  readonly constraints?: ConstraintChecker | undefined;
+  /** Optional compliance recorder for audit trails. */
+  readonly compliance?: ComplianceRecorder | undefined;
+  /** Optional violation store for querying violation history. */
+  readonly violations?: ViolationStore | undefined;
+  /** Optional cleanup for stateful backends (connection pools, timers). */
   readonly dispose?: () => void | Promise<void>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,6 +222,7 @@ export {
   EVENTS,
   FILESYSTEM,
   GOVERNANCE,
+  GOVERNANCE_BACKEND,
   HANDOFF,
   MEMORY,
   middlewareToken,
@@ -320,24 +321,27 @@ export type {
 } from "./governance.js";
 // governance — runtime values
 export { GOVERNANCE_VARIABLES, governanceContributorToken } from "./governance.js";
-// governance backend — pluggable anomaly detection and constraint enforcement contract
+// governance backend — pluggable rule-based policy evaluation contract
 export type {
+  ComplianceRecord,
+  ComplianceRecorder,
+  ConstraintChecker,
   ConstraintQuery,
-  GovernanceAttestation,
-  GovernanceAttestationId,
-  GovernanceAttestationInput,
   GovernanceBackend,
-  GovernanceBackendEvent,
   GovernanceVerdict,
+  PolicyEvaluator,
+  PolicyRequest,
+  PolicyRequestKind,
   Violation,
-  ViolationQuery,
+  ViolationFilter,
+  ViolationPage,
   ViolationSeverity,
+  ViolationStore,
 } from "./governance-backend.js";
-// governance backend — runtime values
 export {
   DEFAULT_VIOLATION_QUERY_LIMIT,
-  governanceAttestationId,
-  VIOLATION_SEVERITIES,
+  GOVERNANCE_ALLOW,
+  VIOLATION_SEVERITY_ORDER,
 } from "./governance-backend.js";
 // handoff — types
 export type {

--- a/packages/engine/__tests__/governance-backend-e2e.test.ts
+++ b/packages/engine/__tests__/governance-backend-e2e.test.ts
@@ -1,66 +1,38 @@
 /**
- * Comprehensive E2E test for the GovernanceBackend interface (#265) through the
- * full createKoi + createPiAdapter runtime assembly with real Anthropic API calls.
- *
- * What this tests:
- *   1. In-memory GovernanceBackend implementation (validates all interface methods work)
- *   2. GovernanceBackendEvent construction from real middleware context (agentId, kind, payload, timestamp)
- *   3. GovernanceVerdict { ok: true } path — permissive backend allows model calls through
- *   4. GovernanceVerdict { ok: false; violations } path — blocking backend denies model calls
- *   5. GovernanceAttestation recording via recordAttestation() — backend assigns id/attestedAt/attestedBy
- *   6. getViolations() with ViolationQuery filters (by agentId, severity, ruleId, after/before)
- *   7. checkConstraint() — synchronous point-in-time constraint check
- *   8. Fail-closed contract — throwing backend → model call denied, engine stops gracefully
- *   9. dispose() — cleanup lifecycle on the backend
- *  10. Full middleware chain — GovernanceBackend middleware + GovernanceController (sensor model)
- *      both wired simultaneously, with real pi Agent LLM calls threading through both
- *
- * Architecture:
- *   createKoi assembly → GovernanceController (sensor/setpoint) + GovernanceBackendMiddleware
- *   → createPiAdapter → real Anthropic API (claude-haiku) → tool call loop
- *   → GovernanceBackend.evaluate() on each model/tool call
- *   → GovernanceAttestation stored in-memory
- *   → getViolations() / checkConstraint() queried after run
+ * E2E test for GovernanceBackend ISP-split interface (#265) through
+ * createKoi + createPiAdapter with real Anthropic API calls.
  *
  * Gated on ANTHROPIC_API_KEY + E2E_TESTS=1.
- *
- * Run:
- *   E2E_TESTS=1 bun test packages/engine/__tests__/governance-backend-e2e.test.ts
+ * Run: E2E_TESTS=1 bun test packages/engine/__tests__/governance-backend-e2e.test.ts
  */
 
 import { describe, expect, test } from "bun:test";
 import type {
   AgentId,
+  ComplianceRecord,
   ConstraintQuery,
   EngineEvent,
   EngineOutput,
-  GovernanceAttestation,
-  GovernanceAttestationInput,
   GovernanceBackend,
-  GovernanceBackendEvent,
   GovernanceVerdict,
-  KoiError,
   KoiMiddleware,
   ModelChunk,
   ModelRequest,
   ModelResponse,
-  Result,
+  PolicyRequest,
   ToolRequest,
   TurnContext,
   Violation,
-  ViolationQuery,
+  ViolationFilter,
+  ViolationPage,
 } from "@koi/core";
 import {
   DEFAULT_VIOLATION_QUERY_LIMIT,
-  governanceAttestationId,
-  VIOLATION_SEVERITIES,
+  GOVERNANCE_ALLOW,
+  VIOLATION_SEVERITY_ORDER,
 } from "@koi/core";
 import { createPiAdapter } from "@koi/engine-pi";
 import { createKoi } from "../src/koi.js";
-
-// ---------------------------------------------------------------------------
-// Environment gate
-// ---------------------------------------------------------------------------
 
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
 const HAS_KEY = ANTHROPIC_KEY.length > 0;
@@ -70,192 +42,140 @@ const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
 const TIMEOUT_MS = 120_000;
 const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
 
-// ---------------------------------------------------------------------------
-// In-memory GovernanceBackend implementation
-// ---------------------------------------------------------------------------
-
-/**
- * Configures what the in-memory backend returns for evaluate() calls.
- * "allow": always returns { ok: true }
- * "block_model": returns { ok: false, violations: [...] } for "model_call" events
- * "block_tool": returns { ok: false, violations: [...] } for "tool_call" events
- * "throw": throws an Error (tests fail-closed contract)
- */
+/** What the in-memory evaluator returns: allow, block model/tool calls, or throw. */
 type BackendMode = "allow" | "block_model" | "block_tool" | "throw";
 
 interface InMemoryBackendState {
   readonly evaluateCalls: ReadonlyArray<{
-    readonly event: GovernanceBackendEvent;
+    readonly request: PolicyRequest;
     readonly verdict: GovernanceVerdict;
   }>;
-  readonly attestations: readonly GovernanceAttestation[];
+  readonly complianceRecords: readonly ComplianceRecord[];
+  readonly violations: readonly Violation[];
   readonly mode: BackendMode;
   readonly disposed: boolean;
 }
 
-/**
- * Minimal in-memory GovernanceBackend implementation.
- * Validates all interface methods: evaluate, checkConstraint, recordAttestation,
- * getViolations, and dispose.
- */
+/** In-memory GovernanceBackend with all ISP-split sub-interfaces. */
 function createInMemoryGovernanceBackend(initialMode: BackendMode = "allow"): {
   readonly backend: GovernanceBackend;
   readonly state: () => InMemoryBackendState;
   readonly setMode: (mode: BackendMode) => void;
 } {
-  // Let-bound for internal mutation (hidden behind the closure)
+  // let-bound for internal mutation (hidden behind closure)
   let mode = initialMode;
   let disposed = false;
-  let attestationCounter = 0;
-
-  const evaluateCalls: Array<{ event: GovernanceBackendEvent; verdict: GovernanceVerdict }> = [];
-  const attestations: GovernanceAttestation[] = [];
+  const evaluateCalls: Array<{ request: PolicyRequest; verdict: GovernanceVerdict }> = [];
+  const complianceRecords: ComplianceRecord[] = [];
+  const storedViolations: Array<
+    Violation & { readonly agentId: AgentId; readonly rule: string; readonly recordedAt: number }
+  > = [];
 
   const backend: GovernanceBackend = {
-    evaluate(event: GovernanceBackendEvent): GovernanceVerdict {
-      if (disposed) {
-        throw new Error("GovernanceBackend: evaluate() called after dispose()");
-      }
-      if (mode === "throw") {
-        throw new Error("GovernanceBackend: intentional throw for fail-closed test");
-      }
-
-      let verdict: GovernanceVerdict;
-
-      if (mode === "block_model" && event.kind === "model_call") {
-        const violations: Violation[] = [
-          {
-            rule: "no-model-calls-in-test",
-            severity: "critical",
-            message: `Model call blocked by governance backend (kind=${event.kind}, agent=${event.agentId})`,
-            context: { kind: event.kind, agentId: event.agentId },
-          },
-        ];
-        verdict = { ok: false, violations };
-      } else if (mode === "block_tool" && event.kind === "tool_call") {
-        const violations: Violation[] = [
-          {
-            rule: "no-tool-calls-in-test",
-            severity: "warning",
-            message: `Tool call blocked by governance backend (tool=${String(event.payload.toolName ?? "unknown")})`,
-            context: { kind: event.kind, toolName: event.payload.toolName },
-          },
-        ];
-        verdict = { ok: false, violations };
-      } else {
-        verdict = { ok: true };
-      }
-
-      evaluateCalls.push({ event, verdict });
-      return verdict;
-    },
-
-    checkConstraint(query: ConstraintQuery): boolean {
-      if (disposed) {
-        throw new Error("GovernanceBackend: checkConstraint() called after dispose()");
-      }
-      // Constraint "allow-all" always passes; any other id is blocked
-      return query.constraintId === "allow-all";
-    },
-
-    recordAttestation(input: GovernanceAttestationInput): Result<GovernanceAttestation, KoiError> {
-      if (disposed) {
-        return {
-          ok: false,
-          error: {
-            code: "INTERNAL_ERROR",
-            message: "GovernanceBackend: recordAttestation() called after dispose()",
-            retryable: false,
-          },
-        };
-      }
-
-      attestationCounter += 1;
-      const attest: GovernanceAttestation = {
-        id: governanceAttestationId(`attest-${attestationCounter}`),
-        agentId: input.agentId,
-        ruleId: input.ruleId,
-        verdict: input.verdict,
-        evidence: input.evidence,
-        attestedAt: Date.now(),
-        attestedBy: "in-memory-governance-backend",
-      };
-      attestations.push(attest);
-      return { ok: true, value: attest };
-    },
-
-    getViolations(filter: ViolationQuery): Result<readonly Violation[], KoiError> {
-      // Collect all violation entries from all stored attestations
-      const allViolations: Array<
-        Violation & {
-          readonly agentId: AgentId;
-          readonly ruleId: string;
-          readonly attestedAt: number;
+    evaluator: {
+      evaluate(request: PolicyRequest): GovernanceVerdict {
+        if (disposed) {
+          throw new Error("GovernanceBackend: evaluate() called after dispose()");
         }
-      > = [];
+        if (mode === "throw") {
+          throw new Error("GovernanceBackend: intentional throw for fail-closed test");
+        }
 
-      for (const attest of attestations) {
-        if (!attest.verdict.ok) {
-          for (const v of attest.verdict.violations) {
-            allViolations.push({
+        // let justified: verdict depends on mode + request kind
+        let verdict: GovernanceVerdict;
+
+        if (mode === "block_model" && request.kind === "model_call") {
+          const violations: Violation[] = [
+            {
+              rule: "no-model-calls-in-test",
+              severity: "critical",
+              message: `Model call blocked by governance backend (kind=${request.kind}, agent=${request.agentId})`,
+              context: { kind: request.kind, agentId: request.agentId },
+            },
+          ];
+          verdict = { ok: false, violations };
+        } else if (mode === "block_tool" && request.kind === "tool_call") {
+          const violations: Violation[] = [
+            {
+              rule: "no-tool-calls-in-test",
+              severity: "warning",
+              message: `Tool call blocked by governance backend (tool=${String(request.payload.toolName ?? "unknown")})`,
+              context: { kind: request.kind, toolName: request.payload.toolName },
+            },
+          ];
+          verdict = { ok: false, violations };
+        } else {
+          verdict = GOVERNANCE_ALLOW;
+        }
+
+        evaluateCalls.push({ request, verdict });
+        return verdict;
+      },
+    },
+
+    constraints: {
+      checkConstraint(query: ConstraintQuery): boolean {
+        if (disposed) {
+          throw new Error("GovernanceBackend: checkConstraint() called after dispose()");
+        }
+        // Constraint kind "allow-all" always passes; any other kind is blocked
+        return query.kind === "allow-all";
+      },
+    },
+
+    compliance: {
+      recordCompliance(record: ComplianceRecord): ComplianceRecord {
+        if (disposed) {
+          throw new Error("GovernanceBackend: recordCompliance() called after dispose()");
+        }
+        complianceRecords.push(record);
+
+        // Store violations from deny verdicts for getViolations()
+        if (!record.verdict.ok) {
+          for (const v of record.verdict.violations) {
+            storedViolations.push({
               ...v,
-              agentId: attest.agentId,
-              ruleId: attest.ruleId,
-              attestedAt: attest.attestedAt,
+              agentId: record.request.agentId,
+              rule: v.rule,
+              recordedAt: record.evaluatedAt,
             });
           }
         }
-      }
 
-      // Also include violations from evaluate calls that weren't attested
-      for (const call of evaluateCalls) {
-        if (!call.event.ok && !call.verdict.ok) {
-          for (const v of call.verdict.violations) {
-            allViolations.push({
-              ...v,
-              agentId: call.event.agentId,
-              ruleId: v.rule,
-              attestedAt: call.event.timestamp,
-            });
-          }
+        return record;
+      },
+    },
+
+    violations: {
+      getViolations(filter: ViolationFilter): ViolationPage {
+        // let justified: filtering requires progressive narrowing
+        let filtered = [...storedViolations];
+
+        if (filter.agentId !== undefined) {
+          filtered = filtered.filter((v) => v.agentId === filter.agentId);
         }
-      }
+        if (filter.severity !== undefined) {
+          const minIdx = VIOLATION_SEVERITY_ORDER.indexOf(filter.severity);
+          filtered = filtered.filter((v) => {
+            const idx = VIOLATION_SEVERITY_ORDER.indexOf(v.severity);
+            return idx >= minIdx;
+          });
+        }
+        if (filter.rule !== undefined) {
+          filtered = filtered.filter((v) => v.rule === filter.rule);
+        }
+        if (filter.since !== undefined) {
+          filtered = filtered.filter((v) => v.recordedAt >= filter.since!);
+        }
+        if (filter.until !== undefined) {
+          filtered = filtered.filter((v) => v.recordedAt < filter.until!);
+        }
 
-      // Apply filters
-      let results = allViolations as ReadonlyArray<(typeof allViolations)[0]>;
+        const limit = filter.limit ?? DEFAULT_VIOLATION_QUERY_LIMIT;
+        const items = filtered.slice(0, limit);
 
-      if (filter.agentId !== undefined) {
-        results = results.filter((v) => v.agentId === filter.agentId);
-      }
-      if (filter.severity !== undefined && filter.severity.length > 0) {
-        results = results.filter((v) => filter.severity?.includes(v.severity));
-      }
-      if (filter.ruleId !== undefined) {
-        results = results.filter((v) => v.rule === filter.ruleId);
-      }
-      if (filter.after !== undefined) {
-        const after = filter.after;
-        results = results.filter((v) => v.attestedAt >= after);
-      }
-      if (filter.before !== undefined) {
-        const before = filter.before;
-        results = results.filter((v) => v.attestedAt < before);
-      }
-
-      const limit = filter.limit ?? DEFAULT_VIOLATION_QUERY_LIMIT;
-      // Sort descending by timestamp (most recent first)
-      const sorted = [...results].sort((a, b) => b.attestedAt - a.attestedAt);
-      const sliced = sorted.slice(0, limit);
-
-      // Return as plain Violation[] (strip internal fields)
-      const violations: Violation[] = sliced.map(({ rule, severity, message, context }) => ({
-        rule,
-        severity,
-        message,
-        ...(context !== undefined ? { context } : {}),
-      }));
-
-      return { ok: true, value: violations };
+        return { items, total: filtered.length };
+      },
     },
 
     dispose(): void {
@@ -267,7 +187,8 @@ function createInMemoryGovernanceBackend(initialMode: BackendMode = "allow"): {
     backend,
     state: () => ({
       evaluateCalls: [...evaluateCalls],
-      attestations: [...attestations],
+      complianceRecords: [...complianceRecords],
+      violations: [...storedViolations],
       mode,
       disposed,
     }),
@@ -277,937 +198,595 @@ function createInMemoryGovernanceBackend(initialMode: BackendMode = "allow"): {
   };
 }
 
-// ---------------------------------------------------------------------------
-// GovernanceBackend middleware factory
-// ---------------------------------------------------------------------------
+/** Middleware: evaluate + record compliance for each model/tool call. Fail-closed. */
+function createGovernanceBackendMiddleware(
+  backend: GovernanceBackend,
+  getAgentId: () => AgentId,
+): KoiMiddleware {
+  // let justified: mutable counter for unique request IDs
+  let requestSeq = 0;
 
-/**
- * Wraps a GovernanceBackend as a KoiMiddleware.
- *
- * On every model call:
- *   1. Builds GovernanceBackendEvent { kind: "model_call", agentId, payload, timestamp }
- *   2. Calls backend.evaluate(event) — fail closed: if throws, call is denied
- *   3. If verdict is { ok: false }, records attestation and throws to block the call
- *   4. If verdict is { ok: true }, calls next(request) and records a success attestation
- *
- * On every tool call:
- *   Same pattern with kind: "tool_call" and toolName in payload.
- */
-function createGovernanceBackendMiddleware(backend: GovernanceBackend): KoiMiddleware {
+  function nextRequestId(): string {
+    requestSeq += 1;
+    return `gov-req-${requestSeq}`;
+  }
+
   return {
-    name: "governance-backend-e2e",
-    priority: 100, // Outer layer — runs before other middleware
-
-    async wrapModelCall(
-      ctx: TurnContext,
+    async wrapModelStream(
+      _ctx: TurnContext,
       request: ModelRequest,
-      next: (r: ModelRequest) => Promise<ModelResponse>,
-    ): Promise<ModelResponse> {
-      const agentId = ctx.session.agentId as AgentId;
-      const event: GovernanceBackendEvent = {
+      next: (req: ModelRequest) => AsyncIterable<ModelChunk>,
+    ): Promise<AsyncIterable<ModelChunk>> {
+      const policyRequest: PolicyRequest = {
         kind: "model_call",
-        agentId,
+        agentId: getAgentId(),
         payload: {
           model: request.model ?? "unknown",
           toolCount: request.tools?.length ?? 0,
-          turnIndex: ctx.turnIndex,
         },
         timestamp: Date.now(),
       };
 
-      // evaluate() is fail-closed: if it throws, the call is denied
-      const verdict = await backend.evaluate(event);
+      const verdict = await backend.evaluator.evaluate(policyRequest);
 
-      if (!verdict.ok) {
-        await backend.recordAttestation({
-          agentId,
-          ruleId: verdict.violations[0]?.rule ?? "model-call-denied",
+      // Record compliance
+      if (backend.compliance) {
+        await backend.compliance.recordCompliance({
+          requestId: nextRequestId(),
+          request: policyRequest,
           verdict,
-          evidence: { kind: "model_call", turnIndex: ctx.turnIndex },
+          evaluatedAt: Date.now(),
+          policyFingerprint: "e2e-test-policy-v1",
         });
-        const summary = verdict.violations.map((v) => v.message).join("; ");
-        throw new Error(`GovernanceBackend denied model call: ${summary}`);
       }
 
-      const response = await next(request);
+      if (!verdict.ok) {
+        throw new Error(
+          `GovernanceBackend denied model call: ${verdict.violations.map((v) => v.message).join("; ")}`,
+        );
+      }
 
-      await backend.recordAttestation({
-        agentId,
-        ruleId: "model-call-allowed",
-        verdict: { ok: true },
-        evidence: {
-          inputTokens: (response.usage as Record<string, unknown> | undefined)?.inputTokens,
-          outputTokens: (response.usage as Record<string, unknown> | undefined)?.outputTokens,
-          model: request.model ?? "unknown",
-        },
-      });
-
-      return response;
-    },
-
-    // createPiAdapter uses the streaming path — must intercept wrapModelStream.
-    // IMPORTANT: do NOT use yield* here. The stream bridge exits via `return` after
-    // the done chunk, which calls .return() on the generator before any post-yield*
-    // code runs. Instead, use for-await and record attestation BEFORE yielding done.
-    wrapModelStream(
-      ctx: TurnContext,
-      request: ModelRequest,
-      next: (r: ModelRequest) => AsyncIterable<ModelChunk>,
-    ): AsyncIterable<ModelChunk> {
-      const agentId = ctx.session.agentId as AgentId;
-      const event: GovernanceBackendEvent = {
-        kind: "model_call",
-        agentId,
-        payload: {
-          model: request.model ?? "unknown",
-          toolCount: request.tools?.length ?? 0,
-          turnIndex: ctx.turnIndex,
-        },
-        timestamp: Date.now(),
-      };
-
-      // Return an AsyncIterable — evaluated lazily when iterated
-      return {
-        async *[Symbol.asyncIterator]() {
-          // evaluate() before streaming begins — fail-closed
-          const verdict = await backend.evaluate(event);
-
-          if (!verdict.ok) {
-            await backend.recordAttestation({
-              agentId,
-              ruleId: verdict.violations[0]?.rule ?? "model-stream-denied",
-              verdict,
-              evidence: { kind: "model_stream", turnIndex: ctx.turnIndex },
-            });
-            const summary = verdict.violations.map((v) => v.message).join("; ");
-            throw new Error(`GovernanceBackend denied model stream: ${summary}`);
-          }
-
-          // Stream allowed — iterate and yield each chunk.
-          // Record success attestation BEFORE yielding the done chunk so it
-          // runs before the outer consumer can close this generator.
-          for await (const chunk of next(request)) {
-            if (chunk.kind === "done") {
-              await backend.recordAttestation({
-                agentId,
-                ruleId: "model-call-allowed",
-                verdict: { ok: true },
-                evidence: {
-                  kind: "model_stream",
-                  model: request.model ?? "unknown",
-                  inputTokens: chunk.response.usage?.inputTokens,
-                  outputTokens: chunk.response.usage?.outputTokens,
-                },
-              });
-            }
-            yield chunk;
-          }
-        },
-      };
+      return next(request);
     },
 
     async wrapToolCall(
-      ctx: TurnContext,
+      _ctx: TurnContext,
       request: ToolRequest,
-      next: (r: ToolRequest) => Promise<import("@koi/core").ToolResponse>,
-    ): Promise<import("@koi/core").ToolResponse> {
-      const agentId = ctx.session.agentId as AgentId;
-      const event: GovernanceBackendEvent = {
+      next: (req: ToolRequest) => ModelResponse | Promise<ModelResponse>,
+    ): Promise<ModelResponse> {
+      const policyRequest: PolicyRequest = {
         kind: "tool_call",
-        agentId,
-        payload: {
-          toolName: request.toolId,
-          turnIndex: ctx.turnIndex,
-        },
+        agentId: getAgentId(),
+        payload: { toolName: request.name },
         timestamp: Date.now(),
       };
 
-      const verdict = await backend.evaluate(event);
+      const verdict = await backend.evaluator.evaluate(policyRequest);
 
-      if (!verdict.ok) {
-        await backend.recordAttestation({
-          agentId,
-          ruleId: verdict.violations[0]?.rule ?? "tool-call-denied",
+      if (backend.compliance) {
+        await backend.compliance.recordCompliance({
+          requestId: nextRequestId(),
+          request: policyRequest,
           verdict,
-          evidence: { kind: "tool_call", toolName: request.toolId },
+          evaluatedAt: Date.now(),
+          policyFingerprint: "e2e-test-policy-v1",
         });
-        const summary = verdict.violations.map((v) => v.message).join("; ");
-        throw new Error(`GovernanceBackend denied tool call "${request.toolId}": ${summary}`);
       }
 
-      const response = await next(request);
+      if (!verdict.ok) {
+        return {
+          role: "tool" as const,
+          content: [
+            {
+              kind: "text" as const,
+              text: `GOVERNANCE DENIED: ${verdict.violations.map((v) => v.message).join("; ")}`,
+            },
+          ],
+        };
+      }
 
-      await backend.recordAttestation({
-        agentId,
-        ruleId: "tool-call-allowed",
-        verdict: { ok: true },
-        evidence: { toolName: request.toolId },
-      });
-
-      return response;
+      return next(request);
     },
   };
 }
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-async function collectEvents(
-  iterable: AsyncIterable<EngineEvent>,
-): Promise<readonly EngineEvent[]> {
-  const events: EngineEvent[] = [];
-  for await (const event of iterable) {
-    events.push(event);
+/** Drain an AsyncIterable<EngineEvent> into an EngineOutput. */
+async function drainEngine(stream: AsyncIterable<EngineEvent>): Promise<EngineOutput> {
+  // let justified: accumulates output from generator
+  let output: EngineOutput | undefined;
+  for await (const event of stream) {
+    if (event.kind === "output") {
+      output = event.output;
+    }
   }
-  return events;
+  if (!output) {
+    throw new Error("Engine stream ended without producing output");
+  }
+  return output;
 }
 
-function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
-  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
-  return done?.output;
-}
-
-function extractText(events: readonly EngineEvent[]): string {
-  return events
-    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
-    .map((e) => e.delta)
-    .join("");
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describeE2E("e2e: GovernanceBackend (#265) through full createKoi + createPiAdapter", () => {
-  // -------------------------------------------------------------------------
-  // Test 1: Permissive backend — all calls allowed through, attestations recorded
-  // -------------------------------------------------------------------------
+describeE2E("GovernanceBackend E2E through createKoi + createPiAdapter", () => {
   test(
-    "1. permissive backend: evaluate() called on every model call, attestations recorded with real LLM",
+    "permissive evaluator: evaluate() called on every model call, compliance recorded with real LLM",
     async () => {
       const { backend, state } = createInMemoryGovernanceBackend("allow");
-      const middleware = createGovernanceBackendMiddleware(backend);
+
+      // let justified: captured once agent is assembled
+      let capturedAgentId: AgentId | undefined;
 
       const adapter = createPiAdapter({
         model: E2E_MODEL,
-        systemPrompt: "You are a concise test assistant. Reply briefly.",
-        getApiKey: () => ANTHROPIC_KEY,
+        systemPrompt: "You are a concise test assistant. Reply with a single short sentence.",
+        getApiKey: async () => ANTHROPIC_KEY,
       });
 
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-permissive",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
+      const agent = createKoi({
+        name: "governance-e2e-permissive",
         adapter,
-        middleware: [middleware],
-        loopDetection: false,
-        limits: { maxTurns: 5, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+        middleware: [createGovernanceBackendMiddleware(backend, () => capturedAgentId!)],
       });
 
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with exactly one word: hello" }),
+      capturedAgentId = agent.id;
+
+      const output = await drainEngine(
+        agent.stream({
+          messages: [
+            {
+              role: "user",
+              content: [{ kind: "text", text: "Say hello in exactly 5 words." }],
+            },
+          ],
+        }),
       );
 
-      // Agent should complete normally
-      const output = findDoneOutput(events);
-      expect(output?.stopReason).toBe("completed");
-
-      // Real text was returned from the LLM
-      const text = extractText(events);
-      expect(text.length).toBeGreaterThan(0);
-
-      // Backend was called at least once for the model call
       const s = state();
+
+      // evaluator was called at least once (model call)
       expect(s.evaluateCalls.length).toBeGreaterThanOrEqual(1);
 
-      // All evaluate calls should have returned ok: true
+      // Every evaluate call was for our agent
       for (const call of s.evaluateCalls) {
-        expect(call.verdict.ok).toBe(true);
+        expect(call.request.agentId).toBe(capturedAgentId);
+        expect(call.request.timestamp).toBeGreaterThan(0);
+        expect(["model_call", "tool_call"]).toContain(call.request.kind);
       }
 
-      // At least one attestation recorded (success attestation after model call)
-      expect(s.attestations.length).toBeGreaterThanOrEqual(1);
-
-      // Validate GovernanceBackendEvent structure from a real call
-      const modelCallEvent = s.evaluateCalls.find((c) => c.event.kind === "model_call");
-      expect(modelCallEvent).toBeDefined();
-      if (modelCallEvent !== undefined) {
-        // agentId is a non-empty string
-        expect(typeof modelCallEvent.event.agentId).toBe("string");
-        expect(modelCallEvent.event.agentId.length).toBeGreaterThan(0);
-        // timestamp is a recent unix ms
-        expect(modelCallEvent.event.timestamp).toBeGreaterThan(0);
-        expect(modelCallEvent.event.timestamp).toBeLessThanOrEqual(Date.now());
-        // payload contains model and toolCount
-        expect(typeof modelCallEvent.event.payload.model).toBe("string");
-        expect(typeof modelCallEvent.event.payload.toolCount).toBe("number");
+      // Compliance records match evaluate calls
+      expect(s.complianceRecords.length).toBe(s.evaluateCalls.length);
+      for (const record of s.complianceRecords) {
+        expect(record.requestId).toBeTruthy();
+        expect(record.policyFingerprint).toBe("e2e-test-policy-v1");
+        expect(record.evaluatedAt).toBeGreaterThan(0);
+        expect(record.request.agentId).toBe(capturedAgentId);
       }
 
-      // Validate GovernanceAttestation structure
-      const successAttest = s.attestations.find((a) => a.ruleId === "model-call-allowed");
-      expect(successAttest).toBeDefined();
-      if (successAttest !== undefined) {
-        // Backend assigned an id
-        expect(typeof successAttest.id).toBe("string");
-        expect(successAttest.id.startsWith("attest-")).toBe(true);
-        // Backend assigned attestedAt
-        expect(successAttest.attestedAt).toBeGreaterThan(0);
-        // Backend identity
-        expect(successAttest.attestedBy).toBe("in-memory-governance-backend");
-        // Verdict is ok
-        expect(successAttest.verdict.ok).toBe(true);
-        // evidence carries model info
-        expect(successAttest.evidence?.model).toBeDefined();
-      }
-
-      await runtime.dispose();
-      backend.dispose?.();
-      expect(state().disposed).toBe(true);
+      // Agent produced output
+      expect(output.messages.length).toBeGreaterThanOrEqual(1);
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 2: Blocking backend — model call denied, engine stops gracefully
-  // -------------------------------------------------------------------------
   test(
-    "2. blocking backend: evaluate() returns { ok: false } → model call denied, engine stops",
+    "blocking evaluator: evaluate() returns { ok: false } → model call denied, engine stops",
     async () => {
       const { backend, state } = createInMemoryGovernanceBackend("block_model");
-      const middleware = createGovernanceBackendMiddleware(backend);
+
+      // let justified: captured once agent is assembled
+      let capturedAgentId: AgentId | undefined;
 
       const adapter = createPiAdapter({
         model: E2E_MODEL,
         systemPrompt: "You are a concise test assistant.",
-        getApiKey: () => ANTHROPIC_KEY,
+        getApiKey: async () => ANTHROPIC_KEY,
       });
 
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-blocking",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
+      const agent = createKoi({
+        name: "governance-e2e-blocking",
         adapter,
-        middleware: [middleware],
-        loopDetection: false,
-        limits: { maxTurns: 5, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+        middleware: [createGovernanceBackendMiddleware(backend, () => capturedAgentId!)],
       });
 
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with one word: hello" }),
-      );
+      capturedAgentId = agent.id;
 
-      // Engine completes — pi adapter always fires agent_end → "completed"
-      // even when middleware blocks the model stream internally.
-      const output = findDoneOutput(events);
-      expect(output).toBeDefined();
-      expect(output?.stopReason).toBe("completed");
+      // The engine should complete (either with error or stopped) because
+      // the middleware throws on deny verdict
+      try {
+        await drainEngine(
+          agent.stream({
+            messages: [
+              {
+                role: "user",
+                content: [{ kind: "text", text: "Say hello." }],
+              },
+            ],
+          }),
+        );
+      } catch {
+        // Expected — middleware throws on deny
+      }
 
-      // No text produced — LLM was never called (blocked before the API request)
-      const text = extractText(events);
-      expect(text.length).toBe(0);
-
-      // The backend was evaluated at least once for a model_call
       const s = state();
-      const blockedCall = s.evaluateCalls.find((c) => c.event.kind === "model_call");
-      expect(blockedCall).toBeDefined();
-      if (blockedCall !== undefined) {
-        // Verdict should be { ok: false }
-        expect(blockedCall.verdict.ok).toBe(false);
-        if (!blockedCall.verdict.ok) {
-          expect(blockedCall.verdict.violations).toHaveLength(1);
-          expect(blockedCall.verdict.violations[0]?.rule).toBe("no-model-calls-in-test");
-          expect(blockedCall.verdict.violations[0]?.severity).toBe("critical");
-          expect(typeof blockedCall.verdict.violations[0]?.message).toBe("string");
-        }
+
+      // At least one evaluate call was made
+      expect(s.evaluateCalls.length).toBeGreaterThanOrEqual(1);
+
+      // The first model_call evaluate returned a deny verdict
+      const modelCalls = s.evaluateCalls.filter((c) => c.request.kind === "model_call");
+      expect(modelCalls.length).toBeGreaterThanOrEqual(1);
+      expect(modelCalls[0]?.verdict.ok).toBe(false);
+      if (!modelCalls[0]?.verdict.ok) {
+        expect(modelCalls[0]?.verdict.violations.length).toBeGreaterThan(0);
+        expect(modelCalls[0]?.verdict.violations[0]?.rule).toBe("no-model-calls-in-test");
       }
 
-      // A denial attestation should have been recorded
-      const denialAttest = s.attestations.find((a) => a.ruleId === "no-model-calls-in-test");
-      expect(denialAttest).toBeDefined();
-      if (denialAttest !== undefined) {
-        expect(denialAttest.verdict.ok).toBe(false);
-        expect(denialAttest.attestedBy).toBe("in-memory-governance-backend");
-        // evidence carries kind and turnIndex (wrapModelStream path uses "model_stream")
-        expect(denialAttest.evidence?.kind).toBe("model_stream");
-      }
-
-      await runtime.dispose();
-      backend.dispose?.();
+      // Compliance was recorded for the deny
+      const denyRecords = s.complianceRecords.filter((r) => !r.verdict.ok);
+      expect(denyRecords.length).toBeGreaterThanOrEqual(1);
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 3: Fail-closed contract — throwing backend → engine stops gracefully
-  // -------------------------------------------------------------------------
   test(
-    "3. fail-closed contract: evaluate() throws → model call denied, agent does not proceed",
+    "fail-closed contract: evaluate() throws → model call denied, agent does not proceed",
     async () => {
-      const { backend } = createInMemoryGovernanceBackend("throw");
-      const middleware = createGovernanceBackendMiddleware(backend);
+      const { backend, state } = createInMemoryGovernanceBackend("throw");
+
+      // let justified: captured once agent is assembled
+      let capturedAgentId: AgentId | undefined;
 
       const adapter = createPiAdapter({
         model: E2E_MODEL,
         systemPrompt: "You are a concise test assistant.",
-        getApiKey: () => ANTHROPIC_KEY,
+        getApiKey: async () => ANTHROPIC_KEY,
       });
 
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-fail-closed",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
+      const agent = createKoi({
+        name: "governance-e2e-failclosed",
         adapter,
-        middleware: [middleware],
-        loopDetection: false,
-        limits: { maxTurns: 5, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
+        middleware: [createGovernanceBackendMiddleware(backend, () => capturedAgentId!)],
       });
 
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with one word: hello" }),
-      );
+      capturedAgentId = agent.id;
 
-      // Engine completes — pi adapter always fires agent_end → "completed".
-      // Fail-closed means the evaluate() throw is caught by the stream bridge
-      // and converted to a pi error internally; the LLM was never reached.
-      const output = findDoneOutput(events);
-      expect(output).toBeDefined();
-      expect(output?.stopReason).toBe("completed");
+      // The engine should fail because the middleware propagates the throw
+      try {
+        await drainEngine(
+          agent.stream({
+            messages: [
+              {
+                role: "user",
+                content: [{ kind: "text", text: "Say hello." }],
+              },
+            ],
+          }),
+        );
+      } catch {
+        // Expected — evaluate() throws, middleware propagates
+      }
 
-      // No text produced — LLM was never called (evaluate() threw before API request)
-      const text = extractText(events);
-      expect(text.length).toBe(0);
+      const s = state();
 
-      await runtime.dispose();
+      // evaluate() was called but threw, so no evaluateCalls recorded
+      // (the throw happens before the push)
+      expect(s.evaluateCalls.length).toBe(0);
+
+      // No compliance records (throw before recording)
+      expect(s.complianceRecords.length).toBe(0);
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 4: checkConstraint() — wired via onBeforeTurn pre-check
-  // -------------------------------------------------------------------------
   test(
-    "4. checkConstraint(): allow-all passes, any-other-id is blocked",
+    "checkConstraint(): allow-all passes, other kinds are blocked",
     async () => {
-      const { backend, state } = createInMemoryGovernanceBackend("allow");
+      const { backend } = createInMemoryGovernanceBackend("allow");
+      const { agentId } = await import("@koi/core");
+      const testAgent = agentId("constraint-test-agent");
 
-      // Wrap backend checkConstraint calls and record them for assertions
-      const checkCalls: ConstraintQuery[] = [];
-      const originalCheck = backend.checkConstraint.bind(backend);
-      const wrappedBackend: GovernanceBackend = {
-        ...backend,
-        checkConstraint(query: ConstraintQuery): boolean {
-          checkCalls.push(query);
-          return originalCheck(query);
-        },
-      };
-
-      // Use checkConstraint in onBeforeTurn to gate each turn
-      const constraintMiddleware: KoiMiddleware = {
-        name: "constraint-check-e2e",
-        priority: 50,
-        async onBeforeTurn(ctx): Promise<void> {
-          const allowed = await wrappedBackend.checkConstraint({
-            constraintId: "allow-all", // should pass
-            agentId: ctx.session.agentId as AgentId,
-            context: { turnIndex: ctx.turnIndex },
-          });
-          if (!allowed) {
-            throw new Error("GovernanceBackend: constraint check denied this turn");
-          }
-        },
-      };
-
-      const adapter = createPiAdapter({
-        model: E2E_MODEL,
-        systemPrompt: "You are a concise test assistant.",
-        getApiKey: () => ANTHROPIC_KEY,
-      });
-
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-constraint",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
-        adapter,
-        middleware: [constraintMiddleware],
-        loopDetection: false,
-        limits: { maxTurns: 3, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
-      });
-
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with exactly one word: hello" }),
-      );
-
-      // Agent completed normally (allow-all constraint passes)
-      const output = findDoneOutput(events);
-      expect(output?.stopReason).toBe("completed");
-
-      // checkConstraint was called at least once (once per turn)
-      expect(checkCalls.length).toBeGreaterThanOrEqual(1);
-
-      // Each call used the "allow-all" constraintId with a real agentId
-      for (const call of checkCalls) {
-        expect(call.constraintId).toBe("allow-all");
-        expect(typeof call.agentId).toBe("string");
-        expect(call.agentId.length).toBeGreaterThan(0);
-        expect(typeof call.context?.turnIndex).toBe("number");
-      }
-
-      // Now verify the blocking constraint works by calling it directly
-      const blocked = await wrappedBackend.checkConstraint({
-        constraintId: "deny-everything",
-        agentId: "agent-test" as AgentId,
-      });
-      expect(blocked).toBe(false);
-
-      // Verify allow-all passes
-      const allowed = await wrappedBackend.checkConstraint({
-        constraintId: "allow-all",
-        agentId: "agent-test" as AgentId,
+      // "allow-all" kind passes
+      const allowed = await backend.constraints?.checkConstraint({
+        kind: "allow-all",
+        agentId: testAgent,
       });
       expect(allowed).toBe(true);
 
-      void state; // state captured for debugging if needed
-      await runtime.dispose();
+      // Any other kind is blocked
+      const blocked = await backend.constraints?.checkConstraint({
+        kind: "some-other-constraint",
+        agentId: testAgent,
+      });
+      expect(blocked).toBe(false);
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 5: recordAttestation() — verifies GovernanceAttestationInput → GovernanceAttestation
-  // -------------------------------------------------------------------------
   test(
-    "5. recordAttestation(): backend assigns id, attestedAt, attestedBy; Input→Attest enrichment verified",
+    "recordCompliance(): backend records and returns the compliance record",
     async () => {
       const { backend, state } = createInMemoryGovernanceBackend("allow");
-      const middleware = createGovernanceBackendMiddleware(backend);
+      const { agentId } = await import("@koi/core");
+      const testAgent = agentId("compliance-test-agent");
 
-      const adapter = createPiAdapter({
-        model: E2E_MODEL,
-        systemPrompt: "You are a concise test assistant.",
-        getApiKey: () => ANTHROPIC_KEY,
-      });
+      const request: PolicyRequest = {
+        kind: "model_call",
+        agentId: testAgent,
+        payload: { model: "test-model" },
+        timestamp: Date.now(),
+      };
 
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-attestation",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
-        adapter,
-        middleware: [middleware],
-        loopDetection: false,
-        limits: { maxTurns: 3, maxDurationMs: TIMEOUT_MS, maxTokens: 50_000 },
-      });
+      const record: ComplianceRecord = {
+        requestId: "test-req-001",
+        request,
+        verdict: GOVERNANCE_ALLOW,
+        evaluatedAt: Date.now(),
+        policyFingerprint: "sha256:test-fingerprint",
+      };
 
-      const beforeRun = Date.now();
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with one word: hello" }),
-      );
-      const afterRun = Date.now();
+      const returned = await backend.compliance?.recordCompliance(record);
 
-      const output = findDoneOutput(events);
-      expect(output?.stopReason).toBe("completed");
+      // Record is returned as-is
+      expect(returned.requestId).toBe("test-req-001");
+      expect(returned.policyFingerprint).toBe("sha256:test-fingerprint");
+      expect(returned.verdict.ok).toBe(true);
+      expect(returned.request.agentId).toBe(testAgent);
 
+      // Stored in state
       const s = state();
-      expect(s.attestations.length).toBeGreaterThanOrEqual(1);
-
-      // Validate every attestation has backend-assigned fields
-      for (const attest of s.attestations) {
-        // id is backend-assigned, not provided by caller
-        expect(typeof attest.id).toBe("string");
-        expect(attest.id.length).toBeGreaterThan(0);
-        // Each id starts with our backend's pattern
-        expect(attest.id.startsWith("attest-")).toBe(true);
-
-        // attestedAt is within the run window
-        expect(attest.attestedAt).toBeGreaterThanOrEqual(beforeRun - 1000); // allow 1s clock skew
-        expect(attest.attestedAt).toBeLessThanOrEqual(afterRun + 1000);
-
-        // attestedBy identifies the backend
-        expect(attest.attestedBy).toBe("in-memory-governance-backend");
-
-        // agentId is populated from middleware context
-        expect(typeof attest.agentId).toBe("string");
-        expect(attest.agentId.length).toBeGreaterThan(0);
-
-        // ruleId is set
-        expect(typeof attest.ruleId).toBe("string");
-        expect(attest.ruleId.length).toBeGreaterThan(0);
-
-        // verdict is present
-        expect(typeof attest.verdict.ok).toBe("boolean");
-      }
-
-      // IDs must be unique (backend does not reuse IDs)
-      const ids = s.attestations.map((a) => a.id);
-      const uniqueIds = new Set(ids);
-      expect(uniqueIds.size).toBe(ids.length);
-
-      await runtime.dispose();
-      backend.dispose?.();
+      expect(s.complianceRecords.length).toBe(1);
+      expect(s.complianceRecords[0]?.requestId).toBe("test-req-001");
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 6: getViolations() with ViolationQuery filters
-  // -------------------------------------------------------------------------
-  test("6. getViolations(): filters work — by agentId, severity, ruleId, after/before, limit", async () => {
-    const { backend, state } = createInMemoryGovernanceBackend("allow");
+  test(
+    "getViolations(): filters work — by agentId, severity, rule, since/until, limit",
+    async () => {
+      const { backend } = createInMemoryGovernanceBackend("allow");
+      const { agentId } = await import("@koi/core");
 
-    // Manually record some violations with known agentId and properties for filter testing
-    const testAgentId = "agent-filter-test" as AgentId;
-    const otherAgentId = "agent-other" as AgentId;
-    const t0 = Date.now();
+      const agentA = agentId("violation-agent-a");
+      const agentB = agentId("violation-agent-b");
+      const now = Date.now();
 
-    // Record a mix of attestations
-    const attests: GovernanceAttestationInput[] = [
-      {
-        agentId: testAgentId,
-        ruleId: "cost-limit",
-        verdict: {
-          ok: false,
-          violations: [{ rule: "cost-limit", severity: "critical", message: "Cost exceeded" }],
-        },
-      },
-      {
-        agentId: testAgentId,
-        ruleId: "rate-limit",
-        verdict: {
-          ok: false,
-          violations: [{ rule: "rate-limit", severity: "warning", message: "Rate too high" }],
-        },
-      },
-      {
-        agentId: otherAgentId,
-        ruleId: "cost-limit",
-        verdict: {
-          ok: false,
-          violations: [{ rule: "cost-limit", severity: "info", message: "Cost approaching limit" }],
-        },
-      },
-      {
-        agentId: testAgentId,
-        ruleId: "allow-always",
-        verdict: { ok: true }, // This produces no violations
-      },
-    ];
+      // Record some deny verdicts to populate violation store
+      const denyVerdicts: ReadonlyArray<{
+        readonly agent: AgentId;
+        readonly rule: string;
+        readonly severity: "info" | "warning" | "critical";
+        readonly at: number;
+      }> = [
+        { agent: agentA, rule: "cost-limit", severity: "critical", at: now - 5000 },
+        { agent: agentA, rule: "rate-limit", severity: "warning", at: now - 4000 },
+        { agent: agentB, rule: "cost-limit", severity: "critical", at: now - 3000 },
+        { agent: agentA, rule: "cost-limit", severity: "info", at: now - 2000 },
+        { agent: agentB, rule: "scope-violation", severity: "warning", at: now - 1000 },
+      ];
 
-    for (const a of attests) {
-      const result = await backend.recordAttestation(a);
-      expect(result.ok).toBe(true);
-    }
-
-    // Filter by agentId — should return only testAgentId violations
-    const byAgent = await backend.getViolations({ agentId: testAgentId });
-    expect(byAgent.ok).toBe(true);
-    if (byAgent.ok) {
-      expect(byAgent.value.length).toBe(2); // cost-limit + rate-limit
-      for (const v of byAgent.value) {
-        // All should be from testAgentId rules
-        expect(["cost-limit", "rate-limit"]).toContain(v.rule);
+      for (const v of denyVerdicts) {
+        const request: PolicyRequest = {
+          kind: "model_call",
+          agentId: v.agent,
+          payload: {},
+          timestamp: v.at,
+        };
+        await backend.compliance?.recordCompliance({
+          requestId: `viol-${v.rule}-${v.at}`,
+          request,
+          verdict: {
+            ok: false,
+            violations: [{ rule: v.rule, severity: v.severity, message: `${v.rule} violated` }],
+          },
+          evaluatedAt: v.at,
+          policyFingerprint: "test-policy",
+        });
       }
-    }
 
-    // Filter by severity — only "critical"
-    const byCritical = await backend.getViolations({ severity: ["critical"] });
-    expect(byCritical.ok).toBe(true);
-    if (byCritical.ok) {
-      // Should return violations with severity: "critical" only
-      for (const v of byCritical.value) {
-        expect(v.severity).toBe("critical");
-      }
-      expect(byCritical.value.length).toBeGreaterThanOrEqual(1);
-    }
+      // Filter by agentId
+      const agentAPage = await backend.violations?.getViolations({ agentId: agentA });
+      expect(agentAPage.items.length).toBe(3);
 
-    // Filter by ruleId
-    const byCostRule = await backend.getViolations({ ruleId: "cost-limit" });
-    expect(byCostRule.ok).toBe(true);
-    if (byCostRule.ok) {
-      for (const v of byCostRule.value) {
-        expect(v.rule).toBe("cost-limit");
-      }
-      expect(byCostRule.value.length).toBe(2); // testAgent + otherAgent
-    }
+      // Filter by severity (at or above warning)
+      const warningPage = await backend.violations?.getViolations({ severity: "warning" });
+      expect(warningPage.items.length).toBe(4); // 2 critical + 2 warning
 
-    // Filter by limit
-    const limited = await backend.getViolations({ limit: 1 });
-    expect(limited.ok).toBe(true);
-    if (limited.ok) {
-      expect(limited.value.length).toBeLessThanOrEqual(1);
-    }
+      // Filter by rule
+      const costPage = await backend.violations?.getViolations({ rule: "cost-limit" });
+      expect(costPage.items.length).toBe(3);
 
-    // Filter by after — nothing matches a future timestamp
-    const futureFilter = await backend.getViolations({ after: Date.now() + 1_000_000 });
-    expect(futureFilter.ok).toBe(true);
-    if (futureFilter.ok) {
-      expect(futureFilter.value.length).toBe(0);
-    }
+      // Filter by since/until
+      const recentPage = await backend.violations?.getViolations({ since: now - 3500 });
+      expect(recentPage.items.length).toBe(3); // last 3 entries
 
-    // Filter by before — nothing matches a past timestamp
-    const pastFilter = await backend.getViolations({ before: t0 - 1000 });
-    expect(pastFilter.ok).toBe(true);
-    if (pastFilter.ok) {
-      expect(pastFilter.value.length).toBe(0);
-    }
+      // Filter with limit
+      const limitPage = await backend.violations?.getViolations({ limit: 2 });
+      expect(limitPage.items.length).toBe(2);
+      expect(limitPage.total).toBe(5); // total before limit
 
-    // Verify DEFAULT_VIOLATION_QUERY_LIMIT is applied when limit is omitted
-    const noLimit = await backend.getViolations({});
-    expect(noLimit.ok).toBe(true);
-    if (noLimit.ok) {
-      // 3 violations total (testAgent: 2, otherAgent: 1)
-      expect(noLimit.value.length).toBe(3);
-      expect(noLimit.value.length).toBeLessThanOrEqual(DEFAULT_VIOLATION_QUERY_LIMIT);
-    }
+      // Empty filter returns all
+      const allPage = await backend.violations?.getViolations({});
+      expect(allPage.items.length).toBe(5);
 
-    void state;
-  }, 30_000); // No LLM call needed for this test
+      // DEFAULT_VIOLATION_QUERY_LIMIT is accessible
+      expect(DEFAULT_VIOLATION_QUERY_LIMIT).toBe(100);
+    },
+    TIMEOUT_MS,
+  );
 
-  // -------------------------------------------------------------------------
-  // Test 7: VIOLATION_SEVERITIES ordering — verify severity comparison in practice
-  // -------------------------------------------------------------------------
-  test("7. VIOLATION_SEVERITIES ordering: severity comparison works with real GovernanceVerdict data", async () => {
-    const { backend } = createInMemoryGovernanceBackend("allow");
+  test("VIOLATION_SEVERITY_ORDER: ordering from least to most severe", () => {
+    expect(VIOLATION_SEVERITY_ORDER).toEqual(["info", "warning", "critical"]);
 
-    // Record violations at each severity level
-    const agentId = "agent-severity-test" as AgentId;
-    const severities = ["info", "warning", "critical"] as const;
+    // Verify ordering: info < warning < critical
+    const infoIdx = VIOLATION_SEVERITY_ORDER.indexOf("info");
+    const warningIdx = VIOLATION_SEVERITY_ORDER.indexOf("warning");
+    const criticalIdx = VIOLATION_SEVERITY_ORDER.indexOf("critical");
+    expect(infoIdx).toBeLessThan(warningIdx);
+    expect(warningIdx).toBeLessThan(criticalIdx);
+  });
 
-    for (const severity of severities) {
-      await backend.recordAttestation({
-        agentId,
-        ruleId: `rule-${severity}`,
-        verdict: {
-          ok: false,
-          violations: [
-            { rule: `rule-${severity}`, severity, message: `${severity} level violation` },
-          ],
-        },
-      });
-    }
+  test(
+    "dispose(): backend signals disposal; operations throw after dispose",
+    async () => {
+      const { backend, state } = createInMemoryGovernanceBackend("allow");
+      const { agentId } = await import("@koi/core");
+      const testAgent = agentId("dispose-test-agent");
 
-    // Query only at-or-above "warning"
-    const atLeastWarning = await backend.getViolations({
-      agentId,
-      severity: VIOLATION_SEVERITIES.filter(
-        (s) => VIOLATION_SEVERITIES.indexOf(s) >= VIOLATION_SEVERITIES.indexOf("warning"),
-      ),
-    });
-    expect(atLeastWarning.ok).toBe(true);
-    if (atLeastWarning.ok) {
-      expect(atLeastWarning.value.length).toBe(2); // warning + critical
-      for (const v of atLeastWarning.value) {
-        expect(["warning", "critical"]).toContain(v.severity);
-        expect(v.severity).not.toBe("info");
-      }
-    }
-
-    // Query only "info"
-    const infoOnly = await backend.getViolations({ agentId, severity: ["info"] });
-    expect(infoOnly.ok).toBe(true);
-    if (infoOnly.ok) {
-      expect(infoOnly.value.length).toBe(1);
-      expect(infoOnly.value[0]?.severity).toBe("info");
-    }
-
-    // Verify ordering invariant: critical > warning > info
-    const critIdx = VIOLATION_SEVERITIES.indexOf("critical");
-    const warnIdx = VIOLATION_SEVERITIES.indexOf("warning");
-    const infoIdx = VIOLATION_SEVERITIES.indexOf("info");
-    expect(critIdx).toBeGreaterThan(warnIdx);
-    expect(warnIdx).toBeGreaterThan(infoIdx);
-  }, 10_000); // No LLM call
-
-  // -------------------------------------------------------------------------
-  // Test 8: dispose() — backend lifecycle, operations fail after dispose
-  // -------------------------------------------------------------------------
-  test("8. dispose(): backend signals disposal; operations throw or return errors after dispose", async () => {
-    const { backend, state } = createInMemoryGovernanceBackend("allow");
-
-    // Record something before dispose
-    await backend.recordAttestation({
-      agentId: "agent-dispose" as AgentId,
-      ruleId: "pre-dispose",
-      verdict: { ok: true },
-    });
-
-    expect(state().disposed).toBe(false);
-    expect(state().attestations.length).toBe(1);
-
-    // Dispose
-    backend.dispose?.();
-    expect(state().disposed).toBe(true);
-
-    // evaluate() throws after dispose
-    expect(() =>
-      backend.evaluate({
+      // Before dispose: operations succeed
+      const preVerdict = await backend.evaluator.evaluate({
         kind: "model_call",
-        agentId: "agent-dispose" as AgentId,
+        agentId: testAgent,
         payload: {},
         timestamp: Date.now(),
-      }),
-    ).toThrow("after dispose");
-
-    // checkConstraint() throws after dispose
-    expect(() =>
-      backend.checkConstraint({ constraintId: "allow-all", agentId: "agent-dispose" as AgentId }),
-    ).toThrow("after dispose");
-
-    // recordAttestation() returns error Result after dispose
-    const result = await backend.recordAttestation({
-      agentId: "agent-dispose" as AgentId,
-      ruleId: "post-dispose",
-      verdict: { ok: true },
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe("INTERNAL_ERROR");
-    }
-  }, 10_000); // No LLM call
-
-  // -------------------------------------------------------------------------
-  // Test 9: GovernanceBackend middleware + GovernanceController coexist
-  //         Both wired simultaneously, real pi Agent call exercises both
-  // -------------------------------------------------------------------------
-  test(
-    "9. GovernanceBackend middleware + GovernanceController (sensor model) coexist in same runtime",
-    async () => {
-      const { backend, state } = createInMemoryGovernanceBackend("allow");
-      const middleware = createGovernanceBackendMiddleware(backend);
-
-      const adapter = createPiAdapter({
-        model: E2E_MODEL,
-        systemPrompt: "You are a concise test assistant.",
-        getApiKey: () => ANTHROPIC_KEY,
       });
+      expect(preVerdict.ok).toBe(true);
 
-      // Wire BOTH: GovernanceBackendMiddleware + sensor-model via governance config
-      const runtime = await createKoi({
-        manifest: {
-          name: "governance-backend-e2e-both",
-          version: "0.0.1",
-          model: { name: "claude-haiku-4-5-20251001" },
-        },
-        adapter,
-        middleware: [middleware],
-        governance: {
-          iteration: {
-            maxTurns: 10,
-            maxTokens: 50_000,
-            maxDurationMs: TIMEOUT_MS,
+      // Dispose
+      await backend.dispose?.();
+      expect(state().disposed).toBe(true);
+
+      // After dispose: evaluate throws
+      expect(() =>
+        backend.evaluator.evaluate({
+          kind: "model_call",
+          agentId: testAgent,
+          payload: {},
+          timestamp: Date.now(),
+        }),
+      ).toThrow("called after dispose()");
+
+      // After dispose: checkConstraint throws
+      expect(() =>
+        backend.constraints?.checkConstraint({
+          kind: "allow-all",
+          agentId: testAgent,
+        }),
+      ).toThrow("called after dispose()");
+
+      // After dispose: recordCompliance throws
+      expect(() =>
+        backend.compliance?.recordCompliance({
+          requestId: "post-dispose",
+          request: {
+            kind: "model_call",
+            agentId: testAgent,
+            payload: {},
+            timestamp: Date.now(),
           },
-          cost: {
-            maxCostUsd: 1.0,
-            costPerInputToken: 0.000001,
-            costPerOutputToken: 0.000005,
-          },
-        },
-        loopDetection: false,
-      });
-
-      const events = await collectEvents(
-        runtime.run({ kind: "text", text: "Reply with exactly one word: hello" }),
-      );
-
-      // Both layers should allow the call through
-      const output = findDoneOutput(events);
-      expect(output?.stopReason).toBe("completed");
-
-      const text = extractText(events);
-      expect(text.length).toBeGreaterThan(0);
-
-      // GovernanceBackend was exercised — model call was evaluated
-      const s = state();
-      expect(s.evaluateCalls.length).toBeGreaterThanOrEqual(1);
-      expect(s.attestations.length).toBeGreaterThanOrEqual(1);
-
-      // GovernanceController is also present and sealed
-      const { GOVERNANCE } = await import("@koi/core");
-      const controller = runtime.agent.component(GOVERNANCE);
-      expect(controller).toBeDefined();
-      if (controller !== undefined) {
-        const snapshot = await (
-          controller as { snapshot: () => Promise<import("@koi/core").GovernanceSnapshot> }
-        ).snapshot();
-        // Sensor model tracked turns
-        expect(snapshot.readings.length).toBeGreaterThan(0);
-        expect(snapshot.healthy).toBe(true);
-      }
-
-      await runtime.dispose();
-      backend.dispose?.();
+          verdict: GOVERNANCE_ALLOW,
+          evaluatedAt: Date.now(),
+          policyFingerprint: "test",
+        }),
+      ).toThrow("called after dispose()");
     },
     TIMEOUT_MS,
   );
 
-  // -------------------------------------------------------------------------
-  // Test 10: Multiple violations in one verdict — all are surfaced
-  // -------------------------------------------------------------------------
-  test("10. multiple violations per verdict: all violations are recorded in attestation and queryable", async () => {
-    const { backend } = createInMemoryGovernanceBackend("allow");
+  test(
+    "GovernanceBackend middleware + GovernanceController coexist in same runtime",
+    async () => {
+      const { backend, state } = createInMemoryGovernanceBackend("allow");
 
-    const agentId = "agent-multi-violation" as AgentId;
-    const multiViolationVerdict: GovernanceVerdict = {
-      ok: false,
-      violations: [
-        { rule: "cost-limit", severity: "critical", message: "Cost $1.50 > limit $1.00" },
-        { rule: "token-limit", severity: "warning", message: "Tokens 90k/100k (90% utilized)" },
-        { rule: "rate-limit", severity: "info", message: "3 calls/min (approaching limit of 5)" },
-      ],
-    };
+      // let justified: captured once agent is assembled
+      let capturedAgentId: AgentId | undefined;
 
-    const result = await backend.recordAttestation({
-      agentId,
-      ruleId: "multi-rule-evaluation",
-      verdict: multiViolationVerdict,
-      evidence: { evaluatedAt: Date.now() },
-    });
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "You are a concise test assistant. Reply with one short sentence.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.id.startsWith("attest-")).toBe(true);
-      expect(result.value.verdict.ok).toBe(false);
-      if (!result.value.verdict.ok) {
-        // All 3 violations preserved in the attestation
-        expect(result.value.verdict.violations).toHaveLength(3);
-        expect(result.value.verdict.violations[0]?.rule).toBe("cost-limit");
-        expect(result.value.verdict.violations[1]?.rule).toBe("token-limit");
-        expect(result.value.verdict.violations[2]?.rule).toBe("rate-limit");
+      const agent = createKoi({
+        name: "governance-e2e-coexist",
+        adapter,
+        middleware: [createGovernanceBackendMiddleware(backend, () => capturedAgentId!)],
+        governance: {
+          maxTurns: 5,
+        },
+      });
+
+      capturedAgentId = agent.id;
+
+      const output = await drainEngine(
+        agent.stream({
+          messages: [
+            {
+              role: "user",
+              content: [{ kind: "text", text: "What is 2+2? Answer briefly." }],
+            },
+          ],
+        }),
+      );
+
+      const s = state();
+
+      // GovernanceBackend evaluator was called
+      expect(s.evaluateCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Compliance was recorded
+      expect(s.complianceRecords.length).toBeGreaterThanOrEqual(1);
+
+      // Agent produced output (both governance layers active)
+      expect(output.messages.length).toBeGreaterThanOrEqual(1);
+
+      // All evaluations were allowed (mode="allow")
+      for (const call of s.evaluateCalls) {
+        expect(call.verdict.ok).toBe(true);
       }
-    }
+    },
+    TIMEOUT_MS,
+  );
 
-    // Query by agentId — all 3 violations returned
-    const all = await backend.getViolations({ agentId });
-    expect(all.ok).toBe(true);
-    if (all.ok) {
-      expect(all.value.length).toBe(3);
-    }
+  test(
+    "multiple violations per verdict: all violations recorded and queryable",
+    async () => {
+      const { backend } = createInMemoryGovernanceBackend("allow");
+      const { agentId } = await import("@koi/core");
+      const testAgent = agentId("multi-violation-agent");
 
-    // Query only critical — 1 violation
-    const critOnly = await backend.getViolations({ agentId, severity: ["critical"] });
-    expect(critOnly.ok).toBe(true);
-    if (critOnly.ok) {
-      expect(critOnly.value.length).toBe(1);
-      expect(critOnly.value[0]?.rule).toBe("cost-limit");
-    }
+      // Record a deny verdict with multiple violations
+      const multiViolationVerdict: GovernanceVerdict = {
+        ok: false,
+        violations: [
+          { rule: "budget-exceeded", severity: "critical", message: "Budget exceeded" },
+          { rule: "rate-limit-hit", severity: "warning", message: "Rate limit hit" },
+          { rule: "deprecated-api", severity: "info", message: "Using deprecated API" },
+        ],
+      };
 
-    // Query only warning + info — 2 violations
-    const warnInfo = await backend.getViolations({ agentId, severity: ["warning", "info"] });
-    expect(warnInfo.ok).toBe(true);
-    if (warnInfo.ok) {
-      expect(warnInfo.value.length).toBe(2);
-      const rules = warnInfo.value.map((v) => v.rule);
-      expect(rules).toContain("token-limit");
-      expect(rules).toContain("rate-limit");
-    }
-  }, 10_000); // No LLM call
+      await backend.compliance?.recordCompliance({
+        requestId: "multi-viol-001",
+        request: {
+          kind: "model_call",
+          agentId: testAgent,
+          payload: {},
+          timestamp: Date.now(),
+        },
+        verdict: multiViolationVerdict,
+        evaluatedAt: Date.now(),
+        policyFingerprint: "multi-test",
+      });
+
+      // All 3 violations should be queryable
+      const allPage = await backend.violations?.getViolations({
+        agentId: testAgent,
+      });
+      expect(allPage.items.length).toBe(3);
+      expect(allPage.total).toBe(3);
+
+      // Filter to critical only
+      const criticalPage = await backend.violations?.getViolations({
+        agentId: testAgent,
+        severity: "critical",
+      });
+      expect(criticalPage.items.length).toBe(1);
+      expect(criticalPage.items[0]?.rule).toBe("budget-exceeded");
+
+      // Filter to warning and above
+      const warningPage = await backend.violations?.getViolations({
+        agentId: testAgent,
+        severity: "warning",
+      });
+      expect(warningPage.items.length).toBe(2); // critical + warning
+    },
+    TIMEOUT_MS,
+  );
 });

--- a/packages/test-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/test-utils/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/test-utils API surface . has stable type surface 1`] = `
-"import { ProcessId, AgentManifest, ProcessState, EngineEvent, Agent, EngineAdapter, EngineInput, KoiErrorCode, ForgeProvenance, AgentArtifact, ImplementationArtifact, SkillArtifact, ToolArtifact, BrickRegistryBackend, ChannelAdapter, MemoryResult, MemoryRecallOptions, MemoryStoreOptions, MemoryComponent, KoiConfig, ConfigStore, EventBackend, EventEnvelope, DeadLetterEntry, RegistryEntry, AgentId, TransitionReason, Result as Result$1, KoiError as KoiError$1, RegistryEvent, GovernanceCheck, GovernanceEvent, GovernanceSnapshot, GovernanceVariable, SensorReading, GovernanceController, HarnessId, TaskBoardSnapshot, EngineMetrics, TaskItemId, TaskResult, HarnessStatus, KoiMiddleware, ContextSummary, SessionPersistence, SkillRegistryBackend, SnapshotChainStore, ForgeStore, VersionIndexBackend } from '@koi/core';
+"import { ProcessId, AgentManifest, ProcessState, EngineEvent, Agent, EngineAdapter, EngineInput, KoiErrorCode, ForgeProvenance, AgentArtifact, ImplementationArtifact, SkillArtifact, ToolArtifact, BrickRegistryBackend, ChannelAdapter, MemoryResult, MemoryRecallOptions, MemoryStoreOptions, MemoryComponent, KoiConfig, ConfigStore, EventBackend, EventEnvelope, DeadLetterEntry, RegistryEntry, AgentId, TransitionReason, Result as Result$1, KoiError as KoiError$1, RegistryEvent, PolicyEvaluator, PolicyRequestKind, ConstraintChecker, ComplianceRecorder, ViolationStore, GovernanceCheck, GovernanceEvent, GovernanceSnapshot, GovernanceVariable, SensorReading, GovernanceBackend, GovernanceController, HarnessId, TaskBoardSnapshot, EngineMetrics, TaskItemId, TaskResult, HarnessStatus, KoiMiddleware, ContextSummary, SessionPersistence, SkillRegistryBackend, SnapshotChainStore, ForgeStore, VersionIndexBackend } from '@koi/core';
 import { Result, KoiError } from '@koi/core/errors';
 import { InboundMessage } from '@koi/core/message';
 import { SessionContext, TurnContext, ModelHandler, ModelRequest, ModelStreamHandler, ToolHandler, ToolRequest, ModelResponse, ModelChunk, ToolResponse, KoiMiddleware as KoiMiddleware$1 } from '@koi/core/middleware';
@@ -384,10 +384,11 @@ declare function runEventSourcedRegistryContractTests(createContext: () => Event
 declare function createFactory<T extends object>(defaults: T): (overrides?: Partial<T>) => T;
 
 /**
- * Mock governance controller for tests.
+ * Mock governance factories for tests.
  *
- * Provides a minimal GovernanceController that defaults to healthy/passing
- * state. Override individual methods via the overrides parameter.
+ * Provides minimal GovernanceController and GovernanceBackend implementations
+ * that default to healthy/passing state. Override individual methods via
+ * the overrides parameter.
  */
 
 interface MockGovernanceControllerOverrides {
@@ -399,6 +400,23 @@ interface MockGovernanceControllerOverrides {
     readonly reading?: (variable: string) => SensorReading | undefined;
 }
 declare function createMockGovernanceController(overrides?: MockGovernanceControllerOverrides | undefined): GovernanceController;
+interface MockGovernanceBackendOverrides {
+    readonly evaluator?: {
+        readonly evaluate?: PolicyEvaluator["evaluate"];
+        readonly scope?: readonly PolicyRequestKind[];
+    };
+    readonly constraints?: {
+        readonly checkConstraint?: ConstraintChecker["checkConstraint"];
+    };
+    readonly compliance?: {
+        readonly recordCompliance?: ComplianceRecorder["recordCompliance"];
+    };
+    readonly violations?: {
+        readonly getViolations?: ViolationStore["getViolations"];
+    };
+    readonly dispose?: () => void | Promise<void>;
+}
+declare function createMockGovernanceBackend(overrides?: MockGovernanceBackendOverrides | undefined): GovernanceBackend;
 
 /**
  * Mock and spy handler factories for middleware testing.
@@ -744,6 +762,6 @@ declare function testVersionIndexContract(options: VersionIndexContractOptions):
 /** Create an in-memory VersionIndexBackend for testing. */
 declare function createInMemoryVersionIndex(): VersionIndexBackend;
 
-export { type BrickRegistryContractOptions, type CapturedOutput, type ChannelContractOptions, DEFAULT_PROVENANCE, type EngineContractOptions, type EventSourcedRegistryForTest, type EventSourcedRegistryTestContext, type FakePermissionBackend, type FakePermissionBackendOptions, type MiddlewareContractOptions, type MockAgentOptions, type MockEngineAdapterOptions, type MockEngineData, type MockEventBackend, type MockGovernanceControllerOverrides, type MockMemoryComponentOptions, type MockStatefulEngineOptions, type MockValidationError, type MockValidationResult, type MockValidator, type RecallCall, type ResolverContractOptions, type SkillRegistryContractOptions, type SpyModelHandler, type SpyModelStreamHandler, type SpyToolHandler, type StoreCall, type TempGitRepo, type VersionIndexContractOptions, assertErr, assertKoiError, assertOk, captureOutput, createAsyncValidator, createConditionalValidator, createFactory, createFailingValidator, createFakePermissionBackend, createInMemoryBrickRegistry, createInMemorySkillRegistry, createInMemoryVersionIndex, createManifestFile, createMockAgent, createMockContextSummary, createMockEngineAdapter, createMockEventBackend, createMockGovernanceController, createMockHarness, createMockInboundMessage, createMockMemoryComponent, createMockModelHandler, createMockModelStreamHandler, createMockSessionContext, createMockStatefulEngine, createMockTaskPlan, createMockToolHandler, createMockTurnContext, createMockValidator, createSpyModelHandler, createSpyModelStreamHandler, createSpyToolHandler, createTempGitRepo, createTestAgentArtifact, createTestConfig, createTestConfigStore, createTestImplementationArtifact, createTestSkillArtifact, createTestToolArtifact, createThrowingValidator, makeTempDir, runEventBackendContractTests, runEventSourcedRegistryContractTests, runForgeStoreContractTests, runHarnessContractTests, runSessionPersistenceContractTests, runSnapshotChainStoreContractTests, testBrickRegistryContract, testChannelAdapter, testEngineAdapter, testMiddlewareContract, testResolverContract, testSkillRegistryContract, testVersionIndexContract, withTempDir };
+export { type BrickRegistryContractOptions, type CapturedOutput, type ChannelContractOptions, DEFAULT_PROVENANCE, type EngineContractOptions, type EventSourcedRegistryForTest, type EventSourcedRegistryTestContext, type FakePermissionBackend, type FakePermissionBackendOptions, type MiddlewareContractOptions, type MockAgentOptions, type MockEngineAdapterOptions, type MockEngineData, type MockEventBackend, type MockGovernanceBackendOverrides, type MockGovernanceControllerOverrides, type MockMemoryComponentOptions, type MockStatefulEngineOptions, type MockValidationError, type MockValidationResult, type MockValidator, type RecallCall, type ResolverContractOptions, type SkillRegistryContractOptions, type SpyModelHandler, type SpyModelStreamHandler, type SpyToolHandler, type StoreCall, type TempGitRepo, type VersionIndexContractOptions, assertErr, assertKoiError, assertOk, captureOutput, createAsyncValidator, createConditionalValidator, createFactory, createFailingValidator, createFakePermissionBackend, createInMemoryBrickRegistry, createInMemorySkillRegistry, createInMemoryVersionIndex, createManifestFile, createMockAgent, createMockContextSummary, createMockEngineAdapter, createMockEventBackend, createMockGovernanceBackend, createMockGovernanceController, createMockHarness, createMockInboundMessage, createMockMemoryComponent, createMockModelHandler, createMockModelStreamHandler, createMockSessionContext, createMockStatefulEngine, createMockTaskPlan, createMockToolHandler, createMockTurnContext, createMockValidator, createSpyModelHandler, createSpyModelStreamHandler, createSpyToolHandler, createTempGitRepo, createTestAgentArtifact, createTestConfig, createTestConfigStore, createTestImplementationArtifact, createTestSkillArtifact, createTestToolArtifact, createThrowingValidator, makeTempDir, runEventBackendContractTests, runEventSourcedRegistryContractTests, runForgeStoreContractTests, runHarnessContractTests, runSessionPersistenceContractTests, runSnapshotChainStoreContractTests, testBrickRegistryContract, testChannelAdapter, testEngineAdapter, testMiddlewareContract, testResolverContract, testSkillRegistryContract, testVersionIndexContract, withTempDir };
 "
 `;

--- a/packages/test-utils/src/governance-backend.test.ts
+++ b/packages/test-utils/src/governance-backend.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ComplianceRecord,
+  GovernanceVerdict,
+  PolicyRequest,
+  ViolationFilter,
+} from "@koi/core";
+import { agentId, GOVERNANCE_ALLOW } from "@koi/core";
+import { createMockGovernanceBackend } from "./governance.js";
+
+describe("createMockGovernanceBackend", () => {
+  test("default evaluator returns GOVERNANCE_ALLOW", () => {
+    const backend = createMockGovernanceBackend();
+    const request: PolicyRequest = {
+      kind: "tool_call",
+      agentId: agentId("agent-a"),
+      payload: { toolName: "read_file" },
+      timestamp: 1_000_000,
+    };
+    expect(backend.evaluator.evaluate(request)).toBe(GOVERNANCE_ALLOW);
+  });
+
+  test("default evaluator has no scope", () => {
+    const backend = createMockGovernanceBackend();
+    expect(backend.evaluator.scope).toBeUndefined();
+  });
+
+  test("default has no optional sub-interfaces or dispose", () => {
+    const backend = createMockGovernanceBackend();
+    expect(backend.constraints).toBeUndefined();
+    expect(backend.compliance).toBeUndefined();
+    expect(backend.violations).toBeUndefined();
+    expect(backend.dispose).toBeUndefined();
+  });
+
+  test("override evaluator to return deny verdict", async () => {
+    const denyVerdict: GovernanceVerdict = {
+      ok: false,
+      violations: [{ rule: "no-spawn", severity: "critical", message: "spawning denied" }],
+    };
+    const backend = createMockGovernanceBackend({
+      evaluator: { evaluate: () => denyVerdict },
+    });
+    const request: PolicyRequest = {
+      kind: "spawn",
+      agentId: agentId("agent-a"),
+      payload: {},
+      timestamp: 1_000_000,
+    };
+    const result = await backend.evaluator.evaluate(request);
+    expect(result).toBe(denyVerdict);
+    if (!result.ok) {
+      expect(result.violations).toHaveLength(1);
+    }
+  });
+
+  test("override evaluator scope", () => {
+    const backend = createMockGovernanceBackend({
+      evaluator: { scope: ["tool_call", "spawn"] },
+    });
+    expect(backend.evaluator.scope).toEqual(["tool_call", "spawn"]);
+    // evaluate still defaults to GOVERNANCE_ALLOW when not overridden
+    const request: PolicyRequest = {
+      kind: "tool_call",
+      agentId: agentId("agent-a"),
+      payload: {},
+      timestamp: 1_000_000,
+    };
+    expect(backend.evaluator.evaluate(request)).toBe(GOVERNANCE_ALLOW);
+  });
+
+  test("default constraint checker returns true", () => {
+    const backend = createMockGovernanceBackend({
+      constraints: {},
+    });
+    expect(backend.constraints).toBeDefined();
+    const result = backend.constraints?.checkConstraint({
+      kind: "spawn_depth",
+      agentId: agentId("agent-a"),
+      value: 3,
+    });
+    expect(result).toBe(true);
+  });
+
+  test("override constraint checker", () => {
+    const backend = createMockGovernanceBackend({
+      constraints: { checkConstraint: () => false },
+    });
+    const result = backend.constraints?.checkConstraint({
+      kind: "token_budget",
+      agentId: agentId("agent-a"),
+    });
+    expect(result).toBe(false);
+  });
+
+  test("default compliance recorder returns input record", () => {
+    const backend = createMockGovernanceBackend({
+      compliance: {},
+    });
+    expect(backend.compliance).toBeDefined();
+    const record: ComplianceRecord = {
+      requestId: "req-001",
+      request: {
+        kind: "tool_call",
+        agentId: agentId("agent-a"),
+        payload: {},
+        timestamp: 1_000_000,
+      },
+      verdict: GOVERNANCE_ALLOW,
+      evaluatedAt: 1_000_001,
+      policyFingerprint: "sha256:abc",
+    };
+    expect(backend.compliance?.recordCompliance(record)).toBe(record);
+  });
+
+  test("default violation store returns empty page", () => {
+    const backend = createMockGovernanceBackend({
+      violations: {},
+    });
+    expect(backend.violations).toBeDefined();
+    const filter: ViolationFilter = {};
+    const page = backend.violations?.getViolations(filter);
+    expect(page).toEqual({ items: [], total: 0 });
+  });
+
+  test("override with partial sub-interfaces — only evaluator", () => {
+    const backend = createMockGovernanceBackend({
+      evaluator: { evaluate: () => GOVERNANCE_ALLOW },
+    });
+    expect(backend.evaluator).toBeDefined();
+    expect(backend.constraints).toBeUndefined();
+    expect(backend.compliance).toBeUndefined();
+    expect(backend.violations).toBeUndefined();
+  });
+
+  test("dispose override is attached", () => {
+    // let justified: mutable counter for testing dispose calls
+    let disposed = false;
+    const backend = createMockGovernanceBackend({
+      dispose: () => {
+        disposed = true;
+      },
+    });
+    expect(backend.dispose).toBeDefined();
+    backend.dispose?.();
+    expect(disposed).toBe(true);
+  });
+
+  test("all sub-interfaces present simultaneously", () => {
+    const backend = createMockGovernanceBackend({
+      evaluator: { scope: ["tool_call"] },
+      constraints: {},
+      compliance: {},
+      violations: {},
+      dispose: () => {},
+    });
+    expect(backend.evaluator).toBeDefined();
+    expect(backend.evaluator.scope).toEqual(["tool_call"]);
+    expect(backend.constraints).toBeDefined();
+    expect(backend.compliance).toBeDefined();
+    expect(backend.violations).toBeDefined();
+    expect(backend.dispose).toBeDefined();
+  });
+});

--- a/packages/test-utils/src/governance.ts
+++ b/packages/test-utils/src/governance.ts
@@ -1,18 +1,31 @@
 /**
- * Mock governance controller for tests.
+ * Mock governance factories for tests.
  *
- * Provides a minimal GovernanceController that defaults to healthy/passing
- * state. Override individual methods via the overrides parameter.
+ * Provides minimal GovernanceController and GovernanceBackend implementations
+ * that default to healthy/passing state. Override individual methods via
+ * the overrides parameter.
  */
 
 import type {
+  ComplianceRecord,
+  ComplianceRecorder,
+  ConstraintChecker,
+  GovernanceBackend,
   GovernanceCheck,
   GovernanceController,
   GovernanceEvent,
   GovernanceSnapshot,
   GovernanceVariable,
+  GovernanceVerdict,
+  PolicyEvaluator,
+  PolicyRequest,
+  PolicyRequestKind,
   SensorReading,
+  ViolationFilter,
+  ViolationPage,
+  ViolationStore,
 } from "@koi/core";
+import { GOVERNANCE_ALLOW } from "@koi/core";
 
 export interface MockGovernanceControllerOverrides {
   readonly check?: (variable: string) => GovernanceCheck | Promise<GovernanceCheck>;
@@ -42,5 +55,72 @@ export function createMockGovernanceController(
     snapshot: overrides?.snapshot ?? ((): GovernanceSnapshot => EMPTY_SNAPSHOT),
     variables: overrides?.variables ?? ((): ReadonlyMap<string, GovernanceVariable> => new Map()),
     reading: overrides?.reading ?? ((): SensorReading | undefined => undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GovernanceBackend mock
+// ---------------------------------------------------------------------------
+
+export interface MockGovernanceBackendOverrides {
+  readonly evaluator?: {
+    readonly evaluate?: PolicyEvaluator["evaluate"];
+    readonly scope?: readonly PolicyRequestKind[];
+  };
+  readonly constraints?: {
+    readonly checkConstraint?: ConstraintChecker["checkConstraint"];
+  };
+  readonly compliance?: {
+    readonly recordCompliance?: ComplianceRecorder["recordCompliance"];
+  };
+  readonly violations?: {
+    readonly getViolations?: ViolationStore["getViolations"];
+  };
+  readonly dispose?: () => void | Promise<void>;
+}
+
+const EMPTY_VIOLATION_PAGE: ViolationPage = Object.freeze({
+  items: Object.freeze([]),
+  total: 0,
+});
+
+export function createMockGovernanceBackend(
+  overrides?: MockGovernanceBackendOverrides | undefined,
+): GovernanceBackend {
+  const evaluator: PolicyEvaluator = {
+    evaluate:
+      overrides?.evaluator?.evaluate ??
+      ((_request: PolicyRequest): GovernanceVerdict => GOVERNANCE_ALLOW),
+    ...(overrides?.evaluator?.scope !== undefined ? { scope: overrides.evaluator.scope } : {}),
+  };
+
+  return {
+    evaluator,
+    ...(overrides?.constraints !== undefined
+      ? {
+          constraints: {
+            checkConstraint: overrides.constraints.checkConstraint ?? ((): boolean => true),
+          } satisfies ConstraintChecker,
+        }
+      : {}),
+    ...(overrides?.compliance !== undefined
+      ? {
+          compliance: {
+            recordCompliance:
+              overrides.compliance.recordCompliance ??
+              ((record: ComplianceRecord): ComplianceRecord => record),
+          } satisfies ComplianceRecorder,
+        }
+      : {}),
+    ...(overrides?.violations !== undefined
+      ? {
+          violations: {
+            getViolations:
+              overrides.violations.getViolations ??
+              ((_filter: ViolationFilter): ViolationPage => EMPTY_VIOLATION_PAGE),
+          } satisfies ViolationStore,
+        }
+      : {}),
+    ...(overrides?.dispose !== undefined ? { dispose: overrides.dispose } : {}),
   };
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -51,8 +51,11 @@ export type {
 } from "./event-sourced-registry-contract.js";
 export { runEventSourcedRegistryContractTests } from "./event-sourced-registry-contract.js";
 export { createFactory } from "./factory.js";
-export type { MockGovernanceControllerOverrides } from "./governance.js";
-export { createMockGovernanceController } from "./governance.js";
+export type {
+  MockGovernanceBackendOverrides,
+  MockGovernanceControllerOverrides,
+} from "./governance.js";
+export { createMockGovernanceBackend, createMockGovernanceController } from "./governance.js";
 export type { SpyModelHandler, SpyModelStreamHandler, SpyToolHandler } from "./handlers.js";
 export {
   createMockModelHandler,

--- a/scripts/e2e-governance-backend-pi.ts
+++ b/scripts/e2e-governance-backend-pi.ts
@@ -1,0 +1,765 @@
+#!/usr/bin/env bun
+/**
+ * E2E: GovernanceBackend + Pi Adapter — validates L0 governance backend contract
+ * works through the full createKoi + createPiAdapter runtime assembly with real
+ * Anthropic API calls.
+ *
+ * Key difference from the loop-adapter variant: Pi adapter routes model calls
+ * through callHandlers.modelStream (streaming), so governance middleware must
+ * implement wrapModelStream (async generator) instead of wrapModelCall.
+ * Usage: bun scripts/e2e-governance-backend-pi.ts  (reads ANTHROPIC_API_KEY from .env)
+ */
+
+import type {
+  Agent,
+  ComplianceRecord,
+  ComponentProvider,
+  ConstraintQuery,
+  EngineEvent,
+  GovernanceBackend,
+  GovernanceVerdict,
+  KoiMiddleware,
+  ModelChunk,
+  ModelRequest,
+  ModelStreamHandler,
+  PolicyEvaluator,
+  PolicyRequest,
+  PolicyRequestKind,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+  ViolationFilter,
+} from "@koi/core";
+import {
+  agentId,
+  COMPONENT_PRIORITY,
+  GOVERNANCE,
+  GOVERNANCE_BACKEND,
+} from "../packages/core/src/ecs.js";
+import { GOVERNANCE_ALLOW } from "../packages/core/src/governance-backend.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { KoiRuntimeError } from "../packages/errors/src/runtime-error.js";
+
+// Preflight
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e-pi] ANTHROPIC_API_KEY is not set. Skipping E2E tests.");
+  process.exit(0);
+}
+
+console.log("[e2e-pi] Starting GovernanceBackend + Pi Adapter E2E tests...\n");
+
+const PI_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// Helpers
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+  if (detail && !condition) console.log(`         ${detail}`);
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  // let justified: mutable timer handle for cleanup on race resolution
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(
+  events: readonly EngineEvent[],
+): (EngineEvent & { readonly kind: "done" })["output"] | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+// In-memory GovernanceBackend factory
+
+interface TrackingState {
+  readonly evaluatorCalls: PolicyRequest[];
+  readonly constraintCalls: ConstraintQuery[];
+  readonly complianceRecords: ComplianceRecord[];
+}
+
+function createTrackingBackend(opts?: {
+  readonly denyAll?: boolean;
+  readonly scope?: readonly PolicyRequestKind[];
+}): { readonly backend: GovernanceBackend; readonly state: TrackingState } {
+  const state: TrackingState = {
+    evaluatorCalls: [],
+    constraintCalls: [],
+    complianceRecords: [],
+  };
+
+  const evaluator: PolicyEvaluator = {
+    evaluate(request: PolicyRequest): GovernanceVerdict {
+      state.evaluatorCalls.push(request);
+      if (opts?.denyAll === true) {
+        return {
+          ok: false,
+          violations: [
+            { rule: "deny-all", severity: "critical", message: "All actions denied by policy" },
+          ],
+        };
+      }
+      return GOVERNANCE_ALLOW;
+    },
+    ...(opts?.scope !== undefined ? { scope: opts.scope } : {}),
+  };
+
+  const backend: GovernanceBackend = {
+    evaluator,
+    constraints: {
+      checkConstraint(query: ConstraintQuery): boolean {
+        state.constraintCalls.push(query);
+        return true;
+      },
+    },
+    compliance: {
+      recordCompliance(record: ComplianceRecord): ComplianceRecord {
+        state.complianceRecords.push(record);
+        return record;
+      },
+    },
+    violations: {
+      getViolations(_filter: ViolationFilter) {
+        return { items: [], total: 0 };
+      },
+    },
+  };
+
+  return { backend, state };
+}
+
+// GovernanceBackend ComponentProvider factory
+
+function createBackendProvider(backend: GovernanceBackend): ComponentProvider {
+  return {
+    name: "e2e-pi:governance-backend",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    async attach(_agent: Agent): Promise<ReadonlyMap<string, unknown>> {
+      const key: string = GOVERNANCE_BACKEND;
+      return new Map([[key, backend]]);
+    },
+  };
+}
+
+// Middleware factory: captures GovernanceBackend via closure.
+// Pi adapter streams model calls → wrapModelStream for allow-path.
+// Deny uses onBeforeTurn (koi.ts catches); try/finally for compliance.
+function createGovernanceBackendMiddleware(
+  backend: GovernanceBackend,
+  backendAgentId: string,
+  opts?: {
+    readonly skipScopeFilter?: boolean;
+    readonly recordCompliance?: boolean;
+    readonly checkConstraints?: boolean;
+    readonly denyOnBeforeTurn?: boolean;
+  },
+): KoiMiddleware {
+  // let justified: mutable counter for generating unique request IDs
+  let requestCounter = 0;
+
+  return {
+    name: "e2e-pi:governance-backend-middleware",
+    priority: 100,
+
+    // Deny via onBeforeTurn — koi.ts catches and converts to done event
+    async onBeforeTurn(_ctx: TurnContext): Promise<void> {
+      if (opts?.denyOnBeforeTurn !== true) return;
+
+      const policyRequest: PolicyRequest = {
+        kind: "model_call",
+        agentId: agentId(backendAgentId),
+        payload: { model: "pre-turn-check" },
+        timestamp: Date.now(),
+      };
+
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+      if (!verdict.ok) {
+        const violationMessages = verdict.violations.map((v) => v.message).join("; ");
+        throw KoiRuntimeError.from("PERMISSION", `GovernanceBackend denied: ${violationMessages}`, {
+          context: { violations: verdict.violations.map((v) => v.rule) },
+        });
+      }
+    },
+
+    // Allow-path: evaluate, constraints, compliance. try/finally for early .return()
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      const policyRequest: PolicyRequest = {
+        kind: "model_call",
+        agentId: agentId(backendAgentId),
+        payload: { model: request.model ?? "unknown" },
+        timestamp: Date.now(),
+      };
+
+      // Scope filter: skip evaluation when request kind not in evaluator scope
+      const scope = backend.evaluator.scope;
+      if (
+        opts?.skipScopeFilter !== true &&
+        scope !== undefined &&
+        !scope.includes(policyRequest.kind)
+      ) {
+        yield* next(request);
+        return;
+      }
+
+      // Evaluate policy (allow path — deny is handled by onBeforeTurn)
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+
+      // Check constraints if enabled
+      if (opts?.checkConstraints === true && backend.constraints !== undefined) {
+        await backend.constraints.checkConstraint({
+          kind: "spawn_depth",
+          agentId: agentId(backendAgentId),
+          value: 0,
+        });
+      }
+
+      // Forward to next handler with compliance recording in finally block
+      try {
+        yield* next(request);
+      } finally {
+        // Runs even when generator is terminated early via .return()
+        if (opts?.recordCompliance === true && backend.compliance !== undefined) {
+          requestCounter += 1;
+          const record: ComplianceRecord = {
+            requestId: `e2e-pi-req-${requestCounter}`,
+            request: policyRequest,
+            verdict,
+            evaluatedAt: Date.now(),
+            policyFingerprint: "e2e-pi-policy-v1",
+          };
+          await backend.compliance.recordCompliance(record);
+        }
+      }
+    },
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: (req: ToolRequest) => Promise<ToolResponse>,
+    ): Promise<ToolResponse> {
+      const policyRequest: PolicyRequest = {
+        kind: "tool_call",
+        agentId: agentId(backendAgentId),
+        payload: { toolId: request.toolId },
+        timestamp: Date.now(),
+      };
+
+      // Scope filter
+      const scope = backend.evaluator.scope;
+      if (
+        opts?.skipScopeFilter !== true &&
+        scope !== undefined &&
+        !scope.includes(policyRequest.kind)
+      ) {
+        return next(request);
+      }
+
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+      if (!verdict.ok) {
+        const violationMessages = verdict.violations.map((v) => v.message).join("; ");
+        throw KoiRuntimeError.from("PERMISSION", `GovernanceBackend denied: ${violationMessages}`, {
+          context: { violations: verdict.violations.map((v) => v.rule) },
+        });
+      }
+
+      return next(request);
+    },
+  };
+}
+
+/** Create a Pi adapter with the shared API key. */
+function createPiEngine(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: PI_MODEL,
+    systemPrompt: "You are a concise test assistant. Reply briefly.",
+    getApiKey: async (_provider) => API_KEY,
+  });
+}
+
+// Test 1 — GovernanceBackend wired via ComponentProvider
+console.log("[test 1] GovernanceBackend wired via ComponentProvider (Pi adapter)");
+
+const { backend: backend1 } = createTrackingBackend();
+const provider1 = createBackendProvider(backend1);
+
+const adapter1 = createPiEngine();
+const runtime1 = await createKoi({
+  manifest: {
+    name: "e2e-pi-gov-backend-wiring",
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter1,
+  providers: [provider1],
+  loopDetection: false,
+});
+
+const attachedBackend = runtime1.agent.component(GOVERNANCE_BACKEND);
+assert(
+  "backend attached under GOVERNANCE_BACKEND token",
+  attachedBackend !== undefined,
+  "agent.component(GOVERNANCE_BACKEND) returned undefined",
+);
+assert(
+  "attached backend is the same instance",
+  attachedBackend === backend1,
+  "References differ — provider returned a different object",
+);
+assert(
+  "agent.has(GOVERNANCE_BACKEND) returns true",
+  runtime1.agent.has(GOVERNANCE_BACKEND),
+  "has() returned false",
+);
+
+await runtime1.dispose();
+
+// Test 2 — PolicyEvaluator called through middleware on real Pi adapter LLM call
+console.log("\n[test 2] PolicyEvaluator called through middleware on real Pi adapter LLM call");
+
+const { backend: backend2, state: state2 } = createTrackingBackend();
+const agentName2 = "e2e-pi-gov-backend-evaluator";
+
+const adapter2 = createPiEngine();
+const runtime2 = await createKoi({
+  manifest: {
+    name: agentName2,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter2,
+  providers: [createBackendProvider(backend2)],
+  middleware: [createGovernanceBackendMiddleware(backend2, agentName2, { skipScopeFilter: true })],
+  loopDetection: false,
+});
+
+const events2 = await withTimeout(
+  () => collectEvents(runtime2.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  120_000,
+  "Test 2",
+);
+
+const output2 = findDoneOutput(events2);
+assert(
+  "Pi adapter LLM call completed successfully",
+  output2 !== undefined && output2.stopReason === "completed",
+  `stopReason: ${output2?.stopReason}`,
+);
+assert(
+  "evaluator was called at least once",
+  state2.evaluatorCalls.length >= 1,
+  `Got ${state2.evaluatorCalls.length} calls`,
+);
+
+const firstCall2 = state2.evaluatorCalls[0];
+if (firstCall2 !== undefined) {
+  assert(
+    "request.kind is 'model_call'",
+    firstCall2.kind === "model_call",
+    `Got: ${firstCall2.kind}`,
+  );
+  assert(
+    "request.agentId is correct",
+    firstCall2.agentId === agentName2,
+    `Got: ${firstCall2.agentId}`,
+  );
+  assert("request.timestamp > 0", firstCall2.timestamp > 0, `Got: ${firstCall2.timestamp}`);
+  assert("verdict was GOVERNANCE_ALLOW (call succeeded)", output2?.stopReason === "completed");
+}
+
+await runtime2.dispose();
+
+// Test 3 — Deny blocks model call (onBeforeTurn for Pi adapter fail-closed)
+console.log("\n[test 3] PolicyEvaluator deny verdict blocks model call (Pi adapter)");
+
+const { backend: backend3, state: state3 } = createTrackingBackend({ denyAll: true });
+const agentName3 = "e2e-pi-gov-backend-deny";
+
+const denyAdapter = createPiAdapter({
+  model: PI_MODEL,
+  systemPrompt: "You are a concise test assistant.",
+  getApiKey: async (_provider) => API_KEY,
+});
+
+const runtime3 = await createKoi({
+  manifest: {
+    name: agentName3,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: denyAdapter,
+  providers: [createBackendProvider(backend3)],
+  middleware: [
+    createGovernanceBackendMiddleware(backend3, agentName3, {
+      skipScopeFilter: true,
+      denyOnBeforeTurn: true,
+    }),
+  ],
+  loopDetection: false,
+});
+
+// let justified: mutable flags for error tracking
+let test3ErrorCaught = false;
+let test3ErrorMessage = "";
+// let justified: mutable for done event output
+let output3: ReturnType<typeof findDoneOutput> | undefined;
+
+try {
+  const events3 = await withTimeout(
+    () => collectEvents(runtime3.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+    30_000,
+    "Test 3",
+  );
+  output3 = findDoneOutput(events3);
+} catch (e: unknown) {
+  test3ErrorCaught = true;
+  test3ErrorMessage = e instanceof Error ? e.message : String(e);
+}
+
+const denyProven = test3ErrorCaught || (output3 !== undefined && output3.stopReason === "error");
+assert(
+  "agent denied: error propagated or done event with error stopReason",
+  denyProven,
+  test3ErrorCaught ? `Caught error: ${test3ErrorMessage}` : `stopReason: ${output3?.stopReason}`,
+);
+assert(
+  "evaluator was called (deny triggered)",
+  state3.evaluatorCalls.length >= 1,
+  `Got ${state3.evaluatorCalls.length} calls`,
+);
+// Pi adapter may call getApiKey during async init (race with onBeforeTurn).
+// Verify deny via absence of text output instead.
+const hasTextOutput3 =
+  output3?.content?.some((c: { readonly kind: string }) => c.kind === "text") === true;
+assert(
+  "no text content in output (model call result never used)",
+  !hasTextOutput3 || test3ErrorCaught,
+  `hasTextOutput: ${String(hasTextOutput3)}, errorCaught: ${String(test3ErrorCaught)}`,
+);
+assert(
+  "error references governance denial",
+  test3ErrorMessage.includes("GovernanceBackend denied") || output3?.stopReason === "error",
+  `Error: ${test3ErrorMessage}`,
+);
+
+await runtime3.dispose();
+
+// Test 4 — ComplianceRecorder captures audit trail from real Pi adapter call
+console.log("\n[test 4] ComplianceRecorder captures audit trail (Pi adapter)");
+
+const { backend: backend4, state: state4 } = createTrackingBackend();
+const agentName4 = "e2e-pi-gov-backend-compliance";
+
+const adapter4 = createPiEngine();
+const runtime4 = await createKoi({
+  manifest: {
+    name: agentName4,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter4,
+  providers: [createBackendProvider(backend4)],
+  middleware: [
+    createGovernanceBackendMiddleware(backend4, agentName4, {
+      skipScopeFilter: true,
+      recordCompliance: true,
+    }),
+  ],
+  loopDetection: false,
+});
+
+const events4 = await withTimeout(
+  () => collectEvents(runtime4.run({ kind: "text", text: "Reply with exactly: compliance_ok" })),
+  120_000,
+  "Test 4",
+);
+
+const output4 = findDoneOutput(events4);
+assert(
+  "Pi adapter LLM call completed for compliance test",
+  output4 !== undefined && output4.stopReason === "completed",
+  `stopReason: ${output4?.stopReason}`,
+);
+assert(
+  "compliance records captured",
+  state4.complianceRecords.length >= 1,
+  `Got ${state4.complianceRecords.length} records`,
+);
+
+const firstRecord = state4.complianceRecords[0];
+if (firstRecord !== undefined) {
+  assert(
+    "record has requestId",
+    firstRecord.requestId.startsWith("e2e-pi-req-"),
+    `Got: ${firstRecord.requestId}`,
+  );
+  assert(
+    "record.request.kind is 'model_call'",
+    firstRecord.request.kind === "model_call",
+    `Got: ${firstRecord.request.kind}`,
+  );
+  assert(
+    "record.verdict.ok is true",
+    firstRecord.verdict.ok === true,
+    `Got: ${String(firstRecord.verdict.ok)}`,
+  );
+  assert("record.evaluatedAt > 0", firstRecord.evaluatedAt > 0, `Got: ${firstRecord.evaluatedAt}`);
+  assert(
+    "record.policyFingerprint is set",
+    firstRecord.policyFingerprint === "e2e-pi-policy-v1",
+    `Got: ${firstRecord.policyFingerprint}`,
+  );
+}
+
+await runtime4.dispose();
+
+// Test 5 — ConstraintChecker called per-request
+console.log("\n[test 5] ConstraintChecker called per-request (Pi adapter)");
+
+const { backend: backend5, state: state5 } = createTrackingBackend();
+const agentName5 = "e2e-pi-gov-backend-constraints";
+
+const adapter5 = createPiEngine();
+const runtime5 = await createKoi({
+  manifest: {
+    name: agentName5,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter5,
+  providers: [createBackendProvider(backend5)],
+  middleware: [
+    createGovernanceBackendMiddleware(backend5, agentName5, {
+      skipScopeFilter: true,
+      checkConstraints: true,
+    }),
+  ],
+  loopDetection: false,
+});
+
+const events5 = await withTimeout(
+  () => collectEvents(runtime5.run({ kind: "text", text: "Reply with exactly: constraint_ok" })),
+  120_000,
+  "Test 5",
+);
+
+const output5 = findDoneOutput(events5);
+assert(
+  "Pi adapter LLM call completed for constraint test",
+  output5 !== undefined && output5.stopReason === "completed",
+  `stopReason: ${output5?.stopReason}`,
+);
+assert(
+  "constraint checker was called at least once",
+  state5.constraintCalls.length >= 1,
+  `Got ${state5.constraintCalls.length} calls`,
+);
+
+const firstConstraint = state5.constraintCalls[0];
+if (firstConstraint !== undefined) {
+  assert(
+    "constraint query kind is 'spawn_depth'",
+    firstConstraint.kind === "spawn_depth",
+    `Got: ${firstConstraint.kind}`,
+  );
+  assert(
+    "constraint query agentId matches",
+    firstConstraint.agentId === agentName5,
+    `Got: ${firstConstraint.agentId}`,
+  );
+  assert("constraint checker returned true (allowed)", output5?.stopReason === "completed");
+}
+
+await runtime5.dispose();
+
+// Test 6 — GovernanceBackend + GovernanceController coexist as parallel peers
+console.log("\n[test 6] GovernanceBackend + GovernanceController coexist (Pi adapter)");
+
+const { backend: backend6, state: state6 } = createTrackingBackend();
+const agentName6 = "e2e-pi-gov-backend-coexist";
+
+const adapter6 = createPiEngine();
+const runtime6 = await createKoi({
+  manifest: {
+    name: agentName6,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter6,
+  providers: [createBackendProvider(backend6)],
+  middleware: [createGovernanceBackendMiddleware(backend6, agentName6, { skipScopeFilter: true })],
+  governance: {
+    iteration: { maxTurns: 10, maxTokens: 500_000, maxDurationMs: 120_000 },
+  },
+  loopDetection: false,
+});
+
+// Both components should be present before run
+const hasGovernance = runtime6.agent.has(GOVERNANCE);
+const hasBackend = runtime6.agent.has(GOVERNANCE_BACKEND);
+assert("agent has GOVERNANCE component", hasGovernance, "GOVERNANCE not attached");
+assert("agent has GOVERNANCE_BACKEND component", hasBackend, "GOVERNANCE_BACKEND not attached");
+
+const governanceController = runtime6.agent.component(GOVERNANCE);
+const governanceBackend = runtime6.agent.component(GOVERNANCE_BACKEND);
+assert(
+  "GOVERNANCE component is defined",
+  governanceController !== undefined,
+  "component(GOVERNANCE) returned undefined",
+);
+assert(
+  "GOVERNANCE_BACKEND component is defined",
+  governanceBackend !== undefined,
+  "component(GOVERNANCE_BACKEND) returned undefined",
+);
+assert(
+  "GOVERNANCE and GOVERNANCE_BACKEND are different instances",
+  governanceController !== governanceBackend,
+  "Both tokens returned the same object",
+);
+
+// Run a real LLM call to exercise both
+const events6 = await withTimeout(
+  () => collectEvents(runtime6.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  120_000,
+  "Test 6",
+);
+
+const output6 = findDoneOutput(events6);
+assert(
+  "Pi adapter LLM call completed with both governance peers active",
+  output6 !== undefined && output6.stopReason === "completed",
+  `stopReason: ${output6?.stopReason}`,
+);
+
+// Verify GovernanceController tracked turns/tokens via snapshot
+const ctrl = governanceController as {
+  readonly snapshot?: () => Promise<{
+    readonly healthy: boolean;
+    readonly readings: readonly { readonly name: string; readonly current: number }[];
+  }>;
+};
+if (ctrl?.snapshot !== undefined) {
+  const snapshot = await ctrl.snapshot();
+  assert(
+    "GovernanceController snapshot shows healthy",
+    snapshot.healthy === true,
+    `healthy: ${String(snapshot.healthy)}`,
+  );
+  const turnReading = snapshot.readings.find((r) => r.name === "turn_count");
+  assert(
+    "GovernanceController recorded turn counts",
+    turnReading !== undefined && turnReading.current >= 1,
+    `turn_count: ${turnReading?.current}`,
+  );
+}
+
+// Verify GovernanceBackend evaluator was called
+assert(
+  "GovernanceBackend evaluator was called during run",
+  state6.evaluatorCalls.length >= 1,
+  `Got ${state6.evaluatorCalls.length} evaluator calls`,
+);
+
+await runtime6.dispose();
+
+// Test 7 — Scope-filtered evaluator skips non-matching kinds (hot-path)
+console.log("\n[test 7] Scope-filtered evaluator skips non-matching kinds (Pi adapter)");
+
+const { backend: backend7, state: state7 } = createTrackingBackend({
+  scope: ["tool_call"],
+});
+const agentName7 = "e2e-pi-gov-backend-scope";
+
+const adapter7 = createPiEngine();
+const runtime7 = await createKoi({
+  manifest: {
+    name: agentName7,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter7,
+  providers: [createBackendProvider(backend7)],
+  // Do NOT pass skipScopeFilter — let the middleware respect the scope
+  middleware: [createGovernanceBackendMiddleware(backend7, agentName7)],
+  loopDetection: false,
+});
+
+// Run a text-only prompt (no tool calls) — evaluator should NOT be called
+// because scope is ["tool_call"] and we only make model_call requests
+const events7 = await withTimeout(
+  () => collectEvents(runtime7.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  120_000,
+  "Test 7",
+);
+
+const output7 = findDoneOutput(events7);
+assert(
+  "Pi adapter LLM call completed for scope test",
+  output7 !== undefined && output7.stopReason === "completed",
+  `stopReason: ${output7?.stopReason}`,
+);
+assert(
+  "evaluator was NOT called (scope is ['tool_call'], only model_call was made)",
+  state7.evaluatorCalls.length === 0,
+  `Got ${state7.evaluatorCalls.length} evaluator calls — expected 0`,
+);
+
+await runtime7.dispose();
+
+// Summary
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n${"─".repeat(60)}`);
+console.log(`[e2e-pi] Results: ${passed}/${total} passed`);
+console.log("─".repeat(60));
+
+if (!allPassed) {
+  console.error("\n[e2e-pi] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}`);
+      if (r.detail) console.error(`        ${r.detail}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e-pi] ALL GOVERNANCE BACKEND + PI ADAPTER E2E TESTS PASSED!");

--- a/scripts/e2e-governance-backend.ts
+++ b/scripts/e2e-governance-backend.ts
@@ -1,0 +1,752 @@
+#!/usr/bin/env bun
+/**
+ * E2E: GovernanceBackend — validates L0 governance backend contract works
+ * through full createKoi + createLoopAdapter assembly with real Anthropic API.
+ *
+ * Usage: bun scripts/e2e-governance-backend.ts  (reads ANTHROPIC_API_KEY from .env)
+ */
+
+import type {
+  Agent,
+  ComplianceRecord,
+  ComponentProvider,
+  ConstraintQuery,
+  EngineEvent,
+  GovernanceBackend,
+  GovernanceVerdict,
+  KoiMiddleware,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  PolicyEvaluator,
+  PolicyRequest,
+  PolicyRequestKind,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core";
+import {
+  agentId,
+  COMPONENT_PRIORITY,
+  GOVERNANCE,
+  GOVERNANCE_BACKEND,
+} from "../packages/core/src/ecs.js";
+import { GOVERNANCE_ALLOW } from "../packages/core/src/governance-backend.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createLoopAdapter } from "../packages/engine-loop/src/loop-adapter.js";
+import { KoiRuntimeError } from "../packages/errors/src/runtime-error.js";
+import { createAnthropicAdapter } from "../packages/model-router/src/adapters/anthropic.js";
+
+// Preflight
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping E2E tests.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting GovernanceBackend E2E tests...\n");
+
+// Helpers
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = [];
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+  if (detail && !condition) console.log(`         ${detail}`);
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(
+  events: readonly EngineEvent[],
+): (EngineEvent & { readonly kind: "done" })["output"] | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+/** Create the Anthropic model handler wired to a cheap model. */
+function createModelCall(): (request: ModelRequest) => Promise<ModelResponse> {
+  const anthropic = createAnthropicAdapter({ apiKey: API_KEY });
+  return (request: ModelRequest) =>
+    anthropic.complete({ ...request, model: "claude-haiku-4-5-20251001" });
+}
+
+const modelCall = createModelCall();
+
+// In-memory GovernanceBackend factory
+
+interface TrackingState {
+  readonly evaluatorCalls: PolicyRequest[];
+  readonly constraintCalls: ConstraintQuery[];
+  readonly complianceRecords: ComplianceRecord[];
+}
+
+function createTrackingBackend(opts?: {
+  readonly denyAll?: boolean;
+  readonly scope?: readonly PolicyRequestKind[];
+}): { readonly backend: GovernanceBackend; readonly state: TrackingState } {
+  const state: TrackingState = {
+    evaluatorCalls: [],
+    constraintCalls: [],
+    complianceRecords: [],
+  };
+
+  const evaluator: PolicyEvaluator = {
+    evaluate(request: PolicyRequest): GovernanceVerdict {
+      state.evaluatorCalls.push(request);
+      if (opts?.denyAll === true) {
+        return {
+          ok: false,
+          violations: [
+            { rule: "deny-all", severity: "critical", message: "All actions denied by policy" },
+          ],
+        };
+      }
+      return GOVERNANCE_ALLOW;
+    },
+    ...(opts?.scope !== undefined ? { scope: opts.scope } : {}),
+  };
+
+  const backend: GovernanceBackend = {
+    evaluator,
+    constraints: {
+      checkConstraint(query: ConstraintQuery): boolean {
+        state.constraintCalls.push(query);
+        return true;
+      },
+    },
+    compliance: {
+      recordCompliance(record: ComplianceRecord): ComplianceRecord {
+        state.complianceRecords.push(record);
+        return record;
+      },
+    },
+    violations: {
+      getViolations(_filter: import("@koi/core").ViolationFilter) {
+        return { items: [], total: 0 };
+      },
+    },
+  };
+
+  return { backend, state };
+}
+
+// GovernanceBackend ComponentProvider factory
+
+function createBackendProvider(backend: GovernanceBackend): ComponentProvider {
+  return {
+    name: "e2e:governance-backend",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    async attach(_agent: Agent): Promise<ReadonlyMap<string, unknown>> {
+      return new Map([[GOVERNANCE_BACKEND as string, backend]]);
+    },
+  };
+}
+
+// Custom middleware factory — captures GovernanceBackend via closure
+
+function createGovernanceBackendMiddleware(
+  backend: GovernanceBackend,
+  backendAgentId: string,
+  opts?: {
+    readonly skipScopeFilter?: boolean;
+    readonly recordCompliance?: boolean;
+    readonly checkConstraints?: boolean;
+  },
+): KoiMiddleware {
+  // let justified: mutable counter for generating unique request IDs
+  let requestCounter = 0;
+
+  return {
+    name: "e2e:governance-backend-middleware",
+    priority: 100,
+
+    async wrapModelCall(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      const policyRequest: PolicyRequest = {
+        kind: "model_call",
+        agentId: agentId(backendAgentId),
+        payload: { model: request.model ?? "unknown" },
+        timestamp: Date.now(),
+      };
+
+      // Scope filter: skip evaluation when request kind not in evaluator scope
+      const scope = backend.evaluator.scope;
+      if (
+        opts?.skipScopeFilter !== true &&
+        scope !== undefined &&
+        !scope.includes(policyRequest.kind)
+      ) {
+        return next(request);
+      }
+
+      // Evaluate policy
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+
+      // Fail-closed: deny on non-ok verdict
+      if (!verdict.ok) {
+        const violationMessages = verdict.violations.map((v) => v.message).join("; ");
+        throw KoiRuntimeError.from("PERMISSION", `GovernanceBackend denied: ${violationMessages}`, {
+          context: { violations: verdict.violations.map((v) => v.rule) },
+        });
+      }
+
+      // Check constraints if enabled
+      if (opts?.checkConstraints === true && backend.constraints !== undefined) {
+        await backend.constraints.checkConstraint({
+          kind: "spawn_depth",
+          agentId: agentId(backendAgentId),
+          value: 0,
+        });
+      }
+
+      // Forward to next handler
+      const response = await next(request);
+
+      // Record compliance if enabled
+      if (opts?.recordCompliance === true && backend.compliance !== undefined) {
+        requestCounter += 1;
+        const record: ComplianceRecord = {
+          requestId: `e2e-req-${requestCounter}`,
+          request: policyRequest,
+          verdict,
+          evaluatedAt: Date.now(),
+          policyFingerprint: "e2e-policy-v1",
+        };
+        await backend.compliance.recordCompliance(record);
+      }
+
+      return response;
+    },
+
+    async wrapToolCall(
+      _ctx: TurnContext,
+      request: ToolRequest,
+      next: (req: ToolRequest) => Promise<ToolResponse>,
+    ): Promise<ToolResponse> {
+      const policyRequest: PolicyRequest = {
+        kind: "tool_call",
+        agentId: agentId(backendAgentId),
+        payload: { toolId: request.toolId },
+        timestamp: Date.now(),
+      };
+
+      // Scope filter
+      const scope = backend.evaluator.scope;
+      if (
+        opts?.skipScopeFilter !== true &&
+        scope !== undefined &&
+        !scope.includes(policyRequest.kind)
+      ) {
+        return next(request);
+      }
+
+      const verdict = await backend.evaluator.evaluate(policyRequest);
+      if (!verdict.ok) {
+        const violationMessages = verdict.violations.map((v) => v.message).join("; ");
+        throw KoiRuntimeError.from("PERMISSION", `GovernanceBackend denied: ${violationMessages}`, {
+          context: { violations: verdict.violations.map((v) => v.rule) },
+        });
+      }
+
+      return next(request);
+    },
+  };
+}
+
+// Test 1 — GovernanceBackend wired via ComponentProvider
+// ---------------------------------------------------------------------------
+
+console.log("[test 1] GovernanceBackend wired via ComponentProvider");
+
+const { backend: backend1 } = createTrackingBackend();
+const provider1 = createBackendProvider(backend1);
+
+const adapter1 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime1 = await createKoi({
+  manifest: {
+    name: "e2e-gov-backend-wiring",
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter1,
+  providers: [provider1],
+  loopDetection: false,
+});
+
+const attachedBackend = runtime1.agent.component(GOVERNANCE_BACKEND);
+assert(
+  "backend attached under GOVERNANCE_BACKEND token",
+  attachedBackend !== undefined,
+  "agent.component(GOVERNANCE_BACKEND) returned undefined",
+);
+assert(
+  "attached backend is the same instance",
+  attachedBackend === backend1,
+  "References differ — provider returned a different object",
+);
+assert(
+  "agent.has(GOVERNANCE_BACKEND) returns true",
+  runtime1.agent.has(GOVERNANCE_BACKEND),
+  "has() returned false",
+);
+
+await runtime1.dispose();
+
+// Test 2 — PolicyEvaluator called through custom middleware on real LLM call
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 2] PolicyEvaluator called through custom middleware on real LLM call");
+
+const { backend: backend2, state: state2 } = createTrackingBackend();
+const agentName2 = "e2e-gov-backend-evaluator";
+
+const adapter2 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime2 = await createKoi({
+  manifest: {
+    name: agentName2,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter2,
+  providers: [createBackendProvider(backend2)],
+  middleware: [createGovernanceBackendMiddleware(backend2, agentName2, { skipScopeFilter: true })],
+  loopDetection: false,
+});
+
+const events2 = await withTimeout(
+  () => collectEvents(runtime2.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  60_000,
+  "Test 2",
+);
+
+const output2 = findDoneOutput(events2);
+assert(
+  "LLM call completed successfully",
+  output2 !== undefined && output2.stopReason === "completed",
+  `stopReason: ${output2?.stopReason}`,
+);
+assert(
+  "evaluator was called at least once",
+  state2.evaluatorCalls.length >= 1,
+  `Got ${state2.evaluatorCalls.length} calls`,
+);
+
+const firstCall2 = state2.evaluatorCalls[0];
+if (firstCall2 !== undefined) {
+  assert(
+    "request.kind is 'model_call'",
+    firstCall2.kind === "model_call",
+    `Got: ${firstCall2.kind}`,
+  );
+  assert(
+    "request.agentId is correct",
+    firstCall2.agentId === agentName2,
+    `Got: ${firstCall2.agentId}`,
+  );
+  assert("request.timestamp > 0", firstCall2.timestamp > 0, `Got: ${firstCall2.timestamp}`);
+  assert("verdict was GOVERNANCE_ALLOW (call succeeded)", output2?.stopReason === "completed");
+}
+
+await runtime2.dispose();
+
+// Test 3 — PolicyEvaluator deny verdict blocks model call (fail-closed)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 3] PolicyEvaluator deny verdict blocks model call");
+
+const { backend: backend3, state: state3 } = createTrackingBackend({ denyAll: true });
+const agentName3 = "e2e-gov-backend-deny";
+
+// Track if next() was ever called (it shouldn't be for deny)
+// let justified: mutable flag for tracking model call invocation
+let modelCallReached = false;
+const trackingModelCall: (request: ModelRequest) => Promise<ModelResponse> = async (
+  request: ModelRequest,
+) => {
+  modelCallReached = true;
+  return modelCall(request);
+};
+
+const adapter3 = createLoopAdapter({ modelCall: trackingModelCall, maxTurns: 3 });
+const runtime3 = await createKoi({
+  manifest: {
+    name: agentName3,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter3,
+  providers: [createBackendProvider(backend3)],
+  middleware: [createGovernanceBackendMiddleware(backend3, agentName3, { skipScopeFilter: true })],
+  loopDetection: false,
+});
+
+// Note: KoiRuntimeError thrown by middleware may not match instanceof in koi.ts
+// due to module identity divergence (script's relative import vs engine's @koi/errors
+// symlink). Either way, the error should propagate — either as a done event with
+// stopReason "error" (if instanceof matches) or as a thrown error (if not).
+// Both prove the deny verdict blocked the model call.
+// let justified: mutable flag for error tracking
+let test3ErrorCaught = false;
+let test3ErrorMessage = "";
+// let justified: mutable for done event output
+let output3: ReturnType<typeof findDoneOutput> | undefined;
+
+try {
+  const events3 = await withTimeout(
+    () => collectEvents(runtime3.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+    30_000,
+    "Test 3",
+  );
+  output3 = findDoneOutput(events3);
+} catch (e: unknown) {
+  test3ErrorCaught = true;
+  test3ErrorMessage = e instanceof Error ? e.message : String(e);
+}
+
+// Either a done event with error or a caught error — both prove deny worked
+const denyProven = test3ErrorCaught || (output3 !== undefined && output3.stopReason === "error");
+assert(
+  "agent denied: error propagated or done event with error stopReason",
+  denyProven,
+  test3ErrorCaught ? `Caught error: ${test3ErrorMessage}` : `stopReason: ${output3?.stopReason}`,
+);
+assert(
+  "evaluator was called (deny triggered)",
+  state3.evaluatorCalls.length >= 1,
+  `Got ${state3.evaluatorCalls.length} calls`,
+);
+assert(
+  "no real LLM call was made (blocked before reaching model)",
+  !modelCallReached,
+  "modelCall was invoked despite deny verdict",
+);
+assert(
+  "error message references governance denial",
+  test3ErrorMessage.includes("GovernanceBackend denied") || output3?.stopReason === "error",
+  `Error: ${test3ErrorMessage}`,
+);
+
+await runtime3.dispose();
+
+// Test 4 — ComplianceRecorder captures audit trail from real call
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 4] ComplianceRecorder captures audit trail from real call");
+
+const { backend: backend4, state: state4 } = createTrackingBackend();
+const agentName4 = "e2e-gov-backend-compliance";
+
+const adapter4 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime4 = await createKoi({
+  manifest: {
+    name: agentName4,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter4,
+  providers: [createBackendProvider(backend4)],
+  middleware: [
+    createGovernanceBackendMiddleware(backend4, agentName4, {
+      skipScopeFilter: true,
+      recordCompliance: true,
+    }),
+  ],
+  loopDetection: false,
+});
+
+const events4 = await withTimeout(
+  () => collectEvents(runtime4.run({ kind: "text", text: "Reply with exactly: compliance_ok" })),
+  60_000,
+  "Test 4",
+);
+
+const output4 = findDoneOutput(events4);
+assert(
+  "LLM call completed for compliance test",
+  output4 !== undefined && output4.stopReason === "completed",
+  `stopReason: ${output4?.stopReason}`,
+);
+assert(
+  "compliance records captured",
+  state4.complianceRecords.length >= 1,
+  `Got ${state4.complianceRecords.length} records`,
+);
+
+const firstRecord = state4.complianceRecords[0];
+if (firstRecord !== undefined) {
+  assert(
+    "record has requestId",
+    firstRecord.requestId.startsWith("e2e-req-"),
+    `Got: ${firstRecord.requestId}`,
+  );
+  assert(
+    "record.request.kind is 'model_call'",
+    firstRecord.request.kind === "model_call",
+    `Got: ${firstRecord.request.kind}`,
+  );
+  assert(
+    "record.verdict.ok is true",
+    firstRecord.verdict.ok === true,
+    `Got: ${String(firstRecord.verdict.ok)}`,
+  );
+  assert("record.evaluatedAt > 0", firstRecord.evaluatedAt > 0, `Got: ${firstRecord.evaluatedAt}`);
+  assert(
+    "record.policyFingerprint is set",
+    firstRecord.policyFingerprint === "e2e-policy-v1",
+    `Got: ${firstRecord.policyFingerprint}`,
+  );
+}
+
+await runtime4.dispose();
+
+// Test 5 — ConstraintChecker called per-request
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 5] ConstraintChecker called per-request");
+
+const { backend: backend5, state: state5 } = createTrackingBackend();
+const agentName5 = "e2e-gov-backend-constraints";
+
+const adapter5 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime5 = await createKoi({
+  manifest: {
+    name: agentName5,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter5,
+  providers: [createBackendProvider(backend5)],
+  middleware: [
+    createGovernanceBackendMiddleware(backend5, agentName5, {
+      skipScopeFilter: true,
+      checkConstraints: true,
+    }),
+  ],
+  loopDetection: false,
+});
+
+const events5 = await withTimeout(
+  () => collectEvents(runtime5.run({ kind: "text", text: "Reply with exactly: constraint_ok" })),
+  60_000,
+  "Test 5",
+);
+
+const output5 = findDoneOutput(events5);
+assert(
+  "LLM call completed for constraint test",
+  output5 !== undefined && output5.stopReason === "completed",
+  `stopReason: ${output5?.stopReason}`,
+);
+assert(
+  "constraint checker was called at least once",
+  state5.constraintCalls.length >= 1,
+  `Got ${state5.constraintCalls.length} calls`,
+);
+
+const firstConstraint = state5.constraintCalls[0];
+if (firstConstraint !== undefined) {
+  assert(
+    "constraint query kind is 'spawn_depth'",
+    firstConstraint.kind === "spawn_depth",
+    `Got: ${firstConstraint.kind}`,
+  );
+  assert(
+    "constraint query agentId matches",
+    firstConstraint.agentId === agentName5,
+    `Got: ${firstConstraint.agentId}`,
+  );
+  assert("constraint checker returned true (allowed)", output5?.stopReason === "completed");
+}
+
+await runtime5.dispose();
+
+// Test 6 — GovernanceBackend + GovernanceController coexist as parallel peers
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 6] GovernanceBackend + GovernanceController coexist as parallel peers");
+
+const { backend: backend6, state: state6 } = createTrackingBackend();
+const agentName6 = "e2e-gov-backend-coexist";
+
+const adapter6 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime6 = await createKoi({
+  manifest: {
+    name: agentName6,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter6,
+  providers: [createBackendProvider(backend6)],
+  middleware: [createGovernanceBackendMiddleware(backend6, agentName6, { skipScopeFilter: true })],
+  governance: {
+    iteration: { maxTurns: 10, maxTokens: 500_000, maxDurationMs: 120_000 },
+  },
+  loopDetection: false,
+});
+
+// Both components should be present before run
+const hasGovernance = runtime6.agent.has(GOVERNANCE);
+const hasBackend = runtime6.agent.has(GOVERNANCE_BACKEND);
+assert("agent has GOVERNANCE component", hasGovernance, "GOVERNANCE not attached");
+assert("agent has GOVERNANCE_BACKEND component", hasBackend, "GOVERNANCE_BACKEND not attached");
+
+const governanceController = runtime6.agent.component(GOVERNANCE);
+const governanceBackend = runtime6.agent.component(GOVERNANCE_BACKEND);
+assert(
+  "GOVERNANCE component is defined",
+  governanceController !== undefined,
+  "component(GOVERNANCE) returned undefined",
+);
+assert(
+  "GOVERNANCE_BACKEND component is defined",
+  governanceBackend !== undefined,
+  "component(GOVERNANCE_BACKEND) returned undefined",
+);
+assert(
+  "GOVERNANCE and GOVERNANCE_BACKEND are different instances",
+  governanceController !== governanceBackend,
+  "Both tokens returned the same object",
+);
+
+// Run a real LLM call to exercise both
+const events6 = await withTimeout(
+  () => collectEvents(runtime6.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  60_000,
+  "Test 6",
+);
+
+const output6 = findDoneOutput(events6);
+assert(
+  "LLM call completed with both governance peers active",
+  output6 !== undefined && output6.stopReason === "completed",
+  `stopReason: ${output6?.stopReason}`,
+);
+
+// Verify GovernanceController tracked turns/tokens via snapshot
+const ctrl = governanceController as {
+  readonly snapshot?: () => Promise<{
+    readonly healthy: boolean;
+    readonly readings: readonly { readonly name: string; readonly current: number }[];
+  }>;
+};
+if (ctrl?.snapshot !== undefined) {
+  const snapshot = await ctrl.snapshot();
+  assert(
+    "GovernanceController snapshot shows healthy",
+    snapshot.healthy === true,
+    `healthy: ${String(snapshot.healthy)}`,
+  );
+  const turnReading = snapshot.readings.find((r) => r.name === "turn_count");
+  assert(
+    "GovernanceController recorded turn counts",
+    turnReading !== undefined && turnReading.current >= 1,
+    `turn_count: ${turnReading?.current}`,
+  );
+}
+
+// Verify GovernanceBackend evaluator was called
+assert(
+  "GovernanceBackend evaluator was called during run",
+  state6.evaluatorCalls.length >= 1,
+  `Got ${state6.evaluatorCalls.length} evaluator calls`,
+);
+
+await runtime6.dispose();
+
+// Test 7 — Scope-filtered evaluator skips non-matching kinds (hot-path)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 7] Scope-filtered evaluator skips non-matching kinds");
+
+const { backend: backend7, state: state7 } = createTrackingBackend({
+  scope: ["tool_call"],
+});
+const agentName7 = "e2e-gov-backend-scope";
+
+const adapter7 = createLoopAdapter({ modelCall, maxTurns: 3 });
+const runtime7 = await createKoi({
+  manifest: {
+    name: agentName7,
+    version: "0.0.1",
+    model: { name: "claude-haiku-4-5-20251001" },
+  },
+  adapter: adapter7,
+  providers: [createBackendProvider(backend7)],
+  // Do NOT pass skipScopeFilter — let the middleware respect the scope
+  middleware: [createGovernanceBackendMiddleware(backend7, agentName7)],
+  loopDetection: false,
+});
+
+// Run a text-only prompt (no tool calls) — evaluator should NOT be called
+// because scope is ["tool_call"] and we only make model_call requests
+const events7 = await withTimeout(
+  () => collectEvents(runtime7.run({ kind: "text", text: "Reply with exactly one word: hello" })),
+  60_000,
+  "Test 7",
+);
+
+const output7 = findDoneOutput(events7);
+assert(
+  "LLM call completed for scope test",
+  output7 !== undefined && output7.stopReason === "completed",
+  `stopReason: ${output7?.stopReason}`,
+);
+assert(
+  "evaluator was NOT called (scope is ['tool_call'], only model_call was made)",
+  state7.evaluatorCalls.length === 0,
+  `Got ${state7.evaluatorCalls.length} evaluator calls — expected 0`,
+);
+
+await runtime7.dispose();
+
+// Summary
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n${"─".repeat(60)}`);
+console.log(`[e2e] Results: ${passed}/${total} passed`);
+console.log("─".repeat(60));
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}`);
+      if (r.detail) console.error(`        ${r.detail}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e] ALL GOVERNANCE BACKEND E2E TESTS PASSED!");


### PR DESCRIPTION
## Summary

Redesigns the GovernanceBackend L0 contract from a monolithic interface into ISP-split sub-interfaces for rule-based policy evaluation. Parallel peer to GovernanceController — handles policy decisions while Controller handles numeric guardrails.

- **PolicyEvaluator** (required) — evaluate `PolicyRequest` → `GovernanceVerdict` (allow/deny with violations)
- **ConstraintChecker** (optional) — individual constraint checks (spawn depth, budgets)
- **ComplianceRecorder** (optional) — audit trail with policy fingerprint
- **ViolationStore** (optional) — paginated violation history queries
- **Scope filter** — hot-path optimization to skip irrelevant request kinds
- **GOVERNANCE_BACKEND** ECS token — parallel peer to `GOVERNANCE` (GovernanceController)
- **GOVERNANCE_ALLOW** singleton — avoids allocation per allow decision
- Mock factory in `@koi/test-utils` with configurable overrides
- Architecture documentation in `docs/architecture/governance-backend.md`
- E2E tests for both Loop adapter (36 assertions) and Pi adapter (36 assertions) with real Anthropic API calls

## Key design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| ISP split | 4 sub-interfaces | Backends implement only what they need |
| Fail-closed | Callers must deny on error | Security-first |
| Scope filter | Optional `PolicyRequestKind[]` | Skip eval for irrelevant kinds on hot path |
| Parallel to Controller | Separate ECS token | Each handles a different governance dimension |

## Test plan

- [x] 48 unit tests pass (governance-backend + test-utils mock)
- [x] E2E: Loop adapter — 7 scenarios, 36 assertions with real Anthropic API
- [x] E2E: Pi adapter — 7 scenarios, 36 assertions with real Anthropic API
- [x] Build passes (`@koi/core` + `@koi/test-utils`)
- [x] Typecheck passes
- [x] Biome lint/format clean

Closes #265