### PR TITLE
feat: soul self-modification awareness (#362)

### DIFF
--- a/docs/L2/soul.md
+++ b/docs/L2/soul.md
@@ -82,6 +82,7 @@ index.ts                 ← public re-exports
 │                           createPersonaMap(), createPersonaWatchedPaths()
 ├── state.ts             ← SoulState (atomic closure state)
 │                           createAllWatchedPaths(), createSoulMessage()
+│                           MetaInstructionSources, generateMetaInstructionText()
 ├── soul.ts              ← createSoulMiddleware() factory
 │                           SoulMiddleware (extends KoiMiddleware with reload())
 │                           enrichRequest() pure function
@@ -95,7 +96,7 @@ index.ts                 ← public re-exports
 | `wrapModelCall` | Resolve soul message (with optional user refresh); prepend to request |
 | `wrapModelStream` | Same as `wrapModelCall` but for streaming responses |
 | `wrapToolCall` | After `next()`, check if `fs_write` targeted a tracked file → auto-reload |
-| `describeCapabilities` | Returns `{ label: "soul", description: "Persona active" }` |
+| `describeCapabilities` | Returns `{ label: "soul", description: "Persona active — self-modification enabled" }` when `selfModify` is true and file sources exist; otherwise `"Persona active"` |
 
 ### Data flow (model call)
 
@@ -106,9 +107,10 @@ wrapModelCall(ctx, request, next)  /  wrapModelStream(ctx, request, next)
        ├─ lookup state.personaMap.get(channelId) → identityText | undefined
        ├─ if refreshUser: re-resolve user content from disk
        │
-       ├─ createSoulMessage(soulText, identityText, userText)
+       ├─ createSoulMessage(soulText, identityText, userText, metaInstructionText)
        │     │
        │     ├─ filter out empty layers
+       │     ├─ append meta-instruction (if non-empty)
        │     ├─ join with "\n\n"
        │     ├─ truncate to DEFAULT_TOTAL_MAX_TOKENS (8000 tokens)
        │     └─ return InboundMessage { senderId: "system:soul" }
@@ -196,6 +198,9 @@ The final system message is built by concatenating non-empty layers in order:
 │  2. Identity (per-channel persona)       │  ← "You are {name}.\n\n{instructions}"
 │                                          │     Only if channelId matches a persona
 │  3. User (per-user context)              │  ← USER.md / inline
+│                                          │
+│  4. Meta-instruction (self-modification) │  ← [Soul System] block
+│                                          │     Only if selfModify: true + file sources exist
 └──────────────────────────────────────────┘
          joined with "\n\n"
          capped at 8000 tokens (32,000 chars)
@@ -203,6 +208,8 @@ The final system message is built by concatenating non-empty layers in order:
 ```
 
 Empty layers are skipped — no extra `\n\n` separators appear when a layer is absent.
+The meta-instruction layer is pre-computed at factory time and included in the atomic
+`SoulState` — no per-call computation.
 
 ### Soul layer (global)
 
@@ -275,6 +282,120 @@ await soul.reload(); // Force re-resolve all layers
 
 ---
 
+## Self-modification awareness
+
+When `selfModify` is `true` (the default) and at least one layer has a file source (not
+inline), the middleware appends a `[Soul System]` meta-instruction to the system message.
+This teaches the agent that it can propose changes to its own personality files, subject
+to human approval.
+
+### What the agent sees
+
+**Single-file mode** (one soul file, no identity/user files):
+
+```
+[Soul System]
+Your personality is defined in /app/SOUL.md.
+You may propose changes by writing to these files.
+Changes require human approval and take effect on your next response.
+
+When to update:
+- When the user gives persistent feedback about your behavior
+- When you learn a pattern that should be permanent
+- When the user explicitly asks you to remember something about yourself
+
+Do NOT update for:
+- One-time task preferences
+- Transient conversation context
+- Information that belongs in memory, not personality
+```
+
+**Multi-file mode** (soul + identity + user, with file routing hints):
+
+```
+[Soul System]
+Your personality is defined in these files:
+- /app/SOUL.md (global personality) — core behavior, tone, values
+- /app/telegram.md (channel persona) — channel-specific style and rules
+- /app/USER.md (user context) — user preferences and context
+You may propose changes by writing to these files.
+Changes require human approval and take effect on your next response.
+...
+```
+
+### How it works
+
+```
+createState(options)
+       │
+       ├─ resolve all three layers in parallel
+       ├─ collect file paths from each layer (filter out "inline")
+       │
+       ├─ generateMetaInstructionText(sources, selfModify)
+       │     │
+       │     ├─ selfModify === false?  → return ""
+       │     ├─ no file paths at all?  → return ""
+       │     ├─ single soul file?      → compact format
+       │     └─ multiple files?        → grouped listing with routing hints
+       │
+       └─ state.metaInstructionText = result  (pre-computed, not per-call)
+```
+
+### HITL integration
+
+The self-modification flow integrates with the middleware chain:
+
+```
+Agent decides to update SOUL.md
+       │
+       ▼
+Agent calls fs_write("SOUL.md", "new content")
+       │
+       ▼
+┌─ Middleware chain (onion) ──────────────────┐
+│  Permissions MW → HITL approval gate        │
+│       │ (approved)                          │
+│       ▼                                     │
+│  Soul MW (wrapToolCall)                     │
+│       ├─ next(request)  ← write executes    │
+│       ├─ detect tracked path                │
+│       └─ reload()       ← atomic state swap │
+└─────────────────────────────────────────────┘
+       │
+       ▼
+Next model call uses updated personality
+```
+
+The write must pass the entire middleware chain — including any permissions or HITL
+middleware — before it reaches the soul middleware's `wrapToolCall`. This is **structural
+pre-approval**, not just a soft instruction to the LLM.
+
+### Kill switch
+
+Set `selfModify: false` to completely disable self-modification awareness:
+
+```typescript
+const mw = await createSoulMiddleware({
+  soul: "SOUL.md",
+  basePath: import.meta.dir,
+  selfModify: false,  // no [Soul System] block, agent has no idea it can self-modify
+});
+```
+
+When disabled:
+- No `[Soul System]` meta-instruction is injected
+- `describeCapabilities` returns `"Persona active"` (no mention of self-modification)
+- Auto-reload on `fs_write` still works (the agent can still write files; it just
+  doesn't know it has personality files to target)
+
+### Inline content
+
+When all layers use inline content (no files on disk), self-modification awareness is
+automatically suppressed regardless of `selfModify` — there's no file path to tell the
+agent about.
+
+---
+
 ## API
 
 ### `createSoulMiddleware(options)`
@@ -316,6 +437,8 @@ interface CreateSoulOptions {
   readonly basePath: string;
   /** When true, user content is re-resolved on each model call. */
   readonly refreshUser?: boolean | undefined;
+  /** Enable self-modification awareness meta-instruction. Default: true. */
+  readonly selfModify?: boolean | undefined;
 }
 ```
 
@@ -365,8 +488,41 @@ interface SoulState {
   readonly userText: string;
   readonly userSources: readonly string[];
   readonly watchedPaths: ReadonlySet<string>;
+  /** Pre-computed meta-instruction text for self-modification awareness. Empty when disabled. */
+  readonly metaInstructionText: string;
 }
 ```
+
+### `MetaInstructionSources`
+
+```typescript
+interface MetaInstructionSources {
+  /** Resolved soul file paths (global personality). */
+  readonly soul: readonly string[];
+  /** Resolved identity file paths (per-channel persona). */
+  readonly identity: readonly string[];
+  /** Resolved user file paths (user context). */
+  readonly user: readonly string[];
+}
+```
+
+### `generateMetaInstructionText(sources, selfModify)`
+
+Pure function that produces the `[Soul System]` meta-instruction text. Returns empty
+string when `selfModify` is false or no file sources exist.
+
+```typescript
+import { generateMetaInstructionText } from "@koi/soul";
+
+const text = generateMetaInstructionText(
+  { soul: ["/app/SOUL.md"], identity: ["/app/persona.md"], user: ["/app/USER.md"] },
+  true,
+);
+// → "[Soul System]\nYour personality is defined in these files:\n- /app/SOUL.md ..."
+```
+
+Pre-computed at factory time and stored in `SoulState.metaInstructionText`. Not called
+per model request.
 
 ### Token budget defaults
 
@@ -545,6 +701,28 @@ const koi = createKoi({
 });
 ```
 
+### 7. Self-modification enabled (default)
+
+```typescript
+// selfModify defaults to true — the agent learns about its personality files
+const mw = await createSoulMiddleware({
+  soul: "SOUL.md",
+  user: "USER.md",
+  basePath: import.meta.dir,
+});
+// Agent sees: "[Soul System] Your personality is defined in these files: ..."
+```
+
+### 8. Self-modification disabled
+
+```typescript
+const mw = await createSoulMiddleware({
+  soul: "SOUL.md",
+  basePath: import.meta.dir,
+  selfModify: false,  // agent has no idea it has a personality file
+});
+```
+
 ---
 
 ## Performance properties
@@ -554,7 +732,8 @@ const koi = createKoi({
 | Soul resolution | Resolved once at factory time, cached in closure | O(file size) |
 | Persona map | `Map<channelId, CachedPersona>` — O(1) lookup | O(personas) |
 | Identity routing | Single `Map.get(channelId)` per model call | O(1) |
-| Message assembly | Filter + join of 3 strings | O(total text) |
+| Meta-instruction | Pre-computed once at factory time / reload | O(file paths) |
+| Message assembly | Filter + join of 4 strings (soul + identity + user + meta) | O(total text) |
 | Reload | Full parallel re-resolve, atomic state swap | O(file size) |
 | Watched paths | `Set<string>` — O(1) membership check per `fs_write` | O(tracked files) |
 | User refresh | Re-reads one file per model call (when `refreshUser: true`) | O(file size) |
@@ -575,6 +754,9 @@ createSoulMiddleware(options)
        │    resolveUserLayer(),         ← file/inline → text
        │  ])
        │
+       ├─ generateMetaInstructionText(sources, selfModify)
+       │     └─ pre-computed → state.metaInstructionText
+       │
        └─ return SoulMiddleware {
             name: "soul",
             priority: 500,
@@ -589,7 +771,7 @@ createSoulMiddleware(options)
     │  wrapModelCall / wrapModelStream                     │
     │    ├─ look up identity for ctx.session.channelId     │
     │    ├─ (optional) re-resolve user content              │
-    │    ├─ createSoulMessage(soul, identity?, user)        │
+    │    ├─ createSoulMessage(soul, identity?, user, meta)  │
     │    ├─ enrichRequest(request, message)                 │
     │    └─ next(enrichedRequest)                           │
     │                                                      │

--- a/packages/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -52,6 +52,12 @@ interface CreateSoulOptions {
     readonly basePath: string;
     /** When true, user content is re-resolved on each model call. */
     readonly refreshUser?: boolean | undefined;
+    /**
+     * When true (default), injects meta-instructions telling the agent it can
+     * modify its own personality via \`fs_write\` to the soul file.
+     * Skipped automatically when soul content is inline (no file to modify).
+     */
+    readonly selfModify?: boolean | undefined;
 }
 /** Default token budgets. */
 declare const DEFAULT_SOUL_MAX_TOKENS = 4000;
@@ -188,20 +194,39 @@ interface SoulState {
     readonly userText: string;
     readonly userSources: readonly string[];
     readonly watchedPaths: ReadonlySet<string>;
+    /** Pre-computed meta-instruction text for self-modification awareness. Empty when disabled. */
+    readonly metaInstructionText: string;
 }
 /**
  * Creates the set of all file paths watched for auto-reload.
  * Excludes "inline" sources (no file to watch).
  */
 declare function createAllWatchedPaths(soulSources: readonly string[], personaMap: ReadonlyMap<string, CachedPersona>, userSources: readonly string[]): Set<string>;
+/** Sources grouped by layer for meta-instruction generation. */
+interface MetaInstructionSources {
+    /** Resolved soul file paths (global personality). */
+    readonly soul: readonly string[];
+    /** Resolved identity file paths (per-channel persona). */
+    readonly identity: readonly string[];
+    /** Resolved user file paths (user context). */
+    readonly user: readonly string[];
+}
 /**
- * Concatenates non-empty soul, identity, and user layers into a single
- * InboundMessage for system prompt injection.
+ * Generates the meta-instruction text that teaches the agent about self-modification.
+ *
+ * Returns empty string when:
+ * - \`selfModify\` is false
+ * - No resolvable file sources exist (all inline or empty)
+ */
+declare function generateMetaInstructionText(sources: MetaInstructionSources, selfModify: boolean): string;
+/**
+ * Concatenates non-empty soul, identity, user, and meta-instruction layers
+ * into a single InboundMessage for system prompt injection.
  *
  * Returns undefined when all layers are empty.
  */
-declare function createSoulMessage(soulText: string, identityText: string | undefined, userText: string): InboundMessage | undefined;
+declare function createSoulMessage(soulText: string, identityText: string | undefined, userText: string, metaInstructionText?: string): InboundMessage | undefined;
 
-export { type CachedPersona, type ChannelPersonaConfig, type ContentInput, type CreateSoulOptions, DEFAULT_IDENTITY_MAX_TOKENS, DEFAULT_SOUL_MAX_TOKENS, DEFAULT_TOTAL_MAX_TOKENS, DEFAULT_USER_MAX_TOKENS, type ResolvedPersona, type SoulMiddleware, type SoulState, createAllWatchedPaths, createPersonaMap, createPersonaWatchedPaths, createSoulMessage, createSoulMiddleware, enrichRequest, extractInput, extractMaxTokens, generatePersonaText, personasFromManifest, resolvePersonaContent, validateSoulConfig };
+export { type CachedPersona, type ChannelPersonaConfig, type ContentInput, type CreateSoulOptions, DEFAULT_IDENTITY_MAX_TOKENS, DEFAULT_SOUL_MAX_TOKENS, DEFAULT_TOTAL_MAX_TOKENS, DEFAULT_USER_MAX_TOKENS, type MetaInstructionSources, type ResolvedPersona, type SoulMiddleware, type SoulState, createAllWatchedPaths, createPersonaMap, createPersonaWatchedPaths, createSoulMessage, createSoulMiddleware, enrichRequest, extractInput, extractMaxTokens, generateMetaInstructionText, generatePersonaText, personasFromManifest, resolvePersonaContent, validateSoulConfig };
 "
 `;

--- a/packages/soul/src/__tests__/e2e-self-modify.test.ts
+++ b/packages/soul/src/__tests__/e2e-self-modify.test.ts
@@ -1,0 +1,577 @@
+/**
+ * E2E: Soul self-modification awareness through the full L1 runtime.
+ *
+ * Validates that the agent actually receives and understands the [Soul System]
+ * meta-instruction — that it knows where its personality is defined, that it
+ * can propose changes, and that changes require human approval.
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test packages/soul/src/__tests__/e2e-self-modify.test.ts
+ *
+ * Requires ANTHROPIC_API_KEY in .env (auto-loaded by Bun).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { AgentManifest, EngineEvent, EngineOutput, KoiMiddleware } from "@koi/core";
+import type { CapabilityFragment } from "@koi/core/middleware";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import type { CreateSoulOptions } from "../config.js";
+import { createSoulMiddleware } from "../soul.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from e2e-soul-middleware.test.ts)
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function testManifest(): AgentManifest {
+  return {
+    name: "E2E Self-Modify Test Agent",
+    version: "0.1.0",
+    model: { name: "claude-haiku-4-5" },
+  };
+}
+
+function createAdapter(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: E2E_MODEL,
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+}
+
+async function runAgent(options: {
+  readonly soulOptions: CreateSoulOptions;
+  readonly prompt: string;
+  readonly channelId?: string;
+  readonly middleware?: readonly KoiMiddleware[];
+}): Promise<{
+  readonly events: readonly EngineEvent[];
+  readonly text: string;
+  readonly output: EngineOutput | undefined;
+}> {
+  const soulMw = await createSoulMiddleware(options.soulOptions);
+  const adapter = createAdapter();
+
+  const runtime = await createKoi({
+    manifest: testManifest(),
+    adapter,
+    middleware: [soulMw, ...(options.middleware ?? [])],
+    loopDetection: false,
+    ...(options.channelId !== undefined ? { channelId: options.channelId } : {}),
+  });
+
+  const events = await collectEvents(runtime.run({ kind: "text", text: options.prompt }));
+  await runtime.dispose();
+
+  return {
+    events,
+    text: extractText(events),
+    output: findDoneOutput(events),
+  };
+}
+
+// Temporary directory for file-based tests
+let tmpDir: string;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: soul self-modification awareness through createKoi + createPiAdapter", () => {
+  const setupTmpDir = async (): Promise<void> => {
+    tmpDir = join(import.meta.dir, "__e2e_tmp__", crypto.randomUUID());
+    await mkdir(tmpDir, { recursive: true });
+  };
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  // ── Test 1: Agent knows about its personality file ────────────────────
+
+  test(
+    "agent knows where its personality is defined (file path awareness)",
+    async () => {
+      await setupTmpDir();
+      await writeFile(
+        join(tmpDir, "SOUL.md"),
+        "You are a cheerful assistant named Sunny. Always be positive.",
+      );
+
+      const result = await runAgent({
+        soulOptions: { soul: "SOUL.md", basePath: tmpDir },
+        prompt: "Where is your personality defined? Reply with just the file path, nothing else.",
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output?.stopReason).toBe("completed");
+
+      // The LLM should reference SOUL.md — either the full path or the filename
+      const text = result.text;
+      const knowsFile =
+        text.includes("SOUL.md") || text.includes("soul.md") || text.includes("SOUL");
+      expect(knowsFile).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Agent knows it can propose changes ─────────────────────────
+
+  test(
+    "agent knows it can propose personality changes via file write",
+    async () => {
+      await setupTmpDir();
+      await writeFile(
+        join(tmpDir, "SOUL.md"),
+        "You are a concise assistant. Never use more than two sentences.",
+      );
+
+      const result = await runAgent({
+        soulOptions: { soul: "SOUL.md", basePath: tmpDir },
+        prompt: "Can you change your own personality? If so, how? Reply in one sentence.",
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output?.stopReason).toBe("completed");
+
+      const lower = result.text.toLowerCase();
+      // The agent should mention writing/modifying the file or proposing changes
+      const knowsHowToChange =
+        lower.includes("write") ||
+        lower.includes("modify") ||
+        lower.includes("update") ||
+        lower.includes("change") ||
+        lower.includes("edit") ||
+        lower.includes("propose");
+      expect(knowsHowToChange).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Agent knows changes require human approval ─────────────────
+
+  test(
+    "agent knows personality changes require human approval (HITL awareness)",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are helpful and direct.");
+
+      const result = await runAgent({
+        soulOptions: { soul: "SOUL.md", basePath: tmpDir },
+        prompt:
+          "If you were to change your personality file, would it happen automatically or does something need to happen first? Reply in one sentence.",
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output?.stopReason).toBe("completed");
+
+      const lower = result.text.toLowerCase();
+      // The agent should mention approval, human, or permission
+      const knowsHitl =
+        lower.includes("approval") ||
+        lower.includes("human") ||
+        lower.includes("permission") ||
+        lower.includes("approv") ||
+        lower.includes("review") ||
+        lower.includes("confirm");
+      expect(knowsHitl).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: selfModify=false hides self-modification awareness ─────────
+
+  test(
+    "agent does NOT know about self-modification when selfModify is false",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are a helpful assistant.");
+
+      const result = await runAgent({
+        soulOptions: { soul: "SOUL.md", basePath: tmpDir, selfModify: false },
+        prompt: "Do you have a personality file that you can modify? Answer only 'yes' or 'no'.",
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output?.stopReason).toBe("completed");
+
+      const lower = result.text.toLowerCase().trim();
+      // Without meta-instruction, the agent shouldn't confidently claim it can
+      // modify a personality file. It should say "no" or express uncertainty.
+      const assertsYes = lower === "yes" || lower === "yes.";
+      expect(assertsYes).toBe(false);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Structural verification — [Soul System] in model request ───
+
+  test(
+    "observer middleware confirms [Soul System] meta-instruction in model request",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are brief and helpful.");
+
+      // let: accumulator for middleware observation
+      let soulSystemDetected = false;
+      let metaInstructionText = "";
+
+      const observerMw: KoiMiddleware = {
+        name: "e2e-meta-observer",
+        priority: 501, // Run after soul middleware (500)
+        async *wrapModelStream(_ctx, request, next) {
+          const firstMsg = request.messages[0];
+          if (firstMsg?.senderId === "system:soul" && firstMsg.content[0]?.kind === "text") {
+            const text = firstMsg.content[0].text;
+            if (text.includes("[Soul System]")) {
+              soulSystemDetected = true;
+              metaInstructionText = text;
+            }
+          }
+          yield* next(request);
+        },
+      };
+
+      const soulMw = await createSoulMiddleware({
+        soul: "SOUL.md",
+        basePath: tmpDir,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [soulMw, observerMw],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Hello." }));
+      await runtime.dispose();
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Structural assertion: [Soul System] block was in the model request
+      expect(soulSystemDetected).toBe(true);
+
+      // Verify content of meta-instruction
+      expect(metaInstructionText).toContain("[Soul System]");
+      expect(metaInstructionText).toContain("SOUL.md");
+      expect(metaInstructionText).toContain("human approval");
+      expect(metaInstructionText).toContain("Do NOT update for:");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Observer confirms NO meta-instruction when selfModify=false ─
+
+  test(
+    "observer confirms [Soul System] block is absent when selfModify is false",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are brief.");
+
+      // let: accumulator for middleware observation
+      let soulSystemDetected = false;
+
+      const observerMw: KoiMiddleware = {
+        name: "e2e-meta-observer",
+        priority: 501,
+        async *wrapModelStream(_ctx, request, next) {
+          const firstMsg = request.messages[0];
+          if (firstMsg?.senderId === "system:soul" && firstMsg.content[0]?.kind === "text") {
+            if (firstMsg.content[0].text.includes("[Soul System]")) {
+              soulSystemDetected = true;
+            }
+          }
+          yield* next(request);
+        },
+      };
+
+      const soulMw = await createSoulMiddleware({
+        soul: "SOUL.md",
+        basePath: tmpDir,
+        selfModify: false,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [soulMw, observerMw],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Hello." }));
+      await runtime.dispose();
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(soulSystemDetected).toBe(false);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Multi-file awareness with soul + identity + user ───────────
+
+  test(
+    "agent is aware of multiple personality files when all layers have file sources",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are a knowledgeable assistant.");
+      await writeFile(join(tmpDir, "USER.md"), "The user is named Bob.");
+      await writeFile(join(tmpDir, "persona.md"), "Be friendly on Telegram.");
+
+      // let: accumulator for multi-file observation
+      let hasGroupedListing = false;
+
+      const observerMw: KoiMiddleware = {
+        name: "e2e-multifile-observer",
+        priority: 501,
+        async *wrapModelStream(_ctx, request, next) {
+          const firstMsg = request.messages[0];
+          if (firstMsg?.senderId === "system:soul" && firstMsg.content[0]?.kind === "text") {
+            const text = firstMsg.content[0].text;
+            // Multi-file mode uses "defined in these files:" with grouped labels
+            if (
+              text.includes("(global personality)") &&
+              text.includes("(channel persona)") &&
+              text.includes("(user context)")
+            ) {
+              hasGroupedListing = true;
+            }
+          }
+          yield* next(request);
+        },
+      };
+
+      const soulMw = await createSoulMiddleware({
+        soul: "SOUL.md",
+        identity: {
+          personas: [
+            {
+              channelId: "@koi/channel-telegram",
+              name: "TeleBot",
+              instructions: { path: "persona.md" },
+            },
+          ],
+        },
+        user: "USER.md",
+        basePath: tmpDir,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [soulMw, observerMw],
+        loopDetection: false,
+        channelId: "@koi/channel-telegram",
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Hello Bob." }));
+      await runtime.dispose();
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      // Structural: observer saw multi-file grouped listing
+      expect(hasGroupedListing).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 8: File routing — observer verifies routing hints in meta-instruction
+
+  test(
+    "observer confirms file routing hints in multi-file meta-instruction",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are knowledgeable.");
+      await writeFile(join(tmpDir, "USER.md"), "The user is named Alice.");
+      await writeFile(join(tmpDir, "persona.md"), "Be concise on Slack.");
+
+      // let: accumulator for routing hint observation
+      let hasRoutingHints = false;
+
+      const observerMw: KoiMiddleware = {
+        name: "e2e-routing-observer",
+        priority: 501,
+        async *wrapModelStream(_ctx, request, next) {
+          const firstMsg = request.messages[0];
+          if (firstMsg?.senderId === "system:soul" && firstMsg.content[0]?.kind === "text") {
+            const text = firstMsg.content[0].text;
+            if (
+              text.includes("core behavior, tone, values") &&
+              text.includes("channel-specific style and rules") &&
+              text.includes("user preferences and context")
+            ) {
+              hasRoutingHints = true;
+            }
+          }
+          yield* next(request);
+        },
+      };
+
+      const soulMw = await createSoulMiddleware({
+        soul: "SOUL.md",
+        identity: {
+          personas: [
+            {
+              channelId: "@koi/channel-slack",
+              name: "SlackBot",
+              instructions: { path: "persona.md" },
+            },
+          ],
+        },
+        user: "USER.md",
+        basePath: tmpDir,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [soulMw, observerMw],
+        loopDetection: false,
+        channelId: "@koi/channel-slack",
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Hello." }));
+      await runtime.dispose();
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(hasRoutingHints).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 9: Agent distinguishes what to self-modify and what not to ───
+
+  test(
+    "agent correctly identifies when NOT to self-modify (transient context)",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are a thoughtful assistant.");
+
+      const result = await runAgent({
+        soulOptions: { soul: "SOUL.md", basePath: tmpDir },
+        prompt:
+          "I want you to use dark mode for this conversation only. Should you update your personality file for this? Answer only 'yes' or 'no' and explain in one sentence.",
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output?.stopReason).toBe("completed");
+
+      const lower = result.text.toLowerCase();
+      // The meta-instruction says "Do NOT update for: One-time task preferences"
+      // The LLM should say "no" since dark mode for one conversation is transient
+      const saysNo =
+        lower.includes("no") ||
+        lower.includes("should not") ||
+        lower.includes("shouldn't") ||
+        lower.includes("not update") ||
+        lower.includes("temporary") ||
+        lower.includes("transient") ||
+        lower.includes("one-time");
+      expect(saysNo).toBe(true);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 10: describeCapabilities reflects selfModify state ────────────
+
+  test(
+    "describeCapabilities returns self-modification enabled for file-based soul",
+    async () => {
+      await setupTmpDir();
+      await writeFile(join(tmpDir, "SOUL.md"), "You are helpful.");
+
+      const soulMw = await createSoulMiddleware({
+        soul: "SOUL.md",
+        basePath: tmpDir,
+      });
+
+      const ctx = {
+        session: {
+          agentId: "test",
+          sessionId: "session:agent:test:abc" as import("@koi/core/ecs").SessionId,
+          runId: "run-uuid" as import("@koi/core/ecs").RunId,
+          metadata: {},
+        },
+        turnIndex: 0,
+        turnId: "turn-uuid" as import("@koi/core/ecs").TurnId,
+        messages: [],
+        metadata: {},
+      };
+
+      const fragment = soulMw.describeCapabilities?.(ctx) as CapabilityFragment;
+      expect(fragment.label).toBe("soul");
+      expect(fragment.description).toContain("self-modification enabled");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 11: Inline soul — no self-modification in describeCapabilities ─
+
+  test(
+    "describeCapabilities returns plain 'Persona active' for inline soul content",
+    async () => {
+      const soulMw = await createSoulMiddleware({
+        soul: "Inline personality.\nBe helpful.",
+        basePath: "/tmp",
+        selfModify: true,
+      });
+
+      const ctx = {
+        session: {
+          agentId: "test",
+          sessionId: "session:agent:test:abc" as import("@koi/core/ecs").SessionId,
+          runId: "run-uuid" as import("@koi/core/ecs").RunId,
+          metadata: {},
+        },
+        turnIndex: 0,
+        turnId: "turn-uuid" as import("@koi/core/ecs").TurnId,
+        messages: [],
+        metadata: {},
+      };
+
+      const fragment = soulMw.describeCapabilities?.(ctx) as CapabilityFragment;
+      expect(fragment.label).toBe("soul");
+      expect(fragment.description).toBe("Persona active");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/soul/src/config.ts
+++ b/packages/soul/src/config.ts
@@ -42,6 +42,12 @@ export interface CreateSoulOptions {
   readonly basePath: string;
   /** When true, user content is re-resolved on each model call. */
   readonly refreshUser?: boolean | undefined;
+  /**
+   * When true (default), injects meta-instructions telling the agent it can
+   * modify its own personality via `fs_write` to the soul file.
+   * Skipped automatically when soul content is inline (no file to modify).
+   */
+  readonly selfModify?: boolean | undefined;
 }
 
 /** Default token budgets. */
@@ -221,6 +227,12 @@ export function validateSoulConfig(config: unknown): Result<CreateSoulOptions, K
     return validationError("refreshUser must be a boolean");
   }
 
+  // Validate selfModify
+  const { selfModify } = config;
+  if (selfModify !== undefined && typeof selfModify !== "boolean") {
+    return validationError("selfModify must be a boolean");
+  }
+
   // Construct validated options — type guards re-narrow fields that were
   // validated above by validateContentInput/validatePersonaEntry.
   return {
@@ -231,6 +243,7 @@ export function validateSoulConfig(config: unknown): Result<CreateSoulOptions, K
       ...(user !== undefined && isContentInput(user) ? { user } : {}),
       ...(identity !== undefined && isIdentityConfig(identity) ? { identity } : {}),
       ...(typeof refreshUser === "boolean" ? { refreshUser } : {}),
+      ...(typeof selfModify === "boolean" ? { selfModify } : {}),
     },
   };
 }

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -33,5 +33,5 @@ export {
 } from "./persona-map.js";
 export type { SoulMiddleware } from "./soul.js";
 export { createSoulMiddleware, enrichRequest } from "./soul.js";
-export type { SoulState } from "./state.js";
-export { createAllWatchedPaths, createSoulMessage } from "./state.js";
+export type { MetaInstructionSources, SoulState } from "./state.js";
+export { createAllWatchedPaths, createSoulMessage, generateMetaInstructionText } from "./state.js";

--- a/packages/soul/src/self-modify.test.ts
+++ b/packages/soul/src/self-modify.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for soul self-modification awareness (issue #362).
+ *
+ * Validates that the soul middleware injects meta-instructions teaching the
+ * agent about its ability to modify SOUL.md, configurable via `selfModify`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ModelRequest } from "@koi/core";
+import type { CapabilityFragment } from "@koi/core/middleware";
+import { createMockTurnContext, createSpyModelHandler } from "@koi/test-utils";
+import { validateSoulConfig } from "./config.js";
+import { createSoulMiddleware } from "./soul.js";
+import { generateMetaInstructionText } from "./state.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = join(import.meta.dir, "__test_tmp__", crypto.randomUUID());
+  await mkdir(tmpDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Helper: create MetaInstructionSources with defaults. */
+function sources(
+  soul: readonly string[] = [],
+  identity: readonly string[] = [],
+  user: readonly string[] = [],
+): {
+  readonly soul: readonly string[];
+  readonly identity: readonly string[];
+  readonly user: readonly string[];
+} {
+  return { soul, identity, user };
+}
+
+// ---------------------------------------------------------------------------
+// generateMetaInstructionText — pure function
+// ---------------------------------------------------------------------------
+
+describe("generateMetaInstructionText", () => {
+  test("returns empty string when selfModify is false", () => {
+    const result = generateMetaInstructionText(sources(["/path/SOUL.md"]), false);
+    expect(result).toBe("");
+  });
+
+  test("returns empty string when all sources are inline", () => {
+    const result = generateMetaInstructionText(sources(["inline"]), true);
+    expect(result).toBe("");
+  });
+
+  test("returns empty string when sources are empty", () => {
+    const result = generateMetaInstructionText(sources(), true);
+    expect(result).toBe("");
+  });
+
+  test("returns compact format for single soul file", () => {
+    const filePath = "/abs/path/SOUL.md";
+    const result = generateMetaInstructionText(sources([filePath]), true);
+
+    expect(result).toContain("[Soul System]");
+    expect(result).toContain(`defined in ${filePath}.`);
+    expect(result).toContain("propose changes");
+    expect(result).toContain("human approval");
+    expect(result).toContain("Do NOT update for:");
+    // Single file — should NOT use grouped listing
+    expect(result).not.toContain("(global personality)");
+  });
+
+  test("uses grouped listing for multiple files", () => {
+    const result = generateMetaInstructionText(
+      sources(["/abs/SOUL.md"], ["/abs/persona.md"], ["/abs/USER.md"]),
+      true,
+    );
+
+    expect(result).toContain("[Soul System]");
+    expect(result).toContain("defined in these files:");
+    expect(result).toContain("/abs/SOUL.md (global personality)");
+    expect(result).toContain("/abs/persona.md (channel persona)");
+    expect(result).toContain("/abs/USER.md (user context)");
+  });
+
+  test("uses grouped listing for soul directory with multiple files", () => {
+    const result = generateMetaInstructionText(sources(["/abs/SOUL.md", "/abs/STYLE.md"]), true);
+
+    expect(result).toContain("defined in these files:");
+    expect(result).toContain("/abs/SOUL.md (global personality)");
+    expect(result).toContain("/abs/STYLE.md (global personality)");
+  });
+
+  test("filters out inline entries from all layers", () => {
+    const result = generateMetaInstructionText(
+      sources(["inline", "/abs/SOUL.md"], ["inline"], ["inline"]),
+      true,
+    );
+
+    // Only one real file — compact format
+    expect(result).toContain(`defined in /abs/SOUL.md.`);
+    expect(result).not.toContain("inline");
+  });
+
+  test("identity-only files produce meta-instruction", () => {
+    const result = generateMetaInstructionText(sources(["inline"], ["/abs/persona.md"]), true);
+
+    expect(result).toContain("[Soul System]");
+    expect(result).toContain("/abs/persona.md (channel persona)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSoulMiddleware — selfModify integration
+// ---------------------------------------------------------------------------
+
+describe("createSoulMiddleware — selfModify default (true)", () => {
+  test("meta-instruction appears in soul message by default", async () => {
+    const soulFile = join(tmpDir, "SOUL.md");
+    await writeFile(soulFile, "I am a helpful assistant.");
+
+    const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain("[Soul System]");
+      expect(msg.content[0].text).toContain("I am a helpful assistant.");
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+
+  test("meta-instruction contains correct absolute file path", async () => {
+    const soulFile = join(tmpDir, "SOUL.md");
+    await writeFile(soulFile, "Soul content.");
+
+    const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain(`defined in ${soulFile}`);
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+});
+
+describe("createSoulMiddleware — selfModify disabled", () => {
+  test("meta-instruction absent when selfModify is false", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "I am helpful.");
+
+    const mw = await createSoulMiddleware({
+      soul: "SOUL.md",
+      basePath: tmpDir,
+      selfModify: false,
+    });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain("I am helpful.");
+      expect(msg.content[0].text).not.toContain("[Soul System]");
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+});
+
+describe("createSoulMiddleware — selfModify with inline content", () => {
+  test("meta-instruction absent for inline soul content even with selfModify true", async () => {
+    const mw = await createSoulMiddleware({
+      soul: "Inline soul\nWith multiple lines",
+      basePath: tmpDir,
+      selfModify: true,
+    });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain("Inline soul");
+      expect(msg.content[0].text).not.toContain("[Soul System]");
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+});
+
+describe("createSoulMiddleware — selfModify with directory content", () => {
+  test("meta-instruction present for directory soul, uses primary file path", async () => {
+    const soulDir = join(tmpDir, "soul");
+    await mkdir(soulDir, { recursive: true });
+    await writeFile(join(soulDir, "SOUL.md"), "Directory soul personality.");
+
+    const mw = await createSoulMiddleware({ soul: "soul", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain("Directory soul personality.");
+      expect(msg.content[0].text).toContain("[Soul System]");
+      // Should reference the actual SOUL.md file, not the directory
+      expect(msg.content[0].text).toContain("SOUL.md");
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concatenation order — meta-instruction comes last
+// ---------------------------------------------------------------------------
+
+describe("createSoulMiddleware — selfModify concatenation order", () => {
+  test("meta-instruction appears after soul + user layers", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "Soul text.");
+    await writeFile(join(tmpDir, "USER.md"), "User text.");
+
+    const mw = await createSoulMiddleware({
+      soul: "SOUL.md",
+      user: "USER.md",
+      basePath: tmpDir,
+    });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+
+    const msg = spy.calls[0]?.messages[0];
+    if (msg?.content[0]?.kind === "text") {
+      const text = msg.content[0].text;
+      const soulIdx = text.indexOf("Soul text.");
+      const userIdx = text.indexOf("User text.");
+      const metaIdx = text.indexOf("[Soul System]");
+      expect(soulIdx).toBeGreaterThanOrEqual(0);
+      expect(userIdx).toBeGreaterThan(soulIdx);
+      expect(metaIdx).toBeGreaterThan(userIdx);
+    } else {
+      throw new Error("Expected text content");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reload — meta-instruction updates
+// ---------------------------------------------------------------------------
+
+describe("createSoulMiddleware — selfModify + reload", () => {
+  test("meta-instruction text updates after reload", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "Version A");
+
+    const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    // Before reload — Version A + meta-instruction
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+    const msg1 = spy.calls[0]?.messages[0];
+    if (msg1?.content[0]?.kind === "text") {
+      expect(msg1.content[0].text).toContain("Version A");
+      expect(msg1.content[0].text).toContain("[Soul System]");
+    }
+
+    // Update file and reload
+    await writeFile(join(tmpDir, "SOUL.md"), "Version B");
+    await mw.reload();
+
+    // After reload — Version B + meta-instruction still present
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+    const msg2 = spy.calls[1]?.messages[0];
+    if (msg2?.content[0]?.kind === "text") {
+      expect(msg2.content[0].text).toContain("Version B");
+      expect(msg2.content[0].text).toContain("[Soul System]");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSoulConfig — selfModify field
+// ---------------------------------------------------------------------------
+
+describe("validateSoulConfig — selfModify", () => {
+  test("accepts selfModify: true", () => {
+    const result = validateSoulConfig({ basePath: "/tmp", selfModify: true });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.selfModify).toBe(true);
+    }
+  });
+
+  test("accepts selfModify: false", () => {
+    const result = validateSoulConfig({ basePath: "/tmp", selfModify: false });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.selfModify).toBe(false);
+    }
+  });
+
+  test("accepts selfModify: undefined (omitted)", () => {
+    const result = validateSoulConfig({ basePath: "/tmp" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.selfModify).toBeUndefined();
+    }
+  });
+
+  test("rejects selfModify: string", () => {
+    const result = validateSoulConfig({ basePath: "/tmp", selfModify: "yes" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("selfModify must be a boolean");
+    }
+  });
+
+  test("rejects selfModify: number", () => {
+    const result = validateSoulConfig({ basePath: "/tmp", selfModify: 1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("selfModify must be a boolean");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeCapabilities — selfModify awareness
+// ---------------------------------------------------------------------------
+
+describe("describeCapabilities — selfModify", () => {
+  test("describes self-modification enabled when selfModify is true with file source", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "Soul content.");
+
+    const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const result = mw.describeCapabilities?.(ctx) as CapabilityFragment;
+
+    expect(result.label).toBe("soul");
+    expect(result.description).toContain("self-modification enabled");
+  });
+
+  test("does not describe self-modification when selfModify is false", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "Soul content.");
+
+    const mw = await createSoulMiddleware({
+      soul: "SOUL.md",
+      basePath: tmpDir,
+      selfModify: false,
+    });
+    const ctx = createMockTurnContext();
+    const result = mw.describeCapabilities?.(ctx) as CapabilityFragment;
+
+    expect(result.label).toBe("soul");
+    expect(result.description).toBe("Persona active");
+    expect(result.description).not.toContain("self-modification");
+  });
+
+  test("does not describe self-modification for inline content", async () => {
+    const mw = await createSoulMiddleware({
+      soul: "Inline soul\nMultiple lines",
+      basePath: tmpDir,
+      selfModify: true,
+    });
+    const ctx = createMockTurnContext();
+    const result = mw.describeCapabilities?.(ctx) as CapabilityFragment;
+
+    expect(result.label).toBe("soul");
+    expect(result.description).toBe("Persona active");
+  });
+});

--- a/packages/soul/src/soul.test.ts
+++ b/packages/soul/src/soul.test.ts
@@ -354,6 +354,7 @@ describe("createSoulMiddleware — layer interactions", () => {
     const mw = await createSoulMiddleware({
       soul: "SOUL.md",
       basePath: tmpDir,
+      selfModify: false,
     });
     const ctx = createMockTurnContext();
     const spy = createSpyModelHandler();

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -30,7 +30,7 @@ import {
 } from "./config.js";
 import { createPersonaMap } from "./persona-map.js";
 import type { SoulState } from "./state.js";
-import { createAllWatchedPaths, createSoulMessage } from "./state.js";
+import { createAllWatchedPaths, createSoulMessage, generateMetaInstructionText } from "./state.js";
 
 /**
  * Extended middleware with a `reload()` method for HITL-approved soul updates.
@@ -116,6 +116,14 @@ async function createState(options: CreateSoulOptions): Promise<SoulState> {
   emitWarnings(userResult.warnings);
 
   const watchedPaths = createAllWatchedPaths(soulResult.sources, personaMap, userResult.sources);
+  const selfModify = options.selfModify ?? true;
+
+  // Collect identity file paths from all personas for meta-instruction
+  const identitySources = Array.from(personaMap.values()).flatMap((cached) => [...cached.sources]);
+  const metaInstructionText = generateMetaInstructionText(
+    { soul: soulResult.sources, identity: identitySources, user: userResult.sources },
+    selfModify,
+  );
 
   return {
     soulText: soulResult.text,
@@ -124,6 +132,7 @@ async function createState(options: CreateSoulOptions): Promise<SoulState> {
     userText: userResult.text,
     userSources: userResult.sources,
     watchedPaths,
+    metaInstructionText,
   };
 }
 
@@ -151,7 +160,12 @@ export async function createSoulMiddleware(options: CreateSoulOptions): Promise<
     const cached = channelId !== undefined ? state.personaMap.get(channelId) : undefined;
     const identityText = cached?.text;
 
-    return createSoulMessage(state.soulText, identityText, state.userText);
+    return createSoulMessage(
+      state.soulText,
+      identityText,
+      state.userText,
+      state.metaInstructionText,
+    );
   }
 
   async function getSoulMessageAsync(ctx: TurnContext): Promise<InboundMessage | undefined> {
@@ -161,22 +175,30 @@ export async function createSoulMiddleware(options: CreateSoulOptions): Promise<
     const userResult = await resolveUserLayer(options);
     const channelId = ctx.session.channelId;
     const cached = channelId !== undefined ? state.personaMap.get(channelId) : undefined;
-    return createSoulMessage(state.soulText, cached?.text, userResult.text);
+    return createSoulMessage(
+      state.soulText,
+      cached?.text,
+      userResult.text,
+      state.metaInstructionText,
+    );
   }
 
   async function reload(): Promise<void> {
     state = await createState(options);
   }
 
-  const capabilityFragment: CapabilityFragment = {
-    label: "soul",
-    description: "Persona active",
-  };
+  const selfModify = options.selfModify ?? true;
 
   return {
     name: "soul",
     priority: 500,
-    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => capabilityFragment,
+    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => ({
+      label: "soul",
+      description:
+        selfModify && state.metaInstructionText.length > 0
+          ? "Persona active — self-modification enabled"
+          : "Persona active",
+    }),
 
     reload,
 

--- a/packages/soul/src/state.ts
+++ b/packages/soul/src/state.ts
@@ -14,6 +14,8 @@ export interface SoulState {
   readonly userText: string;
   readonly userSources: readonly string[];
   readonly watchedPaths: ReadonlySet<string>;
+  /** Pre-computed meta-instruction text for self-modification awareness. Empty when disabled. */
+  readonly metaInstructionText: string;
 }
 
 /**
@@ -35,9 +37,81 @@ export function createAllWatchedPaths(
 /** Default total token cap for the combined system message. */
 const DEFAULT_TOTAL_MAX_CHARS = 8000 * 4; // 8000 tokens * 4 chars/token
 
+/** Sources grouped by layer for meta-instruction generation. */
+export interface MetaInstructionSources {
+  /** Resolved soul file paths (global personality). */
+  readonly soul: readonly string[];
+  /** Resolved identity file paths (per-channel persona). */
+  readonly identity: readonly string[];
+  /** Resolved user file paths (user context). */
+  readonly user: readonly string[];
+}
+
+/** Filters out "inline" entries, returning only real file paths. */
+function filePaths(sources: readonly string[]): readonly string[] {
+  return sources.filter((s) => s !== "inline");
+}
+
 /**
- * Concatenates non-empty soul, identity, and user layers into a single
- * InboundMessage for system prompt injection.
+ * Generates the meta-instruction text that teaches the agent about self-modification.
+ *
+ * Returns empty string when:
+ * - `selfModify` is false
+ * - No resolvable file sources exist (all inline or empty)
+ */
+export function generateMetaInstructionText(
+  sources: MetaInstructionSources,
+  selfModify: boolean,
+): string {
+  if (!selfModify) return "";
+
+  const soulFiles = filePaths(sources.soul);
+  const identityFiles = filePaths(sources.identity);
+  const userFiles = filePaths(sources.user);
+
+  const allFiles = [...soulFiles, ...identityFiles, ...userFiles];
+  if (allFiles.length === 0) return "";
+
+  const lines: string[] = ["[Soul System]"];
+
+  // Single file — compact format
+  if (allFiles.length === 1 && soulFiles.length === 1) {
+    lines.push(`Your personality is defined in ${soulFiles[0]}.`);
+  } else {
+    // Multi-file — grouped listing
+    lines.push("Your personality is defined in these files:");
+    for (const f of soulFiles) {
+      lines.push(`- ${f} (global personality) — core behavior, tone, values`);
+    }
+    for (const f of identityFiles) {
+      lines.push(`- ${f} (channel persona) — channel-specific style and rules`);
+    }
+    for (const f of userFiles) {
+      lines.push(`- ${f} (user context) — user preferences and context`);
+    }
+  }
+
+  lines.push(
+    "You may propose changes by writing to these files.",
+    "Changes require human approval and take effect on your next response.",
+    "",
+    "When to update:",
+    "- When the user gives persistent feedback about your behavior",
+    "- When you learn a pattern that should be permanent",
+    "- When the user explicitly asks you to remember something about yourself",
+    "",
+    "Do NOT update for:",
+    "- One-time task preferences",
+    "- Transient conversation context",
+    "- Information that belongs in memory, not personality",
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Concatenates non-empty soul, identity, user, and meta-instruction layers
+ * into a single InboundMessage for system prompt injection.
  *
  * Returns undefined when all layers are empty.
  */
@@ -45,11 +119,13 @@ export function createSoulMessage(
   soulText: string,
   identityText: string | undefined,
   userText: string,
+  metaInstructionText: string = "",
 ): InboundMessage | undefined {
   const parts = [
     soulText.length > 0 ? soulText : undefined,
     identityText !== undefined && identityText.length > 0 ? identityText : undefined,
     userText.length > 0 ? userText : undefined,
+    metaInstructionText.length > 0 ? metaInstructionText : undefined,
   ].filter((p): p is string => p !== undefined);
 
   if (parts.length === 0) return undefined;


### PR DESCRIPTION
## Summary

Implements #362 — teach agents they can evolve their own personality by modifying SOUL.md via `fs_write`, with structural HITL pre-approval through the middleware chain.

- **`[Soul System]` meta-instruction** appended to the soul system message, teaching the agent where its personality files are and how to propose changes
- **Multi-file routing hints** — grouped listing with per-file guidance (`core behavior, tone, values` / `channel-specific style and rules` / `user preferences and context`)
- **`generateMetaInstructionText`** pure function, pre-computed at factory time (zero per-call overhead)
- **`selfModify: false` kill switch** — completely removes awareness; agent has no idea it has personality files
- **Inline content auto-suppresses** — no file path to reference, no meta-instruction injected
- **`describeCapabilities`** reports `"self-modification enabled"` or `"Persona active"` dynamically
- **Auto-reload** updates meta-instruction atomically via `reload()`
- **23 unit tests + 11 E2E tests** (real LLM calls through `createKoi` + `createPiAdapter`)
- **Updated `docs/L2/soul.md`** with full self-modification awareness section

## Files changed

| File | Change |
|------|--------|
| `packages/soul/src/config.ts` | `selfModify` option + validation |
| `packages/soul/src/state.ts` | `MetaInstructionSources`, `generateMetaInstructionText()`, `metaInstructionText` in `SoulState` |
| `packages/soul/src/soul.ts` | Wired through `createState`, `getSoulMessage`, dynamic `describeCapabilities` |
| `packages/soul/src/index.ts` | New exports |
| `packages/soul/src/soul.test.ts` | Fixed one existing test |
| `packages/soul/src/self-modify.test.ts` | **NEW** — 23 unit tests |
| `packages/soul/src/__tests__/e2e-self-modify.test.ts` | **NEW** — 11 E2E tests |
| `docs/L2/soul.md` | Self-modification awareness section |

## Test plan

- [x] Unit tests: 115 pass, 0 fail
- [x] E2E tests: 11 pass, 0 fail (real LLM calls, `E2E_TESTS=1`)
- [x] Biome lint: clean
- [x] TypeScript typecheck: clean
- [x] No layer leakage (only `@koi/core` + `@koi/file-resolution` imports)
- [x] Pre-computed meta-instruction (no per-call overhead)
- [ ] Run `E2E_TESTS=1 bun test packages/soul/src/__tests__/e2e-self-modify.test.ts` to verify E2E

Closes #362