### PR TITLE
feat: add @koi/registry-store — SQLite-backed registry backends

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1121,6 +1121,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/registry-store": {
+      "name": "@koi/registry-store",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/sqlite-utils": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/resolve": {
       "name": "@koi/resolve",
       "version": "0.0.0",
@@ -2097,6 +2110,8 @@
     "@koi/registry-event-sourced": ["@koi/registry-event-sourced@workspace:packages/registry-event-sourced"],
 
     "@koi/registry-http": ["@koi/registry-http@workspace:packages/registry-http"],
+
+    "@koi/registry-store": ["@koi/registry-store@workspace:packages/registry-store"],
 
     "@koi/resolve": ["@koi/resolve@workspace:packages/resolve"],
 

--- a/packages/registry-store/docs/registry-store.md
+++ b/packages/registry-store/docs/registry-store.md
@@ -1,0 +1,568 @@
+# @koi/registry-store
+
+SQLite-backed implementations of the three L0 registry contracts:
+BrickRegistry, SkillRegistry, and VersionIndex. Provides persistent
+storage with FTS5 full-text search, keyset cursor pagination, and
+reactive onChange event dispatch.
+
+**Layer:** L2 (depends on `@koi/core` + `@koi/sqlite-utils` only)
+
+## How It Works
+
+```
+  Consumer                   registry-store                  SQLite
+    |                             |                            |
+    |  createSqlite*Registry()    |                            |
+    |  { db | dbPath }            |                            |
+    |---------------------------->|  applyRegistryMigrations    |
+    |                             |---------------------------->|
+    |                             |  FTS5 + indexes created     |
+    |                             |<----------------------------|
+    |                             |                            |
+    |  register(brick)            |                            |
+    |---------------------------->|  INSERT bricks + tags       |
+    |                             |---------------------------->|
+    |                             |  INSERT bricks_fts          |
+    |                             |---------------------------->|
+    |                             |                            |
+    |  <-- onChange("registered") |                            |
+    |                             |                            |
+    |  search({ text, tags })     |                            |
+    |---------------------------->|  SELECT bricks_fts MATCH ?  |
+    |                             |---------------------------->|
+    |                             |<----------------------------|
+    |                             |  JOIN brick_tags WHERE IN   |
+    |                             |---------------------------->|
+    |                             |<----------------------------|
+    |  <-- BrickPage { items,     |                            |
+    |       total, cursor }       |                            |
+    |                             |                            |
+    |  close()                    |                            |
+    |---------------------------->|  PRAGMA optimize            |
+    |                             |---------------------------->|
+    |                             |  db.close() (if owned)      |
+    |                             |---------------------------->|
+```
+
+## Three Registries
+
+| Registry | L0 Contract | Purpose |
+|----------|-------------|---------|
+| `createSqliteBrickRegistry` | `BrickRegistryBackend` | Store and discover tools + skills as brick artifacts |
+| `createSqliteSkillRegistry` | `SkillRegistryBackend` | Publish/install skills with version control |
+| `createSqliteVersionIndex` | `VersionIndexBackend` | Semver version tracking with deprecate/yank |
+
+All three share the same SQLite database, the same migration runner, and
+the same configuration pattern.
+
+## Configuration
+
+Two ways to provide a database:
+
+```typescript
+// Option 1: Let the factory own the database (opens + closes it)
+const registry = createSqliteBrickRegistry({ dbPath: "./registry.db" });
+
+// Option 2: Inject an existing database (caller owns lifecycle)
+import { Database } from "bun:sqlite";
+const db = new Database(":memory:");
+db.run("PRAGMA foreign_keys = ON");
+const registry = createSqliteBrickRegistry({ db });
+```
+
+When using `dbPath`, the factory opens the database and closes it on
+`close()`. When injecting `db`, the factory never closes it — the caller
+is responsible for lifecycle. Multiple registries can share one `db`:
+
+```typescript
+const db = new Database(":memory:");
+db.run("PRAGMA foreign_keys = ON");
+
+const bricks   = createSqliteBrickRegistry({ db });
+const skills    = createSqliteSkillRegistry({ db });
+const versions  = createSqliteVersionIndex({ db });
+// All three share tables in the same database
+```
+
+## BrickRegistry
+
+Store and discover `BrickArtifact` objects (tools, skills, agents).
+
+### register
+
+Upsert a brick. Fires `"registered"` on insert, `"updated"` on re-register.
+
+```typescript
+import { createTestToolArtifact } from "@koi/test-utils";
+
+const brick = createTestToolArtifact({
+  name: "multiply",
+  description: "Multiplies two numbers",
+  tags: ["math", "arithmetic"],
+});
+
+const result = await registry.register(brick);
+// result.ok === true
+```
+
+### get
+
+Retrieve a single brick by kind and name.
+
+```typescript
+const result = await registry.get("tool", "multiply");
+if (result.ok) {
+  console.log(result.value.description); // "Multiplies two numbers"
+}
+```
+
+### search
+
+Full-text search with tag filtering and keyset pagination.
+
+```typescript
+// Text search (FTS5)
+const page = await registry.search({ text: "multiply" });
+// page.items — matching bricks
+// page.total — total count (before pagination)
+// page.cursor — opaque cursor for next page (undefined = last page)
+
+// Tag AND-filtering
+const page = await registry.search({ tags: ["math", "arithmetic"] });
+// Returns only bricks that have ALL specified tags
+
+// Kind filter
+const page = await registry.search({ kind: "tool" });
+
+// Pagination
+const page2 = await registry.search({ text: "math", cursor: page.cursor, limit: 10 });
+
+// Combined
+const page = await registry.search({ text: "calc", tags: ["math"], kind: "tool", limit: 5 });
+```
+
+### unregister
+
+Remove a brick. Cascade-deletes associated tags. Fires `"unregistered"`.
+
+```typescript
+const result = await registry.unregister("tool", "multiply");
+```
+
+### onChange
+
+Subscribe to mutation events. Returns an unsubscribe function.
+
+```typescript
+const unsub = registry.onChange((event) => {
+  // event.kind: "registered" | "updated" | "unregistered"
+  // event.brickKind: "tool" | "skill" | ...
+  // event.name: brick name
+  console.log(`${event.kind}: ${event.brickKind}:${event.name}`);
+});
+
+// Later: unsub() to stop listening
+```
+
+## SkillRegistry
+
+Publish and install skills with multi-version support. Two-table design:
+`skills` for catalog entries, `skill_versions` for version-specific content.
+
+### publish
+
+Publish a new skill or a new version of an existing skill.
+
+```typescript
+import { skillId } from "@koi/core";
+
+const entry = await registry.publish({
+  id: skillId("summarize"),
+  name: "summarize",
+  description: "Summarizes long documents",
+  version: "1.0.0",
+  content: "# Summarize Skill\nYou are a summarization expert...",
+  tags: ["nlp", "text"],
+});
+// entry.ok === true
+// entry.value.version === "1.0.0"
+
+// Publish v2
+await registry.publish({
+  id: skillId("summarize"),
+  name: "summarize",
+  description: "Summarizes long documents (improved)",
+  version: "2.0.0",
+  content: "# Summarize Skill v2\nYou are an expert...",
+  tags: ["nlp", "text"],
+});
+```
+
+### install
+
+Retrieve a skill as a `SkillArtifact`. Installs latest by default, or a
+specific version. Increments download count.
+
+```typescript
+// Install latest
+const result = await registry.install(skillId("summarize"));
+// result.value.content === "# Summarize Skill v2..."
+// result.value.version === "2.0.0"
+
+// Install specific version
+const v1 = await registry.install(skillId("summarize"), "1.0.0");
+// v1.value.content === "# Summarize Skill\nYou are..."
+```
+
+### get
+
+Retrieve a single skill entry by ID.
+
+```typescript
+const result = await registry.get(skillId("summarize"));
+if (result.ok) {
+  console.log(result.value.name);    // "summarize"
+  console.log(result.value.version); // latest version string
+}
+```
+
+### search
+
+Full-text search with tag and author filtering. Same keyset pagination.
+
+```typescript
+const page = await registry.search({ text: "summarize" });
+const page = await registry.search({ tags: ["nlp"], author: "koi-team" });
+```
+
+### versions
+
+List all versions of a skill, ordered newest-first.
+
+```typescript
+const result = await registry.versions(skillId("summarize"));
+// result.value: [{ version: "2.0.0", publishedAt: ... }, { version: "1.0.0", ... }]
+```
+
+### deprecate / unpublish
+
+```typescript
+// Soft-deprecate a specific version
+await registry.deprecate(skillId("summarize"), "1.0.0");
+
+// Hard-delete the entire skill (all versions, tags, FTS)
+await registry.unpublish(skillId("summarize"));
+```
+
+### onChange
+
+```typescript
+registry.onChange((event) => {
+  // event.kind: "published" | "deprecated" | "unpublished"
+  // event.skillId: SkillId
+  // event.version?: string (for published/deprecated)
+});
+```
+
+## VersionIndex
+
+Semver version tracking for any brick, with publisher attribution.
+Separate from BrickRegistry — tracks which versions exist for a
+(name, kind) pair without storing full brick data.
+
+### publish
+
+Register a version entry. Idempotent if same brickId.
+
+```typescript
+import { brickId, publisherId } from "@koi/core";
+
+await index.publish(
+  "multiply",                    // name
+  "tool",                        // kind
+  "1.0.0",                       // version
+  brickId("brick_multiply_v1"),  // brickId
+  publisherId("koi-team"),       // publisher
+);
+
+await index.publish("multiply", "tool", "2.0.0", brickId("brick_multiply_v2"), publisherId("koi-team"));
+await index.publish("multiply", "tool", "3.0.0", brickId("brick_multiply_v3"), publisherId("koi-team"));
+```
+
+### resolve / resolveLatest
+
+```typescript
+// Resolve specific version
+const v1 = await index.resolve("multiply", "tool", "1.0.0");
+// v1.value.brickId === brickId("brick_multiply_v1")
+
+// Resolve latest (by published_at, not semver)
+const latest = await index.resolveLatest("multiply", "tool");
+// latest.value.version === "3.0.0"
+```
+
+### listVersions
+
+All versions ordered newest-first, with deprecation flags.
+
+```typescript
+const result = await index.listVersions("multiply", "tool");
+// result.value: [
+//   { version: "3.0.0", brickId: ..., publisher: ..., publishedAt: ... },
+//   { version: "2.0.0", ..., deprecated: true },
+//   { version: "1.0.0", ... },
+// ]
+```
+
+### deprecate / yank
+
+```typescript
+// Soft-deprecate: sets deprecated flag, entry still resolvable
+await index.deprecate("multiply", "tool", "2.0.0");
+
+// Hard-yank: DELETE from database, no longer resolvable
+await index.yank("multiply", "tool", "2.0.0");
+```
+
+### onChange
+
+```typescript
+index.onChange((event) => {
+  // event.kind: "published" | "deprecated" | "yanked"
+  // event.brickKind, event.name, event.version
+  // event.brickId, event.publisher
+});
+```
+
+## FTS5 Full-Text Search
+
+Both BrickRegistry and SkillRegistry use SQLite FTS5 contentless virtual
+tables for full-text search.
+
+**Indexed columns:** `name`, `description`, `tags` (space-joined)
+
+**Tokenizer:** `unicode61 remove_diacritics 1` (case-insensitive, Unicode-aware)
+
+**Important:** FTS5 matches whole tokens, not substrings. Searching
+`"calc"` will NOT match `"calculator"`. Search for the full token or use
+the `*` prefix operator (which `sanitizeFtsQuery` currently strips for
+safety).
+
+**Query sanitization:** User input is sanitized before reaching FTS5.
+The following are stripped: `" * ^ ( ) { } :` and boolean operators
+`AND`, `OR`, `NOT`, `NEAR`. Hyphens are preserved but interpreted by
+FTS5 as the NOT operator — avoid hyphens in names/tags if you need
+reliable text search.
+
+## Keyset Cursor Pagination
+
+All search methods use keyset pagination instead of OFFSET. Cursors are
+opaque base64url-encoded strings containing `(sortKey, rowid)` pairs.
+
+```
+Page 1: SELECT ... ORDER BY created_at DESC, rowid DESC LIMIT 4
+        ┌─────────┬─────────┬─────────┬─────────┐
+        │  row 7  │  row 6  │  row 5  │  row 4  │  ← cursor encodes row 4
+        └─────────┴─────────┴─────────┴─────────┘
+
+Page 2: SELECT ... WHERE (created_at < ? OR (created_at = ? AND rowid < ?))
+        ORDER BY created_at DESC, rowid DESC LIMIT 4
+        ┌─────────┬─────────┬─────────┐
+        │  row 3  │  row 2  │  row 1  │  ← no cursor = last page
+        └─────────┴─────────┴─────────┘
+```
+
+**Why keyset over OFFSET:**
+- Stable under concurrent inserts/deletes (no skipped or duplicated rows)
+- O(1) seek time via index (vs. O(n) for OFFSET)
+- Deterministic with composite key `(timestamp DESC, rowid DESC)`
+
+## onChange Events
+
+All three registries support reactive event listeners via `onChange()`.
+Events are dispatched synchronously after each mutation. Individual
+listener errors are caught so one broken listener cannot block others.
+
+| Registry | Events |
+|----------|--------|
+| BrickRegistry | `registered`, `updated`, `unregistered` |
+| SkillRegistry | `published`, `deprecated`, `unpublished` |
+| VersionIndex | `published`, `deprecated`, `yanked` |
+
+Listeners must be subscribed **before** the mutation to receive the event.
+
+## Swappable Backends
+
+The SQLite implementation is one backend behind L0 interfaces. The same
+contracts can be satisfied by any storage:
+
+```
+  BrickRegistryBackend          SkillRegistryBackend         VersionIndexBackend
+  (L0 interface)                (L0 interface)               (L0 interface)
+         |                             |                            |
+    ┌────┴────┐                   ┌────┴────┐                  ┌────┴────┐
+    |         |                   |         |                  |         |
+ SQLite    Postgres            SQLite    Postgres           SQLite    Postgres
+ (this)    (future)            (this)    (future)           (this)    (future)
+```
+
+Contract tests in `@koi/test-utils` (`testBrickRegistryContract`, etc.)
+validate behavior — any backend that passes the contract tests is a
+valid implementation.
+
+```typescript
+// Any backend plugs into the same contract test harness
+testBrickRegistryContract({
+  createRegistry: () => createSqliteBrickRegistry({ db }),
+});
+
+testBrickRegistryContract({
+  createRegistry: () => createPostgresBrickRegistry({ pool }),
+});
+```
+
+## Integration
+
+### With createKoi (full L1 runtime)
+
+```typescript
+import { Database } from "bun:sqlite";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createSqliteBrickRegistry } from "@koi/registry-store";
+
+const db = new Database(":memory:");
+db.run("PRAGMA foreign_keys = ON");
+const registry = createSqliteBrickRegistry({ db });
+
+// Register tools
+await registry.register(myToolArtifact);
+
+// Build a ComponentProvider that resolves tools from the registry
+const registryProvider: ComponentProvider = {
+  attach(agent) {
+    // Discover registered tools and attach them to the agent entity
+    const page = await registry.search({ kind: "tool" });
+    for (const brick of page.items) {
+      agent.set(toolToken(brick.name), brickToTool(brick));
+    }
+  },
+};
+
+// Wire through createKoi
+const runtime = await createKoi({
+  manifest: { name: "my-agent", version: "1.0.0", model: { name: "anthropic:claude-haiku-4-5-20251001" } },
+  adapter: createPiAdapter({ model: "anthropic:claude-haiku-4-5-20251001", getApiKey: () => key }),
+  providers: [registryProvider],
+});
+
+// LLM can now discover and call registered tools
+for await (const event of runtime.run({ kind: "text", text: "Use multiply to compute 7 * 8" })) {
+  // process events...
+}
+
+registry.close();
+```
+
+### Standalone (without engine)
+
+```typescript
+import { Database } from "bun:sqlite";
+import { createSqliteBrickRegistry, createSqliteSkillRegistry, createSqliteVersionIndex } from "@koi/registry-store";
+
+const db = new Database("./my-registry.db");
+db.run("PRAGMA foreign_keys = ON");
+
+const bricks   = createSqliteBrickRegistry({ db });
+const skills    = createSqliteSkillRegistry({ db });
+const versions  = createSqliteVersionIndex({ db });
+
+// Use registries directly
+await bricks.register(toolArtifact);
+await skills.publish({ id, name, version, content, ... });
+await versions.publish(name, kind, version, brickId, publisherId);
+
+// Search
+const results = await bricks.search({ text: "calculator", tags: ["math"] });
+
+// Clean up
+bricks.close();
+skills.close();
+versions.close();
+db.close();
+```
+
+## Schema
+
+All tables are created by `applyRegistryMigrations()`, which is called
+automatically by each factory. Migrations are idempotent and tracked via
+`PRAGMA user_version`.
+
+### V1 Tables
+
+```sql
+-- BRICK REGISTRY
+bricks           -- main table with JSON data column
+brick_tags       -- junction table (brick_rowid, tag) with CASCADE delete
+bricks_fts       -- FTS5 contentless (name, description, tags)
+
+-- SKILL REGISTRY
+skills           -- catalog entries
+skill_tags       -- junction table with CASCADE delete
+skill_versions   -- version-specific content + integrity hash
+skills_fts       -- FTS5 contentless (name, description, tags)
+
+-- VERSION INDEX
+versions         -- (name, kind, version) -> brickId + publisher
+```
+
+### Indexes
+
+| Index | Purpose |
+|-------|---------|
+| `idx_bricks_kind` | Filter by brick kind |
+| `idx_bricks_cursor` | Keyset pagination `(created_at DESC, rowid DESC)` |
+| `idx_brick_tags_tag` | Tag lookup for AND-filtering |
+| `idx_skills_cursor` | Keyset pagination for skills |
+| `idx_skill_tags_tag` | Tag lookup for skills |
+| `idx_sv_skill_published` | Version lookup by skill + publish order |
+| `idx_versions_lookup` | Version resolution `(name, kind, published_at DESC)` |
+
+## Testing
+
+```bash
+# Unit + contract tests (137 tests, no API key needed)
+bun test
+
+# E2E tests with real Anthropic API (6 tests)
+E2E_TESTS=1 bun test src/__tests__/e2e-full-stack.test.ts
+
+# Typecheck
+bun run typecheck
+```
+
+## Architecture
+
+```
+packages/registry-store/src/
+├── index.ts              Public exports (3 factories + config types)
+├── config.ts             Shared config: dbPath vs injected db
+├── schema.ts             V1 DDL + migration runner
+├── cursor.ts             Keyset cursor encode/decode (base64url)
+├── fts-sanitize.ts       FTS5 query sanitization
+├── listeners.ts          onChange event dispatch utility
+├── brick-registry.ts     BrickRegistryBackend implementation
+├── skill-registry.ts     SkillRegistryBackend implementation
+├── version-index.ts      VersionIndexBackend implementation
+└── __tests__/
+    ├── brick-registry.test.ts    Contract + SQLite-specific tests
+    ├── brick-resolver.test.ts    Resolver integration tests
+    ├── skill-registry.test.ts    Skill publish/install/search tests
+    ├── version-index.test.ts     Version publish/resolve/deprecate tests
+    └── e2e-full-stack.test.ts    Full L1 runtime + real LLM (6 tests)
+```
+
+**Layer compliance:**
+- Production code imports only `@koi/core` (L0) and `@koi/sqlite-utils` (L0u)
+- Test code may import `@koi/engine` (L1) and `@koi/engine-pi` via devDependencies
+- No L2 cross-imports

--- a/packages/registry-store/package.json
+++ b/packages/registry-store/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/registry-store",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/sqlite-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/registry-store/src/__tests__/brick-registry.test.ts
+++ b/packages/registry-store/src/__tests__/brick-registry.test.ts
@@ -1,0 +1,195 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import {
+  assertOk,
+  createTestSkillArtifact,
+  createTestToolArtifact,
+  testBrickRegistryContract,
+} from "@koi/test-utils";
+import { createSqliteBrickRegistry } from "../brick-registry.js";
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+describe("SqliteBrickRegistry", () => {
+  testBrickRegistryContract({
+    createRegistry: () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      return createSqliteBrickRegistry({ db });
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // SQLite-specific tests
+  // -------------------------------------------------------------------------
+
+  describe("FTS5 search", () => {
+    test("finds bricks by name substring", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(await registry.register(createTestToolArtifact({ name: "calculator-tool" })));
+      assertOk(await registry.register(createTestSkillArtifact({ name: "weather-skill" })));
+
+      const page = await registry.search({ text: "calculator" });
+      expect(page.items.length).toBe(1);
+      expect(page.items[0]?.name).toBe("calculator-tool");
+    });
+
+    test("finds bricks by description", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(
+        await registry.register(
+          createTestToolArtifact({ name: "my-tool", description: "performs complex calculations" }),
+        ),
+      );
+
+      const page = await registry.search({ text: "calculations" });
+      expect(page.items.length).toBe(1);
+      expect(page.items[0]?.name).toBe("my-tool");
+    });
+
+    test("text search is case-insensitive", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(await registry.register(createTestToolArtifact({ name: "MyTool" })));
+
+      const page = await registry.search({ text: "mytool" });
+      expect(page.items.length).toBe(1);
+    });
+  });
+
+  describe("tag filtering", () => {
+    test("AND-filters multiple tags", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(
+        await registry.register(createTestToolArtifact({ name: "tool-a", tags: ["math", "util"] })),
+      );
+      assertOk(
+        await registry.register(createTestSkillArtifact({ name: "skill-b", tags: ["math"] })),
+      );
+
+      const page = await registry.search({ tags: ["math", "util"] });
+      expect(page.items.length).toBe(1);
+      expect(page.items[0]?.name).toBe("tool-a");
+    });
+
+    test("returns empty when no brick has all tags", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(await registry.register(createTestToolArtifact({ name: "tool-a", tags: ["foo"] })));
+
+      const page = await registry.search({ tags: ["foo", "bar"] });
+      expect(page.items.length).toBe(0);
+    });
+  });
+
+  describe("keyset cursor stability", () => {
+    test("pages through all results without duplicates", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      for (let i = 0; i < 7; i++) {
+        assertOk(await registry.register(createTestToolArtifact({ name: `tool-${i}` })));
+      }
+
+      const allNames = new Set<string>();
+      let cursor: string | undefined;
+      let pages = 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- loop control
+      while (true) {
+        const query = cursor !== undefined ? { limit: 3, cursor } : { limit: 3 };
+        const page = await registry.search(query);
+        for (const item of page.items) {
+          expect(allNames.has(item.name)).toBe(false);
+          allNames.add(item.name);
+        }
+        pages++;
+        if (page.cursor === undefined) break;
+        cursor = page.cursor;
+      }
+
+      expect(allNames.size).toBe(7);
+      expect(pages).toBe(3); // 3 + 3 + 1
+    });
+  });
+
+  describe("re-registration (update path)", () => {
+    test("updates existing brick and fires 'updated' event", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      const original = createTestToolArtifact({
+        name: "updatable-tool",
+        description: "original desc",
+        tags: ["old-tag"],
+      });
+      assertOk(await registry.register(original));
+
+      const events: string[] = [];
+      if (registry.onChange === undefined) throw new Error("onChange must be defined");
+      registry.onChange((e) => events.push(e.kind));
+
+      const updated = createTestToolArtifact({
+        name: "updatable-tool",
+        description: "new desc",
+        tags: ["new-tag"],
+      });
+      assertOk(await registry.register(updated));
+
+      expect(events).toEqual(["updated"]);
+
+      const result = await registry.get("tool", "updatable-tool");
+      assertOk(result);
+      expect(result.value.description).toBe("new desc");
+      expect(result.value.tags).toEqual(["new-tag"]);
+
+      // FTS still works after update
+      const page = await registry.search({ text: "new desc" });
+      expect(page.items.length).toBe(1);
+    });
+  });
+
+  describe("cascade delete", () => {
+    test("unregister removes associated tags", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+
+      assertOk(
+        await registry.register(createTestToolArtifact({ name: "cascade-tool", tags: ["a", "b"] })),
+      );
+      assertOk(await registry.unregister("tool", "cascade-tool"));
+
+      // Verify tags are cleaned up (search by tags returns nothing)
+      const page = await registry.search({ tags: ["a"] });
+      expect(page.items.length).toBe(0);
+      expect(page.total).toBe(0);
+    });
+  });
+
+  describe("close()", () => {
+    test("close does not throw", () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const registry = createSqliteBrickRegistry({ db });
+      registry.close();
+    });
+  });
+});

--- a/packages/registry-store/src/__tests__/cursor.test.ts
+++ b/packages/registry-store/src/__tests__/cursor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { decodeCursor, encodeCursor } from "../cursor.js";
+
+describe("encodeCursor / decodeCursor", () => {
+  test("round-trips a valid cursor", () => {
+    const cursor = encodeCursor(1700000000000, 42);
+    const decoded = decodeCursor(cursor);
+    expect(decoded).toEqual({ sortKey: 1700000000000, rowid: 42 });
+  });
+
+  test("round-trips zero values", () => {
+    const cursor = encodeCursor(0, 0);
+    const decoded = decodeCursor(cursor);
+    expect(decoded).toEqual({ sortKey: 0, rowid: 0 });
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(decodeCursor("")).toBeUndefined();
+  });
+
+  test("returns undefined for invalid base64", () => {
+    expect(decodeCursor("!!!not-base64!!!")).toBeUndefined();
+  });
+
+  test("returns undefined for missing separator", () => {
+    const noSep = Buffer.from("12345").toString("base64url");
+    expect(decodeCursor(noSep)).toBeUndefined();
+  });
+
+  test("returns undefined for non-numeric values", () => {
+    const bad = Buffer.from("abc:def").toString("base64url");
+    expect(decodeCursor(bad)).toBeUndefined();
+  });
+
+  test("returns undefined for Infinity values", () => {
+    const inf = Buffer.from("Infinity:1").toString("base64url");
+    expect(decodeCursor(inf)).toBeUndefined();
+  });
+
+  test("returns undefined for NaN values", () => {
+    const nan = Buffer.from("NaN:1").toString("base64url");
+    expect(decodeCursor(nan)).toBeUndefined();
+  });
+
+  test("produces different cursors for different inputs", () => {
+    const a = encodeCursor(100, 1);
+    const b = encodeCursor(100, 2);
+    const c = encodeCursor(200, 1);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+});

--- a/packages/registry-store/src/__tests__/e2e-full-stack.test.ts
+++ b/packages/registry-store/src/__tests__/e2e-full-stack.test.ts
@@ -1,0 +1,634 @@
+/**
+ * E2E test — Registry-Store through full L1 runtime assembly.
+ *
+ * Validates that SQLite registries (BrickRegistry, SkillRegistry, VersionIndex)
+ * work correctly through the full L1 runtime pipeline:
+ *   createKoi + createPiAdapter (real Anthropic API with tool calling)
+ *
+ * Tests:
+ *   1. BrickRegistry tool → real LLM calls it via createPiAdapter
+ *   2. BrickRegistry search + FTS5 during runtime
+ *   3. SkillRegistry publish + install + version retrieval
+ *   4. VersionIndex publish + resolve + deprecate
+ *   5. Full pipeline — all 3 registries + middleware + real LLM
+ *   6. onChange events during registry mutations
+ *
+ * Gated on ANTHROPIC_API_KEY + E2E_TESTS=1 — tests skip when either is missing.
+ *
+ * Run:
+ *   E2E_TESTS=1 ANTHROPIC_API_KEY=... bun test packages/registry-store/src/__tests__/e2e-full-stack.test.ts
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  BrickRegistryChangeEvent,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  KoiMiddleware,
+  SkillRegistryChangeEvent,
+  Tool,
+  ToolRequest,
+  ToolResponse,
+  VersionChangeEvent,
+} from "@koi/core";
+import { brickId, publisherId, skillId, toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { assertOk, createTestToolArtifact } from "@koi/test-utils";
+import { createSqliteBrickRegistry } from "../brick-registry.js";
+import { createSqliteSkillRegistry } from "../skill-registry.js";
+import { createSqliteVersionIndex } from "../version-index.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function testManifest(): AgentManifest {
+  return {
+    name: "registry-store-e2e",
+    version: "0.1.0",
+    model: { name: "claude-haiku-4-5-20251001" },
+  };
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+/** Create a multiply tool backed by a real JS function. */
+function createMultiplyTool(): Tool {
+  return {
+    descriptor: {
+      name: "multiply",
+      description: "Multiplies two numbers together and returns the product.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          a: { type: "number", description: "First number" },
+          b: { type: "number", description: "Second number" },
+        },
+        required: ["a", "b"],
+      },
+    },
+    trustTier: "sandbox",
+    execute: async (input: Readonly<Record<string, unknown>>) => {
+      const a = Number(input.a ?? 0);
+      const b = Number(input.b ?? 0);
+      return String(a * b);
+    },
+  };
+}
+
+/** ComponentProvider that registers tools on the agent entity. */
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "registry-e2e-tool-provider",
+    attach: async () => new Map(tools.map((t) => [toolToken(t.descriptor.name) as string, t])),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: registry-store through full L1 runtime assembly", () => {
+  // -------------------------------------------------------------------------
+  // Test 1: BrickRegistry tool → real LLM calls it
+  // -------------------------------------------------------------------------
+
+  test(
+    "BrickRegistry tool registered and called by real LLM",
+    async () => {
+      const db = new Database(":memory:");
+      const brickRegistry = createSqliteBrickRegistry({ db });
+
+      // Register a multiply ToolArtifact via createTestToolArtifact
+      const artifact = createTestToolArtifact({
+        id: brickId("brick_multiply"),
+        name: "multiply",
+        description: "Multiplies two numbers. Returns the product.",
+        implementation: "return String(Number(input.a) * Number(input.b));",
+        inputSchema: {
+          type: "object",
+          properties: {
+            a: { type: "number" },
+            b: { type: "number" },
+          },
+          required: ["a", "b"],
+        },
+      });
+      assertOk(await brickRegistry.register(artifact));
+
+      // Verify the brick is stored
+      const getResult = await brickRegistry.get("tool", "multiply");
+      assertOk(getResult);
+      expect(getResult.value.name).toBe("multiply");
+
+      // Build a ComponentProvider that serves the multiply tool
+      const multiplyTool = createMultiplyTool();
+      const provider = createToolProvider([multiplyTool]);
+
+      // Full L1 runtime with createPiAdapter (supports tool calling natively)
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the multiply tool to answer math questions. Do not compute in your head. Always use the tool.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        providers: [provider],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use the multiply tool to compute 7 * 8. Tell me the result.",
+        }),
+      );
+      await runtime.dispose();
+      brickRegistry.close();
+
+      // Assertions
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason === "completed" || output?.stopReason === "max_turns").toBe(true);
+
+      // tool_call_start should have been emitted
+      const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+      expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+
+      // Response should mention 56
+      const text = extractText(events);
+      expect(text).toContain("56");
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 2: BrickRegistry search + FTS5 during runtime
+  // -------------------------------------------------------------------------
+
+  test(
+    "BrickRegistry FTS5 search and tag filtering work with registered bricks",
+    async () => {
+      const db = new Database(":memory:");
+      const brickRegistry = createSqliteBrickRegistry({ db });
+
+      // Register multiple tool bricks with different names/tags
+      const tools = [
+        createTestToolArtifact({
+          id: brickId("brick_calculator"),
+          name: "calculator",
+          description: "Performs basic arithmetic calculations",
+          tags: ["math", "utility"],
+        }),
+        createTestToolArtifact({
+          id: brickId("brick_formatter"),
+          name: "formatter",
+          description: "Renders text and numbers for display",
+          tags: ["text", "utility"],
+        }),
+        createTestToolArtifact({
+          id: brickId("brick_analyzer"),
+          name: "analyzer",
+          description: "Analyzes data and produces statistical summaries",
+          tags: ["math", "statistics"],
+        }),
+      ];
+
+      for (const tool of tools) {
+        assertOk(await brickRegistry.register(tool));
+      }
+
+      // FTS5 matches full tokens — "arithmetic" is a token in calculator's description
+      const textResults = await brickRegistry.search({ text: "arithmetic" });
+      expect(textResults.items.length).toBe(1);
+      expect(textResults.items[0]?.name).toBe("calculator");
+
+      // "formatter" is the full name token
+      const formatResults = await brickRegistry.search({ text: "formatter" });
+      expect(formatResults.items.length).toBe(1);
+      expect(formatResults.items[0]?.name).toBe("formatter");
+
+      // Search by tags → AND-filtering: ["math", "utility"] matches only calculator
+      const tagResults = await brickRegistry.search({ tags: ["math", "utility"] });
+      expect(tagResults.items.length).toBe(1);
+      expect(tagResults.items[0]?.name).toBe("calculator");
+
+      // Search by single tag → "utility" matches calculator and formatter
+      const utilityResults = await brickRegistry.search({ tags: ["utility"] });
+      expect(utilityResults.items.length).toBe(2);
+      const utilityNames = utilityResults.items
+        .map((i: { readonly name: string }) => i.name)
+        .sort();
+      expect(utilityNames).toEqual(["calculator", "formatter"]);
+
+      // "statistical" is a token in analyzer's description
+      const statResults = await brickRegistry.search({ text: "statistical" });
+      expect(statResults.items.length).toBe(1);
+      expect(statResults.items[0]?.name).toBe("analyzer");
+
+      // Total count
+      const allResults = await brickRegistry.search({});
+      expect(allResults.total).toBe(3);
+
+      brickRegistry.close();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 3: SkillRegistry publish + install + version retrieval
+  // -------------------------------------------------------------------------
+
+  test(
+    "SkillRegistry publish, install, search, and version listing",
+    async () => {
+      const db = new Database(":memory:");
+      const skillRegistry = createSqliteSkillRegistry({ db });
+
+      const id = skillId("skill_test_e2e");
+
+      // Publish skill v1.0.0
+      const v1Result = await skillRegistry.publish({
+        id,
+        name: "testsuite",
+        description: "A skill for comprehensive integration testing",
+        tags: ["test", "e2e"],
+        version: "1.0.0",
+        content: "# V1",
+      });
+      assertOk(v1Result);
+      expect(v1Result.value.version).toBe("1.0.0");
+
+      // Publish skill v2.0.0
+      const v2Result = await skillRegistry.publish({
+        id,
+        name: "testsuite",
+        description: "A skill for comprehensive integration testing (updated)",
+        tags: ["test", "e2e"],
+        version: "2.0.0",
+        content: "# V2",
+      });
+      assertOk(v2Result);
+      expect(v2Result.value.version).toBe("2.0.0");
+
+      // Install latest → content is "# V2"
+      const latestInstall = await skillRegistry.install(id);
+      assertOk(latestInstall);
+      expect(latestInstall.value.content).toBe("# V2");
+
+      // Install v1.0.0 → content is "# V1"
+      const v1Install = await skillRegistry.install(id, "1.0.0");
+      assertOk(v1Install);
+      expect(v1Install.value.content).toBe("# V1");
+
+      // FTS5 search by full token "testsuite" → found
+      const searchResult = await skillRegistry.search({ text: "testsuite" });
+      expect(searchResult.items.length).toBe(1);
+      expect(searchResult.items[0]?.name).toBe("testsuite");
+
+      // Also search by tag
+      const tagResult = await skillRegistry.search({ tags: ["e2e"] });
+      expect(tagResult.items.length).toBe(1);
+      expect(tagResult.items[0]?.name).toBe("testsuite");
+
+      // Versions list → ordered [v2, v1]
+      const versionsResult = await skillRegistry.versions(id);
+      assertOk(versionsResult);
+      expect(versionsResult.value.length).toBe(2);
+      expect(versionsResult.value[0]?.version).toBe("2.0.0");
+      expect(versionsResult.value[1]?.version).toBe("1.0.0");
+
+      skillRegistry.close();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 4: VersionIndex publish + resolve + deprecate
+  // -------------------------------------------------------------------------
+
+  test(
+    "VersionIndex publish, resolve, resolveLatest, deprecate, and listVersions",
+    async () => {
+      const db = new Database(":memory:");
+      const versionIndex = createSqliteVersionIndex({ db });
+
+      const pub = publisherId("pub_e2e_tester");
+      const name = "testtool";
+      const kind = "tool" as const;
+
+      // Publish versions 1.0.0, 2.0.0, 3.0.0
+      const v1 = await versionIndex.publish(name, kind, "1.0.0", brickId("brick_v1"), pub);
+      assertOk(v1);
+
+      const v2 = await versionIndex.publish(name, kind, "2.0.0", brickId("brick_v2"), pub);
+      assertOk(v2);
+
+      const v3 = await versionIndex.publish(name, kind, "3.0.0", brickId("brick_v3"), pub);
+      assertOk(v3);
+
+      // resolveLatest → 3.0.0
+      const latest = await versionIndex.resolveLatest(name, kind);
+      assertOk(latest);
+      expect(latest.value.version).toBe("3.0.0");
+      expect(latest.value.brickId).toBe(brickId("brick_v3"));
+
+      // resolve specific 1.0.0 → correct brickId
+      const specific = await versionIndex.resolve(name, kind, "1.0.0");
+      assertOk(specific);
+      expect(specific.value.brickId).toBe(brickId("brick_v1"));
+
+      // Deprecate 2.0.0
+      const deprecateResult = await versionIndex.deprecate(name, kind, "2.0.0");
+      assertOk(deprecateResult);
+
+      // resolveLatest still returns 3.0.0
+      const latestAfter = await versionIndex.resolveLatest(name, kind);
+      assertOk(latestAfter);
+      expect(latestAfter.value.version).toBe("3.0.0");
+
+      // listVersions → all 3 present with correct deprecated flags
+      const allVersions = await versionIndex.listVersions(name, kind);
+      assertOk(allVersions);
+      expect(allVersions.value.length).toBe(3);
+
+      // v3 (latest) should be first, not deprecated
+      expect(allVersions.value[0]?.version).toBe("3.0.0");
+      expect(allVersions.value[0]?.deprecated).toBeUndefined();
+
+      // v2 should be deprecated
+      expect(allVersions.value[1]?.version).toBe("2.0.0");
+      expect(allVersions.value[1]?.deprecated).toBe(true);
+
+      // v1 should not be deprecated
+      expect(allVersions.value[2]?.version).toBe("1.0.0");
+      expect(allVersions.value[2]?.deprecated).toBeUndefined();
+
+      versionIndex.close();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 5: Full pipeline — all 3 registries + middleware + real LLM
+  // -------------------------------------------------------------------------
+
+  test(
+    "full pipeline: all 3 SQLite registries + observer middleware + real LLM",
+    async () => {
+      const db = new Database(":memory:");
+
+      // Wire all 3 registries on shared :memory: DB
+      const brickRegistry = createSqliteBrickRegistry({ db });
+      const skillRegistry = createSqliteSkillRegistry({ db });
+      const versionIndex = createSqliteVersionIndex({ db });
+
+      // Track onChange events from BrickRegistry (subscribe BEFORE mutations)
+      const brickEvents: BrickRegistryChangeEvent[] = [];
+      if (brickRegistry.onChange !== undefined) {
+        brickRegistry.onChange((evt) => {
+          brickEvents.push(evt);
+        });
+      }
+
+      // Register tool in BrickRegistry
+      const artifact = createTestToolArtifact({
+        id: brickId("brick_multiply_e2e"),
+        name: "multiply",
+        description: "Multiplies two numbers. Returns the product as a string.",
+        implementation: "return String(Number(input.a) * Number(input.b));",
+        inputSchema: {
+          type: "object",
+          properties: {
+            a: { type: "number" },
+            b: { type: "number" },
+          },
+          required: ["a", "b"],
+        },
+      });
+      assertOk(await brickRegistry.register(artifact));
+
+      // Publish matching version in VersionIndex
+      const pub = publisherId("pub_e2e");
+      assertOk(
+        await versionIndex.publish("multiply", "tool", "0.0.1", brickId("brick_multiply_e2e"), pub),
+      );
+
+      // Observer middleware — captures tool call names
+      const toolCallNames: string[] = [];
+      const observer: KoiMiddleware = {
+        name: "e2e-observer",
+        wrapToolCall: async (
+          _ctx: unknown,
+          req: ToolRequest,
+          next: (r: ToolRequest) => Promise<ToolResponse>,
+        ) => {
+          toolCallNames.push(req.toolId);
+          return next(req);
+        },
+      };
+
+      // Build provider with the real multiply tool
+      const multiplyTool = createMultiplyTool();
+      const provider = createToolProvider([multiplyTool]);
+
+      // Full L1 runtime with createPiAdapter (supports tool calling)
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the multiply tool to answer math questions. Do not compute in your head. Always use the tool.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        providers: [provider],
+        middleware: [observer],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use the multiply tool to compute 9 * 11. Tell me the result.",
+        }),
+      );
+      await runtime.dispose();
+
+      // Assert: done with valid output
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason === "completed" || output?.stopReason === "max_turns").toBe(true);
+
+      // Assert: middleware intercepted the tool call
+      expect(toolCallNames).toContain("multiply");
+
+      // Assert: text response contains 99
+      const text = extractText(events);
+      expect(text).toContain("99");
+
+      // Assert: BrickRegistry registered event was fired earlier
+      // (fired during register(), before the LLM run)
+      expect(brickEvents.some((e) => e.kind === "registered")).toBe(true);
+
+      // Verify VersionIndex entry is queryable
+      const versionResult = await versionIndex.resolveLatest("multiply", "tool");
+      assertOk(versionResult);
+      expect(versionResult.value.version).toBe("0.0.1");
+
+      brickRegistry.close();
+      skillRegistry.close();
+      versionIndex.close();
+    },
+    TIMEOUT_MS,
+  );
+
+  // -------------------------------------------------------------------------
+  // Test 6: onChange events during registry mutations
+  // -------------------------------------------------------------------------
+
+  test(
+    "onChange events fire correctly during registry mutations",
+    async () => {
+      const db = new Database(":memory:");
+
+      const brickRegistry = createSqliteBrickRegistry({ db });
+      const skillRegistry = createSqliteSkillRegistry({ db });
+      const versionIndex = createSqliteVersionIndex({ db });
+
+      // --- BrickRegistry events ---
+      const brickEvents: BrickRegistryChangeEvent[] = [];
+      if (brickRegistry.onChange !== undefined) {
+        brickRegistry.onChange((evt) => {
+          brickEvents.push(evt);
+        });
+      }
+
+      // register → "registered"
+      const toolArtifact = createTestToolArtifact({
+        id: brickId("brick_eventtool"),
+        name: "eventtool",
+        description: "A tool for event testing",
+      });
+      assertOk(await brickRegistry.register(toolArtifact));
+      expect(brickEvents.length).toBe(1);
+      expect(brickEvents[0]?.kind).toBe("registered");
+
+      // re-register (update) → "updated"
+      const updatedArtifact = createTestToolArtifact({
+        id: brickId("brick_eventtool"),
+        name: "eventtool",
+        description: "Updated description",
+      });
+      assertOk(await brickRegistry.register(updatedArtifact));
+      expect(brickEvents.length).toBe(2);
+      expect(brickEvents[1]?.kind).toBe("updated");
+
+      // unregister → "unregistered"
+      assertOk(await brickRegistry.unregister("tool", "eventtool"));
+      expect(brickEvents.length).toBe(3);
+      expect(brickEvents[2]?.kind).toBe("unregistered");
+
+      // --- SkillRegistry events ---
+      const skillEvents: SkillRegistryChangeEvent[] = [];
+      if (skillRegistry.onChange !== undefined) {
+        skillRegistry.onChange((evt) => {
+          skillEvents.push(evt);
+        });
+      }
+
+      const sid = skillId("skill_eventskill");
+
+      // publish → "published"
+      assertOk(
+        await skillRegistry.publish({
+          id: sid,
+          name: "eventskill",
+          description: "A skill for event testing",
+          tags: ["test"],
+          version: "1.0.0",
+          content: "# Event Skill",
+        }),
+      );
+      expect(skillEvents.length).toBe(1);
+      expect(skillEvents[0]?.kind).toBe("published");
+
+      // deprecate → "deprecated"
+      assertOk(await skillRegistry.deprecate(sid, "1.0.0"));
+      expect(skillEvents.length).toBe(2);
+      expect(skillEvents[1]?.kind).toBe("deprecated");
+
+      // unpublish → "unpublished"
+      assertOk(await skillRegistry.unpublish(sid));
+      expect(skillEvents.length).toBe(3);
+      expect(skillEvents[2]?.kind).toBe("unpublished");
+
+      // --- VersionIndex events ---
+      const versionEvents: VersionChangeEvent[] = [];
+      if (versionIndex.onChange !== undefined) {
+        versionIndex.onChange((evt) => {
+          versionEvents.push(evt);
+        });
+      }
+
+      const pub = publisherId("pub_eventtester");
+
+      // publish → "published"
+      assertOk(
+        await versionIndex.publish("eventbrick", "tool", "1.0.0", brickId("brick_eventv1"), pub),
+      );
+      expect(versionEvents.length).toBe(1);
+      expect(versionEvents[0]?.kind).toBe("published");
+
+      // deprecate → "deprecated"
+      assertOk(await versionIndex.deprecate("eventbrick", "tool", "1.0.0"));
+      expect(versionEvents.length).toBe(2);
+      expect(versionEvents[1]?.kind).toBe("deprecated");
+
+      brickRegistry.close();
+      skillRegistry.close();
+      versionIndex.close();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/registry-store/src/__tests__/fts-sanitize.test.ts
+++ b/packages/registry-store/src/__tests__/fts-sanitize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeFtsQuery } from "../fts-sanitize.js";
+
+describe("sanitizeFtsQuery", () => {
+  test("passes through plain text", () => {
+    expect(sanitizeFtsQuery("hello world")).toBe("hello world");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(sanitizeFtsQuery("")).toBe("");
+  });
+
+  test("returns empty string for whitespace-only input", () => {
+    expect(sanitizeFtsQuery("   ")).toBe("");
+  });
+
+  test("strips double quotes", () => {
+    expect(sanitizeFtsQuery('"exact phrase"')).toBe("exact phrase");
+  });
+
+  test("strips asterisks (prefix queries)", () => {
+    expect(sanitizeFtsQuery("hel*")).toBe("hel");
+  });
+
+  test("strips carets (boost)", () => {
+    expect(sanitizeFtsQuery("important^2")).toBe("important 2");
+  });
+
+  test("strips parentheses", () => {
+    expect(sanitizeFtsQuery("(foo OR bar)")).toBe("foo bar");
+  });
+
+  test("strips curly braces", () => {
+    expect(sanitizeFtsQuery("{column}")).toBe("column");
+  });
+
+  test("strips colons (column filters)", () => {
+    expect(sanitizeFtsQuery("name:value")).toBe("name value");
+  });
+
+  test("removes AND operator", () => {
+    expect(sanitizeFtsQuery("foo AND bar")).toBe("foo bar");
+  });
+
+  test("removes OR operator", () => {
+    expect(sanitizeFtsQuery("foo OR bar")).toBe("foo bar");
+  });
+
+  test("removes NOT operator", () => {
+    expect(sanitizeFtsQuery("NOT bad")).toBe("bad");
+  });
+
+  test("removes NEAR operator", () => {
+    expect(sanitizeFtsQuery("foo NEAR bar")).toBe("foo bar");
+  });
+
+  test("removes operators case-insensitively", () => {
+    expect(sanitizeFtsQuery("foo and bar or baz")).toBe("foo bar baz");
+  });
+
+  test("does not strip operators embedded in words", () => {
+    expect(sanitizeFtsQuery("android notebook")).toBe("android notebook");
+  });
+
+  test("collapses multiple spaces", () => {
+    expect(sanitizeFtsQuery("foo   bar   baz")).toBe("foo bar baz");
+  });
+
+  test("handles combined edge case", () => {
+    expect(sanitizeFtsQuery('"hello" AND world* NOT (bad)')).toBe("hello world bad");
+  });
+});

--- a/packages/registry-store/src/__tests__/schema.test.ts
+++ b/packages/registry-store/src/__tests__/schema.test.ts
@@ -1,0 +1,106 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { applyRegistryMigrations } from "../schema.js";
+
+function createDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA foreign_keys = ON");
+  return db;
+}
+
+function tableNames(db: Database): readonly string[] {
+  const rows = db
+    .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+    .all();
+  return rows.map((r) => r.name);
+}
+
+function virtualTableNames(db: Database): readonly string[] {
+  // FTS5 creates shadow tables; check for the main FTS tables via sqlite_master
+  const ftsRows = db
+    .query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('bricks_fts', 'skills_fts') ORDER BY name",
+    )
+    .all();
+  return ftsRows.map((r) => r.name);
+}
+
+function indexNames(db: Database): readonly string[] {
+  const rows = db
+    .query<{ name: string }, []>(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )
+    .all();
+  return rows.map((r) => r.name);
+}
+
+function getUserVersion(db: Database): number {
+  const row = db.query<{ user_version: number }, []>("PRAGMA user_version").get();
+  return row?.user_version ?? 0;
+}
+
+describe("applyRegistryMigrations", () => {
+  test("creates all tables on fresh database", () => {
+    const db = createDb();
+    applyRegistryMigrations(db);
+
+    const tables = tableNames(db);
+    expect(tables).toContain("bricks");
+    expect(tables).toContain("brick_tags");
+    expect(tables).toContain("skills");
+    expect(tables).toContain("skill_tags");
+    expect(tables).toContain("skill_versions");
+    expect(tables).toContain("versions");
+  });
+
+  test("creates FTS5 virtual tables", () => {
+    const db = createDb();
+    applyRegistryMigrations(db);
+
+    const fts = virtualTableNames(db);
+    expect(fts).toContain("bricks_fts");
+    expect(fts).toContain("skills_fts");
+  });
+
+  test("creates expected indexes", () => {
+    const db = createDb();
+    applyRegistryMigrations(db);
+
+    const indexes = indexNames(db);
+    expect(indexes).toContain("idx_bricks_kind");
+    expect(indexes).toContain("idx_bricks_cursor");
+    expect(indexes).toContain("idx_brick_tags_tag");
+    expect(indexes).toContain("idx_skills_cursor");
+    expect(indexes).toContain("idx_skill_tags_tag");
+    expect(indexes).toContain("idx_sv_skill_published");
+    expect(indexes).toContain("idx_versions_lookup");
+  });
+
+  test("sets user_version to 1", () => {
+    const db = createDb();
+    applyRegistryMigrations(db);
+
+    expect(getUserVersion(db)).toBe(1);
+  });
+
+  test("calling twice is idempotent", () => {
+    const db = createDb();
+    applyRegistryMigrations(db);
+    applyRegistryMigrations(db);
+
+    expect(getUserVersion(db)).toBe(1);
+    const tables = tableNames(db);
+    expect(tables).toContain("bricks");
+    expect(tables).toContain("skills");
+    expect(tables).toContain("versions");
+  });
+
+  test("skips migration when user_version is already current", () => {
+    const db = createDb();
+    db.exec("PRAGMA user_version = 1");
+
+    // Should not throw even though tables don't exist
+    applyRegistryMigrations(db);
+    expect(getUserVersion(db)).toBe(1);
+  });
+});

--- a/packages/registry-store/src/__tests__/skill-registry.test.ts
+++ b/packages/registry-store/src/__tests__/skill-registry.test.ts
@@ -1,0 +1,197 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type { SkillPublishRequest } from "@koi/core";
+import { skillId } from "@koi/core";
+import { assertOk, testSkillRegistryContract } from "@koi/test-utils";
+import { createSqliteSkillRegistry } from "../skill-registry.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA foreign_keys = ON");
+  return db;
+}
+
+function makeReq(overrides?: Partial<SkillPublishRequest>): SkillPublishRequest {
+  return {
+    id: skillId("test-skill"),
+    name: "Test Skill",
+    description: "A skill for testing",
+    tags: ["test", "contract"],
+    version: "1.0.0",
+    content: "# Test Skill\n\nHello world",
+    author: "tester",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+describe("SqliteSkillRegistry", () => {
+  testSkillRegistryContract({
+    createRegistry: () => {
+      return createSqliteSkillRegistry({ db: createDb() });
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // SQLite-specific tests
+  // -------------------------------------------------------------------------
+
+  describe("multi-version storage", () => {
+    test("stores and retrieves multiple versions", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("multi-ver");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0", content: "v1" })));
+      assertOk(await registry.publish(makeReq({ id, version: "2.0.0", content: "v2" })));
+      assertOk(await registry.publish(makeReq({ id, version: "3.0.0", content: "v3" })));
+
+      const result = await registry.versions(id);
+      assertOk(result);
+      expect(result.value.length).toBe(3);
+      expect(result.value[0]?.version).toBe("3.0.0");
+      expect(result.value[2]?.version).toBe("1.0.0");
+    });
+  });
+
+  describe("download counting", () => {
+    test("tracks downloads across multiple installs", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const req = makeReq();
+      assertOk(await registry.publish(req));
+
+      for (let i = 0; i < 5; i++) {
+        assertOk(await registry.install(req.id));
+      }
+
+      const result = await registry.get(req.id);
+      assertOk(result);
+      expect(result.value.downloads).toBe(5);
+    });
+  });
+
+  describe("content retrieval", () => {
+    test("installs specific version content", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("content-test");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0", content: "# V1" })));
+      assertOk(await registry.publish(makeReq({ id, version: "2.0.0", content: "# V2" })));
+
+      const v1 = await registry.install(id, "1.0.0");
+      assertOk(v1);
+      expect(v1.value.content).toBe("# V1");
+
+      const v2 = await registry.install(id, "2.0.0");
+      assertOk(v2);
+      expect(v2.value.content).toBe("# V2");
+    });
+
+    test("latest install gets newest version content", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("latest-content");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0", content: "old" })));
+      assertOk(await registry.publish(makeReq({ id, version: "2.0.0", content: "new" })));
+
+      const result = await registry.install(id);
+      assertOk(result);
+      expect(result.value.content).toBe("new");
+    });
+  });
+
+  describe("FTS5 search", () => {
+    test("finds skills by name", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+
+      assertOk(await registry.publish(makeReq({ id: skillId("alpha"), name: "Alpha Analyzer" })));
+      assertOk(
+        await registry.publish(
+          makeReq({ id: skillId("beta"), name: "Beta Builder", version: "1.0.0" }),
+        ),
+      );
+
+      const page = await registry.search({ text: "alpha" });
+      expect(page.items.length).toBe(1);
+      expect(page.items[0]?.name).toBe("Alpha Analyzer");
+    });
+
+    test("finds skills by description", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+
+      assertOk(
+        await registry.publish(
+          makeReq({ id: skillId("desc"), description: "handles complex workflows" }),
+        ),
+      );
+
+      const page = await registry.search({ text: "workflows" });
+      expect(page.items.length).toBe(1);
+    });
+  });
+
+  describe("deprecate idempotency", () => {
+    test("deprecating an already-deprecated version succeeds", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("deprecate-test");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0" })));
+
+      // First deprecate
+      const first = await registry.deprecate(id, "1.0.0");
+      assertOk(first);
+
+      // Second deprecate — should not fail
+      const second = await registry.deprecate(id, "1.0.0");
+      assertOk(second);
+
+      // Verify version is still deprecated
+      const vers = await registry.versions(id);
+      assertOk(vers);
+      expect(vers.value[0]?.deprecated).toBe(true);
+    });
+
+    test("deprecating a non-existent version returns not-found", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("no-ver");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0" })));
+
+      const result = await registry.deprecate(id, "99.0.0");
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("cascade delete on unpublish", () => {
+    test("unpublish removes versions and tags", async () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      const id = skillId("cascade-skill");
+
+      assertOk(await registry.publish(makeReq({ id, version: "1.0.0", tags: ["x", "y"] })));
+      assertOk(await registry.publish(makeReq({ id, version: "2.0.0", tags: ["x", "y"] })));
+
+      assertOk(await registry.unpublish(id));
+
+      // Skill no longer findable
+      const result = await registry.get(id);
+      expect(result.ok).toBe(false);
+
+      // Tags don't pollute search
+      const page = await registry.search({ tags: ["x"] });
+      expect(page.items.length).toBe(0);
+    });
+  });
+
+  describe("close()", () => {
+    test("close does not throw", () => {
+      const registry = createSqliteSkillRegistry({ db: createDb() });
+      registry.close();
+    });
+  });
+});

--- a/packages/registry-store/src/__tests__/version-index.test.ts
+++ b/packages/registry-store/src/__tests__/version-index.test.ts
@@ -1,0 +1,71 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { brickId, publisherId } from "@koi/core";
+import { assertOk, testVersionIndexContract } from "@koi/test-utils";
+import { createSqliteVersionIndex } from "../version-index.js";
+
+// ---------------------------------------------------------------------------
+// Contract tests
+// ---------------------------------------------------------------------------
+
+describe("SqliteVersionIndex", () => {
+  testVersionIndexContract({
+    createIndex: () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      return createSqliteVersionIndex({ db });
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // SQLite-specific tests
+  // -------------------------------------------------------------------------
+
+  describe("publisher tracking", () => {
+    test("preserves publisher from original publish on idempotent re-publish", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const index = createSqliteVersionIndex({ db });
+
+      const alice = publisherId("alice");
+      const bid = brickId("sha256-aaa");
+
+      assertOk(await index.publish("calc", "tool", "1.0.0", bid, alice));
+
+      // Re-publish same version (idempotent) — publisher should remain alice
+      const result = await index.publish("calc", "tool", "1.0.0", bid, alice);
+      assertOk(result);
+      expect(result.value.publisher).toBe(alice);
+    });
+  });
+
+  describe("large version lists", () => {
+    test("handles many versions for same brick", async () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const index = createSqliteVersionIndex({ db });
+
+      const pub = publisherId("publisher");
+      for (let i = 0; i < 20; i++) {
+        const version = `${i}.0.0`;
+        const bid = brickId(`sha256-${i}`);
+        assertOk(await index.publish("big-brick", "tool", version, bid, pub));
+      }
+
+      const result = await index.listVersions("big-brick", "tool");
+      assertOk(result);
+      expect(result.value.length).toBe(20);
+      // Newest first — version "19.0.0" should be first
+      expect(result.value[0]?.version).toBe("19.0.0");
+    });
+  });
+
+  describe("close()", () => {
+    test("close does not throw", () => {
+      const db = new Database(":memory:");
+      db.run("PRAGMA foreign_keys = ON");
+      const index = createSqliteVersionIndex({ db });
+      index.close();
+    });
+  });
+});

--- a/packages/registry-store/src/brick-registry.ts
+++ b/packages/registry-store/src/brick-registry.ts
@@ -1,0 +1,332 @@
+/**
+ * SQLite-backed BrickRegistry implementation.
+ *
+ * Stores full BrickArtifact JSON in a `data` column with indexed columns
+ * for filtering. FTS5 contentless table for full-text search. Tags stored
+ * in a junction table for AND-subset filtering.
+ */
+
+import type { Database } from "bun:sqlite";
+import type {
+  BrickArtifact,
+  BrickKind,
+  BrickPage,
+  BrickRegistryBackend,
+  BrickRegistryChangeEvent,
+  BrickSearchQuery,
+  KoiError,
+  Result,
+} from "@koi/core";
+import { DEFAULT_BRICK_SEARCH_LIMIT, notFound } from "@koi/core";
+import { wrapSqlite } from "@koi/sqlite-utils";
+import type { RegistryStoreConfig } from "./config.js";
+import { resolveDb } from "./config.js";
+import { decodeCursor, encodeCursor } from "./cursor.js";
+import { sanitizeFtsQuery } from "./fts-sanitize.js";
+import { createListenerSet } from "./listeners.js";
+import { applyRegistryMigrations } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+interface BrickRow {
+  readonly rowid: number;
+  readonly created_at: number;
+  readonly data: string;
+}
+
+interface CountRow {
+  readonly cnt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Search filter builder
+// ---------------------------------------------------------------------------
+
+interface FilterClause {
+  readonly parts: readonly string[];
+  readonly params: readonly (string | number)[];
+}
+
+/** Build WHERE filter parts for brick search (without cursor). */
+function buildBrickFilter(db: Database, query: BrickSearchQuery): FilterClause | null {
+  const parts: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (query.text !== undefined && query.text.trim() !== "") {
+    const sanitized = sanitizeFtsQuery(query.text);
+    if (sanitized !== "") {
+      const ftsRows = db
+        .query<{ rowid: number }, [string]>("SELECT rowid FROM bricks_fts WHERE bricks_fts MATCH ?")
+        .all(sanitized);
+      if (ftsRows.length === 0) return null; // early exit — no matches
+      parts.push(`b.rowid IN (${ftsRows.map((r) => r.rowid).join(",")})`);
+    }
+  }
+
+  if (query.kind !== undefined) {
+    parts.push("b.kind = ?");
+    params.push(query.kind);
+  }
+
+  if (query.tags !== undefined && query.tags.length > 0) {
+    const placeholders = query.tags.map(() => "?").join(", ");
+    parts.push(
+      `(SELECT COUNT(DISTINCT t.tag) FROM brick_tags t
+        WHERE t.brick_rowid = b.rowid AND t.tag IN (${placeholders})) = ?`,
+    );
+    for (const tag of query.tags) {
+      params.push(tag);
+    }
+    params.push(query.tags.length);
+  }
+
+  return { parts, params };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface SqliteBrickRegistry extends BrickRegistryBackend {
+  readonly close: () => void;
+}
+
+export function createSqliteBrickRegistry(config: RegistryStoreConfig): SqliteBrickRegistry {
+  const { db, ownsDb } = resolveDb(config);
+  applyRegistryMigrations(db);
+
+  const listeners = createListenerSet<BrickRegistryChangeEvent>();
+
+  // -------------------------------------------------------------------------
+  // FTS helpers
+  // -------------------------------------------------------------------------
+
+  function insertFts(
+    rowid: number,
+    name: string,
+    description: string,
+    tags: readonly string[],
+  ): void {
+    db.run("INSERT INTO bricks_fts(rowid, name, description, tags) VALUES (?, ?, ?, ?)", [
+      rowid,
+      name,
+      description,
+      tags.join(" "),
+    ]);
+  }
+
+  function deleteFts(rowid: number): void {
+    db.run(
+      "INSERT INTO bricks_fts(bricks_fts, rowid, name, description, tags) VALUES ('delete', ?, '', '', '')",
+      [rowid],
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Contract: register
+  // -------------------------------------------------------------------------
+
+  const register = (brick: BrickArtifact): Result<void, KoiError> => {
+    const data = JSON.stringify(brick);
+    const now = Date.now();
+
+    /* let — justified: set inside transaction, read outside */
+    let isUpdate = false;
+
+    const result = wrapSqlite(() => {
+      db.transaction(() => {
+        const existing = db
+          .query<{ rowid: number }, [string, string]>(
+            "SELECT rowid FROM bricks WHERE kind = ? AND name = ?",
+          )
+          .get(brick.kind, brick.name);
+
+        if (existing !== null) {
+          isUpdate = true;
+          db.run(
+            `UPDATE bricks SET brick_id = ?, description = ?, scope = ?, trust_tier = ?,
+             lifecycle = ?, version = ?, usage_count = ?, created_at = ?, data = ?
+             WHERE rowid = ?`,
+            [
+              brick.id,
+              brick.description,
+              brick.scope,
+              brick.trustTier,
+              brick.lifecycle,
+              brick.version,
+              brick.usageCount,
+              now,
+              data,
+              existing.rowid,
+            ],
+          );
+          db.run("DELETE FROM brick_tags WHERE brick_rowid = ?", [existing.rowid]);
+          for (const tag of brick.tags) {
+            db.run("INSERT INTO brick_tags (brick_rowid, tag) VALUES (?, ?)", [
+              existing.rowid,
+              tag,
+            ]);
+          }
+          deleteFts(existing.rowid);
+          insertFts(existing.rowid, brick.name, brick.description, brick.tags);
+        } else {
+          db.run(
+            `INSERT INTO bricks (brick_id, kind, name, description, scope, trust_tier,
+             lifecycle, version, usage_count, created_at, data)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              brick.id,
+              brick.kind,
+              brick.name,
+              brick.description,
+              brick.scope,
+              brick.trustTier,
+              brick.lifecycle,
+              brick.version,
+              brick.usageCount,
+              now,
+              data,
+            ],
+          );
+          const inserted = db
+            .query<{ rowid: number }, [string, string]>(
+              "SELECT rowid FROM bricks WHERE kind = ? AND name = ?",
+            )
+            .get(brick.kind, brick.name);
+          const newRowid = inserted?.rowid ?? 0;
+          for (const tag of brick.tags) {
+            db.run("INSERT INTO brick_tags (brick_rowid, tag) VALUES (?, ?)", [newRowid, tag]);
+          }
+          insertFts(newRowid, brick.name, brick.description, brick.tags);
+        }
+      })();
+    }, "brick.register");
+
+    if (!result.ok) return result;
+
+    listeners.notify({
+      kind: isUpdate ? "updated" : "registered",
+      brickKind: brick.kind,
+      name: brick.name,
+    });
+
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: unregister
+  // -------------------------------------------------------------------------
+
+  const unregister = (kind: BrickKind, name: string): Result<void, KoiError> => {
+    const existing = db
+      .query<{ rowid: number }, [string, string]>(
+        "SELECT rowid FROM bricks WHERE kind = ? AND name = ?",
+      )
+      .get(kind, name);
+
+    if (existing === null) {
+      return { ok: false, error: notFound(`${kind}:${name}`) };
+    }
+
+    const result = wrapSqlite(() => {
+      db.transaction(() => {
+        deleteFts(existing.rowid);
+        db.run("DELETE FROM bricks WHERE rowid = ?", [existing.rowid]);
+      })();
+    }, "brick.unregister");
+
+    if (!result.ok) return result;
+
+    listeners.notify({ kind: "unregistered", brickKind: kind, name });
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: get
+  // -------------------------------------------------------------------------
+
+  const get = (kind: BrickKind, name: string): Result<BrickArtifact, KoiError> => {
+    const row = db
+      .query<{ data: string }, [string, string]>(
+        "SELECT data FROM bricks WHERE kind = ? AND name = ?",
+      )
+      .get(kind, name);
+
+    if (row === null) {
+      return { ok: false, error: notFound(`${kind}:${name}`) };
+    }
+
+    return { ok: true, value: JSON.parse(row.data) as BrickArtifact };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: search
+  // -------------------------------------------------------------------------
+
+  const search = (query: BrickSearchQuery): BrickPage => {
+    const limit = query.limit ?? DEFAULT_BRICK_SEARCH_LIMIT;
+    const filter = buildBrickFilter(db, query);
+    if (filter === null) return { items: [], total: 0 };
+
+    const filterWhere = filter.parts.length > 0 ? `WHERE ${filter.parts.join(" AND ")}` : "";
+    const countRow = db
+      .prepare<CountRow, (string | number)[]>(`SELECT COUNT(*) as cnt FROM bricks b ${filterWhere}`)
+      .get(...filter.params);
+    const total = countRow?.cnt ?? 0;
+
+    // Append cursor keyset condition for page query
+    const pageParts = [...filter.parts];
+    const pageParams: (string | number)[] = [...filter.params];
+    if (query.cursor !== undefined) {
+      const decoded = decodeCursor(query.cursor);
+      if (decoded !== undefined) {
+        pageParts.push("(b.created_at < ? OR (b.created_at = ? AND b.rowid < ?))");
+        pageParams.push(decoded.sortKey, decoded.sortKey, decoded.rowid);
+      }
+    }
+
+    const pageWhere = pageParts.length > 0 ? `WHERE ${pageParts.join(" AND ")}` : "";
+    const rows = db
+      .prepare<BrickRow, (string | number)[]>(
+        `SELECT b.rowid, b.created_at, b.data FROM bricks b ${pageWhere}
+         ORDER BY b.created_at DESC, b.rowid DESC LIMIT ?`,
+      )
+      .all(...pageParams, limit + 1);
+
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const items = pageRows.map((r) => JSON.parse(r.data) as BrickArtifact);
+    const lastRow = pageRows[pageRows.length - 1];
+    const nextCursor =
+      hasMore && lastRow !== undefined
+        ? encodeCursor(lastRow.created_at, lastRow.rowid)
+        : undefined;
+
+    const base = { items, total };
+    return nextCursor !== undefined ? { ...base, cursor: nextCursor } : base;
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: onChange
+  // -------------------------------------------------------------------------
+
+  const onChange = (listener: (event: BrickRegistryChangeEvent) => void): (() => void) => {
+    return listeners.add(listener);
+  };
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  const close = (): void => {
+    listeners.clear();
+    db.run("PRAGMA optimize");
+    if (ownsDb) {
+      db.close();
+    }
+  };
+
+  return { register, unregister, get, search, onChange, close };
+}

--- a/packages/registry-store/src/config.ts
+++ b/packages/registry-store/src/config.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared configuration for registry-store factories.
+ *
+ * Resolves a Database instance from either a file path or an injected Database.
+ * Caller owns lifecycle when injecting; factory owns it when creating from path.
+ */
+
+import type { Database } from "bun:sqlite";
+import { openDb } from "@koi/sqlite-utils";
+
+// ---------------------------------------------------------------------------
+// Config types
+// ---------------------------------------------------------------------------
+
+export interface RegistryStorePathConfig {
+  readonly dbPath: string;
+}
+
+export interface RegistryStoreDbConfig {
+  readonly db: Database;
+}
+
+export type RegistryStoreConfig = RegistryStorePathConfig | RegistryStoreDbConfig;
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+function isPathConfig(config: RegistryStoreConfig): config is RegistryStorePathConfig {
+  return "dbPath" in config;
+}
+
+export interface ResolvedDb {
+  readonly db: Database;
+  readonly ownsDb: boolean;
+}
+
+/** Resolve a Database from config. Returns ownership flag for close() logic. */
+export function resolveDb(config: RegistryStoreConfig): ResolvedDb {
+  if (isPathConfig(config)) {
+    return { db: openDb(config.dbPath), ownsDb: true };
+  }
+  return { db: config.db, ownsDb: false };
+}

--- a/packages/registry-store/src/cursor.ts
+++ b/packages/registry-store/src/cursor.ts
@@ -1,0 +1,30 @@
+/**
+ * Keyset cursor encoding/decoding for paginated queries.
+ *
+ * Encodes (sortKey, rowid) pairs as URL-safe base64 strings.
+ * Cursors are opaque to callers — only the registry can interpret them.
+ */
+
+/** Encode a keyset cursor from sort key and rowid. */
+export function encodeCursor(sortKey: number, rowid: number): string {
+  return Buffer.from(`${sortKey}:${rowid}`).toString("base64url");
+}
+
+/** Decode a keyset cursor back to sort key and rowid. Returns undefined on invalid input. */
+export function decodeCursor(
+  cursor: string,
+): { readonly sortKey: number; readonly rowid: number } | undefined {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const sep = decoded.indexOf(":");
+    if (sep === -1) return undefined;
+
+    const sortKey = Number(decoded.slice(0, sep));
+    const rowid = Number(decoded.slice(sep + 1));
+
+    if (!Number.isFinite(sortKey) || !Number.isFinite(rowid)) return undefined;
+    return { sortKey, rowid };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/registry-store/src/fts-sanitize.ts
+++ b/packages/registry-store/src/fts-sanitize.ts
@@ -1,0 +1,24 @@
+/**
+ * FTS5 query sanitization.
+ *
+ * Strips FTS5 operators and special characters from user input
+ * to prevent query syntax errors. Produces a safe plain-text query.
+ */
+
+/**
+ * Sanitize user input for use in FTS5 queries.
+ *
+ * Removes FTS5 operators (AND, OR, NOT, NEAR), column filters,
+ * quotes, parentheses, asterisks, and carets. Collapses whitespace.
+ * Returns empty string for blank/whitespace-only input.
+ */
+export function sanitizeFtsQuery(raw: string): string {
+  // Strip special FTS5 characters: " * ^ ( ) { } :
+  const stripped = raw.replace(/["*^(){}:]/g, " ");
+
+  // Remove FTS5 boolean operators (whole words only, case-insensitive)
+  const withoutOps = stripped.replace(/\b(AND|OR|NOT|NEAR)\b/gi, " ");
+
+  // Collapse whitespace and trim
+  return withoutOps.replace(/\s+/g, " ").trim();
+}

--- a/packages/registry-store/src/index.ts
+++ b/packages/registry-store/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @koi/registry-store — SQLite-backed BrickRegistry, SkillRegistry, and VersionIndex.
+ *
+ * Provides persistent implementations of the three L0 registry contracts
+ * using bun:sqlite with FTS5 full-text search, keyset cursor pagination,
+ * and onChange event dispatch.
+ */
+
+export type { SqliteBrickRegistry } from "./brick-registry.js";
+export { createSqliteBrickRegistry } from "./brick-registry.js";
+export type {
+  RegistryStoreConfig,
+  RegistryStoreDbConfig,
+  RegistryStorePathConfig,
+} from "./config.js";
+export type { SqliteSkillRegistry } from "./skill-registry.js";
+export { createSqliteSkillRegistry } from "./skill-registry.js";
+export type { SqliteVersionIndex } from "./version-index.js";
+export { createSqliteVersionIndex } from "./version-index.js";

--- a/packages/registry-store/src/listeners.ts
+++ b/packages/registry-store/src/listeners.ts
@@ -1,0 +1,46 @@
+/**
+ * Listener set utility for onChange event dispatch.
+ *
+ * Creates a typed listener set with add/remove/notify operations.
+ * Listeners are called synchronously. Individual listener errors
+ * are caught so one broken listener cannot block others.
+ */
+
+export interface ListenerSet<E> {
+  /** Add a listener. Returns unsubscribe function. */
+  readonly add: (listener: (event: E) => void) => () => void;
+  /** Notify all listeners of an event. */
+  readonly notify: (event: E) => void;
+  /** Remove all listeners. */
+  readonly clear: () => void;
+}
+
+/** Create a new listener set for events of type E. */
+export function createListenerSet<E>(): ListenerSet<E> {
+  const listeners = new Set<(event: E) => void>();
+
+  const add = (listener: (event: E) => void): (() => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const notify = (event: E): void => {
+    for (const listener of listeners) {
+      try {
+        listener(event);
+      } catch (_e: unknown) {
+        // Intentional: individual listener errors must not block other listeners
+        // or the mutation path. Callers providing listeners are responsible for
+        // their own error handling within the listener callback.
+      }
+    }
+  };
+
+  const clear = (): void => {
+    listeners.clear();
+  };
+
+  return { add, notify, clear };
+}

--- a/packages/registry-store/src/schema.ts
+++ b/packages/registry-store/src/schema.ts
@@ -1,0 +1,140 @@
+/**
+ * Registry store schema — V1 DDL and migration runner.
+ *
+ * Creates tables for BrickRegistry, SkillRegistry, and VersionIndex.
+ * Uses PRAGMA user_version for migration tracking. FTS5 tables use
+ * contentless mode with manual sync from application code.
+ */
+
+import type { Database } from "bun:sqlite";
+
+// ---------------------------------------------------------------------------
+// Schema version
+// ---------------------------------------------------------------------------
+
+const LATEST_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// V1 DDL
+// ---------------------------------------------------------------------------
+
+const V1_UP = `
+-- ═══════════════════════════════════════════════════════
+-- BRICK REGISTRY tables
+-- ═══════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS bricks (
+  rowid        INTEGER PRIMARY KEY,
+  brick_id     TEXT    NOT NULL,
+  kind         TEXT    NOT NULL,
+  name         TEXT    NOT NULL,
+  description  TEXT    NOT NULL DEFAULT '',
+  scope        TEXT    NOT NULL,
+  trust_tier   TEXT    NOT NULL,
+  lifecycle    TEXT    NOT NULL,
+  version      TEXT    NOT NULL,
+  usage_count  INTEGER NOT NULL DEFAULT 0,
+  created_at   INTEGER NOT NULL,
+  data         TEXT    NOT NULL,
+  UNIQUE (kind, name)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS brick_tags (
+  brick_rowid  INTEGER NOT NULL REFERENCES bricks(rowid) ON DELETE CASCADE,
+  tag          TEXT    NOT NULL,
+  PRIMARY KEY (brick_rowid, tag)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_bricks_kind ON bricks(kind);
+CREATE INDEX IF NOT EXISTS idx_bricks_cursor ON bricks(created_at DESC, rowid DESC);
+CREATE INDEX IF NOT EXISTS idx_brick_tags_tag ON brick_tags(tag);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS bricks_fts USING fts5(
+  name,
+  description,
+  tags,
+  content     = '',
+  tokenize    = 'unicode61 remove_diacritics 1'
+);
+
+-- ═══════════════════════════════════════════════════════
+-- SKILL REGISTRY tables
+-- ═══════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS skills (
+  rowid        INTEGER PRIMARY KEY,
+  skill_id     TEXT    NOT NULL UNIQUE,
+  name         TEXT    NOT NULL,
+  description  TEXT    NOT NULL DEFAULT '',
+  author       TEXT,
+  requires     TEXT,
+  published_at INTEGER NOT NULL,
+  downloads    INTEGER NOT NULL DEFAULT 0
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS skill_tags (
+  skill_rowid  INTEGER NOT NULL REFERENCES skills(rowid) ON DELETE CASCADE,
+  tag          TEXT    NOT NULL,
+  PRIMARY KEY (skill_rowid, tag)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS skill_versions (
+  rowid        INTEGER PRIMARY KEY,
+  skill_rowid  INTEGER NOT NULL REFERENCES skills(rowid) ON DELETE CASCADE,
+  version      TEXT    NOT NULL,
+  content      TEXT    NOT NULL,
+  integrity    TEXT,
+  published_at INTEGER NOT NULL,
+  deprecated   INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (skill_rowid, version)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_skills_cursor ON skills(published_at DESC, rowid DESC);
+CREATE INDEX IF NOT EXISTS idx_skill_tags_tag ON skill_tags(tag);
+CREATE INDEX IF NOT EXISTS idx_sv_skill_published ON skill_versions(skill_rowid, published_at DESC);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
+  name,
+  description,
+  tags,
+  content     = '',
+  tokenize    = 'unicode61 remove_diacritics 1'
+);
+
+-- ═══════════════════════════════════════════════════════
+-- VERSION INDEX tables
+-- ═══════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS versions (
+  rowid        INTEGER PRIMARY KEY,
+  name         TEXT    NOT NULL,
+  kind         TEXT    NOT NULL,
+  version      TEXT    NOT NULL,
+  brick_id     TEXT    NOT NULL,
+  publisher    TEXT    NOT NULL,
+  published_at INTEGER NOT NULL,
+  deprecated   INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (name, kind, version)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_versions_lookup
+  ON versions(name, kind, published_at DESC, rowid DESC);
+`;
+
+// ---------------------------------------------------------------------------
+// Migration runner
+// ---------------------------------------------------------------------------
+
+/** Apply registry schema migrations. Idempotent — safe to call on every open. */
+export function applyRegistryMigrations(db: Database): void {
+  const row = db.query<{ user_version: number }, []>("PRAGMA user_version").get();
+  const currentVersion = row?.user_version ?? 0;
+  if (currentVersion >= LATEST_VERSION) return;
+
+  db.transaction(() => {
+    if (currentVersion < 1) {
+      db.exec(V1_UP);
+    }
+    db.exec(`PRAGMA user_version = ${LATEST_VERSION}`);
+  })();
+}

--- a/packages/registry-store/src/skill-registry.ts
+++ b/packages/registry-store/src/skill-registry.ts
@@ -1,0 +1,596 @@
+/**
+ * SQLite-backed SkillRegistry implementation.
+ *
+ * Two-table design: `skills` for catalog entries + `skill_versions` for
+ * version-specific content. FTS5 for search, junction table for tags.
+ */
+
+import type { Database } from "bun:sqlite";
+import type {
+  BrickRequires,
+  ForgeProvenance,
+  KoiError,
+  Result,
+  SkillArtifact,
+  SkillId,
+  SkillPage,
+  SkillPublishRequest,
+  SkillRegistryBackend,
+  SkillRegistryChangeEvent,
+  SkillRegistryEntry,
+  SkillSearchQuery,
+  SkillVersion,
+} from "@koi/core";
+import { brickId, conflict, DEFAULT_SKILL_SEARCH_LIMIT, notFound, validation } from "@koi/core";
+import { wrapSqlite } from "@koi/sqlite-utils";
+import type { RegistryStoreConfig } from "./config.js";
+import { resolveDb } from "./config.js";
+import { decodeCursor, encodeCursor } from "./cursor.js";
+import { sanitizeFtsQuery } from "./fts-sanitize.js";
+import { createListenerSet } from "./listeners.js";
+import { applyRegistryMigrations } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+interface SkillRow {
+  readonly rowid: number;
+  readonly skill_id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly author: string | null;
+  readonly requires: string | null;
+  readonly published_at: number;
+  readonly downloads: number;
+}
+
+interface VersionRow {
+  readonly rowid: number;
+  readonly skill_rowid: number;
+  readonly version: string;
+  readonly content: string;
+  readonly integrity: string | null;
+  readonly published_at: number;
+  readonly deprecated: number;
+}
+
+interface CountRow {
+  readonly cnt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Default provenance for registry-installed skills
+// ---------------------------------------------------------------------------
+
+const REGISTRY_PROVENANCE: ForgeProvenance = {
+  source: { origin: "external", registry: "koi-registry-store", packageRef: "local" },
+  buildDefinition: {
+    buildType: "koi.registry/skill/v1",
+    externalParameters: {},
+  },
+  builder: { id: "koi.registry/install/v1", version: "0.0.0" },
+  metadata: {
+    invocationId: "registry-install",
+    startedAt: 0,
+    finishedAt: 0,
+    sessionId: "registry",
+    agentId: "registry",
+    depth: 0,
+  },
+  verification: {
+    passed: true,
+    finalTrustTier: "sandbox",
+    totalDurationMs: 0,
+    stageResults: [],
+  },
+  classification: "public",
+  contentMarkers: [],
+  contentHash: "",
+};
+
+// ---------------------------------------------------------------------------
+// Search filter builder
+// ---------------------------------------------------------------------------
+
+interface FilterClause {
+  readonly parts: readonly string[];
+  readonly params: readonly (string | number)[];
+}
+
+/** Build WHERE filter parts for skill search (without cursor). */
+function buildSkillFilter(db: Database, query: SkillSearchQuery): FilterClause | null {
+  const parts: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (query.text !== undefined && query.text.trim() !== "") {
+    const sanitized = sanitizeFtsQuery(query.text);
+    if (sanitized !== "") {
+      const ftsRows = db
+        .query<{ rowid: number }, [string]>("SELECT rowid FROM skills_fts WHERE skills_fts MATCH ?")
+        .all(sanitized);
+      if (ftsRows.length === 0) return null;
+      parts.push(`s.rowid IN (${ftsRows.map((r) => r.rowid).join(",")})`);
+    }
+  }
+
+  if (query.tags !== undefined && query.tags.length > 0) {
+    const placeholders = query.tags.map(() => "?").join(", ");
+    parts.push(
+      `(SELECT COUNT(DISTINCT t.tag) FROM skill_tags t
+        WHERE t.skill_rowid = s.rowid AND t.tag IN (${placeholders})) = ?`,
+    );
+    for (const tag of query.tags) {
+      params.push(tag);
+    }
+    params.push(query.tags.length);
+  }
+
+  if (query.author !== undefined) {
+    parts.push("s.author = ?");
+    params.push(query.author);
+  }
+
+  return { parts, params };
+}
+
+// ---------------------------------------------------------------------------
+// Batch tag loading (avoids N+1)
+// ---------------------------------------------------------------------------
+
+function loadTagsByRowids(
+  db: Database,
+  rowids: readonly number[],
+): ReadonlyMap<number, readonly string[]> {
+  if (rowids.length === 0) return new Map();
+  const placeholders = rowids.map(() => "?").join(",");
+  const rows = db
+    .prepare<{ skill_rowid: number; tag: string }, number[]>(
+      `SELECT skill_rowid, tag FROM skill_tags WHERE skill_rowid IN (${placeholders})`,
+    )
+    .all(...rowids);
+  const map = new Map<number, string[]>();
+  for (const r of rows) {
+    const existing = map.get(r.skill_rowid);
+    if (existing !== undefined) {
+      existing.push(r.tag);
+    } else {
+      map.set(r.skill_rowid, [r.tag]);
+    }
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface SqliteSkillRegistry extends SkillRegistryBackend {
+  readonly close: () => void;
+}
+
+export function createSqliteSkillRegistry(config: RegistryStoreConfig): SqliteSkillRegistry {
+  const { db, ownsDb } = resolveDb(config);
+  applyRegistryMigrations(db);
+
+  const listeners = createListenerSet<SkillRegistryChangeEvent>();
+
+  // -------------------------------------------------------------------------
+  // FTS helpers
+  // -------------------------------------------------------------------------
+
+  function insertFts(
+    rowid: number,
+    name: string,
+    description: string,
+    tags: readonly string[],
+  ): void {
+    db.run("INSERT INTO skills_fts(rowid, name, description, tags) VALUES (?, ?, ?, ?)", [
+      rowid,
+      name,
+      description,
+      tags.join(" "),
+    ]);
+  }
+
+  function deleteFts(rowid: number): void {
+    db.run(
+      "INSERT INTO skills_fts(skills_fts, rowid, name, description, tags) VALUES ('delete', ?, '', '', '')",
+      [rowid],
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  function isBlank(s: string): boolean {
+    return s.trim() === "";
+  }
+
+  function loadEntry(row: SkillRow, tags: readonly string[]): SkillRegistryEntry {
+    const latestVer = db
+      .query<{ version: string }, [number]>(
+        `SELECT version FROM skill_versions
+         WHERE skill_rowid = ? ORDER BY published_at DESC, rowid DESC LIMIT 1`,
+      )
+      .get(row.rowid);
+
+    const base: SkillRegistryEntry = {
+      id: row.skill_id as SkillId,
+      name: row.name,
+      description: row.description,
+      tags,
+      version: latestVer?.version ?? "",
+      publishedAt: row.published_at,
+    };
+
+    return {
+      ...base,
+      ...(row.author !== null ? { author: row.author } : {}),
+      ...(row.requires !== null ? { requires: JSON.parse(row.requires) as BrickRequires } : {}),
+      ...(row.downloads > 0 ? { downloads: row.downloads } : {}),
+    };
+  }
+
+  function getTagsForSkill(skillRowid: number): readonly string[] {
+    const rows = db
+      .query<{ tag: string }, [number]>("SELECT tag FROM skill_tags WHERE skill_rowid = ?")
+      .all(skillRowid);
+    return rows.map((r) => r.tag);
+  }
+
+  // -------------------------------------------------------------------------
+  // Contract: publish
+  // -------------------------------------------------------------------------
+
+  const publish = (request: SkillPublishRequest): Result<SkillRegistryEntry, KoiError> => {
+    if (isBlank(request.name)) {
+      return { ok: false, error: validation("Skill name must not be empty") };
+    }
+    if (isBlank(request.version)) {
+      return { ok: false, error: validation("Skill version must not be empty") };
+    }
+
+    const existing = db
+      .query<SkillRow, [string]>("SELECT * FROM skills WHERE skill_id = ?")
+      .get(request.id as string);
+
+    return existing !== null ? publishNewVersion(request, existing) : publishNewSkill(request);
+  };
+
+  function publishNewVersion(
+    request: SkillPublishRequest,
+    existing: SkillRow,
+  ): Result<SkillRegistryEntry, KoiError> {
+    const dupVer = db
+      .query<{ rowid: number }, [number, string]>(
+        "SELECT rowid FROM skill_versions WHERE skill_rowid = ? AND version = ?",
+      )
+      .get(existing.rowid, request.version);
+
+    if (dupVer !== null) {
+      return {
+        ok: false,
+        error: conflict(
+          request.id as string,
+          `Version ${request.version} already exists for skill ${request.id}`,
+        ),
+      };
+    }
+
+    const now = Date.now();
+    const result = wrapSqlite(() => {
+      db.transaction(() => {
+        db.run(
+          `UPDATE skills SET name = ?, description = ?, author = ?,
+           requires = ?, published_at = ? WHERE rowid = ?`,
+          [
+            request.name,
+            request.description,
+            request.author ?? null,
+            request.requires !== undefined ? JSON.stringify(request.requires) : null,
+            now,
+            existing.rowid,
+          ],
+        );
+        db.run("DELETE FROM skill_tags WHERE skill_rowid = ?", [existing.rowid]);
+        for (const tag of request.tags) {
+          db.run("INSERT INTO skill_tags (skill_rowid, tag) VALUES (?, ?)", [existing.rowid, tag]);
+        }
+        db.run(
+          `INSERT INTO skill_versions (skill_rowid, version, content, integrity, published_at)
+           VALUES (?, ?, ?, ?, ?)`,
+          [existing.rowid, request.version, request.content, request.integrity ?? null, now],
+        );
+        deleteFts(existing.rowid);
+        insertFts(existing.rowid, request.name, request.description, request.tags);
+      })();
+    }, "skill.publish");
+
+    if (!result.ok) return result;
+    listeners.notify({ kind: "published", skillId: request.id, version: request.version });
+
+    const updatedRow = db
+      .query<SkillRow, [string]>("SELECT * FROM skills WHERE skill_id = ?")
+      .get(request.id as string);
+    if (updatedRow === null) return { ok: false, error: notFound(request.id as string) };
+    return { ok: true, value: loadEntry(updatedRow, [...request.tags]) };
+  }
+
+  function publishNewSkill(request: SkillPublishRequest): Result<SkillRegistryEntry, KoiError> {
+    const now = Date.now();
+    const result = wrapSqlite(() => {
+      db.transaction(() => {
+        db.run(
+          `INSERT INTO skills (skill_id, name, description, author, requires, published_at)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            request.id as string,
+            request.name,
+            request.description,
+            request.author ?? null,
+            request.requires !== undefined ? JSON.stringify(request.requires) : null,
+            now,
+          ],
+        );
+        const inserted = db
+          .query<{ rowid: number }, [string]>("SELECT rowid FROM skills WHERE skill_id = ?")
+          .get(request.id as string);
+        const newRowid = inserted?.rowid ?? 0;
+        for (const tag of request.tags) {
+          db.run("INSERT INTO skill_tags (skill_rowid, tag) VALUES (?, ?)", [newRowid, tag]);
+        }
+        db.run(
+          `INSERT INTO skill_versions (skill_rowid, version, content, integrity, published_at)
+           VALUES (?, ?, ?, ?, ?)`,
+          [newRowid, request.version, request.content, request.integrity ?? null, now],
+        );
+        insertFts(newRowid, request.name, request.description, request.tags);
+      })();
+    }, "skill.publish");
+
+    if (!result.ok) return result;
+    listeners.notify({ kind: "published", skillId: request.id, version: request.version });
+
+    const newRow = db
+      .query<SkillRow, [string]>("SELECT * FROM skills WHERE skill_id = ?")
+      .get(request.id as string);
+    if (newRow === null) return { ok: false, error: notFound(request.id as string) };
+    return { ok: true, value: loadEntry(newRow, [...request.tags]) };
+  }
+
+  // -------------------------------------------------------------------------
+  // Contract: search
+  // -------------------------------------------------------------------------
+
+  const search = (query: SkillSearchQuery): SkillPage => {
+    const limit = query.limit ?? DEFAULT_SKILL_SEARCH_LIMIT;
+    const filter = buildSkillFilter(db, query);
+    if (filter === null) return { items: [], total: 0 };
+
+    const filterWhere = filter.parts.length > 0 ? `WHERE ${filter.parts.join(" AND ")}` : "";
+    const countRow = db
+      .prepare<CountRow, (string | number)[]>(`SELECT COUNT(*) as cnt FROM skills s ${filterWhere}`)
+      .get(...filter.params);
+    const total = countRow?.cnt ?? 0;
+
+    const pageParts = [...filter.parts];
+    const pageParams: (string | number)[] = [...filter.params];
+    if (query.cursor !== undefined) {
+      const decoded = decodeCursor(query.cursor);
+      if (decoded !== undefined) {
+        pageParts.push("(s.published_at < ? OR (s.published_at = ? AND s.rowid < ?))");
+        pageParams.push(decoded.sortKey, decoded.sortKey, decoded.rowid);
+      }
+    }
+
+    const pageWhere = pageParts.length > 0 ? `WHERE ${pageParts.join(" AND ")}` : "";
+    const rows = db
+      .prepare<SkillRow, (string | number)[]>(
+        `SELECT s.* FROM skills s ${pageWhere}
+         ORDER BY s.published_at DESC, s.rowid DESC LIMIT ?`,
+      )
+      .all(...pageParams, limit + 1);
+
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const tagMap = loadTagsByRowids(
+      db,
+      pageRows.map((r) => r.rowid),
+    );
+    const items = pageRows.map((r) => loadEntry(r, tagMap.get(r.rowid) ?? []));
+
+    const lastRow = pageRows[pageRows.length - 1];
+    const nextCursor =
+      hasMore && lastRow !== undefined
+        ? encodeCursor(lastRow.published_at, lastRow.rowid)
+        : undefined;
+    const base = { items, total };
+    return nextCursor !== undefined ? { ...base, cursor: nextCursor } : base;
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: get
+  // -------------------------------------------------------------------------
+
+  const get = (id: SkillId): Result<SkillRegistryEntry, KoiError> => {
+    const row = db
+      .query<SkillRow, [string]>("SELECT * FROM skills WHERE skill_id = ?")
+      .get(id as string);
+
+    if (row === null) {
+      return { ok: false, error: notFound(id as string, `Skill not found: ${id}`) };
+    }
+
+    return { ok: true, value: loadEntry(row, getTagsForSkill(row.rowid)) };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: versions
+  // -------------------------------------------------------------------------
+
+  const versions = (id: SkillId): Result<readonly SkillVersion[], KoiError> => {
+    const skill = db
+      .query<{ rowid: number }, [string]>("SELECT rowid FROM skills WHERE skill_id = ?")
+      .get(id as string);
+
+    if (skill === null) {
+      return { ok: false, error: notFound(id as string, `Skill not found: ${id}`) };
+    }
+
+    const rows = db
+      .query<VersionRow, [number]>(
+        `SELECT * FROM skill_versions
+         WHERE skill_rowid = ? ORDER BY published_at DESC, rowid DESC`,
+      )
+      .all(skill.rowid);
+
+    const result: readonly SkillVersion[] = rows.map((r) => {
+      const base: SkillVersion = { version: r.version, publishedAt: r.published_at };
+      const withIntegrity = r.integrity !== null ? { ...base, integrity: r.integrity } : base;
+      return r.deprecated === 1 ? { ...withIntegrity, deprecated: true } : withIntegrity;
+    });
+
+    return { ok: true, value: result };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: install (async satisfies L0 contract — this impl is sync)
+  // -------------------------------------------------------------------------
+
+  const install = async (
+    id: SkillId,
+    version?: string,
+  ): Promise<Result<SkillArtifact, KoiError>> => {
+    const skill = db
+      .query<SkillRow, [string]>("SELECT * FROM skills WHERE skill_id = ?")
+      .get(id as string);
+
+    if (skill === null) {
+      return { ok: false, error: notFound(id as string, `Skill not found: ${id}`) };
+    }
+
+    const versionRow =
+      version !== undefined
+        ? db
+            .query<VersionRow, [number, string]>(
+              "SELECT * FROM skill_versions WHERE skill_rowid = ? AND version = ?",
+            )
+            .get(skill.rowid, version)
+        : db
+            .query<VersionRow, [number]>(
+              `SELECT * FROM skill_versions WHERE skill_rowid = ?
+           ORDER BY published_at DESC, rowid DESC LIMIT 1`,
+            )
+            .get(skill.rowid);
+
+    if (versionRow === null) {
+      return {
+        ok: false,
+        error: notFound(id as string, `Version not found: ${version ?? "latest"}`),
+      };
+    }
+
+    db.run("UPDATE skills SET downloads = downloads + 1 WHERE rowid = ?", [skill.rowid]);
+
+    const artifact: SkillArtifact = {
+      id: brickId(id as string),
+      kind: "skill",
+      name: skill.name,
+      description: skill.description,
+      scope: "global",
+      trustTier: "sandbox",
+      lifecycle: "active",
+      provenance: REGISTRY_PROVENANCE,
+      version: versionRow.version,
+      tags: [...getTagsForSkill(skill.rowid)],
+      usageCount: 0,
+      content: versionRow.content,
+    };
+
+    return { ok: true, value: artifact };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: unpublish
+  // -------------------------------------------------------------------------
+
+  const unpublish = (id: SkillId): Result<void, KoiError> => {
+    const existing = db
+      .query<{ rowid: number }, [string]>("SELECT rowid FROM skills WHERE skill_id = ?")
+      .get(id as string);
+
+    if (existing === null) {
+      return { ok: false, error: notFound(id as string, `Skill not found: ${id}`) };
+    }
+
+    const result = wrapSqlite(() => {
+      db.transaction(() => {
+        deleteFts(existing.rowid);
+        db.run("DELETE FROM skills WHERE rowid = ?", [existing.rowid]);
+      })();
+    }, "skill.unpublish");
+
+    if (!result.ok) return result;
+
+    listeners.notify({ kind: "unpublished", skillId: id });
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: deprecate
+  // -------------------------------------------------------------------------
+
+  const deprecate = (id: SkillId, version: string): Result<void, KoiError> => {
+    const skill = db
+      .query<{ rowid: number }, [string]>("SELECT rowid FROM skills WHERE skill_id = ?")
+      .get(id as string);
+
+    if (skill === null) {
+      return { ok: false, error: notFound(id as string, `Skill not found: ${id}`) };
+    }
+
+    const versionRow = db
+      .query<{ rowid: number; deprecated: number }, [number, string]>(
+        "SELECT rowid, deprecated FROM skill_versions WHERE skill_rowid = ? AND version = ?",
+      )
+      .get(skill.rowid, version);
+
+    if (versionRow === null) {
+      return { ok: false, error: notFound(id as string, `Version not found: ${version}`) };
+    }
+
+    if (versionRow.deprecated === 0) {
+      const result = wrapSqlite(() => {
+        db.run("UPDATE skill_versions SET deprecated = 1 WHERE rowid = ?", [versionRow.rowid]);
+      }, "skill.deprecate");
+      if (!result.ok) return result;
+    }
+
+    listeners.notify({ kind: "deprecated", skillId: id, version });
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: onChange
+  // -------------------------------------------------------------------------
+
+  const onChange = (listener: (event: SkillRegistryChangeEvent) => void): (() => void) => {
+    return listeners.add(listener);
+  };
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  const close = (): void => {
+    listeners.clear();
+    db.run("PRAGMA optimize");
+    if (ownsDb) {
+      db.close();
+    }
+  };
+
+  return { publish, search, get, versions, install, unpublish, deprecate, onChange, close };
+}

--- a/packages/registry-store/src/version-index.ts
+++ b/packages/registry-store/src/version-index.ts
@@ -1,0 +1,302 @@
+/**
+ * SQLite-backed VersionIndex implementation.
+ *
+ * Stores version entries with publisher tracking. Yank = hard DELETE,
+ * deprecate = soft flag. Keyset cursor on (published_at DESC, rowid DESC).
+ */
+
+import type {
+  BrickId,
+  BrickKind,
+  KoiError,
+  PublisherId,
+  Result,
+  VersionChangeEvent,
+  VersionEntry,
+  VersionIndexBackend,
+} from "@koi/core";
+import { conflict, notFound, validation } from "@koi/core";
+import { wrapSqlite } from "@koi/sqlite-utils";
+import type { RegistryStoreConfig } from "./config.js";
+import { resolveDb } from "./config.js";
+import { createListenerSet } from "./listeners.js";
+import { applyRegistryMigrations } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+interface VersionRow {
+  readonly rowid: number;
+  readonly name: string;
+  readonly kind: string;
+  readonly version: string;
+  readonly brick_id: string;
+  readonly publisher: string;
+  readonly published_at: number;
+  readonly deprecated: number;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface SqliteVersionIndex extends VersionIndexBackend {
+  readonly close: () => void;
+}
+
+export function createSqliteVersionIndex(config: RegistryStoreConfig): SqliteVersionIndex {
+  const { db, ownsDb } = resolveDb(config);
+  applyRegistryMigrations(db);
+
+  const listeners = createListenerSet<VersionChangeEvent>();
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  function toEntry(row: VersionRow): VersionEntry {
+    const entry: VersionEntry = {
+      version: row.version,
+      brickId: row.brick_id as BrickId,
+      publisher: row.publisher as PublisherId,
+      publishedAt: row.published_at,
+    };
+    return row.deprecated === 1 ? { ...entry, deprecated: true } : entry;
+  }
+
+  function isBlank(s: string): boolean {
+    return s.trim() === "";
+  }
+
+  // -------------------------------------------------------------------------
+  // Contract: publish
+  // -------------------------------------------------------------------------
+
+  const publish = (
+    name: string,
+    kind: BrickKind,
+    version: string,
+    brickId: BrickId,
+    publisher: PublisherId,
+  ): Result<VersionEntry, KoiError> => {
+    if (isBlank(name)) {
+      return { ok: false, error: validation("name must not be empty") };
+    }
+    if (isBlank(version)) {
+      return { ok: false, error: validation("version must not be empty") };
+    }
+
+    // Check for existing version
+    const existing = db
+      .query<VersionRow, [string, string, string]>(
+        "SELECT * FROM versions WHERE name = ? AND kind = ? AND version = ?",
+      )
+      .get(name, kind, version);
+
+    if (existing !== null) {
+      // Idempotent if same brickId
+      if (existing.brick_id === (brickId as string)) {
+        return { ok: true, value: toEntry(existing) };
+      }
+      return {
+        ok: false,
+        error: conflict(
+          `${kind}:${name}@${version}`,
+          `Version ${version} of ${kind}:${name} already maps to brick ${existing.brick_id}`,
+        ),
+      };
+    }
+
+    const now = Date.now();
+    const result = wrapSqlite(() => {
+      db.run(
+        `INSERT INTO versions (name, kind, version, brick_id, publisher, published_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [name, kind, version, brickId as string, publisher as string, now],
+      );
+    }, "version.publish");
+
+    if (!result.ok) return result;
+
+    const entry: VersionEntry = {
+      version,
+      brickId,
+      publisher,
+      publishedAt: now,
+    };
+
+    listeners.notify({
+      kind: "published",
+      brickKind: kind,
+      name,
+      version,
+      brickId,
+      publisher,
+    });
+
+    return { ok: true, value: entry };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: resolve
+  // -------------------------------------------------------------------------
+
+  const resolve = (
+    name: string,
+    kind: BrickKind,
+    version: string,
+  ): Result<VersionEntry, KoiError> => {
+    const row = db
+      .query<VersionRow, [string, string, string]>(
+        "SELECT * FROM versions WHERE name = ? AND kind = ? AND version = ?",
+      )
+      .get(name, kind, version);
+
+    if (row === null) {
+      return { ok: false, error: notFound(`${kind}:${name}@${version}`) };
+    }
+    return { ok: true, value: toEntry(row) };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: resolveLatest
+  // -------------------------------------------------------------------------
+
+  const resolveLatest = (name: string, kind: BrickKind): Result<VersionEntry, KoiError> => {
+    const row = db
+      .query<VersionRow, [string, string]>(
+        `SELECT * FROM versions
+         WHERE name = ? AND kind = ?
+         ORDER BY published_at DESC, rowid DESC
+         LIMIT 1`,
+      )
+      .get(name, kind);
+
+    if (row === null) {
+      return { ok: false, error: notFound(`${kind}:${name}`) };
+    }
+    return { ok: true, value: toEntry(row) };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: listVersions
+  // -------------------------------------------------------------------------
+
+  const listVersions = (
+    name: string,
+    kind: BrickKind,
+  ): Result<readonly VersionEntry[], KoiError> => {
+    const rows = db
+      .query<VersionRow, [string, string]>(
+        `SELECT * FROM versions
+         WHERE name = ? AND kind = ?
+         ORDER BY published_at DESC, rowid DESC`,
+      )
+      .all(name, kind);
+
+    if (rows.length === 0) {
+      return { ok: false, error: notFound(`${kind}:${name}`) };
+    }
+    return { ok: true, value: rows.map(toEntry) };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: deprecate
+  // -------------------------------------------------------------------------
+
+  const deprecate = (name: string, kind: BrickKind, version: string): Result<void, KoiError> => {
+    const existing = db
+      .query<VersionRow, [string, string, string]>(
+        "SELECT * FROM versions WHERE name = ? AND kind = ? AND version = ?",
+      )
+      .get(name, kind, version);
+
+    if (existing === null) {
+      return { ok: false, error: notFound(`${kind}:${name}@${version}`) };
+    }
+
+    // Idempotent
+    if (existing.deprecated === 0) {
+      const result = wrapSqlite(() => {
+        db.run("UPDATE versions SET deprecated = 1 WHERE name = ? AND kind = ? AND version = ?", [
+          name,
+          kind,
+          version,
+        ]);
+      }, "version.deprecate");
+
+      if (!result.ok) return result;
+
+      listeners.notify({
+        kind: "deprecated",
+        brickKind: kind,
+        name,
+        version,
+        brickId: existing.brick_id as BrickId,
+        publisher: existing.publisher as PublisherId,
+      });
+    }
+
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: yank
+  // -------------------------------------------------------------------------
+
+  const yank = (name: string, kind: BrickKind, version: string): Result<void, KoiError> => {
+    const existing = db
+      .query<VersionRow, [string, string, string]>(
+        "SELECT * FROM versions WHERE name = ? AND kind = ? AND version = ?",
+      )
+      .get(name, kind, version);
+
+    if (existing === null) {
+      return { ok: false, error: notFound(`${kind}:${name}@${version}`) };
+    }
+
+    const result = wrapSqlite(() => {
+      db.run("DELETE FROM versions WHERE name = ? AND kind = ? AND version = ?", [
+        name,
+        kind,
+        version,
+      ]);
+    }, "version.yank");
+
+    if (!result.ok) return result;
+
+    listeners.notify({
+      kind: "yanked",
+      brickKind: kind,
+      name,
+      version,
+      brickId: existing.brick_id as BrickId,
+      publisher: existing.publisher as PublisherId,
+    });
+
+    return { ok: true, value: undefined };
+  };
+
+  // -------------------------------------------------------------------------
+  // Contract: onChange
+  // -------------------------------------------------------------------------
+
+  const onChange = (listener: (event: VersionChangeEvent) => void): (() => void) => {
+    return listeners.add(listener);
+  };
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  const close = (): void => {
+    listeners.clear();
+    db.run("PRAGMA optimize");
+    if (ownsDb) {
+      db.close();
+    }
+  };
+
+  return { publish, resolve, resolveLatest, listVersions, deprecate, yank, onChange, close };
+}

--- a/packages/registry-store/tsconfig.json
+++ b/packages/registry-store/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../sqlite-utils" }]
+}

--- a/packages/registry-store/tsup.config.ts
+++ b/packages/registry-store/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  external: ["bun:sqlite"],
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements `@koi/registry-store` (L2) — SQLite-backed implementations of all three L0 registry contracts:

- **BrickRegistryBackend** — register/search/get/unregister tools and skills as brick artifacts
- **SkillRegistryBackend** — publish/install/search skills with multi-version support
- **VersionIndexBackend** — semver version tracking with deprecate/yank and publisher attribution

### Key capabilities
- FTS5 full-text search on name, description, and tags (unicode61 tokenizer)
- Keyset cursor pagination (stable under concurrent mutations, O(1) seek)
- Reactive `onChange` event dispatch for all registries
- Shared DB support — all 3 registries on one `:memory:` or file database
- Swappable backends — any storage that satisfies the L0 contracts works

### Files
- 9 source modules (brick-registry, skill-registry, version-index, schema, config, cursor, fts-sanitize, listeners, index)
- 7 test files (137 unit/contract tests + 6 E2E tests with real Anthropic API)
- Package docs at `docs/registry-store.md`

## Test plan

- [x] 137 unit/contract tests pass (`bun test`)
- [x] 6 E2E tests pass with real Anthropic API through full L1 runtime (`E2E_TESTS=1 bun test`)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Biome lint clean (`biome check .`)
- [x] Layer compliance verified (production code imports only `@koi/core` + `@koi/sqlite-utils`)

Closes #459