### PR TITLE
feat: add @koi/channel-canvas-fallback — surface-aware channel decorator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,13 @@
         "@koi/errors": "workspace:*",
       },
     },
+    "packages/channel-canvas-fallback": {
+      "name": "@koi/channel-canvas-fallback",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/channel-chat-sdk": {
       "name": "@koi/channel-chat-sdk",
       "version": "0.0.0",
@@ -1535,6 +1542,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@koi/canvas": "workspace:*",
+        "@koi/channel-canvas-fallback": "workspace:*",
         "@koi/core": "workspace:*",
         "@koi/delegation": "workspace:*",
         "@koi/engine": "workspace:*",
@@ -1952,6 +1960,8 @@
     "@koi/capability-verifier": ["@koi/capability-verifier@workspace:packages/capability-verifier"],
 
     "@koi/channel-base": ["@koi/channel-base@workspace:packages/channel-base"],
+
+    "@koi/channel-canvas-fallback": ["@koi/channel-canvas-fallback@workspace:packages/channel-canvas-fallback"],
 
     "@koi/channel-chat-sdk": ["@koi/channel-chat-sdk@workspace:packages/channel-chat-sdk"],
 

--- a/packages/agui/src/agui-channel.ts
+++ b/packages/agui/src/agui-channel.ts
@@ -124,6 +124,7 @@ const AGUI_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: true,
 } as const satisfies ChannelCapabilities;
 
 /** Encode a BaseEvent as UTF-8 SSE bytes. */

--- a/packages/channel-base/src/channel-adapter-factory.test.ts
+++ b/packages/channel-base/src/channel-adapter-factory.test.ts
@@ -30,6 +30,7 @@ const ALL_CAPS: ChannelCapabilities = {
   audio: true,
   video: true,
   threads: true,
+  supportsA2ui: true,
 };
 
 const TEXT_ONLY_CAPS: ChannelCapabilities = {
@@ -40,6 +41,7 @@ const TEXT_ONLY_CAPS: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: false,
+  supportsA2ui: false,
 };
 
 /** Normalizer that maps every MockEvent to an InboundMessage. */

--- a/packages/channel-base/src/render-blocks.test.ts
+++ b/packages/channel-base/src/render-blocks.test.ts
@@ -17,6 +17,7 @@ const ALL_CAPS: ChannelCapabilities = {
   audio: true,
   video: true,
   threads: true,
+  supportsA2ui: true,
 };
 
 const NO_CAPS: ChannelCapabilities = {
@@ -27,6 +28,7 @@ const NO_CAPS: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: false,
+  supportsA2ui: false,
 };
 
 const imageBlock: ContentBlock = {

--- a/packages/channel-canvas-fallback/package.json
+++ b/packages/channel-canvas-fallback/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@koi/channel-canvas-fallback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/channel-canvas-fallback/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/channel-canvas-fallback/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,91 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/channel-canvas-fallback API surface . has stable type surface 1`] = `
+"import { Result, KoiError, ChannelAdapter, ContentBlock, TextBlock } from '@koi/core';
+
+/**
+ * Lightweight HTTP client for Gateway canvas CRUD routes.
+ *
+ * Uses native fetch + AbortSignal.timeout() — no external dependencies.
+ * All operations return Result<T, KoiError> for typed error handling.
+ */
+
+interface GatewayClientConfig {
+    /** Base URL for the canvas API, e.g. "http://localhost:3000/gateway/canvas". */
+    readonly canvasBaseUrl: string;
+    /** Optional auth token sent as Bearer in Authorization header. */
+    readonly authToken?: string;
+    /** Request timeout in milliseconds. Default: 10_000. */
+    readonly timeoutMs?: number;
+}
+/** Result of a successful create/update operation. */
+interface SurfaceResult {
+    readonly surfaceId: string;
+}
+interface GatewayClient {
+    readonly createSurface: (surfaceId: string, content: string) => Promise<Result<SurfaceResult, KoiError>>;
+    readonly updateSurface: (surfaceId: string, content: string) => Promise<Result<SurfaceResult, KoiError>>;
+    readonly deleteSurface: (surfaceId: string) => Promise<Result<boolean, KoiError>>;
+    readonly computeSurfaceUrl: (surfaceId: string) => string;
+}
+/** Creates a Gateway canvas HTTP client. */
+declare function createGatewayClient(config: GatewayClientConfig): GatewayClient;
+
+/**
+ * Channel decorator that intercepts A2UI blocks and replaces them with
+ * text links to the Gateway canvas when the inner channel does not
+ * support A2UI rendering natively.
+ *
+ * If the inner channel declares supportsA2ui: true, the decorator is a
+ * no-op and returns the inner channel unchanged (zero overhead).
+ */
+
+interface CanvasFallbackConfig {
+    readonly gatewayClient: GatewayClient;
+    /** Optional callback invoked when a Gateway call fails. */
+    readonly onGatewayError?: (error: KoiError, surfaceId: string) => void;
+}
+/**
+ * Wraps a channel with A2UI-to-canvas fallback behavior.
+ *
+ * If the inner channel supports A2UI natively, returns it unchanged.
+ * Otherwise, intercepts send() to replace A2UI blocks with text links.
+ */
+declare function createCanvasFallbackChannel(inner: ChannelAdapter, config: CanvasFallbackConfig): ChannelAdapter;
+
+/**
+ * Runtime detection of A2UI content blocks without importing @koi/canvas.
+ *
+ * Uses structural narrowing on CustomBlock.data to identify A2UI messages
+ * and extract their metadata. This avoids an L2-to-L2 import violation.
+ */
+
+/** Extracted metadata from an A2UI content block. */
+interface A2uiBlockInfo {
+    readonly kind: string;
+    readonly surfaceId: string;
+    readonly title?: string;
+    readonly rawData: unknown;
+}
+/** Returns true if the content block is an A2UI custom block. */
+declare function isA2uiBlock(block: ContentBlock): boolean;
+/**
+ * Extracts A2UI metadata from a content block via runtime narrowing.
+ * Returns undefined if the block is not a valid A2UI block.
+ */
+declare function extractA2uiBlockInfo(block: ContentBlock): A2uiBlockInfo | undefined;
+
+/**
+ * Pure functions to generate fallback text blocks for A2UI surfaces.
+ *
+ * Produces TextBlock content for channels that cannot render A2UI natively.
+ */
+
+/** Generates a TextBlock with a link to the rendered surface. */
+declare function generateSuccessText(info: A2uiBlockInfo, url: string): TextBlock;
+/** Generates a degraded TextBlock when the Gateway call fails. */
+declare function generateDegradedText(info: A2uiBlockInfo, errorMessage: string): TextBlock;
+
+export { type A2uiBlockInfo, type CanvasFallbackConfig, type GatewayClient, type GatewayClientConfig, type SurfaceResult, createCanvasFallbackChannel, createGatewayClient, extractA2uiBlockInfo, generateDegradedText, generateSuccessText, isA2uiBlock };
+"
+`;

--- a/packages/channel-canvas-fallback/src/__tests__/api-surface.test.ts
+++ b/packages/channel-canvas-fallback/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/channel-canvas-fallback/src/create-canvas-fallback-channel.test.ts
+++ b/packages/channel-canvas-fallback/src/create-canvas-fallback-channel.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the canvas fallback channel decorator.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  ContentBlock,
+  KoiError,
+  OutboundMessage,
+  Result,
+} from "@koi/core";
+import { createCanvasFallbackChannel } from "./create-canvas-fallback-channel.js";
+import type { GatewayClient, SurfaceResult } from "./gateway-client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCapabilities(supportsA2ui: boolean): ChannelCapabilities {
+  return {
+    text: true,
+    images: false,
+    files: false,
+    buttons: false,
+    audio: false,
+    video: false,
+    threads: false,
+    supportsA2ui,
+  };
+}
+
+function makeChannel(overrides?: Partial<ChannelAdapter>): ChannelAdapter {
+  return {
+    name: "test",
+    capabilities: makeCapabilities(false),
+    connect: mock(() => Promise.resolve()),
+    disconnect: mock(() => Promise.resolve()),
+    send: mock(() => Promise.resolve()),
+    onMessage: mock(() => () => {}),
+    sendStatus: mock(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function makeGatewayClient(overrides?: Partial<GatewayClient>): GatewayClient {
+  return {
+    createSurface: mock(() =>
+      Promise.resolve({ ok: true, value: { surfaceId: "s1" } } as Result<SurfaceResult, KoiError>),
+    ),
+    updateSurface: mock(() =>
+      Promise.resolve({ ok: true, value: { surfaceId: "s1" } } as Result<SurfaceResult, KoiError>),
+    ),
+    deleteSurface: mock(() =>
+      Promise.resolve({ ok: true, value: true } as Result<boolean, KoiError>),
+    ),
+    computeSurfaceUrl: (id: string) => `http://gw/canvas/${id}`,
+    ...overrides,
+  };
+}
+
+const a2uiCreateBlock: ContentBlock = {
+  kind: "custom",
+  type: "a2ui:createSurface",
+  data: { kind: "createSurface", surfaceId: "s1", title: "Dashboard" },
+};
+
+const a2uiUpdateBlock: ContentBlock = {
+  kind: "custom",
+  type: "a2ui:updateComponents",
+  data: { kind: "updateComponents", surfaceId: "s1" },
+};
+
+const a2uiDataModelBlock: ContentBlock = {
+  kind: "custom",
+  type: "a2ui:updateDataModel",
+  data: { kind: "updateDataModel", surfaceId: "s1" },
+};
+
+const a2uiDeleteBlock: ContentBlock = {
+  kind: "custom",
+  type: "a2ui:deleteSurface",
+  data: { kind: "deleteSurface", surfaceId: "s1" },
+};
+
+const textBlock: ContentBlock = { kind: "text", text: "Hello" };
+const imageBlock: ContentBlock = { kind: "image", url: "https://example.com/img.png" };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createCanvasFallbackChannel", () => {
+  test("returns inner channel unchanged when supportsA2ui is true", () => {
+    const inner = makeChannel({ capabilities: makeCapabilities(true) });
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+    expect(wrapped).toBe(inner);
+  });
+
+  test("passes through messages with no A2UI blocks", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    const message: OutboundMessage = { content: [textBlock, imageBlock] };
+    await wrapped.send(message);
+
+    expect(inner.send).toHaveBeenCalledTimes(1);
+    expect(inner.send).toHaveBeenCalledWith(message);
+  });
+
+  test("replaces createSurface block with text link on success", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    const message: OutboundMessage = { content: [a2uiCreateBlock] };
+    await wrapped.send(message);
+
+    expect(client.createSurface).toHaveBeenCalledTimes(1);
+    expect(inner.send).toHaveBeenCalledTimes(1);
+
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect(sentMessage.content).toHaveLength(1);
+    expect(sentMessage.content[0]?.kind).toBe("text");
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain(
+      "[Surface] Dashboard",
+    );
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain(
+      "http://gw/canvas/s1",
+    );
+  });
+
+  test("replaces createSurface block with degraded text on failure", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient({
+      createSurface: mock(() =>
+        Promise.resolve({
+          ok: false,
+          error: { code: "EXTERNAL", message: "server error", retryable: true } as KoiError,
+        } as Result<SurfaceResult, KoiError>),
+      ),
+    });
+    const onGatewayError = mock(() => {});
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client, onGatewayError });
+
+    await wrapped.send({ content: [a2uiCreateBlock] });
+
+    expect(onGatewayError).toHaveBeenCalledTimes(1);
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain("[Warning]");
+  });
+
+  test("handles updateComponents via updateSurface", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    await wrapped.send({ content: [a2uiUpdateBlock] });
+
+    expect(client.updateSurface).toHaveBeenCalledTimes(1);
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain("[Updated]");
+  });
+
+  test("handles updateDataModel via updateSurface", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    await wrapped.send({ content: [a2uiDataModelBlock] });
+
+    expect(client.updateSurface).toHaveBeenCalledTimes(1);
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain("[Data updated]");
+  });
+
+  test("handles deleteSurface", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    await wrapped.send({ content: [a2uiDeleteBlock] });
+
+    expect(client.deleteSurface).toHaveBeenCalledTimes(1);
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect((sentMessage.content[0] as { readonly text: string }).text).toContain("[Removed]");
+  });
+
+  test("only replaces A2UI blocks in mixed content", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client });
+
+    const message: OutboundMessage = { content: [textBlock, a2uiCreateBlock, imageBlock] };
+    await wrapped.send(message);
+
+    const sentMessage = (inner.send as ReturnType<typeof mock>).mock
+      .calls[0]?.[0] as OutboundMessage;
+    expect(sentMessage.content).toHaveLength(3);
+    expect(sentMessage.content[0]).toEqual(textBlock);
+    expect(sentMessage.content[1]?.kind).toBe("text");
+    expect(sentMessage.content[2]).toEqual(imageBlock);
+  });
+
+  test("delegates connect to inner channel", async () => {
+    const inner = makeChannel();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: makeGatewayClient() });
+    await wrapped.connect();
+    expect(inner.connect).toHaveBeenCalledTimes(1);
+  });
+
+  test("delegates disconnect to inner channel", async () => {
+    const inner = makeChannel();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: makeGatewayClient() });
+    await wrapped.disconnect();
+    expect(inner.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test("delegates onMessage to inner channel", () => {
+    const inner = makeChannel();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: makeGatewayClient() });
+    const handler = () => Promise.resolve();
+    wrapped.onMessage(handler);
+    expect(inner.onMessage).toHaveBeenCalledWith(handler);
+  });
+
+  test("delegates sendStatus to inner channel", async () => {
+    const inner = makeChannel();
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: makeGatewayClient() });
+    const status = { kind: "processing" as const, turnIndex: 1 };
+    await wrapped.sendStatus?.(status);
+    expect(inner.sendStatus).toHaveBeenCalledWith(status);
+  });
+
+  test("preserves inner channel name and capabilities", () => {
+    const inner = makeChannel({ name: "slack" });
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: makeGatewayClient() });
+    expect(wrapped.name).toBe("slack");
+    expect(wrapped.capabilities).toBe(inner.capabilities);
+  });
+
+  test("onGatewayError callback is invoked with error and surfaceId", async () => {
+    const inner = makeChannel();
+    const client = makeGatewayClient({
+      createSurface: mock(() =>
+        Promise.resolve({
+          ok: false,
+          error: { code: "TIMEOUT", message: "timed out", retryable: true } as KoiError,
+        } as Result<SurfaceResult, KoiError>),
+      ),
+    });
+    const onGatewayError = mock(() => {});
+    const wrapped = createCanvasFallbackChannel(inner, { gatewayClient: client, onGatewayError });
+
+    await wrapped.send({ content: [a2uiCreateBlock] });
+
+    expect(onGatewayError).toHaveBeenCalledTimes(1);
+    expect(onGatewayError).toHaveBeenCalledWith(expect.objectContaining({ code: "TIMEOUT" }), "s1");
+  });
+});

--- a/packages/channel-canvas-fallback/src/create-canvas-fallback-channel.ts
+++ b/packages/channel-canvas-fallback/src/create-canvas-fallback-channel.ts
@@ -1,0 +1,120 @@
+/**
+ * Channel decorator that intercepts A2UI blocks and replaces them with
+ * text links to the Gateway canvas when the inner channel does not
+ * support A2UI rendering natively.
+ *
+ * If the inner channel declares supportsA2ui: true, the decorator is a
+ * no-op and returns the inner channel unchanged (zero overhead).
+ */
+
+import type { ChannelAdapter, ContentBlock, KoiError, OutboundMessage } from "@koi/core";
+import { extractA2uiBlockInfo, isA2uiBlock } from "./detect-a2ui.js";
+import type { GatewayClient } from "./gateway-client.js";
+import { generateDegradedText, generateSuccessText } from "./generate-fallback-text.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface CanvasFallbackConfig {
+  readonly gatewayClient: GatewayClient;
+  /** Optional callback invoked when a Gateway call fails. */
+  readonly onGatewayError?: (error: KoiError, surfaceId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function processBlock(
+  block: ContentBlock,
+  client: GatewayClient,
+  onError: ((error: KoiError, surfaceId: string) => void) | undefined,
+): Promise<ContentBlock> {
+  if (!isA2uiBlock(block)) return block;
+
+  const info = extractA2uiBlockInfo(block);
+  if (info === undefined) return block;
+
+  const serialized = JSON.stringify(info.rawData);
+
+  switch (info.kind) {
+    case "createSurface": {
+      const result = await client.createSurface(info.surfaceId, serialized);
+      if (result.ok) {
+        const url = client.computeSurfaceUrl(info.surfaceId);
+        return generateSuccessText(info, url);
+      }
+      onError?.(result.error, info.surfaceId);
+      return generateDegradedText(info, result.error.message);
+    }
+    case "updateComponents":
+    case "updateDataModel": {
+      const result = await client.updateSurface(info.surfaceId, serialized);
+      if (result.ok) {
+        const url = client.computeSurfaceUrl(info.surfaceId);
+        return generateSuccessText(info, url);
+      }
+      onError?.(result.error, info.surfaceId);
+      return generateDegradedText(info, result.error.message);
+    }
+    case "deleteSurface": {
+      const result = await client.deleteSurface(info.surfaceId);
+      if (result.ok) {
+        return generateSuccessText(info, "");
+      }
+      onError?.(result.error, info.surfaceId);
+      return generateDegradedText(info, result.error.message);
+    }
+    default:
+      return block;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a channel with A2UI-to-canvas fallback behavior.
+ *
+ * If the inner channel supports A2UI natively, returns it unchanged.
+ * Otherwise, intercepts send() to replace A2UI blocks with text links.
+ */
+export function createCanvasFallbackChannel(
+  inner: ChannelAdapter,
+  config: CanvasFallbackConfig,
+): ChannelAdapter {
+  if (inner.capabilities.supportsA2ui) return inner;
+
+  const { gatewayClient, onGatewayError } = config;
+
+  const base = {
+    name: inner.name,
+    capabilities: inner.capabilities,
+    connect: inner.connect,
+    disconnect: inner.disconnect,
+    onMessage: inner.onMessage,
+
+    async send(message: OutboundMessage): Promise<void> {
+      const hasA2ui = message.content.some(isA2uiBlock);
+      if (!hasA2ui) {
+        await inner.send(message);
+        return;
+      }
+
+      const processedBlocks: readonly ContentBlock[] = await Promise.all(
+        message.content.map((block) => processBlock(block, gatewayClient, onGatewayError)),
+      );
+
+      const processed: OutboundMessage = {
+        ...message,
+        content: processedBlocks,
+      };
+
+      await inner.send(processed);
+    },
+  };
+
+  return inner.sendStatus !== undefined ? { ...base, sendStatus: inner.sendStatus } : base;
+}

--- a/packages/channel-canvas-fallback/src/detect-a2ui.test.ts
+++ b/packages/channel-canvas-fallback/src/detect-a2ui.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for A2UI block detection and metadata extraction.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ContentBlock } from "@koi/core";
+import { extractA2uiBlockInfo, isA2uiBlock } from "./detect-a2ui.js";
+
+describe("isA2uiBlock", () => {
+  test("returns true for a2ui:surface custom block", () => {
+    const block: ContentBlock = { kind: "custom", type: "a2ui:surface", data: {} };
+    expect(isA2uiBlock(block)).toBe(true);
+  });
+
+  test("returns true for a2ui:createSurface custom block", () => {
+    const block: ContentBlock = { kind: "custom", type: "a2ui:createSurface", data: {} };
+    expect(isA2uiBlock(block)).toBe(true);
+  });
+
+  test("returns true for a2ui:component custom block", () => {
+    const block: ContentBlock = { kind: "custom", type: "a2ui:component", data: {} };
+    expect(isA2uiBlock(block)).toBe(true);
+  });
+
+  test("returns false for text block", () => {
+    const block: ContentBlock = { kind: "text", text: "hello" };
+    expect(isA2uiBlock(block)).toBe(false);
+  });
+
+  test("returns false for non-a2ui custom block", () => {
+    const block: ContentBlock = { kind: "custom", type: "koi:state", data: {} };
+    expect(isA2uiBlock(block)).toBe(false);
+  });
+
+  test("returns false for image block", () => {
+    const block: ContentBlock = { kind: "image", url: "https://example.com/img.png" };
+    expect(isA2uiBlock(block)).toBe(false);
+  });
+});
+
+describe("extractA2uiBlockInfo", () => {
+  test("extracts createSurface info", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:createSurface",
+      data: { kind: "createSurface", surfaceId: "s1", title: "Dashboard" },
+    };
+    const info = extractA2uiBlockInfo(block);
+    expect(info).toEqual({
+      kind: "createSurface",
+      surfaceId: "s1",
+      title: "Dashboard",
+      rawData: { kind: "createSurface", surfaceId: "s1", title: "Dashboard" },
+    });
+  });
+
+  test("extracts updateComponents info", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:updateComponents",
+      data: { kind: "updateComponents", surfaceId: "s2" },
+    };
+    const info = extractA2uiBlockInfo(block);
+    expect(info?.kind).toBe("updateComponents");
+    expect(info?.surfaceId).toBe("s2");
+    expect(info?.title).toBeUndefined();
+    expect(info?.rawData).toEqual({ kind: "updateComponents", surfaceId: "s2" });
+  });
+
+  test("extracts updateDataModel info", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:updateDataModel",
+      data: { kind: "updateDataModel", surfaceId: "s3" },
+    };
+    const info = extractA2uiBlockInfo(block);
+    expect(info?.kind).toBe("updateDataModel");
+    expect(info?.surfaceId).toBe("s3");
+    expect(info?.title).toBeUndefined();
+    expect(info?.rawData).toEqual({ kind: "updateDataModel", surfaceId: "s3" });
+  });
+
+  test("extracts deleteSurface info", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:deleteSurface",
+      data: { kind: "deleteSurface", surfaceId: "s4" },
+    };
+    const info = extractA2uiBlockInfo(block);
+    expect(info?.kind).toBe("deleteSurface");
+    expect(info?.surfaceId).toBe("s4");
+    expect(info?.title).toBeUndefined();
+    expect(info?.rawData).toEqual({ kind: "deleteSurface", surfaceId: "s4" });
+  });
+
+  test("returns undefined for non-a2ui block", () => {
+    const block: ContentBlock = { kind: "text", text: "hello" };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("returns undefined when data is not an object", () => {
+    const block: ContentBlock = { kind: "custom", type: "a2ui:createSurface", data: "not-object" };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("returns undefined when data is null", () => {
+    const block: ContentBlock = { kind: "custom", type: "a2ui:createSurface", data: null };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("returns undefined when kind is missing from data", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:createSurface",
+      data: { surfaceId: "s1" },
+    };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("returns undefined when kind is unknown", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:unknown",
+      data: { kind: "unknownKind", surfaceId: "s1" },
+    };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("returns undefined when surfaceId is missing", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:createSurface",
+      data: { kind: "createSurface" },
+    };
+    expect(extractA2uiBlockInfo(block)).toBeUndefined();
+  });
+
+  test("omits title when it is not a string", () => {
+    const block: ContentBlock = {
+      kind: "custom",
+      type: "a2ui:createSurface",
+      data: { kind: "createSurface", surfaceId: "s1", title: 42 },
+    };
+    const info = extractA2uiBlockInfo(block);
+    expect(info?.title).toBeUndefined();
+  });
+});

--- a/packages/channel-canvas-fallback/src/detect-a2ui.ts
+++ b/packages/channel-canvas-fallback/src/detect-a2ui.ts
@@ -1,0 +1,55 @@
+/**
+ * Runtime detection of A2UI content blocks without importing @koi/canvas.
+ *
+ * Uses structural narrowing on CustomBlock.data to identify A2UI messages
+ * and extract their metadata. This avoids an L2-to-L2 import violation.
+ */
+
+import type { ContentBlock } from "@koi/core";
+
+/** A2UI event type prefix used in CustomBlock.type. */
+const A2UI_PREFIX = "a2ui:";
+
+/** Known A2UI message kinds. */
+const A2UI_KINDS: ReadonlySet<string> = new Set([
+  "createSurface",
+  "updateComponents",
+  "updateDataModel",
+  "deleteSurface",
+]);
+
+/** Extracted metadata from an A2UI content block. */
+export interface A2uiBlockInfo {
+  readonly kind: string;
+  readonly surfaceId: string;
+  readonly title?: string;
+  readonly rawData: unknown;
+}
+
+/** Returns true if the content block is an A2UI custom block. */
+export function isA2uiBlock(block: ContentBlock): boolean {
+  return block.kind === "custom" && block.type.startsWith(A2UI_PREFIX);
+}
+
+/**
+ * Extracts A2UI metadata from a content block via runtime narrowing.
+ * Returns undefined if the block is not a valid A2UI block.
+ */
+export function extractA2uiBlockInfo(block: ContentBlock): A2uiBlockInfo | undefined {
+  if (!isA2uiBlock(block)) return undefined;
+
+  if (block.kind !== "custom") return undefined;
+  const data: unknown = block.data;
+  if (typeof data !== "object" || data === null) return undefined;
+
+  const record = data as Readonly<Record<string, unknown>>;
+  const kind = record.kind;
+  if (typeof kind !== "string" || !A2UI_KINDS.has(kind)) return undefined;
+
+  const surfaceId = record.surfaceId;
+  if (typeof surfaceId !== "string") return undefined;
+
+  const base = { kind, surfaceId, rawData: data };
+  const title = record.title;
+  return typeof title === "string" ? { ...base, title } : base;
+}

--- a/packages/channel-canvas-fallback/src/gateway-client.test.ts
+++ b/packages/channel-canvas-fallback/src/gateway-client.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the Gateway canvas HTTP client.
+ *
+ * Uses Bun.serve() as a mock Gateway server.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createGatewayClient } from "./gateway-client.js";
+
+// ---------------------------------------------------------------------------
+// Mock server
+// ---------------------------------------------------------------------------
+
+type MockHandler = (req: Request) => Response | Promise<Response>;
+
+// let: re-assigned per test to swap handler logic
+let currentHandler: MockHandler = () => new Response("not configured", { status: 500 });
+
+// let: server lifecycle — created in beforeEach, stopped in afterEach
+let server: ReturnType<typeof Bun.serve>;
+// let: resolved after server starts
+let baseUrl: string;
+
+beforeEach(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req: Request) {
+      return currentHandler(req);
+    },
+  });
+  baseUrl = `http://localhost:${server.port}`;
+});
+
+afterEach(() => {
+  server.stop(true);
+});
+
+// ---------------------------------------------------------------------------
+// createSurface
+// ---------------------------------------------------------------------------
+
+describe("createSurface", () => {
+  test("POST success returns surfaceId", async () => {
+    currentHandler = (req) => {
+      if (req.method !== "POST") return new Response("bad method", { status: 405 });
+      return new Response(JSON.stringify({ ok: true, surfaceId: "s1" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json", ETag: '"abc"' },
+      });
+    };
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.createSurface("s1", '{"kind":"createSurface"}');
+    expect(result).toEqual({ ok: true, value: { surfaceId: "s1" } });
+  });
+
+  test("POST 409 conflict returns CONFLICT error", async () => {
+    currentHandler = () =>
+      new Response(JSON.stringify({ ok: false, error: "exists" }), { status: 409 });
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.createSurface("s1", "{}");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("CONFLICT");
+    }
+  });
+
+  test("POST 500 error returns EXTERNAL error with retryable true", async () => {
+    currentHandler = () => new Response("boom", { status: 500 });
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.createSurface("s1", "{}");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("EXTERNAL");
+      expect(result.error.retryable).toBe(true);
+    }
+  });
+
+  test("sends Authorization header when authToken is configured", async () => {
+    // let: captured in handler closure
+    let capturedAuth = "";
+    currentHandler = (req) => {
+      capturedAuth = req.headers.get("Authorization") ?? "";
+      return new Response(JSON.stringify({ ok: true }), { status: 201 });
+    };
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl, authToken: "tok123" });
+    await client.createSurface("s1", "{}");
+    expect(capturedAuth).toBe("Bearer tok123");
+  });
+
+  test("network failure returns EXTERNAL error", async () => {
+    const client = createGatewayClient({
+      canvasBaseUrl: "http://localhost:1", // unlikely to be listening
+      timeoutMs: 500,
+    });
+    const result = await client.createSurface("s1", "{}");
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSurface
+// ---------------------------------------------------------------------------
+
+describe("updateSurface", () => {
+  test("PATCH success returns surfaceId", async () => {
+    currentHandler = (req) => {
+      if (req.method !== "PATCH") return new Response("bad method", { status: 405 });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.updateSurface("s1", '{"content":"updated"}');
+    expect(result).toEqual({ ok: true, value: { surfaceId: "s1" } });
+  });
+
+  test("PATCH 404 returns NOT_FOUND error", async () => {
+    currentHandler = () => new Response("not found", { status: 404 });
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.updateSurface("s1", "{}");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSurface
+// ---------------------------------------------------------------------------
+
+describe("deleteSurface", () => {
+  test("DELETE 204 returns true", async () => {
+    currentHandler = (req) => {
+      if (req.method !== "DELETE") return new Response("bad method", { status: 405 });
+      return new Response(null, { status: 204 });
+    };
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.deleteSurface("s1");
+    expect(result).toEqual({ ok: true, value: true });
+  });
+
+  test("DELETE 404 is idempotent — returns false", async () => {
+    currentHandler = () => new Response("not found", { status: 404 });
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl });
+    const result = await client.deleteSurface("s1");
+    expect(result).toEqual({ ok: true, value: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSurfaceUrl
+// ---------------------------------------------------------------------------
+
+describe("computeSurfaceUrl", () => {
+  test("returns correct URL", () => {
+    const client = createGatewayClient({ canvasBaseUrl: "http://gw:3000/gateway/canvas" });
+    expect(client.computeSurfaceUrl("s1")).toBe("http://gw:3000/gateway/canvas/s1");
+  });
+
+  test("strips trailing slash from base URL", () => {
+    const client = createGatewayClient({ canvasBaseUrl: "http://gw:3000/gateway/canvas/" });
+    expect(client.computeSurfaceUrl("s1")).toBe("http://gw:3000/gateway/canvas/s1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+describe("timeout", () => {
+  test("times out on slow server", async () => {
+    currentHandler = async () => {
+      await Bun.sleep(5_000);
+      return new Response("slow", { status: 200 });
+    };
+
+    const client = createGatewayClient({ canvasBaseUrl: baseUrl, timeoutMs: 100 });
+    const result = await client.createSurface("s1", "{}");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("TIMEOUT");
+      expect(result.error.retryable).toBe(true);
+    }
+  });
+});

--- a/packages/channel-canvas-fallback/src/gateway-client.ts
+++ b/packages/channel-canvas-fallback/src/gateway-client.ts
@@ -1,0 +1,170 @@
+/**
+ * Lightweight HTTP client for Gateway canvas CRUD routes.
+ *
+ * Uses native fetch + AbortSignal.timeout() — no external dependencies.
+ * All operations return Result<T, KoiError> for typed error handling.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface GatewayClientConfig {
+  /** Base URL for the canvas API, e.g. "http://localhost:3000/gateway/canvas". */
+  readonly canvasBaseUrl: string;
+  /** Optional auth token sent as Bearer in Authorization header. */
+  readonly authToken?: string;
+  /** Request timeout in milliseconds. Default: 10_000. */
+  readonly timeoutMs?: number;
+}
+
+/** Result of a successful create/update operation. */
+export interface SurfaceResult {
+  readonly surfaceId: string;
+}
+
+export interface GatewayClient {
+  readonly createSurface: (
+    surfaceId: string,
+    content: string,
+  ) => Promise<Result<SurfaceResult, KoiError>>;
+  readonly updateSurface: (
+    surfaceId: string,
+    content: string,
+  ) => Promise<Result<SurfaceResult, KoiError>>;
+  readonly deleteSurface: (surfaceId: string) => Promise<Result<boolean, KoiError>>;
+  readonly computeSurfaceUrl: (surfaceId: string) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHeaders(authToken: string | undefined): Readonly<Record<string, string>> {
+  return authToken !== undefined
+    ? { "Content-Type": "application/json", Authorization: `Bearer ${authToken}` }
+    : { "Content-Type": "application/json" };
+}
+
+function mapHttpError(status: number, body: string, context: string): KoiError {
+  if (status === 404) {
+    return { code: "NOT_FOUND", message: `${context}: surface not found`, retryable: false };
+  }
+  if (status === 409) {
+    return { code: "CONFLICT", message: `${context}: surface already exists`, retryable: false };
+  }
+  if (status === 401 || status === 403) {
+    return { code: "PERMISSION", message: `${context}: unauthorized`, retryable: false };
+  }
+  if (status >= 500) {
+    return {
+      code: "EXTERNAL",
+      message: `${context}: server error (${status}): ${body}`,
+      retryable: true,
+    };
+  }
+  return {
+    code: "EXTERNAL",
+    message: `${context}: unexpected status ${status}: ${body}`,
+    retryable: false,
+  };
+}
+
+function isTimeoutError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === "TimeoutError") return true;
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return msg.includes("abort") || msg.includes("timeout");
+  }
+  return false;
+}
+
+function mapNetworkError(err: unknown, context: string): KoiError {
+  if (isTimeoutError(err)) {
+    return { code: "TIMEOUT", message: `${context}: request timed out`, retryable: true };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return { code: "EXTERNAL", message: `${context}: network error — ${message}`, retryable: true };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/** Creates a Gateway canvas HTTP client. */
+export function createGatewayClient(config: GatewayClientConfig): GatewayClient {
+  const baseUrl = config.canvasBaseUrl.endsWith("/")
+    ? config.canvasBaseUrl.slice(0, -1)
+    : config.canvasBaseUrl;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  async function request(
+    method: string,
+    surfaceId: string,
+    body: Readonly<Record<string, string>> | undefined,
+    context: string,
+  ): Promise<Result<{ readonly status: number; readonly text: string }, KoiError>> {
+    try {
+      const response = await fetch(`${baseUrl}/${surfaceId}`, {
+        method,
+        headers: makeHeaders(config.authToken),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      const text = await response.text();
+      return { ok: true, value: { status: response.status, text } };
+    } catch (err: unknown) {
+      return { ok: false, error: mapNetworkError(err, context) };
+    }
+  }
+
+  return {
+    async createSurface(
+      surfaceId: string,
+      content: string,
+    ): Promise<Result<SurfaceResult, KoiError>> {
+      const result = await request("POST", surfaceId, { content }, "createSurface");
+      if (!result.ok) return result;
+
+      const { status, text } = result.value;
+      if (status === 201) return { ok: true, value: { surfaceId } };
+      return { ok: false, error: mapHttpError(status, text, "createSurface") };
+    },
+
+    async updateSurface(
+      surfaceId: string,
+      content: string,
+    ): Promise<Result<SurfaceResult, KoiError>> {
+      const result = await request("PATCH", surfaceId, { content }, "updateSurface");
+      if (!result.ok) return result;
+
+      const { status, text } = result.value;
+      if (status === 200) return { ok: true, value: { surfaceId } };
+      return { ok: false, error: mapHttpError(status, text, "updateSurface") };
+    },
+
+    async deleteSurface(surfaceId: string): Promise<Result<boolean, KoiError>> {
+      const result = await request("DELETE", surfaceId, undefined, "deleteSurface");
+      if (!result.ok) return result;
+
+      const { status, text } = result.value;
+      if (status === 204) return { ok: true, value: true };
+      // 404 on delete is idempotent — treat as success
+      if (status === 404) return { ok: true, value: false };
+      return { ok: false, error: mapHttpError(status, text, "deleteSurface") };
+    },
+
+    computeSurfaceUrl(surfaceId: string): string {
+      return `${baseUrl}/${surfaceId}`;
+    },
+  };
+}

--- a/packages/channel-canvas-fallback/src/generate-fallback-text.test.ts
+++ b/packages/channel-canvas-fallback/src/generate-fallback-text.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for fallback text generation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { A2uiBlockInfo } from "./detect-a2ui.js";
+import { generateDegradedText, generateSuccessText } from "./generate-fallback-text.js";
+
+const BASE_URL = "http://localhost:3000/gateway/canvas/s1";
+
+describe("generateSuccessText", () => {
+  test("createSurface with title", () => {
+    const info: A2uiBlockInfo = {
+      kind: "createSurface",
+      surfaceId: "s1",
+      title: "Dashboard",
+      rawData: {},
+    };
+    const result = generateSuccessText(info, BASE_URL);
+    expect(result).toEqual({ kind: "text", text: `[Surface] Dashboard: ${BASE_URL}` });
+  });
+
+  test("createSurface without title uses surfaceId", () => {
+    const info: A2uiBlockInfo = { kind: "createSurface", surfaceId: "s1", rawData: {} };
+    const result = generateSuccessText(info, BASE_URL);
+    expect(result).toEqual({ kind: "text", text: `[Surface] s1: ${BASE_URL}` });
+  });
+
+  test("updateComponents", () => {
+    const info: A2uiBlockInfo = {
+      kind: "updateComponents",
+      surfaceId: "s1",
+      title: "Form",
+      rawData: {},
+    };
+    const result = generateSuccessText(info, BASE_URL);
+    expect(result).toEqual({ kind: "text", text: `[Updated] Form: ${BASE_URL}` });
+  });
+
+  test("updateDataModel", () => {
+    const info: A2uiBlockInfo = { kind: "updateDataModel", surfaceId: "s1", rawData: {} };
+    const result = generateSuccessText(info, BASE_URL);
+    expect(result).toEqual({ kind: "text", text: `[Data updated] s1: ${BASE_URL}` });
+  });
+
+  test("deleteSurface", () => {
+    const info: A2uiBlockInfo = {
+      kind: "deleteSurface",
+      surfaceId: "s1",
+      title: "Old",
+      rawData: {},
+    };
+    const result = generateSuccessText(info, "");
+    expect(result).toEqual({ kind: "text", text: "[Removed] Old" });
+  });
+
+  test("unknown kind falls back to [Surface]", () => {
+    const info: A2uiBlockInfo = { kind: "futureKind", surfaceId: "s1", rawData: {} };
+    const result = generateSuccessText(info, BASE_URL);
+    expect(result).toEqual({ kind: "text", text: `[Surface] s1: ${BASE_URL}` });
+  });
+});
+
+describe("generateDegradedText", () => {
+  test("includes warning prefix and error message", () => {
+    const info: A2uiBlockInfo = {
+      kind: "createSurface",
+      surfaceId: "s1",
+      title: "Dashboard",
+      rawData: {},
+    };
+    const result = generateDegradedText(info, "Gateway unreachable");
+    expect(result).toEqual({
+      kind: "text",
+      text: '[Warning] Could not render surface "Dashboard": Gateway unreachable',
+    });
+  });
+
+  test("uses surfaceId when title is absent", () => {
+    const info: A2uiBlockInfo = { kind: "createSurface", surfaceId: "s1", rawData: {} };
+    const result = generateDegradedText(info, "timeout");
+    expect(result).toEqual({
+      kind: "text",
+      text: '[Warning] Could not render surface "s1": timeout',
+    });
+  });
+});

--- a/packages/channel-canvas-fallback/src/generate-fallback-text.ts
+++ b/packages/channel-canvas-fallback/src/generate-fallback-text.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure functions to generate fallback text blocks for A2UI surfaces.
+ *
+ * Produces TextBlock content for channels that cannot render A2UI natively.
+ */
+
+import type { TextBlock } from "@koi/core";
+import type { A2uiBlockInfo } from "./detect-a2ui.js";
+
+/** Generates a TextBlock with a link to the rendered surface. */
+export function generateSuccessText(info: A2uiBlockInfo, url: string): TextBlock {
+  const label = info.title ?? info.surfaceId;
+
+  switch (info.kind) {
+    case "createSurface":
+      return { kind: "text", text: `[Surface] ${label}: ${url}` };
+    case "updateComponents":
+      return { kind: "text", text: `[Updated] ${label}: ${url}` };
+    case "updateDataModel":
+      return { kind: "text", text: `[Data updated] ${label}: ${url}` };
+    case "deleteSurface":
+      return { kind: "text", text: `[Removed] ${label}` };
+    default:
+      return { kind: "text", text: `[Surface] ${label}: ${url}` };
+  }
+}
+
+/** Generates a degraded TextBlock when the Gateway call fails. */
+export function generateDegradedText(info: A2uiBlockInfo, errorMessage: string): TextBlock {
+  const label = info.title ?? info.surfaceId;
+  return { kind: "text", text: `[Warning] Could not render surface "${label}": ${errorMessage}` };
+}

--- a/packages/channel-canvas-fallback/src/index.ts
+++ b/packages/channel-canvas-fallback/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @koi/channel-canvas-fallback — A2UI surface fallback for text-only channels.
+ *
+ * Decorates any ChannelAdapter to automatically replace A2UI content blocks
+ * with text links to the Gateway canvas when the channel cannot render them.
+ */
+
+export type { CanvasFallbackConfig } from "./create-canvas-fallback-channel.js";
+export { createCanvasFallbackChannel } from "./create-canvas-fallback-channel.js";
+export type { A2uiBlockInfo } from "./detect-a2ui.js";
+export { extractA2uiBlockInfo, isA2uiBlock } from "./detect-a2ui.js";
+export type { GatewayClient, GatewayClientConfig, SurfaceResult } from "./gateway-client.js";
+export { createGatewayClient } from "./gateway-client.js";
+export { generateDegradedText, generateSuccessText } from "./generate-fallback-text.js";

--- a/packages/channel-canvas-fallback/tsconfig.json
+++ b/packages/channel-canvas-fallback/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/channel-canvas-fallback/tsup.config.ts
+++ b/packages/channel-canvas-fallback/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/channel-chat-sdk/src/capabilities.ts
+++ b/packages/channel-chat-sdk/src/capabilities.ts
@@ -16,6 +16,7 @@ const SLACK_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const DISCORD_CAPABILITIES: ChannelCapabilities = {
@@ -26,6 +27,7 @@ const DISCORD_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const TEAMS_CAPABILITIES: ChannelCapabilities = {
@@ -36,6 +38,7 @@ const TEAMS_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const GCHAT_CAPABILITIES: ChannelCapabilities = {
@@ -46,6 +49,7 @@ const GCHAT_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const GITHUB_CAPABILITIES: ChannelCapabilities = {
@@ -56,6 +60,7 @@ const GITHUB_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const LINEAR_CAPABILITIES: ChannelCapabilities = {
@@ -66,6 +71,7 @@ const LINEAR_CAPABILITIES: ChannelCapabilities = {
   audio: false,
   video: false,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 const CAPABILITIES_MAP: Readonly<Record<PlatformName, ChannelCapabilities>> = {

--- a/packages/channel-cli/src/cli-channel.test.ts
+++ b/packages/channel-cli/src/cli-channel.test.ts
@@ -104,6 +104,7 @@ describe("createCliChannel", () => {
       audio: false,
       video: false,
       threads: false,
+      supportsA2ui: false,
     });
   });
 

--- a/packages/channel-cli/src/cli-channel.ts
+++ b/packages/channel-cli/src/cli-channel.ts
@@ -40,6 +40,7 @@ const CLI_CAPABILITIES = {
   audio: false,
   video: false,
   threads: false,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 /**

--- a/packages/channel-discord/src/discord-channel.test.ts
+++ b/packages/channel-discord/src/discord-channel.test.ts
@@ -89,6 +89,7 @@ describe("createDiscordChannel — capabilities", () => {
       audio: true,
       video: true,
       threads: true,
+      supportsA2ui: false,
     });
   });
 

--- a/packages/channel-discord/src/discord-channel.ts
+++ b/packages/channel-discord/src/discord-channel.ts
@@ -51,6 +51,7 @@ const DISCORD_CAPABILITIES: ChannelCapabilities = {
   audio: true,
   video: true,
   threads: true,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 // ---------------------------------------------------------------------------

--- a/packages/channel-telegram/src/telegram-channel.test.ts
+++ b/packages/channel-telegram/src/telegram-channel.test.ts
@@ -216,6 +216,7 @@ describe("createTelegramChannel — capabilities", () => {
       audio: true,
       video: true,
       threads: true,
+      supportsA2ui: false,
     });
   });
 

--- a/packages/channel-telegram/src/telegram-channel.ts
+++ b/packages/channel-telegram/src/telegram-channel.ts
@@ -85,6 +85,7 @@ const TELEGRAM_CAPABILITIES: ChannelCapabilities = {
   audio: true,
   video: true,
   threads: true, // Forum topics routed via "chatId:messageThreadId" threadId encoding
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 // ---------------------------------------------------------------------------

--- a/packages/channel-voice/src/voice-channel.test.ts
+++ b/packages/channel-voice/src/voice-channel.test.ts
@@ -54,6 +54,7 @@ describe("createVoiceChannel — capabilities", () => {
       buttons: false,
       video: false,
       threads: false,
+      supportsA2ui: false,
     });
   });
 

--- a/packages/channel-voice/src/voice-channel.ts
+++ b/packages/channel-voice/src/voice-channel.ts
@@ -44,6 +44,7 @@ const VOICE_CAPABILITIES: ChannelCapabilities = {
   buttons: false,
   video: false,
   threads: false,
+  supportsA2ui: false,
 } as const satisfies ChannelCapabilities;
 
 /** Tight retry config for TTS speak() — fast retries on transient failures. */

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -30,6 +30,7 @@ mock.module("@koi/channel-cli", () => ({
       audio: false,
       video: false,
       threads: false,
+      supportsA2ui: false,
     },
     connect: mockConnect,
     disconnect: mockDisconnect,

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1851,6 +1851,7 @@ interface ChannelCapabilities {
     readonly audio: boolean;
     readonly video: boolean;
     readonly threads: boolean;
+    readonly supportsA2ui: boolean;
 }
 type MessageHandler = (message: InboundMessage) => Promise<void>;
 type ChannelStatusKind = "processing" | "idle" | "error";

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -392,6 +392,7 @@ describe("ChannelAdapter negative types", () => {
       audio: false,
       video: false,
       threads: false,
+      supportsA2ui: false,
     };
     // @ts-expect-error — send is required on ChannelAdapter
     const _c: ChannelAdapter = {

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -13,6 +13,7 @@ export interface ChannelCapabilities {
   readonly audio: boolean;
   readonly video: boolean;
   readonly threads: boolean;
+  readonly supportsA2ui: boolean;
 }
 
 export type MessageHandler = (message: InboundMessage) => Promise<void>;

--- a/tests/e2e/e2e-canvas-fallback.test.ts
+++ b/tests/e2e/e2e-canvas-fallback.test.ts
@@ -1,0 +1,755 @@
+/**
+ * E2E: @koi/channel-canvas-fallback through the full L1 runtime assembly.
+ *
+ * Validates that the canvas fallback channel decorator correctly intercepts
+ * A2UI blocks, calls the Gateway canvas API, and replaces them with text
+ * links — all wired through createKoi + createLoopAdapter with real
+ * Anthropic API calls.
+ *
+ * Tests cover:
+ *   1. Tool emits A2UI createSurface → decorator POSTs to Gateway → text link
+ *   2. Full lifecycle: create → update → delete through middleware chain
+ *   3. Mixed content (text + A2UI + image) — only A2UI blocks are replaced
+ *   4. Gateway failure → degraded text with [Warning] + onGatewayError callback
+ *   5. Channel with supportsA2ui: true → decorator is a no-op (passthrough)
+ *   6. No A2UI blocks → messages pass through without Gateway calls
+ *   7. Middleware wrapToolCall observes the full fallback pipeline
+ *
+ * Gated on ANTHROPIC_API_KEY — tests are skipped when the key is not set.
+ *
+ * Run:
+ *   bun test tests/e2e/e2e-canvas-fallback.test.ts
+ *
+ * Cost: ~$0.03-0.06 per run (haiku model, minimal prompts).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createCanvasFallbackChannel, createGatewayClient } from "@koi/channel-canvas-fallback";
+import type {
+  ChannelAdapter,
+  ChannelCapabilities,
+  ComponentProvider,
+  ContentBlock,
+  EngineEvent,
+  KoiError,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  OutboundMessage,
+  Tool,
+  ToolHandler,
+  ToolRequest,
+} from "@koi/core";
+import { toolToken } from "@koi/core/ecs";
+import { createKoi } from "@koi/engine";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const describeFallback = HAS_KEY ? describe : describe.skip;
+
+const TIMEOUT_MS = 60_000;
+const MODEL_NAME = "claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Mock Gateway server
+// ---------------------------------------------------------------------------
+
+interface GatewayLog {
+  readonly method: string;
+  readonly surfaceId: string;
+  readonly body: string;
+}
+
+type MockHandler = (req: Request) => Response | Promise<Response>;
+
+// let: re-assigned per test to swap handler logic
+let currentHandler: MockHandler = () => new Response("not configured", { status: 500 });
+
+// let: server lifecycle — created in beforeEach, stopped in afterEach
+let server: ReturnType<typeof Bun.serve>;
+// let: resolved after server starts
+let gatewayBaseUrl: string;
+// let: accumulates gateway calls per test
+let gatewayLog: GatewayLog[];
+
+beforeEach(() => {
+  gatewayLog = [];
+  server = Bun.serve({
+    port: 0,
+    async fetch(req: Request) {
+      return currentHandler(req);
+    },
+  });
+  gatewayBaseUrl = `http://localhost:${server.port}`;
+});
+
+afterEach(() => {
+  server.stop(true);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+function makeTextOnlyCaps(): ChannelCapabilities {
+  return {
+    text: true,
+    images: false,
+    files: false,
+    buttons: false,
+    audio: false,
+    video: false,
+    threads: false,
+    supportsA2ui: false,
+  };
+}
+
+function makeA2uiCaps(): ChannelCapabilities {
+  return {
+    text: true,
+    images: true,
+    files: true,
+    buttons: true,
+    audio: false,
+    video: false,
+    threads: true,
+    supportsA2ui: true,
+  };
+}
+
+/** Creates a mock inner channel that records all sent messages. */
+function makeInnerChannel(
+  capabilities: ChannelCapabilities,
+): ChannelAdapter & { readonly sentMessages: OutboundMessage[] } {
+  const sentMessages: OutboundMessage[] = []; // let justified: test accumulator
+  return {
+    name: "e2e-mock",
+    capabilities,
+    connect: mock(() => Promise.resolve()),
+    disconnect: mock(() => Promise.resolve()),
+    send: mock(async (message: OutboundMessage) => {
+      sentMessages.push(message);
+    }),
+    onMessage: mock(() => () => {}),
+    sentMessages,
+  };
+}
+
+/** Default mock Gateway handler: accepts all operations, captures request bodies. */
+async function defaultGatewayHandler(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parts = url.pathname.split("/");
+  const sid = parts[parts.length - 1] ?? "unknown";
+  const body = req.method !== "DELETE" ? await req.text() : "";
+
+  gatewayLog.push({ method: req.method, surfaceId: sid, body });
+
+  switch (req.method) {
+    case "POST":
+      return new Response(JSON.stringify({ ok: true, surfaceId: sid }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    case "PATCH":
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    case "DELETE":
+      return new Response(null, { status: 204 });
+    default:
+      return new Response("bad method", { status: 405 });
+  }
+}
+
+function makeCreateSurfaceBlock(sid: string, title: string): ContentBlock {
+  return {
+    kind: "custom",
+    type: "a2ui:createSurface",
+    data: {
+      kind: "createSurface",
+      surfaceId: sid,
+      title,
+      components: [{ id: "c1", type: "Text", properties: { text: "Hello" } }],
+    },
+  };
+}
+
+function makeUpdateComponentsBlock(sid: string): ContentBlock {
+  return {
+    kind: "custom",
+    type: "a2ui:updateComponents",
+    data: {
+      kind: "updateComponents",
+      surfaceId: sid,
+      components: [{ id: "c1", type: "Text", properties: { text: "Updated" } }],
+    },
+  };
+}
+
+function makeDeleteSurfaceBlock(sid: string): ContentBlock {
+  return {
+    kind: "custom",
+    type: "a2ui:deleteSurface",
+    data: { kind: "deleteSurface", surfaceId: sid },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — eliminates repeated boilerplate across tests
+// ---------------------------------------------------------------------------
+
+interface HarnessConfig {
+  readonly manifestName: string;
+  readonly tool: Tool;
+  readonly toolName: string;
+  readonly toolCallInput: Record<string, unknown>;
+  readonly middleware?: readonly KoiMiddleware[];
+  readonly prompt: string;
+}
+
+interface HarnessResult {
+  readonly events: readonly EngineEvent[];
+  readonly modelCallCount: number;
+}
+
+/** Runs the two-phase model handler through createKoi + createLoopAdapter. */
+async function runWithKoi(config: HarnessConfig): Promise<HarnessResult> {
+  let modelCallCount = 0; // let justified: tracks model call phases
+
+  const toolProvider: ComponentProvider = {
+    name: `e2e-${config.manifestName}-provider`,
+    attach: async () => {
+      const components = new Map<string, unknown>();
+      components.set(toolToken(config.toolName), config.tool);
+      return components;
+    },
+  };
+
+  const { createAnthropicAdapter } = await import("@koi/model-router");
+  const modelCall = async (request: ModelRequest): Promise<ModelResponse> => {
+    modelCallCount++;
+    if (modelCallCount === 1) {
+      return {
+        content: "Executing tool.",
+        model: MODEL_NAME,
+        usage: { inputTokens: 10, outputTokens: 15 },
+        metadata: {
+          toolCalls: [
+            {
+              toolName: config.toolName,
+              callId: `call-${config.manifestName}-1`,
+              input: config.toolCallInput,
+            },
+          ],
+        },
+      };
+    }
+    const anthropic = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+    return anthropic.complete({
+      ...request,
+      model: MODEL_NAME,
+      maxTokens: 100,
+    });
+  };
+
+  const { createLoopAdapter } = await import("@koi/engine-loop");
+  const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+  const runtime = await createKoi({
+    manifest: {
+      name: config.manifestName,
+      version: "0.0.1",
+      model: { name: MODEL_NAME },
+    },
+    adapter,
+    middleware: config.middleware !== undefined ? [...config.middleware] : [],
+    providers: [toolProvider],
+  });
+
+  try {
+    const events = await collectEvents(runtime.run({ kind: "text", text: config.prompt }));
+    return { events, modelCallCount };
+  } finally {
+    await runtime.dispose?.();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeFallback("e2e: canvas fallback through createKoi + createLoopAdapter", () => {
+  test(
+    "tool emits A2UI createSurface, decorator POSTs to Gateway, channel receives text link",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      const channelBridge: KoiMiddleware = {
+        name: "e2e-channel-bridge",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          const result = await next(request);
+          const output = result.output as {
+            readonly a2ui?: {
+              readonly kind: string;
+              readonly surfaceId: string;
+              readonly title?: string;
+            };
+          };
+          if (output.a2ui !== undefined) {
+            await channel.send({
+              content: [
+                makeCreateSurfaceBlock(output.a2ui.surfaceId, output.a2ui.title ?? "Untitled"),
+              ],
+            });
+          }
+          return result;
+        },
+      };
+
+      const uiTool: Tool = {
+        descriptor: {
+          name: "create_ui",
+          description: "Creates a UI surface.",
+          inputSchema: {
+            type: "object",
+            properties: { title: { type: "string" } },
+            required: ["title"],
+          },
+        },
+        trustTier: "sandbox",
+        execute: async (args) => ({
+          a2ui: {
+            kind: "createSurface",
+            surfaceId: "dashboard-1",
+            title: String(args.title ?? "Untitled"),
+          },
+        }),
+      };
+
+      const { events, modelCallCount } = await runWithKoi({
+        manifestName: "e2e-canvas-fallback",
+        tool: uiTool,
+        toolName: "create_ui",
+        toolCallInput: { title: "Analytics Dashboard" },
+        middleware: [channelBridge],
+        prompt: "Create an analytics dashboard.",
+      });
+
+      // Agent completed
+      const doneEvent = events.find((e) => e.kind === "done");
+      expect(doneEvent).toBeDefined();
+      if (doneEvent?.kind === "done") {
+        expect(doneEvent.output.stopReason).toBe("completed");
+      }
+
+      // Gateway received POST with body containing surfaceId
+      expect(gatewayLog.length).toBeGreaterThanOrEqual(1);
+      const postCall = gatewayLog.find((l) => l.method === "POST");
+      expect(postCall).toBeDefined();
+      expect(postCall?.surfaceId).toBe("dashboard-1");
+      expect(postCall?.body).toContain("dashboard-1");
+
+      // Inner channel received a text link, not A2UI blocks
+      expect(inner.sentMessages.length).toBeGreaterThanOrEqual(1);
+      const block = inner.sentMessages[0]?.content[0];
+      expect(block?.kind).toBe("text");
+      if (block?.kind === "text") {
+        expect(block.text).toContain("[Surface]");
+        expect(block.text).toContain("Analytics Dashboard");
+        expect(block.text).toContain(gatewayBaseUrl);
+      }
+
+      // Real LLM was called (phase 2)
+      expect(modelCallCount).toBeGreaterThanOrEqual(2);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "full lifecycle: create → update → delete through middleware chain",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      const lifecycleTool: Tool = {
+        descriptor: {
+          name: "surface_lifecycle",
+          description: "Creates, updates, then deletes a surface.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [makeCreateSurfaceBlock("surf-1", "My Surface")],
+          });
+          await channel.send({
+            content: [makeUpdateComponentsBlock("surf-1")],
+          });
+          await channel.send({
+            content: [makeDeleteSurfaceBlock("surf-1")],
+          });
+          return { status: "lifecycle complete" };
+        },
+      };
+
+      const { modelCallCount } = await runWithKoi({
+        manifestName: "e2e-canvas-lifecycle",
+        tool: lifecycleTool,
+        toolName: "surface_lifecycle",
+        toolCallInput: {},
+        prompt: "Run the surface lifecycle.",
+      });
+
+      // Gateway received all three operations: POST, PATCH, DELETE
+      expect(gatewayLog.length).toBe(3);
+      expect(gatewayLog[0]?.method).toBe("POST");
+      expect(gatewayLog[0]?.surfaceId).toBe("surf-1");
+      expect(gatewayLog[1]?.method).toBe("PATCH");
+      expect(gatewayLog[1]?.surfaceId).toBe("surf-1");
+      expect(gatewayLog[2]?.method).toBe("DELETE");
+      expect(gatewayLog[2]?.surfaceId).toBe("surf-1");
+
+      // Inner channel received 3 messages, all text (no A2UI)
+      expect(inner.sentMessages.length).toBe(3);
+
+      const createBlock = inner.sentMessages[0]?.content[0];
+      expect(createBlock?.kind).toBe("text");
+      if (createBlock?.kind === "text") {
+        expect(createBlock.text).toContain("[Surface]");
+        expect(createBlock.text).toContain("My Surface");
+      }
+
+      const updateBlock = inner.sentMessages[1]?.content[0];
+      expect(updateBlock?.kind).toBe("text");
+      if (updateBlock?.kind === "text") {
+        expect(updateBlock.text).toContain("[Updated]");
+      }
+
+      const deleteBlock = inner.sentMessages[2]?.content[0];
+      expect(deleteBlock?.kind).toBe("text");
+      if (deleteBlock?.kind === "text") {
+        expect(deleteBlock.text).toContain("[Removed]");
+      }
+
+      expect(modelCallCount).toBeGreaterThanOrEqual(2);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "mixed content: only A2UI blocks replaced, text and image preserved",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      const mixedTool: Tool = {
+        descriptor: {
+          name: "send_mixed",
+          description: "Sends mixed content.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [
+              { kind: "text", text: "Here is your dashboard:" },
+              makeCreateSurfaceBlock("mixed-1", "Dashboard"),
+              { kind: "image", url: "https://example.com/chart.png" },
+            ],
+          });
+          return { sent: true };
+        },
+      };
+
+      await runWithKoi({
+        manifestName: "e2e-canvas-mixed",
+        tool: mixedTool,
+        toolName: "send_mixed",
+        toolCallInput: {},
+        prompt: "Send mixed content.",
+      });
+
+      expect(inner.sentMessages.length).toBe(1);
+      const msg = inner.sentMessages[0];
+      expect(msg).toBeDefined();
+      if (msg === undefined) return;
+      expect(msg.content.length).toBe(3);
+
+      // Text preserved
+      expect(msg.content[0]?.kind).toBe("text");
+      if (msg.content[0]?.kind === "text") {
+        expect(msg.content[0].text).toBe("Here is your dashboard:");
+      }
+      // A2UI replaced with text link
+      expect(msg.content[1]?.kind).toBe("text");
+      if (msg.content[1]?.kind === "text") {
+        expect(msg.content[1].text).toContain("[Surface]");
+      }
+      // Image preserved
+      expect(msg.content[2]?.kind).toBe("image");
+      if (msg.content[2]?.kind === "image") {
+        expect(msg.content[2].url).toBe("https://example.com/chart.png");
+      }
+
+      expect(gatewayLog.length).toBe(1);
+      expect(gatewayLog[0]?.method).toBe("POST");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "Gateway failure produces degraded [Warning] text and fires onGatewayError",
+    async () => {
+      currentHandler = () => new Response("boom", { status: 500 });
+
+      const gatewayErrors: Array<{
+        readonly error: KoiError;
+        readonly surfaceId: string;
+      }> = []; // let justified: test accumulator
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const onGatewayError = mock((error: KoiError, surfaceId: string) => {
+        gatewayErrors.push({ error, surfaceId });
+      });
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+        onGatewayError,
+      });
+
+      const failTool: Tool = {
+        descriptor: {
+          name: "create_failing_ui",
+          description: "Creates a UI that will fail at Gateway.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [makeCreateSurfaceBlock("fail-1", "Failing Dashboard")],
+          });
+          return { attempted: true };
+        },
+      };
+
+      await runWithKoi({
+        manifestName: "e2e-canvas-fail",
+        tool: failTool,
+        toolName: "create_failing_ui",
+        toolCallInput: {},
+        prompt: "Try creating a UI.",
+      });
+
+      // onGatewayError was called
+      expect(onGatewayError).toHaveBeenCalledTimes(1);
+      expect(gatewayErrors[0]?.surfaceId).toBe("fail-1");
+      expect(gatewayErrors[0]?.error.code).toBe("EXTERNAL");
+      expect(gatewayErrors[0]?.error.retryable).toBe(true);
+
+      // Inner channel received degraded text
+      expect(inner.sentMessages.length).toBe(1);
+      const block = inner.sentMessages[0]?.content[0];
+      expect(block?.kind).toBe("text");
+      if (block?.kind === "text") {
+        expect(block.text).toContain("[Warning]");
+        expect(block.text).toContain("Failing Dashboard");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "channel with supportsA2ui: true passes A2UI blocks through unchanged",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeA2uiCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      // Decorator returns inner unchanged
+      expect(channel).toBe(inner);
+
+      const a2uiTool: Tool = {
+        descriptor: {
+          name: "send_a2ui",
+          description: "Sends A2UI blocks to a capable channel.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [makeCreateSurfaceBlock("native-1", "Native Dashboard")],
+          });
+          return { sent: true };
+        },
+      };
+
+      await runWithKoi({
+        manifestName: "e2e-canvas-native",
+        tool: a2uiTool,
+        toolName: "send_a2ui",
+        toolCallInput: {},
+        prompt: "Send A2UI to native channel.",
+      });
+
+      // Gateway was NOT called
+      expect(gatewayLog.length).toBe(0);
+
+      // Inner channel received the original A2UI block unchanged
+      expect(inner.sentMessages.length).toBe(1);
+      const block = inner.sentMessages[0]?.content[0];
+      expect(block?.kind).toBe("custom");
+      if (block?.kind === "custom") {
+        expect(block.type).toBe("a2ui:createSurface");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "no A2UI blocks: messages pass through without Gateway calls",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      const textTool: Tool = {
+        descriptor: {
+          name: "send_text",
+          description: "Sends a plain text message.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [{ kind: "text", text: "Just plain text" }],
+          });
+          return { sent: true };
+        },
+      };
+
+      await runWithKoi({
+        manifestName: "e2e-canvas-passthrough",
+        tool: textTool,
+        toolName: "send_text",
+        toolCallInput: {},
+        prompt: "Send plain text.",
+      });
+
+      expect(gatewayLog.length).toBe(0);
+      expect(inner.sentMessages.length).toBe(1);
+      const block = inner.sentMessages[0]?.content[0];
+      expect(block?.kind).toBe("text");
+      if (block?.kind === "text") {
+        expect(block.text).toBe("Just plain text");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "middleware wrapToolCall observes the full fallback pipeline",
+    async () => {
+      currentHandler = defaultGatewayHandler;
+      const interceptedToolIds: string[] = []; // let justified: test accumulator
+
+      const client = createGatewayClient({ canvasBaseUrl: gatewayBaseUrl });
+      const inner = makeInnerChannel(makeTextOnlyCaps());
+      const channel = createCanvasFallbackChannel(inner, {
+        gatewayClient: client,
+      });
+
+      const uiTool: Tool = {
+        descriptor: {
+          name: "build_form",
+          description: "Builds a form UI.",
+          inputSchema: { type: "object", properties: {} },
+        },
+        trustTier: "sandbox",
+        execute: async () => {
+          await channel.send({
+            content: [makeCreateSurfaceBlock("form-1", "Contact Form")],
+          });
+          return { surfaceId: "form-1" };
+        },
+      };
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-tool-observer",
+        wrapToolCall: async (_ctx, request: ToolRequest, next: ToolHandler) => {
+          interceptedToolIds.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      const { events } = await runWithKoi({
+        manifestName: "e2e-canvas-middleware",
+        tool: uiTool,
+        toolName: "build_form",
+        toolCallInput: {},
+        middleware: [toolObserver],
+        prompt: "Build me a form.",
+      });
+
+      // Agent completed
+      expect(events.find((e) => e.kind === "done")).toBeDefined();
+
+      // wrapToolCall intercepted the call
+      expect(interceptedToolIds).toContain("build_form");
+
+      // Gateway was called
+      expect(gatewayLog.length).toBe(1);
+      expect(gatewayLog[0]?.method).toBe("POST");
+
+      // Channel received text link
+      const block = inner.sentMessages[0]?.content[0];
+      if (block?.kind === "text") {
+        expect(block.text).toContain("[Surface]");
+        expect(block.text).toContain("Contact Form");
+      }
+
+      // Engine events include tool call lifecycle
+      expect(events.filter((e) => e.kind === "tool_call_start").length).toBeGreaterThan(0);
+      expect(events.filter((e) => e.kind === "tool_call_end").length).toBeGreaterThan(0);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -36,6 +36,7 @@
     "@koi/engine-external": "workspace:*",
     "@koi/sandbox-executor": "workspace:*",
     "@koi/canvas": "workspace:*",
+    "@koi/channel-canvas-fallback": "workspace:*",
     "@koi/orchestrator": "workspace:*",
     "@koi/test-utils": "workspace:*",
     "@koi/git-utils": "workspace:*",


### PR DESCRIPTION
## Summary

Closes #418

Adds automatic A2UI-to-canvas fallback so text-only channels (Slack, Telegram, Discord, CLI) can deliver interactive surfaces as clickable Gateway canvas links — agent code stays completely channel-agnostic.

- **L0 type change**: adds `readonly supportsA2ui: boolean` to `ChannelCapabilities` (all 7 adapters + test fixtures updated)
- **New L2 package `@koi/channel-canvas-fallback`**: channel decorator that intercepts A2UI blocks in `send()`, POSTs/PATCHes/DELETEs them to Gateway canvas, and replaces them with text links
- **Comprehensive E2E test**: 7 scenarios through the full `createKoi` + `createLoopAdapter` runtime assembly with real Anthropic API calls

### Architecture

```
Agent emits OutboundMessage with CustomBlock (type: "a2ui:*")
       │
       └── createCanvasFallbackChannel(innerChannel, { gatewayClient })
              │
              ├── supportsA2ui === true? → return inner unchanged (zero overhead)
              │
              └── supportsA2ui === false? → intercept send()
                    │
                    ├── No A2UI blocks? → pass through unchanged
                    │
                    └── Has A2UI blocks? → for each A2UI block:
                          ├── POST/PATCH/DELETE to Gateway canvas
                          ├── Success → TextBlock with link
                          └── Failure → TextBlock with [Warning]
```

### New files (13)

| File | LOC | Purpose |
|------|-----|---------|
| `detect-a2ui.ts` | 55 | Runtime A2UI block detection (no L2 imports) |
| `gateway-client.ts` | 170 | Lightweight fetch-based Gateway canvas CRUD |
| `generate-fallback-text.ts` | 32 | Success/degraded text generation |
| `create-canvas-fallback-channel.ts` | 120 | Main channel decorator |
| `index.ts` | 14 | Barrel exports |
| + 7 test files | ~780 | Unit tests for all modules |
| `e2e-canvas-fallback.test.ts` | 755 | Full pipeline E2E with real LLM |

### Modified files (20)

- `packages/core/src/channel.ts` — added `supportsA2ui` field
- 6 channel adapter source files — set `supportsA2ui: true/false`
- 8 test fixture files — added `supportsA2ui` to capabilities objects
- `tests/e2e/package.json` — added `@koi/channel-canvas-fallback` dep
- `bun.lock` — updated lockfile
- API surface snapshots — regenerated

## Test plan

- [x] All unit tests pass (`bun test` in `packages/channel-canvas-fallback/`)
- [x] All affected package tests pass (33 turbo test tasks)
- [x] Full monorepo typecheck passes (72 tasks)
- [x] Full monorepo build passes (72 tasks)
- [x] E2E test with real Anthropic API — 7 scenarios, 64 assertions
- [x] Biome lint clean
- [ ] CI green