### PR TITLE
feat: add @koi/competitive-broadcast — GWT-inspired agent coordination

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -259,6 +259,18 @@
         "@koi/model-router": "workspace:*",
       },
     },
+    "packages/competitive-broadcast": {
+      "name": "@koi/competitive-broadcast",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/config": {
       "name": "@koi/config",
       "version": "0.0.0",
@@ -791,7 +803,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
-        "@koi/errors": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",
@@ -1894,6 +1905,8 @@
     "@koi/cli": ["@koi/cli@workspace:packages/cli"],
 
     "@koi/code-mode": ["@koi/code-mode@workspace:packages/code-mode"],
+
+    "@koi/competitive-broadcast": ["@koi/competitive-broadcast@workspace:packages/competitive-broadcast"],
 
     "@koi/config": ["@koi/config@workspace:packages/config"],
 

--- a/docs/L2/competitive-broadcast.md
+++ b/docs/L2/competitive-broadcast.md
@@ -1,0 +1,557 @@
+# @koi/competitive-broadcast — GWT-Inspired Competitive Selection + Broadcast
+
+Implements Global Workspace Theory (Baars)-inspired agent coordination: multiple agents compete to solve the same task, the best result is selected via a pluggable strategy, and the winner is broadcast to all agents for system-wide coherence. Composes with `@koi/parallel-minions` for the spawn/collection phase.
+
+---
+
+## Why It Exists
+
+Koi has fan-out (`@koi/parallel-minions`) and DAG orchestration (`@koi/orchestrator`), but neither provides a **competitive selection + broadcast** pattern. Without this package, when multiple agents solve the same task:
+
+- The user sees N conflicting answers and must pick manually
+- No automatic quality selection — fastest, best-scored, or consensus
+- No coherence mechanism — other agents don't know which answer "won"
+- No broadcast — the winning result isn't shared back for alignment
+
+`@koi/competitive-broadcast` closes this gap with a single `runCycle()` call that selects a winner and broadcasts it.
+
+---
+
+## Architecture
+
+`@koi/competitive-broadcast` is an **L2 feature package** — it depends only on L0 (`@koi/core`). Zero external dependencies.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  @koi/competitive-broadcast  (L2)                            │
+│                                                              │
+│  types.ts       ← Proposal, ProposalId, SelectionStrategy,  │
+│                    BroadcastSink, CycleEvent, Vote           │
+│  selection.ts   ← 3 built-in selection strategy factories    │
+│  broadcast.ts   ← 2 built-in broadcast sink factories        │
+│  cycle.ts       ← runCycle() core pipeline                   │
+│  config.ts      ← CycleConfig validation + defaults          │
+│  index.ts       ← public API surface                         │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│  Dependencies                                                │
+│                                                              │
+│  @koi/core  (L0)   KoiError, Result, AgentId,               │
+│                     RETRYABLE_DEFAULTS                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## How It Works
+
+The package handles the **selection + broadcast** phase — it does not spawn agents. Agent spawning is handled upstream by `@koi/parallel-minions`, `@koi/orchestrator`, or manual `createKoi()` calls. This package receives their outputs as `Proposal` objects.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                      USER REQUEST                            │
+│              "Refactor the auth module"                       │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+              ┌────────────────────────┐
+              │  @koi/parallel-minions  │  ← fan-out (existing)
+              │  spawn N agents         │
+              └────────────┬───────────┘
+                           │
+            ┌──────────────┼──────────────┐
+            ▼              ▼              ▼
+     ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
+     │  Agent A     │ │  Agent B     │ │  Agent C     │
+     │  salience:   │ │  salience:   │ │  salience:   │
+     │    0.6       │ │    0.9       │ │    0.3       │
+     └──────┬───────┘ └──────┬───────┘ └──────┬───────┘
+            │                │                │
+            │         Collect as Proposals     │
+            └────────────────┼────────────────┘
+                             │
+                             ▼
+     ┌───────────────────────────────────────────────────────┐
+     │           @koi/competitive-broadcast                  │
+     │                                                       │
+     │  ┌─────────────────────────────────────────────────┐  │
+     │  │  1. VALIDATE  — count, duplicates, abort signal │  │
+     │  ├─────────────────────────────────────────────────┤  │
+     │  │  2. TRUNCATE  — cap output per maxOutputPerProposal│ │
+     │  ├─────────────────────────────────────────────────┤  │
+     │  │  3. SELECT    — pluggable SelectionStrategy     │  │
+     │  │     first-wins / scored / consensus              │  │
+     │  ├─────────────────────────────────────────────────┤  │
+     │  │  4. BROADCAST — pluggable BroadcastSink         │  │
+     │  │     Delivers winner to all recipients            │  │
+     │  └─────────────────────────────────────────────────┘  │
+     │                                                       │
+     │  Returns: Result<BroadcastResult, KoiError>           │
+     │  Events:  selection_started → winner_selected →       │
+     │           broadcast_started → broadcast_complete       │
+     └───────────────────────────────────────────────────────┘
+                             │
+                             ▼
+                    ALL AGENTS RECEIVE WINNER
+                    (system-wide coherence)
+```
+
+---
+
+## The Proposal Model
+
+A `Proposal` represents one agent's competing output:
+
+```typescript
+interface Proposal {
+  readonly id: ProposalId;           // Branded string (compile-time safety)
+  readonly agentId: AgentId;         // Which agent produced this
+  readonly output: string;           // The agent's response text
+  readonly durationMs: number;       // How long the agent took
+  readonly submittedAt: number;      // Epoch ms — when the agent submitted
+  readonly salience?: number;        // 0-1, used by scored selection
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+```
+
+`ProposalId` is a branded type — prevents accidentally mixing it with other string IDs at compile time:
+
+```typescript
+import { proposalId } from "@koi/competitive-broadcast";
+
+const id = proposalId("my-proposal");  // ProposalId (branded)
+```
+
+---
+
+## Selection Strategies
+
+Three built-in factories. All return `Result<Proposal, KoiError>` — never throw.
+
+### createFirstWinsSelector()
+
+Picks the proposal with the **lowest `submittedAt`** (earliest submission).
+
+```
+  Agent A (1.2s)  ──┐
+  Agent B (3.1s)  ──┼─→ first-wins ─→ Agent C (fastest)
+  Agent C (0.8s)  ──┘
+```
+
+**Tiebreaker chain:** lowest `submittedAt` → highest `salience` → lexicographic `id`
+
+**Use case:** Fastest acceptable answer. Race models of different sizes — Haiku answers in 0.8s, Opus in 9s, first one wins.
+
+### createScoredSelector(scoreFn?)
+
+Picks the proposal with the **highest score**. Default scorer: `salience ?? 0`. Custom `scoreFn` overrides.
+
+```
+  Agent A (salience: 0.6)  ──┐
+  Agent B (salience: 0.9)  ──┼─→ scored ─→ Agent B (highest score)
+  Agent C (salience: 0.3)  ──┘
+```
+
+**NaN/Infinity handling:** Treated as 0 (sanitized before comparison).
+
+**Custom scorers:**
+
+```typescript
+// Score by output length (most thorough wins)
+createScoredSelector((p) => p.output.length);
+
+// Score by speed (fastest wins)
+createScoredSelector((p) => 1 / p.durationMs);
+
+// Score by keyword presence
+createScoredSelector((p) => p.output.includes("SOLUTION") ? 1 : 0);
+```
+
+**Use case:** Best-of-N code generation. Quality-based ranking.
+
+### createConsensusSelector(options)
+
+Selects the proposal that exceeds a **vote-based threshold**. An async `judge` callback evaluates proposals and returns votes.
+
+```typescript
+createConsensusSelector({
+  threshold: 0.6,            // Must exceed 60% of total vote score
+  judge: async (proposals) => [
+    { proposalId: proposalId("a"), score: 0.8 },
+    { proposalId: proposalId("b"), score: 0.2 },
+  ],
+})
+```
+
+```
+  Proposal A: 0.8 / 1.0 = 80%  ──→ exceeds 60% threshold ──→ WINNER
+  Proposal B: 0.2 / 1.0 = 20%  ──→ below threshold
+```
+
+**Threshold validation:** Must be in `[0, 1]`. Throws `RangeError` at construction time if invalid.
+
+**Use case:** Consensus validation ("Is this SQL query safe?" — 3 judges vote), ensemble agreement.
+
+---
+
+## Broadcast Sinks
+
+Two built-in implementations. Both implement the `BroadcastSink` interface.
+
+### createInMemoryBroadcastSink(recipients)
+
+Calls each recipient callback in parallel via `Promise.allSettled`. Never throws — failures are counted in the report.
+
+```typescript
+const sink = createInMemoryBroadcastSink([
+  async (result) => { agentA.receive(result.winner); },
+  async (result) => { agentB.receive(result.winner); },
+  async (result) => { agentC.receive(result.winner); },
+]);
+```
+
+**Delivery report:**
+
+```typescript
+interface BroadcastReport {
+  readonly delivered: number;   // Successful callbacks
+  readonly failed: number;      // Failed callbacks
+  readonly errors?: readonly unknown[];
+}
+```
+
+### createEventBroadcastSink(eventComponent)
+
+Emits a `"broadcast:winner"` event to an `EventComponent` event bus.
+
+```typescript
+const sink = createEventBroadcastSink(eventComponent);
+// Emits: eventComponent.emit("broadcast:winner", result)
+```
+
+**Use case:** Wire into Koi's event system or any pub/sub bus.
+
+---
+
+## The runCycle() Pipeline
+
+The core function. Stateless — safe to call concurrently.
+
+```typescript
+async function runCycle(
+  config: CycleConfig,
+  proposals: readonly Proposal[],
+): Promise<Result<BroadcastResult, KoiError>>
+```
+
+**Pipeline steps:**
+
+```
+1. Check AbortSignal     → TIMEOUT error if already aborted
+2. Validate proposals     → VALIDATION error if empty, < minProposals, or duplicate IDs
+3. Truncate outputs       → Cap each output to maxOutputPerProposal chars
+4. Fire selection_started → onEvent callback
+5. Run strategy.select()  → INTERNAL error if strategy throws
+6. Fire winner_selected   → onEvent callback
+7. Check AbortSignal      → TIMEOUT error if aborted mid-cycle
+8. Fire broadcast_started → onEvent callback
+9. Run sink.broadcast()   → INTERNAL error if sink throws
+10. Fire broadcast_complete→ onEvent callback
+11. Return Result          → { ok: true, value: BroadcastResult }
+```
+
+**Never throws.** All failures are returned as `Result.error` with appropriate `KoiError` codes.
+
+---
+
+## Configuration
+
+```typescript
+interface CycleConfig {
+  readonly strategy: SelectionStrategy;           // Required: how to pick a winner
+  readonly sink: BroadcastSink;                   // Required: how to deliver
+  readonly minProposals: number;                  // Default: 1
+  readonly maxOutputPerProposal: number;          // Default: 10,000 chars
+  readonly signal?: AbortSignal;                  // Optional: cancel the cycle
+  readonly onEvent?: (event: CycleEvent) => void; // Optional: lifecycle events
+}
+```
+
+**Defaults:**
+
+```typescript
+const DEFAULT_CYCLE_CONFIG = Object.freeze({
+  minProposals: 1,
+  maxOutputPerProposal: 10_000,
+});
+```
+
+**Validation:**
+
+```typescript
+import { validateCycleConfig } from "@koi/competitive-broadcast";
+
+const result = validateCycleConfig(rawConfig);
+if (!result.ok) console.error(result.error.message);
+```
+
+---
+
+## Cycle Events
+
+Observable lifecycle events via the `onEvent` callback. Discriminated union on `kind`:
+
+| Event | Payload | When |
+|-------|---------|------|
+| `selection_started` | `{ proposalCount: number }` | Before strategy.select() |
+| `winner_selected` | `{ winner: Proposal }` | After successful selection |
+| `broadcast_started` | `{ winnerId: ProposalId }` | Before sink.broadcast() |
+| `broadcast_complete` | `{ report: BroadcastReport }` | After successful broadcast |
+| `cycle_error` | `{ error: KoiError }` | On any failure (validation, strategy, broadcast) |
+
+**Safety:** If `onEvent` throws, the cycle continues — observer errors never crash the pipeline.
+
+---
+
+## Composing with Other Packages
+
+### With @koi/parallel-minions (spawn + compete)
+
+```typescript
+import { createParallelMinionsProvider } from "@koi/parallel-minions";
+import { runCycle, createScoredSelector, createInMemoryBroadcastSink, proposalId } from "@koi/competitive-broadcast";
+import { agentId } from "@koi/core/ecs";
+
+// 1. Spawn agents via parallel-minions
+const minionResults = await runParallelTasks([
+  { description: "Implement rate limiter with token bucket" },
+  { description: "Implement rate limiter with sliding window" },
+  { description: "Implement rate limiter with leaky bucket" },
+]);
+
+// 2. Convert results to Proposals
+const proposals = minionResults.map((r, i) => ({
+  id: proposalId(`approach-${i}`),
+  agentId: agentId(`minion-${i}`),
+  output: r.output,
+  durationMs: r.durationMs,
+  submittedAt: r.submittedAt,
+  salience: r.qualityScore,
+}));
+
+// 3. Run competitive selection + broadcast
+const result = await runCycle(
+  {
+    strategy: createScoredSelector(),
+    sink: createInMemoryBroadcastSink(recipients),
+    minProposals: 2,
+    maxOutputPerProposal: 5_000,
+  },
+  proposals,
+);
+```
+
+### With @koi/engine-external (CLI tools compete)
+
+Works with any engine adapter — including external processes. The `Proposal` interface is the common contract; the adapter behind it is invisible to competitive-broadcast.
+
+```typescript
+import { createExternalAdapter } from "@koi/engine-external";
+import { createKoi } from "@koi/engine";
+
+// Spawn a Python script and a Rust solver via engine-external
+const pythonAdapter = createExternalAdapter({ command: "python", args: ["solver.py"] });
+const rustAdapter = createExternalAdapter({ command: "./target/release/solver" });
+
+// Both go through createKoi → collect outputs → build Proposals → runCycle()
+```
+
+**Note:** `engine-external` reports zero tokens in metrics. Use a custom `scoreFn` instead of salience:
+
+```typescript
+createScoredSelector((p) => 1 / p.durationMs);  // fastest wins
+```
+
+### With @koi/engine-pi (LLM agents compete)
+
+```typescript
+import { createPiAdapter } from "@koi/engine-pi";
+
+const agents = ["haiku", "sonnet", "opus"].map((model) =>
+  createPiAdapter({
+    model: `anthropic:claude-${model}-...`,
+    getApiKey: async () => API_KEY,
+  })
+);
+
+// Spawn all through createKoi, collect outputs, feed into runCycle()
+```
+
+---
+
+## Adapter Compatibility
+
+Competitive-broadcast is **adapter-agnostic**. It works with any source that produces `Proposal` objects:
+
+```
+                         ┌─────────────────┐
+                         │  Same task       │
+                         └────────┬────────┘
+                 ┌────────────────┼────────────────┐
+                 ▼                ▼                 ▼
+          ┌─────────────┐ ┌──────────────┐ ┌──────────────┐
+          │ engine-pi    │ │engine-external│ │engine-loop   │
+          │ (Claude LLM) │ │ (Python CLI) │ │ (OpenRouter) │
+          └──────┬───────┘ └──────┬───────┘ └──────┬───────┘
+                 │                │                 │
+                 ▼                ▼                 ▼
+          ┌──────────────────────────────────────────────┐
+          │              Proposal[]                       │
+          │  (adapter type is invisible at this layer)    │
+          └──────────────────────┬───────────────────────┘
+                                 │
+                                 ▼
+                          ┌─────────────┐
+                          │  runCycle()  │
+                          └─────────────┘
+```
+
+---
+
+## Real-World Patterns
+
+### Best-of-N Code Generation
+
+```
+  "Implement a rate limiter"
+     │
+     ├─→ Agent 1: token bucket    ──┐
+     ├─→ Agent 2: sliding window  ──┼─→ scored(quality) ─→ best one
+     └─→ Agent 3: leaky bucket    ──┘
+```
+
+### Consensus Validation
+
+```
+  "Is this SQL query safe?"
+     │
+     ├─→ Judge 1: "yes, safe"     ──┐
+     ├─→ Judge 2: "yes, safe"     ──┼─→ consensus(0.66) ─→ safe
+     └─→ Judge 3: "no, injection" ──┘
+```
+
+### Fastest Acceptable Answer
+
+```
+  "Summarize this document"
+     │
+     ├─→ Haiku  (0.8s)  ──┐
+     ├─→ Sonnet (3.1s)  ──┼─→ first-wins ─→ Haiku's answer
+     └─→ Opus   (9.2s)  ──┘
+```
+
+### A/B Model Testing
+
+```
+  Same prompt → different models
+     │
+     ├─→ Claude  ──┐
+     ├─→ GPT-4o  ──┼─→ scored(quality) ─→ track winner % per model
+     └─→ Gemini  ──┘      over 1000 runs
+```
+
+---
+
+## Error Handling
+
+All errors are returned as `Result<BroadcastResult, KoiError>` — never thrown.
+
+| Error Code | When | Retryable |
+|------------|------|-----------|
+| `VALIDATION` | Empty proposals, below minProposals, duplicate IDs | No |
+| `VALIDATION` | No consensus reached (below threshold) | No |
+| `TIMEOUT` | AbortSignal already aborted or aborted mid-cycle | Yes |
+| `INTERNAL` | strategy.select() threw unexpectedly | Depends |
+| `INTERNAL` | sink.broadcast() threw unexpectedly | Depends |
+
+**Error shape:**
+
+```typescript
+interface KoiError {
+  readonly code: "VALIDATION" | "TIMEOUT" | "INTERNAL";
+  readonly message: string;      // Human-readable: what + why + what to do
+  readonly retryable: boolean;
+  readonly cause?: unknown;      // Original error (for INTERNAL)
+  readonly context?: Readonly<Record<string, unknown>>;
+}
+```
+
+---
+
+## API Reference
+
+### Core Function
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `runCycle(config, proposals)` | `Promise<Result<BroadcastResult, KoiError>>` | Execute the full selection + broadcast pipeline |
+
+### Selection Strategy Factories
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `createFirstWinsSelector()` | `SelectionStrategy` | Picks earliest `submittedAt` |
+| `createScoredSelector(scoreFn?)` | `SelectionStrategy` | Picks highest score (default: salience) |
+| `createConsensusSelector(options)` | `SelectionStrategy` | Picks proposal exceeding vote threshold |
+
+### Broadcast Sink Factories
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `createInMemoryBroadcastSink(recipients)` | `BroadcastSink` | Parallel delivery via `Promise.allSettled` |
+| `createEventBroadcastSink(eventComponent)` | `BroadcastSink` | Emits `"broadcast:winner"` event |
+
+### Config
+
+| Export | Type | Description |
+|--------|------|-------------|
+| `validateCycleConfig(raw)` | `(unknown) => Result<CycleConfig, KoiError>` | Schema validation with defaults |
+| `DEFAULT_CYCLE_CONFIG` | `{ minProposals: 1, maxOutputPerProposal: 10_000 }` | Frozen defaults |
+
+### Branded Constructors + Type Guards
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `proposalId(id)` | `ProposalId` | Branded string constructor |
+| `isProposal(value)` | `value is Proposal` | Runtime type guard |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `Proposal` | Competing agent output with id, agentId, output, timing, salience |
+| `ProposalId` | Branded string for compile-time safety |
+| `SelectionStrategy` | `{ name, select(proposals) → Result }` |
+| `BroadcastSink` | `{ broadcast(result) → Promise<BroadcastReport> }` |
+| `BroadcastResult` | `{ winner, allProposals, cycleId }` |
+| `BroadcastReport` | `{ delivered, failed, errors? }` |
+| `CycleConfig` | Strategy, sink, limits, signal, onEvent |
+| `CycleEvent` | Discriminated union (5 event kinds) |
+| `Vote` | `{ proposalId, score }` for consensus |
+| `ConsensusOptions` | `{ threshold, judge }` for consensus selector |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ─────────────────────────────────────────────┐
+    KoiError, Result, RETRYABLE_DEFAULTS, AgentId           │
+                                                            ▼
+L2  @koi/competitive-broadcast <────────────────────────────┘
+    imports from L0 only
+    x never imports @koi/engine (L1)
+    x never imports peer L2 packages
+    x zero external dependencies
+    ~ package.json: { "dependencies": { "@koi/core": "workspace:*" } }
+```

--- a/packages/competitive-broadcast/package.json
+++ b/packages/competitive-broadcast/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koi/competitive-broadcast",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts",
+    "test:e2e": "E2E_TESTS=1 bun test src/__tests__/e2e-full-stack.test.ts"
+  }
+}

--- a/packages/competitive-broadcast/src/__tests__/cycle.integration.test.ts
+++ b/packages/competitive-broadcast/src/__tests__/cycle.integration.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for competitive broadcast cycles.
+ *
+ * Tests full selection-broadcast pipelines with real (non-spy) strategies and sinks.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createEventBroadcastSink, createInMemoryBroadcastSink } from "../broadcast.js";
+import type { CycleConfig } from "../config.js";
+import { DEFAULT_CYCLE_CONFIG } from "../config.js";
+import { runCycle } from "../cycle.js";
+import {
+  createConsensusSelector,
+  createFirstWinsSelector,
+  createScoredSelector,
+} from "../selection.js";
+import { mockProposal, resetMockCounter } from "../test-helpers.js";
+import type { BroadcastResult, CycleEvent, Vote } from "../types.js";
+import { proposalId } from "../types.js";
+
+beforeEach(() => {
+  resetMockCounter();
+});
+
+// ---------------------------------------------------------------------------
+// First-wins + InMemorySink
+// ---------------------------------------------------------------------------
+
+describe("first-wins + InMemorySink integration", () => {
+  test("correct winner is broadcasted to all recipients", async () => {
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: createFirstWinsSelector(),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    };
+
+    const early = mockProposal({ id: "early", submittedAt: 1000 });
+    const late = mockProposal({ id: "late", submittedAt: 2000 });
+
+    const result = await runCycle(config, [late, early]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(proposalId("early"));
+    }
+    expect(received).toHaveLength(2);
+    expect(received[0]?.winner.id).toBe(proposalId("early"));
+    expect(received[1]?.winner.id).toBe(proposalId("early"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScoredSelector + EventSink
+// ---------------------------------------------------------------------------
+
+describe("scored + EventSink integration", () => {
+  test("winner emitted to event bus", async () => {
+    const emit = mock(async () => {});
+    const eventComponent = { emit, on: () => () => {} };
+    const sink = createEventBroadcastSink(eventComponent);
+
+    const config: CycleConfig = {
+      strategy: createScoredSelector(),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    };
+
+    const low = mockProposal({ id: "low", salience: 0.2 });
+    const high = mockProposal({ id: "high", salience: 0.95 });
+
+    const result = await runCycle(config, [low, high]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(proposalId("high"));
+    }
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith("broadcast:winner", expect.anything());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConsensusSelector boundary tests
+// ---------------------------------------------------------------------------
+
+describe("consensus + threshold boundary integration", () => {
+  test("consensus reached — winner broadcasted", async () => {
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: createConsensusSelector({
+        threshold: 0.6,
+        judge: async (): Promise<readonly Vote[]> => [
+          { proposalId: proposalId("strong"), score: 0.8 },
+          { proposalId: proposalId("weak"), score: 0.2 },
+        ],
+      }),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    };
+
+    const strong = mockProposal({ id: "strong" });
+    const weak = mockProposal({ id: "weak" });
+
+    const result = await runCycle(config, [strong, weak]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(proposalId("strong"));
+    }
+    expect(received).toHaveLength(1);
+  });
+
+  test("no consensus reached — returns error, no broadcast", async () => {
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: createConsensusSelector({
+        threshold: 0.9,
+        judge: async (): Promise<readonly Vote[]> => [
+          { proposalId: proposalId("a"), score: 0.4 },
+          { proposalId: proposalId("b"), score: 0.4 },
+        ],
+      }),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    };
+
+    const a = mockProposal({ id: "a" });
+    const b = mockProposal({ id: "b" });
+
+    const result = await runCycle(config, [a, b]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("consensus");
+    }
+    // No broadcast should have happened
+    expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed: truncation + selection
+// ---------------------------------------------------------------------------
+
+describe("truncation + selection integration", () => {
+  test("truncated proposals still go through selection correctly", async () => {
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: createScoredSelector(),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: 50,
+    };
+
+    const longLow = mockProposal({ id: "long-low", output: "x".repeat(200), salience: 0.1 });
+    const longHigh = mockProposal({ id: "long-high", output: "y".repeat(200), salience: 0.9 });
+
+    const result = await runCycle(config, [longLow, longHigh]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(proposalId("long-high"));
+      expect(result.value.winner.output.length).toBeLessThanOrEqual(50);
+      expect(result.value.winner.output).toContain("[output truncated]");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error path: sink fails
+// ---------------------------------------------------------------------------
+
+describe("sink failure integration", () => {
+  test("returns error when broadcast throws", async () => {
+    const sink = {
+      broadcast: async () => {
+        throw new Error("network down");
+      },
+    };
+
+    const config: CycleConfig = {
+      strategy: createFirstWinsSelector(),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    };
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+      expect(result.error.cause).toBeInstanceOf(Error);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort mid-cycle
+// ---------------------------------------------------------------------------
+
+describe("abort signal integration", () => {
+  test("signal aborted between selection and broadcast — winner selected but not broadcast", async () => {
+    const received: BroadcastResult[] = [];
+    const controller = new AbortController();
+
+    // Strategy that aborts the signal as a side effect of selection
+    const abortingStrategy = {
+      name: "aborting",
+      select: (proposals: readonly import("../types.js").Proposal[]) => {
+        controller.abort("user cancelled");
+        const first = proposals[0];
+        if (first === undefined) {
+          return {
+            ok: false as const,
+            error: { code: "VALIDATION" as const, message: "empty", retryable: false },
+          };
+        }
+        return { ok: true as const, value: first };
+      },
+    };
+
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: abortingStrategy,
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+      signal: controller.signal,
+    };
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("TIMEOUT");
+    }
+    // Broadcast should not have happened
+    expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full event lifecycle
+// ---------------------------------------------------------------------------
+
+describe("full event lifecycle integration", () => {
+  test("all events fire in correct order with correct data", async () => {
+    const events: CycleEvent[] = [];
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const config: CycleConfig = {
+      strategy: createScoredSelector(),
+      sink,
+      minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+      maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+      onEvent: (e) => events.push(e),
+    };
+
+    const p1 = mockProposal({ id: "p1", salience: 0.3 });
+    const p2 = mockProposal({ id: "p2", salience: 0.7 });
+
+    await runCycle(config, [p1, p2]);
+
+    expect(events).toHaveLength(4);
+
+    const [e0, e1, e2, e3] = events;
+    expect(e0?.kind).toBe("selection_started");
+    if (e0?.kind === "selection_started") expect(e0?.proposalCount).toBe(2);
+
+    expect(e1?.kind).toBe("winner_selected");
+    if (e1?.kind === "winner_selected") expect(e1?.winner.id).toBe(proposalId("p2"));
+
+    expect(e2?.kind).toBe("broadcast_started");
+    if (e2?.kind === "broadcast_started") expect(e2?.winnerId).toBe(proposalId("p2"));
+
+    expect(e3?.kind).toBe("broadcast_complete");
+    if (e3?.kind === "broadcast_complete") {
+      expect(e3?.report.delivered).toBe(1);
+      expect(e3?.report.failed).toBe(0);
+    }
+  });
+});

--- a/packages/competitive-broadcast/src/__tests__/e2e-full-stack.test.ts
+++ b/packages/competitive-broadcast/src/__tests__/e2e-full-stack.test.ts
@@ -1,0 +1,797 @@
+/**
+ * E2E: competitive-broadcast through the full Koi runtime stack.
+ *
+ * Validates that the selection + broadcast pipeline works end-to-end with
+ * real Anthropic API calls flowing through createKoi + createPiAdapter.
+ *
+ * Tests:
+ *   1. Parallel competing agents → first-wins selection → broadcast
+ *   2. Scored selection on real LLM outputs
+ *   3. Consensus selection with LLM-based judge
+ *   4. Full createKoi + middleware chain + competitive-broadcast
+ *   5. Event lifecycle fires correctly with real proposals
+ *   6. Truncation on real verbose LLM output
+ *   7. Abort signal cancels cycle mid-flight
+ *
+ * Run:
+ *   E2E_TESTS=1 ANTHROPIC_API_KEY=sk-ant-... bun test src/__tests__/e2e-full-stack.test.ts
+ *
+ * Or via script:
+ *   bun run test:e2e
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest, EngineEvent, EngineOutput, KoiMiddleware } from "@koi/core";
+import { agentId } from "@koi/core/ecs";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createInMemoryBroadcastSink } from "../broadcast.js";
+import { DEFAULT_CYCLE_CONFIG } from "../config.js";
+import { runCycle } from "../cycle.js";
+import {
+  createConsensusSelector,
+  createFirstWinsSelector,
+  createScoredSelector,
+} from "../selection.js";
+import type { BroadcastResult, CycleEvent, Proposal, Vote } from "../types.js";
+import { proposalId } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function testManifest(name: string): AgentManifest {
+  return {
+    name,
+    version: "0.1.0",
+    model: { name: "claude-haiku-4-5" },
+  };
+}
+
+/**
+ * Spawn a real LLM agent via createKoi + createPiAdapter (full L1 runtime),
+ * collect its text output, and return a Proposal with timing data.
+ */
+async function spawnCompetingAgent(opts: {
+  readonly id: string;
+  readonly prompt: string;
+  readonly systemPrompt?: string;
+}): Promise<Proposal> {
+  const start = Date.now();
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: opts.systemPrompt ?? "You are a concise assistant. Reply briefly.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const runtime = await createKoi({
+    manifest: testManifest(`competitor-${opts.id}`),
+    adapter,
+    loopDetection: false,
+  });
+
+  const events = await collectEvents(runtime.run({ kind: "text", text: opts.prompt }));
+
+  const durationMs = Date.now() - start;
+  const output = extractText(events);
+  const done = findDoneOutput(events);
+
+  await runtime.dispose();
+
+  return {
+    id: proposalId(opts.id),
+    agentId: agentId(`agent-${opts.id}`),
+    output: output.length > 0 ? output : "(empty response)",
+    durationMs,
+    submittedAt: start,
+    salience:
+      done?.metrics.outputTokens !== undefined
+        ? Math.min(1, done.metrics.outputTokens / 200)
+        : undefined,
+  };
+}
+
+/**
+ * Spawn a real LLM agent through the full createKoi L1 runtime and return a Proposal.
+ */
+async function spawnViaKoiRuntime(opts: {
+  readonly id: string;
+  readonly prompt: string;
+  readonly systemPrompt?: string;
+  readonly middleware?: readonly KoiMiddleware[];
+}): Promise<{ readonly proposal: Proposal; readonly events: readonly EngineEvent[] }> {
+  const start = Date.now();
+
+  const adapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: opts.systemPrompt ?? "You are a concise assistant. Reply briefly.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  const koiOpts = {
+    manifest: testManifest(`competitor-${opts.id}`),
+    adapter,
+    loopDetection: false as const,
+    ...(opts.middleware !== undefined ? { middleware: opts.middleware } : {}),
+  };
+  const runtime = await createKoi(koiOpts);
+
+  const events = await collectEvents(runtime.run({ kind: "text", text: opts.prompt }));
+
+  const durationMs = Date.now() - start;
+  const output = extractText(events);
+  const done = findDoneOutput(events);
+
+  await runtime.dispose();
+
+  const proposal: Proposal = {
+    id: proposalId(opts.id),
+    agentId: agentId(`agent-${opts.id}`),
+    output: output.length > 0 ? output : "(empty response)",
+    durationMs,
+    submittedAt: start,
+    salience:
+      done?.metrics.outputTokens !== undefined
+        ? Math.min(1, done.metrics.outputTokens / 200)
+        : undefined,
+  };
+
+  return { proposal, events };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: competitive-broadcast full stack", () => {
+  // ── Test 1: Parallel competing agents → first-wins selection ──────────
+
+  test(
+    "parallel agents compete → first-wins selects earliest submitter → broadcast delivers",
+    async () => {
+      // Spawn 3 agents in parallel with the same question
+      const [p1, p2, p3] = await Promise.all([
+        spawnCompetingAgent({
+          id: "fast",
+          prompt: "Reply with exactly one word: alpha",
+          systemPrompt: "Reply with exactly one word. No explanation.",
+        }),
+        spawnCompetingAgent({
+          id: "medium",
+          prompt: "Reply with exactly one word: beta",
+          systemPrompt: "Reply with exactly one word. No explanation.",
+        }),
+        spawnCompetingAgent({
+          id: "slow",
+          prompt: "Reply with exactly one word: gamma",
+          systemPrompt: "Reply with exactly one word. No explanation.",
+        }),
+      ]);
+
+      // All proposals should have non-empty output
+      expect(p1.output.length).toBeGreaterThan(0);
+      expect(p2.output.length).toBeGreaterThan(0);
+      expect(p3.output.length).toBeGreaterThan(0);
+
+      // Set up broadcast sink
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      // Run cycle with first-wins selector
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        [p1, p2, p3],
+      );
+
+      // Cycle should succeed
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Winner should be the one with the lowest submittedAt
+      const earliest = [p1, p2, p3].sort((a, b) => a.submittedAt - b.submittedAt);
+      const firstProposal = earliest[0];
+      expect(firstProposal).toBeDefined();
+      if (firstProposal === undefined) return;
+      expect(result.value.winner.id).toBe(firstProposal.id);
+      expect(result.value.allProposals).toHaveLength(3);
+
+      // Broadcast should have been delivered to both recipients
+      expect(received).toHaveLength(2);
+      expect(received[0]?.winner.id).toBe(firstProposal.id);
+      expect(received[1]?.winner.id).toBe(firstProposal.id);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Scored selection on real LLM outputs ─────────────────────
+
+  test(
+    "scored selector picks highest-salience proposal from real LLM outputs",
+    async () => {
+      // Spawn agents with different verbosity → different salience
+      const [concise, verbose] = await Promise.all([
+        spawnCompetingAgent({
+          id: "concise",
+          prompt: "What is 2+2?",
+          systemPrompt: "Reply with just the number. Nothing else.",
+        }),
+        spawnCompetingAgent({
+          id: "verbose",
+          prompt: "What is 2+2? Explain your reasoning in detail with examples.",
+          systemPrompt: "Be very thorough and detailed in your response. Explain step by step.",
+        }),
+      ]);
+
+      // Override salience to make the test deterministic
+      const conciseWithSalience: Proposal = { ...concise, salience: 0.3 };
+      const verboseWithSalience: Proposal = { ...verbose, salience: 0.9 };
+
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      const result = await runCycle(
+        {
+          strategy: createScoredSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        [conciseWithSalience, verboseWithSalience],
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Scored selector should pick the one with higher salience
+      expect(result.value.winner.id).toBe(proposalId("verbose"));
+      expect(received).toHaveLength(1);
+      expect(received[0]?.winner.output.length).toBeGreaterThan(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Scored selection with custom scoreFn ─────────────────────
+
+  test(
+    "scored selector with custom scoreFn picks shortest output",
+    async () => {
+      const [short, long] = await Promise.all([
+        spawnCompetingAgent({
+          id: "short",
+          prompt: "Say hi",
+          systemPrompt: "Reply with one word only.",
+        }),
+        spawnCompetingAgent({
+          id: "long",
+          prompt: "Write a paragraph about the history of computing.",
+          systemPrompt: "Be detailed and thorough.",
+        }),
+      ]);
+
+      // Custom scorer: shorter output = higher score (inverse of length)
+      const inverseLengthScorer = (p: Proposal): number => 1 / (1 + p.output.length);
+
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      const result = await runCycle(
+        {
+          strategy: createScoredSelector(inverseLengthScorer),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        [short, long],
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Shorter output should win
+      expect(result.value.winner.id).toBe(proposalId("short"));
+      expect(result.value.winner.output.length).toBeLessThan(long.output.length);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: Consensus selection with deterministic judge ─────────────
+
+  test(
+    "consensus selector reaches consensus on real proposals",
+    async () => {
+      const [p1, p2] = await Promise.all([
+        spawnCompetingAgent({
+          id: "candidate-a",
+          prompt: "What is the capital of France?",
+          systemPrompt: "Reply with just the city name.",
+        }),
+        spawnCompetingAgent({
+          id: "candidate-b",
+          prompt: "Name a random European country capital.",
+          systemPrompt: "Reply with just one city name.",
+        }),
+      ]);
+
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      // Judge strongly favors candidate-a (deterministic votes)
+      const result = await runCycle(
+        {
+          strategy: createConsensusSelector({
+            threshold: 0.6,
+            judge: async (): Promise<readonly Vote[]> => [
+              { proposalId: proposalId("candidate-a"), score: 0.9 },
+              { proposalId: proposalId("candidate-b"), score: 0.1 },
+            ],
+          }),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        [p1, p2],
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.winner.id).toBe(proposalId("candidate-a"));
+      expect(result.value.winner.output.toLowerCase()).toContain("paris");
+      expect(received).toHaveLength(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Full createKoi L1 runtime → competitive-broadcast ───────
+
+  test(
+    "full createKoi + middleware chain → proposals → competitive-broadcast pipeline",
+    async () => {
+      const turnHooks: string[] = [];
+
+      const observer: KoiMiddleware = {
+        name: "e2e-observer",
+        onSessionStart: async () => {
+          turnHooks.push("session_start");
+        },
+        onSessionEnd: async () => {
+          turnHooks.push("session_end");
+        },
+        onAfterTurn: async () => {
+          turnHooks.push("after_turn");
+        },
+      };
+
+      // Spawn 2 agents through the full createKoi L1 runtime
+      const [agent1, agent2] = await Promise.all([
+        spawnViaKoiRuntime({
+          id: "koi-agent-1",
+          prompt: "Reply with exactly: I am agent one",
+          middleware: [observer],
+        }),
+        spawnViaKoiRuntime({
+          id: "koi-agent-2",
+          prompt: "Reply with exactly: I am agent two",
+          middleware: [observer],
+        }),
+      ]);
+
+      // Verify agents ran through L1 runtime (middleware fired)
+      expect(turnHooks).toContain("session_start");
+      expect(turnHooks).toContain("session_end");
+      expect(turnHooks).toContain("after_turn");
+
+      // Verify outputs are real LLM responses
+      expect(agent1.proposal.output.length).toBeGreaterThan(0);
+      expect(agent2.proposal.output.length).toBeGreaterThan(0);
+
+      // Verify done events have metrics
+      const done1 = findDoneOutput(agent1.events);
+      const done2 = findDoneOutput(agent2.events);
+      expect(done1).toBeDefined();
+      expect(done2).toBeDefined();
+      expect(done1?.metrics.inputTokens).toBeGreaterThan(0);
+      expect(done2?.metrics.inputTokens).toBeGreaterThan(0);
+
+      // Now feed through competitive-broadcast
+      const cycleEvents: CycleEvent[] = [];
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+          onEvent: (e) => {
+            cycleEvents.push(e);
+          },
+        },
+        [agent1.proposal, agent2.proposal],
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Winner should have real content
+      expect(result.value.winner.output.length).toBeGreaterThan(0);
+      expect(result.value.allProposals).toHaveLength(2);
+
+      // Broadcast delivered
+      expect(received).toHaveLength(1);
+      expect(received[0]?.cycleId).toContain("cycle-");
+
+      // Cycle events fired correctly
+      expect(cycleEvents).toHaveLength(4);
+      expect(cycleEvents[0]?.kind).toBe("selection_started");
+      expect(cycleEvents[1]?.kind).toBe("winner_selected");
+      expect(cycleEvents[2]?.kind).toBe("broadcast_started");
+      expect(cycleEvents[3]?.kind).toBe("broadcast_complete");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Event lifecycle with real proposals ──────────────────────
+
+  test(
+    "cycle events contain correct data from real LLM proposals",
+    async () => {
+      const proposal = await spawnCompetingAgent({
+        id: "event-test",
+        prompt: "Say hello",
+        systemPrompt: "Reply with just: hello",
+      });
+
+      const cycleEvents: CycleEvent[] = [];
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+          onEvent: (e) => {
+            cycleEvents.push(e);
+          },
+        },
+        [proposal],
+      );
+
+      expect(result.ok).toBe(true);
+
+      // Validate each event has correct data
+      const selectionStarted = cycleEvents.find((e) => e.kind === "selection_started");
+      expect(selectionStarted).toBeDefined();
+      if (selectionStarted?.kind === "selection_started") {
+        expect(selectionStarted.proposalCount).toBe(1);
+      }
+
+      const winnerSelected = cycleEvents.find((e) => e.kind === "winner_selected");
+      expect(winnerSelected).toBeDefined();
+      if (winnerSelected?.kind === "winner_selected") {
+        expect(winnerSelected.winner.id).toBe(proposalId("event-test"));
+        expect(winnerSelected.winner.output.length).toBeGreaterThan(0);
+        expect(winnerSelected.winner.durationMs).toBeGreaterThan(0);
+      }
+
+      const broadcastStarted = cycleEvents.find((e) => e.kind === "broadcast_started");
+      expect(broadcastStarted).toBeDefined();
+      if (broadcastStarted?.kind === "broadcast_started") {
+        expect(broadcastStarted.winnerId).toBe(proposalId("event-test"));
+      }
+
+      const broadcastComplete = cycleEvents.find((e) => e.kind === "broadcast_complete");
+      expect(broadcastComplete).toBeDefined();
+      if (broadcastComplete?.kind === "broadcast_complete") {
+        expect(broadcastComplete.report.delivered).toBe(1);
+        expect(broadcastComplete.report.failed).toBe(0);
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Truncation on real verbose LLM output ────────────────────
+
+  test(
+    "truncation works correctly on real verbose LLM output",
+    async () => {
+      const verbose = await spawnCompetingAgent({
+        id: "verbose-truncation",
+        prompt:
+          "Write a detailed essay about the history of programming languages. Include at least 10 languages and their key contributions.",
+        systemPrompt: "Be extremely detailed and thorough. Write at least 500 words.",
+      });
+
+      // Verify we got substantial output
+      expect(verbose.output.length).toBeGreaterThan(100);
+
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      // Truncate to 200 chars
+      const maxOutput = 200;
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: maxOutput,
+        },
+        [verbose],
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // Winner output should be truncated
+      expect(result.value.winner.output.length).toBeLessThanOrEqual(maxOutput);
+      expect(result.value.winner.output).toContain("[output truncated]");
+
+      // Broadcast should also have the truncated version
+      expect(received).toHaveLength(1);
+      expect(received[0]?.winner.output.length).toBeLessThanOrEqual(maxOutput);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 8: Abort signal cancels cycle ───────────────────────────────
+
+  test(
+    "abort signal prevents broadcast of real proposals",
+    async () => {
+      const proposal = await spawnCompetingAgent({
+        id: "abort-test",
+        prompt: "Say hello",
+        systemPrompt: "Reply with just: hello",
+      });
+
+      const controller = new AbortController();
+      controller.abort("e2e test abort");
+
+      const received: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received.push(r);
+        },
+      ]);
+
+      const cycleEvents: CycleEvent[] = [];
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+          signal: controller.signal,
+          onEvent: (e) => {
+            cycleEvents.push(e);
+          },
+        },
+        [proposal],
+      );
+
+      // Cycle should fail with abort error
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("TIMEOUT");
+        expect(result.error.message).toContain("aborted");
+      }
+
+      // No broadcast should have happened
+      expect(received).toHaveLength(0);
+
+      // Error event should have fired
+      const errorEvent = cycleEvents.find((e) => e.kind === "cycle_error");
+      expect(errorEvent).toBeDefined();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 9: Multiple broadcast recipients receive real results ───────
+
+  test(
+    "multiple recipients all receive the broadcast with real proposal data",
+    async () => {
+      const proposal = await spawnCompetingAgent({
+        id: "multi-recipient",
+        prompt: "What is the meaning of life? Reply in one sentence.",
+        systemPrompt: "Be concise.",
+      });
+
+      const received1: BroadcastResult[] = [];
+      const received2: BroadcastResult[] = [];
+      const received3: BroadcastResult[] = [];
+      const sink = createInMemoryBroadcastSink([
+        async (r) => {
+          received1.push(r);
+        },
+        async (r) => {
+          received2.push(r);
+        },
+        async (r) => {
+          received3.push(r);
+        },
+      ]);
+
+      const result = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink,
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        [proposal],
+      );
+
+      expect(result.ok).toBe(true);
+
+      // All 3 recipients should have received the same winner
+      expect(received1).toHaveLength(1);
+      expect(received2).toHaveLength(1);
+      expect(received3).toHaveLength(1);
+
+      const w1 = received1[0]?.winner;
+      const w2 = received2[0]?.winner;
+      const w3 = received3[0]?.winner;
+      expect(w1?.id).toBe(proposalId("multi-recipient"));
+      expect(w2?.id).toBe(proposalId("multi-recipient"));
+      expect(w3?.id).toBe(proposalId("multi-recipient"));
+
+      // All should have the same output
+      expect(w1?.output).toBe(w2?.output);
+      expect(w2?.output).toBe(w3?.output);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 10: End-to-end with all three strategies on same proposals ──
+
+  test(
+    "all three strategies can process the same real proposals",
+    async () => {
+      // Spawn 2 agents once, reuse proposals across all strategies
+      const [early, late] = await Promise.all([
+        spawnCompetingAgent({
+          id: "early-bird",
+          prompt: "Say: first",
+          systemPrompt: "Reply with one word.",
+        }),
+        spawnCompetingAgent({
+          id: "late-comer",
+          prompt: "Say: second",
+          systemPrompt: "Reply with one word.",
+        }),
+      ]);
+
+      // Override timing to make order deterministic
+      const earlyProposal: Proposal = { ...early, submittedAt: 1000, salience: 0.3 };
+      const lateProposal: Proposal = { ...late, submittedAt: 2000, salience: 0.9 };
+      const proposals = [earlyProposal, lateProposal];
+
+      // Strategy 1: first-wins → picks earliest submittedAt
+      const r1 = await runCycle(
+        {
+          strategy: createFirstWinsSelector(),
+          sink: createInMemoryBroadcastSink([]),
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        proposals,
+      );
+      expect(r1.ok).toBe(true);
+      if (r1.ok) expect(r1.value.winner.id).toBe(proposalId("early-bird"));
+
+      // Strategy 2: scored → picks highest salience
+      const r2 = await runCycle(
+        {
+          strategy: createScoredSelector(),
+          sink: createInMemoryBroadcastSink([]),
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        proposals,
+      );
+      expect(r2.ok).toBe(true);
+      if (r2.ok) expect(r2.value.winner.id).toBe(proposalId("late-comer"));
+
+      // Strategy 3: consensus → picks the one with highest vote share
+      const r3 = await runCycle(
+        {
+          strategy: createConsensusSelector({
+            threshold: 0.5,
+            judge: async (): Promise<readonly Vote[]> => [
+              { proposalId: proposalId("early-bird"), score: 0.7 },
+              { proposalId: proposalId("late-comer"), score: 0.3 },
+            ],
+          }),
+          sink: createInMemoryBroadcastSink([]),
+          minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+          maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+        },
+        proposals,
+      );
+      expect(r3.ok).toBe(true);
+      if (r3.ok) expect(r3.value.winner.id).toBe(proposalId("early-bird"));
+
+      // All three should have selected from the same proposal set
+      if (r1.ok) expect(r1.value.allProposals).toHaveLength(2);
+      if (r2.ok) expect(r2.value.allProposals).toHaveLength(2);
+      if (r3.ok) expect(r3.value.allProposals).toHaveLength(2);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/competitive-broadcast/src/broadcast.test.ts
+++ b/packages/competitive-broadcast/src/broadcast.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createEventBroadcastSink, createInMemoryBroadcastSink } from "./broadcast.js";
+import { mockProposal, resetMockCounter } from "./test-helpers.js";
+import type { BroadcastResult } from "./types.js";
+
+beforeEach(() => {
+  resetMockCounter();
+});
+
+function makeBroadcastResult(overrides?: Partial<BroadcastResult>): BroadcastResult {
+  const winner = mockProposal({ id: "winner" });
+  return {
+    winner,
+    allProposals: [winner, mockProposal({ id: "loser" })],
+    cycleId: "cycle-1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createInMemoryBroadcastSink
+// ---------------------------------------------------------------------------
+
+describe("createInMemoryBroadcastSink", () => {
+  test("delivers to all recipients in parallel", async () => {
+    const received: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        received.push(r);
+      },
+      async (r) => {
+        received.push(r);
+      },
+    ]);
+
+    const result = makeBroadcastResult();
+    const report = await sink.broadcast(result);
+
+    expect(report.delivered).toBe(2);
+    expect(report.failed).toBe(0);
+    expect(received).toHaveLength(2);
+    expect(received[0]).toBe(result);
+  });
+
+  test("counts failures but does not throw", async () => {
+    const sink = createInMemoryBroadcastSink([
+      async () => {
+        throw new Error("recipient down");
+      },
+      async () => {
+        /* success */
+      },
+    ]);
+
+    const report = await sink.broadcast(makeBroadcastResult());
+
+    expect(report.delivered).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(report.errors).toHaveLength(1);
+  });
+
+  test("all recipients fail — failed matches total", async () => {
+    const sink = createInMemoryBroadcastSink([
+      async () => {
+        throw new Error("fail-1");
+      },
+      async () => {
+        throw new Error("fail-2");
+      },
+    ]);
+
+    const report = await sink.broadcast(makeBroadcastResult());
+
+    expect(report.delivered).toBe(0);
+    expect(report.failed).toBe(2);
+    expect(report.errors).toHaveLength(2);
+  });
+
+  test("zero recipients — returns ok with delivered=0", async () => {
+    const sink = createInMemoryBroadcastSink([]);
+    const report = await sink.broadcast(makeBroadcastResult());
+
+    expect(report.delivered).toBe(0);
+    expect(report.failed).toBe(0);
+    expect(report.errors).toBeUndefined();
+  });
+
+  test("recipients receive the exact BroadcastResult object", async () => {
+    const captured: BroadcastResult[] = [];
+    const sink = createInMemoryBroadcastSink([
+      async (r) => {
+        captured.push(r);
+      },
+    ]);
+
+    const result = makeBroadcastResult();
+    await sink.broadcast(result);
+
+    expect(captured[0]).toBe(result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEventBroadcastSink
+// ---------------------------------------------------------------------------
+
+describe("createEventBroadcastSink", () => {
+  test("emits broadcast:winner event with the result", async () => {
+    const emit = mock(async () => {});
+    const eventComponent = { emit, on: () => () => {} };
+    const sink = createEventBroadcastSink(eventComponent);
+
+    const result = makeBroadcastResult();
+    const report = await sink.broadcast(result);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith("broadcast:winner", result);
+    expect(report.delivered).toBe(1);
+    expect(report.failed).toBe(0);
+  });
+
+  test("reports failure when emit throws", async () => {
+    const emitError = new Error("event bus down");
+    const emit = mock(async () => {
+      throw emitError;
+    });
+    const eventComponent = { emit, on: () => () => {} };
+    const sink = createEventBroadcastSink(eventComponent);
+
+    const report = await sink.broadcast(makeBroadcastResult());
+
+    expect(report.delivered).toBe(0);
+    expect(report.failed).toBe(1);
+    expect(report.errors).toHaveLength(1);
+  });
+});

--- a/packages/competitive-broadcast/src/broadcast.ts
+++ b/packages/competitive-broadcast/src/broadcast.ts
@@ -1,0 +1,82 @@
+/**
+ * Broadcast sinks for delivering competitive selection results.
+ *
+ * Two built-in implementations:
+ * - InMemoryBroadcastSink: calls recipient callbacks in parallel
+ * - EventBroadcastSink: emits to an EventComponent event bus
+ */
+
+import type { BroadcastReport, BroadcastResult, BroadcastSink } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Recipient callback type
+// ---------------------------------------------------------------------------
+
+/** Async callback invoked with the broadcast result. */
+export type BroadcastRecipient = (result: BroadcastResult) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// createInMemoryBroadcastSink
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a BroadcastSink that calls each recipient callback in parallel
+ * via Promise.allSettled. Never throws — failures are counted in the report.
+ */
+export function createInMemoryBroadcastSink(
+  recipients: readonly BroadcastRecipient[],
+): BroadcastSink {
+  return {
+    broadcast: async (result: BroadcastResult): Promise<BroadcastReport> => {
+      if (recipients.length === 0) {
+        return { delivered: 0, failed: 0 };
+      }
+
+      const settled = await Promise.allSettled(recipients.map((r) => r(result)));
+
+      const errors: unknown[] = [];
+      /* let is required for accumulator */
+      let delivered = 0;
+
+      for (const outcome of settled) {
+        if (outcome.status === "fulfilled") {
+          delivered++;
+        } else {
+          errors.push(outcome.reason);
+        }
+      }
+
+      return {
+        delivered,
+        failed: errors.length,
+        errors: errors.length > 0 ? errors : undefined,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createEventBroadcastSink
+// ---------------------------------------------------------------------------
+
+/** Minimal EventComponent shape needed by the event sink. */
+export interface EventComponentLike {
+  readonly emit: (type: string, data: unknown) => Promise<void>;
+}
+
+/**
+ * Creates a BroadcastSink that emits a "broadcast:winner" event
+ * to an EventComponent. Single recipient (the event bus).
+ */
+export function createEventBroadcastSink(eventComponent: EventComponentLike): BroadcastSink {
+  return {
+    broadcast: async (result: BroadcastResult): Promise<BroadcastReport> => {
+      try {
+        await eventComponent.emit("broadcast:winner", result);
+        return { delivered: 1, failed: 0 };
+      } catch (e: unknown) {
+        return { delivered: 0, failed: 1, errors: [e] };
+      }
+    },
+  };
+}

--- a/packages/competitive-broadcast/src/config.test.ts
+++ b/packages/competitive-broadcast/src/config.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CYCLE_CONFIG, validateCycleConfig } from "./config.js";
+import {
+  createSpyBroadcastSink,
+  createSpySelectionStrategy,
+  resetMockCounter,
+} from "./test-helpers.js";
+
+beforeEach(() => {
+  resetMockCounter();
+});
+
+describe("DEFAULT_CYCLE_CONFIG", () => {
+  test("has expected defaults", () => {
+    expect(DEFAULT_CYCLE_CONFIG.minProposals).toBe(1);
+    expect(DEFAULT_CYCLE_CONFIG.maxOutputPerProposal).toBe(10_000);
+  });
+
+  test("is frozen", () => {
+    expect(Object.isFrozen(DEFAULT_CYCLE_CONFIG)).toBe(true);
+  });
+});
+
+describe("validateCycleConfig", () => {
+  const validConfig = {
+    strategy: createSpySelectionStrategy(),
+    sink: createSpyBroadcastSink().sink,
+  };
+
+  test("accepts valid config with required fields only", () => {
+    const result = validateCycleConfig(validConfig);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.strategy).toBe(validConfig.strategy);
+      expect(result.value.sink).toBe(validConfig.sink);
+      expect(result.value.minProposals).toBe(DEFAULT_CYCLE_CONFIG.minProposals);
+      expect(result.value.maxOutputPerProposal).toBe(DEFAULT_CYCLE_CONFIG.maxOutputPerProposal);
+    }
+  });
+
+  test("accepts valid config with all optional fields", () => {
+    const controller = new AbortController();
+    const onEvent = () => {};
+    const full = {
+      ...validConfig,
+      minProposals: 3,
+      maxOutputPerProposal: 5_000,
+      signal: controller.signal,
+      onEvent,
+    };
+    const result = validateCycleConfig(full);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.minProposals).toBe(3);
+      expect(result.value.maxOutputPerProposal).toBe(5_000);
+      expect(result.value.signal).toBe(controller.signal);
+      expect(result.value.onEvent).toBe(onEvent);
+    }
+  });
+
+  test("rejects null", () => {
+    const result = validateCycleConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects undefined", () => {
+    const result = validateCycleConfig(undefined);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects non-object", () => {
+    const result = validateCycleConfig("string");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects config without strategy", () => {
+    const result = validateCycleConfig({ sink: validConfig.sink });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("strategy");
+  });
+
+  test("rejects config without sink", () => {
+    const result = validateCycleConfig({ strategy: validConfig.strategy });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("sink");
+  });
+
+  test("rejects strategy without select method", () => {
+    const result = validateCycleConfig({
+      strategy: { name: "bad" },
+      sink: validConfig.sink,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("strategy.select");
+  });
+
+  test("rejects sink without broadcast method", () => {
+    const result = validateCycleConfig({
+      strategy: validConfig.strategy,
+      sink: {},
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("sink.broadcast");
+  });
+
+  test("rejects minProposals < 1", () => {
+    const result = validateCycleConfig({ ...validConfig, minProposals: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("minProposals");
+  });
+
+  test("rejects negative maxOutputPerProposal", () => {
+    const result = validateCycleConfig({ ...validConfig, maxOutputPerProposal: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxOutputPerProposal");
+  });
+
+  test("rejects non-integer minProposals", () => {
+    const result = validateCycleConfig({ ...validConfig, minProposals: 1.5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("minProposals");
+  });
+});

--- a/packages/competitive-broadcast/src/config.ts
+++ b/packages/competitive-broadcast/src/config.ts
@@ -1,0 +1,107 @@
+/**
+ * Cycle configuration validation and defaults.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BroadcastSink, CycleEvent, SelectionStrategy } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// CycleConfig
+// ---------------------------------------------------------------------------
+
+/** Configuration for a single competitive broadcast cycle. */
+export interface CycleConfig {
+  readonly strategy: SelectionStrategy;
+  readonly sink: BroadcastSink;
+  /** Minimum number of proposals required to run a cycle. Default: 1. */
+  readonly minProposals: number;
+  /** Maximum characters per proposal output. Truncated before selection. Default: 10,000. */
+  readonly maxOutputPerProposal: number;
+  /** Optional abort signal for cycle cancellation. */
+  readonly signal?: AbortSignal | undefined;
+  /** Optional callback for cycle lifecycle events. */
+  readonly onEvent?: ((event: CycleEvent) => void) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_CYCLE_CONFIG: Readonly<{
+  readonly minProposals: 1;
+  readonly maxOutputPerProposal: 10_000;
+}> = Object.freeze({
+  minProposals: 1,
+  maxOutputPerProposal: 10_000,
+} as const);
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function validationError(message: string): Result<CycleConfig, KoiError> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+/** Validates an unknown value as a CycleConfig. Applies defaults for optional fields. */
+export function validateCycleConfig(config: unknown): Result<CycleConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = config as Record<string, unknown>;
+
+  // Required: strategy
+  if (c.strategy === null || c.strategy === undefined || typeof c.strategy !== "object") {
+    return validationError("Config must include a strategy object");
+  }
+  const strategy = c.strategy as Record<string, unknown>;
+  if (typeof strategy.select !== "function") {
+    return validationError("Config must include strategy.select as a function");
+  }
+
+  // Required: sink
+  if (c.sink === null || c.sink === undefined || typeof c.sink !== "object") {
+    return validationError("Config must include a sink object");
+  }
+  const sink = c.sink as Record<string, unknown>;
+  if (typeof sink.broadcast !== "function") {
+    return validationError("Config must include sink.broadcast as a function");
+  }
+
+  // Optional: minProposals
+  const minProposals =
+    c.minProposals !== undefined ? (c.minProposals as number) : DEFAULT_CYCLE_CONFIG.minProposals;
+  if (typeof minProposals !== "number" || !Number.isInteger(minProposals) || minProposals < 1) {
+    return validationError("minProposals must be a positive integer (>= 1)");
+  }
+
+  // Optional: maxOutputPerProposal
+  const maxOutputPerProposal =
+    c.maxOutputPerProposal !== undefined
+      ? (c.maxOutputPerProposal as number)
+      : DEFAULT_CYCLE_CONFIG.maxOutputPerProposal;
+  if (typeof maxOutputPerProposal !== "number" || maxOutputPerProposal < 0) {
+    return validationError("maxOutputPerProposal must be a non-negative number");
+  }
+
+  return {
+    ok: true,
+    value: {
+      strategy: c.strategy as SelectionStrategy,
+      sink: c.sink as BroadcastSink,
+      minProposals,
+      maxOutputPerProposal,
+      signal: c.signal as AbortSignal | undefined,
+      onEvent: c.onEvent as ((event: CycleEvent) => void) | undefined,
+    },
+  };
+}

--- a/packages/competitive-broadcast/src/cycle.test.ts
+++ b/packages/competitive-broadcast/src/cycle.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { KoiError } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CycleConfig } from "./config.js";
+import { DEFAULT_CYCLE_CONFIG } from "./config.js";
+import { runCycle } from "./cycle.js";
+import {
+  createFailingBroadcastSink,
+  createFailingSelectionStrategy,
+  createSpyBroadcastSink,
+  createSpySelectionStrategy,
+  mockProposal,
+  resetMockCounter,
+} from "./test-helpers.js";
+import type { CycleEvent } from "./types.js";
+import { proposalId } from "./types.js";
+
+beforeEach(() => {
+  resetMockCounter();
+});
+
+function makeConfig(overrides?: Partial<CycleConfig>): CycleConfig {
+  const { sink } = createSpyBroadcastSink();
+  return {
+    strategy: createSpySelectionStrategy(),
+    sink,
+    minProposals: DEFAULT_CYCLE_CONFIG.minProposals,
+    maxOutputPerProposal: DEFAULT_CYCLE_CONFIG.maxOutputPerProposal,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("runCycle — happy path", () => {
+  test("selects winner and broadcasts", async () => {
+    const { sink, broadcasts } = createSpyBroadcastSink();
+    const config = makeConfig({ sink });
+    const p1 = mockProposal();
+    const p2 = mockProposal();
+
+    const result = await runCycle(config, [p1, p2]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(p1.id); // spy picks first
+      expect(result.value.allProposals).toHaveLength(2);
+      expect(result.value.cycleId).toBeDefined();
+      expect(broadcasts).toHaveLength(1);
+    }
+  });
+
+  test("single proposal auto-selects and broadcasts", async () => {
+    const { sink, broadcasts } = createSpyBroadcastSink();
+    const config = makeConfig({ sink });
+    const solo = mockProposal();
+
+    const result = await runCycle(config, [solo]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.id).toBe(solo.id);
+      expect(broadcasts).toHaveLength(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output truncation
+// ---------------------------------------------------------------------------
+
+describe("runCycle — output truncation", () => {
+  test("truncates output exceeding maxOutputPerProposal", async () => {
+    const { sink } = createSpyBroadcastSink();
+    const maxLen = 50;
+    const config = makeConfig({ sink, maxOutputPerProposal: maxLen });
+    const longOutput = "a".repeat(200);
+    const p = mockProposal({ output: longOutput });
+
+    const result = await runCycle(config, [p]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // winner output should be truncated to approximately maxLen
+      expect(result.value.winner.output.length).toBeLessThanOrEqual(maxLen);
+      expect(result.value.winner.output).toContain("[output truncated]");
+    }
+  });
+
+  test("does not truncate output within limit", async () => {
+    const config = makeConfig({ maxOutputPerProposal: 100 });
+    const p = mockProposal({ output: "short" });
+
+    const result = await runCycle(config, [p]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.winner.output).toBe("short");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("runCycle — validation", () => {
+  test("returns error for empty proposals", async () => {
+    const config = makeConfig();
+    const result = await runCycle(config, []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("proposals");
+    }
+  });
+
+  test("returns error when proposals < minProposals", async () => {
+    const config = makeConfig({ minProposals: 3 });
+    const result = await runCycle(config, [mockProposal(), mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("minimum");
+    }
+  });
+
+  test("returns error for duplicate proposal IDs", async () => {
+    const config = makeConfig();
+    const p1 = mockProposal({ id: "dup" });
+    const p2 = mockProposal({ id: "dup" });
+
+    const result = await runCycle(config, [p1, p2]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("duplicate");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abort signal
+// ---------------------------------------------------------------------------
+
+describe("runCycle — abort signal", () => {
+  test("returns error when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort("user cancelled");
+    const config = makeConfig({ signal: controller.signal });
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("TIMEOUT");
+      expect(result.error.message).toContain("aborted");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("runCycle — error handling", () => {
+  test("returns error when strategy.select fails", async () => {
+    const error: KoiError = {
+      code: "INTERNAL",
+      message: "strategy exploded",
+      retryable: RETRYABLE_DEFAULTS.INTERNAL,
+    };
+    const config = makeConfig({ strategy: createFailingSelectionStrategy(error) });
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+      expect(result.error.message).toContain("strategy exploded");
+    }
+  });
+
+  test("returns error when strategy.select throws", async () => {
+    const config = makeConfig({
+      strategy: {
+        name: "throwing",
+        select: () => {
+          throw new Error("unexpected boom");
+        },
+      },
+    });
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+      expect(result.error.message).toContain("Selection failed");
+    }
+  });
+
+  test("returns error when sink.broadcast throws", async () => {
+    const config = makeConfig({
+      sink: createFailingBroadcastSink(new Error("sink down")),
+    });
+
+    const result = await runCycle(config, [mockProposal()]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+      expect(result.error.message).toContain("Broadcast failed");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event callbacks
+// ---------------------------------------------------------------------------
+
+describe("runCycle — onEvent callbacks", () => {
+  test("fires events in correct order on success", async () => {
+    const events: CycleEvent[] = [];
+    const config = makeConfig({ onEvent: (e) => events.push(e) });
+
+    await runCycle(config, [mockProposal()]);
+
+    expect(events).toHaveLength(4);
+    expect(events[0]?.kind).toBe("selection_started");
+    expect(events[1]?.kind).toBe("winner_selected");
+    expect(events[2]?.kind).toBe("broadcast_started");
+    expect(events[3]?.kind).toBe("broadcast_complete");
+  });
+
+  test("fires selection_started with proposal count", async () => {
+    const events: CycleEvent[] = [];
+    const config = makeConfig({ onEvent: (e) => events.push(e) });
+
+    await runCycle(config, [mockProposal(), mockProposal(), mockProposal()]);
+
+    const started = events.find((e) => e.kind === "selection_started");
+    expect(started).toBeDefined();
+    if (started?.kind === "selection_started") {
+      expect(started.proposalCount).toBe(3);
+    }
+  });
+
+  test("fires cycle_error on strategy failure", async () => {
+    const events: CycleEvent[] = [];
+    const error: KoiError = {
+      code: "INTERNAL",
+      message: "bad strategy",
+      retryable: false,
+    };
+    const config = makeConfig({
+      strategy: createFailingSelectionStrategy(error),
+      onEvent: (e) => events.push(e),
+    });
+
+    await runCycle(config, [mockProposal()]);
+
+    const errorEvent = events.find((e) => e.kind === "cycle_error");
+    expect(errorEvent).toBeDefined();
+  });
+
+  test("does not crash when onEvent is undefined", async () => {
+    const config = makeConfig({ onEvent: undefined });
+    const result = await runCycle(config, [mockProposal()]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("does not crash when onEvent throws", async () => {
+    const config = makeConfig({
+      onEvent: () => {
+        throw new Error("observer exploded");
+      },
+    });
+    const result = await runCycle(config, [mockProposal()]);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent calls
+// ---------------------------------------------------------------------------
+
+describe("runCycle — concurrency", () => {
+  test("concurrent calls do not interfere", async () => {
+    const { sink: sink1, broadcasts: b1 } = createSpyBroadcastSink();
+    const { sink: sink2, broadcasts: b2 } = createSpyBroadcastSink();
+    const config1 = makeConfig({ sink: sink1 });
+    const config2 = makeConfig({ sink: sink2 });
+
+    const [r1, r2] = await Promise.all([
+      runCycle(config1, [mockProposal({ id: "c1" })]),
+      runCycle(config2, [mockProposal({ id: "c2" })]),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    expect(b1).toHaveLength(1);
+    expect(b2).toHaveLength(1);
+    if (r1.ok) expect(r1.value.winner.id).toBe(proposalId("c1"));
+    if (r2.ok) expect(r2.value.winner.id).toBe(proposalId("c2"));
+  });
+});

--- a/packages/competitive-broadcast/src/cycle.ts
+++ b/packages/competitive-broadcast/src/cycle.ts
@@ -1,0 +1,175 @@
+/**
+ * Core competitive broadcast cycle pipeline.
+ *
+ * runCycle() validates → truncates → selects → broadcasts → returns Result.
+ * Stateless — safe to call concurrently.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CycleConfig } from "./config.js";
+import type { BroadcastResult, CycleEvent, Proposal } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Truncation helper (~5 lines, copied from parallel-minions pattern)
+// ---------------------------------------------------------------------------
+
+const TRUNCATION_MARKER = "\n... [output truncated]";
+
+function truncateOutput(output: string, maxLen: number): string {
+  if (output.length <= maxLen) return output;
+  const contentLen = Math.max(0, maxLen - TRUNCATION_MARKER.length);
+  return output.slice(0, contentLen) + TRUNCATION_MARKER;
+}
+
+// ---------------------------------------------------------------------------
+// Cycle ID generator
+// ---------------------------------------------------------------------------
+
+function generateCycleId(): string {
+  return `cycle-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function validationError(message: string): KoiError {
+  return {
+    code: "VALIDATION",
+    message,
+    retryable: RETRYABLE_DEFAULTS.VALIDATION,
+  };
+}
+
+function abortError(message: string): KoiError {
+  return {
+    code: "TIMEOUT",
+    message,
+    retryable: RETRYABLE_DEFAULTS.TIMEOUT,
+  };
+}
+
+function internalError(message: string, cause: unknown): KoiError {
+  return {
+    code: "INTERNAL",
+    message,
+    retryable: RETRYABLE_DEFAULTS.INTERNAL,
+    cause,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Safe event emit
+// ---------------------------------------------------------------------------
+
+function emitEvent(config: CycleConfig, event: CycleEvent): void {
+  if (config.onEvent !== undefined) {
+    try {
+      config.onEvent(event);
+    } catch {
+      /* onEvent is observability-only — never let it crash the cycle */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runCycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes a competitive broadcast cycle:
+ * 1. Validate proposals (count, duplicates, abort signal)
+ * 2. Truncate outputs to maxOutputPerProposal
+ * 3. Run selection strategy
+ * 4. Broadcast winner to sink
+ *
+ * Returns Result — never throws.
+ */
+export async function runCycle(
+  config: CycleConfig,
+  proposals: readonly Proposal[],
+): Promise<Result<BroadcastResult, KoiError>> {
+  // 1. Check abort signal
+  if (config.signal?.aborted === true) {
+    const error = abortError("Cycle aborted before start");
+    emitEvent(config, { kind: "cycle_error", error });
+    return { ok: false, error };
+  }
+
+  // 2. Validate proposal count
+  if (proposals.length < config.minProposals) {
+    const error = validationError(
+      proposals.length === 0
+        ? "Cannot run cycle with zero proposals"
+        : `Received ${proposals.length} proposals but minimum is ${config.minProposals}`,
+    );
+    emitEvent(config, { kind: "cycle_error", error });
+    return { ok: false, error };
+  }
+
+  // 3. Check for duplicate IDs
+  const ids = new Set<string>();
+  for (const p of proposals) {
+    if (ids.has(p.id)) {
+      const error = validationError(`Found duplicate proposal ID: ${p.id}`);
+      emitEvent(config, { kind: "cycle_error", error });
+      return { ok: false, error };
+    }
+    ids.add(p.id);
+  }
+
+  // 4. Truncate outputs
+  const truncated: readonly Proposal[] = proposals.map((p) => {
+    const output = truncateOutput(p.output, config.maxOutputPerProposal);
+    return output === p.output ? p : { ...p, output };
+  });
+
+  // 5. Selection
+  emitEvent(config, { kind: "selection_started", proposalCount: truncated.length });
+
+  /* let is required because selectResult is set in try/catch */
+  let selectResult: Result<Proposal, KoiError>;
+  try {
+    selectResult = await config.strategy.select(truncated);
+  } catch (e: unknown) {
+    const error = internalError("Selection failed unexpectedly", e);
+    emitEvent(config, { kind: "cycle_error", error });
+    return { ok: false, error };
+  }
+
+  if (!selectResult.ok) {
+    emitEvent(config, { kind: "cycle_error", error: selectResult.error });
+    return selectResult;
+  }
+
+  const winner = selectResult.value;
+  emitEvent(config, { kind: "winner_selected", winner });
+
+  // 6. Check abort signal after selection (re-read to catch mid-cycle abort)
+  if (config.signal?.aborted) {
+    const error = abortError("Cycle aborted after selection but before broadcast");
+    emitEvent(config, { kind: "cycle_error", error });
+    return { ok: false, error };
+  }
+
+  // 7. Broadcast
+  const cycleId = generateCycleId();
+  const broadcastPayload: BroadcastResult = {
+    winner,
+    allProposals: truncated,
+    cycleId,
+  };
+
+  emitEvent(config, { kind: "broadcast_started", winnerId: winner.id });
+
+  try {
+    const report = await config.sink.broadcast(broadcastPayload);
+    emitEvent(config, { kind: "broadcast_complete", report });
+    return { ok: true, value: broadcastPayload };
+  } catch (e: unknown) {
+    const error = internalError("Broadcast failed unexpectedly", e);
+    emitEvent(config, { kind: "cycle_error", error });
+    return { ok: false, error };
+  }
+}

--- a/packages/competitive-broadcast/src/index.ts
+++ b/packages/competitive-broadcast/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * @koi/competitive-broadcast — Competitive selection + broadcast (Layer 2)
+ *
+ * Implements GWT-inspired agent coordination: multiple agents compete
+ * to solve a task, the best result is selected, and the winner is
+ * broadcast to all agents for system-wide coherence.
+ *
+ * Depends on @koi/core and @koi/errors only.
+ */
+
+// Broadcast sink factories
+export {
+  type BroadcastRecipient,
+  createEventBroadcastSink,
+  createInMemoryBroadcastSink,
+  type EventComponentLike,
+} from "./broadcast.js";
+// Config
+export type { CycleConfig } from "./config.js";
+export { DEFAULT_CYCLE_CONFIG, validateCycleConfig } from "./config.js";
+// Core function
+export { runCycle } from "./cycle.js";
+// Selection strategy factories
+export {
+  type ConsensusOptions,
+  createConsensusSelector,
+  createFirstWinsSelector,
+  createScoredSelector,
+} from "./selection.js";
+// Types
+export type {
+  BroadcastReport,
+  BroadcastResult,
+  BroadcastSink,
+  CycleEvent,
+  Proposal,
+  ProposalId,
+  SelectionStrategy,
+  Vote,
+} from "./types.js";
+// Branded constructors + type guards
+export { isProposal, proposalId } from "./types.js";

--- a/packages/competitive-broadcast/src/selection.test.ts
+++ b/packages/competitive-broadcast/src/selection.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  createConsensusSelector,
+  createFirstWinsSelector,
+  createScoredSelector,
+} from "./selection.js";
+import { mockProposal, resetMockCounter } from "./test-helpers.js";
+import type { Proposal, Vote } from "./types.js";
+import { proposalId } from "./types.js";
+
+beforeEach(() => {
+  resetMockCounter();
+});
+
+// ---------------------------------------------------------------------------
+// createFirstWinsSelector
+// ---------------------------------------------------------------------------
+
+describe("createFirstWinsSelector", () => {
+  const selector = createFirstWinsSelector();
+
+  test("has name 'first-wins'", () => {
+    expect(selector.name).toBe("first-wins");
+  });
+
+  test("picks proposal with lowest submittedAt", async () => {
+    const early = mockProposal({ submittedAt: 1000 });
+    const late = mockProposal({ submittedAt: 2000 });
+    const result = await selector.select([late, early]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(early.id);
+  });
+
+  test("breaks ties by highest salience", async () => {
+    const a = mockProposal({ submittedAt: 1000, salience: 0.5 });
+    const b = mockProposal({ submittedAt: 1000, salience: 0.9 });
+    const result = await selector.select([a, b]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(b.id);
+  });
+
+  test("breaks salience ties by lexicographic id", async () => {
+    const a = mockProposal({ id: "aaa", submittedAt: 1000, salience: 0.5 });
+    const b = mockProposal({ id: "bbb", submittedAt: 1000, salience: 0.5 });
+    const result = await selector.select([a, b]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("aaa"));
+  });
+
+  test("handles single proposal", async () => {
+    const solo = mockProposal();
+    const result = await selector.select([solo]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(solo.id);
+  });
+
+  test("returns error for empty proposals", async () => {
+    const result = await selector.select([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("treats undefined salience as 0 for tiebreaking", async () => {
+    const noSalience = mockProposal({ id: "no-sal", submittedAt: 1000 });
+    const withSalience = mockProposal({ id: "has-sal", submittedAt: 1000, salience: 0.1 });
+    const result = await selector.select([noSalience, withSalience]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("has-sal"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createScoredSelector
+// ---------------------------------------------------------------------------
+
+describe("createScoredSelector", () => {
+  test("has name 'scored'", () => {
+    const selector = createScoredSelector();
+    expect(selector.name).toBe("scored");
+  });
+
+  test("picks proposal with highest default salience", async () => {
+    const selector = createScoredSelector();
+    const low = mockProposal({ salience: 0.2 });
+    const high = mockProposal({ salience: 0.9 });
+    const mid = mockProposal({ salience: 0.5 });
+    const result = await selector.select([low, high, mid]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(high.id);
+  });
+
+  test("uses custom scoreFn when provided", async () => {
+    const selector = createScoredSelector((p: Proposal) => p.durationMs);
+    const slow = mockProposal({ durationMs: 500 });
+    const fast = mockProposal({ durationMs: 50 });
+    const result = await selector.select([slow, fast]);
+    expect(result.ok).toBe(true);
+    // highest score = highest durationMs
+    if (result.ok) expect(result.value.id).toBe(slow.id);
+  });
+
+  test("treats NaN score as 0", async () => {
+    const selector = createScoredSelector(() => Number.NaN);
+    const a = mockProposal({ salience: 0.5 });
+    const b = mockProposal({ salience: 0.9 });
+    // all scores become 0, so first by submittedAt wins (tiebreaker)
+    const result = await selector.select([a, b]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("treats Infinity score as 0", async () => {
+    const selector = createScoredSelector(() => Number.POSITIVE_INFINITY);
+    const a = mockProposal();
+    const result = await selector.select([a]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("treats -Infinity score as 0", async () => {
+    const selector = createScoredSelector(() => Number.NEGATIVE_INFINITY);
+    const a = mockProposal();
+    const result = await selector.select([a]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("treats undefined salience as 0 in default scorer", async () => {
+    const selector = createScoredSelector();
+    const noSalience = mockProposal({ id: "ns" });
+    const withSalience = mockProposal({ id: "ws", salience: 0.1 });
+    const result = await selector.select([noSalience, withSalience]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("ws"));
+  });
+
+  test("returns error for empty proposals", async () => {
+    const selector = createScoredSelector();
+    const result = await selector.select([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("all saliences are 0 — picks first by submittedAt", async () => {
+    const selector = createScoredSelector();
+    const first = mockProposal({ id: "first", submittedAt: 100, salience: 0 });
+    const second = mockProposal({ id: "second", submittedAt: 200, salience: 0 });
+    const result = await selector.select([second, first]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("first"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createConsensusSelector
+// ---------------------------------------------------------------------------
+
+describe("createConsensusSelector", () => {
+  test("has name 'consensus'", () => {
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async () => [],
+    });
+    expect(selector.name).toBe("consensus");
+  });
+
+  test("picks proposal exceeding threshold", async () => {
+    const p1 = mockProposal({ id: "p1" });
+    const p2 = mockProposal({ id: "p2" });
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async (): Promise<readonly Vote[]> => [
+        { proposalId: proposalId("p1"), score: 0.8 },
+        { proposalId: proposalId("p2"), score: 0.2 },
+      ],
+    });
+    const result = await selector.select([p1, p2]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("p1"));
+  });
+
+  test("returns error when no proposal exceeds threshold", async () => {
+    const p1 = mockProposal({ id: "p1" });
+    const p2 = mockProposal({ id: "p2" });
+    const selector = createConsensusSelector({
+      threshold: 0.9,
+      judge: async (): Promise<readonly Vote[]> => [
+        { proposalId: proposalId("p1"), score: 0.4 },
+        { proposalId: proposalId("p2"), score: 0.4 },
+      ],
+    });
+    const result = await selector.select([p1, p2]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toContain("consensus");
+    }
+  });
+
+  test("accepts proposal at exact threshold boundary", async () => {
+    const p1 = mockProposal({ id: "p1" });
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async (): Promise<readonly Vote[]> => [{ proposalId: proposalId("p1"), score: 0.5 }],
+    });
+    const result = await selector.select([p1]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("p1"));
+  });
+
+  test("returns error for empty proposals", async () => {
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async () => [],
+    });
+    const result = await selector.select([]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("ignores votes for unknown proposal IDs", async () => {
+    const p1 = mockProposal({ id: "p1" });
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async (): Promise<readonly Vote[]> => [
+        { proposalId: proposalId("unknown"), score: 1.0 },
+        { proposalId: proposalId("p1"), score: 0.6 },
+      ],
+    });
+    const result = await selector.select([p1]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.id).toBe(proposalId("p1"));
+  });
+
+  test("aggregates multiple votes for same proposal", async () => {
+    const p1 = mockProposal({ id: "p1" });
+    const selector = createConsensusSelector({
+      threshold: 0.5,
+      judge: async (): Promise<readonly Vote[]> => [
+        { proposalId: proposalId("p1"), score: 0.3 },
+        { proposalId: proposalId("p1"), score: 0.4 },
+      ],
+    });
+    // total score for p1 = 0.7, total all votes = 0.7, fraction = 1.0
+    const result = await selector.select([p1]);
+    expect(result.ok).toBe(true);
+  });
+
+  test("throws RangeError for threshold > 1", () => {
+    expect(() => createConsensusSelector({ threshold: 1.5, judge: async () => [] })).toThrow(
+      RangeError,
+    );
+  });
+
+  test("throws RangeError for negative threshold", () => {
+    expect(() => createConsensusSelector({ threshold: -0.1, judge: async () => [] })).toThrow(
+      RangeError,
+    );
+  });
+
+  test("accepts threshold at boundary 0", () => {
+    expect(() => createConsensusSelector({ threshold: 0, judge: async () => [] })).not.toThrow();
+  });
+
+  test("accepts threshold at boundary 1", () => {
+    expect(() => createConsensusSelector({ threshold: 1, judge: async () => [] })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Table-driven invariants
+// ---------------------------------------------------------------------------
+
+describe("selection invariants", () => {
+  const strategies = [
+    { name: "first-wins", factory: () => createFirstWinsSelector() },
+    { name: "scored", factory: () => createScoredSelector() },
+  ] as const;
+
+  for (const { name, factory } of strategies) {
+    test(`${name}: single proposal always wins`, async () => {
+      const selector = factory();
+      const solo = mockProposal();
+      const result = await selector.select([solo]);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.value.id).toBe(solo.id);
+    });
+
+    test(`${name}: winner is always from the input set`, async () => {
+      const selector = factory();
+      const proposals = [mockProposal(), mockProposal(), mockProposal()];
+      const result = await selector.select(proposals);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const winnerInSet = proposals.some((p) => p.id === result.value.id);
+        expect(winnerInSet).toBe(true);
+      }
+    });
+
+    test(`${name}: deterministic — same input yields same winner`, async () => {
+      const selector = factory();
+      const proposals = [
+        mockProposal({ id: "d1", submittedAt: 1000, salience: 0.5 }),
+        mockProposal({ id: "d2", submittedAt: 1000, salience: 0.5 }),
+      ];
+      const r1 = await selector.select(proposals);
+      const r2 = await selector.select(proposals);
+      expect(r1.ok).toBe(true);
+      expect(r2.ok).toBe(true);
+      if (r1.ok && r2.ok) expect(r1.value.id).toBe(r2.value.id);
+    });
+  }
+});

--- a/packages/competitive-broadcast/src/selection.ts
+++ b/packages/competitive-broadcast/src/selection.ts
@@ -1,0 +1,191 @@
+/**
+ * Selection strategies for competitive broadcast.
+ *
+ * Three built-in strategies: first-wins, scored, and consensus.
+ * All return Result<Proposal, KoiError> — never throw.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { Proposal, SelectionStrategy, Vote } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_ERROR: KoiError = {
+  code: "VALIDATION",
+  message: "Cannot select from empty proposals list",
+  retryable: RETRYABLE_DEFAULTS.VALIDATION,
+};
+
+/** Sanitize a score: NaN and Infinity become 0. */
+function sanitizeScore(score: number): number {
+  if (!Number.isFinite(score)) return 0;
+  return score;
+}
+
+// ---------------------------------------------------------------------------
+// Tiebreaker: lowest submittedAt → highest salience → lexicographic id
+// ---------------------------------------------------------------------------
+
+function tiebreak(a: Proposal, b: Proposal): number {
+  if (a.submittedAt !== b.submittedAt) return a.submittedAt - b.submittedAt;
+  const salienceA = a.salience ?? 0;
+  const salienceB = b.salience ?? 0;
+  if (salienceA !== salienceB) return salienceB - salienceA; // higher salience wins
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+/**
+ * Returns the first element of an array, or an error Result if the array is empty.
+ * Satisfies noUncheckedIndexedAccess without non-null assertions.
+ */
+function firstOrError<T>(items: readonly T[]): Result<T, KoiError> {
+  const first = items[0];
+  if (first === undefined) return { ok: false, error: EMPTY_ERROR };
+  return { ok: true, value: first };
+}
+
+// ---------------------------------------------------------------------------
+// createFirstWinsSelector
+// ---------------------------------------------------------------------------
+
+/**
+ * Picks the proposal with the lowest `submittedAt`.
+ * Tiebreaker: highest salience, then lexicographic id.
+ */
+export function createFirstWinsSelector(): SelectionStrategy {
+  return {
+    name: "first-wins",
+    select: (proposals: readonly Proposal[]): Result<Proposal, KoiError> => {
+      if (proposals.length === 0) return { ok: false, error: EMPTY_ERROR };
+      const sorted = [...proposals].sort(tiebreak);
+      return firstOrError(sorted);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createScoredSelector
+// ---------------------------------------------------------------------------
+
+/**
+ * Picks the proposal with the highest score.
+ * Default score = `salience ?? 0`. Custom `scoreFn` overrides.
+ * NaN/Infinity scores are treated as 0.
+ * Tiebreaker: lowest submittedAt → lexicographic id.
+ */
+export function createScoredSelector(scoreFn?: (proposal: Proposal) => number): SelectionStrategy {
+  const score = scoreFn ?? ((p: Proposal): number => p.salience ?? 0);
+
+  return {
+    name: "scored",
+    select: (proposals: readonly Proposal[]): Result<Proposal, KoiError> => {
+      if (proposals.length === 0) return { ok: false, error: EMPTY_ERROR };
+
+      const scored = proposals
+        .map((p) => ({
+          proposal: p,
+          score: sanitizeScore(score(p)),
+        }))
+        .sort((a, b) => {
+          if (a.score !== b.score) return b.score - a.score; // higher score wins
+          return tiebreak(a.proposal, b.proposal);
+        });
+
+      const winner = firstOrError(scored);
+      if (!winner.ok) return winner;
+      return { ok: true, value: winner.value.proposal };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createConsensusSelector
+// ---------------------------------------------------------------------------
+
+/** Options for consensus selection. */
+export interface ConsensusOptions {
+  /** Fraction of total vote score a proposal must reach to win. */
+  readonly threshold: number;
+  /** Async judge callback that evaluates proposals and returns votes. */
+  readonly judge: (proposals: readonly Proposal[]) => Promise<readonly Vote[]>;
+}
+
+/**
+ * Selects the proposal that exceeds a `threshold` fraction of total vote score.
+ * Returns VALIDATION error if no proposal reaches consensus.
+ */
+export function createConsensusSelector(options: ConsensusOptions): SelectionStrategy {
+  if (options.threshold < 0 || options.threshold > 1) {
+    throw new RangeError(`Consensus threshold must be in [0, 1], got ${options.threshold}`);
+  }
+
+  return {
+    name: "consensus",
+    select: async (proposals: readonly Proposal[]): Promise<Result<Proposal, KoiError>> => {
+      if (proposals.length === 0) return { ok: false, error: EMPTY_ERROR };
+
+      const votes = await options.judge(proposals);
+
+      // Build a map of proposalId → total score (only for known proposals)
+      const proposalIds = new Set(proposals.map((p) => p.id));
+      const scoreMap = new Map<string, number>();
+      let totalScore = 0;
+
+      for (const vote of votes) {
+        if (!proposalIds.has(vote.proposalId)) continue;
+        const current = scoreMap.get(vote.proposalId) ?? 0;
+        const sanitized = sanitizeScore(vote.score);
+        scoreMap.set(vote.proposalId, current + sanitized);
+        totalScore += sanitized;
+      }
+
+      // Find the proposal with the highest fraction of total score
+      if (totalScore === 0) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: "No consensus reached: total vote score is zero",
+            retryable: RETRYABLE_DEFAULTS.VALIDATION,
+          },
+        };
+      }
+
+      // Sort proposals by their fraction (descending), tiebreak by submittedAt
+      const ranked = proposals
+        .map((p) => ({
+          proposal: p,
+          fraction: (scoreMap.get(p.id) ?? 0) / totalScore,
+        }))
+        .sort((a, b) => {
+          if (a.fraction !== b.fraction) return b.fraction - a.fraction;
+          return tiebreak(a.proposal, b.proposal);
+        });
+
+      const bestResult = firstOrError(ranked);
+      if (!bestResult.ok) return bestResult;
+      const best = bestResult.value;
+
+      if (best.fraction >= options.threshold) {
+        return { ok: true, value: best.proposal };
+      }
+
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `No consensus reached: best fraction ${best.fraction.toFixed(3)} < threshold ${options.threshold}`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+          context: {
+            bestProposalId: best.proposal.id,
+            bestFraction: best.fraction,
+            threshold: options.threshold,
+          },
+        },
+      };
+    },
+  };
+}

--- a/packages/competitive-broadcast/src/test-helpers.ts
+++ b/packages/competitive-broadcast/src/test-helpers.ts
@@ -1,0 +1,123 @@
+/**
+ * Test doubles and mock factories for @koi/competitive-broadcast tests.
+ * NOT exported from the public API (index.ts).
+ */
+
+import { agentId } from "@koi/core/ecs";
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type {
+  BroadcastReport,
+  BroadcastResult,
+  BroadcastSink,
+  Proposal,
+  SelectionStrategy,
+} from "./types.js";
+import { proposalId } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Counter for unique IDs
+// ---------------------------------------------------------------------------
+
+/* let is required for monotonic counter across mock calls */
+let nextId = 1;
+
+/** Reset the internal mock counter. Call in beforeEach. */
+export function resetMockCounter(): void {
+  nextId = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Mock proposal factory
+// ---------------------------------------------------------------------------
+
+/** Creates a valid Proposal with sensible defaults. Override any field. */
+export function mockProposal(
+  overrides?: Partial<Omit<Proposal, "id">> & { readonly id?: string },
+): Proposal {
+  const id = overrides?.id ?? `p-${nextId++}`;
+  return {
+    id: proposalId(id),
+    agentId: overrides?.agentId ?? agentId(`agent-${id}`),
+    output: overrides?.output ?? `output-${id}`,
+    durationMs: overrides?.durationMs ?? 100,
+    submittedAt: overrides?.submittedAt ?? Date.now(),
+    salience: overrides?.salience,
+    metadata: overrides?.metadata,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Spy broadcast sink (doubles as in-memory implementation)
+// ---------------------------------------------------------------------------
+
+export interface SpyBroadcastSink {
+  readonly sink: BroadcastSink;
+  readonly broadcasts: readonly BroadcastResult[];
+}
+
+/** Creates a BroadcastSink that records all broadcast calls. */
+export function createSpyBroadcastSink(): SpyBroadcastSink {
+  const broadcasts: BroadcastResult[] = [];
+  const sink: BroadcastSink = {
+    broadcast: async (result: BroadcastResult): Promise<BroadcastReport> => {
+      broadcasts.push(result);
+      return { delivered: 1, failed: 0 };
+    },
+  };
+  return { sink, broadcasts };
+}
+
+// ---------------------------------------------------------------------------
+// Spy selection strategy
+// ---------------------------------------------------------------------------
+
+/** Creates a SelectionStrategy that always picks the first proposal (or a specific winner). */
+export function createSpySelectionStrategy(winnerId?: string): SelectionStrategy {
+  return {
+    name: "spy",
+    select: (proposals: readonly Proposal[]): Result<Proposal, KoiError> => {
+      if (winnerId !== undefined) {
+        const found = proposals.find((p) => p.id === winnerId);
+        if (found !== undefined) {
+          return { ok: true, value: found };
+        }
+      }
+      const first = proposals[0];
+      if (first === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: "No proposals to select from",
+            retryable: RETRYABLE_DEFAULTS.VALIDATION,
+          },
+        };
+      }
+      return { ok: true, value: first };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Failing doubles
+// ---------------------------------------------------------------------------
+
+/** Creates a BroadcastSink that always throws. */
+export function createFailingBroadcastSink(error: Error): BroadcastSink {
+  return {
+    broadcast: async (): Promise<BroadcastReport> => {
+      throw error;
+    },
+  };
+}
+
+/** Creates a SelectionStrategy that always returns an error. */
+export function createFailingSelectionStrategy(error: KoiError): SelectionStrategy {
+  return {
+    name: "failing",
+    select: (): Result<Proposal, KoiError> => {
+      return { ok: false, error };
+    },
+  };
+}

--- a/packages/competitive-broadcast/src/types.test.ts
+++ b/packages/competitive-broadcast/src/types.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { agentId } from "@koi/core/ecs";
+import { isProposal, proposalId } from "./types.js";
+
+describe("proposalId", () => {
+  test("creates a branded ProposalId from a string", () => {
+    const id = proposalId("p-1");
+    expect(id).toBe(proposalId("p-1"));
+    // branded type is compile-time only — runtime value is the string
+    expect(typeof id).toBe("string");
+    expect(id as string).toBe("p-1");
+  });
+
+  test("preserves distinct values", () => {
+    const a = proposalId("a");
+    const b = proposalId("b");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("isProposal", () => {
+  const validProposal = {
+    id: proposalId("p-1"),
+    agentId: agentId("agent-1"),
+    output: "result text",
+    durationMs: 100,
+    submittedAt: Date.now(),
+  };
+
+  test("returns true for a valid proposal", () => {
+    expect(isProposal(validProposal)).toBe(true);
+  });
+
+  test("returns true for a proposal with optional fields", () => {
+    const withOptional = {
+      ...validProposal,
+      salience: 0.8,
+      metadata: { source: "test" },
+    };
+    expect(isProposal(withOptional)).toBe(true);
+  });
+
+  test("returns false for null", () => {
+    expect(isProposal(null)).toBe(false);
+  });
+
+  test("returns false for undefined", () => {
+    expect(isProposal(undefined)).toBe(false);
+  });
+
+  test("returns false for a non-object", () => {
+    expect(isProposal("string")).toBe(false);
+    expect(isProposal(42)).toBe(false);
+    expect(isProposal(true)).toBe(false);
+  });
+
+  test("returns false when id is missing", () => {
+    const { id: _, ...rest } = validProposal;
+    expect(isProposal(rest)).toBe(false);
+  });
+
+  test("returns false when agentId is missing", () => {
+    const { agentId: _, ...rest } = validProposal;
+    expect(isProposal(rest)).toBe(false);
+  });
+
+  test("returns false when output is missing", () => {
+    const { output: _, ...rest } = validProposal;
+    expect(isProposal(rest)).toBe(false);
+  });
+
+  test("returns false when durationMs is missing", () => {
+    const { durationMs: _, ...rest } = validProposal;
+    expect(isProposal(rest)).toBe(false);
+  });
+
+  test("returns false when submittedAt is missing", () => {
+    const { submittedAt: _, ...rest } = validProposal;
+    expect(isProposal(rest)).toBe(false);
+  });
+
+  test("returns false when id is not a string", () => {
+    expect(isProposal({ ...validProposal, id: 123 })).toBe(false);
+  });
+
+  test("returns false for an empty object", () => {
+    expect(isProposal({})).toBe(false);
+  });
+});

--- a/packages/competitive-broadcast/src/types.ts
+++ b/packages/competitive-broadcast/src/types.ts
@@ -1,0 +1,115 @@
+/**
+ * @koi/competitive-broadcast — Core types for competitive selection + broadcast.
+ *
+ * Defines the Proposal data type, selection/broadcast contracts, cycle events,
+ * and branded ProposalId. All types are L2-local (no L0 changes needed).
+ */
+
+import type { AgentId } from "@koi/core/ecs";
+import type { KoiError, Result } from "@koi/core/errors";
+
+// ---------------------------------------------------------------------------
+// Branded ProposalId
+// ---------------------------------------------------------------------------
+
+declare const __proposalBrand: unique symbol;
+
+/** Branded string type for proposal identifiers. */
+export type ProposalId = string & { readonly [__proposalBrand]: "ProposalId" };
+
+/** Create a branded ProposalId from a plain string. */
+export function proposalId(id: string): ProposalId {
+  return id as ProposalId;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal
+// ---------------------------------------------------------------------------
+
+/** A competing agent's output submitted for selection. */
+export interface Proposal {
+  readonly id: ProposalId;
+  readonly agentId: AgentId;
+  readonly output: string;
+  readonly durationMs: number;
+  readonly submittedAt: number;
+  /** Salience score in [0, 1] — used by scored selection. */
+  readonly salience?: number | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Selection strategy contract
+// ---------------------------------------------------------------------------
+
+/** Pluggable strategy for choosing a winning proposal. */
+export interface SelectionStrategy {
+  readonly name: string;
+  readonly select: (
+    proposals: readonly Proposal[],
+  ) => Result<Proposal, KoiError> | Promise<Result<Proposal, KoiError>>;
+}
+
+// ---------------------------------------------------------------------------
+// Broadcast types
+// ---------------------------------------------------------------------------
+
+/** The result of a competitive selection cycle, ready for broadcast. */
+export interface BroadcastResult {
+  readonly winner: Proposal;
+  readonly allProposals: readonly Proposal[];
+  readonly cycleId: string;
+}
+
+/** Report from a broadcast delivery attempt. */
+export interface BroadcastReport {
+  readonly delivered: number;
+  readonly failed: number;
+  readonly errors?: readonly unknown[] | undefined;
+}
+
+/** Pluggable sink for delivering broadcast results. */
+export interface BroadcastSink {
+  readonly broadcast: (result: BroadcastResult) => Promise<BroadcastReport>;
+}
+
+// ---------------------------------------------------------------------------
+// Cycle events (discriminated union)
+// ---------------------------------------------------------------------------
+
+/** Observable events emitted during a competitive broadcast cycle. */
+export type CycleEvent =
+  | { readonly kind: "selection_started"; readonly proposalCount: number }
+  | { readonly kind: "winner_selected"; readonly winner: Proposal }
+  | { readonly kind: "broadcast_started"; readonly winnerId: ProposalId }
+  | { readonly kind: "broadcast_complete"; readonly report: BroadcastReport }
+  | { readonly kind: "cycle_error"; readonly error: KoiError };
+
+// ---------------------------------------------------------------------------
+// Consensus vote (used by consensus selector)
+// ---------------------------------------------------------------------------
+
+/** A vote cast by a judge for a specific proposal. */
+export interface Vote {
+  readonly proposalId: ProposalId;
+  readonly score: number;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Type guard for Proposal values. */
+export function isProposal(value: unknown): value is Proposal {
+  if (value === null || value === undefined || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.agentId === "string" &&
+    typeof candidate.output === "string" &&
+    typeof candidate.durationMs === "number" &&
+    typeof candidate.submittedAt === "number"
+  );
+}

--- a/packages/competitive-broadcast/tsconfig.json
+++ b/packages/competitive-broadcast/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }]
+}

--- a/packages/competitive-broadcast/tsup.config.ts
+++ b/packages/competitive-broadcast/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements Issue #287 — new L2 package for Global Workspace Theory (Baars)-inspired competitive agent coordination.

- **Selection + Broadcast pipeline**: multiple agents solve the same task, the best result is selected via pluggable strategy, and the winner is broadcast to all participants for system-wide coherence
- **3 built-in selection strategies**: `first-wins` (earliest submission), `scored` (highest salience/custom score), `consensus` (judge-based voting with threshold)
- **2 broadcast sinks**: `InMemoryBroadcastSink` (parallel delivery via `Promise.allSettled`), `EventBroadcastSink` (event bus wrapper)
- **Stateless `runCycle()` pipeline**: validate → truncate → select → broadcast, returns `Result<BroadcastResult, KoiError>`, never throws
- **CycleEvent discriminated union** for full observability (selection_started, winner_selected, broadcast_started, broadcast_complete, cycle_error)
- **Composes with `@koi/parallel-minions`** for the spawn/collection phase — this package handles selection + broadcast only
- **Adapter-agnostic**: works with engine-pi, engine-external, or any EngineAdapter

### Package structure

```
packages/competitive-broadcast/
├── src/
│   ├── types.ts           # Proposal, branded ProposalId, CycleEvent, interfaces
│   ├── selection.ts       # 3 SelectionStrategy factories
│   ├── broadcast.ts       # 2 BroadcastSink implementations
│   ├── config.ts          # CycleConfig validation + defaults
│   ├── cycle.ts           # runCycle() core pipeline
│   ├── test-helpers.ts    # Mock factories (package-local)
│   ├── index.ts           # Public API exports
│   └── __tests__/         # Integration + E2E tests
└── docs/L2/competitive-broadcast.md
```

### Test coverage

- **93 unit/integration tests** — 95%+ line coverage
- **10 E2E tests** with real Anthropic API calls through full `createKoi` + `createPiAdapter` L1 runtime
- Edge cases: empty proposals, duplicate IDs, NaN/Infinity scores, abort signals, sink failures, onEvent throws, threshold boundaries, truncation

### Layer compliance

- Only imports from `@koi/core` (L0) — no L1 or L2 peer dependencies
- `@koi/engine` and `@koi/engine-pi` are devDependencies only (E2E tests)
- All interface properties are `readonly`
- No vendor-specific concepts

## Test plan

- [x] `bun test` — 93 unit/integration tests pass
- [x] `E2E_TESTS=1 bun test src/__tests__/e2e-full-stack.test.ts` — 10 E2E tests pass (real LLM calls)
- [x] `bun run build` — ESM + .d.ts output
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — Biome clean
- [x] Pre-push hook (turborepo full build) — passes