### PR TITLE
feat: fitness-scored brick discovery (#151)

### DIFF
--- a/docs/L2/forge.md
+++ b/docs/L2/forge.md
@@ -78,7 +78,11 @@ index.ts                         ← public re-exports (60+ symbols)
 │   ├── forge-agent.ts           ← forge_agent
 │   ├── forge-middleware.ts      ← forge_middleware
 │   ├── forge-channel.ts         ← forge_channel
-│   └── promote-forge.ts         ← promote_forge, search_forge
+│   └── promote-forge.ts         ← promote_forge
+│       search-forge.ts          ← search_forge (fitness-ranked discovery)
+│
+├── usage.ts                     ← recordBrickUsage(), UsageSignal, auto-promotion
+├── forge-usage-middleware.ts    ← wrapToolCall: timing + success/error tracking
 │
 ├── verify.ts                    ← 5-stage verification orchestrator
 ├── verify-static.ts             ← stage 1: static analysis (+ network evasion detection)
@@ -229,7 +233,7 @@ Every brick's ID **is** its integrity proof:
   promoted:  human-approved for interposition (middleware, channel)
 ```
 
-Auto-promotion (optional):
+Auto-promotion (optional, driven by fitness metrics — see [Fitness-scored discovery](#fitness-scored-discovery-issue-151)):
 
 ```
   ForgeConfig.autoPromotion = {
@@ -616,6 +620,171 @@ Scope promotion requires governance approval:
 
 ---
 
+## Fitness-scored discovery (Issue #151)
+
+When multiple bricks match a `search_forge` query, the runtime ranks results by a **composite
+fitness score** computed from runtime signals — no LLM in the scoring loop. Battle-tested bricks
+surface above untested ones, creating evolutionary pressure toward reliability.
+
+### How fitness is recorded
+
+The `forge-usage-middleware` wraps every tool call. For bricks forged through the forge pipeline,
+it mechanically records timing and outcome:
+
+```
+  Agent calls tool "calc"
+          │
+          ▼
+  ┌───────────────────────────────────┐
+  │  forge-usage-middleware           │
+  │  (wrapToolCall)                   │
+  │                                   │
+  │  1. Is this a forged brick?       │──── no ──▶ pass through
+  │     resolveBrickId("calc")        │
+  │                                   │
+  │  2. start = Date.now()            │
+  │  3. call next(request)            │
+  │  4. latencyMs = Date.now() - start│
+  │  5. success = !threw              │
+  │                                   │
+  │  6. recordBrickUsage(store, id, { │   fire-and-forget:
+  │       success: true,              │   never blocks the tool response,
+  │       latencyMs: 47               │   errors routed to onUsageError
+  │     })                            │
+  └───────────────────────────────────┘
+          │
+          ▼
+  response back to agent
+```
+
+Every call updates `BrickFitnessMetrics` on the brick:
+
+```typescript
+interface BrickFitnessMetrics {
+  readonly successCount: number;    // incremented on success
+  readonly errorCount: number;      // incremented on failure
+  readonly latency: LatencySampler; // bounded sorted-sample buffer (P99)
+  readonly lastUsedAt: number;      // epoch ms of last call
+}
+```
+
+The `usageCount` field is derived: `successCount + errorCount`. No double-bookkeeping.
+
+### How fitness is scored
+
+At **query time**, `search_forge` computes a composite score for each matching brick.
+Scores are always fresh — never cached or stale.
+
+```
+  computeBrickFitness(metrics, nowMs)
+      │
+      ├── successRate = success / (success + errors)
+      │   successFactor = successRate ^ 2.0              [0, 1]
+      │
+      ├── daysSinceUsed = (now - lastUsedAt) / 86400000
+      │   recencyFactor = e^(-λ × daysSinceUsed)         [0, 1]
+      │   (half-life: 30 days)
+      │
+      ├── totalCalls = success + errors
+      │   usageNorm = log₂(1 + total) / log₂(101)       [0, ~1]
+      │
+      ├── p99 = computePercentile(latency, 0.99)
+      │   latencyFactor = 1 - 0.1 × min(1, p99/5000)    [0.9, 1]
+      │
+      └── fitness = min(1, successFactor × recencyFactor × usageNorm × latencyFactor)
+```
+
+The formula is **multiplicative** — all factors must be strong. A brick with 100% success but
+zero usage scores 0 (no evidence). A brick with high usage but 50% errors scores low
+(unreliable). A brick unused for months decays toward 0 (stale).
+
+### Latency sampler
+
+P99 latency uses a bounded sorted-sample buffer with reservoir sampling:
+
+```
+  Buffer:  [12, 23, 34, 42, 55, 67, 89, 120, 340, 510]   cap: 200
+                                                             │
+  New sample arrives: 45ms                                   │
+    ├── below cap? → binary insert to maintain sort order    │
+    └── at cap?    → reservoir sampling (random replacement) │
+                                                             │
+  computePercentile(sampler, 0.99) → 510ms                   │
+```
+
+All functions are pure (`@koi/validation`). No I/O, no side effects.
+
+### Search ranking
+
+`search_forge` returns results sorted by fitness score (descending), with two new query fields:
+
+```
+  search_forge({
+    kind: "tool",
+    tags: ["math"],
+    orderBy: "fitness",       ← "fitness" (default), "recency", or "usage"
+    minFitnessScore: 0.3      ← exclude bricks below this threshold [0, 1]
+  })
+
+  Results:
+  ┌──────────────────────────────────────────────────────────┐
+  │  1. calc_v2  ██████████████████░░ fitness: 0.91          │
+  │     usage:83  success:98.8%  p99:42ms  last:2h ago       │
+  │                                                           │
+  │  2. calc_v1  ████████░░░░░░░░░░░░ fitness: 0.34          │
+  │     usage:47  success:74.5%  p99:310ms last:3d ago       │
+  │                                                           │
+  │  ✗  calc_v3  ░░░░░░░░░░░░░░░░░░░░ fitness: 0.00          │
+  │     (filtered: below minFitnessScore 0.3)                │
+  └──────────────────────────────────────────────────────────┘
+```
+
+Tiebreak: alphabetical by brick name when scores are equal.
+
+### Trust tier auto-promotion
+
+Auto-promotion is driven by usage count (derived from fitness metrics):
+
+```
+  sandbox ──── 5 successful uses ────▶ verified ──── 20 uses ────▶ promoted
+     │                                    │
+     └── ForgeConfig.autoPromotion:       └── thresholds are configurable
+         sandboxToVerifiedThreshold: 5
+         verifiedToPromotedThreshold: 20
+```
+
+When `recordBrickUsage` detects the usage count has crossed a threshold, it promotes the
+brick's `trustTier` in the same store update — no separate call needed.
+
+### Scoring config
+
+All scoring parameters are configurable via `FitnessScoringConfig`:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `halfLifeDays` | `30` | Recency decay half-life |
+| `usageSaturation` | `100` | Usage count where normalization plateaus |
+| `successExponent` | `2.0` | How harshly to penalize errors (higher = harsher) |
+| `latencyWeight` | `0.1` | Blend factor for P99 latency penalty |
+| `maxAcceptableLatencyMs` | `5000` | P99 above this gets maximum penalty |
+
+### The evolutionary loop
+
+```
+  ┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
+  │  FORGE   │────▶│   USE    │────▶│  SCORE   │────▶│ DISCOVER │
+  │ new brick│     │ in agent │     │ fitness  │     │ ranked   │
+  └──────────┘     │  turns   │     │ (auto)   │     │ results  │
+                   └──────────┘     └──────────┘     └────┬─────┘
+                                                          │
+                        ┌─────────────────────────────────┘
+                        │  agents prefer top-ranked bricks
+                        ▼  → more usage → more signal → better ranking
+                   Natural selection: reliable bricks rise, broken bricks fade
+```
+
+---
+
 ## Atomic scope promotion (Issue #404)
 
 When an agent promotes a brick's scope (e.g., `agent → zone`), the store must update
@@ -871,7 +1040,7 @@ These are the tools an agent calls to forge bricks:
 | `forge_agent` | `{ name, description, manifestYaml }` or `{ name, description, brickIds }` | `ForgeResult` |
 | `forge_middleware` | `{ name, description, implementation }` | `ForgeResult` |
 | `forge_channel` | `{ name, description, implementation }` | `ForgeResult` |
-| `search_forge` | `{ query?, kind?, scope?, lifecycle? }` | `BrickArtifact[]` |
+| `search_forge` | `{ kind?, scope?, lifecycle?, tags?, orderBy?, minFitnessScore? }` | `BrickArtifact[]` (fitness-ranked) |
 | `promote_forge` | `{ brickId, scope?, trustTier?, lifecycle? }` | `PromoteResult` |
 
 All inputs accept optional `classification`, `contentMarkers`, `tags`, `requires`, and `files`.
@@ -1304,3 +1473,4 @@ with a real LLM.
 - [@koi/sandbox-executor](./sandbox-executor.md) — trust-tiered executor dispatch (subprocess + promoted + fallback)
 - [#72](https://github.com/windoliver/koi/issues/72) — OS-level sandbox isolation (Seatbelt/bubblewrap/gVisor)
 - [#394](https://github.com/windoliver/koi/issues/394) — cross-device workspace sync via Nexus
+- [#151](https://github.com/windoliver/koi/issues/151) — fitness-scored brick discovery (runtime natural selection)

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -11,7 +11,7 @@ import { TransitionReason, AgentCondition, AgentStatus, RegistryEntry, AgentRegi
 export { RegistryEvent, RegistryFilter, VALID_TRANSITIONS } from './lifecycle.js';
 import { JsonObject } from './common.js';
 import { I as ImplementationArtifact, B as BrickArtifact } from './brick-store-HASH.js';
-export { A as AdvisoryLock, a as AgentArtifact, b as BrickArtifactBase, c as BrickRequires, d as BrickUpdate, C as ContentMarker, D as DataClassification, F as ForgeAttestationSignature, e as ForgeBuildDefinition, f as ForgeBuilder, g as ForgeProvenance, h as ForgeQuery, i as ForgeResourceRef, j as ForgeRunMetadata, k as ForgeStageDigest, l as ForgeStore, m as ForgeVerificationSummary, n as InTotoStatementV1, o as InTotoSubject, L as LockHandle, p as LockMode, q as LockRequest, S as SigningBackend, r as SkillArtifact, s as StoreChangeEvent, t as StoreChangeKind, u as StoreChangeNotifier, T as TestCase, v as ToolArtifact } from './brick-store-HASH.js';
+export { A as AdvisoryLock, a as AgentArtifact, b as BrickArtifactBase, c as BrickFitnessMetrics, d as BrickRequires, e as BrickUpdate, C as ContentMarker, D as DEFAULT_BRICK_FITNESS, f as DataClassification, F as ForgeAttestationSignature, g as ForgeBuildDefinition, h as ForgeBuilder, i as ForgeProvenance, j as ForgeQuery, k as ForgeResourceRef, l as ForgeRunMetadata, m as ForgeStageDigest, n as ForgeStore, o as ForgeVerificationSummary, p as InTotoStatementV1, q as InTotoSubject, L as LatencySampler, r as LockHandle, s as LockMode, t as LockRequest, S as SigningBackend, u as SkillArtifact, v as StoreChangeEvent, w as StoreChangeKind, x as StoreChangeNotifier, T as TestCase, y as ToolArtifact } from './brick-store-HASH.js';
 export { ChannelAdapter, ChannelCapabilities, ChannelStatus, ChannelStatusKind, MessageHandler } from './channel.js';
 export { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, FeatureFlags, ForgeConfigSection, KoiConfig, LimitsConfig, LogLevel, LoopDetectionConfigSection, ModelRouterConfigSection, ModelTargetConfigEntry, SpawnConfig, TelemetryConfig } from './config.js';
 export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js';
@@ -2650,7 +2650,7 @@ exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
 "import './brick-snapshot-HASH.js';
 import './assembly-HASH.js';
 import './errors.js';
-export { A as AdvisoryLock, a as AgentArtifact, B as BrickArtifact, b as BrickArtifactBase, c as BrickRequires, d as BrickUpdate, h as ForgeQuery, l as ForgeStore, I as ImplementationArtifact, L as LockHandle, p as LockMode, q as LockRequest, r as SkillArtifact, s as StoreChangeEvent, t as StoreChangeKind, u as StoreChangeNotifier, T as TestCase, v as ToolArtifact } from './brick-store-HASH.js';
+export { A as AdvisoryLock, a as AgentArtifact, B as BrickArtifact, b as BrickArtifactBase, c as BrickFitnessMetrics, d as BrickRequires, e as BrickUpdate, D as DEFAULT_BRICK_FITNESS, j as ForgeQuery, n as ForgeStore, I as ImplementationArtifact, L as LatencySampler, r as LockHandle, s as LockMode, t as LockRequest, u as SkillArtifact, v as StoreChangeEvent, w as StoreChangeKind, x as StoreChangeNotifier, T as TestCase, y as ToolArtifact } from './brick-store-HASH.js';
 import './common.js';
 import './webhook.js';
 import './channel.js';
@@ -2866,7 +2866,7 @@ export type { FilesystemPolicy, NetworkPolicy, ResourceLimits, SandboxProfile };
 `;
 
 exports[`@koi/core API surface ./skill-registry has stable type surface 1`] = `
-"import { c as BrickRequires, r as SkillArtifact } from './brick-store-HASH.js';
+"import { d as BrickRequires, u as SkillArtifact } from './brick-store-HASH.js';
 import { Result, KoiError } from './errors.js';
 import './brick-snapshot-HASH.js';
 import './assembly-HASH.js';

--- a/packages/core/src/brick-store.ts
+++ b/packages/core/src/brick-store.ts
@@ -41,6 +41,34 @@ export interface BrickRequires {
 }
 
 // ---------------------------------------------------------------------------
+// Fitness metrics — runtime performance tracking for brick discovery ranking
+// ---------------------------------------------------------------------------
+
+/** Bounded sorted-sample buffer for percentile estimation (e.g., P99 latency). */
+export interface LatencySampler {
+  readonly samples: readonly number[];
+  readonly count: number;
+  readonly cap: number;
+}
+
+/** Runtime fitness metrics tracked per brick for discovery ranking. */
+export interface BrickFitnessMetrics {
+  readonly successCount: number;
+  readonly errorCount: number;
+  readonly latency: LatencySampler;
+  /** Epoch ms of the most recent usage (success or failure). */
+  readonly lastUsedAt: number;
+}
+
+/** Zero-usage default — immutable singleton for newly forged bricks. */
+export const DEFAULT_BRICK_FITNESS: BrickFitnessMetrics = Object.freeze({
+  successCount: 0,
+  errorCount: 0,
+  latency: Object.freeze({ samples: Object.freeze([]) as readonly number[], count: 0, cap: 200 }),
+  lastUsedAt: 0,
+});
+
+// ---------------------------------------------------------------------------
 // Brick artifact — discriminated union on `kind`
 // ---------------------------------------------------------------------------
 
@@ -65,6 +93,8 @@ export interface BrickArtifactBase {
   readonly configSchema?: Readonly<Record<string, unknown>>;
   /** Epoch millis of last successful re-verification. Undefined = never re-verified. */
   readonly lastVerifiedAt?: number;
+  /** Runtime fitness metrics for discovery ranking. Undefined = never used. */
+  readonly fitness?: BrickFitnessMetrics | undefined;
 }
 
 export interface ToolArtifact extends BrickArtifactBase {
@@ -109,6 +139,10 @@ export interface ForgeQuery {
   /** Case-insensitive substring match against brick name and description. */
   readonly text?: string;
   readonly limit?: number;
+  /** Sort order for results. Default: "fitness". */
+  readonly orderBy?: "fitness" | "recency" | "usage";
+  /** Minimum fitness score threshold (0–1). Bricks scoring below are excluded. */
+  readonly minFitnessScore?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +157,8 @@ export interface BrickUpdate {
   readonly tags?: readonly string[] | undefined;
   /** Epoch millis of last successful re-verification. */
   readonly lastVerifiedAt?: number;
+  /** Updated fitness metrics (replaces entire fitness object). */
+  readonly fitness?: BrickFitnessMetrics | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,11 +64,13 @@ export type {
   AgentArtifact,
   BrickArtifact,
   BrickArtifactBase,
+  BrickFitnessMetrics,
   BrickRequires,
   BrickUpdate,
   ForgeQuery,
   ForgeStore,
   ImplementationArtifact,
+  LatencySampler,
   LockHandle,
   LockMode,
   LockRequest,
@@ -79,6 +81,7 @@ export type {
   TestCase,
   ToolArtifact,
 } from "./brick-store.js";
+export { DEFAULT_BRICK_FITNESS } from "./brick-store.js";
 // browser driver — cross-engine abstraction for browser automation
 export type {
   BrowserActionOptions,

--- a/packages/forge/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/forge/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1091,6 +1091,12 @@ interface UsagePromotedResult {
     readonly newTier: TrustTier;
 }
 type UsageResult = UsageRecordedResult | UsagePromotedResult;
+/** Optional signal providing success/failure and latency for fitness tracking. */
+interface UsageSignal {
+    readonly success: boolean;
+    readonly latencyMs: number;
+    readonly timestamp?: number;
+}
 /**
  * Given a brick's current trust tier and its new usage count, returns the
  * tier it should be promoted to — or \`undefined\` if no promotion applies.
@@ -1100,8 +1106,12 @@ declare function computeAutoPromotion(currentTier: TrustTier, newUsageCount: num
  * Records a single usage of a brick. Increments \`usageCount\` and, when
  * auto-promotion is enabled and a threshold is crossed, promotes the
  * brick's trust tier.
+ *
+ * When \`signal\` is provided, also updates fitness metrics (success/error
+ * counts, latency, recency). The \`usageCount\` is derived from total
+ * fitness calls to stay DRY.
  */
-declare function recordBrickUsage(store: ForgeStore, brickId: string, config: ForgeConfig): Promise<Result<UsageResult, ForgeError>>;
+declare function recordBrickUsage(store: ForgeStore, brickId: string, config: ForgeConfig, signal?: UsageSignal): Promise<Result<UsageResult, ForgeError>>;
 
 /**
  * Pipeline orchestrator — runs verification stages sequentially with early termination.

--- a/packages/forge/src/forge-usage-middleware.test.ts
+++ b/packages/forge/src/forge-usage-middleware.test.ts
@@ -122,7 +122,7 @@ describe("createForgeUsageMiddleware", () => {
     expect(response.output).toBe("ok");
   });
 
-  test("propagates tool call errors without recording usage", async () => {
+  test("propagates tool call errors and records failure in fitness", async () => {
     const store = createInMemoryForgeStore();
     const brick = createToolBrick({ id: brickId("brick_fail"), name: "fail_tool" });
     await store.save(brick);
@@ -142,11 +142,17 @@ describe("createForgeUsageMiddleware", () => {
 
     await expect(getWrapToolCall(mw)(ctx, request, next)).rejects.toThrow("Tool execution failed");
 
-    // Usage should NOT be recorded for failed calls
+    // Allow fire-and-forget to complete
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Usage IS recorded for failed calls (as error in fitness)
     const loaded = await store.load(brickId("brick_fail"));
     expect(loaded.ok).toBe(true);
     if (loaded.ok) {
-      expect(loaded.value.usageCount).toBe(0);
+      expect(loaded.value.usageCount).toBe(1);
+      expect(loaded.value.fitness).toBeDefined();
+      expect(loaded.value.fitness?.errorCount).toBe(1);
+      expect(loaded.value.fitness?.successCount).toBe(0);
     }
   });
 
@@ -211,6 +217,12 @@ describe("createForgeUsageMiddleware", () => {
       name: "promo_tool",
       trustTier: "sandbox",
       usageCount: 4, // One more will cross the threshold
+      fitness: {
+        successCount: 4,
+        errorCount: 0,
+        latency: { samples: [50, 60, 70, 80], count: 4, cap: 200 },
+        lastUsedAt: Date.now() - 1000,
+      },
     });
     await store.save(brick);
 
@@ -250,7 +262,11 @@ describe("createForgeUsageMiddleware", () => {
 
   test("fires 'updated' notification after successful usage recording", async () => {
     const store = createInMemoryForgeStore();
-    const brick = createToolBrick({ id: brickId("brick_notify"), name: "notify_tool" });
+    const brick = createToolBrick({
+      id: brickId("brick_notify"),
+      name: "notify_tool",
+      usageCount: 0,
+    });
     await store.save(brick);
 
     const notifier = createMemoryStoreChangeNotifier();
@@ -343,6 +359,68 @@ describe("createForgeUsageMiddleware", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(events.length).toBe(0);
+  });
+
+  describe("fitness tracking", () => {
+    test("records success with fitness metrics after successful call", async () => {
+      const store = createInMemoryForgeStore();
+      const brick = createToolBrick({ id: brickId("brick_fit"), name: "fit_tool" });
+      await store.save(brick);
+
+      const mw = createForgeUsageMiddleware({
+        store,
+        config: createDefaultForgeConfig(),
+        resolveBrickId: (name) => (name === "fit_tool" ? "brick_fit" : undefined),
+      });
+
+      const next = async (_req: ToolRequest): Promise<ToolResponse> => ({ output: "ok" });
+      const ctx = stubTurnContext();
+      await getWrapToolCall(mw)(ctx, { toolId: "fit_tool", input: {} }, next);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const loaded = await store.load(brickId("brick_fit"));
+      expect(loaded.ok).toBe(true);
+      if (loaded.ok) {
+        expect(loaded.value.fitness).toBeDefined();
+        expect(loaded.value.fitness?.successCount).toBe(1);
+        expect(loaded.value.fitness?.errorCount).toBe(0);
+        expect(loaded.value.fitness?.latency.count).toBe(1);
+        expect(loaded.value.fitness?.lastUsedAt).toBeGreaterThan(0);
+      }
+    });
+
+    test("records latency in fitness metrics", async () => {
+      const store = createInMemoryForgeStore();
+      const brick = createToolBrick({ id: brickId("brick_lat"), name: "lat_tool" });
+      await store.save(brick);
+
+      const mw = createForgeUsageMiddleware({
+        store,
+        config: createDefaultForgeConfig(),
+        resolveBrickId: (name) => (name === "lat_tool" ? "brick_lat" : undefined),
+      });
+
+      // Simulate a slow tool call
+      const next = async (_req: ToolRequest): Promise<ToolResponse> => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { output: "ok" };
+      };
+
+      const ctx = stubTurnContext();
+      await getWrapToolCall(mw)(ctx, { toolId: "lat_tool", input: {} }, next);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const loaded = await store.load(brickId("brick_lat"));
+      expect(loaded.ok).toBe(true);
+      if (loaded.ok) {
+        expect(loaded.value.fitness?.latency.samples.length).toBe(1);
+        // Latency should be at least 20ms (the simulated delay)
+        const sample = loaded.value.fitness?.latency.samples[0];
+        expect(sample).toBeGreaterThanOrEqual(15); // allow small timing variance
+      }
+    });
   });
 
   describe("describeCapabilities", () => {

--- a/packages/forge/src/forge-usage-middleware.ts
+++ b/packages/forge/src/forge-usage-middleware.ts
@@ -18,6 +18,7 @@ import type {
 } from "@koi/core";
 import { brickId as toBrickId } from "@koi/core";
 import type { ForgeConfig } from "./config.js";
+import type { UsageSignal } from "./usage.js";
 import { recordBrickUsage } from "./usage.js";
 
 // ---------------------------------------------------------------------------
@@ -64,37 +65,50 @@ export function createForgeUsageMiddleware(cfg: ForgeUsageMiddlewareConfig): Koi
       request: ToolRequest,
       next: ToolHandler,
     ): Promise<ToolResponse> => {
-      const response = await next(request);
+      const brickIdStr = cfg.resolveBrickId(request.toolId);
 
-      const brickId = cfg.resolveBrickId(request.toolId);
-      if (brickId !== undefined) {
-        void recordBrickUsage(cfg.store, brickId, cfg.config)
+      // Non-forged tools: pass through without timing overhead
+      if (brickIdStr === undefined) {
+        return next(request);
+      }
+
+      const startMs = Date.now();
+      let success = true;
+      try {
+        const response = await next(request);
+        return response;
+      } catch (error: unknown) {
+        success = false;
+        throw error;
+      } finally {
+        const latencyMs = Date.now() - startMs;
+        const signal: UsageSignal = { success, latencyMs };
+
+        void recordBrickUsage(cfg.store, brickIdStr, cfg.config, signal)
           .then((result) => {
             if (!result.ok) {
               if (cfg.onUsageError !== undefined) {
-                cfg.onUsageError(request.toolId, brickId, result.error);
+                cfg.onUsageError(request.toolId, brickIdStr, result.error);
               }
               return;
             }
             // Notify after successful usage recording (trust tier may have changed)
             if (cfg.notifier !== undefined) {
               void Promise.resolve(
-                cfg.notifier.notify({ kind: "updated", brickId: toBrickId(brickId) }),
+                cfg.notifier.notify({ kind: "updated", brickId: toBrickId(brickIdStr) }),
               ).catch(() => {});
             }
           })
           .catch((error: unknown) => {
             try {
               if (cfg.onUsageError !== undefined) {
-                cfg.onUsageError(request.toolId, brickId, error);
+                cfg.onUsageError(request.toolId, brickIdStr, error);
               }
             } catch (_: unknown) {
               // Error handler must not crash the process
             }
           });
       }
-
-      return response;
     },
   };
 }

--- a/packages/forge/src/memory-store.ts
+++ b/packages/forge/src/memory-store.ts
@@ -15,7 +15,7 @@ import type {
   StoreChangeEvent,
 } from "@koi/core";
 import { notFound } from "@koi/core";
-import { matchesBrickQuery } from "@koi/validation";
+import { applyBrickUpdate, matchesBrickQuery } from "@koi/validation";
 
 // Error helpers use shared factories from @koi/core.
 function notFoundError(id: BrickId): KoiError {
@@ -90,16 +90,7 @@ export function createInMemoryForgeStore(): ForgeStore {
     if (existing === undefined) {
       return { ok: false, error: notFoundError(id) };
     }
-    const updated: BrickArtifact = {
-      ...existing,
-      ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
-      ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
-      ...(updates.scope !== undefined ? { scope: updates.scope } : {}),
-      ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
-      ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-      ...(updates.lastVerifiedAt !== undefined ? { lastVerifiedAt: updates.lastVerifiedAt } : {}),
-    };
-    bricks.set(id, updated);
+    bricks.set(id, applyBrickUpdate(existing, updates));
     notifyListeners({ kind: "updated", brickId: id });
     return { ok: true, value: undefined };
   };
@@ -117,14 +108,7 @@ export function createInMemoryForgeStore(): ForgeStore {
     if (existing === undefined) {
       return { ok: false, error: notFoundError(id) };
     }
-    const merged: BrickArtifact = {
-      ...existing,
-      scope: targetScope,
-      ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
-      ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
-      ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
-      ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-    };
+    const merged = applyBrickUpdate(existing, { ...updates, scope: targetScope });
     bricks.set(id, merged);
     notifyListeners({ kind: "promoted", brickId: id, scope: targetScope });
     return { ok: true, value: undefined };

--- a/packages/forge/src/tools/search-forge.test.ts
+++ b/packages/forge/src/tools/search-forge.test.ts
@@ -340,4 +340,129 @@ describe("createSearchForgeTool", () => {
     expect(ids).toContain(brickId("b1"));
     expect(ids).toContain(brickId("b2"));
   });
+
+  // ---------------------------------------------------------------------------
+  // Fitness-based ranking
+  // ---------------------------------------------------------------------------
+
+  test("ranks bricks with fitness higher than bricks without", async () => {
+    const store = createInMemoryForgeStore();
+    const now = Date.now();
+    await store.save(
+      createToolBrick({
+        id: brickId("b_unused"),
+        name: "unused-brick",
+      }),
+    );
+    await store.save(
+      createToolBrick({
+        id: brickId("b_used"),
+        name: "used-brick",
+        usageCount: 10,
+        fitness: {
+          successCount: 10,
+          errorCount: 0,
+          latency: { samples: [50], count: 1, cap: 200 },
+          lastUsedAt: now,
+        },
+      }),
+    );
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(2);
+    expect(result.value[0]?.name).toBe("used-brick");
+    expect(result.value[1]?.name).toBe("unused-brick");
+  });
+
+  test("orderBy 'usage' sorts by usageCount descending", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("b_few"), name: "few", usageCount: 2 }));
+    await store.save(createToolBrick({ id: brickId("b_many"), name: "many", usageCount: 50 }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ orderBy: "usage" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value[0]?.name).toBe("many");
+    expect(result.value[1]?.name).toBe("few");
+  });
+
+  test("minFitnessScore filters out zero-fitness bricks", async () => {
+    const store = createInMemoryForgeStore();
+    const now = Date.now();
+    await store.save(createToolBrick({ id: brickId("b_no"), name: "no-fitness" }));
+    await store.save(
+      createToolBrick({
+        id: brickId("b_yes"),
+        name: "has-fitness",
+        usageCount: 10,
+        fitness: {
+          successCount: 10,
+          errorCount: 0,
+          latency: { samples: [50], count: 1, cap: 200 },
+          lastUsedAt: now,
+        },
+      }),
+    );
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ minFitnessScore: 0.01 })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]?.name).toBe("has-fitness");
+  });
+
+  test("invalid orderBy defaults to fitness", async () => {
+    const store = createInMemoryForgeStore();
+    const now = Date.now();
+    await store.save(
+      createToolBrick({
+        id: brickId("b1"),
+        name: "brick-a",
+        usageCount: 5,
+        fitness: {
+          successCount: 5,
+          errorCount: 0,
+          latency: { samples: [50], count: 1, cap: 200 },
+          lastUsedAt: now,
+        },
+      }),
+    );
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({ orderBy: "invalid" })) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    expect(result.value).toHaveLength(1);
+  });
+
+  test("tiebreak sorts alphabetically by name", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("b1"), name: "charlie" }));
+    await store.save(createToolBrick({ id: brickId("b2"), name: "alpha" }));
+    await store.save(createToolBrick({ id: brickId("b3"), name: "bravo" }));
+
+    const tool = createSearchForgeTool(createDeps({ store }));
+    const result = (await tool.execute({})) as {
+      readonly ok: true;
+      readonly value: readonly BrickArtifact[];
+    };
+    expect(result.ok).toBe(true);
+    // All have zero fitness, so tiebreak by name
+    expect(result.value[0]?.name).toBe("alpha");
+    expect(result.value[1]?.name).toBe("bravo");
+    expect(result.value[2]?.name).toBe("charlie");
+  });
 });

--- a/packages/forge/src/tools/search-forge.ts
+++ b/packages/forge/src/tools/search-forge.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Result, Tool } from "@koi/core";
+import { sortBricks } from "@koi/validation";
 import type { ForgeError } from "../errors.js";
 import { staticError } from "../errors.js";
 import { filterByAgentScope } from "../scope-filter.js";
@@ -14,9 +15,12 @@ import { createForgeTool } from "./shared.js";
 // Tool config
 // ---------------------------------------------------------------------------
 
+const VALID_ORDER_BY = new Set(["fitness", "recency", "usage"]);
+
 const SEARCH_FORGE_CONFIG: ForgeToolConfig = {
   name: "search_forge",
-  description: "Discovers existing forged bricks by kind, scope, tags, and other criteria",
+  description:
+    "Discovers existing forged bricks by kind, scope, tags, and other criteria. Results are ranked by fitness score (composite of success rate, recency, usage, and latency).",
   inputSchema: {
     type: "object",
     properties: {
@@ -28,6 +32,14 @@ const SEARCH_FORGE_CONFIG: ForgeToolConfig = {
       createdBy: { type: "string" },
       text: { type: "string" },
       limit: { type: "number" },
+      orderBy: {
+        type: "string",
+        description: "Sort order: 'fitness' (default), 'recency', or 'usage'",
+      },
+      minFitnessScore: {
+        type: "number",
+        description: "Minimum fitness score (0-1). Bricks below this threshold are excluded.",
+      },
     },
   },
   handler: searchForgeHandler,
@@ -50,7 +62,23 @@ async function searchForgeHandler(
   }
 
   // All fields are optional — cast safely since ForgeQuery is all-optional
-  const query = (input ?? {}) as ForgeQuery;
+  const rawQuery = (input ?? {}) as ForgeQuery;
+
+  // Lightweight validation: clamp minFitnessScore to [0,1], default invalid orderBy
+  const orderBy =
+    rawQuery.orderBy !== undefined && VALID_ORDER_BY.has(rawQuery.orderBy)
+      ? rawQuery.orderBy
+      : "fitness";
+  const clampedMin =
+    rawQuery.minFitnessScore !== undefined
+      ? Math.max(0, Math.min(1, rawQuery.minFitnessScore))
+      : undefined;
+  const query: ForgeQuery = {
+    ...rawQuery,
+    orderBy,
+    ...(clampedMin !== undefined ? { minFitnessScore: clampedMin } : {}),
+  };
+
   const result = await deps.store.search(query);
 
   if (!result.ok) {
@@ -64,8 +92,9 @@ async function searchForgeHandler(
     };
   }
 
-  const filtered = filterByAgentScope(result.value, deps.context.agentId);
-  return { ok: true, value: filtered };
+  const scoped = filterByAgentScope(result.value, deps.context.agentId);
+  const ranked = sortBricks(scoped, query, { nowMs: Date.now() });
+  return { ok: true, value: ranked };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/src/usage.test.ts
+++ b/packages/forge/src/usage.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PROVENANCE } from "@koi/test-utils";
 import { createDefaultForgeConfig } from "./config.js";
 import { createInMemoryForgeStore } from "./memory-store.js";
 import type { ToolArtifact } from "./types.js";
+import type { UsageSignal } from "./usage.js";
 import { computeAutoPromotion, recordBrickUsage } from "./usage.js";
 
 // ---------------------------------------------------------------------------
@@ -243,6 +244,137 @@ describe("recordBrickUsage", () => {
     expect(loaded.ok).toBe(true);
     if (loaded.ok) {
       expect(loaded.value.trustTier).toBe("sandbox");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordBrickUsage with UsageSignal (fitness tracking)
+// ---------------------------------------------------------------------------
+
+describe("recordBrickUsage with UsageSignal", () => {
+  const NOW = 1_700_000_000_000;
+
+  test("records success signal and updates fitness metrics", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("brick_fit"), usageCount: 0 }));
+
+    const config = createDefaultForgeConfig();
+    const signal: UsageSignal = { success: true, latencyMs: 100, timestamp: NOW };
+
+    const result = await recordBrickUsage(store, "brick_fit", config, signal);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("recorded");
+      expect(result.value.newUsageCount).toBe(1);
+    }
+
+    const loaded = await store.load(brickId("brick_fit"));
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) {
+      expect(loaded.value.fitness).toBeDefined();
+      expect(loaded.value.fitness?.successCount).toBe(1);
+      expect(loaded.value.fitness?.errorCount).toBe(0);
+      expect(loaded.value.fitness?.lastUsedAt).toBe(NOW);
+      expect(loaded.value.fitness?.latency.samples).toContain(100);
+    }
+  });
+
+  test("records error signal and increments errorCount", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("brick_err"), usageCount: 0 }));
+
+    const config = createDefaultForgeConfig();
+    const signal: UsageSignal = { success: false, latencyMs: 500, timestamp: NOW };
+
+    const result = await recordBrickUsage(store, "brick_err", config, signal);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.newUsageCount).toBe(1);
+    }
+
+    const loaded = await store.load(brickId("brick_err"));
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) {
+      expect(loaded.value.fitness?.successCount).toBe(0);
+      expect(loaded.value.fitness?.errorCount).toBe(1);
+    }
+  });
+
+  test("accumulates fitness over multiple signals", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("brick_acc"), usageCount: 0 }));
+
+    const config = createDefaultForgeConfig();
+
+    await recordBrickUsage(store, "brick_acc", config, {
+      success: true,
+      latencyMs: 50,
+      timestamp: NOW,
+    });
+    await recordBrickUsage(store, "brick_acc", config, {
+      success: true,
+      latencyMs: 100,
+      timestamp: NOW + 1000,
+    });
+    await recordBrickUsage(store, "brick_acc", config, {
+      success: false,
+      latencyMs: 200,
+      timestamp: NOW + 2000,
+    });
+
+    const loaded = await store.load(brickId("brick_acc"));
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) {
+      expect(loaded.value.fitness?.successCount).toBe(2);
+      expect(loaded.value.fitness?.errorCount).toBe(1);
+      expect(loaded.value.usageCount).toBe(3);
+      expect(loaded.value.fitness?.lastUsedAt).toBe(NOW + 2000);
+    }
+  });
+
+  test("derives usageCount from fitness totals", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("brick_derive"), usageCount: 0 }));
+
+    const config = createDefaultForgeConfig();
+    await recordBrickUsage(store, "brick_derive", config, {
+      success: true,
+      latencyMs: 10,
+      timestamp: NOW,
+    });
+    await recordBrickUsage(store, "brick_derive", config, {
+      success: false,
+      latencyMs: 20,
+      timestamp: NOW,
+    });
+
+    const loaded = await store.load(brickId("brick_derive"));
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) {
+      // usageCount = successCount + errorCount = 1 + 1 = 2
+      expect(loaded.value.usageCount).toBe(2);
+      expect(loaded.value.fitness?.successCount).toBe(1);
+      expect(loaded.value.fitness?.errorCount).toBe(1);
+    }
+  });
+
+  test("backward-compatible: no signal means no fitness update", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createToolBrick({ id: brickId("brick_compat"), usageCount: 5 }));
+
+    const config = createDefaultForgeConfig();
+    const result = await recordBrickUsage(store, "brick_compat", config);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.newUsageCount).toBe(6);
+    }
+
+    const loaded = await store.load(brickId("brick_compat"));
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) {
+      // No fitness field set (was undefined before, stays undefined)
+      expect(loaded.value.fitness).toBeUndefined();
     }
   });
 });

--- a/packages/forge/src/usage.ts
+++ b/packages/forge/src/usage.ts
@@ -3,8 +3,16 @@
  * when configurable thresholds are crossed.
  */
 
-import type { BrickArtifact, ForgeStore, KoiError, Result, TrustTier } from "@koi/core";
-import { brickId as toBrickId } from "@koi/core";
+import type {
+  BrickArtifact,
+  BrickFitnessMetrics,
+  ForgeStore,
+  KoiError,
+  Result,
+  TrustTier,
+} from "@koi/core";
+import { DEFAULT_BRICK_FITNESS, brickId as toBrickId } from "@koi/core";
+import { recordLatency } from "@koi/validation";
 import type { AutoPromotionConfig, ForgeConfig } from "./config.js";
 import type { ForgeError } from "./errors.js";
 import { storeError } from "./errors.js";
@@ -28,6 +36,17 @@ export interface UsagePromotedResult {
 }
 
 export type UsageResult = UsageRecordedResult | UsagePromotedResult;
+
+// ---------------------------------------------------------------------------
+// Usage signal (fitness-aware usage tracking)
+// ---------------------------------------------------------------------------
+
+/** Optional signal providing success/failure and latency for fitness tracking. */
+export interface UsageSignal {
+  readonly success: boolean;
+  readonly latencyMs: number;
+  readonly timestamp?: number; // defaults to Date.now()
+}
 
 // ---------------------------------------------------------------------------
 // Trust tier ordering (for threshold comparisons)
@@ -76,14 +95,36 @@ function toForgeError(err: KoiError): ForgeError {
 }
 
 /**
+ * Computes updated fitness metrics from an existing brick and a usage signal.
+ * Returns a new BrickFitnessMetrics object (never mutates).
+ */
+function computeUpdatedFitness(
+  existing: BrickFitnessMetrics,
+  signal: UsageSignal,
+): BrickFitnessMetrics {
+  const now = signal.timestamp ?? Date.now();
+  return {
+    successCount: existing.successCount + (signal.success ? 1 : 0),
+    errorCount: existing.errorCount + (signal.success ? 0 : 1),
+    latency: recordLatency(existing.latency, signal.latencyMs),
+    lastUsedAt: now,
+  };
+}
+
+/**
  * Records a single usage of a brick. Increments `usageCount` and, when
  * auto-promotion is enabled and a threshold is crossed, promotes the
  * brick's trust tier.
+ *
+ * When `signal` is provided, also updates fitness metrics (success/error
+ * counts, latency, recency). The `usageCount` is derived from total
+ * fitness calls to stay DRY.
  */
 export async function recordBrickUsage(
   store: ForgeStore,
   brickId: string,
   config: ForgeConfig,
+  signal?: UsageSignal,
 ): Promise<Result<UsageResult, ForgeError>> {
   const loadResult = await store.load(toBrickId(brickId));
   if (!loadResult.ok) {
@@ -91,12 +132,23 @@ export async function recordBrickUsage(
   }
 
   const brick: BrickArtifact = loadResult.value;
-  const newUsageCount = brick.usageCount + 1;
+
+  // When signal is provided, update fitness and derive usageCount from it
+  const updatedFitness =
+    signal !== undefined
+      ? computeUpdatedFitness(brick.fitness ?? DEFAULT_BRICK_FITNESS, signal)
+      : undefined;
+  const newUsageCount =
+    updatedFitness !== undefined
+      ? updatedFitness.successCount + updatedFitness.errorCount
+      : brick.usageCount + 1;
+
   const promotedTier = computeAutoPromotion(brick.trustTier, newUsageCount, config.autoPromotion);
 
   const updateResult = await store.update(toBrickId(brickId), {
     usageCount: newUsageCount,
     ...(promotedTier !== undefined ? { trustTier: promotedTier } : {}),
+    ...(updatedFitness !== undefined ? { fitness: updatedFitness } : {}),
   });
 
   if (!updateResult.ok) {

--- a/packages/store-fs/src/fs-store.ts
+++ b/packages/store-fs/src/fs-store.ts
@@ -23,7 +23,7 @@ import type {
   StoreChangeEvent,
 } from "@koi/core";
 import { notFound } from "@koi/core";
-import { validateBrickArtifact } from "@koi/validation";
+import { applyBrickUpdate, validateBrickArtifact } from "@koi/validation";
 import { mapFsError, mapParseError } from "./errors.js";
 import { brickPath, shardDir, tmpPath } from "./paths.js";
 import { matchesBrickQuery } from "./query.js";
@@ -371,15 +371,7 @@ export async function createFsForgeStore(
     }
 
     // Merge updates immutably
-    const existing = readResult.value;
-    const updated: BrickArtifact = {
-      ...existing,
-      ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
-      ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
-      ...(updates.scope !== undefined ? { scope: updates.scope } : {}),
-      ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
-      ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-    };
+    const updated = applyBrickUpdate(readResult.value, updates);
 
     // Atomic write back
     const temp = tmpPath(baseDir, id);

--- a/packages/store-fs/src/overlay-store.ts
+++ b/packages/store-fs/src/overlay-store.ts
@@ -20,6 +20,7 @@ import type {
   StoreChangeEvent,
 } from "@koi/core";
 import { notFound, permission, validation } from "@koi/core";
+import { applyBrickUpdate } from "@koi/validation";
 import type { FsForgeStoreExtended } from "./fs-store.js";
 import { createFsForgeStore } from "./fs-store.js";
 import type { TierDescriptor, TierName } from "./tier.js";
@@ -288,14 +289,7 @@ export async function createOverlayForgeStore(config: OverlayConfig): Promise<Ov
           return loadResult;
         }
         // Merge updates in memory to avoid a redundant save→read→save cycle
-        const merged: BrickArtifact = {
-          ...loadResult.value,
-          ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
-          ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
-          ...(updates.scope !== undefined ? { scope: updates.scope } : {}),
-          ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
-          ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-        };
+        const merged = applyBrickUpdate(loadResult.value, updates);
         return writable.store.save(merged);
       }
     }
@@ -431,14 +425,7 @@ export async function createOverlayForgeStore(config: OverlayConfig): Promise<Ov
         }
 
         // Merge all updates + scope in memory (single operation)
-        const merged: BrickArtifact = {
-          ...loadResult.value,
-          scope: targetScope,
-          ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
-          ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
-          ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
-          ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-        };
+        const merged = applyBrickUpdate(loadResult.value, { ...updates, scope: targetScope });
 
         // Save merged brick to target tier (single write — atomic point)
         const saveResult = await targetEntry.store.save(merged);

--- a/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,8 +1,23 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/validation API surface . has stable type surface 1`] = `
-"import { Result, BrickArtifact, KoiError, BrickArtifactBase, ForgeQuery } from '@koi/core';
+"import { BrickArtifactBase, BrickUpdate, Result, BrickArtifact, KoiError, BrickFitnessMetrics, LatencySampler, ForgeQuery } from '@koi/core';
 import { z } from 'zod';
+
+/**
+ * Brick update applicator — immutable merge of BrickUpdate onto a BrickArtifact.
+ *
+ * Replaces the repeated conditional-spread pattern across store implementations
+ * (memory-store, fs-store, overlay-store). Single source of truth for which
+ * BrickUpdate fields are applied and how.
+ */
+
+/**
+ * Applies defined fields from \`updates\` to \`existing\`, returning a new object.
+ * Never mutates either argument. Only fields explicitly present (not undefined)
+ * in \`updates\` override the corresponding field in \`existing\`.
+ */
+declare function applyBrickUpdate<T extends BrickArtifactBase>(existing: T, updates: BrickUpdate): T;
 
 /**
  * Lightweight type guard for BrickArtifact loaded from storage.
@@ -19,6 +34,71 @@ import { z } from 'zod';
  * @param source - Backend-agnostic context for error messages (file path, DB row id, etc.)
  */
 declare function validateBrickArtifact(data: unknown, source: string): Result<BrickArtifact, KoiError>;
+
+/**
+ * Fitness scoring — multiplicative composite score for brick discovery ranking.
+ *
+ * Pure function operating on BrickFitnessMetrics from @koi/core.
+ * All factors are in [0, 1]; the composite score is their product clamped to [0, 1].
+ *
+ * Formula:
+ *   successRate^exponent × recencyDecay × usageNorm × latencyFactor
+ */
+
+interface FitnessScoringConfig {
+    /** Half-life in days for the recency decay factor. Default: 30. */
+    readonly halfLifeDays: number;
+    /** Usage count at which usageNorm reaches ~1. Default: 100. */
+    readonly usageSaturation: number;
+    /** Exponent applied to success rate. Higher = harsher penalty for errors. Default: 2.0. */
+    readonly successExponent: number;
+    /** Blend factor for P99 latency penalty (0 = ignore latency). Default: 0.1. */
+    readonly latencyWeight: number;
+    /** Latency threshold in ms above which the penalty is maximal. Default: 5000. */
+    readonly maxAcceptableLatencyMs: number;
+}
+declare const DEFAULT_FITNESS_SCORING_CONFIG: FitnessScoringConfig;
+/**
+ * Computes a composite fitness score for a brick based on its runtime metrics.
+ *
+ * Returns 0 for bricks with zero usage (no data = no fitness signal).
+ * Returns a value in (0, 1] for bricks with usage data.
+ *
+ * @param metrics - Runtime fitness metrics from the brick.
+ * @param nowMs - Current time in epoch ms (injectable for testability).
+ * @param config - Optional partial config (merged with defaults).
+ */
+declare function computeBrickFitness(metrics: BrickFitnessMetrics, nowMs: number, config?: Partial<FitnessScoringConfig>): number;
+
+/**
+ * Bounded sorted-sample buffer for percentile estimation.
+ *
+ * Pure functions — no I/O, no side effects. Operates on LatencySampler
+ * from @koi/core. Uses reservoir sampling when the sample buffer is full,
+ * keeping samples sorted for O(1) percentile lookups.
+ */
+
+/** Creates an empty latency sampler with the given capacity. */
+declare function createLatencySampler(cap?: number): LatencySampler;
+/**
+ * Records a latency sample. Below cap: always inserts (sorted).
+ * At/above cap: reservoir sampling — replaces a random existing sample
+ * with probability \`cap / count\`, maintaining statistical representativeness.
+ */
+declare function recordLatency(sampler: LatencySampler, valueMs: number): LatencySampler;
+/**
+ * Computes a percentile from the sorted sample buffer.
+ * Returns undefined if the buffer is empty.
+ *
+ * @param p - Percentile in [0, 1], e.g. 0.99 for P99.
+ */
+declare function computePercentile(sampler: LatencySampler, p: number): number | undefined;
+/**
+ * Merges two samplers into one. The resulting sampler has capacity
+ * equal to the max of both inputs. Samples are merged and truncated
+ * to fit within the capacity using uniform random selection.
+ */
+declare function mergeSamplers(a: LatencySampler, b: LatencySampler): LatencySampler;
 
 /**
  * Pure query-matching logic for ForgeStore.search().
@@ -40,6 +120,29 @@ declare function matchesBrickQuery(brick: BrickArtifactBase, query: ForgeQuery):
 type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 declare const SEVERITY_ORDER: Readonly<Record<Severity, number>>;
 declare function severityAtOrAbove(severity: Severity, threshold: Severity): boolean;
+
+/**
+ * Brick sorting — query-time ranking for search_forge results.
+ *
+ * Pure function. Computes fitness scores at query time (always fresh),
+ * applies minFitnessScore filtering, and sorts by the requested orderBy.
+ * Tiebreak: alphabetical by brick name.
+ */
+
+interface SortBricksOptions {
+    readonly nowMs: number;
+    readonly fitnessConfig?: Partial<FitnessScoringConfig>;
+}
+/**
+ * Sorts and optionally filters bricks based on ForgeQuery ordering options.
+ *
+ * - Computes fitness per brick at query time (no stale cached scores).
+ * - Filters by \`minFitnessScore\` if specified in the query.
+ * - Sorts by \`orderBy\` (default: \`"fitness"\`).
+ * - Tiebreak: alphabetical by \`brick.name\`.
+ * - Returns a new array — never mutates the input.
+ */
+declare function sortBricks<T extends BrickArtifactBase>(bricks: readonly T[], query: ForgeQuery, options: SortBricksOptions): readonly T[];
 
 /**
  * Shared Zod → KoiError validation utilities.
@@ -64,6 +167,6 @@ declare function zodToKoiError(zodError: z.core.$ZodError, prefix?: string): Koi
  */
 declare function validateWith<T>(schema: z.ZodType<T>, raw: unknown, prefix?: string): Result<T, KoiError>;
 
-export { SEVERITY_ORDER, type Severity, matchesBrickQuery, severityAtOrAbove, validateBrickArtifact, validateWith, zodToKoiError };
+export { DEFAULT_FITNESS_SCORING_CONFIG, type FitnessScoringConfig, SEVERITY_ORDER, type Severity, type SortBricksOptions, applyBrickUpdate, computeBrickFitness, computePercentile, createLatencySampler, matchesBrickQuery, mergeSamplers, recordLatency, severityAtOrAbove, sortBricks, validateBrickArtifact, validateWith, zodToKoiError };
 "
 `;

--- a/packages/validation/src/apply-brick-update.test.ts
+++ b/packages/validation/src/apply-brick-update.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifactBase, BrickFitnessMetrics, BrickUpdate } from "@koi/core";
+import { applyBrickUpdate } from "./apply-brick-update.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createBrick(overrides?: Partial<BrickArtifactBase>): BrickArtifactBase {
+  return {
+    id: `sha256:${"a".repeat(64)}` as BrickArtifactBase["id"],
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    provenance: {
+      buildDefinition: { buildType: "forge/v1", externalParameters: {}, internalParameters: {} },
+      runDetails: {
+        builder: { id: "agent-1", version: "0.0.1" },
+        metadata: { agentId: "agent-1", sessionId: "s1", invocationId: "inv1", depth: 0 },
+        byProducts: [],
+      },
+      classification: "internal",
+      contentMarkers: [],
+    },
+    version: "0.0.1",
+    tags: ["original"],
+    usageCount: 0,
+    ...overrides,
+  } as BrickArtifactBase;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("applyBrickUpdate", () => {
+  test("returns same shape when updates is empty", () => {
+    const brick = createBrick();
+    const result = applyBrickUpdate(brick, {});
+    expect(result).toEqual(brick);
+  });
+
+  test("does not mutate the original brick", () => {
+    const brick = createBrick();
+    const original = { ...brick };
+    applyBrickUpdate(brick, { usageCount: 99 });
+    expect(brick).toEqual(original);
+  });
+
+  test("returns a new object (not same reference)", () => {
+    const brick = createBrick();
+    const result = applyBrickUpdate(brick, {});
+    expect(result).not.toBe(brick);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Individual field updates
+  // ---------------------------------------------------------------------------
+
+  test("updates lifecycle", () => {
+    const brick = createBrick({ lifecycle: "active" });
+    const result = applyBrickUpdate(brick, { lifecycle: "deprecated" });
+    expect(result.lifecycle).toBe("deprecated");
+  });
+
+  test("updates trustTier", () => {
+    const brick = createBrick({ trustTier: "sandbox" });
+    const result = applyBrickUpdate(brick, { trustTier: "verified" });
+    expect(result.trustTier).toBe("verified");
+  });
+
+  test("updates scope", () => {
+    const brick = createBrick({ scope: "agent" });
+    const result = applyBrickUpdate(brick, { scope: "global" });
+    expect(result.scope).toBe("global");
+  });
+
+  test("updates usageCount", () => {
+    const brick = createBrick({ usageCount: 5 });
+    const result = applyBrickUpdate(brick, { usageCount: 10 });
+    expect(result.usageCount).toBe(10);
+  });
+
+  test("updates tags", () => {
+    const brick = createBrick({ tags: ["old"] });
+    const result = applyBrickUpdate(brick, { tags: ["new", "updated"] });
+    expect(result.tags).toEqual(["new", "updated"]);
+  });
+
+  test("updates lastVerifiedAt", () => {
+    const brick = createBrick();
+    const now = Date.now();
+    const result = applyBrickUpdate(brick, { lastVerifiedAt: now });
+    expect(result.lastVerifiedAt).toBe(now);
+  });
+
+  test("updates fitness", () => {
+    const brick = createBrick();
+    const fitness: BrickFitnessMetrics = {
+      successCount: 5,
+      errorCount: 1,
+      latency: { samples: [100], count: 1, cap: 200 },
+      lastUsedAt: Date.now(),
+    };
+    const result = applyBrickUpdate(brick, { fitness });
+    expect(result.fitness).toEqual(fitness);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multiple fields
+  // ---------------------------------------------------------------------------
+
+  test("applies multiple fields at once", () => {
+    const brick = createBrick({ usageCount: 0, trustTier: "sandbox" });
+    const result = applyBrickUpdate(brick, {
+      usageCount: 5,
+      trustTier: "verified",
+      lifecycle: "deprecated",
+    });
+    expect(result.usageCount).toBe(5);
+    expect(result.trustTier).toBe("verified");
+    expect(result.lifecycle).toBe("deprecated");
+    // Unmodified fields preserved
+    expect(result.name).toBe("test-brick");
+    expect(result.scope).toBe("agent");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Undefined fields are NOT applied
+  // ---------------------------------------------------------------------------
+
+  test("undefined fields in update do not override existing values", () => {
+    const brick = createBrick({
+      usageCount: 5,
+      trustTier: "verified",
+      tags: ["keep"],
+    });
+    // Intentionally pass undefined values to verify conditional-spread ignores them.
+    // Use double cast because exactOptionalPropertyTypes forbids explicit undefined.
+    const updates = {
+      usageCount: undefined,
+      trustTier: undefined,
+      tags: undefined,
+    } as unknown as BrickUpdate;
+    const result = applyBrickUpdate(brick, updates);
+    expect(result.usageCount).toBe(5);
+    expect(result.trustTier).toBe("verified");
+    expect(result.tags).toEqual(["keep"]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Preserves extra fields from subtypes (ToolArtifact, etc.)
+  // ---------------------------------------------------------------------------
+
+  test("preserves fields from ToolArtifact subtype", () => {
+    const toolBrick = {
+      ...createBrick(),
+      kind: "tool" as const,
+      implementation: "return 42;",
+      inputSchema: { type: "object" },
+    };
+    const result = applyBrickUpdate(toolBrick, { usageCount: 10 });
+    expect(result.usageCount).toBe(10);
+    expect((result as typeof toolBrick).implementation).toBe("return 42;");
+    expect((result as typeof toolBrick).inputSchema).toEqual({ type: "object" });
+  });
+});

--- a/packages/validation/src/apply-brick-update.ts
+++ b/packages/validation/src/apply-brick-update.ts
@@ -1,0 +1,30 @@
+/**
+ * Brick update applicator — immutable merge of BrickUpdate onto a BrickArtifact.
+ *
+ * Replaces the repeated conditional-spread pattern across store implementations
+ * (memory-store, fs-store, overlay-store). Single source of truth for which
+ * BrickUpdate fields are applied and how.
+ */
+
+import type { BrickArtifactBase, BrickUpdate } from "@koi/core";
+
+/**
+ * Applies defined fields from `updates` to `existing`, returning a new object.
+ * Never mutates either argument. Only fields explicitly present (not undefined)
+ * in `updates` override the corresponding field in `existing`.
+ */
+export function applyBrickUpdate<T extends BrickArtifactBase>(
+  existing: T,
+  updates: BrickUpdate,
+): T {
+  return {
+    ...existing,
+    ...(updates.lifecycle !== undefined ? { lifecycle: updates.lifecycle } : {}),
+    ...(updates.trustTier !== undefined ? { trustTier: updates.trustTier } : {}),
+    ...(updates.scope !== undefined ? { scope: updates.scope } : {}),
+    ...(updates.usageCount !== undefined ? { usageCount: updates.usageCount } : {}),
+    ...(updates.tags !== undefined ? { tags: updates.tags } : {}),
+    ...(updates.lastVerifiedAt !== undefined ? { lastVerifiedAt: updates.lastVerifiedAt } : {}),
+    ...(updates.fitness !== undefined ? { fitness: updates.fitness } : {}),
+  };
+}

--- a/packages/validation/src/fitness-scoring.test.ts
+++ b/packages/validation/src/fitness-scoring.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickFitnessMetrics } from "@koi/core";
+import { DEFAULT_BRICK_FITNESS } from "@koi/core";
+import { computeBrickFitness, DEFAULT_FITNESS_SCORING_CONFIG } from "./fitness-scoring.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = 1_700_000_000_000; // fixed reference point
+const MS_PER_DAY = 86_400_000;
+
+function createMetrics(overrides?: Partial<BrickFitnessMetrics>): BrickFitnessMetrics {
+  return {
+    successCount: 10,
+    errorCount: 0,
+    latency: { samples: [50, 100, 150], count: 3, cap: 200 },
+    lastUsedAt: NOW,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Zero-usage edge case
+// ---------------------------------------------------------------------------
+
+describe("computeBrickFitness", () => {
+  test("returns 0 for zero-usage brick", () => {
+    expect(computeBrickFitness(DEFAULT_BRICK_FITNESS, NOW)).toBe(0);
+  });
+
+  test("returns 0 when both successCount and errorCount are 0", () => {
+    const metrics = createMetrics({ successCount: 0, errorCount: 0 });
+    expect(computeBrickFitness(metrics, NOW)).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Success rate factor
+  // ---------------------------------------------------------------------------
+
+  test("100% success rate gives maximum success factor", () => {
+    const perfect = createMetrics({ successCount: 10, errorCount: 0, lastUsedAt: NOW });
+    const imperfect = createMetrics({ successCount: 8, errorCount: 2, lastUsedAt: NOW });
+    const perfectScore = computeBrickFitness(perfect, NOW);
+    const imperfectScore = computeBrickFitness(imperfect, NOW);
+    expect(perfectScore).toBeGreaterThan(imperfectScore);
+  });
+
+  test("50% success rate with exponent 2 gives 0.25 success factor", () => {
+    const metrics = createMetrics({
+      successCount: 5,
+      errorCount: 5,
+      lastUsedAt: NOW,
+      latency: { samples: [], count: 0, cap: 200 },
+    });
+    const score = computeBrickFitness(metrics, NOW, { successExponent: 2.0 });
+    // successFactor = 0.5^2 = 0.25
+    // recencyFactor = 1 (just used)
+    // usageNorm = log2(11) / log2(101) ≈ 0.519
+    // latencyFactor = 1 (no latency data)
+    // score ≈ 0.25 * 1 * 0.519 * 1 ≈ 0.130
+    expect(score).toBeGreaterThan(0.1);
+    expect(score).toBeLessThan(0.2);
+  });
+
+  test("0% success rate gives score of 0", () => {
+    const metrics = createMetrics({ successCount: 0, errorCount: 10, lastUsedAt: NOW });
+    expect(computeBrickFitness(metrics, NOW)).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Recency factor
+  // ---------------------------------------------------------------------------
+
+  test("recently used brick scores higher than stale brick", () => {
+    const recent = createMetrics({ lastUsedAt: NOW });
+    const stale = createMetrics({ lastUsedAt: NOW - 60 * MS_PER_DAY });
+    expect(computeBrickFitness(recent, NOW)).toBeGreaterThan(computeBrickFitness(stale, NOW));
+  });
+
+  test("brick used exactly one half-life ago scores ~50% of recent", () => {
+    const halfLifeDays = 30;
+    const recent = createMetrics({ lastUsedAt: NOW });
+    const halfLife = createMetrics({ lastUsedAt: NOW - halfLifeDays * MS_PER_DAY });
+    const recentScore = computeBrickFitness(recent, NOW, { halfLifeDays });
+    const halfLifeScore = computeBrickFitness(halfLife, NOW, { halfLifeDays });
+    // recency factor should be ~0.5 at half-life
+    const ratio = halfLifeScore / recentScore;
+    expect(ratio).toBeCloseTo(0.5, 1);
+  });
+
+  test("future lastUsedAt is clamped to elapsed=0", () => {
+    const metrics = createMetrics({ lastUsedAt: NOW + 1000 });
+    const score = computeBrickFitness(metrics, NOW);
+    const atNow = computeBrickFitness(createMetrics({ lastUsedAt: NOW }), NOW);
+    expect(score).toBeCloseTo(atNow, 10);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Usage normalization factor
+  // ---------------------------------------------------------------------------
+
+  test("more usage increases score", () => {
+    const low = createMetrics({ successCount: 2, errorCount: 0, lastUsedAt: NOW });
+    const high = createMetrics({ successCount: 50, errorCount: 0, lastUsedAt: NOW });
+    expect(computeBrickFitness(high, NOW)).toBeGreaterThan(computeBrickFitness(low, NOW));
+  });
+
+  test("score approaches 1 near saturation with perfect metrics", () => {
+    const metrics = createMetrics({
+      successCount: 100,
+      errorCount: 0,
+      lastUsedAt: NOW,
+      latency: { samples: [10], count: 1, cap: 200 },
+    });
+    const score = computeBrickFitness(metrics, NOW, { usageSaturation: 100 });
+    // usageNorm = log2(101) / log2(101) = 1.0
+    // All other factors ≈ 1
+    expect(score).toBeGreaterThan(0.9);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Latency factor
+  // ---------------------------------------------------------------------------
+
+  test("low latency gives near-maximum latency factor", () => {
+    const fast = createMetrics({
+      latency: { samples: [10, 20, 30], count: 3, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    const slow = createMetrics({
+      latency: { samples: [4000, 4500, 5000], count: 3, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    expect(computeBrickFitness(fast, NOW)).toBeGreaterThan(computeBrickFitness(slow, NOW));
+  });
+
+  test("latency at maxAcceptableLatencyMs gives maximum penalty", () => {
+    const fast = createMetrics({
+      latency: { samples: [0], count: 1, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    const maxLatency = createMetrics({
+      latency: { samples: [5000], count: 1, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    const fastScore = computeBrickFitness(fast, NOW);
+    const slowScore = computeBrickFitness(maxLatency, NOW);
+    // latencyFactor = 1 - 0.1 * 1 = 0.9 for max latency
+    const ratio = slowScore / fastScore;
+    expect(ratio).toBeCloseTo(0.9, 1);
+  });
+
+  test("no latency samples gives latencyFactor of 1", () => {
+    const withLatency = createMetrics({
+      latency: { samples: [1000], count: 1, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    const noLatency = createMetrics({
+      latency: { samples: [], count: 0, cap: 200 },
+      lastUsedAt: NOW,
+    });
+    // noLatency should score slightly higher (latencyFactor = 1 vs < 1)
+    expect(computeBrickFitness(noLatency, NOW)).toBeGreaterThanOrEqual(
+      computeBrickFitness(withLatency, NOW),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config overrides
+  // ---------------------------------------------------------------------------
+
+  test("custom config overrides defaults", () => {
+    const metrics = createMetrics({ lastUsedAt: NOW });
+    const defaultScore = computeBrickFitness(metrics, NOW);
+    const customScore = computeBrickFitness(metrics, NOW, { successExponent: 1.0 });
+    // With exponent 1 instead of 2, successFactor is higher for same rate
+    expect(customScore).toBeGreaterThanOrEqual(defaultScore);
+  });
+
+  test("default config is frozen", () => {
+    expect(Object.isFrozen(DEFAULT_FITNESS_SCORING_CONFIG)).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Score bounds
+  // ---------------------------------------------------------------------------
+
+  test("score is always in [0, 1]", () => {
+    // Extremely high usage (usageNorm > 1 before clamping)
+    const extreme = createMetrics({
+      successCount: 10000,
+      errorCount: 0,
+      lastUsedAt: NOW,
+      latency: { samples: [1], count: 1, cap: 200 },
+    });
+    const score = computeBrickFitness(extreme, NOW);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  test("score is non-negative for all-error brick", () => {
+    const allErrors = createMetrics({
+      successCount: 0,
+      errorCount: 100,
+      lastUsedAt: NOW,
+    });
+    expect(computeBrickFitness(allErrors, NOW)).toBe(0);
+  });
+});

--- a/packages/validation/src/fitness-scoring.ts
+++ b/packages/validation/src/fitness-scoring.ts
@@ -1,0 +1,85 @@
+/**
+ * Fitness scoring — multiplicative composite score for brick discovery ranking.
+ *
+ * Pure function operating on BrickFitnessMetrics from @koi/core.
+ * All factors are in [0, 1]; the composite score is their product clamped to [0, 1].
+ *
+ * Formula:
+ *   successRate^exponent × recencyDecay × usageNorm × latencyFactor
+ */
+
+import type { BrickFitnessMetrics } from "@koi/core";
+import { computePercentile } from "./latency-sampler.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface FitnessScoringConfig {
+  /** Half-life in days for the recency decay factor. Default: 30. */
+  readonly halfLifeDays: number;
+  /** Usage count at which usageNorm reaches ~1. Default: 100. */
+  readonly usageSaturation: number;
+  /** Exponent applied to success rate. Higher = harsher penalty for errors. Default: 2.0. */
+  readonly successExponent: number;
+  /** Blend factor for P99 latency penalty (0 = ignore latency). Default: 0.1. */
+  readonly latencyWeight: number;
+  /** Latency threshold in ms above which the penalty is maximal. Default: 5000. */
+  readonly maxAcceptableLatencyMs: number;
+}
+
+export const DEFAULT_FITNESS_SCORING_CONFIG: FitnessScoringConfig = Object.freeze({
+  halfLifeDays: 30,
+  usageSaturation: 100,
+  successExponent: 2.0,
+  latencyWeight: 0.1,
+  maxAcceptableLatencyMs: 5000,
+});
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Computes a composite fitness score for a brick based on its runtime metrics.
+ *
+ * Returns 0 for bricks with zero usage (no data = no fitness signal).
+ * Returns a value in (0, 1] for bricks with usage data.
+ *
+ * @param metrics - Runtime fitness metrics from the brick.
+ * @param nowMs - Current time in epoch ms (injectable for testability).
+ * @param config - Optional partial config (merged with defaults).
+ */
+export function computeBrickFitness(
+  metrics: BrickFitnessMetrics,
+  nowMs: number,
+  config?: Partial<FitnessScoringConfig>,
+): number {
+  const cfg: FitnessScoringConfig = { ...DEFAULT_FITNESS_SCORING_CONFIG, ...config };
+
+  const totalCalls = metrics.successCount + metrics.errorCount;
+  if (totalCalls === 0) {
+    return 0;
+  }
+
+  // Success factor: successRate ^ exponent  →  [0, 1]
+  const successRate = metrics.successCount / totalCalls;
+  const successFactor = successRate ** cfg.successExponent;
+
+  // Recency factor: exponential decay  →  (0, 1]
+  const lambda = Math.LN2 / (cfg.halfLifeDays * MS_PER_DAY);
+  const elapsed = Math.max(0, nowMs - metrics.lastUsedAt);
+  const recencyFactor = Math.exp(-lambda * elapsed);
+
+  // Usage normalization: log2(1 + totalCalls) / log2(1 + saturation)  →  [0, ~1]
+  const usageNorm = Math.log2(1 + totalCalls) / Math.log2(1 + cfg.usageSaturation);
+
+  // Latency factor: 1 - weight × min(1, p99 / max)  →  [1-weight, 1]
+  const p99 = computePercentile(metrics.latency, 0.99) ?? 0;
+  const latencyRatio = Math.min(1, p99 / cfg.maxAcceptableLatencyMs);
+  const latencyFactor = 1 - cfg.latencyWeight * latencyRatio;
+
+  return Math.min(1, successFactor * recencyFactor * usageNorm * latencyFactor);
+}

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -6,7 +6,20 @@
  * Depends on @koi/core (for KoiError/Result) and zod.
  */
 
+export { applyBrickUpdate } from "./apply-brick-update.js";
 export { validateBrickArtifact } from "./brick-validation.js";
+export {
+  computeBrickFitness,
+  DEFAULT_FITNESS_SCORING_CONFIG,
+  type FitnessScoringConfig,
+} from "./fitness-scoring.js";
+export {
+  computePercentile,
+  createLatencySampler,
+  mergeSamplers,
+  recordLatency,
+} from "./latency-sampler.js";
 export { matchesBrickQuery } from "./query-match.js";
 export { SEVERITY_ORDER, type Severity, severityAtOrAbove } from "./severity.js";
+export { type SortBricksOptions, sortBricks } from "./sort-bricks.js";
 export { validateWith, zodToKoiError } from "./validation.js";

--- a/packages/validation/src/latency-sampler.test.ts
+++ b/packages/validation/src/latency-sampler.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import type { LatencySampler } from "@koi/core";
+import {
+  computePercentile,
+  createLatencySampler,
+  mergeSamplers,
+  recordLatency,
+} from "./latency-sampler.js";
+
+describe("createLatencySampler", () => {
+  test("creates empty sampler with default cap", () => {
+    const s = createLatencySampler();
+    expect(s.samples).toEqual([]);
+    expect(s.count).toBe(0);
+    expect(s.cap).toBe(200);
+  });
+
+  test("creates empty sampler with custom cap", () => {
+    const s = createLatencySampler(50);
+    expect(s.cap).toBe(50);
+  });
+
+  test("clamps cap to minimum of 1", () => {
+    const s = createLatencySampler(0);
+    expect(s.cap).toBe(1);
+  });
+
+  test("rounds fractional cap", () => {
+    const s = createLatencySampler(3.7);
+    expect(s.cap).toBe(4);
+  });
+});
+
+describe("recordLatency", () => {
+  test("inserts first sample", () => {
+    const s = createLatencySampler(10);
+    const result = recordLatency(s, 42);
+    expect(result.samples).toEqual([42]);
+    expect(result.count).toBe(1);
+  });
+
+  test("maintains sorted order", () => {
+    let s = createLatencySampler(10);
+    s = recordLatency(s, 30);
+    s = recordLatency(s, 10);
+    s = recordLatency(s, 20);
+    expect(result(s)).toEqual([10, 20, 30]);
+  });
+
+  test("never mutates the original sampler", () => {
+    const original = createLatencySampler(10);
+    const updated = recordLatency(original, 42);
+    expect(original.samples).toEqual([]);
+    expect(original.count).toBe(0);
+    expect(updated.samples).toEqual([42]);
+  });
+
+  test("fills to capacity", () => {
+    let s = createLatencySampler(3);
+    s = recordLatency(s, 30);
+    s = recordLatency(s, 10);
+    s = recordLatency(s, 20);
+    expect(result(s)).toEqual([10, 20, 30]);
+    expect(s.count).toBe(3);
+    expect(s.samples.length).toBe(3);
+  });
+
+  test("reservoir sampling keeps buffer at cap size", () => {
+    let s = createLatencySampler(5);
+    for (let i = 0; i < 100; i++) {
+      s = recordLatency(s, i);
+    }
+    expect(s.count).toBe(100);
+    expect(s.samples.length).toBe(5);
+    // Samples should still be sorted
+    for (let i = 1; i < s.samples.length; i++) {
+      const current = s.samples[i];
+      const prev = s.samples[i - 1];
+      if (current !== undefined && prev !== undefined) {
+        expect(current).toBeGreaterThanOrEqual(prev);
+      }
+    }
+  });
+
+  test("handles duplicate values", () => {
+    let s = createLatencySampler(10);
+    s = recordLatency(s, 5);
+    s = recordLatency(s, 5);
+    s = recordLatency(s, 5);
+    expect(result(s)).toEqual([5, 5, 5]);
+  });
+});
+
+describe("computePercentile", () => {
+  test("returns undefined for empty sampler", () => {
+    const s = createLatencySampler();
+    expect(computePercentile(s, 0.99)).toBeUndefined();
+  });
+
+  test("returns the single sample for a 1-element buffer", () => {
+    let s = createLatencySampler();
+    s = recordLatency(s, 42);
+    expect(computePercentile(s, 0.5)).toBe(42);
+    expect(computePercentile(s, 0.99)).toBe(42);
+  });
+
+  test("returns correct P50 for sorted samples", () => {
+    const s: LatencySampler = {
+      samples: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+      count: 10,
+      cap: 200,
+    };
+    const p50 = computePercentile(s, 0.5);
+    expect(p50).toBe(60); // index = floor(0.5 * 10) = 5
+  });
+
+  test("returns correct P99 for sorted samples", () => {
+    const s: LatencySampler = {
+      samples: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+      count: 10,
+      cap: 200,
+    };
+    const p99 = computePercentile(s, 0.99);
+    expect(p99).toBe(100); // index = min(floor(0.99 * 10), 9) = 9
+  });
+
+  test("returns first element for P0", () => {
+    const s: LatencySampler = {
+      samples: [10, 20, 30],
+      count: 3,
+      cap: 200,
+    };
+    expect(computePercentile(s, 0)).toBe(10);
+  });
+
+  test("returns last element for P100", () => {
+    const s: LatencySampler = {
+      samples: [10, 20, 30],
+      count: 3,
+      cap: 200,
+    };
+    expect(computePercentile(s, 1.0)).toBe(30);
+  });
+
+  test("clamps percentile below 0", () => {
+    const s: LatencySampler = { samples: [10, 20, 30], count: 3, cap: 200 };
+    expect(computePercentile(s, -0.5)).toBe(10);
+  });
+
+  test("clamps percentile above 1", () => {
+    const s: LatencySampler = { samples: [10, 20, 30], count: 3, cap: 200 };
+    expect(computePercentile(s, 1.5)).toBe(30);
+  });
+});
+
+describe("mergeSamplers", () => {
+  test("merges two empty samplers", () => {
+    const a = createLatencySampler(10);
+    const b = createLatencySampler(10);
+    const merged = mergeSamplers(a, b);
+    expect(merged.samples).toEqual([]);
+    expect(merged.count).toBe(0);
+  });
+
+  test("merges one empty and one non-empty", () => {
+    const a: LatencySampler = { samples: [10, 20, 30], count: 3, cap: 10 };
+    const b = createLatencySampler(10);
+    const merged = mergeSamplers(a, b);
+    expect(merged.samples).toEqual([10, 20, 30]);
+    expect(merged.count).toBe(3);
+  });
+
+  test("merges two non-empty samplers maintaining sort order", () => {
+    const a: LatencySampler = { samples: [10, 30, 50], count: 3, cap: 10 };
+    const b: LatencySampler = { samples: [20, 40, 60], count: 3, cap: 10 };
+    const merged = mergeSamplers(a, b);
+    expect(merged.samples).toEqual([10, 20, 30, 40, 50, 60]);
+    expect(merged.count).toBe(6);
+  });
+
+  test("uses max cap from both inputs", () => {
+    const a: LatencySampler = { samples: [10], count: 1, cap: 5 };
+    const b: LatencySampler = { samples: [20], count: 1, cap: 15 };
+    const merged = mergeSamplers(a, b);
+    expect(merged.cap).toBe(15);
+  });
+
+  test("downsamples when merged exceeds cap", () => {
+    const a: LatencySampler = { samples: [10, 20, 30, 40, 50], count: 5, cap: 5 };
+    const b: LatencySampler = { samples: [15, 25, 35, 45, 55], count: 5, cap: 5 };
+    const merged = mergeSamplers(a, b);
+    expect(merged.samples.length).toBe(5);
+    expect(merged.count).toBe(10);
+    // Should still be sorted
+    for (let i = 1; i < merged.samples.length; i++) {
+      const current = merged.samples[i];
+      const prev = merged.samples[i - 1];
+      if (current !== undefined && prev !== undefined) {
+        expect(current).toBeGreaterThanOrEqual(prev);
+      }
+    }
+  });
+
+  test("sums total count from both samplers", () => {
+    const a: LatencySampler = { samples: [10], count: 50, cap: 5 };
+    const b: LatencySampler = { samples: [20], count: 30, cap: 5 };
+    const merged = mergeSamplers(a, b);
+    expect(merged.count).toBe(80);
+  });
+});
+
+// Helper to extract samples array for readability
+function result(s: LatencySampler): readonly number[] {
+  return s.samples;
+}

--- a/packages/validation/src/latency-sampler.ts
+++ b/packages/validation/src/latency-sampler.ts
@@ -1,0 +1,162 @@
+/**
+ * Bounded sorted-sample buffer for percentile estimation.
+ *
+ * Pure functions — no I/O, no side effects. Operates on LatencySampler
+ * from @koi/core. Uses reservoir sampling when the sample buffer is full,
+ * keeping samples sorted for O(1) percentile lookups.
+ */
+
+import type { LatencySampler } from "@koi/core";
+
+const DEFAULT_CAP = 200;
+
+/** Creates an empty latency sampler with the given capacity. */
+export function createLatencySampler(cap: number = DEFAULT_CAP): LatencySampler {
+  return { samples: [], count: 0, cap: Math.max(1, Math.round(cap)) };
+}
+
+/**
+ * Inserts a value into a sorted array at the correct position (binary search).
+ * Returns a new array — never mutates the input.
+ */
+function sortedInsert(arr: readonly number[], value: number): readonly number[] {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    const midVal = arr[mid];
+    if (midVal !== undefined && midVal < value) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return [...arr.slice(0, lo), value, ...arr.slice(lo)];
+}
+
+/**
+ * Replaces a value in a sorted array: removes the old value and inserts the new one.
+ * Returns a new array — never mutates the input.
+ */
+function sortedReplace(
+  arr: readonly number[],
+  oldValue: number,
+  newValue: number,
+): readonly number[] {
+  // Remove old value (find first occurrence via binary search)
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    const midVal = arr[mid];
+    if (midVal !== undefined && midVal < oldValue) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  const without = [...arr.slice(0, lo), ...arr.slice(lo + 1)];
+  return sortedInsert(without, newValue);
+}
+
+/**
+ * Records a latency sample. Below cap: always inserts (sorted).
+ * At/above cap: reservoir sampling — replaces a random existing sample
+ * with probability `cap / count`, maintaining statistical representativeness.
+ */
+export function recordLatency(sampler: LatencySampler, valueMs: number): LatencySampler {
+  const newCount = sampler.count + 1;
+
+  if (sampler.samples.length < sampler.cap) {
+    // Below capacity — always insert (sorted)
+    return {
+      samples: sortedInsert(sampler.samples, valueMs),
+      count: newCount,
+      cap: sampler.cap,
+    };
+  }
+
+  // Reservoir sampling: replace with probability cap/count
+  const replaceIndex = Math.floor(Math.random() * newCount);
+  if (replaceIndex >= sampler.cap) {
+    // Don't replace — just increment count
+    return { samples: sampler.samples, count: newCount, cap: sampler.cap };
+  }
+
+  // Replace the chosen sample, maintaining sort order
+  const oldValue = sampler.samples[replaceIndex];
+  if (oldValue === undefined) {
+    return { samples: sampler.samples, count: newCount, cap: sampler.cap };
+  }
+  return {
+    samples: sortedReplace(sampler.samples, oldValue, valueMs),
+    count: newCount,
+    cap: sampler.cap,
+  };
+}
+
+/**
+ * Computes a percentile from the sorted sample buffer.
+ * Returns undefined if the buffer is empty.
+ *
+ * @param p - Percentile in [0, 1], e.g. 0.99 for P99.
+ */
+export function computePercentile(sampler: LatencySampler, p: number): number | undefined {
+  if (sampler.samples.length === 0) {
+    return undefined;
+  }
+  const clampedP = Math.max(0, Math.min(1, p));
+  const index = Math.min(Math.floor(clampedP * sampler.samples.length), sampler.samples.length - 1);
+  return sampler.samples[index];
+}
+
+/**
+ * Merges two samplers into one. The resulting sampler has capacity
+ * equal to the max of both inputs. Samples are merged and truncated
+ * to fit within the capacity using uniform random selection.
+ */
+export function mergeSamplers(a: LatencySampler, b: LatencySampler): LatencySampler {
+  const cap = Math.max(a.cap, b.cap);
+  const totalCount = a.count + b.count;
+
+  // Merge both sorted arrays
+  const merged: number[] = [];
+  let ai = 0;
+  let bi = 0;
+  while (ai < a.samples.length && bi < b.samples.length) {
+    const av = a.samples[ai];
+    const bv = b.samples[bi];
+    if (av !== undefined && (bv === undefined || av <= bv)) {
+      merged.push(av);
+      ai++;
+    } else if (bv !== undefined) {
+      merged.push(bv);
+      bi++;
+    }
+  }
+  while (ai < a.samples.length) {
+    const v = a.samples[ai];
+    if (v !== undefined) merged.push(v);
+    ai++;
+  }
+  while (bi < b.samples.length) {
+    const v = b.samples[bi];
+    if (v !== undefined) merged.push(v);
+    bi++;
+  }
+
+  // If within cap, return as-is
+  if (merged.length <= cap) {
+    return { samples: merged, count: totalCount, cap };
+  }
+
+  // Downsample: pick cap elements uniformly spaced from the sorted merged array
+  const downsampled: number[] = [];
+  for (let i = 0; i < cap; i++) {
+    const idx = Math.floor((i * merged.length) / cap);
+    const v = merged[idx];
+    if (v !== undefined) downsampled.push(v);
+  }
+
+  return { samples: downsampled, count: totalCount, cap };
+}

--- a/packages/validation/src/sort-bricks.test.ts
+++ b/packages/validation/src/sort-bricks.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifactBase, BrickFitnessMetrics, ForgeQuery } from "@koi/core";
+import { sortBricks } from "./sort-bricks.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = 1_700_000_000_000;
+const MS_PER_DAY = 86_400_000;
+
+function createBrick(name: string, overrides?: Partial<BrickArtifactBase>): BrickArtifactBase {
+  return {
+    id: `sha256:${"a".repeat(64)}` as BrickArtifactBase["id"],
+    kind: "tool",
+    name,
+    description: `Brick ${name}`,
+    scope: "agent",
+    trustTier: "sandbox",
+    lifecycle: "active",
+    provenance: {
+      buildDefinition: { buildType: "forge/v1", externalParameters: {}, internalParameters: {} },
+      runDetails: {
+        builder: { id: "agent-1", version: "0.0.1" },
+        metadata: { agentId: "agent-1", sessionId: "s1", invocationId: "inv1", depth: 0 },
+        byProducts: [],
+      },
+      classification: "internal",
+      contentMarkers: [],
+    },
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    ...overrides,
+  } as BrickArtifactBase;
+}
+
+function createFitness(overrides?: Partial<BrickFitnessMetrics>): BrickFitnessMetrics {
+  return {
+    successCount: 10,
+    errorCount: 0,
+    latency: { samples: [50], count: 1, cap: 200 },
+    lastUsedAt: NOW,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Basic sorting
+// ---------------------------------------------------------------------------
+
+describe("sortBricks", () => {
+  test("returns empty array for empty input", () => {
+    const result = sortBricks([], {}, { nowMs: NOW });
+    expect(result).toEqual([]);
+  });
+
+  test("returns single brick unchanged", () => {
+    const brick = createBrick("alpha");
+    const result = sortBricks([brick], {}, { nowMs: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("alpha");
+  });
+
+  test("does not mutate original array", () => {
+    const bricks = [
+      createBrick("beta", { fitness: createFitness({ successCount: 5 }) }),
+      createBrick("alpha", { fitness: createFitness({ successCount: 10 }) }),
+    ];
+    const originalNames = bricks.map((b) => b.name);
+    sortBricks(bricks, {}, { nowMs: NOW });
+    expect(bricks.map((b) => b.name)).toEqual(originalNames);
+  });
+
+  // ---------------------------------------------------------------------------
+  // orderBy: "fitness" (default)
+  // ---------------------------------------------------------------------------
+
+  test("default orderBy sorts by fitness descending", () => {
+    const bricks = [
+      createBrick("low", {
+        fitness: createFitness({ successCount: 1, errorCount: 9 }),
+        usageCount: 1,
+      }),
+      createBrick("high", {
+        fitness: createFitness({ successCount: 50, errorCount: 0 }),
+        usageCount: 50,
+      }),
+      createBrick("mid", {
+        fitness: createFitness({ successCount: 10, errorCount: 5 }),
+        usageCount: 10,
+      }),
+    ];
+    const result = sortBricks(bricks, {}, { nowMs: NOW });
+    expect(result[0]?.name).toBe("high");
+    expect(result[2]?.name).toBe("low");
+  });
+
+  test("bricks without fitness are scored as 0", () => {
+    const bricks = [
+      createBrick("unused"),
+      createBrick("used", { fitness: createFitness(), usageCount: 10 }),
+    ];
+    const result = sortBricks(bricks, {}, { nowMs: NOW });
+    expect(result[0]?.name).toBe("used");
+    expect(result[1]?.name).toBe("unused");
+  });
+
+  // ---------------------------------------------------------------------------
+  // orderBy: "recency"
+  // ---------------------------------------------------------------------------
+
+  test("orderBy recency sorts by lastUsedAt descending", () => {
+    const bricks = [
+      createBrick("old", { fitness: createFitness({ lastUsedAt: NOW - 30 * MS_PER_DAY }) }),
+      createBrick("new", { fitness: createFitness({ lastUsedAt: NOW }) }),
+      createBrick("mid", { fitness: createFitness({ lastUsedAt: NOW - 10 * MS_PER_DAY }) }),
+    ];
+    const query: ForgeQuery = { orderBy: "recency" };
+    const result = sortBricks(bricks, query, { nowMs: NOW });
+    expect(result[0]?.name).toBe("new");
+    expect(result[1]?.name).toBe("mid");
+    expect(result[2]?.name).toBe("old");
+  });
+
+  // ---------------------------------------------------------------------------
+  // orderBy: "usage"
+  // ---------------------------------------------------------------------------
+
+  test("orderBy usage sorts by usageCount descending", () => {
+    const bricks = [
+      createBrick("few", { usageCount: 2 }),
+      createBrick("many", { usageCount: 100 }),
+      createBrick("some", { usageCount: 20 }),
+    ];
+    const query: ForgeQuery = { orderBy: "usage" };
+    const result = sortBricks(bricks, query, { nowMs: NOW });
+    expect(result[0]?.name).toBe("many");
+    expect(result[1]?.name).toBe("some");
+    expect(result[2]?.name).toBe("few");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tiebreak
+  // ---------------------------------------------------------------------------
+
+  test("tiebreak sorts alphabetically by name", () => {
+    const fitness = createFitness({ successCount: 10, errorCount: 0 });
+    const bricks = [
+      createBrick("charlie", { fitness, usageCount: 10 }),
+      createBrick("alpha", { fitness, usageCount: 10 }),
+      createBrick("bravo", { fitness, usageCount: 10 }),
+    ];
+    const result = sortBricks(bricks, {}, { nowMs: NOW });
+    expect(result[0]?.name).toBe("alpha");
+    expect(result[1]?.name).toBe("bravo");
+    expect(result[2]?.name).toBe("charlie");
+  });
+
+  // ---------------------------------------------------------------------------
+  // minFitnessScore filtering
+  // ---------------------------------------------------------------------------
+
+  test("minFitnessScore filters out low-scoring bricks", () => {
+    const bricks = [
+      createBrick("good", {
+        fitness: createFitness({ successCount: 50, errorCount: 0 }),
+        usageCount: 50,
+      }),
+      createBrick("unused"),
+    ];
+    const query: ForgeQuery = { minFitnessScore: 0.01 };
+    const result = sortBricks(bricks, query, { nowMs: NOW });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("good");
+  });
+
+  test("minFitnessScore of 0 keeps all bricks", () => {
+    const bricks = [createBrick("a"), createBrick("b", { fitness: createFitness() })];
+    const query: ForgeQuery = { minFitnessScore: 0 };
+    const result = sortBricks(bricks, query, { nowMs: NOW });
+    expect(result).toHaveLength(2);
+  });
+
+  test("minFitnessScore of 1 filters very aggressively", () => {
+    const bricks = [
+      createBrick("a", {
+        fitness: createFitness({ successCount: 10, errorCount: 0 }),
+        usageCount: 10,
+      }),
+    ];
+    const query: ForgeQuery = { minFitnessScore: 1.0 };
+    const result = sortBricks(bricks, query, { nowMs: NOW });
+    // usageNorm < 1 so score < 1, should be filtered
+    expect(result).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Custom fitness config passthrough
+  // ---------------------------------------------------------------------------
+
+  test("passes fitnessConfig through to scoring", () => {
+    const bricks = [
+      createBrick("a", {
+        fitness: createFitness({
+          successCount: 5,
+          errorCount: 5,
+          lastUsedAt: NOW,
+        }),
+        usageCount: 10,
+      }),
+    ];
+    // With exponent 1 vs 2, scores will differ
+    const score1 = sortBricks(bricks, {}, { nowMs: NOW, fitnessConfig: { successExponent: 1.0 } });
+    const score2 = sortBricks(bricks, {}, { nowMs: NOW, fitnessConfig: { successExponent: 3.0 } });
+    // Both should return the single brick (no minFitnessScore filter)
+    expect(score1).toHaveLength(1);
+    expect(score2).toHaveLength(1);
+  });
+});

--- a/packages/validation/src/sort-bricks.ts
+++ b/packages/validation/src/sort-bricks.ts
@@ -1,0 +1,101 @@
+/**
+ * Brick sorting — query-time ranking for search_forge results.
+ *
+ * Pure function. Computes fitness scores at query time (always fresh),
+ * applies minFitnessScore filtering, and sorts by the requested orderBy.
+ * Tiebreak: alphabetical by brick name.
+ */
+
+import type { BrickArtifactBase, ForgeQuery } from "@koi/core";
+import { DEFAULT_BRICK_FITNESS } from "@koi/core";
+import type { FitnessScoringConfig } from "./fitness-scoring.js";
+import { computeBrickFitness } from "./fitness-scoring.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface SortBricksOptions {
+  readonly nowMs: number;
+  readonly fitnessConfig?: Partial<FitnessScoringConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+/**
+ * Sorts and optionally filters bricks based on ForgeQuery ordering options.
+ *
+ * - Computes fitness per brick at query time (no stale cached scores).
+ * - Filters by `minFitnessScore` if specified in the query.
+ * - Sorts by `orderBy` (default: `"fitness"`).
+ * - Tiebreak: alphabetical by `brick.name`.
+ * - Returns a new array — never mutates the input.
+ */
+export function sortBricks<T extends BrickArtifactBase>(
+  bricks: readonly T[],
+  query: ForgeQuery,
+  options: SortBricksOptions,
+): readonly T[] {
+  const orderBy = query.orderBy ?? "fitness";
+
+  // Pre-compute fitness scores for each brick
+  const scored = bricks.map((brick) => ({
+    brick,
+    fitness: computeBrickFitness(
+      brick.fitness ?? DEFAULT_BRICK_FITNESS,
+      options.nowMs,
+      options.fitnessConfig,
+    ),
+  }));
+
+  // Apply minFitnessScore filter
+  const minScore = query.minFitnessScore;
+  const filtered =
+    minScore !== undefined && minScore > 0
+      ? scored.filter((entry) => entry.fitness >= minScore)
+      : scored;
+
+  // Sort by orderBy with tiebreak on name
+  const sorted = [...filtered].sort((a, b) => {
+    const primary = comparePrimary(a, b, orderBy, options.nowMs);
+    if (primary !== 0) return primary;
+    return a.brick.name.localeCompare(b.brick.name);
+  });
+
+  return sorted.map((entry) => entry.brick);
+}
+
+// ---------------------------------------------------------------------------
+// Comparison helpers
+// ---------------------------------------------------------------------------
+
+interface ScoredBrick {
+  readonly brick: BrickArtifactBase;
+  readonly fitness: number;
+}
+
+function comparePrimary(
+  a: ScoredBrick,
+  b: ScoredBrick,
+  orderBy: "fitness" | "recency" | "usage",
+  _nowMs: number,
+): number {
+  switch (orderBy) {
+    case "fitness":
+      return b.fitness - a.fitness; // descending
+
+    case "recency": {
+      const aTime = a.brick.fitness?.lastUsedAt ?? 0;
+      const bTime = b.brick.fitness?.lastUsedAt ?? 0;
+      return bTime - aTime; // descending (most recent first)
+    }
+
+    case "usage": {
+      const aUsage = a.brick.usageCount;
+      const bUsage = b.brick.usageCount;
+      return bUsage - aUsage; // descending (most used first)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add runtime fitness metrics (`BrickFitnessMetrics`) to forged bricks — tracks success/error counts, P99 latency via bounded reservoir sampling, and recency
- Rank `search_forge` results by composite fitness score: `successRate² × recencyDecay × usageNorm × latencyFactor`
- Support `orderBy` (fitness/recency/usage) and `minFitnessScore` filtering in `search_forge` queries
- Auto-promote bricks through trust tiers (sandbox → verified → promoted) based on usage thresholds derived from fitness metrics
- DRY refactor: extract `applyBrickUpdate` helper used by 3 store implementations

## Architecture

```
L0  @koi/core        → BrickFitnessMetrics, LatencySampler types, ForgeQuery extensions
L0u @koi/validation  → latency-sampler, fitness-scoring, sort-bricks, apply-brick-update (pure)
L2  @koi/forge       → UsageSignal, middleware timing, search ranking, store refactors
L2  @koi/store-fs    → applyBrickUpdate refactor
```

All scoring is mechanical (no LLM) — middleware records timing + outcome per tool call, pure functions compute scores at query time.

## Changed files (24 files, ~1920 net LOC)

| Package | Files | Change |
|---------|-------|--------|
| `@koi/core` | `brick-store.ts`, `index.ts`, snapshot | +40 LOC types |
| `@koi/validation` | 8 new files (4 modules + 4 tests), `index.ts`, snapshot | +540 LOC |
| `@koi/forge` | `usage.ts`, `forge-usage-middleware.ts`, `search-forge.ts`, `memory-store.ts`, tests, snapshot | +380 LOC |
| `@koi/store-fs` | `fs-store.ts`, `overlay-store.ts` | -5 LOC (DRY) |
| Docs | `docs/L2/forge.md` | +170 LOC |

## Test plan

- [x] `bun test packages/core/` — 486 pass (API surface snapshot regenerated)
- [x] `bun test packages/validation/` — 121 pass (all new pure function tests)
- [x] `bun test packages/forge/` — 1058 pass (fitness tracking, ranking, auto-promotion)
- [x] `bun test packages/store-fs/` — 146 pass (applyBrickUpdate refactor)
- [x] `turbo build` — 125/125 tasks pass
- [x] `turbo typecheck` — all packages pass
- [x] Anti-leak checklist: L0 has zero imports, no function bodies, all readonly

Closes #151