### PR TITLE
feat: add @koi/middleware-output-verifier — two-stage output quality gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -906,6 +906,17 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-output-verifier": {
+      "name": "@koi/middleware-output-verifier",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-pay": {
       "name": "@koi/middleware-pay",
       "version": "0.0.0",
@@ -2096,6 +2107,8 @@
     "@koi/middleware-integration": ["@koi/middleware-integration@workspace:packages/middleware-integration"],
 
     "@koi/middleware-memory": ["@koi/middleware-memory@workspace:packages/middleware-memory"],
+
+    "@koi/middleware-output-verifier": ["@koi/middleware-output-verifier@workspace:packages/middleware-output-verifier"],
 
     "@koi/middleware-pay": ["@koi/middleware-pay@workspace:packages/middleware-pay"],
 

--- a/docs/L2/middleware-output-verifier.md
+++ b/docs/L2/middleware-output-verifier.md
@@ -1,0 +1,545 @@
+# @koi/middleware-output-verifier — Two-Stage Output Quality Gate
+
+Intercepts every model response before delivery and runs it through two sequential stages: fast deterministic checks (regex, length, policy), then an optional LLM-as-judge for semantic quality scoring. Supports three actions per check — block, warn, revise — with per-session stats and a mutable rubric for runtime control.
+
+---
+
+## Why It Exists
+
+LLMs produce outputs that can fail in two fundamentally different ways:
+
+1. **Structural failures** — too long, empty, contains a banned pattern, missing a required field, raw `<script>` injection. These are detectable in microseconds with a predicate.
+2. **Semantic failures** — factually wrong, off-topic, low quality, violates a subtle policy. These require judgment that only another LLM can reliably provide.
+
+Handling both in one place prevents every agent from reimplementing the same guard logic. The Spotify pattern targets a **25% baseline veto rate** — caught by this middleware, not silently delivered to users.
+
+Without this package:
+- Guards scattered across agent logic, hard to audit
+- No consistent veto event surface for monitoring
+- No path to inject revision feedback and retry without boilerplate
+- Streaming responses go un-checked entirely
+
+---
+
+## Architecture
+
+`@koi/middleware-output-verifier` is an **L2 feature package** — it depends only on `@koi/core` (L0) and `@koi/errors` (L0u). Zero external dependencies.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  @koi/middleware-output-verifier  (L2)                    │
+│                                                          │
+│  types.ts           ← 8 types + discriminated unions     │
+│  builtin-checks.ts  ← nonEmpty, maxLength, matchesPattern│
+│                       validJson, BUILTIN_CHECKS registry  │
+│  judge.ts           ← prompt builder + response parser   │
+│  output-verifier.ts ← middleware factory + revision loop │
+│  index.ts           ← public API surface                 │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│  Dependencies                                            │
+│                                                          │
+│  @koi/core   (L0)   KoiMiddleware, ModelRequest,         │
+│                      ModelResponse, TurnContext,          │
+│                      InboundMessage, CapabilityFragment   │
+│  @koi/errors (L0u)  KoiRuntimeError                      │
+└──────────────────────────────────────────────────────────┘
+```
+
+Priority **385** — runs after guardrails (375), before memory (400).
+
+---
+
+## How It Works
+
+### Two-Stage Pipeline
+
+```
+  model response
+       │
+       ▼
+┌──────────────────────────────────────────┐
+│  Stage 1: Deterministic  (μs, zero cost) │
+│  Run ALL checks — first block short-     │
+│  circuits Stage 2                        │
+│                                          │
+│  [ nonEmpty ] [ maxLength ] [ noXSS ] …  │
+└──────────────────┬───────────────────────┘
+                   │
+        ┌──────────┴─────────────┐
+      BLOCK                  all pass / warn
+        │                        │
+      throw                ┌─────▼──────────────────────┐
+    (skip S2)              │  Stage 2: LLM judge  (ms,$) │
+                           │  score 0.0 ──────────► 1.0  │
+                           │  threshold (default: 0.75)   │
+                           └──────┬───────────────────────┘
+                                  │
+              ┌───────────────────┼───────────────┐
+            pass                warn          block/revise
+              │                   │                │
+          deliver             deliver +        see below
+                              onVeto()
+```
+
+### Three Actions
+
+| Action | Non-streaming | Streaming |
+|--------|--------------|-----------|
+| **block** | Throws `KoiRuntimeError(VALIDATION)`. Output never delivered. | Degrades to **warn** (content already yielded). |
+| **warn** | Output delivered. `onVeto` fires with event. | Same. |
+| **revise** | Feedback injected into `messages[]`, model retried (up to `maxRevisions`). | Degrades to **warn**. |
+
+> **Note:** `revise` calls `next()` multiple times within one `wrapModelCall` invocation. This is designed for direct-invocation contexts and custom integration code, not the standard `composeModelChain` path (which guards against multiple `next()` calls on the success path by contract).
+
+### Middleware Position (Onion)
+
+```
+         Incoming Model Call
+                │
+                ▼
+  ┌─────────────────────────┐
+  │  middleware-guardrails   │  priority: 375 (outermost)
+  ├─────────────────────────┤
+  │  middleware-output-      │  priority: 385
+  │  verifier (THIS)        │◄─ two-stage gate
+  ├─────────────────────────┤
+  │  middleware-memory       │  priority: 400
+  ├─────────────────────────┤
+  │  engine adapter          │
+  │  → LLM API call         │
+  └─────────────────────────┘
+```
+
+---
+
+## Stage 1: Deterministic Checks
+
+Each check is a named predicate with an action. All checks run sequentially. The first `block` throws immediately (short-circuiting Stage 2). `warn` and `revise` continue to the next check.
+
+```typescript
+interface DeterministicCheck {
+  readonly name: string;
+  readonly check: (content: string) => boolean | string; // true = pass, string = fail reason
+  readonly action: "block" | "warn" | "revise";
+}
+```
+
+### Built-in Checks
+
+| Function | Description |
+|----------|-------------|
+| `BUILTIN_CHECKS.nonEmpty(action)` | Fails if trimmed content is empty |
+| `BUILTIN_CHECKS.maxLength(n, action)` | Fails if content exceeds `n` characters |
+| `BUILTIN_CHECKS.validJson(action)` | Fails if content is not valid JSON |
+| `BUILTIN_CHECKS.matchesPattern(re, action, name?)` | Fails if content does not match regex |
+| `matchesPattern(re, action, name?)` | Standalone export — same as above |
+| `nonEmpty(action)` | Standalone export |
+| `maxLength(n, action)` | Standalone export |
+| `validJson(action)` | Standalone export |
+
+### Revision Loop (Deterministic)
+
+```
+  1st call → check fails (action: revise)
+      │
+      ▼
+  inject feedback message into request.messages:
+    "Check 'name' failed: reason. Please revise."
+      │
+      ▼
+  retry → check passes → proceed to Stage 2
+      │
+  (if still fails after maxRevisions)
+      ▼
+  throw KoiRuntimeError(VALIDATION)
+```
+
+---
+
+## Stage 2: LLM-as-Judge
+
+The judge receives the full assembled content and the configured rubric, asks a fast model to score 0.0–1.0, and parses the JSON response.
+
+### Judge Prompt Format
+
+```
+You are a quality judge evaluating an AI assistant's response.
+
+RUBRIC:
+{rubric}
+
+RESPONSE TO EVALUATE:
+{content}
+
+Respond ONLY with valid JSON:
+{"score": 0.85, "reasoning": "..."}
+
+Score 1.0 = perfect quality. Score 0.0 = completely unacceptable.
+```
+
+### Score Parsing
+
+```typescript
+export function parseJudgeResponse(response: string): JudgeResult {
+  // Non-greedy regex to extract first JSON object
+  // isRecord() guard replaces banned `as` assertion
+  // Fail-closed: parse error → score 0 → veto fires
+}
+```
+
+Fail-closed means: if the judge LLM returns an unparseable response, score defaults to `0.0` and the configured action fires. This prevents a broken judge from silently passing bad content.
+
+### Sampling Rate
+
+```typescript
+judge: {
+  samplingRate: 0.1,  // Run judge on only 10% of calls — saves cost in production
+}
+```
+
+Deterministic checks always run regardless of sampling rate.
+
+---
+
+## Streaming
+
+In streaming mode (`wrapModelStream`), the middleware accumulates chunks into a buffer, then validates the complete content after the `done` chunk:
+
+```
+  chunk 1 → buffer
+  chunk 2 → buffer       (all yielded to caller immediately)
+  chunk N → buffer
+  done chunk
+      │
+      ▼
+  validate buffer
+  (block/revise degrade to warn — content already yielded)
+      │
+      ▼
+  yield done chunk
+```
+
+Buffer overflow (> `maxBufferSize`, default 256 KB) fires a `warn` event and skips validation. Prevents memory spikes on very long streams.
+
+---
+
+## Stats and Observability
+
+Every middleware instance tracks per-session stats:
+
+```typescript
+interface VerifierStats {
+  readonly totalChecks: number;       // Total wrapModelCall invocations
+  readonly vetoed: number;            // Calls where block or revise fired
+  readonly warned: number;            // Calls where warn fired
+  readonly deterministicVetoes: number;
+  readonly judgeVetoes: number;
+  readonly judgedChecks: number;      // Calls where judge actually ran (per samplingRate)
+  readonly vetoRate: number;          // vetoed / totalChecks (0 when totalChecks = 0)
+}
+```
+
+`vetoRate` targeting 25% is the Spotify quality baseline. Higher means your rubric is too strict or content quality is genuinely low. Lower means the gate is too permissive.
+
+### Veto Events
+
+`onVeto` fires for every block, warn, and revise — both stages:
+
+```typescript
+interface VerifierVetoEvent {
+  readonly source: "deterministic" | "judge";
+  readonly action: "block" | "warn" | "revise";
+  readonly checkName?: string;   // deterministic only
+  readonly checkReason?: string; // deterministic only
+  readonly score?: number;       // judge only
+  readonly reasoning?: string;   // judge only
+  readonly judgeError?: string;  // set when judge threw or returned unparseable response
+  readonly degraded?: boolean;   // set when streaming downgraded block/revise → warn
+}
+```
+
+Wire `onVeto` to your metrics system:
+
+```typescript
+createOutputVerifierMiddleware({
+  onVeto(event) {
+    metrics.increment("agent.output_veto", {
+      source: event.source,
+      action: event.action,
+    });
+    if (event.source === "judge") {
+      metrics.histogram("agent.judge_score", event.score ?? 0);
+    }
+  },
+});
+```
+
+---
+
+## API Reference
+
+### Factory Function
+
+#### `createOutputVerifierMiddleware(config)`
+
+Creates the middleware and returns a `VerifierHandle`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `config.deterministic` | `readonly DeterministicCheck[]` | — | Stage 1 checks. At least one of `deterministic` or `judge` required. |
+| `config.judge` | `JudgeConfig` | — | Stage 2 judge configuration. |
+| `config.onVeto` | `(event: VerifierVetoEvent) => void` | — | Called on every veto or warn. |
+| `config.maxBufferSize` | `number` | `262144` | Max stream buffer (bytes) before validation is skipped. |
+
+**Throws** `KoiRuntimeError(VALIDATION)` at factory time if neither `deterministic` nor `judge` is configured.
+
+**Returns** `VerifierHandle`:
+
+```typescript
+interface VerifierHandle {
+  readonly middleware: KoiMiddleware;
+  readonly getStats: () => VerifierStats;
+  readonly setRubric: (rubric: string) => void;  // hot-swap rubric without restart
+  readonly reset: () => void;                    // zero all stats counters
+}
+```
+
+### `JudgeConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rubric` | `string` | — | Quality criteria the judge uses to score. |
+| `modelCall` | `(prompt: string, signal?: AbortSignal) => Promise<string>` | — | Raw model invocation — receives the assembled judge prompt, returns raw text. |
+| `vetoThreshold` | `number` | `0.75` | Minimum score to pass. Below this → action fires. |
+| `action` | `"block" \| "warn" \| "revise"` | `"block"` | What to do when score < threshold. |
+| `samplingRate` | `number` | `1.0` | Fraction of calls on which judge runs (0.0–1.0). |
+| `maxRevisions` | `number` | `1` | Max revision attempts before throwing. |
+| `revisionFeedbackMaxLength` | `number` | `400` | Max characters of judge reasoning injected during revise. |
+
+### `DeterministicCheck`
+
+```typescript
+interface DeterministicCheck {
+  readonly name: string;
+  readonly check: (content: string) => boolean | string;
+  readonly action: "block" | "warn" | "revise";
+}
+```
+
+Return `true` to pass. Return `false` or a string (failure reason) to fail.
+
+### Types Reference
+
+| Type | Description |
+|------|-------------|
+| `VerifierAction` | `"block" \| "warn" \| "revise"` |
+| `VerifierConfig` | Config for `createOutputVerifierMiddleware()` |
+| `VerifierHandle` | Return type — middleware + runtime control |
+| `VerifierStats` | Accumulated per-session counters |
+| `VerifierVetoEvent` | Event payload fired via `onVeto` |
+| `JudgeConfig` | Stage 2 judge configuration |
+| `DeterministicCheck` | Stage 1 predicate + action |
+| `JudgeResult` | `{ score, reasoning, parseError? }` — from `parseJudgeResponse()` |
+
+---
+
+## Examples
+
+### Deterministic Only
+
+```typescript
+import { BUILTIN_CHECKS, createOutputVerifierMiddleware } from "@koi/middleware-output-verifier";
+
+const { middleware, getStats } = createOutputVerifierMiddleware({
+  deterministic: [
+    BUILTIN_CHECKS.nonEmpty("block"),
+    BUILTIN_CHECKS.maxLength(8_000, "warn"),
+    BUILTIN_CHECKS.validJson("block"),
+  ],
+  onVeto(event) {
+    console.warn("[verifier]", event.source, event.action, event.checkReason);
+  },
+});
+
+const agent = await createKoi({ manifest, middleware: [middleware] });
+```
+
+### Deterministic + LLM Judge
+
+```typescript
+import {
+  BUILTIN_CHECKS,
+  createOutputVerifierMiddleware,
+} from "@koi/middleware-output-verifier";
+
+const { middleware, getStats, setRubric } = createOutputVerifierMiddleware({
+  deterministic: [
+    BUILTIN_CHECKS.nonEmpty("block"),
+    BUILTIN_CHECKS.maxLength(10_000, "warn"),
+  ],
+  judge: {
+    rubric: [
+      "Score 0.0–1.0.",
+      "0.8+ if the response directly and correctly answers the user's question.",
+      "Below 0.5 if the response is empty, off-topic, or factually wrong.",
+    ].join("\n"),
+    modelCall: async (prompt, signal) => {
+      const resp = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": process.env.ANTHROPIC_API_KEY ?? "",
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-haiku-4-5-20251001",
+          max_tokens: 256,
+          messages: [{ role: "user", content: prompt }],
+        }),
+        signal,
+      });
+      const json = await resp.json() as { content: { text: string }[] };
+      return json.content[0]?.text ?? "";
+    },
+    vetoThreshold: 0.6,
+    action: "warn",      // deliver but fire event
+    samplingRate: 0.2,   // judge 20% of calls in production
+  },
+  onVeto(event) {
+    if (event.source === "judge") {
+      console.warn(`[judge] score=${event.score?.toFixed(2)} — ${event.reasoning?.slice(0, 100)}`);
+    }
+  },
+});
+```
+
+### Custom Policy Check
+
+```typescript
+import { createOutputVerifierMiddleware } from "@koi/middleware-output-verifier";
+import type { DeterministicCheck } from "@koi/middleware-output-verifier";
+
+const noSecrets: DeterministicCheck = {
+  name: "no-api-keys",
+  check: (content) => {
+    if (/sk-[a-zA-Z0-9]{20,}/.test(content)) {
+      return "Response contains what looks like an API key";
+    }
+    return true;
+  },
+  action: "block",
+};
+
+const { middleware } = createOutputVerifierMiddleware({
+  deterministic: [noSecrets],
+});
+```
+
+### Dynamic Rubric (e.g. per-user config)
+
+```typescript
+const { middleware, setRubric } = createOutputVerifierMiddleware({
+  judge: {
+    rubric: "Default: be concise and factual.",
+    modelCall: myJudge,
+  },
+});
+
+// Later — when user updates their quality preferences:
+setRubric("Formal tone required. No bullet points. Cite sources.");
+// Takes effect on next wrapModelCall/wrapModelStream invocation.
+```
+
+### Per-Session Stats Reset
+
+```typescript
+const { middleware, getStats, reset } = createOutputVerifierMiddleware({ ... });
+
+// On session end:
+const sessionStats = getStats();
+console.log(`Session veto rate: ${(sessionStats.vetoRate * 100).toFixed(1)}%`);
+reset(); // zero counters for next session
+```
+
+---
+
+## Flow Diagrams
+
+### Revise Loop
+
+```
+  wrapModelCall(ctx, request, next)
+      │
+      │  revision = 0
+      │  ┌─────────────────────────────────────────────┐
+      │  │  call next(currentRequest)                  │
+      │  │  → response.content                         │
+      │  │                                             │
+      │  │  Stage 1: all checks                        │
+      │  │    check → fail (action: revise)            │
+      │  │    revision < maxRevisions? yes             │
+      │  │    revision++                               │
+      │  │    currentRequest += feedbackMessage        │
+      │  │    onVeto(revise)                           │
+      │  │  ← continue (restart loop)                  │
+      │  │                                             │
+      │  │  Stage 1: all checks pass                   │
+      │  │                                             │
+      │  │  Stage 2: judge                             │
+      │  │    score >= threshold → pass                │
+      │  │  ← return response                         │
+      │  └─────────────────────────────────────────────┘
+```
+
+### Stats Overcounting Prevention
+
+Stats are incremented with per-call boolean flags flushed in `finally` — prevents a multi-revision loop from counting the same logical call multiple times:
+
+```
+try {
+  while (true) {
+    // set callVetoed / callWarned flags — not stats directly
+  }
+} finally {
+  if (callVetoed) stats.vetoed++;
+  if (callWarned) stats.warned++;
+}
+```
+
+---
+
+## Comparison: Koi vs. OpenClaw vs. NanoClaw
+
+| Feature | Koi (`middleware-output-verifier`) | OpenClaw (Lobster) | NanoClaw |
+|---------|------------------------------------|--------------------|----------|
+| Deterministic checks | Yes — composable, named, per-check action | Yes — approval gates (block/warn) | None |
+| LLM-as-judge | Yes — pluggable, rubric-driven, score-based | No | No |
+| Actions | block, warn, revise | block, warn | — |
+| Streaming support | Yes (block/revise degrade to warn) | No | No |
+| Per-session stats | Yes — vetoRate, judgedChecks, etc. | No | No |
+| Hot-swap rubric | Yes — `setRubric()` | No | No |
+| Sampling rate | Yes — reduce judge cost in production | No | No |
+| onVeto event surface | Yes — structured, typed | No | No |
+| Revision loop | Yes — injects feedback, retries model | No | No |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ────────────────────────────────────────────┐
+    KoiMiddleware, ModelRequest, ModelResponse,            │
+    TurnContext, InboundMessage, CapabilityFragment        │
+                                                           │
+L0u @koi/errors ──────────────────────────────────────────┤
+    KoiRuntimeError                                        │
+                                                           ▼
+L2  @koi/middleware-output-verifier ◄──────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external dependencies
+```
+
+Dev-only dependency: `@koi/test-utils` (used in tests only, not in runtime).

--- a/packages/middleware-output-verifier/package.json
+++ b/packages/middleware-output-verifier/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/middleware-output-verifier",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-output-verifier/src/builtin-checks.ts
+++ b/packages/middleware-output-verifier/src/builtin-checks.ts
@@ -1,0 +1,83 @@
+/**
+ * Built-in deterministic checks for common output quality assertions.
+ *
+ * Use these as-is or as starting points for custom checks.
+ */
+
+import type { DeterministicCheck, VerifierAction } from "./types.js";
+
+/** Default action for built-in checks. */
+const DEFAULT_ACTION = "block" satisfies VerifierAction;
+
+/**
+ * Fails if the output is empty or contains only whitespace.
+ */
+export function nonEmpty(action: VerifierAction = DEFAULT_ACTION): DeterministicCheck {
+  return {
+    name: "non-empty",
+    check: (content) => content.trim().length > 0 || "Output must not be empty",
+    action,
+  };
+}
+
+/**
+ * Fails if the output exceeds `max` characters.
+ */
+export function maxLength(
+  max: number,
+  action: VerifierAction = DEFAULT_ACTION,
+): DeterministicCheck {
+  return {
+    name: `max-length-${max}`,
+    check: (content) =>
+      content.length <= max || `Output exceeds maximum length of ${max} characters`,
+    action,
+  };
+}
+
+/**
+ * Fails if the output does not contain valid JSON.
+ */
+export function validJson(action: VerifierAction = DEFAULT_ACTION): DeterministicCheck {
+  return {
+    name: "valid-json",
+    check: (content) => {
+      try {
+        JSON.parse(content);
+        return true;
+      } catch {
+        return "Output must be valid JSON";
+      }
+    },
+    action,
+  };
+}
+
+/**
+ * Fails if the output does not match the given regular expression.
+ */
+export function matchesPattern(
+  pattern: RegExp,
+  name: string,
+  action: VerifierAction = DEFAULT_ACTION,
+): DeterministicCheck {
+  return {
+    name,
+    check: (content) =>
+      pattern.test(content) || `Output does not match required pattern: ${pattern.source}`,
+    action,
+  };
+}
+
+/** Convenience namespace for built-in checks. */
+export const BUILTIN_CHECKS: {
+  readonly nonEmpty: typeof nonEmpty;
+  readonly maxLength: typeof maxLength;
+  readonly validJson: typeof validJson;
+  readonly matchesPattern: typeof matchesPattern;
+} = {
+  nonEmpty,
+  maxLength,
+  validJson,
+  matchesPattern,
+};

--- a/packages/middleware-output-verifier/src/index.ts
+++ b/packages/middleware-output-verifier/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @koi/middleware-output-verifier — Two-stage output quality gate (Layer 2)
+ *
+ * Runs deterministic checks and an optional LLM-as-judge before delivering
+ * any model output. Tracks veto rate (targeting 25% baseline per Spotify pattern).
+ *
+ * Stage 1 (deterministic): Fast content checks — always runs.
+ * Stage 2 (LLM-as-judge): Semantic quality scoring — skipped if Stage 1 blocks.
+ *
+ * Actions: block (throw), warn (deliver + event), revise (inject feedback + retry).
+ * For streaming: revise/block degrade to warn (content already yielded).
+ *
+ * Priority 385: between guardrails (375) and memory (400).
+ *
+ * Depends on @koi/core and @koi/errors only.
+ */
+
+export {
+  BUILTIN_CHECKS,
+  matchesPattern,
+  maxLength,
+  nonEmpty,
+  validJson,
+} from "./builtin-checks.js";
+export type { JudgeResult } from "./judge.js";
+export { buildJudgePrompt, clampScore, parseJudgeResponse } from "./judge.js";
+export { createOutputVerifierMiddleware } from "./output-verifier.js";
+export type {
+  DeterministicCheck,
+  JudgeConfig,
+  VerifierAction,
+  VerifierConfig,
+  VerifierHandle,
+  VerifierStats,
+  VerifierVetoEvent,
+} from "./types.js";

--- a/packages/middleware-output-verifier/src/judge.ts
+++ b/packages/middleware-output-verifier/src/judge.ts
@@ -1,0 +1,68 @@
+/**
+ * Inlined LLM-as-judge helpers.
+ *
+ * Duplicates ~30 lines from @koi/eval/src/graders/llm-judge.ts intentionally.
+ * Rule of Three: only 2 consumers exist. Extract to @koi/llm-judge-util at 3rd.
+ */
+
+export interface JudgeResult {
+  readonly score: number;
+  readonly reasoning: string;
+  readonly parseError?: string | undefined;
+}
+
+/** Build the judge prompt from a rubric and model output content. */
+export function buildJudgePrompt(rubric: string, content: string): string {
+  return [
+    "You are an output quality judge. Evaluate the following agent output.",
+    "",
+    "## Rubric",
+    rubric,
+    "",
+    "## Agent Output",
+    content,
+    "",
+    "## Instructions",
+    'Respond with ONLY a JSON object: {"score": <0.0-1.0>, "reasoning": "<explanation>"}',
+    "The score must be between 0.0 (worst) and 1.0 (best).",
+  ].join("\n");
+}
+
+function isRecord(v: unknown): v is Readonly<Record<string, unknown>> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Parse the judge model response into a score + reasoning.
+ * On any parse failure, returns score=0 with a parseError field (fail-closed).
+ */
+export function parseJudgeResponse(response: string): JudgeResult {
+  // Non-greedy match avoids spanning multiple JSON objects in the response
+  const jsonMatch = /\{[\s\S]*?\}/.exec(response);
+  if (jsonMatch?.[0] !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonMatch[0]);
+    } catch (e: unknown) {
+      return {
+        score: 0,
+        reasoning: "",
+        parseError: `Failed to parse judge JSON: ${e instanceof Error ? e.message : "unknown"} — raw: ${response.slice(0, 200)}`,
+      };
+    }
+    if (isRecord(parsed)) {
+      const score = typeof parsed.score === "number" ? clampScore(parsed.score) : 0;
+      const reasoning = typeof parsed.reasoning === "string" ? parsed.reasoning : response;
+      return { score, reasoning };
+    }
+  }
+  return {
+    score: 0,
+    reasoning: "",
+    parseError: `Failed to parse judge response: ${response.slice(0, 200)}`,
+  };
+}
+
+export function clampScore(score: number): number {
+  return Math.max(0, Math.min(1, score));
+}

--- a/packages/middleware-output-verifier/src/output-verifier.test.ts
+++ b/packages/middleware-output-verifier/src/output-verifier.test.ts
@@ -1,0 +1,990 @@
+/**
+ * Unit tests for @koi/middleware-output-verifier.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { ModelChunk, ModelRequest, ModelResponse } from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import {
+  createMockModelHandler,
+  createMockTurnContext,
+  createSpyModelStreamHandler,
+} from "@koi/test-utils";
+import { BUILTIN_CHECKS } from "./builtin-checks.js";
+import { createOutputVerifierMiddleware } from "./output-verifier.js";
+import type { DeterministicCheck, JudgeConfig, VerifierVetoEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const ctx = createMockTurnContext();
+const request: ModelRequest = { messages: [] };
+
+const passCheck: DeterministicCheck = {
+  name: "always-pass",
+  check: () => true,
+  action: "block",
+};
+
+const blockCheck: DeterministicCheck = {
+  name: "always-block",
+  check: () => "Content blocked by policy",
+  action: "block",
+};
+
+const warnCheck: DeterministicCheck = {
+  name: "always-warn",
+  check: () => "Suspicious content",
+  action: "warn",
+};
+
+const reviseCheck: DeterministicCheck = {
+  name: "always-revise",
+  check: () => "Needs improvement",
+  action: "revise",
+};
+
+function makePassingJudge(score = 0.9): JudgeConfig {
+  return {
+    rubric: "Be helpful and accurate",
+    modelCall: mock(async () => JSON.stringify({ score, reasoning: "Good output" })),
+    vetoThreshold: 0.75,
+    action: "block",
+  };
+}
+
+function makeBlockingJudge(score = 0.5): JudgeConfig {
+  return {
+    rubric: "Be helpful and accurate",
+    modelCall: mock(async () => JSON.stringify({ score, reasoning: "Poor quality" })),
+    vetoThreshold: 0.75,
+    action: "block",
+  };
+}
+
+async function collectStream(stream: AsyncIterable<ModelChunk>): Promise<readonly ModelChunk[]> {
+  const chunks: ModelChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function assertStream(s: AsyncIterable<ModelChunk> | undefined): AsyncIterable<ModelChunk> {
+  if (s === undefined) throw new Error("Expected wrapModelStream to be defined");
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Factory validation
+// ---------------------------------------------------------------------------
+
+describe("createOutputVerifierMiddleware", () => {
+  test("throws at factory time if neither deterministic nor judge is configured", () => {
+    expect(() => createOutputVerifierMiddleware({})).toThrow(KoiRuntimeError);
+  });
+
+  test("throws with VALIDATION code when empty config", () => {
+    try {
+      createOutputVerifierMiddleware({});
+      expect(true).toBe(false);
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiRuntimeError);
+      if (e instanceof KoiRuntimeError) {
+        expect(e.code).toBe("VALIDATION");
+      }
+    }
+  });
+
+  test("succeeds with only deterministic checks", () => {
+    expect(() => createOutputVerifierMiddleware({ deterministic: [passCheck] })).not.toThrow();
+  });
+
+  test("succeeds with only judge config", () => {
+    expect(() => createOutputVerifierMiddleware({ judge: makePassingJudge() })).not.toThrow();
+  });
+
+  test("succeeds with both deterministic and judge", () => {
+    expect(() =>
+      createOutputVerifierMiddleware({
+        deterministic: [passCheck],
+        judge: makePassingJudge(),
+      }),
+    ).not.toThrow();
+  });
+
+  test("has name 'output-verifier' and priority 385", () => {
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+    expect(middleware.name).toBe("output-verifier");
+    expect(middleware.priority).toBe(385);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapModelCall — deterministic stage
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — deterministic checks", () => {
+  test("passes through output when all checks pass", async () => {
+    const handler = createMockModelHandler({ content: "Good output" });
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Good output");
+  });
+
+  test("block action throws KoiRuntimeError", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [blockCheck] });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("block action throws with VALIDATION code", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [blockCheck] });
+
+    try {
+      await middleware.wrapModelCall?.(ctx, request, handler);
+      expect(true).toBe(false);
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiRuntimeError);
+      if (e instanceof KoiRuntimeError) {
+        expect(e.code).toBe("VALIDATION");
+      }
+    }
+  });
+
+  test("block action fires onVeto with source='deterministic'", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.source).toBe("deterministic");
+    expect(events[0]?.checkName).toBe("always-block");
+    expect(events[0]?.action).toBe("block");
+    expect(events[0]?.checkReason).toBe("Content blocked by policy");
+  });
+
+  test("warn action fires onVeto but delivers output", async () => {
+    const handler = createMockModelHandler({ content: "Suspicious output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Suspicious output");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe("warn");
+  });
+
+  test("revise action retries with injected feedback", async () => {
+    // let justified: count calls to verify retry happens
+    let callCount = 0;
+    const handler = async (_req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      if (callCount === 1) return { content: "needs-improvement", model: "test" };
+      return { content: "improved", model: "test" };
+    };
+
+    const reviseOnce: DeterministicCheck = {
+      name: "quality",
+      check: (c) => c === "improved" || "Needs improvement",
+      action: "revise",
+    };
+
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [reviseOnce] });
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(callCount).toBe(2);
+    expect(response?.content).toBe("improved");
+  });
+
+  test("revise action throws after maxRevisions exhausted", async () => {
+    const handler = createMockModelHandler({ content: "always-bad" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [reviseCheck],
+      judge: { ...makePassingJudge(), maxRevisions: 1 },
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("first blocking check short-circuits remaining checks", async () => {
+    const spyCheck = mock((_: string) => true);
+    const afterBlock: DeterministicCheck = {
+      name: "after-block",
+      check: spyCheck,
+      action: "block",
+    };
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck, afterBlock],
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(spyCheck).not.toHaveBeenCalled();
+  });
+
+  test("multiple checks: warn continues, block after warn still throws", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck, blockCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    // warn fired first, then block
+    expect(events).toHaveLength(2);
+    expect(events[0]?.action).toBe("warn");
+    expect(events[1]?.action).toBe("block");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapModelCall — judge stage
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — judge stage", () => {
+  test("passing judge delivers output", async () => {
+    const handler = createMockModelHandler({ content: "Great output" });
+    const { middleware } = createOutputVerifierMiddleware({ judge: makePassingJudge() });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Great output");
+  });
+
+  test("blocking judge throws KoiRuntimeError", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const { middleware } = createOutputVerifierMiddleware({ judge: makeBlockingJudge() });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("blocking judge fires veto with source='judge' and score", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      judge: makeBlockingJudge(0.4),
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(events[0]?.source).toBe("judge");
+    expect(events[0]?.score).toBe(0.4);
+    expect(events[0]?.action).toBe("block");
+    expect(events[0]?.reasoning).toBe("Poor quality");
+  });
+
+  test("score exactly at threshold passes (>= not >)", async () => {
+    const handler = createMockModelHandler({ content: "Borderline output" });
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => JSON.stringify({ score: 0.75, reasoning: "Borderline" }),
+      vetoThreshold: 0.75,
+      action: "block",
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Borderline output");
+  });
+
+  test("warn action fires event and delivers output", async () => {
+    const handler = createMockModelHandler({ content: "Mediocre output" });
+    const events: VerifierVetoEvent[] = [];
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => JSON.stringify({ score: 0.5, reasoning: "Mediocre" }),
+      vetoThreshold: 0.75,
+      action: "warn",
+    };
+    const { middleware } = createOutputVerifierMiddleware({
+      judge,
+      onVeto: (e) => events.push(e),
+    });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Mediocre output");
+    expect(events[0]?.action).toBe("warn");
+    expect(events[0]?.source).toBe("judge");
+  });
+
+  test("revise action retries with judge reasoning injected", async () => {
+    // let justified: counts calls to verify the retry
+    let callCount = 0;
+    const handler = async (_req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      return { content: `output-${callCount}`, model: "test" };
+    };
+    const scores = [0.5, 0.9];
+    // let justified: index tracks which score to return
+    let scoreIndex = 0;
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => {
+        const score = scores[scoreIndex] ?? 0.9;
+        scoreIndex++;
+        return JSON.stringify({ score, reasoning: "Needs improvement" });
+      },
+      vetoThreshold: 0.75,
+      action: "revise",
+      maxRevisions: 1,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(callCount).toBe(2);
+    expect(response?.content).toBe("output-2");
+  });
+
+  test("revise action throws after maxRevisions exhausted", async () => {
+    const handler = createMockModelHandler({ content: "Bad output" });
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => JSON.stringify({ score: 0.3, reasoning: "Always bad" }),
+      vetoThreshold: 0.75,
+      action: "revise",
+      maxRevisions: 1,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("judge revision feedback is truncated to revisionFeedbackMaxLength", async () => {
+    const longReasoning = "x".repeat(1000);
+    const capturedMessages: ModelRequest[] = [];
+    // let justified: call count for multi-attempt tracking
+    let callCount = 0;
+    const handler = async (req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      capturedMessages.push(req);
+      return { content: "output", model: "test" };
+    };
+    const scores = [0.3, 0.9];
+    // let justified: index tracks which score to return
+    let scoreIndex = 0;
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => {
+        const score = scores[scoreIndex] ?? 0.9;
+        scoreIndex++;
+        return JSON.stringify({ score, reasoning: longReasoning });
+      },
+      vetoThreshold: 0.75,
+      action: "revise",
+      maxRevisions: 1,
+      revisionFeedbackMaxLength: 100,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+    await middleware.wrapModelCall?.(ctx, request, handler);
+
+    // Second call should have an injected message with truncated reasoning
+    expect(callCount).toBe(2);
+    const secondRequest = capturedMessages[1];
+    expect(secondRequest).toBeDefined();
+    const lastMsg = secondRequest?.messages[secondRequest.messages.length - 1];
+    const textBlock = lastMsg?.content[0];
+    if (textBlock?.kind === "text") {
+      // Verify truncation (feedback message contains judge reasoning, bounded)
+      expect(textBlock.text.length).toBeLessThan(300); // 100-char reasoning + fixed prefix
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed: judge errors treated as score 0
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — judge failure modes (fail-closed)", () => {
+  test("judge modelCall throws → treated as score 0 → veto fires", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => {
+        throw new Error("Network error");
+      },
+      vetoThreshold: 0.75,
+      action: "block",
+    };
+    const { middleware } = createOutputVerifierMiddleware({
+      judge,
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+    expect(events[0]?.judgeError).toBe("Network error");
+    expect(events[0]?.score).toBe(0);
+  });
+
+  test("judge returns unparseable response → score 0 → veto fires", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => "not json at all",
+      vetoThreshold: 0.75,
+      action: "block",
+    };
+    const { middleware } = createOutputVerifierMiddleware({
+      judge,
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+    expect(events[0]?.judgeError).toBeDefined();
+  });
+
+  test("judge returns regex-matched but malformed JSON → score 0 → veto fires with parse error", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      // Has braces so regex matches, but JSON.parse throws
+      modelCall: async () => "{malformed: json}",
+      vetoThreshold: 0.75,
+      action: "block",
+    };
+    const { middleware } = createOutputVerifierMiddleware({
+      judge,
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+    expect(events[0]?.judgeError).toBeDefined();
+    expect(events[0]?.score).toBe(0);
+  });
+
+  test("judge returns empty string → score 0 → veto fires", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => "",
+      vetoThreshold: 0.75,
+      action: "block",
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Short-circuit: warn in deterministic still runs judge
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — short-circuit logic", () => {
+  test("block in deterministic skips judge", async () => {
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75 },
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(judgeModelCall).not.toHaveBeenCalled();
+  });
+
+  test("warn in deterministic still runs judge", async () => {
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck],
+      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75 },
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(judgeModelCall).toHaveBeenCalledTimes(1);
+  });
+
+  test("deterministic pass + judge pass = output delivered", async () => {
+    const handler = createMockModelHandler({ content: "Great output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [passCheck],
+      judge: makePassingJudge(),
+    });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("Great output");
+  });
+
+  test("deterministic warn + judge block = veto events from both sources", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck],
+      judge: makeBlockingJudge(),
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    const sources = events.map((e) => e.source);
+    expect(sources).toContain("deterministic");
+    expect(sources).toContain("judge");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stats tracking
+// ---------------------------------------------------------------------------
+
+describe("getStats", () => {
+  test("initial state is all zeros", () => {
+    const { getStats } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+    const s = getStats();
+    expect(s.totalChecks).toBe(0);
+    expect(s.vetoed).toBe(0);
+    expect(s.warned).toBe(0);
+    expect(s.vetoRate).toBe(0);
+  });
+
+  test("totalChecks increments on each wrapModelCall", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware, getStats } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(getStats().totalChecks).toBe(2);
+  });
+
+  test("warn does NOT count as vetoed (warn only increments warned)", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    const s = getStats();
+    expect(s.vetoed).toBe(0);
+    expect(s.warned).toBe(1);
+    expect(s.vetoRate).toBe(0);
+  });
+
+  test("block increments vetoed, not warned", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    const s = getStats();
+    expect(s.vetoed).toBe(1);
+    expect(s.warned).toBe(0);
+  });
+
+  test("vetoRate = vetoed / totalChecks — 25% Spotify baseline example", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+
+    // Let blockCheck fire 1 out of 4 calls
+    let callNum = 0;
+    const conditionalCheck: DeterministicCheck = {
+      name: "conditional",
+      check: () => {
+        callNum++;
+        return callNum % 4 !== 0 || "blocked";
+      },
+      action: "block",
+    };
+
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      deterministic: [conditionalCheck],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await middleware.wrapModelCall?.(ctx, request, handler);
+    }
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+
+    const s = getStats();
+    expect(s.totalChecks).toBe(4);
+    expect(s.vetoed).toBe(1);
+    expect(s.vetoRate).toBe(0.25);
+  });
+
+  test("deterministicVetoes vs judgeVetoes tracked separately", async () => {
+    // let justified: call count for alternating responses
+    let callN = 0;
+    const handler = async (): Promise<ModelResponse> => {
+      callN++;
+      return { content: `output-${callN}`, model: "test" };
+    };
+    const events: VerifierVetoEvent[] = [];
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      judge: makeBlockingJudge(),
+      onVeto: (e) => events.push(e),
+    });
+
+    // 1st call: block from deterministic (judge skipped)
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+
+    const s = getStats();
+    expect(s.deterministicVetoes).toBe(1);
+    expect(s.judgeVetoes).toBe(0);
+  });
+
+  test("judgedChecks tracks how many times the judge actually ran", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      judge: makePassingJudge(),
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(getStats().judgedChecks).toBe(2);
+  });
+
+  test("samplingRate=0 means judge never runs", async () => {
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      judge: {
+        rubric: "Test",
+        modelCall: judgeModelCall,
+        vetoThreshold: 0.75,
+        samplingRate: 0,
+      },
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(judgeModelCall).not.toHaveBeenCalled();
+    expect(getStats().judgedChecks).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handle control
+// ---------------------------------------------------------------------------
+
+describe("setRubric", () => {
+  test("judge uses updated rubric on the next call", async () => {
+    const capturedPrompts: string[] = [];
+    const handler = createMockModelHandler({ content: "output" });
+    const judge: JudgeConfig = {
+      rubric: "Original rubric",
+      modelCall: async (prompt) => {
+        capturedPrompts.push(prompt);
+        return JSON.stringify({ score: 0.9, reasoning: "ok" });
+      },
+      vetoThreshold: 0.75,
+    };
+    const handle = createOutputVerifierMiddleware({ judge });
+
+    await handle.middleware.wrapModelCall?.(ctx, request, handler);
+    handle.setRubric("New rubric");
+    await handle.middleware.wrapModelCall?.(ctx, request, handler);
+
+    expect(capturedPrompts[0]).toContain("Original rubric");
+    expect(capturedPrompts[1]).toContain("New rubric");
+  });
+});
+
+describe("reset", () => {
+  test("reset() clears all stats to zero", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware, getStats, reset } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(getStats().totalChecks).toBe(1);
+
+    reset();
+    const s = getStats();
+    expect(s.totalChecks).toBe(0);
+    expect(s.vetoed).toBe(0);
+    expect(s.warned).toBe(0);
+    expect(s.deterministicVetoes).toBe(0);
+    expect(s.judgeVetoes).toBe(0);
+    expect(s.judgedChecks).toBe(0);
+    expect(s.vetoRate).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal propagation
+// ---------------------------------------------------------------------------
+
+describe("AbortSignal propagation", () => {
+  test("judge modelCall receives ctx.signal", async () => {
+    const capturedSignals: (AbortSignal | undefined)[] = [];
+    const handler = createMockModelHandler({ content: "output" });
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async (_prompt, signal) => {
+        capturedSignals.push(signal);
+        return JSON.stringify({ score: 0.9, reasoning: "ok" });
+      },
+      vetoThreshold: 0.75,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge });
+
+    const ctxWithSignal = createMockTurnContext();
+
+    await middleware.wrapModelCall?.(ctxWithSignal, request, handler);
+    // Signal is passed through (may be undefined in test context, but the parameter is forwarded)
+    expect(capturedSignals).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapModelStream
+// ---------------------------------------------------------------------------
+
+describe("wrapModelStream", () => {
+  test("valid output passes through all chunks", async () => {
+    const doneResponse: ModelResponse = { content: "Great output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "Great " },
+      { kind: "text_delta", delta: "output" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [passCheck],
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    const collected = await collectStream(stream);
+    expect(collected).toHaveLength(3);
+    expect(collected[2]?.kind).toBe("done");
+  });
+
+  test("block action degrades to warn for streaming (with degraded=true)", async () => {
+    const doneResponse: ModelResponse = { content: "Bad output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "Bad output" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    // Should NOT throw — block degrades to warn for streams
+    const collected = await collectStream(stream);
+    expect(collected).toHaveLength(2); // All chunks still yielded
+    expect(events[0]?.degraded).toBe(true);
+    expect(events[0]?.action).toBe("block");
+  });
+
+  test("revise action degrades to warn for streaming (with degraded=true)", async () => {
+    const doneResponse: ModelResponse = { content: "output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "output" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [reviseCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    await collectStream(stream); // Must not throw
+    expect(events[0]?.degraded).toBe(true);
+  });
+
+  test("judge block degrades to warn for streaming", async () => {
+    const doneResponse: ModelResponse = { content: "output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "output" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      judge: makeBlockingJudge(),
+      onVeto: (e) => events.push(e),
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    await collectStream(stream); // Must not throw
+    expect(events[0]?.source).toBe("judge");
+    expect(events[0]?.degraded).toBe(true);
+  });
+
+  test("judge warn fires event and increments stats for streaming (no degraded flag)", async () => {
+    const doneResponse: ModelResponse = { content: "mediocre output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "mediocre output" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const events: VerifierVetoEvent[] = [];
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => JSON.stringify({ score: 0.5, reasoning: "Mediocre" }),
+      vetoThreshold: 0.75,
+      action: "warn",
+    };
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      judge,
+      onVeto: (e) => events.push(e),
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    await collectStream(stream); // Must not throw — warn never blocks
+    expect(events).toHaveLength(1);
+    expect(events[0]?.source).toBe("judge");
+    expect(events[0]?.action).toBe("warn");
+    expect(events[0]?.degraded).toBeUndefined(); // warn is native, not degraded
+    const s = getStats();
+    expect(s.judgeVetoes).toBe(1);
+    expect(s.warned).toBe(1);
+  });
+
+  test("stream buffer overflow fires warn event with degraded=true", async () => {
+    const overflowContent = "x".repeat(300);
+    const doneResponse: ModelResponse = { content: overflowContent, model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: overflowContent },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      maxBufferSize: 100,
+      onVeto: (e) => events.push(e),
+    });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    await collectStream(stream);
+    const overflow = events.find((e) => e.checkName === "stream-buffer-overflow");
+    expect(overflow).toBeDefined();
+    expect(overflow?.degraded).toBe(true);
+  });
+
+  test("non-text chunks pass through unchanged", async () => {
+    const validContent = "Great output";
+    const doneResponse: ModelResponse = { content: validContent, model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: validContent },
+      { kind: "usage", inputTokens: 10, outputTokens: 5 },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    const collected = await collectStream(stream);
+    expect(collected.find((c) => c.kind === "usage")).toBeDefined();
+  });
+
+  test("empty buffer skips validation on done", async () => {
+    const doneResponse: ModelResponse = { content: "", model: "test" };
+    const chunks: readonly ModelChunk[] = [{ kind: "done", response: doneResponse }];
+    const handler = createSpyModelStreamHandler(chunks);
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [blockCheck] });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    const collected = await collectStream(stream);
+    expect(collected).toHaveLength(1);
+  });
+
+  test("totalChecks increments for wrapModelStream calls", async () => {
+    const doneResponse: ModelResponse = { content: "ok", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "ok" },
+      { kind: "done", response: doneResponse },
+    ];
+    const handler = createSpyModelStreamHandler(chunks);
+    const { middleware, getStats } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+
+    const stream = assertStream(middleware.wrapModelStream?.(ctx, request, handler.handler));
+    await collectStream(stream);
+    expect(getStats().totalChecks).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeCapabilities
+// ---------------------------------------------------------------------------
+
+describe("describeCapabilities", () => {
+  test("returns label 'output-gate'", () => {
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [passCheck] });
+    const cap = middleware.describeCapabilities?.(ctx);
+    expect(cap?.label).toBe("output-gate");
+  });
+
+  test("description reflects current veto stats", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [blockCheck] });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    const cap = middleware.describeCapabilities?.(ctx);
+    expect(cap?.description).toContain("1/1");
+  });
+
+  test("description includes threshold when judge is configured", () => {
+    const { middleware } = createOutputVerifierMiddleware({ judge: makePassingJudge() });
+    const cap = middleware.describeCapabilities?.(ctx);
+    expect(cap?.description).toContain("0.75");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUILTIN_CHECKS
+// ---------------------------------------------------------------------------
+
+describe("BUILTIN_CHECKS", () => {
+  test("nonEmpty blocks empty string", () => {
+    const check = BUILTIN_CHECKS.nonEmpty();
+    expect(check.check("")).not.toBe(true);
+    expect(check.check("   ")).not.toBe(true);
+    expect(check.check("hello")).toBe(true);
+  });
+
+  test("maxLength blocks content over limit", () => {
+    const check = BUILTIN_CHECKS.maxLength(5);
+    expect(check.check("hello")).toBe(true);
+    expect(check.check("hello world")).not.toBe(true);
+  });
+
+  test("validJson passes valid JSON and blocks invalid", () => {
+    const check = BUILTIN_CHECKS.validJson();
+    expect(check.check('{"a":1}')).toBe(true);
+    expect(check.check("not json")).not.toBe(true);
+  });
+
+  test("matchesPattern works with regex", () => {
+    const check = BUILTIN_CHECKS.matchesPattern(/^\d+$/, "digits-only");
+    expect(check.check("123")).toBe(true);
+    expect(check.check("abc")).not.toBe(true);
+  });
+});

--- a/packages/middleware-output-verifier/src/output-verifier.ts
+++ b/packages/middleware-output-verifier/src/output-verifier.ts
@@ -1,0 +1,530 @@
+/**
+ * Output verifier middleware factory — two-stage quality gate before delivery.
+ *
+ * Stage 1: Deterministic checks (fast, always runs).
+ * Stage 2: LLM-as-judge (async, optional, skipped if Stage 1 blocks).
+ *
+ * Priority 385: runs after guardrails (375), before memory (400).
+ */
+
+import type { InboundMessage } from "@koi/core/message";
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  TurnContext,
+} from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
+import { buildJudgePrompt, parseJudgeResponse } from "./judge.js";
+import type { VerifierConfig, VerifierHandle, VerifierStats, VerifierVetoEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIDDLEWARE_NAME = "output-verifier";
+const MIDDLEWARE_PRIORITY = 385;
+const DEFAULT_MAX_BUFFER_SIZE = 262_144; // 256 KB
+const DEFAULT_VETO_THRESHOLD = 0.75;
+const DEFAULT_SAMPLING_RATE = 1.0;
+const DEFAULT_MAX_REVISIONS = 1;
+const DEFAULT_REVISION_FEEDBACK_MAX_LENGTH = 400;
+const VERIFIER_SENDER_ID = "system" as const;
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** Outcome of a single judge evaluation over one content string. */
+type JudgeOutcome =
+  | { readonly kind: "pass" }
+  | { readonly kind: "skip" } // Not sampled
+  | { readonly kind: "warn"; readonly score: number; readonly reasoning: string }
+  | {
+      readonly kind: "block";
+      readonly score: number;
+      readonly reasoning: string;
+      readonly judgeError?: string;
+    }
+  | {
+      readonly kind: "revise";
+      readonly score: number;
+      readonly reasoning: string;
+      readonly judgeError?: string;
+    };
+
+/** Mutable stats counters (not exported). */
+interface MutableStats {
+  totalChecks: number;
+  vetoed: number;
+  warned: number;
+  deterministicVetoes: number;
+  judgeVetoes: number;
+  judgedChecks: number;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the output verifier middleware.
+ *
+ * @throws {KoiRuntimeError} At factory time if neither `deterministic` nor `judge` is configured.
+ */
+export function createOutputVerifierMiddleware(config: VerifierConfig): VerifierHandle {
+  const hasDeterministic = config.deterministic !== undefined && config.deterministic.length > 0;
+  const hasJudge = config.judge !== undefined;
+
+  if (!hasDeterministic && !hasJudge) {
+    throw KoiRuntimeError.from(
+      "VALIDATION",
+      "createOutputVerifierMiddleware: at least one of 'deterministic' or 'judge' must be configured",
+    );
+  }
+
+  const maxBufferSize = config.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+  const onVeto = config.onVeto;
+
+  // let: mutable judge rubric — updated via handle.setRubric()
+  let currentRubric = config.judge?.rubric ?? "";
+
+  const stats: MutableStats = {
+    totalChecks: 0,
+    vetoed: 0,
+    warned: 0,
+    deterministicVetoes: 0,
+    judgeVetoes: 0,
+    judgedChecks: 0,
+  };
+
+  // ---------------------------------------------------------------------------
+  // Stage 2 helpers
+  // ---------------------------------------------------------------------------
+
+  async function runJudge(content: string, signal?: AbortSignal): Promise<JudgeOutcome> {
+    const judge = config.judge;
+    if (judge === undefined) return { kind: "skip" };
+
+    const samplingRate = judge.samplingRate ?? DEFAULT_SAMPLING_RATE;
+    if (Math.random() > samplingRate) return { kind: "skip" };
+
+    stats.judgedChecks++;
+
+    const vetoThreshold = judge.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
+    const judgeAction = judge.action ?? "block";
+    const feedbackMaxLength =
+      judge.revisionFeedbackMaxLength ?? DEFAULT_REVISION_FEEDBACK_MAX_LENGTH;
+
+    const prompt = buildJudgePrompt(currentRubric, content);
+
+    let score = 0;
+    let reasoning = "";
+    let judgeError: string | undefined;
+
+    try {
+      const response = await judge.modelCall(prompt, signal);
+      const parsed = parseJudgeResponse(response);
+      score = parsed.score;
+      reasoning = parsed.reasoning.slice(0, feedbackMaxLength);
+      judgeError = parsed.parseError;
+    } catch (e: unknown) {
+      judgeError = e instanceof Error ? e.message : "Unknown judge error";
+      // Fail-closed: treat judge error as score 0
+    }
+
+    if (score >= vetoThreshold && judgeError === undefined) {
+      return { kind: "pass" };
+    }
+
+    if (judgeAction === "warn") {
+      return { kind: "warn", score, reasoning };
+    }
+
+    if (judgeAction === "revise") {
+      return {
+        kind: "revise",
+        score,
+        reasoning,
+        ...(judgeError !== undefined ? { judgeError } : {}),
+      };
+    }
+
+    // block (default)
+    return { kind: "block", score, reasoning, ...(judgeError !== undefined ? { judgeError } : {}) };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Revision injection
+  // ---------------------------------------------------------------------------
+
+  function injectRevisionMessage(request: ModelRequest, feedback: string): ModelRequest {
+    const msg: InboundMessage = {
+      content: [{ kind: "text", text: feedback }],
+      senderId: VERIFIER_SENDER_ID,
+      timestamp: Date.now(),
+    };
+    return { ...request, messages: [...request.messages, msg] };
+  }
+
+  function deterministicRevisionFeedback(checkName: string, reason: string): string {
+    return `Check "${checkName}" failed: ${reason}. Please revise your output.`;
+  }
+
+  function judgeRevisionFeedback(
+    score: number,
+    vetoThreshold: number,
+    reasoning: string,
+    feedbackMaxLength: number,
+  ): string {
+    const reasonPart = reasoning.slice(0, feedbackMaxLength);
+    return [
+      `Your output was rejected by the quality judge (score: ${score.toFixed(2)}, required: ≥${vetoThreshold}).`,
+      reasonPart
+        ? `Reason: ${reasonPart}`
+        : "Please revise your output to meet the quality criteria.",
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core verification loop (iterative)
+  // ---------------------------------------------------------------------------
+
+  async function verify(
+    request: ModelRequest,
+    next: ModelHandler,
+    ctx: TurnContext,
+  ): Promise<ModelResponse> {
+    const maxRevisions = config.judge?.maxRevisions ?? DEFAULT_MAX_REVISIONS;
+    const vetoThreshold = config.judge?.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
+    const feedbackMaxLength =
+      config.judge?.revisionFeedbackMaxLength ?? DEFAULT_REVISION_FEEDBACK_MAX_LENGTH;
+
+    // let justified: current request may change across revision attempts
+    let currentRequest = request;
+    // let justified: revision counter increments across attempts
+    let revision = 0;
+
+    // let justified: per-call flags prevent overcounting stats across revision attempts
+    let callVetoed = false;
+    let callWarned = false;
+    let callDeterministicVeto = false;
+    let callJudgeVeto = false;
+
+    try {
+      while (true) {
+        const response = await next(currentRequest);
+        const content = response.content;
+
+        // Stage 1: deterministic — process ALL checks, firing events for each.
+        // warn: fires event and continues to next check (and then to judge).
+        // block: fires event and throws — short-circuits judge.
+        // revise: fires event, injects feedback, and restarts the while loop.
+        // let justified: tracks whether a revise was triggered this iteration
+        let deterministicRevised = false;
+        for (const check of config.deterministic ?? []) {
+          const result = check.check(content);
+          if (result === true) continue;
+
+          const reason = typeof result === "string" ? result : `Check "${check.name}" failed`;
+
+          if (check.action === "warn") {
+            callDeterministicVeto = true;
+            callWarned = true;
+            fireVeto({
+              source: "deterministic",
+              checkName: check.name,
+              checkReason: reason,
+              action: "warn",
+            });
+            continue; // fire event, then check next rule
+          }
+
+          if (check.action === "block") {
+            callDeterministicVeto = true;
+            callVetoed = true;
+            fireVeto({
+              source: "deterministic",
+              checkName: check.name,
+              checkReason: reason,
+              action: "block",
+            });
+            throw KoiRuntimeError.from(
+              "VALIDATION",
+              `Output verifier: deterministic check "${check.name}" blocked output: ${reason}`,
+              { context: { checkName: check.name, reason } },
+            );
+          }
+
+          // action === "revise"
+          callDeterministicVeto = true;
+          callVetoed = true;
+          fireVeto({
+            source: "deterministic",
+            checkName: check.name,
+            checkReason: reason,
+            action: "revise",
+          });
+          if (revision >= maxRevisions) {
+            throw KoiRuntimeError.from(
+              "VALIDATION",
+              `Output verifier: deterministic check "${check.name}" failed after ${maxRevisions} revision(s): ${reason}`,
+              { context: { checkName: check.name, reason, revision } },
+            );
+          }
+          revision++;
+          currentRequest = injectRevisionMessage(
+            currentRequest,
+            deterministicRevisionFeedback(check.name, reason),
+          );
+          deterministicRevised = true;
+          break; // Inject feedback for first revise; restart loop
+        }
+        if (deterministicRevised) continue;
+
+        // Stage 2: judge (skip if Stage 1 blocked — already threw above)
+        const judge = await runJudge(content, ctx.signal);
+
+        if (judge.kind === "pass" || judge.kind === "skip") {
+          return response;
+        }
+
+        if (judge.kind === "warn") {
+          callJudgeVeto = true;
+          callWarned = true;
+          fireVeto({
+            source: "judge",
+            action: "warn",
+            score: judge.score,
+            reasoning: judge.reasoning || undefined,
+          });
+          return response;
+        }
+
+        if (judge.kind === "block") {
+          callJudgeVeto = true;
+          callVetoed = true;
+          fireVeto({
+            source: "judge",
+            action: "block",
+            score: judge.score,
+            reasoning: judge.reasoning || undefined,
+            ...(judge.judgeError !== undefined ? { judgeError: judge.judgeError } : {}),
+          });
+          throw KoiRuntimeError.from(
+            "VALIDATION",
+            `Output verifier: judge blocked output (score ${judge.score.toFixed(2)} < ${vetoThreshold})${judge.reasoning ? `: ${judge.reasoning.slice(0, 200)}` : ""}`,
+            { context: { score: judge.score, vetoThreshold } },
+          );
+        }
+
+        // judge.kind === "revise"
+        callJudgeVeto = true;
+        callVetoed = true;
+        fireVeto({
+          source: "judge",
+          action: "revise",
+          score: judge.score,
+          reasoning: judge.reasoning || undefined,
+          ...(judge.judgeError !== undefined ? { judgeError: judge.judgeError } : {}),
+        });
+        if (revision >= maxRevisions) {
+          throw KoiRuntimeError.from(
+            "VALIDATION",
+            `Output verifier: judge blocked output after ${maxRevisions} revision(s) (score ${judge.score.toFixed(2)} < ${vetoThreshold})`,
+            { context: { score: judge.score, vetoThreshold, revision } },
+          );
+        }
+        revision++;
+        currentRequest = injectRevisionMessage(
+          currentRequest,
+          judgeRevisionFeedback(judge.score, vetoThreshold, judge.reasoning, feedbackMaxLength),
+        );
+      }
+    } finally {
+      if (callVetoed) stats.vetoed++;
+      if (callWarned) stats.warned++;
+      if (callDeterministicVeto) stats.deterministicVetoes++;
+      if (callJudgeVeto) stats.judgeVetoes++;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Veto event helper
+  // ---------------------------------------------------------------------------
+
+  function fireVeto(event: VerifierVetoEvent): void {
+    onVeto?.(event);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Streaming helpers
+  // ---------------------------------------------------------------------------
+
+  async function verifyStream(content: string, ctx: TurnContext): Promise<void> {
+    // Stage 1: deterministic (streaming: ALL actions degrade to warn — content already yielded)
+    for (const check of config.deterministic ?? []) {
+      const result = check.check(content);
+      if (result === true) continue;
+
+      const reason = typeof result === "string" ? result : `Check "${check.name}" failed`;
+      const action = check.action;
+      const degraded = action === "block" || action === "revise";
+
+      stats.deterministicVetoes++;
+      stats.warned++;
+      fireVeto({
+        source: "deterministic",
+        checkName: check.name,
+        checkReason: reason,
+        action,
+        ...(degraded ? { degraded: true } : {}),
+      });
+      // Don't throw — content was already yielded
+    }
+
+    // Stage 2: judge (streaming: revise/block degrade to warn)
+    const judge = await runJudge(content, ctx.signal);
+    if (judge.kind === "warn") {
+      stats.judgeVetoes++;
+      stats.warned++;
+      fireVeto({
+        source: "judge",
+        action: "warn",
+        score: judge.score,
+        reasoning: judge.reasoning || undefined,
+      });
+    } else if (judge.kind === "block" || judge.kind === "revise") {
+      stats.judgeVetoes++;
+      stats.warned++; // degraded
+      fireVeto({
+        source: "judge",
+        action: judge.kind,
+        score: judge.score,
+        reasoning: judge.reasoning || undefined,
+        ...(judge.judgeError !== undefined ? { judgeError: judge.judgeError } : {}),
+        degraded: true,
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Capability fragment
+  // ---------------------------------------------------------------------------
+
+  function buildCapabilityFragment(): CapabilityFragment {
+    const { totalChecks, vetoed } = stats;
+    const threshold = config.judge?.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
+    const desc = hasJudge
+      ? `score ≥${threshold} required. ${vetoed}/${totalChecks} vetoed this session.`
+      : `deterministic checks active. ${vetoed}/${totalChecks} blocked this session.`;
+    return { label: "output-gate", description: `Output gate: ${desc}` };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Middleware
+  // ---------------------------------------------------------------------------
+
+  const middleware: KoiMiddleware = {
+    name: MIDDLEWARE_NAME,
+    priority: MIDDLEWARE_PRIORITY,
+
+    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => buildCapabilityFragment(),
+
+    async wrapModelCall(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      stats.totalChecks++;
+      return await verify(request, next, ctx);
+    },
+
+    async *wrapModelStream(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      stats.totalChecks++;
+      // let justified: buffer grows across stream chunks
+      let buffer = "";
+      // let justified: tracks buffer overflow state
+      let overflowed = false;
+
+      for await (const chunk of next(request)) {
+        if (chunk.kind === "text_delta") {
+          if (!overflowed) {
+            if (buffer.length + chunk.delta.length > maxBufferSize) {
+              overflowed = true;
+              fireVeto({
+                source: "deterministic",
+                checkName: "stream-buffer-overflow",
+                checkReason: `Stream buffer exceeded ${maxBufferSize} characters; validation skipped`,
+                action: "warn",
+                degraded: true,
+              });
+            } else {
+              buffer += chunk.delta;
+            }
+          }
+          yield chunk;
+          continue;
+        }
+
+        if (chunk.kind === "done") {
+          if (!overflowed && buffer.length > 0) {
+            const content = buffer;
+            buffer = ""; // Release memory before async work
+            await verifyStream(content, ctx);
+          } else {
+            buffer = ""; // Release memory
+          }
+          yield chunk;
+          continue;
+        }
+
+        yield chunk;
+      }
+    },
+  };
+
+  // ---------------------------------------------------------------------------
+  // Handle
+  // ---------------------------------------------------------------------------
+
+  return {
+    middleware,
+
+    getStats(): VerifierStats {
+      const { totalChecks, vetoed, warned, deterministicVetoes, judgeVetoes, judgedChecks } = stats;
+      return {
+        totalChecks,
+        vetoed,
+        warned,
+        deterministicVetoes,
+        judgeVetoes,
+        judgedChecks,
+        vetoRate: totalChecks === 0 ? 0 : vetoed / totalChecks,
+      };
+    },
+
+    setRubric(rubric: string): void {
+      currentRubric = rubric;
+    },
+
+    reset(): void {
+      stats.totalChecks = 0;
+      stats.vetoed = 0;
+      stats.warned = 0;
+      stats.deterministicVetoes = 0;
+      stats.judgeVetoes = 0;
+      stats.judgedChecks = 0;
+    },
+  };
+}

--- a/packages/middleware-output-verifier/src/types.ts
+++ b/packages/middleware-output-verifier/src/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Type definitions for @koi/middleware-output-verifier.
+ *
+ * Two-stage output quality gate: deterministic checks (Stage 1) followed by
+ * an LLM-as-judge (Stage 2). Only "block" in Stage 1 short-circuits Stage 2.
+ */
+
+import type { KoiMiddleware } from "@koi/core/middleware";
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/** Action to take when a veto is triggered. */
+export type VerifierAction = "block" | "warn" | "revise";
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Deterministic checks
+// ---------------------------------------------------------------------------
+
+/**
+ * A named deterministic check applied to the raw model output string.
+ *
+ * @example
+ * const nonEmpty: DeterministicCheck = {
+ *   name: "non-empty",
+ *   check: (c) => c.trim().length > 0 || "Output must not be empty",
+ *   action: "block",
+ * };
+ */
+export interface DeterministicCheck {
+  /** Human-readable name used in veto events for debugging. */
+  readonly name: string;
+  /**
+   * Predicate function.
+   * - Return `true` to pass.
+   * - Return `false` or a `string` (failure reason) to fail.
+   */
+  readonly check: (content: string) => boolean | string;
+  /** Action to take when this check fails. */
+  readonly action: VerifierAction;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2 — LLM-as-judge
+// ---------------------------------------------------------------------------
+
+/** Configuration for the LLM-as-judge stage. */
+export interface JudgeConfig {
+  /** Rubric describing what constitutes a high-quality output. */
+  readonly rubric: string;
+  /**
+   * Model call function. Receives the judge prompt and an optional AbortSignal.
+   * Must return the raw model response string.
+   */
+  readonly modelCall: (prompt: string, signal?: AbortSignal) => Promise<string>;
+  /**
+   * Minimum score required to pass. Outputs scoring below this are vetoed.
+   * Range: 0.0–1.0. Default: 0.75 (targeting ~25% veto rate baseline).
+   */
+  readonly vetoThreshold?: number | undefined;
+  /** Action to take when the judge vetoes. Default: "block". */
+  readonly action?: VerifierAction | undefined;
+  /**
+   * Fraction of calls on which the judge runs. Range: 0.0–1.0. Default: 1.0.
+   * Set below 1.0 in production to reduce latency at the cost of coverage.
+   * Deterministic checks always run regardless of this setting.
+   */
+  readonly samplingRate?: number | undefined;
+  /** Maximum revision attempts before throwing. Default: 1. */
+  readonly maxRevisions?: number | undefined;
+  /**
+   * Maximum characters of judge reasoning injected during revise.
+   * Prevents context bloat from verbose judge explanations. Default: 400.
+   */
+  readonly revisionFeedbackMaxLength?: number | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the output verifier middleware.
+ * At least one of `deterministic` or `judge` must be provided.
+ */
+export interface VerifierConfig {
+  /** Stage 1: deterministic checks. Run sequentially; first "block" short-circuits. */
+  readonly deterministic?: readonly DeterministicCheck[] | undefined;
+  /** Stage 2: LLM-as-judge. Skipped if Stage 1 produced a "block". */
+  readonly judge?: JudgeConfig | undefined;
+  /** Called whenever a veto or warn is triggered. */
+  readonly onVeto?: ((event: VerifierVetoEvent) => void) | undefined;
+  /**
+   * Maximum characters to buffer for streaming validation. Default: 262144 (256 KB).
+   * If the stream exceeds this size, streaming validation is skipped with a warn event.
+   */
+  readonly maxBufferSize?: number | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Veto event
+// ---------------------------------------------------------------------------
+
+/** Event fired when a check vetoes or warns on an output. */
+export interface VerifierVetoEvent {
+  /** Which stage detected the issue. */
+  readonly source: "deterministic" | "judge";
+  /** Name of the deterministic check that failed (source = "deterministic" only). */
+  readonly checkName?: string | undefined;
+  /** Failure reason from the check function (source = "deterministic" only). */
+  readonly checkReason?: string | undefined;
+  /** Action taken (or that would have been taken for streaming degradation). */
+  readonly action: VerifierAction;
+  /** Judge score (0.0–1.0), present when source = "judge". */
+  readonly score?: number | undefined;
+  /** Judge reasoning, truncated to revisionFeedbackMaxLength. */
+  readonly reasoning?: string | undefined;
+  /** Set when the judge threw or returned an unparseable response. */
+  readonly judgeError?: string | undefined;
+  /**
+   * Set to true when streaming degraded "revise" or "block" to "warn".
+   * Content was already yielded; retry is impossible.
+   */
+  readonly degraded?: boolean | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+/** Accumulated statistics for the verifier session. Manual reset via Handle. */
+export interface VerifierStats {
+  /** Total model calls evaluated (regardless of sampling). */
+  readonly totalChecks: number;
+  /** Calls where action was "block" or "revise" (output was prevented or revised). */
+  readonly vetoed: number;
+  /** Calls where action was "warn" (output delivered with advisory event). */
+  readonly warned: number;
+  /** Veto events originating from Stage 1 deterministic checks. */
+  readonly deterministicVetoes: number;
+  /** Veto events originating from Stage 2 judge. */
+  readonly judgeVetoes: number;
+  /** Calls where the judge actually ran (affected by samplingRate). */
+  readonly judgedChecks: number;
+  /** vetoed / totalChecks. Returns 0 when totalChecks = 0. */
+  readonly vetoRate: number;
+}
+
+// ---------------------------------------------------------------------------
+// Handle
+// ---------------------------------------------------------------------------
+
+/** Returned by createOutputVerifierMiddleware. Provides runtime control and stats. */
+export interface VerifierHandle {
+  /** The KoiMiddleware to add to your agent's middleware chain. */
+  readonly middleware: KoiMiddleware;
+  /** Returns a snapshot of accumulated stats since last reset. */
+  readonly getStats: () => VerifierStats;
+  /**
+   * Updates the judge rubric for subsequent calls.
+   * Takes effect on the next wrapModelCall / wrapModelStream invocation.
+   */
+  readonly setRubric: (rubric: string) => void;
+  /** Resets all stat counters to zero. Call in onSessionStart for per-session tracking. */
+  readonly reset: () => void;
+}

--- a/packages/middleware-output-verifier/tsconfig.json
+++ b/packages/middleware-output-verifier/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/middleware-output-verifier/tsup.config.ts
+++ b/packages/middleware-output-verifier/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/e2e-output-verifier.ts
+++ b/scripts/e2e-output-verifier.ts
@@ -1,0 +1,710 @@
+#!/usr/bin/env bun
+/**
+ * E2E test script for @koi/middleware-output-verifier — validates the two-stage
+ * output quality gate works end-to-end with real Anthropic API calls through the
+ * full Koi middleware and runtime stack.
+ *
+ * Part A — composeModelChain (middleware chain, no Pi runtime overhead)
+ *   1.  Deterministic pass   — nonEmpty + maxLength pass on real LLM output
+ *   2.  Deterministic block  — always-block check throws KoiRuntimeError
+ *   3.  Deterministic warn   — output delivered + onVeto fired
+ *   4.  Judge pass           — real judge scores quality output >= threshold
+ *   5.  Judge warn action    — unreachable threshold, warn fires, output delivered
+ *   6.  Revise loop          — check fails first call, revision injected, passes second
+ *   7.  Stats tracking       — vetoRate = 1/4 = 0.25 (Spotify 25% baseline)
+ *   8.  setRubric            — rubric change takes effect on next judge call
+ *
+ * Part B — Full createKoi + Pi agent (end-to-end L1 runtime integration)
+ *   9.  Pi + deterministic   — nonEmpty + maxLength through full runtime
+ *  10.  Pi + judge           — real judge evaluates Pi output, stats tracked
+ *
+ * Usage:
+ *   bun scripts/e2e-output-verifier.ts        (reads .env automatically)
+ *   ANTHROPIC_API_KEY=sk-... bun scripts/e2e-output-verifier.ts
+ *
+ * Cost: ~$0.05–0.10 per run (~15–18 Haiku calls, minimal prompts).
+ */
+
+import type {
+  EngineEvent,
+  InboundMessage,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+} from "../packages/core/src/index.js";
+import { composeModelChain } from "../packages/engine/src/compose.js";
+import { createKoi } from "../packages/engine/src/koi.js";
+import { createPiAdapter } from "../packages/engine-pi/src/adapter.js";
+import { KoiRuntimeError } from "../packages/errors/dist/index.js";
+import {
+  BUILTIN_CHECKS,
+  createOutputVerifierMiddleware,
+} from "../packages/middleware-output-verifier/src/index.js";
+import type {
+  DeterministicCheck,
+  VerifierVetoEvent,
+} from "../packages/middleware-output-verifier/src/types.js";
+import { createMockTurnContext } from "../packages/test-utils/src/index.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!API_KEY) {
+  console.error("[e2e] ANTHROPIC_API_KEY is not set. Skipping E2E tests.");
+  process.exit(0);
+}
+
+console.log("[e2e] Starting output-verifier E2E tests...\n");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface TestResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly detail?: string;
+}
+
+const results: TestResult[] = []; // let justified: test accumulator
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  results.push({ name, passed: condition, detail });
+  const tag = condition ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+  console.log(`  ${tag}  ${name}`);
+  if (detail !== undefined && !condition) console.log(`         ${detail}`);
+}
+
+function makeMessage(text: string): InboundMessage {
+  return {
+    senderId: "e2e-user",
+    timestamp: Date.now(),
+    content: [{ kind: "text", text }],
+  };
+}
+
+function createAnthropicTerminal(): ModelHandler {
+  return async (request: ModelRequest): Promise<ModelResponse> => {
+    const systemParts: string[] = [];
+    const userParts: string[] = [];
+
+    for (const msg of request.messages) {
+      const text = msg.content
+        .filter((b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text")
+        .map((b) => b.text)
+        .join("\n");
+
+      if (msg.senderId.startsWith("system:")) {
+        systemParts.push(text);
+      } else {
+        userParts.push(text);
+      }
+    }
+
+    const body = {
+      model: request.model ?? "claude-haiku-4-5-20251001",
+      max_tokens: request.maxTokens ?? 256,
+      temperature: request.temperature ?? 0,
+      ...(systemParts.length > 0 ? { system: systemParts.join("\n\n") } : {}),
+      messages: [{ role: "user", content: userParts.join("\n\n") }],
+    };
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic API error ${response.status}: ${errorText}`);
+    }
+
+    const json = (await response.json()) as {
+      readonly model: string;
+      readonly content: readonly { readonly type: string; readonly text: string }[];
+      readonly usage: { readonly input_tokens: number; readonly output_tokens: number };
+    };
+
+    return {
+      content: json.content
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+        .join(""),
+      model: json.model,
+      usage: {
+        inputTokens: json.usage.input_tokens,
+        outputTokens: json.usage.output_tokens,
+      },
+    };
+  };
+}
+
+function createJudgeTerminal(): (prompt: string, signal?: AbortSignal) => Promise<string> {
+  return async (prompt: string, signal?: AbortSignal): Promise<string> => {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY as string,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: 256,
+        temperature: 0,
+        messages: [{ role: "user", content: prompt }],
+      }),
+      signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic judge API error ${response.status}: ${errorText}`);
+    }
+
+    const json = (await response.json()) as {
+      readonly content: readonly { readonly type: string; readonly text: string }[];
+    };
+
+    return json.content
+      .filter((b) => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+  };
+}
+
+async function withTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+const TIMEOUT_MS = 30_000;
+const PI_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const ctx = createMockTurnContext();
+const terminal = createAnthropicTerminal();
+
+// =============================================================================
+// PART A: composeModelChain tests
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Test 1 — Deterministic pass: nonEmpty + maxLength on real LLM output
+// ---------------------------------------------------------------------------
+
+console.log("[test 1] Deterministic checks pass — nonEmpty + maxLength (happy path)");
+
+const vetoEvents1: VerifierVetoEvent[] = [];
+const handle1 = createOutputVerifierMiddleware({
+  deterministic: [BUILTIN_CHECKS.nonEmpty("block"), BUILTIN_CHECKS.maxLength(5_000, "warn")],
+  onVeto: (e) => vetoEvents1.push(e),
+});
+
+const chain1 = composeModelChain([handle1.middleware], terminal);
+const response1 = await withTimeout(
+  () =>
+    chain1(ctx, {
+      messages: [makeMessage("Reply with exactly: VERIFIER_OK")],
+      maxTokens: 64,
+      temperature: 0,
+    }),
+  TIMEOUT_MS,
+  "Test 1",
+);
+
+console.log(`  LLM: "${response1.content.slice(0, 80)}"`);
+assert("response is non-empty", response1.content.length > 0);
+assert("no veto events on clean response", vetoEvents1.length === 0, `Got ${vetoEvents1.length}`);
+const s1 = handle1.getStats();
+assert("totalChecks=1", s1.totalChecks === 1, `Got ${s1.totalChecks}`);
+assert("vetoed=0, vetoRate=0", s1.vetoed === 0 && s1.vetoRate === 0);
+
+// Also smoke-test describeCapabilities shape here
+const cap1 = handle1.middleware.describeCapabilities?.(ctx);
+assert("describeCapabilities label='output-gate'", cap1?.label === "output-gate");
+assert("describeCapabilities has description", typeof cap1?.description === "string");
+
+// ---------------------------------------------------------------------------
+// Test 2 — Deterministic block: always-block check throws KoiRuntimeError
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 2] Deterministic block — throws KoiRuntimeError + fires onVeto");
+
+const vetoEvents2: VerifierVetoEvent[] = [];
+const alwaysBlock: DeterministicCheck = {
+  name: "policy-block",
+  check: () => "Blocked by policy",
+  action: "block",
+};
+const handle2 = createOutputVerifierMiddleware({
+  deterministic: [alwaysBlock],
+  onVeto: (e) => vetoEvents2.push(e),
+});
+const chain2 = composeModelChain([handle2.middleware], terminal);
+
+let blockThrown = false; // let justified: toggled in catch
+let blockCode: string | undefined;
+try {
+  await withTimeout(
+    () => chain2(ctx, { messages: [makeMessage("Say anything.")], maxTokens: 64, temperature: 0 }),
+    TIMEOUT_MS,
+    "Test 2",
+  );
+} catch (e: unknown) {
+  if (e instanceof KoiRuntimeError) {
+    blockThrown = true;
+    blockCode = e.code;
+  }
+}
+
+assert("block throws KoiRuntimeError", blockThrown);
+assert("error code is VALIDATION", blockCode === "VALIDATION", `Got: ${blockCode}`);
+assert("onVeto fired once", vetoEvents2.length === 1, `Got ${vetoEvents2.length}`);
+assert("veto source=deterministic", vetoEvents2[0]?.source === "deterministic");
+assert("veto action=block", vetoEvents2[0]?.action === "block");
+assert("veto checkName=policy-block", vetoEvents2[0]?.checkName === "policy-block");
+assert("veto checkReason present", typeof vetoEvents2[0]?.checkReason === "string");
+const s2 = handle2.getStats();
+assert("block: vetoed=1", s2.vetoed === 1, `Got ${s2.vetoed}`);
+assert("block: warned=0", s2.warned === 0, `Got ${s2.warned}`);
+assert("block: vetoRate=1.0", s2.vetoRate === 1.0, `Got ${s2.vetoRate}`);
+
+// ---------------------------------------------------------------------------
+// Test 3 — Deterministic warn: output delivered + onVeto fired
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 3] Deterministic warn — output delivered + onVeto fired");
+
+const vetoEvents3: VerifierVetoEvent[] = [];
+const alwaysWarn: DeterministicCheck = {
+  name: "advisory-flag",
+  check: () => "Suspicious pattern detected",
+  action: "warn",
+};
+const handle3 = createOutputVerifierMiddleware({
+  deterministic: [alwaysWarn],
+  onVeto: (e) => vetoEvents3.push(e),
+});
+const chain3 = composeModelChain([handle3.middleware], terminal);
+const response3 = await withTimeout(
+  () => chain3(ctx, { messages: [makeMessage("Say: WARN_PASS")], maxTokens: 32, temperature: 0 }),
+  TIMEOUT_MS,
+  "Test 3",
+);
+
+console.log(`  LLM: "${response3.content.slice(0, 80)}"`);
+assert("warn: output was delivered (not blocked)", response3.content.length > 0);
+assert("warn: onVeto fired once", vetoEvents3.length === 1, `Got ${vetoEvents3.length}`);
+assert("warn: event action=warn", vetoEvents3[0]?.action === "warn");
+assert("warn: event source=deterministic", vetoEvents3[0]?.source === "deterministic");
+const s3 = handle3.getStats();
+assert("warn: vetoed=0 (warn is NOT a veto)", s3.vetoed === 0, `Got ${s3.vetoed}`);
+assert("warn: warned=1", s3.warned === 1, `Got ${s3.warned}`);
+assert("warn: vetoRate=0", s3.vetoRate === 0, `Got ${s3.vetoRate}`);
+
+// ---------------------------------------------------------------------------
+// Test 4 — Judge pass: real judge evaluates quality output
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 4] LLM-as-judge pass — real judge scores quality output >= threshold");
+
+const vetoEvents4: VerifierVetoEvent[] = [];
+const handle4 = createOutputVerifierMiddleware({
+  judge: {
+    rubric: [
+      "Score the output 0.0–1.0.",
+      "Give 0.8+ if it directly and correctly answers the question.",
+      "Give 0.3 or less if the response is empty, nonsensical, or off-topic.",
+    ].join("\n"),
+    modelCall: createJudgeTerminal(),
+    vetoThreshold: 0.5,
+    action: "block",
+    samplingRate: 1.0,
+  },
+  onVeto: (e) => vetoEvents4.push(e),
+});
+const chain4 = composeModelChain([handle4.middleware], terminal);
+const response4 = await withTimeout(
+  () =>
+    chain4(ctx, {
+      messages: [makeMessage("In one sentence: what is a quality gate in software delivery?")],
+      maxTokens: 128,
+      temperature: 0,
+    }),
+  TIMEOUT_MS * 2, // agent call + judge call
+  "Test 4",
+);
+
+console.log(`  LLM: "${response4.content.slice(0, 120)}"`);
+assert("judge pass: output delivered (score >= 0.5)", response4.content.length > 0);
+assert("judge pass: no veto events", vetoEvents4.length === 0, `Got ${vetoEvents4.length}`);
+const s4 = handle4.getStats();
+assert("judge pass: judgedChecks=1", s4.judgedChecks === 1, `Got ${s4.judgedChecks}`);
+assert("judge pass: vetoed=0", s4.vetoed === 0, `Got ${s4.vetoed}`);
+
+// ---------------------------------------------------------------------------
+// Test 5 — Judge warn action: unreachable threshold, warns but delivers
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 5] LLM-as-judge warn action — fires event, output still delivered");
+
+const vetoEvents5: VerifierVetoEvent[] = [];
+const handle5 = createOutputVerifierMiddleware({
+  judge: {
+    rubric: [
+      "You are an impossibly strict judge. Score 1.0 only for perfect scholarly prose.",
+      "Score all other outputs 0.0–0.2. Common conversational replies score <= 0.1.",
+    ].join("\n"),
+    modelCall: createJudgeTerminal(),
+    vetoThreshold: 0.99, // no real LLM output can reach this
+    action: "warn", // warn so output is still delivered
+    samplingRate: 1.0,
+  },
+  onVeto: (e) => vetoEvents5.push(e),
+});
+const chain5 = composeModelChain([handle5.middleware], terminal);
+const response5 = await withTimeout(
+  () => chain5(ctx, { messages: [makeMessage("Say hello.")], maxTokens: 32, temperature: 0 }),
+  TIMEOUT_MS * 2,
+  "Test 5",
+);
+
+console.log(`  LLM: "${response5.content.slice(0, 80)}"`);
+assert("judge warn: output delivered despite low score", response5.content.length > 0);
+assert("judge warn: onVeto fired once", vetoEvents5.length === 1, `Got ${vetoEvents5.length}`);
+assert("judge warn: event source=judge", vetoEvents5[0]?.source === "judge");
+assert("judge warn: event action=warn", vetoEvents5[0]?.action === "warn");
+assert("judge warn: event.score is a number", typeof vetoEvents5[0]?.score === "number");
+assert("judge warn: event.reasoning is present", typeof vetoEvents5[0]?.reasoning === "string");
+const s5 = handle5.getStats();
+assert("judge warn: warned=1 (NOT vetoed)", s5.warned === 1, `Got ${s5.warned}`);
+assert("judge warn: vetoed=0", s5.vetoed === 0, `Got ${s5.vetoed}`);
+assert("judge warn: judgedChecks=1", s5.judgedChecks === 1, `Got ${s5.judgedChecks}`);
+
+// ---------------------------------------------------------------------------
+// Test 6 — Revise action: retry loop injects feedback, LLM passes on second try
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 6] Revise action — retry loop: check fails → feedback injected → passes");
+
+// NOTE: The revise loop calls next() multiple times within one wrapModelCall invocation.
+// composeModelChain intentionally guards against this on the success path (by design).
+// Test 6 therefore calls wrapModelCall directly (as unit tests do) to validate the
+// revise mechanism without conflicting with the composition guard contract.
+
+// let justified: tracks actual LLM call count across revision attempts
+let callCount6 = 0;
+const countingTerminal6: ModelHandler = async (request: ModelRequest): Promise<ModelResponse> => {
+  callCount6++;
+  return terminal(request);
+};
+
+const handle6 = createOutputVerifierMiddleware({
+  // Check fails until LLM includes the marker. The revision message will instruct it to add it.
+  deterministic: [
+    {
+      name: "needs-gate-marker",
+      check: (c) => c.includes("GATE_PASS") || "Response must include the text GATE_PASS",
+      action: "revise",
+    },
+  ],
+});
+
+// Call wrapModelCall directly — bypasses composeModelChain's single-next() guard.
+// The wrapModelCall hook is always defined for this middleware.
+const wrapModelCall6 = handle6.middleware.wrapModelCall;
+if (wrapModelCall6 === undefined)
+  throw new Error("wrapModelCall not defined on handle6 middleware");
+
+// Initial prompt doesn't mention GATE_PASS — LLM won't include it on first attempt.
+// The revision feedback ("must include GATE_PASS") instructs LLM to add it on retry.
+const response6 = await withTimeout(
+  () =>
+    wrapModelCall6(
+      ctx,
+      {
+        messages: [makeMessage("Describe a cloud in one sentence.")],
+        maxTokens: 128,
+        temperature: 0,
+      },
+      countingTerminal6,
+    ),
+  TIMEOUT_MS * 2,
+  "Test 6",
+);
+
+console.log(`  LLM calls: ${callCount6}, Final: "${response6.content.slice(0, 120)}"`);
+assert(
+  "revise: LLM called at least twice (retry loop fired)",
+  callCount6 >= 2,
+  `Called ${callCount6} times`,
+);
+assert(
+  "revise: final response contains GATE_PASS",
+  response6.content.includes("GATE_PASS"),
+  `Response: "${response6.content.slice(0, 100)}"`,
+);
+const s6 = handle6.getStats();
+assert("revise: totalChecks=1 (one wrapModelCall)", s6.totalChecks === 1, `Got ${s6.totalChecks}`);
+assert("revise: vetoed=1 (revise counts as veto)", s6.vetoed === 1, `Got ${s6.vetoed}`);
+
+// ---------------------------------------------------------------------------
+// Test 7 — Stats: vetoRate = 1/4 = 0.25 (Spotify 25% baseline example)
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 7] Stats tracking — vetoRate baseline across 4 calls");
+
+// let justified: shared counter drives conditional block logic
+let callNum7 = 0;
+const handle7 = createOutputVerifierMiddleware({
+  deterministic: [
+    {
+      name: "every-fourth",
+      check: () => {
+        callNum7++;
+        return callNum7 % 4 !== 0 || "Blocked on every 4th call";
+      },
+      action: "block",
+    },
+  ],
+});
+const chain7 = composeModelChain([handle7.middleware], terminal);
+const tiny = { messages: [makeMessage("Say 'ok'.")], maxTokens: 16, temperature: 0 };
+
+for (let i = 0; i < 3; i++) {
+  await withTimeout(() => chain7(ctx, tiny), TIMEOUT_MS, `Test 7 call ${i + 1}`);
+}
+let blocked7 = false; // let justified: toggled in catch
+try {
+  await withTimeout(() => chain7(ctx, tiny), TIMEOUT_MS, "Test 7 block call");
+} catch (_e: unknown) {
+  blocked7 = true;
+}
+
+const s7 = handle7.getStats();
+assert("stats: totalChecks=4", s7.totalChecks === 4, `Got ${s7.totalChecks}`);
+assert("stats: vetoed=1 (one block)", s7.vetoed === 1, `Got ${s7.vetoed}`);
+assert("stats: warned=0", s7.warned === 0, `Got ${s7.warned}`);
+assert("stats: vetoRate=0.25", s7.vetoRate === 0.25, `Got ${s7.vetoRate}`);
+assert("stats: 4th call was blocked", blocked7);
+
+// Also verify reset() works
+handle7.reset();
+const s7r = handle7.getStats();
+assert(
+  "reset: all counters zeroed",
+  s7r.totalChecks === 0 && s7r.vetoed === 0 && s7r.vetoRate === 0,
+);
+
+// ---------------------------------------------------------------------------
+// Test 8 — setRubric: dynamic rubric change takes effect on next call
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 8] setRubric — dynamic rubric update reflected in judge prompts");
+
+const capturedPrompts8: string[] = []; // let justified: captures judge prompts
+const handle8 = createOutputVerifierMiddleware({
+  judge: {
+    rubric: "ORIGINAL_RUBRIC: Be kind and concise.",
+    modelCall: async (prompt) => {
+      capturedPrompts8.push(prompt);
+      return JSON.stringify({ score: 1.0, reasoning: "ok" });
+    },
+    vetoThreshold: 0.5,
+    action: "warn",
+  },
+});
+const chain8 = composeModelChain([handle8.middleware], terminal);
+const req8 = { messages: [makeMessage("Say hello.")], maxTokens: 16, temperature: 0 };
+
+await withTimeout(() => chain8(ctx, req8), TIMEOUT_MS, "Test 8 first call");
+handle8.setRubric("UPDATED_RUBRIC: Be extremely precise.");
+await withTimeout(() => chain8(ctx, req8), TIMEOUT_MS, "Test 8 second call");
+
+assert(
+  "setRubric: first call uses original rubric",
+  capturedPrompts8[0]?.includes("ORIGINAL_RUBRIC") === true,
+  `First prompt excerpt: "${capturedPrompts8[0]?.slice(0, 80)}"`,
+);
+assert(
+  "setRubric: second call uses updated rubric",
+  capturedPrompts8[1]?.includes("UPDATED_RUBRIC") === true,
+  `Second prompt excerpt: "${capturedPrompts8[1]?.slice(0, 80)}"`,
+);
+assert(
+  "setRubric: original rubric NOT in second prompt",
+  capturedPrompts8[1]?.includes("ORIGINAL_RUBRIC") === false,
+);
+
+// =============================================================================
+// PART B: Full createKoi + Pi agent tests
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Test 9 — Full Pi + deterministic: nonEmpty + maxLength through L1 runtime
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 9] Full createKoi + Pi — deterministic nonEmpty + maxLength");
+
+const vetoEvents9: VerifierVetoEvent[] = [];
+const handle9 = createOutputVerifierMiddleware({
+  deterministic: [BUILTIN_CHECKS.nonEmpty("block"), BUILTIN_CHECKS.maxLength(10_000, "warn")],
+  onVeto: (e) => vetoEvents9.push(e),
+});
+
+const piAdapter9 = createPiAdapter({
+  model: PI_MODEL,
+  systemPrompt: "You are a concise assistant. Reply with a single short sentence.",
+  getApiKey: async () => API_KEY,
+});
+const runtime9 = await createKoi({
+  manifest: { name: "e2e-verifier-det", version: "0.0.1", model: { name: PI_MODEL } },
+  adapter: piAdapter9,
+  middleware: [handle9.middleware],
+  limits: { maxTurns: 5, maxDurationMs: TIMEOUT_MS * 2, maxTokens: 10_000 },
+});
+
+try {
+  const events9 = await Promise.race([
+    collectEvents(runtime9.run({ kind: "text", text: "What is 2 + 2? Answer in one word." })),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Test 9 timed out")), TIMEOUT_MS * 2),
+    ),
+  ]);
+
+  const doneEvent9 = events9.find((e) => e.kind === "done");
+  assert("pi+det: done event present", doneEvent9 !== undefined);
+  if (doneEvent9?.kind === "done") {
+    assert(
+      "pi+det: stopReason=completed",
+      doneEvent9.output.stopReason === "completed",
+      `Got: ${doneEvent9.output.stopReason}`,
+    );
+  }
+  assert(
+    "pi+det: no veto events on clean output",
+    vetoEvents9.length === 0,
+    `Got ${vetoEvents9.length}`,
+  );
+  const s9 = handle9.getStats();
+  assert("pi+det: totalChecks >= 1", s9.totalChecks >= 1, `Got ${s9.totalChecks}`);
+  assert("pi+det: vetoed=0", s9.vetoed === 0, `Got ${s9.vetoed}`);
+  console.log(`  Pi completed: ${events9.length} events, ${s9.totalChecks} model checks`);
+} finally {
+  await runtime9.dispose?.();
+}
+
+// ---------------------------------------------------------------------------
+// Test 10 — Full Pi + judge: real judge evaluates Pi output end-to-end
+// ---------------------------------------------------------------------------
+
+console.log("\n[test 10] Full createKoi + Pi + judge — end-to-end quality gate");
+
+const vetoEvents10: VerifierVetoEvent[] = [];
+const handle10 = createOutputVerifierMiddleware({
+  deterministic: [BUILTIN_CHECKS.nonEmpty("block")],
+  judge: {
+    rubric: [
+      "Score the output 0.0–1.0.",
+      "Give 0.8+ if it directly and correctly answers the question.",
+      "Give below 0.5 if the answer is wrong, empty, or off-topic.",
+    ].join("\n"),
+    modelCall: createJudgeTerminal(),
+    vetoThreshold: 0.5,
+    action: "warn", // warn so the run always completes — tests the judge fires
+    samplingRate: 1.0,
+  },
+  onVeto: (e) => vetoEvents10.push(e),
+});
+
+const piAdapter10 = createPiAdapter({
+  model: PI_MODEL,
+  systemPrompt: "You are a knowledgeable assistant. Answer factually and concisely.",
+  getApiKey: async () => API_KEY,
+});
+const runtime10 = await createKoi({
+  manifest: { name: "e2e-verifier-judge", version: "0.0.1", model: { name: PI_MODEL } },
+  adapter: piAdapter10,
+  middleware: [handle10.middleware],
+  limits: { maxTurns: 5, maxDurationMs: TIMEOUT_MS * 3, maxTokens: 10_000 },
+});
+
+try {
+  const events10 = await Promise.race([
+    collectEvents(runtime10.run({ kind: "text", text: "Name the capital of France." })),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Test 10 timed out")), TIMEOUT_MS * 3),
+    ),
+  ]);
+
+  const doneEvent10 = events10.find((e) => e.kind === "done");
+  assert("pi+judge: done event present", doneEvent10 !== undefined);
+  if (doneEvent10?.kind === "done") {
+    assert(
+      "pi+judge: stopReason=completed",
+      doneEvent10.output.stopReason === "completed",
+      `Got: ${doneEvent10.output.stopReason}`,
+    );
+  }
+
+  const s10 = handle10.getStats();
+  assert(
+    "pi+judge: judgedChecks >= 1 (judge ran)",
+    s10.judgedChecks >= 1,
+    `Got ${s10.judgedChecks}`,
+  );
+  // Capital of France is Paris — judge should score >= 0.5 → no veto
+  assert("pi+judge: vetoed=0 (correct answer scored well)", s10.vetoed === 0, `Got ${s10.vetoed}`);
+  assert("pi+judge: warned=0 (score >= 0.5)", s10.warned === 0, `Got ${s10.warned}`);
+
+  console.log(
+    `  Pi+judge: ${events10.length} events, judgedChecks=${s10.judgedChecks}, vetoRate=${s10.vetoRate}`,
+  );
+} finally {
+  await runtime10.dispose?.();
+}
+
+// =============================================================================
+// Summary
+// =============================================================================
+
+const passed = results.filter((r) => r.passed).length;
+const total = results.length;
+const allPassed = passed === total;
+
+console.log(`\n${"─".repeat(60)}`);
+console.log(`[e2e] Results: ${passed}/${total} passed`);
+console.log("─".repeat(60));
+
+if (!allPassed) {
+  console.error("\n[e2e] Failed assertions:");
+  for (const r of results) {
+    if (!r.passed) {
+      console.error(`  FAIL  ${r.name}`);
+      if (r.detail !== undefined) console.error(`        ${r.detail}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("\n[e2e] ALL OUTPUT-VERIFIER E2E TESTS PASSED!");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     { "path": "packages/middleware-guided-retry" },
     { "path": "packages/middleware-semantic-retry" },
     { "path": "packages/middleware-memory" },
+    { "path": "packages/middleware-output-verifier" },
     { "path": "packages/middleware-pay" },
     { "path": "packages/middleware-permissions" },
     { "path": "packages/middleware-turn-ack" },


### PR DESCRIPTION
Closes #518

## Summary

- Adds `@koi/middleware-output-verifier` — L2 middleware with two-stage output quality gate
- **Stage 1 (deterministic):** Named predicate checks (nonEmpty, maxLength, validJson, matchesPattern), zero cost, always runs
- **Stage 2 (LLM-as-judge):** Pluggable model call scores 0.0–1.0 against a configurable rubric, skipped if Stage 1 blocks
- Three actions per check: **block** (throw KoiRuntimeError), **warn** (deliver + onVeto event), **revise** (inject feedback, retry model)
- Streaming support: block/revise degrade to warn (content already yielded)
- Per-session stats: `totalChecks`, `vetoed`, `warned`, `judgedChecks`, `vetoRate` (targeting 25% Spotify baseline)
- `VerifierHandle`: `getStats()`, `setRubric()` (hot-swap), `reset()`
- Fail-closed: judge parse error → score 0 → action fires
- Priority 385 — after guardrails (375), before memory (400)
- Adds `docs/L2/middleware-output-verifier.md`
- Adds `scripts/e2e-output-verifier.ts` — 10 tests, 59 assertions

## Test plan

- [x] 58/58 unit tests pass, 99.19% line coverage
- [x] 59/59 E2E assertions pass (real Anthropic API calls)
  - Part A: 8 tests via `composeModelChain` — deterministic pass/block/warn, judge pass/warn/revise, stats, setRubric
  - Part B: 2 tests via full `createKoi + createPiAdapter` — deterministic and judge through L1 runtime
- [x] Biome check clean
- [x] Typecheck passes
- [x] Build passes
- [x] Rebased on latest main