### PR TITLE
feat: Docker container workspace backend with mount mode, scope, and sandbox enforcement

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -50,7 +50,7 @@ The workspace is an **ECS component** attached to agents via a `ComponentProvide
      │          WorkspaceBackend                │
      │  ┌────────────┐ ┌────────┐ ┌─────────┐ │
      │  │Git Worktree│ │Temp Dir│ │ Docker  │ │
-     │  │ (shipped)  │ │(future)│ │(future) │ │
+     │  │ (shipped)  │ │(custom)│ │(shipped)│ │
      │  └────────────┘ └────────┘ └─────────┘ │
      └─────────────────────────────────────────┘
 ```
@@ -101,6 +101,7 @@ The strategy interface — implement this to add new isolation mechanisms:
 ```typescript
 interface WorkspaceBackend {
   readonly name: string;
+  readonly isSandboxed: boolean;
   readonly create: (agentId: AgentId, config: ResolvedWorkspaceConfig)
     => Promise<Result<WorkspaceInfo, KoiError>>;
   readonly dispose: (workspaceId: string)
@@ -110,8 +111,10 @@ interface WorkspaceBackend {
 }
 ```
 
-| Method | Purpose |
+| Member | Purpose |
 |--------|---------|
+| `name` | Backend identifier (e.g., `"docker"`, `"git-worktree"`) |
+| `isSandboxed` | Whether this backend provides OS-level container isolation |
 | `create` | Allocate an isolated workspace for the agent |
 | `dispose` | Tear down the workspace and free resources |
 | `isHealthy` | Check if the workspace is still usable |
@@ -159,6 +162,206 @@ repo-workspaces/               ← worktreeBasePath
     ├── src/
     └── README.md
 ```
+
+## Docker Container Backend
+
+Container-based workspace isolation via a pluggable `SandboxAdapter`. Each agent runs inside an isolated container with configurable filesystem access and container reuse policies.
+
+```typescript
+import { createDockerWorkspaceBackend, createWorkspaceProvider } from "@koi/workspace";
+
+const backend = createDockerWorkspaceBackend({
+  adapter: mySandboxAdapter,   // SandboxAdapter from L0 — Docker, E2B, Fly.io, etc.
+  mountMode: "ro",             // "none" | "ro" | "rw" (default: "none")
+  scope: "session",            // "session" | "per-agent" | "shared" (default: "per-agent")
+  workDir: "/workspace",       // default: "/workspace"
+});
+if (!backend.ok) throw new Error(backend.error.message);
+
+const provider = createWorkspaceProvider({
+  backend: backend.value,
+  requireSandbox: true,        // reject non-container backends
+  cleanupPolicy: "always",
+});
+```
+
+The `SandboxAdapter` is injected — the Docker backend doesn't import any Docker SDK. You bring your own adapter (Docker CLI wrapper, E2B client, Fly.io API, etc.) that implements `create(profile) → SandboxInstance`.
+
+### Mount Mode
+
+Controls what the container can see of the host filesystem:
+
+```
+  mountMode: "none" (DEFAULT — most restrictive)
+  ┌─────────────────────┐       Host /workspace
+  │  Container          │       ┌─────────────┐
+  │  /workspace (empty) │──✗───│ code/        │
+  │  Can't read host.   │       │ secrets/     │
+  │  Can't write host.  │       └─────────────┘
+  └─────────────────────┘
+
+  mountMode: "ro"
+  ┌─────────────────────┐       Host /workspace
+  │  Container          │       ┌─────────────┐
+  │  /workspace         │──👁───│ code/   [R]  │
+  │  Read-only access.  │──✗───│ secrets/ [R] │
+  └─────────────────────┘       └─────────────┘
+
+  mountMode: "rw"
+  ┌─────────────────────┐       Host /workspace
+  │  Container          │       ┌─────────────┐
+  │  /workspace         │──⟷───│ code/  [RW]  │
+  │  Full read+write.   │       │ secrets/[RW] │
+  └─────────────────────┘       └─────────────┘
+```
+
+| Mode | `allowRead` | `allowWrite` | Use case |
+|------|-------------|--------------|----------|
+| `"none"` (default) | `[]` | `[]` | Untrusted code execution, strongest isolation |
+| `"ro"` | `[workDir]` | `[]` | Code review agents, analysis, read-only inspection |
+| `"rw"` | `[workDir]` | `[workDir]` | Development agents that need to modify files |
+
+`profileOverrides.filesystem` takes precedence over `mountMode` if both are provided.
+
+### Container Scope
+
+Controls how containers are shared across agents:
+
+```
+  scope: "session" — fresh container per create(), destroyed on dispose
+  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+  │ Container #1 │  │ Container #2 │  │ Container #3 │
+  │ (Agent A)    │  │ (Agent A)    │  │ (Agent B)    │
+  │ born → dies  │  │ born → dies  │  │ born → dies  │
+  └──────────────┘  └──────────────┘  └──────────────┘
+  Three requests = three containers. Nothing persists.
+
+  scope: "per-agent" (DEFAULT) — one container per agentId
+  ┌────────────────────────────────┐  ┌──────────────┐
+  │     Container #1 (Agent A)     │  │ Container #2 │
+  │     reused across requests     │  │ (Agent B)    │
+  └────────────────────────────────┘  └──────────────┘
+
+  scope: "shared" — single container, unique sub-paths per agent
+  ┌──────────────────────────────────────────────┐
+  │           Container #1 (shared)              │
+  │  /workspace/agent-a/   ← Agent A's space     │
+  │  /workspace/agent-b/   ← Agent B's space     │
+  │  ref_count: 2                                │
+  │  destroyed when last agent disposes          │
+  └──────────────────────────────────────────────┘
+```
+
+| Scope | Containers created | Isolation | State persistence | Best for |
+|-------|-------------------|-----------|-------------------|----------|
+| `"session"` | One per `create()` | Strongest | None | Untrusted workloads |
+| `"per-agent"` (default) | One per `agentId` | Per-agent | Across requests | Long-running dev agents |
+| `"shared"` | One total | Sub-path only | Shared container | Cost-sensitive, many agents |
+
+### Require Sandbox
+
+Policy guard that rejects non-container backends at factory time:
+
+```typescript
+const provider = createWorkspaceProvider({
+  backend: gitWorktreeBackend,   // isSandboxed: false
+  requireSandbox: true,          // ← VALIDATION error!
+});
+// Result.error: "requireSandbox is enabled but backend 'git-worktree'
+//               does not provide container isolation"
+```
+
+Backends self-declare their isolation capability via `isSandboxed: boolean`:
+
+| Backend | `isSandboxed` | `requireSandbox: true` |
+|---------|---------------|------------------------|
+| Docker container | `true` | Allowed |
+| Git worktree | `false` | Rejected |
+| Temp directory | `false` | Rejected |
+| E2B (custom) | `true` | Allowed |
+
+### Blocked Path Patterns
+
+In shared scope, agent IDs become sub-path names (`/workspace/{agentId}`). To prevent agents from targeting credential directories, the backend rejects agent IDs containing sensitive segments:
+
+```
+Blocked: .ssh  .gnupg  .aws  .azure  .gcloud  .kube  .docker
+         .env  .netrc  .npmrc  .secret  credentials
+         id_rsa  id_ed25519  private_key
+```
+
+```typescript
+// ❌ Rejected — ".ssh" segment detected
+backend.create(agentId("agent-.ssh-keys"), config);
+// Result.error: 'Agent ID "agent-.ssh-keys" contains blocked path segment ".ssh"'
+
+// ❌ Rejected — path traversal
+backend.create(agentId("../../etc/passwd"), config);
+// Result.error: 'Agent ID "../../etc/passwd" would escape workDir boundary'
+
+// ✅ Allowed
+backend.create(agentId("code-reviewer-42"), config);
+```
+
+These checks only apply to shared scope (where agent IDs become sub-paths). Per-agent and session scopes use the root `workDir` directly.
+
+### Docker Backend Quick Start
+
+```typescript
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createDockerWorkspaceBackend, createWorkspaceProvider } from "@koi/workspace";
+import type { WorkspaceComponent } from "@koi/core";
+import { WORKSPACE } from "@koi/core";
+
+// 1. Create backend with your SandboxAdapter
+const backend = createDockerWorkspaceBackend({
+  adapter: myDockerAdapter,
+  mountMode: "ro",
+  scope: "session",
+});
+if (!backend.ok) throw new Error(backend.error.message);
+
+// 2. Create provider with sandbox enforcement
+const provider = createWorkspaceProvider({
+  backend: backend.value,
+  requireSandbox: true,
+  cleanupPolicy: "always",
+});
+if (!provider.ok) throw new Error(provider.error.message);
+
+// 3. Wire into runtime
+const runtime = await createKoi({
+  manifest: { name: "reviewer", version: "1.0.0", model: { name: "claude-haiku-4-5-20251001" } },
+  adapter: createPiAdapter({ model: "anthropic:claude-haiku-4-5-20251001", getApiKey }),
+  providers: [provider.value],
+});
+
+// 4. Agent runs inside container with read-only filesystem
+const ws = runtime.agent.component<WorkspaceComponent>(WORKSPACE);
+console.log(ws?.path);     // /workspace
+console.log(ws?.metadata); // { adapterName: "docker", workDir: "/workspace" }
+```
+
+### SandboxAdapter Contract
+
+The Docker backend delegates container lifecycle to a `SandboxAdapter` (defined in L0):
+
+```typescript
+interface SandboxAdapter {
+  readonly name: string;
+  readonly create: (profile: SandboxProfile) => Promise<SandboxInstance>;
+}
+
+interface SandboxInstance {
+  readonly exec: (command: string, args: readonly string[]) => Promise<SandboxAdapterResult>;
+  readonly readFile: (path: string) => Promise<Uint8Array>;
+  readonly writeFile: (path: string, content: Uint8Array) => Promise<void>;
+  readonly destroy: () => Promise<void>;
+}
+```
+
+You implement this interface to plug in any container runtime — Docker CLI, E2B, Fly.io, OrbStack, etc.
 
 ## Cleanup Policies
 
@@ -342,6 +545,7 @@ function createTmpDirBackend(): Result<WorkspaceBackend, KoiError> {
     ok: true,
     value: {
       name: "tmpdir",
+      isSandboxed: false,  // no container isolation
 
       create: async (agentId: AgentId, _config: ResolvedWorkspaceConfig) => {
         const dir = await mkdtemp(`/tmp/koi-ws-${agentId}-`);
@@ -385,13 +589,18 @@ const provider = createWorkspaceProvider({
 |--------|------|---------|
 | `createWorkspaceProvider` | Factory | Creates a `ComponentProvider` for workspace isolation |
 | `createGitWorktreeBackend` | Factory | Git worktree `WorkspaceBackend` implementation |
+| `createDockerWorkspaceBackend` | Factory | Docker container `WorkspaceBackend` implementation |
+| `createFilesystemPolicy` | Utility | Derive `FilesystemPolicy` from a `MountMode` and workDir (Docker backend) |
 | `createShellSetup` | Factory | Convenience `postCreate` hook for shell commands |
 | `pruneStaleWorkspaces` | Utility | Detect and clean up orphaned workspaces |
 | `validateWorkspaceConfig` | Validation | Validate and apply defaults to config |
 | `WorkspaceBackend` | Interface | Strategy interface for custom backends |
 | `WorkspaceInfo` | Interface | Workspace metadata returned by backends |
-| `WorkspaceProviderConfig` | Interface | User-facing provider configuration (includes `pruneStale` hook) |
+| `WorkspaceProviderConfig` | Interface | User-facing provider configuration |
+| `DockerWorkspaceBackendConfig` | Interface | Docker backend configuration |
 | `CleanupPolicy` | Type | `"always" \| "on_success" \| "never"` |
+| `MountMode` | Type | `"none" \| "ro" \| "rw"` |
+| `ContainerScope` | Type | `"session" \| "per-agent" \| "shared"` |
 
 ## L0 Types (in @koi/core)
 

--- a/packages/workspace/src/__tests__/e2e-docker-features.test.ts
+++ b/packages/workspace/src/__tests__/e2e-docker-features.test.ts
@@ -1,0 +1,994 @@
+/**
+ * E2E: Docker workspace backend — MountMode, ContainerScope, requireSandbox.
+ *
+ * Validates the three new features end-to-end through the full Koi runtime
+ * assembly (createKoi) with real LLM calls via createPiAdapter and
+ * createLoopAdapter. Uses mock SandboxAdapter backed by real temp directories.
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test packages/workspace/src/__tests__/e2e-docker-features.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type {
+  AgentManifest,
+  EngineEvent,
+  EngineOutput,
+  SandboxAdapter,
+  SandboxAdapterResult,
+  SandboxInstance,
+  SandboxProfile,
+  WorkspaceComponent,
+} from "@koi/core";
+import { agentId, WORKSPACE } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createAnthropicAdapter } from "@koi/model-router";
+import { createDockerWorkspaceBackend } from "../docker-backend.js";
+import { createWorkspaceProvider } from "../provider.js";
+import type { WorkspaceBackend } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// E2E mock SandboxAdapter — backed by real host temp directory
+// ---------------------------------------------------------------------------
+
+const OK_EXEC: SandboxAdapterResult = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  durationMs: 1,
+  timedOut: false,
+  oomKilled: false,
+};
+
+interface AdapterTracking {
+  readonly createCalls: readonly SandboxProfile[];
+  readonly destroyCalls: readonly number[];
+}
+
+function createE2EMockAdapter(tempDir: string): SandboxAdapter & AdapterTracking {
+  // Mutable arrays justified: test-only tracking state.
+  const createCalls: SandboxProfile[] = [];
+  const destroyCalls: number[] = [];
+
+  return {
+    name: "e2e-feature-mock",
+    createCalls,
+    destroyCalls,
+
+    create: async (profile: SandboxProfile): Promise<SandboxInstance> => {
+      createCalls.push(profile);
+
+      return {
+        exec: async (command: string, args: readonly string[]): Promise<SandboxAdapterResult> => {
+          if (command === "test" && args[0] === "-d" && args[1]) {
+            const hostPath = join(tempDir, args[1]);
+            return { ...OK_EXEC, exitCode: existsSync(hostPath) ? 0 : 1 };
+          }
+          return OK_EXEC;
+        },
+
+        readFile: async (path: string): Promise<Uint8Array> => {
+          const hostPath = join(tempDir, path);
+          return new Uint8Array(await Bun.file(hostPath).arrayBuffer());
+        },
+
+        writeFile: async (path: string, content: Uint8Array): Promise<void> => {
+          const hostPath = join(tempDir, path);
+          const parentDir = dirname(hostPath);
+          if (!existsSync(parentDir)) {
+            await mkdir(parentDir, { recursive: true });
+          }
+          await Bun.write(hostPath, content);
+        },
+
+        destroy: async (): Promise<void> => {
+          destroyCalls.push(Date.now());
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function requireWs(ws: WorkspaceComponent | undefined): WorkspaceComponent {
+  if (ws === undefined) throw new Error("workspace component missing");
+  return ws;
+}
+
+function testManifest(name: string): AgentManifest {
+  return {
+    name,
+    version: "1.0.0",
+    description: `E2E feature test: ${name}`,
+    model: { name: "claude-haiku-4-5-20251001" },
+  };
+}
+
+function createModelHandler(): (
+  request: Parameters<import("@koi/core").ModelHandler>[0],
+) => ReturnType<import("@koi/core").ModelHandler> {
+  const adapter = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+  return (request) => adapter.complete(request);
+}
+
+// ===========================================================================
+// Feature 1: MountMode — via createPiAdapter (real LLM)
+// ===========================================================================
+
+describeE2E("e2e: MountMode through full Koi runtime", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-mountmode-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test(
+    'mountMode "ro" passes read-only profile to adapter, real LLM call succeeds',
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        mountMode: "ro",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with exactly: mount_ro_ok",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("mountmode-ro"),
+        adapter: piAdapter,
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      // Verify profile passed to adapter has ro settings
+      expect(mockAdapter.createCalls.length).toBe(1);
+      const profile = mockAdapter.createCalls[0];
+      if (!profile) throw new Error("expected adapter.create call");
+      expect(profile.filesystem.allowRead).toEqual(["/workspace"]);
+      expect(profile.filesystem.allowWrite).toEqual([]);
+
+      // Workspace should be attached
+      const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws.path).toBe("/workspace");
+
+      // Real LLM call
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: mount_ro_ok" }),
+      );
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      const text = extractText(events);
+      expect(text.toLowerCase()).toContain("mount_ro_ok");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    'mountMode "none" passes empty filesystem policy, real LLM call succeeds',
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        mountMode: "none",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with exactly: mount_none_ok",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("mountmode-none"),
+        adapter: piAdapter,
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      // Verify profile passed to adapter has none settings
+      const profile = mockAdapter.createCalls[0];
+      if (!profile) throw new Error("expected adapter.create call");
+      expect(profile.filesystem.allowRead).toEqual([]);
+      expect(profile.filesystem.allowWrite).toEqual([]);
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: mount_none_ok" }),
+      );
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(extractText(events).toLowerCase()).toContain("mount_none_ok");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test("profileOverrides.filesystem takes precedence over mountMode in full stack", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      mountMode: "none",
+      profileOverrides: {
+        filesystem: { allowRead: ["/override"], allowWrite: ["/override"] },
+      },
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const providerResult = createWorkspaceProvider({
+      backend: backendResult.value,
+      cleanupPolicy: "always",
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const loopAdapter = createLoopAdapter({
+      modelCall: createModelHandler(),
+      maxTurns: 1,
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest("mountmode-override"),
+      adapter: loopAdapter,
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    // Override should win over mountMode "none"
+    const profile = mockAdapter.createCalls[0];
+    if (!profile) throw new Error("expected adapter.create call");
+    expect(profile.filesystem.allowRead).toEqual(["/override"]);
+    expect(profile.filesystem.allowWrite).toEqual(["/override"]);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Reply: override_ok" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+    await runtime.dispose();
+  }, 60_000);
+});
+
+// ===========================================================================
+// Feature 1b: Default MountMode is "none" (most restrictive)
+// ===========================================================================
+
+describeE2E("e2e: default mountMode through full Koi runtime", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-default-mount-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test(
+    "omitting mountMode defaults to 'none' — empty filesystem policy, real LLM call succeeds",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      // No mountMode specified → should default to "none"
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const piAdapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with exactly: default_none_ok",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("default-mountmode"),
+        adapter: piAdapter,
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      // Verify: default is "none" — empty read and write arrays
+      expect(mockAdapter.createCalls.length).toBe(1);
+      const profile = mockAdapter.createCalls[0];
+      if (!profile) throw new Error("expected adapter.create call");
+      expect(profile.filesystem.allowRead).toEqual([]);
+      expect(profile.filesystem.allowWrite).toEqual([]);
+
+      // Real LLM call succeeds
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: default_none_ok" }),
+      );
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(extractText(events).toLowerCase()).toContain("default_none_ok");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "explicit mountMode 'rw' overrides default 'none', real LLM call succeeds",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        mountMode: "rw",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const runtime = await createKoi({
+        manifest: testManifest("explicit-rw"),
+        adapter: createPiAdapter({
+          model: E2E_MODEL,
+          systemPrompt: "Reply with exactly: rw_explicit_ok",
+          getApiKey: async () => ANTHROPIC_KEY,
+        }),
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      // Verify: explicit "rw" sets read+write
+      const profile = mockAdapter.createCalls[0];
+      if (!profile) throw new Error("expected adapter.create call");
+      expect(profile.filesystem.allowRead).toEqual(["/workspace"]);
+      expect(profile.filesystem.allowWrite).toEqual(["/workspace"]);
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: rw_explicit_ok" }),
+      );
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(extractText(events).toLowerCase()).toContain("rw_explicit_ok");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// Feature 1c: Blocked path patterns in shared scope
+// ===========================================================================
+
+describeE2E("e2e: blocked path patterns in shared scope", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-blocked-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("shared scope rejects agentId containing .ssh", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "shared",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    // Direct backend call with malicious agentId
+    const result = await backendResult.value.create(agentId("agent-.ssh-keys"), {
+      cleanupPolicy: "on_success",
+      cleanupTimeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("blocked path segment");
+    expect(result.error.message).toContain(".ssh");
+  });
+
+  test("shared scope rejects agentId containing credentials", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "shared",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const result = await backendResult.value.create(agentId("steal-credentials-now"), {
+      cleanupPolicy: "on_success",
+      cleanupTimeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("blocked path segment");
+  });
+
+  test("shared scope rejects agentId containing .env", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "shared",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const result = await backendResult.value.create(agentId("read-.env-file"), {
+      cleanupPolicy: "on_success",
+      cleanupTimeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("blocked path segment");
+    expect(result.error.message).toContain(".env");
+  });
+
+  test("shared scope allows safe agentId and full runtime succeeds", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "shared",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const providerResult = createWorkspaceProvider({
+      backend: backendResult.value,
+      cleanupPolicy: "always",
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const runtime = await createKoi({
+      manifest: testManifest("safe-shared-agent"),
+      adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    // Shared scope with safe name → workspace created
+    const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+    expect(ws.path).toContain("/workspace/");
+
+    // Real LLM call succeeds
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Say: safe_ok" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+    await runtime.dispose();
+  }, 60_000);
+
+  test("per-agent scope does NOT apply blocked path check (non-shared)", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "per-agent",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    // Per-agent scope doesn't use sub-paths, so blocked patterns don't apply
+    const result = await backendResult.value.create(agentId("agent-.ssh-keys"), {
+      cleanupPolicy: "on_success",
+      cleanupTimeoutMs: 5_000,
+    });
+    // Should succeed — blocked patterns only apply to shared scope sub-paths
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Feature 2: ContainerScope — session + shared via createLoopAdapter
+// ===========================================================================
+
+describeE2E("e2e: ContainerScope through full Koi runtime", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-scope-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Session scope ───────────────────────────────────────────────────────
+
+  test(
+    "session scope: fresh container per agent, real LLM calls succeed",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        scope: "session",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      // Agent 1
+      const provider1Result = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!provider1Result.ok) throw new Error(provider1Result.error.message);
+
+      const runtime1 = await createKoi({
+        manifest: testManifest("session-agent-1"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider1Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Agent 2
+      const provider2Result = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!provider2Result.ok) throw new Error(provider2Result.error.message);
+
+      const runtime2 = await createKoi({
+        manifest: testManifest("session-agent-2"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider2Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Session scope → two adapter.create calls (no reuse)
+      expect(mockAdapter.createCalls.length).toBe(2);
+
+      // Both get standard workspace path
+      const ws1 = requireWs(runtime1.agent.component<WorkspaceComponent>(WORKSPACE));
+      const ws2 = requireWs(runtime2.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws1.path).toBe("/workspace");
+      expect(ws2.path).toBe("/workspace");
+      expect(ws1.id).not.toBe(ws2.id);
+
+      // Real LLM calls in parallel
+      const [events1, events2] = await Promise.all([
+        collectEvents(runtime1.run({ kind: "text", text: "Say: session1" })),
+        collectEvents(runtime2.run({ kind: "text", text: "Say: session2" })),
+      ]);
+      expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+      expect(findDoneOutput(events2)?.stopReason).toBe("completed");
+
+      await Promise.all([runtime1.dispose(), runtime2.dispose()]);
+    },
+    TIMEOUT_MS,
+  );
+
+  test("session scope: dispose destroys container immediately", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({
+      adapter: mockAdapter,
+      scope: "session",
+    });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const providerResult = createWorkspaceProvider({
+      backend: backendResult.value,
+      cleanupPolicy: "always",
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const runtime = await createKoi({
+      manifest: testManifest("session-dispose"),
+      adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    expect(mockAdapter.destroyCalls.length).toBe(0);
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "OK" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+    // Detach with "always" policy → container destroyed
+    if (providerResult.value.detach) {
+      await providerResult.value.detach(runtime.agent);
+    }
+    expect(mockAdapter.destroyCalls.length).toBe(1);
+
+    await runtime.dispose();
+  }, 60_000);
+
+  // ── Shared scope ────────────────────────────────────────────────────────
+
+  test(
+    "shared scope: two agents share one container with unique sub-paths, real LLM calls succeed",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        scope: "shared",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      // Agent 1
+      const provider1Result = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!provider1Result.ok) throw new Error(provider1Result.error.message);
+
+      const runtime1 = await createKoi({
+        manifest: testManifest("shared-agent-1"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider1Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Agent 2
+      const provider2Result = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!provider2Result.ok) throw new Error(provider2Result.error.message);
+
+      const runtime2 = await createKoi({
+        manifest: testManifest("shared-agent-2"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider2Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Shared scope → only ONE adapter.create call
+      expect(mockAdapter.createCalls.length).toBe(1);
+
+      // Each agent gets unique sub-path
+      const ws1 = requireWs(runtime1.agent.component<WorkspaceComponent>(WORKSPACE));
+      const ws2 = requireWs(runtime2.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws1.path).toContain("/workspace/");
+      expect(ws2.path).toContain("/workspace/");
+      expect(ws1.path).not.toBe(ws2.path);
+
+      // Marker files exist on host at different sub-paths
+      const marker1 = join(tempDir, ws1.path, ".koi-workspace");
+      const marker2 = join(tempDir, ws2.path, ".koi-workspace");
+      expect(existsSync(marker1)).toBe(true);
+      expect(existsSync(marker2)).toBe(true);
+
+      // Real LLM calls in parallel
+      const [events1, events2] = await Promise.all([
+        collectEvents(runtime1.run({ kind: "text", text: "Say: shared1" })),
+        collectEvents(runtime2.run({ kind: "text", text: "Say: shared2" })),
+      ]);
+      expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+      expect(findDoneOutput(events2)?.stopReason).toBe("completed");
+
+      await Promise.all([runtime1.dispose(), runtime2.dispose()]);
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "shared scope: last dispose destroys the container",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        scope: "shared",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+      const backend = backendResult.value;
+
+      // Agent 1
+      const provider1Result = createWorkspaceProvider({
+        backend,
+        cleanupPolicy: "always",
+      });
+      if (!provider1Result.ok) throw new Error(provider1Result.error.message);
+
+      const runtime1 = await createKoi({
+        manifest: testManifest("shared-refcount-1"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider1Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Agent 2
+      const provider2Result = createWorkspaceProvider({
+        backend,
+        cleanupPolicy: "always",
+      });
+      if (!provider2Result.ok) throw new Error(provider2Result.error.message);
+
+      const runtime2 = await createKoi({
+        manifest: testManifest("shared-refcount-2"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        providers: [provider2Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Run both
+      await Promise.all([
+        collectEvents(runtime1.run({ kind: "text", text: "Say: ref1" })),
+        collectEvents(runtime2.run({ kind: "text", text: "Say: ref2" })),
+      ]);
+
+      // First detach → container NOT destroyed (ref count > 0)
+      if (provider1Result.value.detach) {
+        await provider1Result.value.detach(runtime1.agent);
+      }
+      expect(mockAdapter.destroyCalls.length).toBe(0);
+
+      // Second detach → container destroyed (last ref)
+      if (provider2Result.value.detach) {
+        await provider2Result.value.detach(runtime2.agent);
+      }
+      expect(mockAdapter.destroyCalls.length).toBe(1);
+
+      await Promise.all([runtime1.dispose(), runtime2.dispose()]);
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ===========================================================================
+// Feature 3: requireSandbox + isSandboxed
+// ===========================================================================
+
+describeE2E("e2e: requireSandbox through full Koi runtime", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-sandbox-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test(
+    "requireSandbox: true + docker backend (isSandboxed: true) → full runtime succeeds",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      // Verify isSandboxed flag
+      expect(backendResult.value.isSandboxed).toBe(true);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        requireSandbox: true,
+        cleanupPolicy: "always",
+      });
+      // Should succeed — docker backend is sandboxed
+      expect(providerResult.ok).toBe(true);
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const runtime = await createKoi({
+        manifest: testManifest("require-sandbox-pass"),
+        adapter: createPiAdapter({
+          model: E2E_MODEL,
+          systemPrompt: "Reply with exactly: sandbox_ok",
+          getApiKey: async () => ANTHROPIC_KEY,
+        }),
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws.path).toBe("/workspace");
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: sandbox_ok" }),
+      );
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+      expect(extractText(events).toLowerCase()).toContain("sandbox_ok");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  test("requireSandbox: true + non-sandboxed backend → provider creation fails", () => {
+    const fakeBackend: WorkspaceBackend = {
+      name: "tmpdir",
+      isSandboxed: false,
+      create: async () => ({
+        ok: true,
+        value: { id: "x", path: "/tmp", createdAt: 0, metadata: {} },
+      }),
+      dispose: async () => ({ ok: true, value: undefined }),
+      isHealthy: () => false,
+    };
+
+    const providerResult = createWorkspaceProvider({
+      backend: fakeBackend,
+      requireSandbox: true,
+    });
+
+    expect(providerResult.ok).toBe(false);
+    if (providerResult.ok) return;
+    expect(providerResult.error.code).toBe("VALIDATION");
+    expect(providerResult.error.message).toContain("requireSandbox");
+    expect(providerResult.error.message).toContain("container isolation");
+  });
+
+  test("requireSandbox: false (default) allows non-sandboxed backends", () => {
+    const fakeBackend: WorkspaceBackend = {
+      name: "tmpdir",
+      isSandboxed: false,
+      create: async () => ({
+        ok: true,
+        value: { id: "x", path: "/tmp", createdAt: 0, metadata: {} },
+      }),
+      dispose: async () => ({ ok: true, value: undefined }),
+      isHealthy: () => false,
+    };
+
+    // No requireSandbox → should succeed
+    const providerResult = createWorkspaceProvider({ backend: fakeBackend });
+    expect(providerResult.ok).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Combined: MountMode + Scope + Middleware chain via createPiAdapter
+// ===========================================================================
+
+describeE2E("e2e: all features combined through full runtime with middleware", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-e2e-combined-"));
+    await mkdir(join(tempDir, "workspace"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test(
+    'mountMode "ro" + session scope + requireSandbox + middleware: full integration',
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({
+        adapter: mockAdapter,
+        mountMode: "ro",
+        scope: "session",
+      });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        requireSandbox: true,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      // Middleware: observe model calls
+      // let justified: test tracking counter
+      let modelCallCount = 0;
+      const observer: import("@koi/core").KoiMiddleware = {
+        name: "e2e-model-observer",
+        wrapModelCall: async (_ctx, request, next) => {
+          modelCallCount += 1;
+          return next(request);
+        },
+      };
+
+      const runtime = await createKoi({
+        manifest: testManifest("combined-all-features"),
+        adapter: createLoopAdapter({ modelCall: createModelHandler(), maxTurns: 1 }),
+        middleware: [observer],
+        providers: [providerResult.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Verify: mountMode "ro" applied
+      const profile = mockAdapter.createCalls[0];
+      if (!profile) throw new Error("expected adapter.create call");
+      expect(profile.filesystem.allowRead).toEqual(["/workspace"]);
+      expect(profile.filesystem.allowWrite).toEqual([]);
+
+      // Verify: workspace attached
+      const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws.path).toBe("/workspace");
+
+      // Verify: isSandboxed flag
+      expect(backendResult.value.isSandboxed).toBe(true);
+
+      // Real LLM call through middleware chain
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: combined_ok" }),
+      );
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      // Middleware was exercised
+      expect(modelCallCount).toBeGreaterThanOrEqual(1);
+
+      // Session scope → container created once
+      expect(mockAdapter.createCalls.length).toBe(1);
+
+      // Cleanup
+      if (providerResult.value.detach) {
+        await providerResult.value.detach(runtime.agent);
+      }
+      // Session scope → destroyed on detach
+      expect(mockAdapter.destroyCalls.length).toBe(1);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/workspace/src/__tests__/e2e-docker.test.ts
+++ b/packages/workspace/src/__tests__/e2e-docker.test.ts
@@ -1,0 +1,702 @@
+/**
+ * E2E: Docker workspace backend wired through the full Koi runtime stack.
+ *
+ * Validates that createDockerWorkspaceBackend works end-to-end with:
+ *   - Full L1 runtime assembly (createKoi)
+ *   - Real LLM calls via both createPiAdapter and createLoopAdapter
+ *   - Middleware chain integration
+ *   - Workspace lifecycle (attach -> run -> detach -> cleanup)
+ *
+ * Uses a mock SandboxAdapter backed by a real temp directory on the host FS
+ * so that writeFile/exec operations are inspectable without a Docker daemon.
+ *
+ * Run:
+ *   E2E_TESTS=1 ANTHROPIC_API_KEY=sk-ant-... bun test packages/workspace/src/__tests__/e2e-docker.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentManifest,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  KoiMiddleware,
+  ModelHandler,
+  SandboxAdapter,
+  SandboxAdapterResult,
+  SandboxInstance,
+  SandboxProfile,
+  Tool,
+  WorkspaceComponent,
+} from "@koi/core";
+import { toolToken, WORKSPACE } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createLoopAdapter } from "@koi/engine-loop";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createAnthropicAdapter } from "@koi/model-router";
+import { createDockerWorkspaceBackend } from "../docker-backend.js";
+import { createWorkspaceProvider } from "../provider.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// E2E mock SandboxAdapter — backed by real host temp directory
+// ---------------------------------------------------------------------------
+
+const OK_EXEC_RESULT: SandboxAdapterResult = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  durationMs: 1,
+  timedOut: false,
+  oomKilled: false,
+};
+
+interface E2EMockAdapterTracking {
+  readonly createCalls: readonly SandboxProfile[];
+  readonly destroyCalls: readonly number[];
+}
+
+/**
+ * Create a mock SandboxAdapter backed by a real temp directory on host FS.
+ *
+ * - `writeFile(path, content)` writes to `tempDir + path` on host
+ * - `exec("test", ["-d", dir])` checks `tempDir + dir` exists (real FS check)
+ * - `destroy()` tracks the call for assertions
+ *
+ * This gives real filesystem inspection while avoiding Docker.
+ */
+function createE2EMockAdapter(tempDir: string): SandboxAdapter & E2EMockAdapterTracking {
+  // Mutable arrays justified: test-only tracking state.
+  const createCalls: SandboxProfile[] = [];
+  const destroyCalls: number[] = [];
+
+  return {
+    name: "e2e-mock-docker",
+    createCalls,
+    destroyCalls,
+
+    create: async (profile: SandboxProfile): Promise<SandboxInstance> => {
+      createCalls.push(profile);
+
+      return {
+        exec: async (command: string, args: readonly string[]): Promise<SandboxAdapterResult> => {
+          // Support real FS checks for "test -d <dir>"
+          if (command === "test" && args[0] === "-d" && args[1]) {
+            const hostPath = join(tempDir, args[1]);
+            const dirExists = existsSync(hostPath);
+            return { ...OK_EXEC_RESULT, exitCode: dirExists ? 0 : 1 };
+          }
+          return OK_EXEC_RESULT;
+        },
+
+        readFile: async (path: string): Promise<Uint8Array> => {
+          const hostPath = join(tempDir, path);
+          const file = Bun.file(hostPath);
+          return new Uint8Array(await file.arrayBuffer());
+        },
+
+        writeFile: async (path: string, content: Uint8Array): Promise<void> => {
+          const hostPath = join(tempDir, path);
+          // Ensure parent directory exists
+          const parentDir = hostPath.substring(0, hostPath.lastIndexOf("/"));
+          if (!existsSync(parentDir)) {
+            await Bun.write(hostPath, content);
+          } else {
+            await Bun.write(hostPath, content);
+          }
+        },
+
+        destroy: async (): Promise<void> => {
+          destroyCalls.push(Date.now());
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function requireWs(ws: WorkspaceComponent | undefined): WorkspaceComponent {
+  if (ws === undefined) throw new Error("workspace component missing");
+  return ws;
+}
+
+function testManifest(name: string = "e2e-docker-agent"): AgentManifest {
+  return {
+    name,
+    version: "1.0.0",
+    description: "E2E test agent with Docker workspace isolation",
+    model: { name: "claude-haiku-4-5-20251001" },
+  };
+}
+
+function createModelHandler(): ModelHandler {
+  const adapter = createAnthropicAdapter({ apiKey: ANTHROPIC_KEY });
+  return (request) => adapter.complete(request);
+}
+
+const ECHO_TOOL: Tool = {
+  descriptor: {
+    name: "echo",
+    description: "Returns the input text as-is. Use to confirm you can call tools.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "Text to echo back" },
+      },
+      required: ["text"],
+    },
+  },
+  trustTier: "sandbox",
+  execute: async (input: Readonly<Record<string, unknown>>) => {
+    return String(input.text ?? "");
+  },
+};
+
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-tool-provider",
+    attach: async () => new Map(tools.map((t) => [toolToken(t.descriptor.name) as string, t])),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createPiAdapter path (4 tests)
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: Docker workspace backend + createPiAdapter", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-docker-e2e-pi-"));
+    // Pre-create the /workspace directory so marker file writes succeed
+    await Bun.write(join(tempDir, "workspace", ".gitkeep"), "");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Test 1: Assembly + real LLM call ─────────────────────────────────
+
+  test(
+    "Docker workspace attaches via createKoi, real LLM call succeeds",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply with exactly: pong",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("docker-pi-assembly"),
+        adapter,
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      // Workspace component should be on the agent entity
+      const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws.path).toBe("/workspace");
+      expect(ws.metadata.adapterName).toBe("e2e-mock-docker");
+      expect(ws.metadata.workDir).toBe("/workspace");
+
+      // Marker file should exist on host FS
+      expect(existsSync(join(tempDir, "workspace", ".koi-workspace"))).toBe(true);
+
+      // Run a real LLM call
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: pong" }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+      expect(runtime.agent.state).toBe("terminated");
+      expect(runtime.agent.terminationOutcome).toBe("success");
+
+      const text = extractText(events);
+      expect(text.toLowerCase()).toContain("pong");
+
+      // Adapter should have been called once to create container
+      expect(mockAdapter.createCalls.length).toBe(1);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Cleanup "always" ─────────────────────────────────────────
+
+  test(
+    "cleanup 'always' disposes container after successful agent run",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt: "Reply briefly.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("docker-pi-cleanup"),
+        adapter,
+        providers: [providerResult.value],
+        loopDetection: false,
+      });
+
+      expect(mockAdapter.destroyCalls.length).toBe(0);
+
+      await collectEvents(runtime.run({ kind: "text", text: "Say: OK" }));
+
+      expect(runtime.agent.state).toBe("terminated");
+      expect(runtime.agent.terminationOutcome).toBe("success");
+
+      // Detach with "always" — container should be destroyed
+      if (providerResult.value.detach) {
+        await providerResult.value.detach(runtime.agent);
+      }
+      expect(mockAdapter.destroyCalls.length).toBe(1);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: on_success + interrupted ─────────────────────────────────
+
+  test(
+    "on_success preserves workspace on interrupted + pruneStale fires",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const pruneStale = mock(async (): Promise<void> => {});
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "on_success",
+        pruneStale,
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the echo tool to respond. Always call echo with the user's message.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("docker-pi-interrupted"),
+        adapter,
+        providers: [providerResult.value, createToolProvider([ECHO_TOOL])],
+        loopDetection: false,
+      });
+
+      // Start the run but abort it mid-stream to trigger "interrupted"
+      const controller = new AbortController();
+
+      const events: EngineEvent[] = [];
+      for await (const event of runtime.run({
+        kind: "text",
+        text: "Use the echo tool with 'hello'. Then explain the result in detail.",
+        signal: controller.signal,
+      })) {
+        events.push(event);
+        // Abort after we see the first text delta
+        if (event.kind === "text_delta") {
+          controller.abort();
+          break;
+        }
+      }
+
+      expect(runtime.agent.state).toBe("terminated");
+      expect(runtime.agent.terminationOutcome).toBe("interrupted");
+
+      // Detach — on_success + interrupted -> workspace preserved + pruneStale fires
+      if (providerResult.value.detach) {
+        await providerResult.value.detach(runtime.agent);
+      }
+      // Container should NOT be destroyed (preserved)
+      expect(mockAdapter.destroyCalls.length).toBe(0);
+      expect(pruneStale).toHaveBeenCalledTimes(1);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: Middleware + tool + workspace ─────────────────────────────
+
+  test(
+    "tool observer middleware intercepts echo tool call with Docker workspace attached",
+    async () => {
+      const mockAdapter = createE2EMockAdapter(tempDir);
+      const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+      if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+      const providerResult = createWorkspaceProvider({
+        backend: backendResult.value,
+        cleanupPolicy: "always",
+      });
+      if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+      // let justified: tracking middleware interception count
+      let toolCallCount = 0;
+      const toolObserver: KoiMiddleware = {
+        name: "tool-observer",
+        wrapToolCall: async (_ctx, request, next) => {
+          toolCallCount += 1;
+          return next(request);
+        },
+      };
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the echo tool for every request. Call echo with the user's text.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest("docker-pi-middleware"),
+        adapter,
+        middleware: [toolObserver],
+        providers: [providerResult.value, createToolProvider([ECHO_TOOL])],
+        loopDetection: false,
+      });
+
+      // Both workspace and tool should be on the agent
+      const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+      expect(ws.path).toBe("/workspace");
+      expect(ws.metadata.adapterName).toBe("e2e-mock-docker");
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Use echo with 'docker workspace test'" }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Middleware should have intercepted at least one tool call
+      expect(toolCallCount).toBeGreaterThanOrEqual(1);
+
+      // tool_call_start events should exist
+      const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+      expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+
+      if (providerResult.value.detach) {
+        await providerResult.value.detach(runtime.agent);
+      }
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// createLoopAdapter path (4 tests)
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: Docker workspace backend + createLoopAdapter", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-docker-e2e-loop-"));
+    // Pre-create the /workspace directory so marker file writes succeed
+    await Bun.write(join(tempDir, "workspace", ".gitkeep"), "");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Test 5: Assembly + real LLM call ─────────────────────────────────
+
+  test("Docker workspace attaches via createLoopAdapter, real LLM call succeeds", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const providerResult = createWorkspaceProvider({
+      backend: backendResult.value,
+      cleanupPolicy: "always",
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const adapter = createLoopAdapter({
+      modelCall: createModelHandler(),
+      maxTurns: 1,
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest("docker-loop-assembly"),
+      adapter,
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    // Workspace component should be on the agent entity
+    const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+    expect(ws.path).toBe("/workspace");
+    expect(ws.metadata.adapterName).toBe("e2e-mock-docker");
+    expect(ws.metadata.workDir).toBe("/workspace");
+
+    // Run a real LLM call
+    const events = await collectEvents(
+      runtime.run({ kind: "text", text: "Reply with exactly: DOCKER_OK" }),
+    );
+
+    const output = findDoneOutput(events);
+    expect(output).toBeDefined();
+    expect(output?.stopReason).toBe("completed");
+    expect(output?.metrics.totalTokens).toBeGreaterThan(0);
+
+    await runtime.dispose();
+  }, 60_000);
+
+  // ── Test 6: postCreate hook fires ────────────────────────────────────
+
+  test("postCreate hook runs during assembly, can write files in workspace", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    let hookCalled = false;
+    let hookWorkspacePath: string | undefined;
+
+    const providerResult = createWorkspaceProvider({
+      backend: backendResult.value,
+      cleanupPolicy: "always",
+      postCreate: async (ws) => {
+        hookCalled = true;
+        hookWorkspacePath = ws.path;
+        // The workspace path is "/workspace" (container-internal),
+        // but we can verify the hook received correct workspace info
+        expect(ws.metadata.adapterName).toBe("e2e-mock-docker");
+        expect(ws.id).toMatch(/^docker-/);
+      },
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const adapter = createLoopAdapter({
+      modelCall: createModelHandler(),
+      maxTurns: 1,
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest("docker-loop-postcreate"),
+      adapter,
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    expect(hookCalled).toBe(true);
+    expect(hookWorkspacePath).toBe("/workspace");
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Say yes." }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+    await runtime.dispose();
+  }, 60_000);
+
+  // ── Test 7: Two agents isolated ──────────────────────────────────────
+
+  test("two agents get independent Docker containers (parallel swarm)", async () => {
+    // Each agent gets its own mock adapter with its own temp dir
+    const tempDir2 = await mkdtemp(join(tmpdir(), "koi-docker-e2e-loop2-"));
+    await Bun.write(join(tempDir2, "workspace", ".gitkeep"), "");
+
+    try {
+      const mockAdapter1 = createE2EMockAdapter(tempDir);
+      const mockAdapter2 = createE2EMockAdapter(tempDir2);
+
+      const backend1Result = createDockerWorkspaceBackend({ adapter: mockAdapter1 });
+      const backend2Result = createDockerWorkspaceBackend({ adapter: mockAdapter2 });
+      if (!backend1Result.ok) throw new Error(backend1Result.error.message);
+      if (!backend2Result.ok) throw new Error(backend2Result.error.message);
+
+      const provider1Result = createWorkspaceProvider({
+        backend: backend1Result.value,
+        cleanupPolicy: "never",
+      });
+      const provider2Result = createWorkspaceProvider({
+        backend: backend2Result.value,
+        cleanupPolicy: "never",
+      });
+      if (!provider1Result.ok) throw new Error("Provider 1 failed");
+      if (!provider2Result.ok) throw new Error("Provider 2 failed");
+
+      const adapter1 = createLoopAdapter({
+        modelCall: createModelHandler(),
+        maxTurns: 1,
+      });
+      const adapter2 = createLoopAdapter({
+        modelCall: createModelHandler(),
+        maxTurns: 1,
+      });
+
+      const runtime1 = await createKoi({
+        manifest: testManifest("docker-swarm-1"),
+        adapter: adapter1,
+        providers: [provider1Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      const runtime2 = await createKoi({
+        manifest: testManifest("docker-swarm-2"),
+        adapter: adapter2,
+        providers: [provider2Result.value],
+        loopDetection: false,
+        limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+      });
+
+      // Both should have workspace components
+      const ws1 = requireWs(runtime1.agent.component<WorkspaceComponent>(WORKSPACE));
+      const ws2 = requireWs(runtime2.agent.component<WorkspaceComponent>(WORKSPACE));
+
+      // Path is the same ("/workspace") but the underlying instances are separate
+      expect(ws1.path).toBe("/workspace");
+      expect(ws2.path).toBe("/workspace");
+      // IDs must differ (includes agentId + timestamp)
+      expect(ws1.id).not.toBe(ws2.id);
+
+      // Marker files on different host temp dirs confirm isolation
+      expect(existsSync(join(tempDir, "workspace", ".koi-workspace"))).toBe(true);
+      expect(existsSync(join(tempDir2, "workspace", ".koi-workspace"))).toBe(true);
+
+      // Each adapter created exactly one container
+      expect(mockAdapter1.createCalls.length).toBe(1);
+      expect(mockAdapter2.createCalls.length).toBe(1);
+
+      // Run both agents in parallel
+      const [events1, events2] = await Promise.all([
+        collectEvents(runtime1.run({ kind: "text", text: "Say 'agent 1'." })),
+        collectEvents(runtime2.run({ kind: "text", text: "Say 'agent 2'." })),
+      ]);
+
+      expect(findDoneOutput(events1)?.stopReason).toBe("completed");
+      expect(findDoneOutput(events2)?.stopReason).toBe("completed");
+
+      await Promise.all([runtime1.dispose(), runtime2.dispose()]);
+    } finally {
+      await rm(tempDir2, { recursive: true, force: true });
+    }
+  }, 90_000);
+
+  // ── Test 8: isHealthy during lifecycle ───────────────────────────────
+
+  test("isHealthy returns true during run, false after dispose", async () => {
+    const mockAdapter = createE2EMockAdapter(tempDir);
+    const backendResult = createDockerWorkspaceBackend({ adapter: mockAdapter });
+    if (!backendResult.ok) throw new Error(backendResult.error.message);
+
+    const backend = backendResult.value;
+
+    const providerResult = createWorkspaceProvider({
+      backend,
+      cleanupPolicy: "always",
+    });
+    if (!providerResult.ok) throw new Error(providerResult.error.message);
+
+    const adapter = createLoopAdapter({
+      modelCall: createModelHandler(),
+      maxTurns: 1,
+    });
+
+    const runtime = await createKoi({
+      manifest: testManifest("docker-loop-healthy"),
+      adapter,
+      providers: [providerResult.value],
+      loopDetection: false,
+      limits: { maxTurns: 1, maxDurationMs: 30_000, maxTokens: 5_000 },
+    });
+
+    const ws = requireWs(runtime.agent.component<WorkspaceComponent>(WORKSPACE));
+
+    // isHealthy should return true while workspace is alive
+    // The mock adapter checks if tempDir + "/workspace" exists
+    const healthyDuringRun = await backend.isHealthy(ws.id);
+    expect(healthyDuringRun).toBe(true);
+
+    // Run a real LLM call
+    const events = await collectEvents(runtime.run({ kind: "text", text: "Reply: healthy" }));
+    expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+    // Detach triggers dispose for "always" policy
+    if (providerResult.value.detach) {
+      await providerResult.value.detach(runtime.agent);
+    }
+
+    // After dispose, isHealthy should return false (workspace removed from tracking)
+    const healthyAfterDispose = await backend.isHealthy(ws.id);
+    expect(healthyAfterDispose).toBe(false);
+
+    await runtime.dispose();
+  }, 60_000);
+});

--- a/packages/workspace/src/docker-backend.test.ts
+++ b/packages/workspace/src/docker-backend.test.ts
@@ -1,0 +1,684 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type {
+  AgentId,
+  SandboxAdapter,
+  SandboxAdapterResult,
+  SandboxInstance,
+  SandboxProfile,
+} from "@koi/core";
+import { agentId } from "@koi/core";
+import { createDockerWorkspaceBackend, createFilesystemPolicy } from "./docker-backend.js";
+import type { ResolvedWorkspaceConfig, WorkspaceBackend } from "./types.js";
+import { validateWorkspaceConfig } from "./validate-config.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIG: ResolvedWorkspaceConfig = {
+  cleanupPolicy: "on_success",
+  cleanupTimeoutMs: 5_000,
+};
+
+const OK_EXEC_RESULT: SandboxAdapterResult = {
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+  durationMs: 1,
+  timedOut: false,
+  oomKilled: false,
+};
+
+function createMockInstance(overrides?: {
+  readonly exec?: SandboxInstance["exec"];
+  readonly writeFile?: SandboxInstance["writeFile"];
+  readonly destroy?: SandboxInstance["destroy"];
+}): SandboxInstance & {
+  readonly destroyCalls: readonly unknown[];
+  readonly writtenFiles: readonly { readonly path: string; readonly content: Uint8Array }[];
+  readonly execCalls: readonly { readonly command: string; readonly args: readonly string[] }[];
+} {
+  // Mutable arrays justified: test-only tracking state, not production code.
+  const destroyCalls: unknown[] = [];
+  const writtenFiles: { readonly path: string; readonly content: Uint8Array }[] = [];
+  const execCalls: { readonly command: string; readonly args: readonly string[] }[] = [];
+
+  return {
+    destroyCalls,
+    writtenFiles,
+    execCalls,
+    exec:
+      overrides?.exec ??
+      (async (command, args) => {
+        execCalls.push({ command, args });
+        return OK_EXEC_RESULT;
+      }),
+    readFile: async () => new Uint8Array(0),
+    writeFile:
+      overrides?.writeFile ??
+      (async (path, content) => {
+        writtenFiles.push({ path, content });
+      }),
+    destroy:
+      overrides?.destroy ??
+      (async () => {
+        destroyCalls.push(Date.now());
+      }),
+  };
+}
+
+function createMockAdapter(
+  instance?: SandboxInstance,
+): SandboxAdapter & { readonly createCalls: readonly SandboxProfile[] } {
+  // Mutable array justified: test-only tracking state.
+  const createCalls: SandboxProfile[] = [];
+  const defaultInstance = instance ?? createMockInstance();
+
+  return {
+    name: "mock-docker",
+    createCalls,
+    create: async (profile: SandboxProfile) => {
+      createCalls.push(profile);
+      return defaultInstance;
+    },
+  };
+}
+
+const aid: AgentId = agentId("test-agent-1");
+
+// ---------------------------------------------------------------------------
+// Factory tests
+// ---------------------------------------------------------------------------
+
+describe("createDockerWorkspaceBackend", () => {
+  it("returns VALIDATION error when adapter is missing", () => {
+    // @ts-expect-error — testing runtime validation of missing adapter
+    const result = createDockerWorkspaceBackend({});
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("adapter");
+  });
+
+  it("returns ok with valid config", () => {
+    const adapter = createMockAdapter();
+    const result = createDockerWorkspaceBackend({ adapter });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.name).toBe("docker");
+  });
+
+  it("uses default workDir when not specified", async () => {
+    const adapter = createMockAdapter();
+    const result = createDockerWorkspaceBackend({ adapter });
+    if (!result.ok) throw new Error("factory failed");
+
+    const createResult = await result.value.create(aid, DEFAULT_CONFIG);
+    expect(createResult.ok).toBe(true);
+    if (!createResult.ok) return;
+    expect(createResult.value.path).toBe("/workspace");
+    expect(createResult.value.metadata.workDir).toBe("/workspace");
+  });
+
+  it("uses custom workDir when specified", async () => {
+    const adapter = createMockAdapter();
+    const result = createDockerWorkspaceBackend({ adapter, workDir: "/custom" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const createResult = await result.value.create(aid, DEFAULT_CONFIG);
+    expect(createResult.ok).toBe(true);
+    if (!createResult.ok) return;
+    expect(createResult.value.path).toBe("/custom");
+    expect(createResult.value.metadata.workDir).toBe("/custom");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backend method tests
+// ---------------------------------------------------------------------------
+
+describe("DockerWorkspaceBackend", () => {
+  let backend: WorkspaceBackend;
+  let mockInstance: ReturnType<typeof createMockInstance>;
+  let mockAdapter: ReturnType<typeof createMockAdapter>;
+
+  beforeEach(() => {
+    mockInstance = createMockInstance();
+    mockAdapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter: mockAdapter });
+    if (!result.ok) throw new Error(`Backend creation failed: ${result.error.message}`);
+    backend = result.value;
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  describe("create", () => {
+    it("returns correct WorkspaceInfo", async () => {
+      const result = await backend.create(aid, DEFAULT_CONFIG);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.id).toMatch(/^docker-test-agent-1-\d+$/);
+      expect(result.value.path).toBe("/workspace");
+      expect(typeof result.value.createdAt).toBe("number");
+      expect(result.value.metadata.adapterName).toBe("mock-docker");
+    });
+
+    it("writes marker file inside container", async () => {
+      const result = await backend.create(aid, DEFAULT_CONFIG);
+      if (!result.ok) throw new Error("create failed");
+
+      expect(mockInstance.writtenFiles.length).toBe(1);
+      const written = mockInstance.writtenFiles[0];
+      if (!written) throw new Error("expected written file");
+      expect(written.path).toBe("/workspace/.koi-workspace");
+
+      const marker = JSON.parse(new TextDecoder().decode(written.content));
+      expect(marker.agentId).toBe(String(aid));
+      expect(marker.workDir).toBe("/workspace");
+    });
+
+    it("returns EXTERNAL error when adapter.create throws", async () => {
+      const failAdapter: SandboxAdapter = {
+        name: "fail-docker",
+        create: async () => {
+          throw new Error("Docker daemon unavailable");
+        },
+      };
+      const failResult = createDockerWorkspaceBackend({ adapter: failAdapter });
+      if (!failResult.ok) throw new Error("factory failed");
+
+      const result = await failResult.value.create(aid, DEFAULT_CONFIG);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("EXTERNAL");
+      expect(result.error.retryable).toBe(true);
+      expect(result.error.message).toContain("Docker daemon unavailable");
+    });
+
+    it("returns EXTERNAL error when marker write fails", async () => {
+      const failInstance = createMockInstance({
+        writeFile: async () => {
+          throw new Error("Read-only filesystem");
+        },
+      });
+      const adapter = createMockAdapter(failInstance);
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      const result = await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("EXTERNAL");
+      expect(result.error.message).toContain("marker file");
+    });
+
+    it("cleans up container when marker write fails", async () => {
+      const failInstance = createMockInstance({
+        writeFile: async () => {
+          throw new Error("Read-only filesystem");
+        },
+      });
+      const adapter = createMockAdapter(failInstance);
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      expect(failInstance.destroyCalls.length).toBe(1);
+    });
+
+    it("defaults to mountMode 'none' (most restrictive)", async () => {
+      const adapter = createMockAdapter();
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      const call = adapter.createCalls[0];
+      if (!call) throw new Error("expected adapter.create call");
+      expect(call.filesystem.allowRead).toEqual([]);
+      expect(call.filesystem.allowWrite).toEqual([]);
+    });
+
+    it("passes profile overrides to adapter", async () => {
+      const adapter = createMockAdapter();
+      const factoryResult = createDockerWorkspaceBackend({
+        adapter,
+        profileOverrides: { network: { allow: true } },
+      });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      expect(adapter.createCalls.length).toBe(1);
+      const call = adapter.createCalls[0];
+      if (!call) throw new Error("expected adapter.create call");
+      expect(call.network.allow).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // dispose
+  // -------------------------------------------------------------------------
+
+  describe("dispose", () => {
+    it("destroys container and returns ok", async () => {
+      const createResult = await backend.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      const disposeResult = await backend.dispose(createResult.value.id);
+      expect(disposeResult.ok).toBe(true);
+      expect(mockInstance.destroyCalls.length).toBe(1);
+    });
+
+    it("returns NOT_FOUND for unknown workspace ID", async () => {
+      const result = await backend.dispose("unknown-id");
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns EXTERNAL error when destroy throws", async () => {
+      const failInstance = createMockInstance({
+        destroy: async () => {
+          throw new Error("Container stuck");
+        },
+      });
+      const adapter = createMockAdapter(failInstance);
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      const createResult = await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      const result = await factoryResult.value.dispose(createResult.value.id);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("EXTERNAL");
+      expect(result.error.retryable).toBe(false);
+    });
+
+    it("removes workspace from tracking after dispose", async () => {
+      const createResult = await backend.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      await backend.dispose(createResult.value.id);
+
+      // Second dispose should return NOT_FOUND
+      const second = await backend.dispose(createResult.value.id);
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isHealthy
+  // -------------------------------------------------------------------------
+
+  describe("isHealthy", () => {
+    it("returns true when exec probe succeeds", async () => {
+      const createResult = await backend.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      const healthy = await backend.isHealthy(createResult.value.id);
+      expect(healthy).toBe(true);
+    });
+
+    it("returns false for unknown workspace ID", async () => {
+      const healthy = await backend.isHealthy("nonexistent");
+      expect(healthy).toBe(false);
+    });
+
+    it("returns false when exec returns non-zero exit code", async () => {
+      const unhealthyInstance = createMockInstance({
+        exec: async () => ({ ...OK_EXEC_RESULT, exitCode: 1 }),
+      });
+      const adapter = createMockAdapter(unhealthyInstance);
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      const createResult = await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      const healthy = await factoryResult.value.isHealthy(createResult.value.id);
+      expect(healthy).toBe(false);
+    });
+
+    it("returns false when exec throws", async () => {
+      const throwInstance = createMockInstance({
+        exec: async () => {
+          throw new Error("Connection refused");
+        },
+      });
+      const adapter = createMockAdapter(throwInstance);
+      const factoryResult = createDockerWorkspaceBackend({ adapter });
+      if (!factoryResult.ok) throw new Error("factory failed");
+
+      const createResult = await factoryResult.value.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      const healthy = await factoryResult.value.isHealthy(createResult.value.id);
+      expect(healthy).toBe(false);
+    });
+
+    it("returns false after dispose", async () => {
+      const createResult = await backend.create(aid, DEFAULT_CONFIG);
+      if (!createResult.ok) throw new Error("create failed");
+
+      await backend.dispose(createResult.value.id);
+      const healthy = await backend.isHealthy(createResult.value.id);
+      expect(healthy).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MountMode tests
+// ---------------------------------------------------------------------------
+
+describe("createFilesystemPolicy", () => {
+  it('mountMode "none" sets empty allowRead/allowWrite', () => {
+    const policy = createFilesystemPolicy("none", "/workspace");
+    expect(policy.allowRead).toEqual([]);
+    expect(policy.allowWrite).toEqual([]);
+  });
+
+  it('mountMode "ro" sets allowRead only', () => {
+    const policy = createFilesystemPolicy("ro", "/workspace");
+    expect(policy.allowRead).toEqual(["/workspace"]);
+    expect(policy.allowWrite).toEqual([]);
+  });
+
+  it('mountMode "rw" matches default behavior', () => {
+    const policy = createFilesystemPolicy("rw", "/workspace");
+    expect(policy.allowRead).toEqual(["/workspace"]);
+    expect(policy.allowWrite).toEqual(["/workspace"]);
+  });
+});
+
+describe("mountMode config integration", () => {
+  it("applies mountMode to the profile passed to adapter", async () => {
+    const adapter = createMockAdapter();
+    const result = createDockerWorkspaceBackend({ adapter, mountMode: "ro" });
+    if (!result.ok) throw new Error("factory failed");
+
+    await result.value.create(aid, DEFAULT_CONFIG);
+    expect(adapter.createCalls.length).toBe(1);
+    const call = adapter.createCalls[0];
+    if (!call) throw new Error("expected adapter.create call");
+    expect(call.filesystem.allowRead).toEqual(["/workspace"]);
+    expect(call.filesystem.allowWrite).toEqual([]);
+  });
+
+  it("profileOverrides.filesystem takes precedence over mountMode", async () => {
+    const adapter = createMockAdapter();
+    const result = createDockerWorkspaceBackend({
+      adapter,
+      mountMode: "none",
+      profileOverrides: {
+        filesystem: { allowRead: ["/custom"], allowWrite: ["/custom"] },
+      },
+    });
+    if (!result.ok) throw new Error("factory failed");
+
+    await result.value.create(aid, DEFAULT_CONFIG);
+    const call = adapter.createCalls[0];
+    if (!call) throw new Error("expected adapter.create call");
+    expect(call.filesystem.allowRead).toEqual(["/custom"]);
+    expect(call.filesystem.allowWrite).toEqual(["/custom"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContainerScope tests
+// ---------------------------------------------------------------------------
+
+describe("shared scope", () => {
+  it("reuses same container for two agents", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    const agent2: AgentId = agentId("agent-2");
+    await result.value.create(agent1, DEFAULT_CONFIG);
+    await result.value.create(agent2, DEFAULT_CONFIG);
+
+    // adapter.create should only be called once for shared scope
+    expect(adapter.createCalls.length).toBe(1);
+  });
+
+  it("creates unique sub-paths per agent", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    const agent2: AgentId = agentId("agent-2");
+    const r1 = await result.value.create(agent1, DEFAULT_CONFIG);
+    const r2 = await result.value.create(agent2, DEFAULT_CONFIG);
+
+    if (!r1.ok || !r2.ok) throw new Error("create failed");
+    expect(r1.value.path).toBe("/workspace/agent-1");
+    expect(r2.value.path).toBe("/workspace/agent-2");
+  });
+
+  it("destroys container when last agent disposes", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    const agent2: AgentId = agentId("agent-2");
+    const r1 = await result.value.create(agent1, DEFAULT_CONFIG);
+    const r2 = await result.value.create(agent2, DEFAULT_CONFIG);
+    if (!r1.ok || !r2.ok) throw new Error("create failed");
+
+    // First dispose: should NOT destroy
+    await result.value.dispose(r1.value.id);
+    expect(mockInstance.destroyCalls.length).toBe(0);
+
+    // Second dispose: should destroy
+    await result.value.dispose(r2.value.id);
+    expect(mockInstance.destroyCalls.length).toBe(1);
+  });
+
+  it("isHealthy works for shared scope", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    const r1 = await result.value.create(agent1, DEFAULT_CONFIG);
+    if (!r1.ok) throw new Error("create failed");
+
+    const healthy = await result.value.isHealthy(r1.value.id);
+    expect(healthy).toBe(true);
+  });
+
+  it("rejects path-traversal agentId", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const malicious: AgentId = agentId("../../etc/passwd");
+    const r = await result.value.create(malicious, DEFAULT_CONFIG);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("VALIDATION");
+    expect(r.error.message).toContain("escape workDir");
+  });
+
+  it.each([
+    ".ssh",
+    ".gnupg",
+    ".aws",
+    ".azure",
+    ".gcloud",
+    ".kube",
+    ".docker",
+    ".env",
+    ".netrc",
+    ".npmrc",
+    ".secret",
+    "credentials",
+    "id_rsa",
+    "id_ed25519",
+    "private_key",
+  ])("rejects agentId containing blocked segment '%s'", async (segment) => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const r = await result.value.create(agentId(`agent-${segment}-x`), DEFAULT_CONFIG);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("VALIDATION");
+    expect(r.error.message).toContain("blocked path segment");
+    expect(r.error.message).toContain(segment);
+  });
+
+  it("allows safe agentId in shared scope", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const r = await result.value.create(agentId("safe-agent-42"), DEFAULT_CONFIG);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.path).toBe("/workspace/safe-agent-42");
+  });
+
+  it("serializes concurrent creates to single container", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "shared" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    const agent2: AgentId = agentId("agent-2");
+    const [r1, r2] = await Promise.all([
+      result.value.create(agent1, DEFAULT_CONFIG),
+      result.value.create(agent2, DEFAULT_CONFIG),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    // Only one container should be created
+    expect(adapter.createCalls.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSandbox tests
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Session scope tests
+// ---------------------------------------------------------------------------
+
+describe("session scope", () => {
+  it("creates a fresh container for every create call", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "session" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const agent1: AgentId = agentId("agent-1");
+    await result.value.create(agent1, DEFAULT_CONFIG);
+    await result.value.create(agent1, DEFAULT_CONFIG);
+
+    // Two create calls → two adapter.create calls (no reuse)
+    expect(adapter.createCalls.length).toBe(2);
+  });
+
+  it("destroys container immediately on dispose", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "session" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const r = await result.value.create(agentId("agent-1"), DEFAULT_CONFIG);
+    if (!r.ok) throw new Error("create failed");
+
+    const disposeResult = await result.value.dispose(r.value.id);
+    expect(disposeResult.ok).toBe(true);
+    expect(mockInstance.destroyCalls.length).toBe(1);
+  });
+
+  it("uses workDir directly (not sub-path)", async () => {
+    const mockInstance = createMockInstance();
+    const adapter = createMockAdapter(mockInstance);
+    const result = createDockerWorkspaceBackend({ adapter, scope: "session" });
+    if (!result.ok) throw new Error("factory failed");
+
+    const r = await result.value.create(agentId("agent-1"), DEFAULT_CONFIG);
+    if (!r.ok) throw new Error("create failed");
+    expect(r.value.path).toBe("/workspace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSandbox tests
+// ---------------------------------------------------------------------------
+
+describe("requireSandbox", () => {
+  it("passes with sandboxed backend (isSandboxed: true)", () => {
+    const adapter = createMockAdapter();
+    const backendResult = createDockerWorkspaceBackend({ adapter });
+    if (!backendResult.ok) throw new Error("factory failed");
+
+    const result = validateWorkspaceConfig({
+      backend: backendResult.value,
+      requireSandbox: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails with non-sandboxed backend (isSandboxed: false)", () => {
+    const fakeBackend: WorkspaceBackend = {
+      name: "tmpdir",
+      isSandboxed: false,
+      create: async () => ({
+        ok: true,
+        value: { id: "x", path: "/tmp", createdAt: 0, metadata: {} },
+      }),
+      dispose: async () => ({ ok: true, value: undefined }),
+      isHealthy: () => false,
+    };
+
+    const result = validateWorkspaceConfig({
+      backend: fakeBackend,
+      requireSandbox: true,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("requireSandbox");
+    expect(result.error.message).toContain("container isolation");
+  });
+
+  it("defaults to false — allows any backend", () => {
+    const fakeBackend: WorkspaceBackend = {
+      name: "tmpdir",
+      isSandboxed: false,
+      create: async () => ({
+        ok: true,
+        value: { id: "x", path: "/tmp", createdAt: 0, metadata: {} },
+      }),
+      dispose: async () => ({ ok: true, value: undefined }),
+      isHealthy: () => false,
+    };
+
+    const result = validateWorkspaceConfig({ backend: fakeBackend });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/workspace/src/docker-backend.ts
+++ b/packages/workspace/src/docker-backend.ts
@@ -1,0 +1,421 @@
+/**
+ * Docker container backend for workspace isolation.
+ *
+ * Creates isolated container workspaces per agent via a SandboxAdapter,
+ * with marker files for lifecycle tracking. No Docker SDK dependency —
+ * uses the L0 SandboxAdapter contract via dependency injection.
+ */
+
+import type {
+  AgentId,
+  FilesystemPolicy,
+  KoiError,
+  Result,
+  SandboxAdapter,
+  SandboxInstance,
+  SandboxProfile,
+} from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core";
+import type { ResolvedWorkspaceConfig, WorkspaceBackend, WorkspaceInfo } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Host filesystem mount mode for the container workspace. */
+export type MountMode = "none" | "ro" | "rw";
+
+/**
+ * Container reuse scope across agents.
+ * - "session": fresh ephemeral container per create(), destroyed on dispose (strongest isolation)
+ * - "per-agent": one container per agentId (default)
+ * - "shared": reuse a single container across all agents with unique sub-paths
+ */
+export type ContainerScope = "session" | "per-agent" | "shared";
+
+/** Configuration for the Docker container workspace backend. */
+export interface DockerWorkspaceBackendConfig {
+  /** Sandbox adapter that creates container instances. Injected from L2. */
+  readonly adapter: SandboxAdapter;
+  /** Override default sandbox profile settings (shallow merge). */
+  readonly profileOverrides?: Partial<SandboxProfile>;
+  /** Working directory inside the container. Default: "/workspace". */
+  readonly workDir?: string;
+  /**
+   * Filesystem mount mode. Default: "none" (most restrictive).
+   * - "none": isolated sandbox, no host mount
+   * - "ro": read-only workspace
+   * - "rw": full read-write
+   *
+   * `profileOverrides.filesystem` takes precedence over `mountMode` if both provided.
+   */
+  readonly mountMode?: MountMode;
+  /**
+   * Container reuse scope. Default: "per-agent".
+   * - "session": fresh ephemeral container per create(), destroyed on dispose (strongest isolation)
+   * - "per-agent": one container per agentId (current default)
+   * - "shared": reuse a single container across all agents with unique sub-paths
+   */
+  readonly scope?: ContainerScope;
+}
+
+const DEFAULT_WORK_DIR = "/workspace";
+const MARKER_FILENAME = ".koi-workspace";
+
+/**
+ * Path segments that must never appear in agent IDs used for shared-scope sub-paths.
+ * Prevents agents from targeting credential directories or sensitive files.
+ * Mirrors NanoClaw's blocked patterns.
+ */
+const BLOCKED_PATH_SEGMENTS: readonly string[] = [
+  ".ssh",
+  ".gnupg",
+  ".aws",
+  ".azure",
+  ".gcloud",
+  ".kube",
+  ".docker",
+  ".env",
+  ".netrc",
+  ".npmrc",
+  ".secret",
+  "credentials",
+  "id_rsa",
+  "id_ed25519",
+  "private_key",
+] as const;
+
+/** Derive FilesystemPolicy from a MountMode and workDir. */
+export function createFilesystemPolicy(mode: MountMode, workDir: string): FilesystemPolicy {
+  switch (mode) {
+    case "none":
+      return { allowRead: [], allowWrite: [] };
+    case "ro":
+      return { allowRead: [workDir], allowWrite: [] };
+    case "rw":
+      return { allowRead: [workDir], allowWrite: [workDir] };
+  }
+}
+
+const DEFAULT_PROFILE: SandboxProfile = {
+  tier: "sandbox",
+  filesystem: {
+    allowRead: [],
+    allowWrite: [],
+  },
+  network: { allow: false },
+  resources: { maxMemoryMb: 512 },
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Docker container WorkspaceBackend.
+ *
+ * Validates that the adapter is provided. Returns Result.error on
+ * validation failure. The returned backend creates one container per
+ * agent via the injected SandboxAdapter (or reuses a shared container
+ * when `scope: "shared"`).
+ */
+export function createDockerWorkspaceBackend(
+  config: DockerWorkspaceBackendConfig,
+): Result<WorkspaceBackend, KoiError> {
+  if (!config.adapter) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "DockerWorkspaceBackendConfig.adapter is required",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const { adapter } = config;
+  const workDir = config.workDir ?? DEFAULT_WORK_DIR;
+  const scope = config.scope ?? "per-agent";
+
+  // Resolve profile: profileOverrides.filesystem takes precedence over mountMode
+  const mountMode = config.mountMode ?? "none";
+  const baseProfile: SandboxProfile = {
+    ...DEFAULT_PROFILE,
+    filesystem: createFilesystemPolicy(mountMode, workDir),
+  };
+  const profile: SandboxProfile = config.profileOverrides
+    ? { ...baseProfile, ...config.profileOverrides }
+    : baseProfile;
+
+  /** Tracked entry: instance + the workspace directory for isHealthy probes. */
+  interface TrackedEntry {
+    readonly instance: SandboxInstance;
+    readonly workDir: string;
+  }
+
+  // Mutable Map justified: internal tracking state encapsulated in closure,
+  // not exposed to callers. Maps workspace ID → TrackedEntry for dispose/isHealthy.
+  const tracked = new Map<string, TrackedEntry>();
+
+  // Shared scope state: mutable ref count + instance, encapsulated in closure.
+  // let justified: shared instance is re-assigned on first create and last dispose.
+  let sharedState: { readonly instance: SandboxInstance; refCount: number } | undefined;
+  // let justified: serializes concurrent shared-scope creates to prevent double-create.
+  let pendingCreate: Promise<SandboxInstance> | undefined;
+
+  // TS control-flow narrows closure variables after early returns, but `await`
+  // can cause them to be modified by another microtask. This accessor prevents
+  // the narrowing so post-await reads see the actual runtime value.
+  function getSharedState(): typeof sharedState {
+    return sharedState;
+  }
+
+  function resolveSharedWorkDir(agentId: AgentId): Result<string, KoiError> {
+    const idStr = String(agentId);
+    const agentWorkDir = `${workDir}/${idStr}`;
+
+    // Defense-in-depth: reject paths that could escape the workDir container root
+    if (idStr.includes("..") || !agentWorkDir.startsWith(`${workDir}/`)) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `Agent ID "${idStr}" would escape workDir boundary`,
+          retryable: false,
+        },
+      };
+    }
+
+    // Reject agent IDs targeting credential/sensitive directories
+    const idLower = idStr.toLowerCase();
+    const blocked = BLOCKED_PATH_SEGMENTS.find((seg) => idLower.includes(seg));
+    if (blocked !== undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `Agent ID "${idStr}" contains blocked path segment "${blocked}"`,
+          retryable: false,
+        },
+      };
+    }
+
+    return { ok: true, value: agentWorkDir };
+  }
+
+  async function acquireInstance(
+    agentId: AgentId,
+  ): Promise<
+    Result<{ readonly instance: SandboxInstance; readonly agentWorkDir: string }, KoiError>
+  > {
+    if (scope === "shared") {
+      const resolved = resolveSharedWorkDir(agentId);
+      if (!resolved.ok) return resolved;
+      const agentWorkDir = resolved.value;
+
+      if (sharedState) {
+        sharedState.refCount += 1;
+        return { ok: true, value: { instance: sharedState.instance, agentWorkDir } };
+      }
+
+      // Serialize: if another create is in-flight, wait for it
+      if (pendingCreate) {
+        try {
+          await pendingCreate;
+        } catch (_e: unknown) {
+          // First caller handles the error; check sharedState below
+        }
+        // Re-read via accessor: TS narrowing can't track async mutations
+        const current = getSharedState();
+        if (current) {
+          current.refCount += 1;
+          return { ok: true, value: { instance: current.instance, agentWorkDir } };
+        }
+      }
+
+      try {
+        const createPromise = adapter.create(profile);
+        pendingCreate = createPromise;
+        const instance = await createPromise;
+        pendingCreate = undefined;
+        sharedState = { instance, refCount: 1 };
+        return { ok: true, value: { instance, agentWorkDir } };
+      } catch (e: unknown) {
+        pendingCreate = undefined;
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: `Failed to create shared container: ${e instanceof Error ? e.message : String(e)}`,
+            retryable: true,
+            cause: e,
+          },
+        };
+      }
+    }
+
+    // session / per-agent: each call creates a new container
+    try {
+      const instance = await adapter.create(profile);
+      return { ok: true, value: { instance, agentWorkDir: workDir } };
+    } catch (e: unknown) {
+      return {
+        ok: false,
+        error: {
+          code: "EXTERNAL",
+          message: `Failed to create container for agent ${agentId}: ${e instanceof Error ? e.message : String(e)}`,
+          retryable: true,
+          cause: e,
+        },
+      };
+    }
+  }
+
+  const backend: WorkspaceBackend = {
+    name: "docker",
+    isSandboxed: true,
+
+    create: async (
+      agentId: AgentId,
+      _config: ResolvedWorkspaceConfig,
+    ): Promise<Result<WorkspaceInfo, KoiError>> => {
+      const createdAt = Date.now();
+      const id = `docker-${agentId}-${createdAt}`;
+
+      const acquired = await acquireInstance(agentId);
+      if (!acquired.ok) return acquired;
+      const { instance, agentWorkDir } = acquired.value;
+
+      // Write marker file inside container for lifecycle tracking
+      const marker = JSON.stringify({ id, agentId, createdAt, workDir: agentWorkDir });
+      try {
+        await instance.writeFile(
+          `${agentWorkDir}/${MARKER_FILENAME}`,
+          new TextEncoder().encode(marker),
+        );
+      } catch (e: unknown) {
+        // Cleanup container on marker write failure (destroy if session or per-agent)
+        if (scope === "session" || scope === "per-agent") {
+          try {
+            await instance.destroy();
+          } catch (destroyErr: unknown) {
+            console.warn(
+              `[workspace] Best-effort container cleanup failed for agent ${agentId}:`,
+              destroyErr instanceof Error ? destroyErr.message : String(destroyErr),
+            );
+          }
+        } else if (sharedState) {
+          sharedState.refCount -= 1;
+          if (sharedState.refCount <= 0) {
+            try {
+              await sharedState.instance.destroy();
+            } catch (destroyErr: unknown) {
+              console.warn(
+                `[workspace] Best-effort shared container cleanup failed for agent ${agentId}:`,
+                destroyErr instanceof Error ? destroyErr.message : String(destroyErr),
+              );
+            }
+            sharedState = undefined;
+          }
+        }
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: `Failed to write marker file in container for agent ${agentId}: ${e instanceof Error ? e.message : String(e)}`,
+            retryable: true,
+            cause: e,
+          },
+        };
+      }
+
+      tracked.set(id, { instance, workDir: agentWorkDir });
+
+      return {
+        ok: true,
+        value: {
+          id,
+          path: agentWorkDir,
+          createdAt,
+          metadata: {
+            adapterName: adapter.name,
+            workDir: agentWorkDir,
+          },
+        },
+      };
+    },
+
+    dispose: async (workspaceId: string): Promise<Result<void, KoiError>> => {
+      const entry = tracked.get(workspaceId);
+      if (!entry) {
+        return {
+          ok: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `Unknown workspace ID: ${workspaceId}`,
+            retryable: RETRYABLE_DEFAULTS.NOT_FOUND,
+          },
+        };
+      }
+
+      // Delete before destroy (mirrors git backend pattern — prevents
+      // double-dispose if destroy throws and caller retries)
+      tracked.delete(workspaceId);
+
+      if (scope === "shared" && sharedState) {
+        sharedState.refCount -= 1;
+        if (sharedState.refCount > 0) {
+          return { ok: true, value: undefined };
+        }
+        // Last ref — destroy the shared container
+        const inst = sharedState.instance;
+        sharedState = undefined;
+        try {
+          await inst.destroy();
+        } catch (e: unknown) {
+          return {
+            ok: false,
+            error: {
+              code: "EXTERNAL",
+              message: `Failed to destroy shared container ${workspaceId}: ${e instanceof Error ? e.message : String(e)}`,
+              retryable: false,
+              cause: e,
+            },
+          };
+        }
+        return { ok: true, value: undefined };
+      }
+
+      try {
+        await entry.instance.destroy();
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: `Failed to destroy container ${workspaceId}: ${e instanceof Error ? e.message : String(e)}`,
+            retryable: false,
+            cause: e,
+          },
+        };
+      }
+
+      return { ok: true, value: undefined };
+    },
+
+    isHealthy: async (workspaceId: string): Promise<boolean> => {
+      const entry = tracked.get(workspaceId);
+      if (!entry) return false;
+
+      try {
+        const result = await entry.instance.exec("test", ["-d", entry.workDir]);
+        return result.exitCode === 0;
+      } catch (_e: unknown) {
+        // Probe semantics: any failure → unhealthy
+        return false;
+      }
+    },
+  };
+
+  return { ok: true, value: backend };
+}

--- a/packages/workspace/src/git-backend.ts
+++ b/packages/workspace/src/git-backend.ts
@@ -75,6 +75,7 @@ export function createGitWorktreeBackend(
 
   const backend: WorkspaceBackend = {
     name: "git-worktree",
+    isSandboxed: false,
 
     create: async (
       agentId: AgentId,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -5,6 +5,8 @@
  * via a pluggable WorkspaceBackend strategy (git worktrees, temp dirs, etc.).
  */
 
+export type { ContainerScope, DockerWorkspaceBackendConfig, MountMode } from "./docker-backend.js";
+export { createDockerWorkspaceBackend, createFilesystemPolicy } from "./docker-backend.js";
 export type { GitWorktreeBackendConfig } from "./git-backend.js";
 export { createGitWorktreeBackend } from "./git-backend.js";
 export { createWorkspaceProvider } from "./provider.js";

--- a/packages/workspace/src/provider.test.ts
+++ b/packages/workspace/src/provider.test.ts
@@ -44,6 +44,7 @@ function createMockBackend(): WorkspaceBackend & {
 
   return {
     name: "mock",
+    isSandboxed: false,
     createCalls,
     disposeCalls,
 
@@ -162,6 +163,7 @@ describe("WorkspaceProvider.attach", () => {
   it("throws when backend.create fails", async () => {
     const failBackend: WorkspaceBackend = {
       name: "fail",
+      isSandboxed: false,
       create: async () => ({
         ok: false as const,
         error: { code: "EXTERNAL" as const, message: "disk full", retryable: false },

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -27,6 +27,8 @@ export interface WorkspaceInfo {
  */
 export interface WorkspaceBackend {
   readonly name: string;
+  /** Whether this backend provides OS-level container isolation. */
+  readonly isSandboxed: boolean;
   readonly create: (
     agentId: AgentId,
     config: ResolvedWorkspaceConfig,
@@ -49,6 +51,11 @@ export interface WorkspaceProviderConfig {
   readonly postCreate?: (workspace: WorkspaceInfo) => Promise<void>;
   readonly pruneStale?: () => Promise<void>;
   readonly cleanupTimeoutMs?: number;
+  /**
+   * When `true`, validation rejects backends that are not container-based.
+   * Default: `false`.
+   */
+  readonly requireSandbox?: boolean;
 }
 
 /** Validated configuration with defaults applied. */

--- a/packages/workspace/src/validate-config.test.ts
+++ b/packages/workspace/src/validate-config.test.ts
@@ -5,6 +5,7 @@ import { validateWorkspaceConfig } from "./validate-config.js";
 
 const stubBackend: WorkspaceBackend = {
   name: "stub",
+  isSandboxed: false,
   create: async (
     _agentId: AgentId,
     _config: ResolvedWorkspaceConfig,

--- a/packages/workspace/src/validate-config.ts
+++ b/packages/workspace/src/validate-config.ts
@@ -65,6 +65,17 @@ export function validateWorkspaceConfig(
     };
   }
 
+  if (raw.requireSandbox === true && !raw.backend.isSandboxed) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `requireSandbox is enabled but backend '${raw.backend.name}' does not provide container isolation`,
+        retryable: false,
+      },
+    };
+  }
+
   return {
     ok: true,
     value: {


### PR DESCRIPTION
## Summary

Adds `createDockerWorkspaceBackend` to `@koi/workspace` — container-based agent isolation via pluggable `SandboxAdapter` with three configurable features:

- **MountMode** (`"none"` / `"ro"` / `"rw"`) — controls host filesystem visibility. Defaults to `"none"` (most restrictive, matching OpenClaw/NanoClaw industry practice)
- **ContainerScope** (`"session"` / `"per-agent"` / `"shared"`) — controls container reuse. Session = ephemeral per-create; per-agent = one per agentId; shared = ref-counted single container with unique sub-paths
- **requireSandbox + isSandboxed** — policy guard rejecting non-container backends at factory time via `backend.isSandboxed` capability flag

### Security hardening
- Path traversal guard in shared scope sub-paths (`..` detection)
- 15 blocked credential path patterns (`.ssh`, `.gnupg`, `.aws`, `.env`, `credentials`, etc.)
- Concurrent create serialization via `pendingCreate` promise (prevents double-create race)
- Best-effort cleanup logging on marker write failure

### Documentation
- Updated `docs/workspace.md` with full Docker backend section (mount mode, scope, requireSandbox, blocked paths, quick start, SandboxAdapter contract)

## Files changed

| File | Change |
|------|--------|
| `packages/workspace/src/docker-backend.ts` | New — Docker container backend implementation |
| `packages/workspace/src/docker-backend.test.ts` | New — 37 unit tests |
| `packages/workspace/src/__tests__/e2e-docker-features.test.ts` | New — 18 E2E tests (real LLM calls) |
| `packages/workspace/src/__tests__/e2e-docker.test.ts` | New — 8 base E2E tests |
| `packages/workspace/src/types.ts` | Add `isSandboxed`, `requireSandbox` |
| `packages/workspace/src/validate-config.ts` | Add `requireSandbox` validation |
| `packages/workspace/src/git-backend.ts` | Add `isSandboxed: false` |
| `packages/workspace/src/index.ts` | Export new types and factories |
| `docs/workspace.md` | Docker backend documentation |
| `**/provider.test.ts`, `**/validate-config.test.ts` | Add `isSandboxed` to mocks |

## Test plan

- [x] 86 unit tests pass (docker-backend + provider + validate-config)
- [x] 18 E2E feature tests pass (real LLM calls via `createKoi` + `createPiAdapter`/`createLoopAdapter`)
- [x] 8 original E2E tests pass (backward compatible)
- [x] Typecheck clean
- [x] Biome lint clean
- [x] Coverage: 95.45% functions, 92.73% lines

## Related issues

- Extends #16 (sandbox contract) with Docker workspace backend
- Prerequisite for #72 (K8s sandbox) and #485 (cloud sandbox adapters)
- Related to #394 (Nexus workspace backend)