### PR TITLE
feat: named tool profiles + model-capability-aware dynamic scaling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1020,6 +1020,8 @@
         "@koi/resolve": "workspace:*",
       },
       "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
         "@koi/test-utils": "workspace:*",
       },
     },

--- a/packages/middleware-tool-selector/package.json
+++ b/packages/middleware-tool-selector/package.json
@@ -15,6 +15,8 @@
     "@koi/resolve": "workspace:*"
   },
   "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
     "@koi/test-utils": "workspace:*"
   },
   "scripts": {

--- a/packages/middleware-tool-selector/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-tool-selector/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -5,29 +5,135 @@ exports[`@koi/middleware-tool-selector API surface . has stable type surface 1`]
 import { BrickDescriptor } from '@koi/resolve';
 
 /**
+ * Model capability tier detection — maps model names to capability tiers.
+ *
+ * Used by autoScale to cap tool surface based on the running model's capacity.
+ * Smaller models (Haiku, GPT-4o-mini) get fewer tools; larger models get more.
+ */
+/** Capability tier determines the maximum tool budget for a model. */
+type CapabilityTier = "minimal" | "standard" | "advanced" | "full";
+/** Per-tier tool budget configuration. */
+declare const MODEL_CAPABILITY_TIERS: Readonly<Record<CapabilityTier, {
+    readonly maxTools: number;
+}>>;
+/**
+ * Detects a model's capability tier from its name.
+ *
+ * Resolution order:
+ * 1. Exact match in overrides map (if provided)
+ * 2. First substring match in built-in patterns (ordered specific-to-general)
+ * 3. Default: "standard"
+ */
+declare function detectModelTier(modelName: string, overrides?: Readonly<Record<string, CapabilityTier>>): CapabilityTier;
+
+/**
+ * Named tool profiles — declarative presets for common agent roles.
+ *
+ * Instead of writing a custom selectTools function, declare \`profile: "coding"\`
+ * in the manifest and get a curated 4-10 tool set automatically.
+ */
+/**
+ * Predefined tool profiles. Each maps a role name to a readonly list of tool
+ * names. An empty list (like "full") means no filtering — all tools pass through.
+ */
+declare const TOOL_PROFILES: {
+    readonly minimal: readonly string[];
+    readonly coding: readonly string[];
+    readonly research: readonly string[];
+    readonly automation: readonly string[];
+    readonly conversation: readonly string[];
+    readonly full: readonly string[];
+};
+/** Valid profile name — one of the keys in TOOL_PROFILES. */
+type ToolProfileName = keyof typeof TOOL_PROFILES;
+/** Type guard for ToolProfileName. */
+declare function isToolProfileName(value: unknown): value is ToolProfileName;
+
+/**
  * Configuration for the tool-selector middleware.
+ *
+ * Supports three modes via discriminated union (kind is inferred from shape):
+ * - "custom": caller-provided selectTools function (backward compatible)
+ * - "profile": named tool profile (e.g., "coding", "research")
+ * - "auto": profile + model-capability-aware dynamic scaling
  */
 
-interface ToolSelectorConfig {
-    /** Caller-provided function that selects relevant tool names for a query. */
+interface ValidatedCustomConfig {
+    readonly kind: "custom";
     readonly selectTools: (query: string, tools: readonly ToolDescriptor[]) => Promise<readonly string[]>;
-    /** Tool names always included regardless of selection. */
     readonly alwaysInclude?: readonly string[];
-    /** Max tools to return from selector (default: 10). */
     readonly maxTools?: number;
-    /** Min tools threshold to activate filtering (default: 5). */
     readonly minTools?: number;
-    /** Custom query extraction from messages (default: last message text). */
     readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
 }
-declare function validateToolSelectorConfig(config: unknown): Result<ToolSelectorConfig, KoiError>;
+interface ValidatedProfileConfig {
+    readonly kind: "profile";
+    readonly profile: ToolProfileName;
+    readonly include?: readonly string[];
+    readonly exclude?: readonly string[];
+    readonly maxTools?: number;
+    readonly minTools?: number;
+    readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+}
+interface ValidatedAutoConfig {
+    readonly kind: "auto";
+    readonly profile: ToolProfileName | "auto";
+    readonly autoScale: true;
+    readonly modelTierOverrides?: Readonly<Record<string, CapabilityTier>>;
+    readonly tier?: CapabilityTier;
+    readonly include?: readonly string[];
+    readonly exclude?: readonly string[];
+    readonly maxTools?: number;
+    readonly minTools?: number;
+    readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+}
+type ValidatedToolSelectorConfig = ValidatedCustomConfig | ValidatedProfileConfig | ValidatedAutoConfig;
+/**
+ * Public config — callers provide one of:
+ * 1. \`{ selectTools }\` — custom selector (backward compatible)
+ * 2. \`{ profile }\` — named profile
+ * 3. \`{ profile, autoScale: true }\` — auto-scaling profile
+ */
+type ToolSelectorConfig = {
+    readonly selectTools: (query: string, tools: readonly ToolDescriptor[]) => Promise<readonly string[]>;
+    readonly alwaysInclude?: readonly string[];
+    readonly maxTools?: number;
+    readonly minTools?: number;
+    readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+} | {
+    readonly profile: ToolProfileName;
+    readonly include?: readonly string[];
+    readonly exclude?: readonly string[];
+    readonly maxTools?: number;
+    readonly minTools?: number;
+    readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+} | {
+    readonly profile: ToolProfileName | "auto";
+    readonly autoScale: true;
+    readonly modelTierOverrides?: Readonly<Record<string, CapabilityTier>>;
+    readonly tier?: CapabilityTier;
+    readonly include?: readonly string[];
+    readonly exclude?: readonly string[];
+    readonly maxTools?: number;
+    readonly minTools?: number;
+    readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+};
+/**
+ * Validates and normalizes tool selector config. Infers \`kind\` from shape:
+ * - \`selectTools\` present -> "custom"
+ * - \`profile\` present, no \`autoScale\` -> "profile"
+ * - \`profile\` present + \`autoScale: true\` -> "auto"
+ */
+declare function validateToolSelectorConfig(config: unknown): Result<ValidatedToolSelectorConfig, KoiError>;
 
 /**
  * BrickDescriptor for @koi/middleware-tool-selector.
  *
- * Enables manifest auto-resolution: validates tool selector config,
- * then creates the tool selector middleware with a basic keyword-matching
- * selectTools implementation for YAML-driven use.
+ * Enables manifest auto-resolution: validates tool selector config from
+ * YAML options, then creates the middleware. Supports three modes:
+ * - No profile: keyword-based defaultSelectTools (backward compatible)
+ * - profile: named tool profile (static filtering)
+ * - profile + autoScale: model-capability-aware dynamic profiles
  */
 
 /**
@@ -47,16 +153,54 @@ declare const descriptor: BrickDescriptor<KoiMiddleware>;
 declare function extractLastUserText(messages: readonly InboundMessage[]): string;
 
 /**
+ * Three-phase profile resolution: Resolve -> Modify -> Cap.
+ *
+ * Composes a final tool name list from a named profile, optional
+ * include/exclude modifiers, and an optional model tier cap.
+ */
+
+/** Input to the composed resolution pipeline. */
+interface ProfileResolutionInput {
+    readonly profile: ToolProfileName | "auto";
+    readonly tier?: CapabilityTier | undefined;
+    readonly include?: readonly string[] | undefined;
+    readonly exclude?: readonly string[] | undefined;
+}
+/** Result of profile resolution. */
+interface ResolvedProfile {
+    readonly toolNames: readonly string[];
+    readonly isFullProfile: boolean;
+}
+/**
+ * Composed profile resolution: Resolve -> Modify -> Cap.
+ *
+ * Returns the final tool name list and whether this is a "full" profile
+ * (which should short-circuit filtering entirely).
+ */
+declare function resolveProfile(input: ProfileResolutionInput): ResolvedProfile;
+
+/**
  * Tool-selector middleware — pre-filters tools before each model call.
+ *
+ * Supports three modes:
+ * - custom: dynamic selectTools function per call
+ * - profile: static precomputed tool set from a named profile
+ * - auto: profile + model-capability-aware scaling
  */
 
 /**
- * Creates a middleware that filters tools before each model call using a
- * caller-provided selector function. When the agent has many tools (20+),
- * this reduces token usage and improves model selection accuracy.
+ * Creates a middleware that filters tools before each model call.
+ *
+ * - custom config: uses caller-provided selectTools per call
+ * - profile/auto config: precomputes allowed tool Set at factory time
+ * - full profile: short-circuits (no filtering)
+ *
+ * For profile/auto modes, the tool allowlist is resolved once at creation time.
+ * If the model changes after middleware creation (e.g., fallback), the tier cap
+ * will NOT be re-evaluated. Recreate the middleware to pick up model changes.
  */
 declare function createToolSelectorMiddleware(config: ToolSelectorConfig): KoiMiddleware;
 
-export { type ToolSelectorConfig, createToolSelectorMiddleware, descriptor, extractLastUserText, validateToolSelectorConfig };
+export { type CapabilityTier, MODEL_CAPABILITY_TIERS, type ProfileResolutionInput, type ResolvedProfile, TOOL_PROFILES, type ToolProfileName, type ToolSelectorConfig, type ValidatedToolSelectorConfig, createToolSelectorMiddleware, descriptor, detectModelTier, extractLastUserText, isToolProfileName, resolveProfile, validateToolSelectorConfig };
 "
 `;

--- a/packages/middleware-tool-selector/src/__tests__/e2e-tool-profiles.test.ts
+++ b/packages/middleware-tool-selector/src/__tests__/e2e-tool-profiles.test.ts
@@ -1,0 +1,560 @@
+/**
+ * End-to-end tests for named tool profiles + model-capability-aware dynamic profiles.
+ *
+ * Validates the full stack: createKoi + createPiAdapter + real Anthropic LLM
+ * with tool-selector middleware wired through the middleware chain.
+ *
+ * Tests:
+ *   1. Profile mode ("coding") filters tools before model sees them
+ *   2. Profile mode with include/exclude modifiers
+ *   3. Auto mode with tier detection from manifest model name
+ *   4. Full profile short-circuits (all tools pass through)
+ *   5. Custom selectTools (backward compat) still works through createKoi
+ *   6. Profile middleware records profileMissingTools in metadata
+ *   7. Descriptor factory integration: profile from YAML-style options
+ *   8. Multi-tool agent: profile filters then model uses surviving tools
+ *
+ * Gated on ANTHROPIC_API_KEY + E2E_TESTS=1.
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test src/__tests__/e2e-tool-profiles.test.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentManifest,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  KoiMiddleware,
+  ModelChunk,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  ModelStreamHandler,
+  Tool,
+  TurnContext,
+} from "@koi/core";
+import { toolToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { TOOL_PROFILES } from "../tool-profiles.js";
+import { createToolSelectorMiddleware } from "../tool-selector.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function testManifest(modelName = "claude-haiku-4-5"): AgentManifest {
+  return {
+    name: "E2E Tool-Profile Agent",
+    version: "0.1.0",
+    model: { name: modelName },
+  };
+}
+
+function createAdapter(): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt:
+      "You are a concise test assistant. When asked to use a tool, always use it. Reply briefly.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions — 10 tools to exceed minTools threshold (default: 5)
+// ---------------------------------------------------------------------------
+
+function makeTool(name: string, description: string): Tool {
+  return {
+    descriptor: {
+      name,
+      description,
+      inputSchema: {
+        type: "object",
+        properties: { input: { type: "string" } },
+      },
+    },
+    trustTier: "sandbox",
+    execute: async (input: Readonly<Record<string, unknown>>) => {
+      return `${name} executed with: ${JSON.stringify(input)}`;
+    },
+  };
+}
+
+const MULTIPLY_TOOL: Tool = {
+  descriptor: {
+    name: "multiply",
+    description: "Multiplies two numbers together and returns the product.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First number" },
+        b: { type: "number", description: "Second number" },
+      },
+      required: ["a", "b"],
+    },
+  },
+  trustTier: "sandbox",
+  execute: async (input: Readonly<Record<string, unknown>>) => {
+    const a = Number(input.a ?? 0);
+    const b = Number(input.b ?? 0);
+    return String(a * b);
+  },
+};
+
+// Create many dummy tools to exceed minTools threshold
+const DUMMY_TOOLS: readonly Tool[] = [
+  makeTool("file_read", "Reads a file from disk"),
+  makeTool("file_write", "Writes content to a file"),
+  makeTool("file_list", "Lists files in a directory"),
+  makeTool("file_delete", "Deletes a file"),
+  makeTool("shell_exec", "Executes a shell command"),
+  makeTool("apply_patch", "Applies a diff patch to a file"),
+  makeTool("search_forge", "Searches the forge index"),
+  makeTool("web_fetch", "Fetches content from a URL"),
+  makeTool("web_search", "Searches the web"),
+  makeTool("memory_store", "Stores a memory"),
+  makeTool("memory_recall", "Recalls stored memories"),
+  makeTool("schedule_create", "Creates a scheduled task"),
+  makeTool("browser_navigate", "Navigates a browser to a URL"),
+];
+
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-tool-provider",
+    attach: async () => new Map(tools.map((t) => [toolToken(t.descriptor.name) as string, t])),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Middleware observer — captures what the model actually receives
+// ---------------------------------------------------------------------------
+
+interface ModelCallCapture {
+  readonly toolsBefore: number;
+  readonly toolsAfter: number;
+  readonly toolNames: readonly string[];
+  readonly profileMissingTools?: readonly string[] | undefined;
+}
+
+function createObserverMiddleware(): {
+  readonly middleware: KoiMiddleware;
+  readonly captures: ModelCallCapture[];
+} {
+  const captures: ModelCallCapture[] = [];
+
+  const middleware: KoiMiddleware = {
+    name: "e2e-observer",
+    priority: 999, // runs last (innermost) — sees the request AFTER tool-selector filters
+    describeCapabilities: () => undefined,
+    async wrapModelCall(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      const metadata = request.metadata as Record<string, unknown> | undefined;
+      captures.push({
+        toolsBefore: (metadata?.toolsBeforeFilter as number) ?? -1,
+        toolsAfter: (metadata?.toolsAfterFilter as number) ?? -1,
+        toolNames: (request.tools ?? []).map((t) => t.name),
+        profileMissingTools: metadata?.profileMissingTools as readonly string[] | undefined,
+      });
+      return next(request);
+    },
+
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): AsyncIterable<ModelChunk> {
+      const metadata = request.metadata as Record<string, unknown> | undefined;
+      captures.push({
+        toolsBefore: (metadata?.toolsBeforeFilter as number) ?? -1,
+        toolsAfter: (metadata?.toolsAfterFilter as number) ?? -1,
+        toolNames: (request.tools ?? []).map((t) => t.name),
+        profileMissingTools: metadata?.profileMissingTools as readonly string[] | undefined,
+      });
+      yield* next(request);
+    },
+  };
+
+  return { middleware, captures };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: tool profiles through createKoi + createPiAdapter", () => {
+  // ── Test 1: Profile mode filters tools ──────────────────────────────
+
+  test(
+    "profile: 'coding' filters 13 tools down to coding subset",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "coding",
+        minTools: 0, // always filter, even for small sets
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(DUMMY_TOOLS)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say hello" }));
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Observer should have captured the filtered request
+      expect(captures.length).toBeGreaterThanOrEqual(1);
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // All tool names after filtering should be from the coding profile
+      for (const name of capture.toolNames) {
+        expect(TOOL_PROFILES.coding).toContain(name);
+      }
+
+      // Metadata shows before/after counts
+      expect(capture.toolsBefore).toBeGreaterThan(capture.toolsAfter);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Profile with include/exclude modifiers ──────────────────
+
+  test(
+    "profile: 'minimal' with include=['multiply'] adds the multiply tool",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "minimal",
+        include: ["multiply"],
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const allTools = [...DUMMY_TOOLS, MULTIPLY_TOOL];
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(allTools)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say ok" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Should include multiply (from include) + minimal profile tools
+      expect(capture.toolNames).toContain("multiply");
+      expect(capture.toolNames).toContain("memory_store");
+      expect(capture.toolNames).toContain("memory_recall");
+
+      // Should NOT include coding-only tools like shell_exec
+      expect(capture.toolNames).not.toContain("shell_exec");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Auto mode with tier detection ───────────────────────────
+
+  test(
+    "autoScale with haiku model detects 'minimal' tier and caps tools",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "coding",
+        autoScale: true,
+        tier: "minimal", // simulate what descriptor would compute for haiku
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest("claude-haiku-4-5"),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(DUMMY_TOOLS)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say hi" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Minimal tier caps at 5 tools
+      expect(capture.toolNames.length).toBeLessThanOrEqual(5);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: Full profile short-circuits ─────────────────────────────
+
+  test(
+    "profile: 'full' passes all tools through (no filtering)",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "full",
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(DUMMY_TOOLS)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say ok" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Full profile = no filtering, all 13 tools should pass through
+      expect(capture.toolNames.length).toBe(DUMMY_TOOLS.length);
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Backward compat — custom selectTools works ─────────────
+
+  test(
+    "custom selectTools (backward compat) filters through createKoi",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        selectTools: async (_query, tools) => {
+          // Only keep tools with "file" in the name
+          return tools.filter((t) => t.name.includes("file")).map((t) => t.name);
+        },
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(DUMMY_TOOLS)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "List my tools" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Only file_* tools should survive
+      for (const name of capture.toolNames) {
+        expect(name).toContain("file");
+      }
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Profile missing tools metadata ──────────────────────────
+
+  test(
+    "records profileMissingTools when profile tools are absent from agent",
+    async () => {
+      // Register only 2 of the coding profile tools
+      const partialTools = [
+        makeTool("file_read", "Reads a file"),
+        makeTool("file_write", "Writes a file"),
+        // Missing: file_list, file_delete, shell_exec, apply_patch, search_forge
+        ...Array.from({ length: 4 }, (_, i) => makeTool(`extra_${i}`, `Extra tool ${i}`)),
+      ];
+
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "coding",
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(partialTools)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say ok" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Should report missing tools from the coding profile
+      expect(capture.profileMissingTools).toBeDefined();
+      expect(capture.profileMissingTools?.length).toBeGreaterThan(0);
+      // shell_exec is in coding profile but not in our registered tools
+      expect(capture.profileMissingTools).toContain("shell_exec");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Multi-tool agent with profile — model uses surviving tool
+
+  test(
+    "profile filters tools, model uses surviving multiply tool",
+    async () => {
+      // Use minimal profile + include multiply so model can use it
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "minimal",
+        include: ["multiply"],
+        minTools: 0,
+      });
+
+      const allTools = [...DUMMY_TOOLS, MULTIPLY_TOOL];
+
+      const adapter = createPiAdapter({
+        model: E2E_MODEL,
+        systemPrompt:
+          "You MUST use the multiply tool to answer math questions. Do not compute in your head.",
+        getApiKey: async () => ANTHROPIC_KEY,
+      });
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [toolSelectorMw],
+        providers: [createToolProvider(allTools)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Use the multiply tool to compute 6 * 7. Tell me the result.",
+        }),
+      );
+
+      const output = findDoneOutput(events);
+      expect(output).toBeDefined();
+      expect(output?.stopReason).toBe("completed");
+
+      // Tool should have been called
+      const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+      expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+
+      // Response should contain 42
+      const text = extractText(events);
+      expect(text).toContain("42");
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 8: Conversation profile — very small tool set ──────────────
+
+  test(
+    "profile: 'conversation' restricts to only memory tools",
+    async () => {
+      const toolSelectorMw = createToolSelectorMiddleware({
+        profile: "conversation",
+        minTools: 0,
+      });
+      const { middleware: observer, captures } = createObserverMiddleware();
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter: createAdapter(),
+        middleware: [toolSelectorMw, observer],
+        providers: [createToolProvider(DUMMY_TOOLS)],
+        loopDetection: false,
+      });
+
+      const events = await collectEvents(runtime.run({ kind: "text", text: "Say ok" }));
+
+      expect(findDoneOutput(events)?.stopReason).toBe("completed");
+
+      const capture = captures[0];
+      expect(capture).toBeDefined();
+      if (!capture) return;
+
+      // Conversation profile = only memory_store + memory_recall
+      expect(capture.toolNames.length).toBeLessThanOrEqual(2);
+      for (const name of capture.toolNames) {
+        expect(["memory_store", "memory_recall"]).toContain(name);
+      }
+
+      await runtime.dispose();
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/middleware-tool-selector/src/config.test.ts
+++ b/packages/middleware-tool-selector/src/config.test.ts
@@ -103,4 +103,91 @@ describe("validateToolSelectorConfig", () => {
       expect(result.error.message).toContain("extractQuery");
     }
   });
+
+  // -----------------------------------------------------------------------
+  // Profile config validation
+  // -----------------------------------------------------------------------
+
+  test("accepts valid profile config", () => {
+    const result = validateToolSelectorConfig({ profile: "coding" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("profile");
+    }
+  });
+
+  test("accepts profile config with include/exclude", () => {
+    const result = validateToolSelectorConfig({
+      profile: "coding",
+      include: ["extra"],
+      exclude: ["shell_exec"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("profile");
+    }
+  });
+
+  test("rejects invalid profile name", () => {
+    const result = validateToolSelectorConfig({ profile: "nonexistent" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("nonexistent");
+    }
+  });
+
+  test("rejects profile: 'auto' without autoScale", () => {
+    const result = validateToolSelectorConfig({ profile: "auto" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("auto");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto config validation
+  // -----------------------------------------------------------------------
+
+  test("accepts valid auto config", () => {
+    const result = validateToolSelectorConfig({
+      profile: "coding",
+      autoScale: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("auto");
+    }
+  });
+
+  test("accepts auto config with profile: 'auto'", () => {
+    const result = validateToolSelectorConfig({
+      profile: "auto",
+      autoScale: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("auto");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Mutual exclusion
+  // -----------------------------------------------------------------------
+
+  test("rejects config with both selectTools and profile", () => {
+    const result = validateToolSelectorConfig({
+      selectTools: validSelectTools,
+      profile: "coding",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("selectTools");
+      expect(result.error.message).toContain("profile");
+    }
+  });
+
+  test("rejects config with neither selectTools nor profile", () => {
+    const result = validateToolSelectorConfig({ maxTools: 10 });
+    expect(result.ok).toBe(false);
+  });
 });

--- a/packages/middleware-tool-selector/src/config.ts
+++ b/packages/middleware-tool-selector/src/config.ts
@@ -1,100 +1,276 @@
 /**
  * Configuration for the tool-selector middleware.
+ *
+ * Supports three modes via discriminated union (kind is inferred from shape):
+ * - "custom": caller-provided selectTools function (backward compatible)
+ * - "profile": named tool profile (e.g., "coding", "research")
+ * - "auto": profile + model-capability-aware dynamic scaling
  */
 
 import type { InboundMessage, KoiError, Result, ToolDescriptor } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CapabilityTier } from "./model-tier.js";
+import type { ToolProfileName } from "./tool-profiles.js";
+import { isToolProfileName } from "./tool-profiles.js";
 
-export interface ToolSelectorConfig {
-  /** Caller-provided function that selects relevant tool names for a query. */
+// ---------------------------------------------------------------------------
+// Internal validated config types (discriminated union)
+// ---------------------------------------------------------------------------
+
+export interface ValidatedCustomConfig {
+  readonly kind: "custom";
   readonly selectTools: (
     query: string,
     tools: readonly ToolDescriptor[],
   ) => Promise<readonly string[]>;
-  /** Tool names always included regardless of selection. */
   readonly alwaysInclude?: readonly string[];
-  /** Max tools to return from selector (default: 10). */
   readonly maxTools?: number;
-  /** Min tools threshold to activate filtering (default: 5). */
   readonly minTools?: number;
-  /** Custom query extraction from messages (default: last message text). */
   readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
 }
 
-export function validateToolSelectorConfig(config: unknown): Result<ToolSelectorConfig, KoiError> {
-  if (config === null || config === undefined || typeof config !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Config must be a non-null object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
+export interface ValidatedProfileConfig {
+  readonly kind: "profile";
+  readonly profile: ToolProfileName;
+  readonly include?: readonly string[];
+  readonly exclude?: readonly string[];
+  readonly maxTools?: number;
+  readonly minTools?: number;
+  readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+}
 
-  const c = config as Record<string, unknown>;
+export interface ValidatedAutoConfig {
+  readonly kind: "auto";
+  readonly profile: ToolProfileName | "auto";
+  readonly autoScale: true;
+  readonly modelTierOverrides?: Readonly<Record<string, CapabilityTier>>;
+  readonly tier?: CapabilityTier;
+  readonly include?: readonly string[];
+  readonly exclude?: readonly string[];
+  readonly maxTools?: number;
+  readonly minTools?: number;
+  readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+}
 
-  if (typeof c.selectTools !== "function") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Config requires a 'selectTools' function",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
+export type ValidatedToolSelectorConfig =
+  | ValidatedCustomConfig
+  | ValidatedProfileConfig
+  | ValidatedAutoConfig;
 
-  if (c.alwaysInclude !== undefined) {
-    if (!Array.isArray(c.alwaysInclude) || !c.alwaysInclude.every((x) => typeof x === "string")) {
-      return {
-        ok: false,
-        error: {
-          code: "VALIDATION",
-          message: "alwaysInclude must be an array of strings",
-          retryable: RETRYABLE_DEFAULTS.VALIDATION,
-        },
-      };
+// ---------------------------------------------------------------------------
+// Public input type (backward compatible — no `kind` required)
+// ---------------------------------------------------------------------------
+
+/**
+ * Public config — callers provide one of:
+ * 1. `{ selectTools }` — custom selector (backward compatible)
+ * 2. `{ profile }` — named profile
+ * 3. `{ profile, autoScale: true }` — auto-scaling profile
+ */
+export type ToolSelectorConfig =
+  | {
+      readonly selectTools: (
+        query: string,
+        tools: readonly ToolDescriptor[],
+      ) => Promise<readonly string[]>;
+      readonly alwaysInclude?: readonly string[];
+      readonly maxTools?: number;
+      readonly minTools?: number;
+      readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
     }
-  }
+  | {
+      readonly profile: ToolProfileName;
+      readonly include?: readonly string[];
+      readonly exclude?: readonly string[];
+      readonly maxTools?: number;
+      readonly minTools?: number;
+      readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+    }
+  | {
+      readonly profile: ToolProfileName | "auto";
+      readonly autoScale: true;
+      readonly modelTierOverrides?: Readonly<Record<string, CapabilityTier>>;
+      readonly tier?: CapabilityTier;
+      readonly include?: readonly string[];
+      readonly exclude?: readonly string[];
+      readonly maxTools?: number;
+      readonly minTools?: number;
+      readonly extractQuery?: (messages: readonly InboundMessage[]) => string;
+    };
 
+// ---------------------------------------------------------------------------
+// Shared field validation
+// ---------------------------------------------------------------------------
+
+function validationError(message: string): Result<never, KoiError> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function validateSharedFields(c: Record<string, unknown>): Result<true, KoiError> {
   if (c.maxTools !== undefined) {
     if (typeof c.maxTools !== "number" || c.maxTools <= 0 || !Number.isInteger(c.maxTools)) {
-      return {
-        ok: false,
-        error: {
-          code: "VALIDATION",
-          message: "maxTools must be a positive integer",
-          retryable: RETRYABLE_DEFAULTS.VALIDATION,
-        },
-      };
+      return validationError("maxTools must be a positive integer");
     }
   }
 
   if (c.minTools !== undefined) {
     if (typeof c.minTools !== "number" || c.minTools < 0 || !Number.isInteger(c.minTools)) {
-      return {
-        ok: false,
-        error: {
-          code: "VALIDATION",
-          message: "minTools must be a non-negative integer",
-          retryable: RETRYABLE_DEFAULTS.VALIDATION,
-        },
-      };
+      return validationError("minTools must be a non-negative integer");
     }
   }
 
   if (c.extractQuery !== undefined && typeof c.extractQuery !== "function") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "extractQuery must be a function",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
+    return validationError("extractQuery must be a function");
   }
 
-  return { ok: true, value: config as ToolSelectorConfig };
+  return { ok: true, value: true };
+}
+
+function validateStringArray(value: unknown, fieldName: string): Result<true, KoiError> {
+  if (value !== undefined) {
+    if (!Array.isArray(value) || !value.every((x) => typeof x === "string")) {
+      return validationError(`${fieldName} must be an array of strings`);
+    }
+  }
+  return { ok: true, value: true };
+}
+
+// ---------------------------------------------------------------------------
+// Builder helpers (avoid assigning undefined to optional properties)
+// ---------------------------------------------------------------------------
+
+/** Picks only defined optional fields — avoids exactOptionalPropertyTypes violations. */
+function pickDefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
+}
+
+function buildCustomConfig(c: Record<string, unknown>): ValidatedCustomConfig {
+  return {
+    kind: "custom",
+    selectTools: c.selectTools as ValidatedCustomConfig["selectTools"],
+    ...pickDefined({
+      alwaysInclude: c.alwaysInclude as readonly string[] | undefined,
+      maxTools: c.maxTools as number | undefined,
+      minTools: c.minTools as number | undefined,
+      extractQuery: c.extractQuery as ValidatedCustomConfig["extractQuery"],
+    }),
+  } as ValidatedCustomConfig;
+}
+
+function buildProfileConfig(
+  c: Record<string, unknown>,
+  profile: ToolProfileName,
+): ValidatedProfileConfig {
+  return {
+    kind: "profile",
+    profile,
+    ...pickDefined({
+      include: c.include as readonly string[] | undefined,
+      exclude: c.exclude as readonly string[] | undefined,
+      maxTools: c.maxTools as number | undefined,
+      minTools: c.minTools as number | undefined,
+      extractQuery: c.extractQuery as ValidatedProfileConfig["extractQuery"],
+    }),
+  } as ValidatedProfileConfig;
+}
+
+function buildAutoConfig(
+  c: Record<string, unknown>,
+  profile: ToolProfileName | "auto",
+): ValidatedAutoConfig {
+  return {
+    kind: "auto",
+    profile,
+    autoScale: true,
+    ...pickDefined({
+      modelTierOverrides: c.modelTierOverrides as
+        | Readonly<Record<string, CapabilityTier>>
+        | undefined,
+      tier: c.tier as CapabilityTier | undefined,
+      include: c.include as readonly string[] | undefined,
+      exclude: c.exclude as readonly string[] | undefined,
+      maxTools: c.maxTools as number | undefined,
+      minTools: c.minTools as number | undefined,
+      extractQuery: c.extractQuery as ValidatedAutoConfig["extractQuery"],
+    }),
+  } as ValidatedAutoConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Main validation function
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates and normalizes tool selector config. Infers `kind` from shape:
+ * - `selectTools` present -> "custom"
+ * - `profile` present, no `autoScale` -> "profile"
+ * - `profile` present + `autoScale: true` -> "auto"
+ */
+export function validateToolSelectorConfig(
+  config: unknown,
+): Result<ValidatedToolSelectorConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = config as Record<string, unknown>;
+
+  // Mutual exclusion: profile + selectTools is invalid
+  if ("selectTools" in c && "profile" in c) {
+    return validationError("Config cannot have both 'selectTools' and 'profile' — choose one");
+  }
+
+  // Validate shared fields
+  const sharedResult = validateSharedFields(c);
+  if (!sharedResult.ok) return sharedResult;
+
+  // Infer kind from shape
+  if (typeof c.selectTools === "function") {
+    // kind: "custom" (backward compatible path)
+    const includeResult = validateStringArray(c.alwaysInclude, "alwaysInclude");
+    if (!includeResult.ok) return includeResult;
+
+    return { ok: true, value: buildCustomConfig(c) };
+  }
+
+  if ("selectTools" in c) {
+    return validationError("Config requires a 'selectTools' function");
+  }
+
+  if ("profile" in c) {
+    // Validate profile name
+    const profileValue = c.profile;
+    if (profileValue !== "auto" && !isToolProfileName(profileValue)) {
+      return validationError(
+        `Invalid profile name '${String(profileValue)}' — must be a valid profile name or 'auto'`,
+      );
+    }
+
+    // Validate include/exclude
+    const includeResult = validateStringArray(c.include, "include");
+    if (!includeResult.ok) return includeResult;
+    const excludeResult = validateStringArray(c.exclude, "exclude");
+    if (!excludeResult.ok) return excludeResult;
+
+    if (c.autoScale === true) {
+      return { ok: true, value: buildAutoConfig(c, profileValue as ToolProfileName | "auto") };
+    }
+
+    // kind: "profile" — profile name must not be "auto" without autoScale
+    if (profileValue === "auto") {
+      return validationError("profile: 'auto' requires autoScale: true");
+    }
+
+    return { ok: true, value: buildProfileConfig(c, profileValue as ToolProfileName) };
+  }
+
+  // No selectTools and no profile — require at least one
+  return validationError("Config requires a 'selectTools' function or a 'profile' name");
 }

--- a/packages/middleware-tool-selector/src/descriptor.test.ts
+++ b/packages/middleware-tool-selector/src/descriptor.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest, ModelRequest, ModelResponse, ToolDescriptor } from "@koi/core";
+import type { ResolutionContext } from "@koi/resolve";
+import { createMockInboundMessage, createMockTurnContext } from "@koi/test-utils";
+import { descriptor } from "./descriptor.js";
+import { TOOL_PROFILES } from "./tool-profiles.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(modelName = "claude-sonnet-4-5"): ResolutionContext {
+  return {
+    manifestDir: "/tmp",
+    manifest: {
+      name: "test-agent",
+      version: "1.0.0",
+      model: { name: modelName },
+    } as AgentManifest,
+    env: {},
+  };
+}
+
+function makeTools(names: readonly string[]): readonly ToolDescriptor[] {
+  return names.map((name) => ({ name, description: `Tool ${name}`, inputSchema: {} }));
+}
+
+function makeRequest(tools: readonly ToolDescriptor[], text = "hello"): ModelRequest {
+  return {
+    messages: [createMockInboundMessage({ text })],
+    tools,
+  };
+}
+
+function mockModelResponse(): ModelResponse {
+  return { content: "ok", model: "test-model" };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("descriptor", () => {
+  test("has correct metadata", () => {
+    expect(descriptor.kind).toBe("middleware");
+    expect(descriptor.name).toBe("@koi/middleware-tool-selector");
+    expect(descriptor.aliases).toContain("tool-selector");
+  });
+
+  test("options: {} creates backward-compatible keyword matcher", async () => {
+    const mw = await descriptor.factory({}, makeContext());
+    expect(mw.name).toBe("tool-selector");
+  });
+
+  test("options: { profile: 'coding' } filters to profile tools", async () => {
+    const allTools = makeTools([
+      ...TOOL_PROFILES.coding,
+      "extra_tool_1",
+      "extra_tool_2",
+      "extra_tool_3",
+      "extra_tool_4",
+      "extra_tool_5",
+      "extra_tool_6",
+    ]);
+
+    const mw = await descriptor.factory({ profile: "coding" }, makeContext());
+    const ctx = createMockTurnContext();
+
+    let receivedRequest: ModelRequest | undefined;
+    const next = async (req: ModelRequest): Promise<ModelResponse> => {
+      receivedRequest = req;
+      return mockModelResponse();
+    };
+
+    await mw.wrapModelCall?.(ctx, makeRequest(allTools), next);
+
+    expect(receivedRequest).toBeDefined();
+    const names = receivedRequest?.tools?.map((t: { readonly name: string }) => t.name) ?? [];
+    // Should only contain tools from the coding profile
+    for (const name of names) {
+      expect(TOOL_PROFILES.coding).toContain(name);
+    }
+  });
+
+  test("options: { profile: 'coding', autoScale: true } with haiku model caps tools", async () => {
+    const allTools = makeTools([
+      ...TOOL_PROFILES.coding,
+      "extra_tool_1",
+      "extra_tool_2",
+      "extra_tool_3",
+    ]);
+
+    // Haiku model → minimal tier → maxTools: 5
+    const mw = await descriptor.factory(
+      { profile: "coding", autoScale: true },
+      makeContext("claude-3-haiku-20240307"),
+    );
+
+    const ctx = createMockTurnContext();
+    let receivedRequest: ModelRequest | undefined;
+    const next = async (req: ModelRequest): Promise<ModelResponse> => {
+      receivedRequest = req;
+      return mockModelResponse();
+    };
+
+    await mw.wrapModelCall?.(ctx, makeRequest(allTools), next);
+
+    expect(receivedRequest).toBeDefined();
+    // Coding has 7 tools but minimal tier caps at 5
+    expect((receivedRequest?.tools ?? []).length).toBeLessThanOrEqual(5);
+  });
+
+  test("options: { profile: 'nonexistent' } fails validation", () => {
+    const result = descriptor.optionsValidator({ profile: "nonexistent" });
+    expect(result.ok).toBe(false);
+  });
+
+  test("options: { profile: 'auto' } without autoScale fails validation", () => {
+    const result = descriptor.optionsValidator({ profile: "auto" });
+    expect(result.ok).toBe(false);
+  });
+
+  test("options: { maxTools: -1 } fails validation", () => {
+    const result = descriptor.optionsValidator({ maxTools: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("options: null fails validation", () => {
+    const result = descriptor.optionsValidator(null);
+    expect(result.ok).toBe(false);
+  });
+
+  test("options: {} keyword matcher selects tools by name/description overlap", async () => {
+    const tools = makeTools([
+      "file_read",
+      "web_search",
+      "shell_exec",
+      "memory_store",
+      "file_write",
+      "apply_patch",
+    ]);
+    const mw = await descriptor.factory({}, makeContext());
+    const ctx = createMockTurnContext();
+
+    let receivedRequest: ModelRequest | undefined;
+    const next = async (req: ModelRequest): Promise<ModelResponse> => {
+      receivedRequest = req;
+      return mockModelResponse();
+    };
+
+    // "file" should match file_read, file_write, and possibly apply_patch via description
+    await mw.wrapModelCall?.(ctx, makeRequest(tools, "read the file content"), next);
+
+    expect(receivedRequest).toBeDefined();
+    const names = receivedRequest?.tools?.map((t: { readonly name: string }) => t.name) ?? [];
+    expect(names).toContain("file_read");
+  });
+
+  test("options: {} keyword matcher passes all tools when query terms are short", async () => {
+    const tools = makeTools([
+      "file_read",
+      "web_search",
+      "shell_exec",
+      "memory_store",
+      "file_write",
+      "apply_patch",
+    ]);
+    const mw = await descriptor.factory({}, makeContext());
+    const ctx = createMockTurnContext();
+
+    let receivedRequest: ModelRequest | undefined;
+    const next = async (req: ModelRequest): Promise<ModelResponse> => {
+      receivedRequest = req;
+      return mockModelResponse();
+    };
+
+    // All terms are <= 2 chars, so keyword matcher returns all tools
+    await mw.wrapModelCall?.(ctx, makeRequest(tools, "hi go"), next);
+
+    expect(receivedRequest).toBeDefined();
+    // All 6 tools pass through because no terms match (all terms too short)
+    expect(receivedRequest?.tools).toHaveLength(6);
+  });
+});

--- a/packages/middleware-tool-selector/src/descriptor.ts
+++ b/packages/middleware-tool-selector/src/descriptor.ts
@@ -1,15 +1,20 @@
 /**
  * BrickDescriptor for @koi/middleware-tool-selector.
  *
- * Enables manifest auto-resolution: validates tool selector config,
- * then creates the tool selector middleware with a basic keyword-matching
- * selectTools implementation for YAML-driven use.
+ * Enables manifest auto-resolution: validates tool selector config from
+ * YAML options, then creates the middleware. Supports three modes:
+ * - No profile: keyword-based defaultSelectTools (backward compatible)
+ * - profile: named tool profile (static filtering)
+ * - profile + autoScale: model-capability-aware dynamic profiles
  */
 
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
-import type { BrickDescriptor } from "@koi/resolve";
+import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import type { ToolSelectorConfig } from "./config.js";
 import { extractLastUserText } from "./extract-query.js";
+import { detectModelTier } from "./model-tier.js";
+import { isToolProfileName } from "./tool-profiles.js";
 import { createToolSelectorMiddleware } from "./tool-selector.js";
 
 function validateToolSelectorDescriptorOptions(input: unknown): Result<unknown, KoiError> {
@@ -32,6 +37,30 @@ function validateToolSelectorDescriptorOptions(input: unknown): Result<unknown, 
       error: {
         code: "VALIDATION",
         message: "tool-selector.maxTools must be a positive number",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  // Validate profile name if present
+  if (opts.profile !== undefined && opts.profile !== "auto" && !isToolProfileName(opts.profile)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `tool-selector.profile '${String(opts.profile)}' is not a valid profile name`,
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  // profile: "auto" requires autoScale: true
+  if (opts.profile === "auto" && opts.autoScale !== true) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "tool-selector.profile 'auto' requires autoScale: true",
         retryable: RETRYABLE_DEFAULTS.VALIDATION,
       },
     };
@@ -67,6 +96,58 @@ async function defaultSelectTools(
 }
 
 /**
+ * Builds a ToolSelectorConfig from YAML options and resolution context.
+ */
+function createConfigFromOptions(
+  options: Record<string, unknown>,
+  context: ResolutionContext,
+): ToolSelectorConfig {
+  const maxTools = typeof options.maxTools === "number" ? options.maxTools : undefined;
+
+  // Profile mode or auto mode
+  if (typeof options.profile === "string") {
+    const include = Array.isArray(options.include)
+      ? (options.include as readonly string[])
+      : undefined;
+    const exclude = Array.isArray(options.exclude)
+      ? (options.exclude as readonly string[])
+      : undefined;
+
+    if (options.autoScale === true) {
+      // Auto mode: detect model tier from manifest
+      const modelName = context.manifest.model.name;
+      const tier = detectModelTier(modelName);
+
+      return {
+        profile: options.profile as "auto" | (typeof options.profile & string),
+        autoScale: true,
+        tier,
+        include,
+        exclude,
+        ...(maxTools !== undefined ? { maxTools } : {}),
+      } as ToolSelectorConfig;
+    }
+
+    // Profile mode
+    return {
+      profile: options.profile as string,
+      include,
+      exclude,
+      ...(maxTools !== undefined ? { maxTools } : {}),
+    } as ToolSelectorConfig;
+  }
+
+  // Custom mode (backward compatible): keyword-based default
+  const config: ToolSelectorConfig = {
+    selectTools: defaultSelectTools,
+    extractQuery: extractLastUserText,
+    ...(maxTools !== undefined ? { maxTools } : {}),
+  };
+
+  return config;
+}
+
+/**
  * Descriptor for tool-selector middleware.
  * Exported for registration with createRegistry().
  */
@@ -75,18 +156,9 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   name: "@koi/middleware-tool-selector",
   aliases: ["tool-selector"],
   optionsValidator: validateToolSelectorDescriptorOptions,
-  factory(options): KoiMiddleware {
-    const maxTools = typeof options.maxTools === "number" ? options.maxTools : undefined;
-
-    const config: Parameters<typeof createToolSelectorMiddleware>[0] = {
-      selectTools: defaultSelectTools,
-      extractQuery: extractLastUserText,
-    };
-
-    if (maxTools !== undefined) {
-      return createToolSelectorMiddleware({ ...config, maxTools });
-    }
-
+  factory(options, context): KoiMiddleware {
+    const opts = options as Record<string, unknown>;
+    const config = createConfigFromOptions(opts, context);
     return createToolSelectorMiddleware(config);
   },
 };

--- a/packages/middleware-tool-selector/src/index.ts
+++ b/packages/middleware-tool-selector/src/index.ts
@@ -1,13 +1,19 @@
 /**
  * @koi/middleware-tool-selector — Pre-filter tools before model calls (Layer 2)
  *
- * Uses a caller-provided selector function to reduce the set of tools
- * sent to the model, saving tokens and improving selection accuracy.
+ * Uses a caller-provided selector function or named profile to reduce the set
+ * of tools sent to the model, saving tokens and improving selection accuracy.
  * Depends on @koi/core only.
  */
 
-export type { ToolSelectorConfig } from "./config.js";
+export type { ToolSelectorConfig, ValidatedToolSelectorConfig } from "./config.js";
 export { validateToolSelectorConfig } from "./config.js";
 export { descriptor } from "./descriptor.js";
 export { extractLastUserText } from "./extract-query.js";
+export type { CapabilityTier } from "./model-tier.js";
+export { detectModelTier, MODEL_CAPABILITY_TIERS } from "./model-tier.js";
+export type { ProfileResolutionInput, ResolvedProfile } from "./resolve-profile.js";
+export { resolveProfile } from "./resolve-profile.js";
+export type { ToolProfileName } from "./tool-profiles.js";
+export { isToolProfileName, TOOL_PROFILES } from "./tool-profiles.js";
 export { createToolSelectorMiddleware } from "./tool-selector.js";

--- a/packages/middleware-tool-selector/src/model-tier.test.ts
+++ b/packages/middleware-tool-selector/src/model-tier.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { CapabilityTier } from "./model-tier.js";
+import { detectModelTier, MODEL_CAPABILITY_TIERS } from "./model-tier.js";
+
+describe("MODEL_CAPABILITY_TIERS", () => {
+  test("minimal tier has maxTools 5", () => {
+    expect(MODEL_CAPABILITY_TIERS.minimal.maxTools).toBe(5);
+  });
+
+  test("full tier has maxTools Infinity", () => {
+    expect(MODEL_CAPABILITY_TIERS.full.maxTools).toBe(Infinity);
+  });
+});
+
+describe("detectModelTier", () => {
+  const cases: Array<{ readonly model: string; readonly expected: CapabilityTier }> = [
+    { model: "claude-3-haiku-20240307", expected: "minimal" },
+    { model: "claude-haiku-4-5", expected: "minimal" },
+    { model: "gpt-4o-mini", expected: "minimal" },
+    { model: "claude-sonnet-4-5", expected: "standard" },
+    { model: "gpt-4o-2024-08-06", expected: "standard" },
+    { model: "claude-opus-4-5", expected: "advanced" },
+    { model: "o3-mini", expected: "standard" },
+    { model: "o3", expected: "advanced" },
+    { model: "o1-mini", expected: "standard" },
+    { model: "o1-preview", expected: "advanced" },
+  ];
+
+  test.each(cases)("detects $model as $expected", ({ model, expected }) => {
+    expect(detectModelTier(model)).toBe(expected);
+  });
+
+  test("returns 'standard' for unknown model", () => {
+    expect(detectModelTier("some-custom-model")).toBe("standard");
+  });
+
+  test("override map takes precedence over built-in patterns", () => {
+    const result = detectModelTier("claude-3-haiku-20240307", {
+      "claude-3-haiku-20240307": "full",
+    });
+    expect(result).toBe("full");
+  });
+
+  test("falls through to built-in when override has no match", () => {
+    const result = detectModelTier("claude-3-haiku-20240307", {
+      "other-model": "full",
+    });
+    expect(result).toBe("minimal");
+  });
+});

--- a/packages/middleware-tool-selector/src/model-tier.ts
+++ b/packages/middleware-tool-selector/src/model-tier.ts
@@ -1,0 +1,71 @@
+/**
+ * Model capability tier detection — maps model names to capability tiers.
+ *
+ * Used by autoScale to cap tool surface based on the running model's capacity.
+ * Smaller models (Haiku, GPT-4o-mini) get fewer tools; larger models get more.
+ */
+
+/** Capability tier determines the maximum tool budget for a model. */
+export type CapabilityTier = "minimal" | "standard" | "advanced" | "full";
+
+/** Per-tier tool budget configuration. */
+export const MODEL_CAPABILITY_TIERS: Readonly<
+  Record<CapabilityTier, { readonly maxTools: number }>
+> = {
+  minimal: { maxTools: 5 },
+  standard: { maxTools: 15 },
+  advanced: { maxTools: 30 },
+  full: { maxTools: Infinity },
+} as const satisfies Record<CapabilityTier, { readonly maxTools: number }>;
+
+/**
+ * Built-in model name -> tier patterns. Checked via substring match,
+ * ordered specific-to-general (e.g., "gpt-4o-mini" before "gpt-4o").
+ */
+const BUILTIN_MODEL_PATTERNS: readonly {
+  readonly pattern: string;
+  readonly tier: CapabilityTier;
+}[] = [
+  { pattern: "haiku", tier: "minimal" },
+  { pattern: "gpt-4o-mini", tier: "minimal" },
+  { pattern: "sonnet", tier: "standard" },
+  { pattern: "gpt-4o", tier: "standard" },
+  { pattern: "opus", tier: "advanced" },
+  { pattern: "o3-mini", tier: "standard" },
+  { pattern: "o3", tier: "advanced" },
+  { pattern: "o1-mini", tier: "standard" },
+  { pattern: "o1", tier: "advanced" },
+];
+
+const DEFAULT_TIER: CapabilityTier = "standard";
+
+/**
+ * Detects a model's capability tier from its name.
+ *
+ * Resolution order:
+ * 1. Exact match in overrides map (if provided)
+ * 2. First substring match in built-in patterns (ordered specific-to-general)
+ * 3. Default: "standard"
+ */
+export function detectModelTier(
+  modelName: string,
+  overrides?: Readonly<Record<string, CapabilityTier>>,
+): CapabilityTier {
+  // Check overrides first
+  if (overrides !== undefined) {
+    const override = overrides[modelName];
+    if (override !== undefined) {
+      return override;
+    }
+  }
+
+  // Substring match against built-in patterns
+  const lower = modelName.toLowerCase();
+  for (const entry of BUILTIN_MODEL_PATTERNS) {
+    if (lower.includes(entry.pattern)) {
+      return entry.tier;
+    }
+  }
+
+  return DEFAULT_TIER;
+}

--- a/packages/middleware-tool-selector/src/resolve-profile.test.ts
+++ b/packages/middleware-tool-selector/src/resolve-profile.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { resolveProfile } from "./resolve-profile.js";
+import { TOOL_PROFILES } from "./tool-profiles.js";
+
+describe("resolveProfile", () => {
+  test("profile: 'coding' returns the coding tool set", () => {
+    const result = resolveProfile({ profile: "coding" });
+    expect(result.toolNames).toEqual(TOOL_PROFILES.coding);
+    expect(result.isFullProfile).toBe(false);
+  });
+
+  test("profile: 'coding' with include adds extra tools", () => {
+    const result = resolveProfile({ profile: "coding", include: ["extra_tool"] });
+    expect(result.toolNames).toContain("extra_tool");
+    expect(result.toolNames.length).toBe(TOOL_PROFILES.coding.length + 1);
+  });
+
+  test("profile: 'coding' with exclude removes tools", () => {
+    const result = resolveProfile({ profile: "coding", exclude: ["shell_exec"] });
+    expect(result.toolNames).not.toContain("shell_exec");
+    expect(result.toolNames.length).toBe(TOOL_PROFILES.coding.length - 1);
+  });
+
+  test("include does not create duplicates", () => {
+    const result = resolveProfile({ profile: "coding", include: ["file_read"] });
+    const fileReadCount = result.toolNames.filter((n) => n === "file_read").length;
+    expect(fileReadCount).toBe(1);
+    expect(result.toolNames.length).toBe(TOOL_PROFILES.coding.length);
+  });
+
+  test("excluding all tools yields empty set", () => {
+    const result = resolveProfile({
+      profile: "coding",
+      exclude: [...TOOL_PROFILES.coding],
+    });
+    expect(result.toolNames).toEqual([]);
+    expect(result.isFullProfile).toBe(false);
+  });
+
+  test("profile: 'full' returns isFullProfile=true with empty toolNames", () => {
+    const result = resolveProfile({ profile: "full" });
+    expect(result.isFullProfile).toBe(true);
+    expect(result.toolNames).toEqual([]);
+  });
+
+  test("profile: 'auto' with tier 'minimal' resolves to minimal profile", () => {
+    const result = resolveProfile({ profile: "auto", tier: "minimal" });
+    expect(result.toolNames).toEqual(TOOL_PROFILES.minimal);
+  });
+
+  test("profile: 'auto' with no tier resolves to coding (standard default)", () => {
+    const result = resolveProfile({ profile: "auto" });
+    expect(result.toolNames).toEqual(TOOL_PROFILES.coding);
+    expect(result.isFullProfile).toBe(false);
+  });
+
+  test("tier cap truncates tools beyond maxTools", () => {
+    // coding has 7 tools; minimal tier caps at 5
+    const result = resolveProfile({ profile: "coding", tier: "minimal" });
+    expect(result.toolNames.length).toBeLessThanOrEqual(5);
+  });
+
+  test("nonexistent include/exclude names are no-ops", () => {
+    const result = resolveProfile({
+      profile: "minimal",
+      include: ["nonexistent_tool"],
+      exclude: ["also_nonexistent"],
+    });
+    // include adds it (it's just a name), exclude has nothing to remove from base
+    expect(result.toolNames).toContain("nonexistent_tool");
+    expect(result.toolNames.length).toBe(TOOL_PROFILES.minimal.length + 1);
+  });
+
+  test("profile: 'auto' with tier 'full' resolves to full profile", () => {
+    const result = resolveProfile({ profile: "auto", tier: "full" });
+    expect(result.isFullProfile).toBe(true);
+  });
+
+  test("profile: 'auto' with tier 'advanced' resolves to coding profile", () => {
+    const result = resolveProfile({ profile: "auto", tier: "advanced" });
+    expect(result.toolNames).toEqual(TOOL_PROFILES.coding);
+  });
+});

--- a/packages/middleware-tool-selector/src/resolve-profile.ts
+++ b/packages/middleware-tool-selector/src/resolve-profile.ts
@@ -1,0 +1,112 @@
+/**
+ * Three-phase profile resolution: Resolve -> Modify -> Cap.
+ *
+ * Composes a final tool name list from a named profile, optional
+ * include/exclude modifiers, and an optional model tier cap.
+ */
+
+import type { CapabilityTier } from "./model-tier.js";
+import { MODEL_CAPABILITY_TIERS } from "./model-tier.js";
+import type { ToolProfileName } from "./tool-profiles.js";
+import { TOOL_PROFILES } from "./tool-profiles.js";
+
+/** Input to the composed resolution pipeline. */
+export interface ProfileResolutionInput {
+  readonly profile: ToolProfileName | "auto";
+  readonly tier?: CapabilityTier | undefined;
+  readonly include?: readonly string[] | undefined;
+  readonly exclude?: readonly string[] | undefined;
+}
+
+/** Result of profile resolution. */
+export interface ResolvedProfile {
+  readonly toolNames: readonly string[];
+  readonly isFullProfile: boolean;
+}
+
+/** Maps auto profile to the appropriate named profile for a given tier. */
+const AUTO_TIER_MAP: Record<CapabilityTier, ToolProfileName> = {
+  minimal: "minimal",
+  standard: "coding",
+  advanced: "coding",
+  full: "full",
+} as const;
+
+/**
+ * Phase 1: Resolve a profile name (or "auto") to a base tool list.
+ *
+ * For "auto", the tier determines which named profile to use.
+ * For a named profile, returns its tool list directly.
+ */
+function resolveBaseProfile(
+  profile: ToolProfileName | "auto",
+  tier?: CapabilityTier,
+): readonly string[] {
+  if (profile === "auto") {
+    const resolvedName = AUTO_TIER_MAP[tier ?? "standard"];
+    return TOOL_PROFILES[resolvedName];
+  }
+  return TOOL_PROFILES[profile];
+}
+
+/**
+ * Phase 2: Apply include/exclude modifiers to a base tool list.
+ *
+ * - include: adds tools not already present
+ * - exclude: removes tools by name
+ */
+function applyModifiers(
+  base: readonly string[],
+  include?: readonly string[],
+  exclude?: readonly string[],
+): readonly string[] {
+  const excludeSet = exclude !== undefined ? new Set(exclude) : undefined;
+
+  // Start with base, exclude any in the exclude set
+  const filtered =
+    excludeSet !== undefined ? base.filter((name) => !excludeSet.has(name)) : [...base];
+
+  // Add included names not already present
+  if (include !== undefined) {
+    const existing = new Set(filtered);
+    const additions = include.filter((name) => !existing.has(name));
+    return [...filtered, ...additions];
+  }
+
+  return filtered;
+}
+
+/**
+ * Phase 3: Cap tool count by model tier limit.
+ *
+ * If the list exceeds the tier's maxTools, truncate to fit.
+ */
+function applyTierCap(tools: readonly string[], tier: CapabilityTier): readonly string[] {
+  const { maxTools } = MODEL_CAPABILITY_TIERS[tier];
+  if (tools.length <= maxTools) {
+    return tools;
+  }
+  return tools.slice(0, maxTools);
+}
+
+/**
+ * Composed profile resolution: Resolve -> Modify -> Cap.
+ *
+ * Returns the final tool name list and whether this is a "full" profile
+ * (which should short-circuit filtering entirely).
+ */
+export function resolveProfile(input: ProfileResolutionInput): ResolvedProfile {
+  const base = resolveBaseProfile(input.profile, input.tier);
+
+  // "full" profile means no filtering
+  if (base.length === 0) {
+    return { toolNames: [], isFullProfile: true };
+  }
+
+  const modified = applyModifiers(base, input.include, input.exclude);
+
+  // Apply tier cap only if a tier is specified
+  const capped = input.tier !== undefined ? applyTierCap(modified, input.tier) : modified;
+
+  return { toolNames: capped, isFullProfile: false };
+}

--- a/packages/middleware-tool-selector/src/tool-profiles.test.ts
+++ b/packages/middleware-tool-selector/src/tool-profiles.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { isToolProfileName, TOOL_PROFILES } from "./tool-profiles.js";
+
+describe("TOOL_PROFILES", () => {
+  test("contains all 6 expected profiles", () => {
+    expect(Object.keys(TOOL_PROFILES)).toEqual([
+      "minimal",
+      "coding",
+      "research",
+      "automation",
+      "conversation",
+      "full",
+    ]);
+  });
+
+  test("full profile is an empty array (no filtering)", () => {
+    expect(TOOL_PROFILES.full).toEqual([]);
+  });
+
+  test("coding profile has 7 tools", () => {
+    expect(TOOL_PROFILES.coding).toHaveLength(7);
+  });
+
+  test("profiles are readonly arrays", () => {
+    expect(Array.isArray(TOOL_PROFILES.minimal)).toBe(true);
+    expect(Array.isArray(TOOL_PROFILES.coding)).toBe(true);
+  });
+});
+
+describe("isToolProfileName", () => {
+  test("returns true for valid profile names", () => {
+    expect(isToolProfileName("coding")).toBe(true);
+    expect(isToolProfileName("minimal")).toBe(true);
+    expect(isToolProfileName("full")).toBe(true);
+  });
+
+  test("returns false for invalid profile names", () => {
+    expect(isToolProfileName("nonexistent")).toBe(false);
+    expect(isToolProfileName("")).toBe(false);
+    expect(isToolProfileName(42)).toBe(false);
+    expect(isToolProfileName(null)).toBe(false);
+  });
+
+  test("returns false for 'auto' (auto is not a profile name)", () => {
+    expect(isToolProfileName("auto")).toBe(false);
+  });
+});

--- a/packages/middleware-tool-selector/src/tool-profiles.ts
+++ b/packages/middleware-tool-selector/src/tool-profiles.ts
@@ -1,0 +1,42 @@
+/**
+ * Named tool profiles — declarative presets for common agent roles.
+ *
+ * Instead of writing a custom selectTools function, declare `profile: "coding"`
+ * in the manifest and get a curated 4-10 tool set automatically.
+ */
+
+/**
+ * Predefined tool profiles. Each maps a role name to a readonly list of tool
+ * names. An empty list (like "full") means no filtering — all tools pass through.
+ */
+export const TOOL_PROFILES: {
+  readonly minimal: readonly string[];
+  readonly coding: readonly string[];
+  readonly research: readonly string[];
+  readonly automation: readonly string[];
+  readonly conversation: readonly string[];
+  readonly full: readonly string[];
+} = {
+  minimal: ["memory_store", "memory_recall", "file_read", "file_write"],
+  coding: [
+    "file_read",
+    "file_write",
+    "file_list",
+    "file_delete",
+    "shell_exec",
+    "apply_patch",
+    "search_forge",
+  ],
+  research: ["web_fetch", "web_search", "memory_store", "memory_recall", "file_write"],
+  automation: ["shell_exec", "file_read", "file_write", "schedule_create", "browser_navigate"],
+  conversation: ["memory_store", "memory_recall"],
+  full: [],
+} as const satisfies Record<string, readonly string[]>;
+
+/** Valid profile name — one of the keys in TOOL_PROFILES. */
+export type ToolProfileName = keyof typeof TOOL_PROFILES;
+
+/** Type guard for ToolProfileName. */
+export function isToolProfileName(value: unknown): value is ToolProfileName {
+  return typeof value === "string" && value in TOOL_PROFILES;
+}

--- a/packages/middleware-tool-selector/src/tool-selector.ts
+++ b/packages/middleware-tool-selector/src/tool-selector.ts
@@ -1,5 +1,10 @@
 /**
  * Tool-selector middleware — pre-filters tools before each model call.
+ *
+ * Supports three modes:
+ * - custom: dynamic selectTools function per call
+ * - profile: static precomputed tool set from a named profile
+ * - auto: profile + model-capability-aware scaling
  */
 
 import type {
@@ -14,17 +19,24 @@ import type {
   TurnContext,
 } from "@koi/core";
 import { KoiRuntimeError, swallowError } from "@koi/errors";
-import type { ToolSelectorConfig } from "./config.js";
+import type { ToolSelectorConfig, ValidatedToolSelectorConfig } from "./config.js";
 import { validateToolSelectorConfig } from "./config.js";
 import { extractLastUserText } from "./extract-query.js";
+import { resolveProfile } from "./resolve-profile.js";
 
 const DEFAULT_MAX_TOOLS = 10;
 const DEFAULT_MIN_TOOLS = 5;
 
 /**
- * Creates a middleware that filters tools before each model call using a
- * caller-provided selector function. When the agent has many tools (20+),
- * this reduces token usage and improves model selection accuracy.
+ * Creates a middleware that filters tools before each model call.
+ *
+ * - custom config: uses caller-provided selectTools per call
+ * - profile/auto config: precomputes allowed tool Set at factory time
+ * - full profile: short-circuits (no filtering)
+ *
+ * For profile/auto modes, the tool allowlist is resolved once at creation time.
+ * If the model changes after middleware creation (e.g., fallback), the tier cap
+ * will NOT be re-evaluated. Recreate the middleware to pick up model changes.
  */
 export function createToolSelectorMiddleware(config: ToolSelectorConfig): KoiMiddleware {
   const validResult = validateToolSelectorConfig(config);
@@ -32,29 +44,46 @@ export function createToolSelectorMiddleware(config: ToolSelectorConfig): KoiMid
     throw KoiRuntimeError.from(validResult.error.code, validResult.error.message);
   }
 
+  return createFromValidated(validResult.value);
+}
+
+function createFromValidated(config: ValidatedToolSelectorConfig): KoiMiddleware {
+  switch (config.kind) {
+    case "custom":
+      return createCustomMiddleware(config);
+    case "profile":
+    case "auto":
+      return createProfileMiddleware(config);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Custom mode (backward compatible)
+// ---------------------------------------------------------------------------
+
+function createCustomMiddleware(
+  config: Extract<ValidatedToolSelectorConfig, { readonly kind: "custom" }>,
+): KoiMiddleware {
   const {
     selectTools,
     alwaysInclude = [],
     maxTools = DEFAULT_MAX_TOOLS,
     minTools = DEFAULT_MIN_TOOLS,
     extractQuery = extractLastUserText,
-  } = validResult.value;
+  } = config;
 
   async function filterRequest(request: ModelRequest): Promise<ModelRequest> {
     const tools = request.tools;
 
-    // Skip if no tools or at/below threshold
     if (tools === undefined || tools.length <= minTools) {
       return request;
     }
 
-    // Extract query from messages
     const query = extractQuery(request.messages);
     if (query === "") {
       return request;
     }
 
-    // Call selector with graceful degradation
     // let: required by try/catch — assigned in try, read after catch
     let selectedNames: readonly string[];
     try {
@@ -64,13 +93,9 @@ export function createToolSelectorMiddleware(config: ToolSelectorConfig): KoiMid
       return request;
     }
 
-    // Build name set: selected (capped at maxTools) + alwaysInclude
     const nameSet = new Set<string>([...selectedNames.slice(0, maxTools), ...alwaysInclude]);
-
-    // Filter tools (only keep tools whose name is in the set)
     const filteredTools = tools.filter((t) => nameSet.has(t.name));
 
-    // Record counts in metadata for observability
     const metadata: JsonObject = {
       ...request.metadata,
       toolsBeforeFilter: tools.length,
@@ -80,11 +105,86 @@ export function createToolSelectorMiddleware(config: ToolSelectorConfig): KoiMid
     return { ...request, tools: filteredTools, metadata };
   }
 
+  const description =
+    `Tool filtering: selects up to ${String(maxTools)} tools per call (skip below ${String(minTools)})` +
+    (alwaysInclude.length > 0 ? `, always includes ${alwaysInclude.join(", ")}` : "");
+
+  return buildMiddleware(filterRequest, description);
+}
+
+// ---------------------------------------------------------------------------
+// Profile / Auto mode
+// ---------------------------------------------------------------------------
+
+function createProfileMiddleware(
+  config:
+    | Extract<ValidatedToolSelectorConfig, { readonly kind: "profile" }>
+    | Extract<ValidatedToolSelectorConfig, { readonly kind: "auto" }>,
+): KoiMiddleware {
+  const { minTools = DEFAULT_MIN_TOOLS } = config;
+
+  // Resolve profile at factory time. If the model changes after middleware
+  // creation (e.g., fallback), the tier cap will NOT be re-evaluated.
+  // Recreate the middleware to pick up model changes.
+  const resolved = resolveProfile({
+    profile: config.profile,
+    tier: config.kind === "auto" ? config.tier : undefined,
+    include: config.include,
+    exclude: config.exclude,
+  });
+
+  // Full profile → short-circuit (no filtering)
+  if (resolved.isFullProfile) {
+    return buildMiddleware(
+      async (request) => request,
+      "Tool filtering: full profile (no filtering)",
+    );
+  }
+
+  // Precompute Set for O(1) lookup during filtering
+  const allowedSet = new Set(resolved.toolNames);
+
+  async function filterRequest(request: ModelRequest): Promise<ModelRequest> {
+    const tools = request.tools;
+
+    if (tools === undefined || tools.length <= minTools) {
+      return request;
+    }
+
+    // Profile filtering is static — always apply regardless of query content
+    const filteredTools = tools.filter((t) => allowedSet.has(t.name));
+
+    // Detect profile tools missing from available tools (for observability)
+    const availableNames = new Set(tools.map((t) => t.name));
+    const missingTools = resolved.toolNames.filter((name) => !availableNames.has(name));
+
+    const metadata: JsonObject = {
+      ...request.metadata,
+      toolsBeforeFilter: tools.length,
+      toolsAfterFilter: filteredTools.length,
+      ...(missingTools.length > 0 ? { profileMissingTools: missingTools } : {}),
+    };
+
+    return { ...request, tools: filteredTools, metadata };
+  }
+
+  const profileDesc = `profile "${config.profile}" (${String(resolved.toolNames.length)} tools)`;
+  const description = `Tool filtering: ${profileDesc}, skip below ${String(minTools)}`;
+
+  return buildMiddleware(filterRequest, description);
+}
+
+// ---------------------------------------------------------------------------
+// Shared middleware builder
+// ---------------------------------------------------------------------------
+
+function buildMiddleware(
+  filterRequest: (request: ModelRequest) => Promise<ModelRequest>,
+  description: string,
+): KoiMiddleware {
   const capabilityFragment: CapabilityFragment = {
     label: "tool-filter",
-    description:
-      `Tool filtering: selects up to ${String(maxTools)} tools per call (skip below ${String(minTools)})` +
-      (alwaysInclude.length > 0 ? `, always includes ${alwaysInclude.join(", ")}` : ""),
+    description,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Add 6 declarative tool profiles (`coding`, `research`, `minimal`, `automation`, `conversation`, `full`) so agents can filter tools with `profile: "coding"` in YAML instead of writing custom `selectTools` functions
- Add `autoScale: true` mode that adapts tool surface to model capabilities (Haiku→5 tools, Sonnet→15, Opus→30) via three-phase resolution: resolve base profile → apply include/exclude modifiers → cap by model tier
- Fully backward compatible — existing `selectTools` configs work unchanged

~1,850 LOC across 8 new files + 8 modified files, all within `@koi/middleware-tool-selector` (L2). Zero L0/L1 changes.

**Token savings**: ~13K tokens/call by filtering 41 tools to 4-10.

Closes #492
Closes #504

## New files

| File | Purpose |
|------|---------|
| `tool-profiles.ts` | 6 named profile definitions |
| `model-tier.ts` | Model name → capability tier mapping |
| `resolve-profile.ts` | Three-phase resolution pipeline |
| `descriptor.test.ts` | Descriptor factory integration tests |
| `tool-profiles.test.ts` | Profile definition tests |
| `model-tier.test.ts` | Tier detection tests |
| `resolve-profile.test.ts` | Resolution pipeline tests (10 edge cases) |
| `e2e-tool-profiles.test.ts` | 8 E2E tests through createKoi + createPiAdapter |

## Test plan

- [x] 89 unit tests pass (22 existing regression + 67 new)
- [x] 99.5% line coverage
- [x] 8 E2E tests pass through full createKoi + createPiAdapter stack with real Anthropic API calls
- [x] TypeScript strict mode (0 errors)
- [x] Biome lint (0 errors)
- [x] Build passes (ESM + DTS)
- [x] Rebased on latest main