### PR TITLE
feat: harden @koi/middleware-output-verifier — 16 improvements

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -905,8 +905,11 @@
       "dependencies": {
         "@koi/core": "workspace:*",
         "@koi/errors": "workspace:*",
+        "@koi/resolve": "workspace:*",
       },
       "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
         "@koi/test-utils": "workspace:*",
       },
     },

--- a/packages/middleware-output-verifier/package.json
+++ b/packages/middleware-output-verifier/package.json
@@ -11,15 +11,19 @@
   },
   "dependencies": {
     "@koi/core": "workspace:*",
-    "@koi/errors": "workspace:*"
+    "@koi/errors": "workspace:*",
+    "@koi/resolve": "workspace:*"
   },
   "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
     "@koi/test-utils": "workspace:*"
   },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "bun test"
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
   }
 }

--- a/packages/middleware-output-verifier/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-output-verifier/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,268 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-output-verifier API surface . has stable type surface 1`] = `
+"import { KoiMiddleware } from '@koi/core/middleware';
+import { Result, KoiError } from '@koi/core/errors';
+import { KoiMiddleware as KoiMiddleware$1 } from '@koi/core';
+import { BrickDescriptor } from '@koi/resolve';
+
+/**
+ * Type definitions for @koi/middleware-output-verifier.
+ *
+ * Two-stage output quality gate: deterministic checks (Stage 1) followed by
+ * an LLM-as-judge (Stage 2). Only "block" in Stage 1 short-circuits Stage 2.
+ */
+
+/** Action to take when a veto is triggered. */
+type VerifierAction = "block" | "warn" | "revise";
+/**
+ * A named deterministic check applied to the raw model output string.
+ *
+ * @example
+ * const nonEmpty: DeterministicCheck = {
+ *   name: "non-empty",
+ *   check: (c) => c.trim().length > 0 || "Output must not be empty",
+ *   action: "block",
+ * };
+ */
+interface DeterministicCheck {
+    /** Human-readable name used in veto events for debugging. */
+    readonly name: string;
+    /**
+     * Predicate function.
+     * - Return \`true\` to pass.
+     * - Return \`false\` or a \`string\` (failure reason) to fail.
+     */
+    readonly check: (content: string) => boolean | string;
+    /** Action to take when this check fails. */
+    readonly action: VerifierAction;
+}
+/** Configuration for the LLM-as-judge stage. */
+interface JudgeConfig {
+    /** Rubric describing what constitutes a high-quality output. */
+    readonly rubric: string;
+    /**
+     * Model call function. Receives the judge prompt and an optional AbortSignal.
+     * Must return the raw model response string.
+     */
+    readonly modelCall: (prompt: string, signal?: AbortSignal) => Promise<string>;
+    /**
+     * Minimum score required to pass. Outputs scoring below this are vetoed.
+     * Range: 0.0–1.0. Default: 0.75 (targeting ~25% veto rate baseline).
+     */
+    readonly vetoThreshold?: number | undefined;
+    /** Action to take when the judge vetoes. Default: "block". */
+    readonly action?: VerifierAction | undefined;
+    /**
+     * Fraction of calls on which the judge runs. Range: 0.0–1.0. Default: 1.0.
+     * Set below 1.0 in production to reduce latency at the cost of coverage.
+     * Deterministic checks always run regardless of this setting.
+     */
+    readonly samplingRate?: number | undefined;
+    /**
+     * Maximum characters of agent output sent to the judge prompt.
+     * Longer content is truncated (60% head + 40% tail) with an elision marker.
+     * Default: 16384 (16K chars).
+     */
+    readonly maxContentLength?: number | undefined;
+    /**
+     * Random number generator used for sampling decisions.
+     * Must return a value in [0, 1). Default: Math.random.
+     * Inject a deterministic function in tests for reproducibility.
+     */
+    readonly randomFn?: (() => number) | undefined;
+}
+/**
+ * Configuration for the output verifier middleware.
+ * At least one of \`deterministic\` or \`judge\` must be provided.
+ */
+interface VerifierConfig {
+    /** Stage 1: deterministic checks. Run sequentially; first "block" short-circuits. */
+    readonly deterministic?: readonly DeterministicCheck[] | undefined;
+    /** Stage 2: LLM-as-judge. Skipped if Stage 1 produced a "block". */
+    readonly judge?: JudgeConfig | undefined;
+    /**
+     * Maximum revision attempts before throwing. Default: 1.
+     * Governs both deterministic revise and judge revise.
+     */
+    readonly maxRevisions?: number | undefined;
+    /**
+     * Maximum characters of judge reasoning injected during revise.
+     * Prevents context bloat from verbose judge explanations. Default: 400.
+     */
+    readonly revisionFeedbackMaxLength?: number | undefined;
+    /** Called whenever a veto or warn is triggered. */
+    readonly onVeto?: ((event: VerifierVetoEvent) => void) | undefined;
+    /**
+     * Maximum characters to buffer for streaming validation. Default: 262144 (256 KB).
+     * If the stream exceeds this size, streaming validation is skipped with a warn event.
+     */
+    readonly maxBufferSize?: number | undefined;
+}
+/** Event fired when a check vetoes or warns on an output. */
+interface VerifierVetoEvent {
+    /** Which stage detected the issue. */
+    readonly source: "deterministic" | "judge";
+    /** Name of the deterministic check that failed (source = "deterministic" only). */
+    readonly checkName?: string | undefined;
+    /** Failure reason from the check function (source = "deterministic" only). */
+    readonly checkReason?: string | undefined;
+    /** Action taken (or that would have been taken for streaming degradation). */
+    readonly action: VerifierAction;
+    /** Judge score (0.0–1.0), present when source = "judge". */
+    readonly score?: number | undefined;
+    /** Judge reasoning, truncated to revisionFeedbackMaxLength. */
+    readonly reasoning?: string | undefined;
+    /** Set when the judge threw or returned an unparseable response. */
+    readonly judgeError?: string | undefined;
+    /**
+     * Set to true when streaming degraded "revise" or "block" to "warn".
+     * Content was already yielded; retry is impossible.
+     */
+    readonly degraded?: boolean | undefined;
+}
+/** Accumulated statistics for the verifier session. Manual reset via Handle. */
+interface VerifierStats {
+    /** Total model calls evaluated (regardless of sampling). */
+    readonly totalChecks: number;
+    /** Calls where action was "block" or "revise" (output was prevented or revised). */
+    readonly vetoed: number;
+    /** Calls where action was "warn" (output delivered with advisory event). */
+    readonly warned: number;
+    /** Veto events originating from Stage 1 deterministic checks. */
+    readonly deterministicVetoes: number;
+    /** Veto events originating from Stage 2 judge. */
+    readonly judgeVetoes: number;
+    /** Calls where the judge actually ran (affected by samplingRate). */
+    readonly judgedChecks: number;
+    /** vetoed / totalChecks. Returns 0 when totalChecks = 0. */
+    readonly vetoRate: number;
+}
+/** Returned by createOutputVerifierMiddleware. Provides runtime control and stats. */
+interface VerifierHandle {
+    /** The KoiMiddleware to add to your agent's middleware chain. */
+    readonly middleware: KoiMiddleware;
+    /** Returns a snapshot of accumulated stats since last reset. */
+    readonly getStats: () => VerifierStats;
+    /**
+     * Updates the judge rubric for subsequent calls.
+     * Takes effect on the next wrapModelCall / wrapModelStream invocation.
+     */
+    readonly setRubric: (rubric: string) => void;
+    /** Resets all stat counters to zero. Call in onSessionStart for per-session tracking. */
+    readonly reset: () => void;
+}
+
+/**
+ * Built-in deterministic checks for common output quality assertions.
+ *
+ * Use these as-is or as starting points for custom checks.
+ */
+
+/**
+ * Fails if the output is empty or contains only whitespace.
+ */
+declare function nonEmpty(action?: VerifierAction): DeterministicCheck;
+/**
+ * Fails if the output exceeds \`max\` characters.
+ */
+declare function maxLength(max: number, action?: VerifierAction): DeterministicCheck;
+/**
+ * Fails if the output does not contain valid JSON.
+ */
+declare function validJson(action?: VerifierAction): DeterministicCheck;
+/**
+ * Fails if the output does not match the given regular expression.
+ */
+declare function matchesPattern(pattern: RegExp, name: string, action?: VerifierAction): DeterministicCheck;
+/** Convenience namespace for built-in checks. */
+declare const BUILTIN_CHECKS: {
+    readonly nonEmpty: typeof nonEmpty;
+    readonly maxLength: typeof maxLength;
+    readonly validJson: typeof validJson;
+    readonly matchesPattern: typeof matchesPattern;
+};
+
+/**
+ * Configuration validation for @koi/middleware-output-verifier.
+ *
+ * Validates raw config input and returns a typed Result.
+ */
+
+/**
+ * Validates raw config input for the output verifier middleware.
+ *
+ * At least one of \`deterministic\` or \`judge\` must be present.
+ */
+declare function validateVerifierConfig(input: unknown): Result<VerifierConfig, KoiError>;
+
+/**
+ * BrickDescriptor for @koi/middleware-output-verifier.
+ *
+ * Enables manifest auto-resolution: validates verifier config,
+ * then creates the output verifier middleware with a nonEmpty deterministic
+ * check by default.
+ */
+
+/**
+ * Descriptor for output verifier middleware.
+ * Defaults to a nonEmpty deterministic check when no deterministic checks are provided.
+ * Exported for registration with createRegistry().
+ */
+declare const descriptor: BrickDescriptor<KoiMiddleware$1>;
+
+/**
+ * Inlined LLM-as-judge helpers.
+ *
+ * Duplicates ~30 lines from @koi/eval/src/graders/llm-judge.ts intentionally.
+ * Rule of Three: only 2 consumers exist. Extract to @koi/llm-judge-util at 3rd.
+ */
+interface JudgeResult {
+    readonly score: number;
+    readonly reasoning: string;
+    readonly parseError?: string | undefined;
+}
+/**
+ * Truncate content to fit within maxLength, preserving head and tail context.
+ *
+ * Split: 60% from the start, 40% from the end, with an elision marker.
+ * Returns content unchanged if it fits within maxLength.
+ */
+declare function truncateContent(content: string, maxLength: number): string;
+/** Build the judge prompt from a rubric and model output content. */
+declare function buildJudgePrompt(rubric: string, content: string, maxContentLength?: number): string;
+/**
+ * Normalize a raw 1-5 integer score to the 0.0–1.0 range.
+ *
+ * Formula: (clamp(raw, 1, 5) - 1) / 4
+ *   Score 1 → 0.00, Score 2 → 0.25, Score 3 → 0.50,
+ *   Score 4 → 0.75, Score 5 → 1.00
+ */
+declare function normalizeScore(raw: number): number;
+/**
+ * Parse the judge model response into a score + reasoning.
+ * On any parse failure, returns score=0 with a parseError field (fail-closed).
+ */
+declare function parseJudgeResponse(response: string): JudgeResult;
+/** @deprecated Use normalizeScore instead. Kept for backward compatibility. */
+declare function clampScore(score: number): number;
+
+/**
+ * Output verifier middleware factory — two-stage quality gate before delivery.
+ *
+ * Stage 1: Deterministic checks (fast, always runs).
+ * Stage 2: LLM-as-judge (async, optional, skipped if Stage 1 blocks).
+ *
+ * Priority 385: runs after guardrails (375), before memory (400).
+ */
+
+/**
+ * Creates the output verifier middleware.
+ *
+ * @throws {KoiRuntimeError} At factory time if neither \`deterministic\` nor \`judge\` is configured.
+ */
+declare function createOutputVerifierMiddleware(config: VerifierConfig): VerifierHandle;
+
+export { BUILTIN_CHECKS, type DeterministicCheck, type JudgeConfig, type JudgeResult, type VerifierAction, type VerifierConfig, type VerifierHandle, type VerifierStats, type VerifierVetoEvent, buildJudgePrompt, clampScore, createOutputVerifierMiddleware, descriptor, matchesPattern, maxLength, nonEmpty, normalizeScore, parseJudgeResponse, truncateContent, validJson, validateVerifierConfig };
+"
+`;

--- a/packages/middleware-output-verifier/src/__tests__/api-surface.test.ts
+++ b/packages/middleware-output-verifier/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware-output-verifier/src/__tests__/e2e-real-llm.test.ts
+++ b/packages/middleware-output-verifier/src/__tests__/e2e-real-llm.test.ts
@@ -1,0 +1,665 @@
+/**
+ * Full-stack E2E: createKoi + createPiAdapter + @koi/middleware-output-verifier.
+ *
+ * Validates output verifier middleware with real LLM calls through the full
+ * L1 runtime assembly. Tests all two stages (deterministic + judge) and all
+ * three actions (block, warn, revise) with real model output.
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test src/__tests__/e2e-real-llm.test.ts
+ *
+ * Requires ANTHROPIC_API_KEY in .env at repo root.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EngineEvent } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createOutputVerifierMiddleware, nonEmpty } from "../index.js";
+import type { DeterministicCheck, JudgeConfig, VerifierVetoEvent } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+
+const E2E_MANIFEST = {
+  name: "E2E Verifier Agent",
+  version: "0.1.0",
+  model: { name: E2E_MODEL },
+} as const;
+
+const JUDGE_MANIFEST = {
+  name: "Judge",
+  version: "0.1.0",
+  model: { name: E2E_MODEL },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function extractText(events: readonly EngineEvent[]): string {
+  return events
+    .filter((e): e is EngineEvent & { readonly kind: "text_delta" } => e.kind === "text_delta")
+    .map((e) => e.delta)
+    .join("");
+}
+
+function createAdapter(
+  systemPrompt = "You are a concise assistant. Reply briefly.",
+): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt,
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+}
+
+/**
+ * Creates a judge modelCall using a real LLM call.
+ * The judge uses a separate Haiku instance to evaluate agent output.
+ */
+function createRealJudgeModelCall(): JudgeConfig["modelCall"] {
+  const judgeAdapter = createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt: "You are an output quality judge. Respond with ONLY valid JSON.",
+    getApiKey: async () => ANTHROPIC_KEY,
+  });
+
+  return async (prompt: string, signal?: AbortSignal): Promise<string> => {
+    const runtime = await createKoi({
+      manifest: JUDGE_MANIFEST,
+      adapter: judgeAdapter,
+      loopDetection: false,
+    });
+
+    const events = await collectEvents(runtime.run({ kind: "text", text: prompt, signal }));
+    await runtime.dispose();
+    return extractText(events);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: @koi/middleware-output-verifier through full L1 runtime", () => {
+  // ── Test 1: Deterministic pass — LLM output passes nonEmpty check ────
+
+  test(
+    "deterministic pass: nonEmpty check passes real LLM output",
+    async () => {
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(
+        runtime.run({ kind: "text", text: "Reply with exactly: hello world" }),
+      );
+      await runtime.dispose();
+
+      // Output should be delivered (no block)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // No veto events should have fired
+      expect(events).toHaveLength(0);
+
+      // Stats should show 1 check, 0 vetoes
+      const stats = handle.getStats();
+      expect(stats.totalChecks).toBeGreaterThanOrEqual(1);
+      expect(stats.vetoed).toBe(0);
+      expect(stats.warned).toBe(0);
+
+      // Should have completed successfully
+      const done = engineEvents.find((e) => e.kind === "done");
+      expect(done).toBeDefined();
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Deterministic warn — fires event but delivers output ─────
+
+  test(
+    "deterministic warn: fires veto event but delivers LLM output",
+    async () => {
+      // Warn if output contains "hello" (which it should)
+      const warnOnHello: DeterministicCheck = {
+        name: "warn-on-hello",
+        check: (c) => !c.toLowerCase().includes("hello") || "Contains hello",
+        action: "warn",
+      };
+
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [warnOnHello],
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(
+        runtime.run({ kind: "text", text: "Say exactly: hello" }),
+      );
+      await runtime.dispose();
+
+      // Output should still be delivered (warn doesn't block)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Warn event should have fired
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0]?.source).toBe("deterministic");
+      expect(events[0]?.action).toBe("warn");
+      expect(events[0]?.checkName).toBe("warn-on-hello");
+
+      // Stats
+      const stats = handle.getStats();
+      expect(stats.warned).toBeGreaterThanOrEqual(1);
+      expect(stats.vetoed).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Deterministic block — degrades to warn in streaming mode ─
+  //
+  // Pi adapter always uses wrapModelStream. In streaming mode, content is
+  // yielded before verification runs, so block/revise degrade to warn
+  // with `degraded: true`. This is by design — we test the degradation
+  // behavior that real users will encounter with the Pi adapter.
+
+  test(
+    "deterministic block: degrades to warn in streaming mode (Pi always streams)",
+    async () => {
+      // Block all output (always returns false)
+      const blockAll: DeterministicCheck = {
+        name: "block-all",
+        check: () => "All output blocked for testing",
+        action: "block",
+      };
+
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [blockAll],
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(runtime.run({ kind: "text", text: "Say: hello" }));
+      await runtime.dispose();
+
+      // Output is still delivered (streaming: content already yielded)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Block event fires with degraded flag (block → warn in streaming mode)
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0]?.source).toBe("deterministic");
+      expect(events[0]?.action).toBe("block");
+      expect(events[0]?.degraded).toBe(true);
+
+      // Stats: streaming degradation increments warned + deterministicVetoes, not vetoed
+      const stats = handle.getStats();
+      expect(stats.warned).toBeGreaterThanOrEqual(1);
+      expect(stats.deterministicVetoes).toBeGreaterThanOrEqual(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: Deterministic revise — degrades to warn in streaming mode ─
+  //
+  // Same degradation as block: Pi always streams, so revise cannot retry.
+  // The check runs once post-hoc and fires a degraded warn event.
+
+  test(
+    "deterministic revise: degrades to warn in streaming mode (no retry possible)",
+    async () => {
+      // let justified: tracks call count across verifyStream invocations
+      let checkCount = 0;
+      const reviseOnce: DeterministicCheck = {
+        name: "revise-first-attempt",
+        check: () => {
+          checkCount++;
+          // Always fails — in streaming mode, no retry will happen
+          return checkCount > 1 || "First attempt always needs revision";
+        },
+        action: "revise",
+      };
+
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [reviseOnce],
+        maxRevisions: 1,
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(
+        runtime.run({ kind: "text", text: "Say: revised output" }),
+      );
+      await runtime.dispose();
+
+      // Output is still delivered (streaming: content already yielded)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Revise event fires with degraded flag (no retry in streaming mode)
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0]?.action).toBe("revise");
+      expect(events[0]?.degraded).toBe(true);
+
+      // Check only ran once — no retry possible in streaming mode
+      expect(checkCount).toBe(1);
+
+      // Stats: warned (degraded), not vetoed
+      const stats = handle.getStats();
+      expect(stats.warned).toBeGreaterThanOrEqual(1);
+      expect(stats.deterministicVetoes).toBeGreaterThanOrEqual(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Judge stage with real LLM — passing score ────────────────
+
+  test(
+    "judge pass: real LLM-as-judge scores output above threshold",
+    async () => {
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        judge: {
+          rubric:
+            "The output should be a friendly greeting. It should contain a greeting word like 'hello', 'hi', or 'hey'.",
+          modelCall: createRealJudgeModelCall(),
+          vetoThreshold: 0.5, // Low threshold — greeting should easily pass
+          action: "block",
+          randomFn: () => 0, // Always sample
+        },
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter("You are a friendly assistant. Always greet users warmly."),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(
+        runtime.run({ kind: "text", text: "Greet me warmly" }),
+      );
+      await runtime.dispose();
+
+      // Output should be delivered (score above threshold)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Judge should have run
+      const stats = handle.getStats();
+      expect(stats.judgedChecks).toBeGreaterThanOrEqual(1);
+
+      // No block events should have fired (expect pass or warn at most)
+      const blockEvents = events.filter((e) => e.action === "block");
+      expect(blockEvents).toHaveLength(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Judge stage with real LLM — warn action ──────────────────
+
+  test(
+    "judge warn: real LLM-as-judge warns but delivers output",
+    async () => {
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        judge: {
+          rubric:
+            "The output must be a perfectly formatted haiku with exactly 5-7-5 syllable structure. No other format is acceptable.",
+          modelCall: createRealJudgeModelCall(),
+          vetoThreshold: 0.99, // Very high threshold — almost nothing passes
+          action: "warn",
+          randomFn: () => 0, // Always sample
+        },
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter("You are a concise assistant. Just say hello."),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(runtime.run({ kind: "text", text: "Say hello" }));
+      await runtime.dispose();
+
+      // Output should still be delivered (warn doesn't block)
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Judge should have run and issued a warn
+      const stats = handle.getStats();
+      expect(stats.judgedChecks).toBeGreaterThanOrEqual(1);
+      expect(stats.warned).toBeGreaterThanOrEqual(1);
+
+      // Warn event should contain judge score
+      if (events.length > 0) {
+        expect(events[0]?.source).toBe("judge");
+        expect(events[0]?.action).toBe("warn");
+        expect(typeof events[0]?.score).toBe("number");
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Both stages — deterministic + judge ──────────────────────
+
+  test(
+    "both stages: deterministic checks run first, then judge evaluates",
+    async () => {
+      const events: VerifierVetoEvent[] = [];
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+        judge: {
+          rubric: "The output should be helpful and relevant to the user's question.",
+          modelCall: createRealJudgeModelCall(),
+          vetoThreshold: 0.25, // Low threshold — should pass
+          action: "block",
+          randomFn: () => 0, // Always sample
+        },
+        onVeto: (e) => events.push(e),
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      const engineEvents = await collectEvents(
+        runtime.run({ kind: "text", text: "What is 2 + 2?" }),
+      );
+      await runtime.dispose();
+
+      // Output delivered
+      const text = extractText(engineEvents);
+      expect(text.length).toBeGreaterThan(0);
+
+      // Both stages ran
+      const stats = handle.getStats();
+      expect(stats.totalChecks).toBeGreaterThanOrEqual(1);
+      expect(stats.judgedChecks).toBeGreaterThanOrEqual(1);
+      expect(stats.vetoed).toBe(0); // Low threshold → pass
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 8: setRubric updates judge dynamically ──────────────────────
+
+  test(
+    "setRubric: dynamically updates judge rubric between calls",
+    async () => {
+      const capturedRubrics: string[] = [];
+      const realCall = createRealJudgeModelCall();
+
+      const handle = createOutputVerifierMiddleware({
+        judge: {
+          rubric: "First rubric: output must mention cats",
+          modelCall: async (prompt, signal) => {
+            // Capture rubric from prompt
+            const rubricMatch = /## Rubric\n(.*?)\n\n/s.exec(prompt);
+            if (rubricMatch?.[1]) capturedRubrics.push(rubricMatch[1]);
+            return await realCall(prompt, signal);
+          },
+          vetoThreshold: 0.25,
+          action: "warn",
+          randomFn: () => 0,
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      // First call with original rubric
+      await collectEvents(runtime.run({ kind: "text", text: "Say: test one" }));
+
+      // Update rubric
+      handle.setRubric("Second rubric: output must mention dogs");
+
+      // Second call with new rubric
+      await collectEvents(runtime.run({ kind: "text", text: "Say: test two" }));
+      await runtime.dispose();
+
+      // Verify rubrics changed between calls
+      expect(capturedRubrics.length).toBeGreaterThanOrEqual(2);
+      expect(capturedRubrics[0]).toContain("cats");
+      expect(capturedRubrics[1]).toContain("dogs");
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 9: Stats accumulate across multiple calls ───────────────────
+
+  test(
+    "stats: accumulate correctly across multiple run calls",
+    async () => {
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      // Three sequential calls
+      await collectEvents(runtime.run({ kind: "text", text: "Say: one" }));
+      await collectEvents(runtime.run({ kind: "text", text: "Say: two" }));
+      await collectEvents(runtime.run({ kind: "text", text: "Say: three" }));
+      await runtime.dispose();
+
+      const stats = handle.getStats();
+      expect(stats.totalChecks).toBeGreaterThanOrEqual(3);
+      expect(stats.vetoed).toBe(0);
+      expect(stats.vetoRate).toBe(0);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 10: Reset clears stats mid-session ──────────────────────────
+
+  test(
+    "reset: clears all stats to zero mid-session",
+    async () => {
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      await collectEvents(runtime.run({ kind: "text", text: "Say: before reset" }));
+
+      // Stats should be non-zero
+      expect(handle.getStats().totalChecks).toBeGreaterThanOrEqual(1);
+
+      // Reset
+      handle.reset();
+
+      // Stats should be zero
+      const afterReset = handle.getStats();
+      expect(afterReset.totalChecks).toBe(0);
+      expect(afterReset.vetoed).toBe(0);
+      expect(afterReset.warned).toBe(0);
+
+      // New call after reset
+      await collectEvents(runtime.run({ kind: "text", text: "Say: after reset" }));
+      await runtime.dispose();
+
+      const finalStats = handle.getStats();
+      expect(finalStats.totalChecks).toBeGreaterThanOrEqual(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 11: describeCapabilities through real runtime ───────────────
+
+  test(
+    "describeCapabilities: returns correct fragment through L1 runtime",
+    async () => {
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+        judge: {
+          rubric: "Test",
+          modelCall: createRealJudgeModelCall(),
+          vetoThreshold: 0.75,
+          randomFn: () => 0,
+        },
+      });
+
+      // Middleware should have capability description
+      expect(handle.middleware.describeCapabilities).toBeDefined();
+      expect(handle.middleware.name).toBe("output-verifier");
+      expect(handle.middleware.priority).toBe(385);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 12: maxContentLength truncation with real judge ─────────────
+
+  test(
+    "maxContentLength: truncates long content before sending to judge",
+    async () => {
+      let capturedPromptLength = 0;
+      const realCall = createRealJudgeModelCall();
+
+      const handle = createOutputVerifierMiddleware({
+        judge: {
+          rubric: "Any output is acceptable.",
+          modelCall: async (prompt, signal) => {
+            capturedPromptLength = prompt.length;
+            return await realCall(prompt, signal);
+          },
+          vetoThreshold: 0.25,
+          action: "warn",
+          maxContentLength: 100, // Very short — will truncate any real LLM output
+          randomFn: () => 0,
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(
+          "You are verbose. Write at least 200 words in your response, elaborating extensively.",
+        ),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      await collectEvents(
+        runtime.run({
+          kind: "text",
+          text: "Tell me about the history of computing in great detail.",
+        }),
+      );
+      await runtime.dispose();
+
+      // The judge prompt should have been truncated
+      // (prompt includes rubric + instructions + truncated content)
+      // A non-truncated verbose response would be 1000+ chars
+      // With maxContentLength=100, total prompt should be much smaller
+      expect(capturedPromptLength).toBeGreaterThan(0);
+      expect(handle.getStats().judgedChecks).toBeGreaterThanOrEqual(1);
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 13: randomFn controls sampling deterministically ────────────
+
+  test(
+    "randomFn: injected function controls judge sampling",
+    async () => {
+      // randomFn returns 1.0 → always > any samplingRate < 1.0 → judge skipped
+      const handle = createOutputVerifierMiddleware({
+        deterministic: [nonEmpty("block")],
+        judge: {
+          rubric: "Test",
+          modelCall: createRealJudgeModelCall(),
+          vetoThreshold: 0.75,
+          samplingRate: 0.5,
+          randomFn: () => 1.0, // Always skip
+        },
+      });
+
+      const runtime = await createKoi({
+        manifest: E2E_MANIFEST,
+        adapter: createAdapter(),
+        middleware: [handle.middleware],
+        loopDetection: false,
+      });
+
+      await collectEvents(runtime.run({ kind: "text", text: "Say: sampled" }));
+      await runtime.dispose();
+
+      // Judge should NOT have run (randomFn=1.0 > samplingRate=0.5)
+      const stats = handle.getStats();
+      expect(stats.judgedChecks).toBe(0);
+      expect(stats.totalChecks).toBeGreaterThanOrEqual(1);
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/middleware-output-verifier/src/builtin-checks.ts
+++ b/packages/middleware-output-verifier/src/builtin-checks.ts
@@ -45,7 +45,7 @@ export function validJson(action: VerifierAction = DEFAULT_ACTION): Deterministi
       try {
         JSON.parse(content);
         return true;
-      } catch {
+      } catch (_e: unknown) {
         return "Output must be valid JSON";
       }
     },

--- a/packages/middleware-output-verifier/src/config.test.ts
+++ b/packages/middleware-output-verifier/src/config.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for validateVerifierConfig.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateVerifierConfig } from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Valid configs
+// ---------------------------------------------------------------------------
+
+describe("validateVerifierConfig — valid configs", () => {
+  test("deterministic only", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "non-empty", check: (c: string) => c.length > 0, action: "block" }],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("judge only", () => {
+    const result = validateVerifierConfig({
+      judge: {
+        rubric: "Be helpful",
+        modelCall: async () => "{}",
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("both deterministic and judge", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "warn" }],
+      judge: {
+        rubric: "Be helpful",
+        modelCall: async () => "{}",
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("all optional fields present", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "revise" }],
+      judge: {
+        rubric: "Be helpful",
+        modelCall: async () => "{}",
+        vetoThreshold: 0.8,
+        samplingRate: 0.5,
+        action: "warn",
+        maxContentLength: 1000,
+        randomFn: () => 0.5,
+      },
+      maxRevisions: 2,
+      revisionFeedbackMaxLength: 200,
+      maxBufferSize: 1024,
+      onVeto: () => {},
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid: non-object / empty
+// ---------------------------------------------------------------------------
+
+describe("validateVerifierConfig — invalid top-level", () => {
+  test("null returns error", () => {
+    const result = validateVerifierConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("undefined returns error", () => {
+    const result = validateVerifierConfig(undefined);
+    expect(result.ok).toBe(false);
+  });
+
+  test("string returns error", () => {
+    const result = validateVerifierConfig("not an object");
+    expect(result.ok).toBe(false);
+  });
+
+  test("number returns error", () => {
+    const result = validateVerifierConfig(42);
+    expect(result.ok).toBe(false);
+  });
+
+  test("array returns error", () => {
+    const result = validateVerifierConfig([1, 2, 3]);
+    expect(result.ok).toBe(false);
+  });
+
+  test("empty object returns error (no deterministic or judge)", () => {
+    const result = validateVerifierConfig({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("at least one");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid deterministic checks
+// ---------------------------------------------------------------------------
+
+describe("validateVerifierConfig — invalid deterministic", () => {
+  test("deterministic not array", () => {
+    const result = validateVerifierConfig({ deterministic: "not-array" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("array");
+  });
+
+  test("deterministic entry not object", () => {
+    const result = validateVerifierConfig({ deterministic: [42] });
+    expect(result.ok).toBe(false);
+  });
+
+  test("deterministic entry missing name", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ check: () => true, action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("name");
+  });
+
+  test("deterministic entry empty name", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "", check: () => true, action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("deterministic entry missing check", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", action: "block" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("check");
+  });
+
+  test("deterministic entry invalid action", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "invalid" }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("action");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid judge config
+// ---------------------------------------------------------------------------
+
+describe("validateVerifierConfig — invalid judge", () => {
+  test("judge not object", () => {
+    const result = validateVerifierConfig({ judge: "string" });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge missing rubric", () => {
+    const result = validateVerifierConfig({
+      judge: { modelCall: async () => "{}" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("rubric");
+  });
+
+  test("judge empty rubric", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "", modelCall: async () => "{}" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge missing modelCall", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("modelCall");
+  });
+
+  test("judge vetoThreshold out of range (negative)", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", vetoThreshold: -0.1 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge vetoThreshold out of range (> 1)", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", vetoThreshold: 1.1 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge samplingRate out of range", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", samplingRate: 2 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge maxContentLength not positive integer", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", maxContentLength: 0 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge randomFn not a function", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", randomFn: 42 },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("judge invalid action", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", action: "invalid" },
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge values
+// ---------------------------------------------------------------------------
+
+describe("validateVerifierConfig — edge values", () => {
+  test("maxRevisions=0 is valid", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      maxRevisions: 0,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("maxRevisions negative is invalid", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      maxRevisions: -1,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("maxRevisions float is invalid", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      maxRevisions: 1.5,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("vetoThreshold=0 is valid", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", vetoThreshold: 0 },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("vetoThreshold=1 is valid", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", vetoThreshold: 1 },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("samplingRate=0 is valid", () => {
+    const result = validateVerifierConfig({
+      judge: { rubric: "test", modelCall: async () => "{}", samplingRate: 0 },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("maxBufferSize=0 is invalid (must be positive)", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      maxBufferSize: 0,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("onVeto not a function is invalid", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      onVeto: "not-a-function",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("revisionFeedbackMaxLength=0 is invalid (must be positive)", () => {
+    const result = validateVerifierConfig({
+      deterministic: [{ name: "test", check: () => true, action: "block" }],
+      revisionFeedbackMaxLength: 0,
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/middleware-output-verifier/src/config.ts
+++ b/packages/middleware-output-verifier/src/config.ts
@@ -1,0 +1,156 @@
+/**
+ * Configuration validation for @koi/middleware-output-verifier.
+ *
+ * Validates raw config input and returns a typed Result.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { VerifierConfig } from "./types.js";
+
+const VALID_ACTIONS = new Set<string>(["block", "warn", "revise"]);
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validateDeterministicChecks(
+  checks: unknown,
+): { readonly ok: false; readonly error: KoiError } | undefined {
+  if (!Array.isArray(checks)) {
+    return validationError("'deterministic' must be an array");
+  }
+  for (const [i, check] of (checks as readonly unknown[]).entries()) {
+    if (!isRecord(check)) {
+      return validationError(`'deterministic[${String(i)}]' must be an object`);
+    }
+    if (typeof check.name !== "string" || check.name.length === 0) {
+      return validationError(`'deterministic[${String(i)}].name' must be a non-empty string`);
+    }
+    if (typeof check.check !== "function") {
+      return validationError(`'deterministic[${String(i)}].check' must be a function`);
+    }
+    if (typeof check.action !== "string" || !VALID_ACTIONS.has(check.action)) {
+      return validationError(
+        `'deterministic[${String(i)}].action' must be "block", "warn", or "revise"`,
+      );
+    }
+  }
+  return undefined;
+}
+
+function validateJudgeConfig(
+  judge: unknown,
+): { readonly ok: false; readonly error: KoiError } | undefined {
+  if (!isRecord(judge)) {
+    return validationError("'judge' must be an object");
+  }
+  if (typeof judge.rubric !== "string" || judge.rubric.length === 0) {
+    return validationError("'judge.rubric' must be a non-empty string");
+  }
+  if (typeof judge.modelCall !== "function") {
+    return validationError("'judge.modelCall' must be a function");
+  }
+  if (
+    judge.vetoThreshold !== undefined &&
+    (typeof judge.vetoThreshold !== "number" || judge.vetoThreshold < 0 || judge.vetoThreshold > 1)
+  ) {
+    return validationError("'judge.vetoThreshold' must be a number between 0.0 and 1.0");
+  }
+  if (
+    judge.samplingRate !== undefined &&
+    (typeof judge.samplingRate !== "number" || judge.samplingRate < 0 || judge.samplingRate > 1)
+  ) {
+    return validationError("'judge.samplingRate' must be a number between 0.0 and 1.0");
+  }
+  if (
+    judge.action !== undefined &&
+    (typeof judge.action !== "string" || !VALID_ACTIONS.has(judge.action))
+  ) {
+    return validationError('\'judge.action\' must be "block", "warn", or "revise"');
+  }
+  if (
+    judge.maxContentLength !== undefined &&
+    (typeof judge.maxContentLength !== "number" ||
+      !Number.isInteger(judge.maxContentLength) ||
+      judge.maxContentLength <= 0)
+  ) {
+    return validationError("'judge.maxContentLength' must be a positive integer");
+  }
+  if (judge.randomFn !== undefined && typeof judge.randomFn !== "function") {
+    return validationError("'judge.randomFn' must be a function");
+  }
+  return undefined;
+}
+
+/**
+ * Validates raw config input for the output verifier middleware.
+ *
+ * At least one of `deterministic` or `judge` must be present.
+ */
+export function validateVerifierConfig(input: unknown): Result<VerifierConfig, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = input as Record<string, unknown>;
+
+  const hasDeterministic = c.deterministic !== undefined;
+  const hasJudge = c.judge !== undefined;
+
+  if (!hasDeterministic && !hasJudge) {
+    return validationError("Config requires at least one of 'deterministic' or 'judge'");
+  }
+
+  if (hasDeterministic) {
+    const err = validateDeterministicChecks(c.deterministic);
+    if (err !== undefined) return err;
+  }
+
+  if (hasJudge) {
+    const err = validateJudgeConfig(c.judge);
+    if (err !== undefined) return err;
+  }
+
+  if (
+    c.maxRevisions !== undefined &&
+    (typeof c.maxRevisions !== "number" || !Number.isInteger(c.maxRevisions) || c.maxRevisions < 0)
+  ) {
+    return validationError("'maxRevisions' must be a non-negative integer");
+  }
+
+  if (
+    c.revisionFeedbackMaxLength !== undefined &&
+    (typeof c.revisionFeedbackMaxLength !== "number" ||
+      !Number.isInteger(c.revisionFeedbackMaxLength) ||
+      c.revisionFeedbackMaxLength <= 0)
+  ) {
+    return validationError("'revisionFeedbackMaxLength' must be a positive integer");
+  }
+
+  if (
+    c.maxBufferSize !== undefined &&
+    (typeof c.maxBufferSize !== "number" ||
+      !Number.isInteger(c.maxBufferSize) ||
+      c.maxBufferSize <= 0)
+  ) {
+    return validationError("'maxBufferSize' must be a positive integer");
+  }
+
+  if (c.onVeto !== undefined && typeof c.onVeto !== "function") {
+    return validationError("'onVeto' must be a function");
+  }
+
+  return { ok: true, value: input as VerifierConfig };
+}

--- a/packages/middleware-output-verifier/src/descriptor.ts
+++ b/packages/middleware-output-verifier/src/descriptor.ts
@@ -1,0 +1,106 @@
+/**
+ * BrickDescriptor for @koi/middleware-output-verifier.
+ *
+ * Enables manifest auto-resolution: validates verifier config,
+ * then creates the output verifier middleware with a nonEmpty deterministic
+ * check by default.
+ */
+
+import type { KoiError, KoiMiddleware, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BrickDescriptor } from "@koi/resolve";
+import { nonEmpty } from "./builtin-checks.js";
+import { createOutputVerifierMiddleware } from "./output-verifier.js";
+import type { JudgeConfig, VerifierConfig } from "./types.js";
+
+function validateVerifierDescriptorOptions(input: unknown): Result<unknown, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Output verifier options must be an object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const opts = input as Record<string, unknown>;
+
+  if (
+    opts.vetoThreshold !== undefined &&
+    (typeof opts.vetoThreshold !== "number" || opts.vetoThreshold < 0 || opts.vetoThreshold > 1)
+  ) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "output-verifier.vetoThreshold must be between 0.0 and 1.0",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (
+    opts.samplingRate !== undefined &&
+    (typeof opts.samplingRate !== "number" || opts.samplingRate < 0 || opts.samplingRate > 1)
+  ) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "output-verifier.samplingRate must be between 0.0 and 1.0",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (opts.rubric !== undefined && typeof opts.rubric !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "output-verifier.rubric must be a string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return { ok: true, value: input };
+}
+
+/**
+ * Descriptor for output verifier middleware.
+ * Defaults to a nonEmpty deterministic check when no deterministic checks are provided.
+ * Exported for registration with createRegistry().
+ */
+export const descriptor: BrickDescriptor<KoiMiddleware> = {
+  kind: "middleware",
+  name: "@koi/middleware-output-verifier",
+  aliases: ["output-verifier"],
+  optionsValidator: validateVerifierDescriptorOptions,
+  factory(options): KoiMiddleware {
+    const rubric = typeof options.rubric === "string" ? options.rubric : undefined;
+    const vetoThreshold =
+      typeof options.vetoThreshold === "number" ? options.vetoThreshold : undefined;
+    const samplingRate =
+      typeof options.samplingRate === "number" ? options.samplingRate : undefined;
+
+    const config: VerifierConfig = {
+      deterministic: [nonEmpty("block")],
+      ...(rubric !== undefined && typeof options.modelCall === "function"
+        ? {
+            judge: {
+              rubric,
+              modelCall: options.modelCall as JudgeConfig["modelCall"],
+              ...(vetoThreshold !== undefined ? { vetoThreshold } : {}),
+              ...(samplingRate !== undefined ? { samplingRate } : {}),
+            },
+          }
+        : {}),
+    };
+
+    const handle = createOutputVerifierMiddleware(config);
+    return handle.middleware;
+  },
+};

--- a/packages/middleware-output-verifier/src/index.ts
+++ b/packages/middleware-output-verifier/src/index.ts
@@ -12,7 +12,7 @@
  *
  * Priority 385: between guardrails (375) and memory (400).
  *
- * Depends on @koi/core and @koi/errors only.
+ * Depends on @koi/core, @koi/errors, and @koi/resolve.
  */
 
 export {
@@ -22,8 +22,16 @@ export {
   nonEmpty,
   validJson,
 } from "./builtin-checks.js";
+export { validateVerifierConfig } from "./config.js";
+export { descriptor } from "./descriptor.js";
 export type { JudgeResult } from "./judge.js";
-export { buildJudgePrompt, clampScore, parseJudgeResponse } from "./judge.js";
+export {
+  buildJudgePrompt,
+  clampScore,
+  normalizeScore,
+  parseJudgeResponse,
+  truncateContent,
+} from "./judge.js";
 export { createOutputVerifierMiddleware } from "./output-verifier.js";
 export type {
   DeterministicCheck,

--- a/packages/middleware-output-verifier/src/judge.ts
+++ b/packages/middleware-output-verifier/src/judge.ts
@@ -5,14 +5,37 @@
  * Rule of Three: only 2 consumers exist. Extract to @koi/llm-judge-util at 3rd.
  */
 
+const DEFAULT_HEAD_RATIO = 0.6;
+
 export interface JudgeResult {
   readonly score: number;
   readonly reasoning: string;
   readonly parseError?: string | undefined;
 }
 
+/**
+ * Truncate content to fit within maxLength, preserving head and tail context.
+ *
+ * Split: 60% from the start, 40% from the end, with an elision marker.
+ * Returns content unchanged if it fits within maxLength.
+ */
+export function truncateContent(content: string, maxLength: number): string {
+  if (content.length <= maxLength) return content;
+
+  const headLen = Math.floor(maxLength * DEFAULT_HEAD_RATIO);
+  const tailLen = maxLength - headLen;
+  const elided = content.length - maxLength;
+  return `${content.slice(0, headLen)}\n[...truncated ${String(elided)} chars...]\n${content.slice(-tailLen)}`;
+}
+
 /** Build the judge prompt from a rubric and model output content. */
-export function buildJudgePrompt(rubric: string, content: string): string {
+export function buildJudgePrompt(
+  rubric: string,
+  content: string,
+  maxContentLength?: number,
+): string {
+  const truncated =
+    maxContentLength !== undefined ? truncateContent(content, maxContentLength) : content;
   return [
     "You are an output quality judge. Evaluate the following agent output.",
     "",
@@ -20,16 +43,34 @@ export function buildJudgePrompt(rubric: string, content: string): string {
     rubric,
     "",
     "## Agent Output",
-    content,
+    truncated,
     "",
     "## Instructions",
-    'Respond with ONLY a JSON object: {"score": <0.0-1.0>, "reasoning": "<explanation>"}',
-    "The score must be between 0.0 (worst) and 1.0 (best).",
+    'Respond with ONLY a JSON object: {"score": <1-5>, "reasoning": "<explanation>"}',
+    "",
+    "Score rubric:",
+    "  1 — Completely fails the rubric criteria",
+    "  2 — Major deficiencies, mostly fails criteria",
+    "  3 — Partially meets criteria, significant gaps",
+    "  4 — Mostly meets criteria, minor issues",
+    "  5 — Fully meets or exceeds all criteria",
   ].join("\n");
 }
 
 function isRecord(v: unknown): v is Readonly<Record<string, unknown>> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Normalize a raw 1-5 integer score to the 0.0–1.0 range.
+ *
+ * Formula: (clamp(raw, 1, 5) - 1) / 4
+ *   Score 1 → 0.00, Score 2 → 0.25, Score 3 → 0.50,
+ *   Score 4 → 0.75, Score 5 → 1.00
+ */
+export function normalizeScore(raw: number): number {
+  const clamped = Math.max(1, Math.min(5, Math.round(raw)));
+  return (clamped - 1) / 4;
 }
 
 /**
@@ -51,7 +92,7 @@ export function parseJudgeResponse(response: string): JudgeResult {
       };
     }
     if (isRecord(parsed)) {
-      const score = typeof parsed.score === "number" ? clampScore(parsed.score) : 0;
+      const score = typeof parsed.score === "number" ? normalizeScore(parsed.score) : 0;
       const reasoning = typeof parsed.reasoning === "string" ? parsed.reasoning : response;
       return { score, reasoning };
     }
@@ -63,6 +104,7 @@ export function parseJudgeResponse(response: string): JudgeResult {
   };
 }
 
+/** @deprecated Use normalizeScore instead. Kept for backward compatibility. */
 export function clampScore(score: number): number {
-  return Math.max(0, Math.min(1, score));
+  return normalizeScore(score);
 }

--- a/packages/middleware-output-verifier/src/output-verifier.test.ts
+++ b/packages/middleware-output-verifier/src/output-verifier.test.ts
@@ -11,6 +11,7 @@ import {
   createSpyModelStreamHandler,
 } from "@koi/test-utils";
 import { BUILTIN_CHECKS } from "./builtin-checks.js";
+import { buildJudgePrompt, clampScore, normalizeScore, truncateContent } from "./judge.js";
 import { createOutputVerifierMiddleware } from "./output-verifier.js";
 import type { DeterministicCheck, JudgeConfig, VerifierVetoEvent } from "./types.js";
 
@@ -45,21 +46,30 @@ const reviseCheck: DeterministicCheck = {
   action: "revise",
 };
 
-function makePassingJudge(score = 0.9): JudgeConfig {
+/** Check that returns boolean false (not a string). */
+const falseCheck: DeterministicCheck = {
+  name: "boolean-false",
+  check: () => false,
+  action: "block",
+};
+
+function makePassingJudge(score = 5): JudgeConfig {
   return {
     rubric: "Be helpful and accurate",
     modelCall: mock(async () => JSON.stringify({ score, reasoning: "Good output" })),
     vetoThreshold: 0.75,
     action: "block",
+    randomFn: () => 0, // Ensure judge always runs in tests (0 ≤ any samplingRate)
   };
 }
 
-function makeBlockingJudge(score = 0.5): JudgeConfig {
+function makeBlockingJudge(score = 2): JudgeConfig {
   return {
     rubric: "Be helpful and accurate",
     modelCall: mock(async () => JSON.stringify({ score, reasoning: "Poor quality" })),
     vetoThreshold: 0.75,
     action: "block",
+    randomFn: () => 0,
   };
 }
 
@@ -213,7 +223,7 @@ describe("wrapModelCall — deterministic checks", () => {
     const handler = createMockModelHandler({ content: "always-bad" });
     const { middleware } = createOutputVerifierMiddleware({
       deterministic: [reviseCheck],
-      judge: { ...makePassingJudge(), maxRevisions: 1 },
+      maxRevisions: 1,
     });
 
     await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
@@ -254,6 +264,165 @@ describe("wrapModelCall — deterministic checks", () => {
 });
 
 // ---------------------------------------------------------------------------
+// wrapModelCall — boolean false check (#9)
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — boolean false deterministic checks", () => {
+  test("boolean false with block action throws KoiRuntimeError", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({ deterministic: [falseCheck] });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("boolean false fires event with default message 'Check \"name\" failed'", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [falseCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.checkReason).toBe('Check "boolean-false" failed');
+  });
+
+  test("boolean false with warn action delivers output and fires event", async () => {
+    const falseWarn: DeterministicCheck = {
+      name: "false-warn",
+      check: () => false,
+      action: "warn",
+    };
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [falseWarn],
+      onVeto: (e) => events.push(e),
+    });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("output");
+    expect(events[0]?.checkReason).toBe('Check "false-warn" failed');
+    expect(events[0]?.action).toBe("warn");
+  });
+
+  test("boolean false with revise action retries and uses default message", async () => {
+    // let justified: call count for multi-attempt tracking
+    let callCount = 0;
+    const handler = async (_req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      if (callCount === 1) return { content: "bad", model: "test" };
+      return { content: "good", model: "test" };
+    };
+
+    const falseRevise: DeterministicCheck = {
+      name: "false-revise",
+      check: (c) => c === "good",
+      action: "revise",
+    };
+
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [falseRevise],
+      onVeto: (e) => events.push(e),
+    });
+
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(callCount).toBe(2);
+    expect(response?.content).toBe("good");
+    expect(events[0]?.checkReason).toBe('Check "false-revise" failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapModelCall — deterministic check throwing (#7)
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — deterministic check throws", () => {
+  test("check that throws is treated as failure (fail-closed)", async () => {
+    const throwingCheck: DeterministicCheck = {
+      name: "throws",
+      check: () => {
+        throw new Error("Unexpected error in check");
+      },
+      action: "block",
+    };
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [throwingCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.checkReason).toContain("threw");
+    expect(events[0]?.checkReason).toContain("Unexpected error in check");
+  });
+
+  test("check that throws non-Error is handled", async () => {
+    const throwingCheck: DeterministicCheck = {
+      name: "throws-string",
+      check: () => {
+        throw "oops"; // eslint-disable-line no-throw-literal
+      },
+      action: "block",
+    };
+    const handler = createMockModelHandler({ content: "output" });
+    const events: VerifierVetoEvent[] = [];
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [throwingCheck],
+      onVeto: (e) => events.push(e),
+    });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+    expect(events[0]?.checkReason).toContain("Unknown error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapModelCall — onVeto observer resilience (#3)
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — onVeto observer resilience", () => {
+  test("onVeto throwing does not affect verification correctness", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [warnCheck],
+      onVeto: () => {
+        throw new Error("Observer crashed");
+      },
+    });
+
+    // Should not throw — onVeto error is swallowed
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(response?.content).toBe("output");
+  });
+
+  test("onVeto throwing during block does not prevent the block throw", async () => {
+    const handler = createMockModelHandler({ content: "output" });
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [blockCheck],
+      onVeto: () => {
+        throw new Error("Observer crashed");
+      },
+    });
+
+    // The KoiRuntimeError from block should still propagate
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // wrapModelCall — judge stage
 // ---------------------------------------------------------------------------
 
@@ -279,13 +448,14 @@ describe("wrapModelCall — judge stage", () => {
     const handler = createMockModelHandler({ content: "Bad output" });
     const events: VerifierVetoEvent[] = [];
     const { middleware } = createOutputVerifierMiddleware({
-      judge: makeBlockingJudge(0.4),
+      judge: makeBlockingJudge(2),
       onVeto: (e) => events.push(e),
     });
 
     await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
     expect(events[0]?.source).toBe("judge");
-    expect(events[0]?.score).toBe(0.4);
+    // score 2 → normalizeScore → 0.25
+    expect(events[0]?.score).toBe(0.25);
     expect(events[0]?.action).toBe("block");
     expect(events[0]?.reasoning).toBe("Poor quality");
   });
@@ -294,9 +464,11 @@ describe("wrapModelCall — judge stage", () => {
     const handler = createMockModelHandler({ content: "Borderline output" });
     const judge: JudgeConfig = {
       rubric: "Test",
-      modelCall: async () => JSON.stringify({ score: 0.75, reasoning: "Borderline" }),
+      // score 4 → normalizeScore → 0.75, which equals threshold
+      modelCall: async () => JSON.stringify({ score: 4, reasoning: "Borderline" }),
       vetoThreshold: 0.75,
       action: "block",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({ judge });
 
@@ -309,9 +481,11 @@ describe("wrapModelCall — judge stage", () => {
     const events: VerifierVetoEvent[] = [];
     const judge: JudgeConfig = {
       rubric: "Test",
-      modelCall: async () => JSON.stringify({ score: 0.5, reasoning: "Mediocre" }),
+      // score 3 → normalizeScore → 0.5, below threshold
+      modelCall: async () => JSON.stringify({ score: 3, reasoning: "Mediocre" }),
       vetoThreshold: 0.75,
       action: "warn",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({
       judge,
@@ -331,21 +505,21 @@ describe("wrapModelCall — judge stage", () => {
       callCount++;
       return { content: `output-${callCount}`, model: "test" };
     };
-    const scores = [0.5, 0.9];
+    const scores = [2, 5]; // 2 → 0.25 (fail), 5 → 1.0 (pass)
     // let justified: index tracks which score to return
     let scoreIndex = 0;
     const judge: JudgeConfig = {
       rubric: "Test",
       modelCall: async () => {
-        const score = scores[scoreIndex] ?? 0.9;
+        const score = scores[scoreIndex] ?? 5;
         scoreIndex++;
         return JSON.stringify({ score, reasoning: "Needs improvement" });
       },
       vetoThreshold: 0.75,
       action: "revise",
-      maxRevisions: 1,
+      randomFn: () => 0,
     };
-    const { middleware } = createOutputVerifierMiddleware({ judge });
+    const { middleware } = createOutputVerifierMiddleware({ judge, maxRevisions: 1 });
     const response = await middleware.wrapModelCall?.(ctx, request, handler);
     expect(callCount).toBe(2);
     expect(response?.content).toBe("output-2");
@@ -355,12 +529,13 @@ describe("wrapModelCall — judge stage", () => {
     const handler = createMockModelHandler({ content: "Bad output" });
     const judge: JudgeConfig = {
       rubric: "Test",
-      modelCall: async () => JSON.stringify({ score: 0.3, reasoning: "Always bad" }),
+      // score 1 → 0.0, always below threshold
+      modelCall: async () => JSON.stringify({ score: 1, reasoning: "Always bad" }),
       vetoThreshold: 0.75,
       action: "revise",
-      maxRevisions: 1,
+      randomFn: () => 0,
     };
-    const { middleware } = createOutputVerifierMiddleware({ judge });
+    const { middleware } = createOutputVerifierMiddleware({ judge, maxRevisions: 1 });
 
     await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
       KoiRuntimeError,
@@ -377,22 +552,25 @@ describe("wrapModelCall — judge stage", () => {
       capturedMessages.push(req);
       return { content: "output", model: "test" };
     };
-    const scores = [0.3, 0.9];
+    const scores = [1, 5]; // 1 → 0.0 (fail), 5 → 1.0 (pass)
     // let justified: index tracks which score to return
     let scoreIndex = 0;
     const judge: JudgeConfig = {
       rubric: "Test",
       modelCall: async () => {
-        const score = scores[scoreIndex] ?? 0.9;
+        const score = scores[scoreIndex] ?? 5;
         scoreIndex++;
         return JSON.stringify({ score, reasoning: longReasoning });
       },
       vetoThreshold: 0.75,
       action: "revise",
+      randomFn: () => 0,
+    };
+    const { middleware } = createOutputVerifierMiddleware({
+      judge,
       maxRevisions: 1,
       revisionFeedbackMaxLength: 100,
-    };
-    const { middleware } = createOutputVerifierMiddleware({ judge });
+    });
     await middleware.wrapModelCall?.(ctx, request, handler);
 
     // Second call should have an injected message with truncated reasoning
@@ -405,6 +583,113 @@ describe("wrapModelCall — judge stage", () => {
       // Verify truncation (feedback message contains judge reasoning, bounded)
       expect(textBlock.text.length).toBeLessThan(300); // 100-char reasoning + fixed prefix
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-revision tests (#10)
+// ---------------------------------------------------------------------------
+
+describe("wrapModelCall — multi-revision", () => {
+  test("maxRevisions=2 allows 3 handler calls and passes on 3rd attempt", async () => {
+    // let justified: call count for multi-attempt tracking
+    let callCount = 0;
+    const handler = async (_req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      return { content: `output-${callCount}`, model: "test" };
+    };
+    const scores = [1, 2, 5]; // 0.0, 0.25, 1.0
+    // let justified: index tracks which score to return
+    let scoreIndex = 0;
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => {
+        const score = scores[scoreIndex] ?? 5;
+        scoreIndex++;
+        return JSON.stringify({ score, reasoning: "Improving" });
+      },
+      vetoThreshold: 0.75,
+      action: "revise",
+      randomFn: () => 0,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge, maxRevisions: 2 });
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(callCount).toBe(3);
+    expect(response?.content).toBe("output-3");
+  });
+
+  test("maxRevisions=2 throws after exhausting all revisions", async () => {
+    const handler = createMockModelHandler({ content: "always-bad" });
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => JSON.stringify({ score: 1, reasoning: "Always bad" }),
+      vetoThreshold: 0.75,
+      action: "revise",
+      randomFn: () => 0,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge, maxRevisions: 2 });
+
+    await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("multi-revision accumulates messages across revisions", async () => {
+    const capturedRequests: ModelRequest[] = [];
+    // let justified: call count for multi-attempt tracking
+    let callCount = 0;
+    const handler = async (req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      capturedRequests.push(req);
+      return { content: `output-${callCount}`, model: "test" };
+    };
+    const scores = [1, 1, 5]; // fail, fail, pass
+    // let justified: index tracks which score to return
+    let scoreIndex = 0;
+    const judge: JudgeConfig = {
+      rubric: "Test",
+      modelCall: async () => {
+        const score = scores[scoreIndex] ?? 5;
+        scoreIndex++;
+        return JSON.stringify({ score, reasoning: "Revise" });
+      },
+      vetoThreshold: 0.75,
+      action: "revise",
+      randomFn: () => 0,
+    };
+    const { middleware } = createOutputVerifierMiddleware({ judge, maxRevisions: 2 });
+    await middleware.wrapModelCall?.(ctx, request, handler);
+
+    // 1st call: original request (0 messages)
+    expect(capturedRequests[0]?.messages).toHaveLength(0);
+    // 2nd call: 1 injected revision message
+    expect(capturedRequests[1]?.messages).toHaveLength(1);
+    // 3rd call: 2 injected revision messages (accumulated)
+    expect(capturedRequests[2]?.messages).toHaveLength(2);
+  });
+
+  test("deterministic multi-revision with maxRevisions=2", async () => {
+    // let justified: call count for multi-attempt tracking
+    let callCount = 0;
+    const handler = async (_req: ModelRequest): Promise<ModelResponse> => {
+      callCount++;
+      if (callCount <= 2) return { content: "bad", model: "test" };
+      return { content: "good", model: "test" };
+    };
+
+    const conditionalCheck: DeterministicCheck = {
+      name: "quality",
+      check: (c) => c === "good" || "Not good enough",
+      action: "revise",
+    };
+
+    const { middleware } = createOutputVerifierMiddleware({
+      deterministic: [conditionalCheck],
+      maxRevisions: 2,
+    });
+    const response = await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(callCount).toBe(3);
+    expect(response?.content).toBe("good");
   });
 });
 
@@ -423,6 +708,7 @@ describe("wrapModelCall — judge failure modes (fail-closed)", () => {
       },
       vetoThreshold: 0.75,
       action: "block",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({
       judge,
@@ -444,6 +730,7 @@ describe("wrapModelCall — judge failure modes (fail-closed)", () => {
       modelCall: async () => "not json at all",
       vetoThreshold: 0.75,
       action: "block",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({
       judge,
@@ -465,6 +752,7 @@ describe("wrapModelCall — judge failure modes (fail-closed)", () => {
       modelCall: async () => "{malformed: json}",
       vetoThreshold: 0.75,
       action: "block",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({
       judge,
@@ -485,6 +773,7 @@ describe("wrapModelCall — judge failure modes (fail-closed)", () => {
       modelCall: async () => "",
       vetoThreshold: 0.75,
       action: "block",
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({ judge });
 
@@ -500,11 +789,11 @@ describe("wrapModelCall — judge failure modes (fail-closed)", () => {
 
 describe("wrapModelCall — short-circuit logic", () => {
   test("block in deterministic skips judge", async () => {
-    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 5, reasoning: "good" }));
     const handler = createMockModelHandler({ content: "output" });
     const { middleware } = createOutputVerifierMiddleware({
       deterministic: [blockCheck],
-      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75 },
+      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75, randomFn: () => 0 },
     });
 
     await expect(middleware.wrapModelCall?.(ctx, request, handler)).rejects.toThrow();
@@ -512,11 +801,11 @@ describe("wrapModelCall — short-circuit logic", () => {
   });
 
   test("warn in deterministic still runs judge", async () => {
-    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 5, reasoning: "good" }));
     const handler = createMockModelHandler({ content: "output" });
     const { middleware } = createOutputVerifierMiddleware({
       deterministic: [warnCheck],
-      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75 },
+      judge: { rubric: "Test", modelCall: judgeModelCall, vetoThreshold: 0.75, randomFn: () => 0 },
     });
 
     await middleware.wrapModelCall?.(ctx, request, handler);
@@ -663,7 +952,7 @@ describe("getStats", () => {
   });
 
   test("samplingRate=0 means judge never runs", async () => {
-    const judgeModelCall = mock(async () => JSON.stringify({ score: 0.9, reasoning: "good" }));
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 5, reasoning: "good" }));
     const handler = createMockModelHandler({ content: "output" });
     const { middleware, getStats } = createOutputVerifierMiddleware({
       judge: {
@@ -682,6 +971,51 @@ describe("getStats", () => {
 });
 
 // ---------------------------------------------------------------------------
+// randomFn injection (#16)
+// ---------------------------------------------------------------------------
+
+describe("randomFn injection", () => {
+  test("injected randomFn controls sampling", async () => {
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 5, reasoning: "good" }));
+    const handler = createMockModelHandler({ content: "output" });
+
+    // randomFn returns 0.8 → > 0.5 samplingRate → judge skipped
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      judge: {
+        rubric: "Test",
+        modelCall: judgeModelCall,
+        vetoThreshold: 0.75,
+        samplingRate: 0.5,
+        randomFn: () => 0.8,
+      },
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(judgeModelCall).not.toHaveBeenCalled();
+    expect(getStats().judgedChecks).toBe(0);
+  });
+
+  test("injected randomFn returning 0 always samples", async () => {
+    const judgeModelCall = mock(async () => JSON.stringify({ score: 5, reasoning: "good" }));
+    const handler = createMockModelHandler({ content: "output" });
+
+    const { middleware, getStats } = createOutputVerifierMiddleware({
+      judge: {
+        rubric: "Test",
+        modelCall: judgeModelCall,
+        vetoThreshold: 0.75,
+        samplingRate: 0.5,
+        randomFn: () => 0,
+      },
+    });
+
+    await middleware.wrapModelCall?.(ctx, request, handler);
+    expect(judgeModelCall).toHaveBeenCalledTimes(1);
+    expect(getStats().judgedChecks).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Handle control
 // ---------------------------------------------------------------------------
 
@@ -693,9 +1027,10 @@ describe("setRubric", () => {
       rubric: "Original rubric",
       modelCall: async (prompt) => {
         capturedPrompts.push(prompt);
-        return JSON.stringify({ score: 0.9, reasoning: "ok" });
+        return JSON.stringify({ score: 5, reasoning: "ok" });
       },
       vetoThreshold: 0.75,
+      randomFn: () => 0,
     };
     const handle = createOutputVerifierMiddleware({ judge });
 
@@ -742,9 +1077,10 @@ describe("AbortSignal propagation", () => {
       rubric: "Test",
       modelCall: async (_prompt, signal) => {
         capturedSignals.push(signal);
-        return JSON.stringify({ score: 0.9, reasoning: "ok" });
+        return JSON.stringify({ score: 5, reasoning: "ok" });
       },
       vetoThreshold: 0.75,
+      randomFn: () => 0,
     };
     const { middleware } = createOutputVerifierMiddleware({ judge });
 
@@ -847,9 +1183,11 @@ describe("wrapModelStream", () => {
     const events: VerifierVetoEvent[] = [];
     const judge: JudgeConfig = {
       rubric: "Test",
-      modelCall: async () => JSON.stringify({ score: 0.5, reasoning: "Mediocre" }),
+      // score 3 → 0.5, below threshold
+      modelCall: async () => JSON.stringify({ score: 3, reasoning: "Mediocre" }),
       vetoThreshold: 0.75,
       action: "warn",
+      randomFn: () => 0,
     };
     const { middleware, getStats } = createOutputVerifierMiddleware({
       judge,
@@ -932,6 +1270,52 @@ describe("wrapModelStream", () => {
 });
 
 // ---------------------------------------------------------------------------
+// wrapModelStream — setRubric (#11)
+// ---------------------------------------------------------------------------
+
+describe("wrapModelStream — setRubric", () => {
+  test("streaming path uses updated rubric after setRubric", async () => {
+    const capturedPrompts: string[] = [];
+    const doneResponse: ModelResponse = { content: "output", model: "test" };
+    const chunks: readonly ModelChunk[] = [
+      { kind: "text_delta", delta: "output" },
+      { kind: "done", response: doneResponse },
+    ];
+
+    const judge: JudgeConfig = {
+      rubric: "Original rubric",
+      modelCall: async (prompt) => {
+        capturedPrompts.push(prompt);
+        return JSON.stringify({ score: 5, reasoning: "ok" });
+      },
+      vetoThreshold: 0.75,
+      randomFn: () => 0,
+    };
+    const handle = createOutputVerifierMiddleware({ judge });
+
+    // First streaming call with original rubric
+    const handler1 = createSpyModelStreamHandler(chunks);
+    const stream1 = assertStream(
+      handle.middleware.wrapModelStream?.(ctx, request, handler1.handler),
+    );
+    await collectStream(stream1);
+
+    // Update rubric
+    handle.setRubric("New rubric");
+
+    // Second streaming call with new rubric
+    const handler2 = createSpyModelStreamHandler(chunks);
+    const stream2 = assertStream(
+      handle.middleware.wrapModelStream?.(ctx, request, handler2.handler),
+    );
+    await collectStream(stream2);
+
+    expect(capturedPrompts[0]).toContain("Original rubric");
+    expect(capturedPrompts[1]).toContain("New rubric");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // describeCapabilities
 // ---------------------------------------------------------------------------
 
@@ -986,5 +1370,80 @@ describe("BUILTIN_CHECKS", () => {
     const check = BUILTIN_CHECKS.matchesPattern(/^\d+$/, "digits-only");
     expect(check.check("123")).toBe(true);
     expect(check.check("abc")).not.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// judge.ts helpers
+// ---------------------------------------------------------------------------
+
+describe("normalizeScore", () => {
+  test("normalizes 1-5 integer scale to 0.0-1.0", () => {
+    expect(normalizeScore(1)).toBe(0);
+    expect(normalizeScore(2)).toBe(0.25);
+    expect(normalizeScore(3)).toBe(0.5);
+    expect(normalizeScore(4)).toBe(0.75);
+    expect(normalizeScore(5)).toBe(1);
+  });
+
+  test("clamps values outside 1-5 range", () => {
+    expect(normalizeScore(0)).toBe(0); // clamped to 1 → 0
+    expect(normalizeScore(-1)).toBe(0);
+    expect(normalizeScore(6)).toBe(1); // clamped to 5 → 1
+    expect(normalizeScore(100)).toBe(1);
+  });
+
+  test("rounds fractional scores to nearest integer before normalizing", () => {
+    expect(normalizeScore(2.4)).toBe(0.25); // rounds to 2
+    expect(normalizeScore(2.6)).toBe(0.5); // rounds to 3
+  });
+});
+
+describe("clampScore (deprecated alias)", () => {
+  test("delegates to normalizeScore", () => {
+    expect(clampScore(3)).toBe(normalizeScore(3));
+    expect(clampScore(5)).toBe(normalizeScore(5));
+  });
+});
+
+describe("truncateContent", () => {
+  test("returns content unchanged when within limit", () => {
+    expect(truncateContent("hello", 100)).toBe("hello");
+  });
+
+  test("truncates with 60/40 split and elision marker", () => {
+    const content = "a".repeat(100);
+    const result = truncateContent(content, 50);
+    // 60% of 50 = 30 head, 40% of 50 = 20 tail
+    expect(result).toContain("a".repeat(30));
+    expect(result).toContain("[...truncated 50 chars...]");
+    expect(result.endsWith("a".repeat(20))).toBe(true);
+  });
+
+  test("exact length is not truncated", () => {
+    const content = "x".repeat(50);
+    expect(truncateContent(content, 50)).toBe(content);
+  });
+});
+
+describe("buildJudgePrompt", () => {
+  test("includes 1-5 scale instructions", () => {
+    const prompt = buildJudgePrompt("test rubric", "test content");
+    expect(prompt).toContain('{"score": <1-5>');
+    expect(prompt).toContain("1 — Completely fails");
+    expect(prompt).toContain("5 — Fully meets");
+  });
+
+  test("truncates content when maxContentLength provided", () => {
+    const longContent = "x".repeat(200);
+    const prompt = buildJudgePrompt("rubric", longContent, 50);
+    expect(prompt).toContain("[...truncated");
+    expect(prompt).not.toContain("x".repeat(200));
+  });
+
+  test("does not truncate when maxContentLength not provided", () => {
+    const longContent = "x".repeat(200);
+    const prompt = buildJudgePrompt("rubric", longContent);
+    expect(prompt).toContain(longContent);
   });
 });

--- a/packages/middleware-output-verifier/src/output-verifier.ts
+++ b/packages/middleware-output-verifier/src/output-verifier.ts
@@ -30,7 +30,7 @@ const MIDDLEWARE_NAME = "output-verifier";
 const MIDDLEWARE_PRIORITY = 385;
 const DEFAULT_MAX_BUFFER_SIZE = 262_144; // 256 KB
 const DEFAULT_VETO_THRESHOLD = 0.75;
-const DEFAULT_SAMPLING_RATE = 1.0;
+const DEFAULT_SAMPLING_RATE = 0.3;
 const DEFAULT_MAX_REVISIONS = 1;
 const DEFAULT_REVISION_FEEDBACK_MAX_LENGTH = 400;
 const VERIFIER_SENDER_ID = "system" as const;
@@ -57,7 +57,12 @@ type JudgeOutcome =
       readonly judgeError?: string;
     };
 
-/** Mutable stats counters (not exported). */
+/**
+ * Mutable stats counters — internal only, never exported.
+ * Properties are intentionally non-readonly: these are accumulator
+ * counters mutated via stats helper functions within the closure.
+ * The public VerifierStats interface (returned by getStats) is readonly.
+ */
 interface MutableStats {
   totalChecks: number;
   vetoed: number;
@@ -88,7 +93,12 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
   }
 
   const maxBufferSize = config.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+  const maxRevisions = config.maxRevisions ?? DEFAULT_MAX_REVISIONS;
+  const feedbackMaxLength =
+    config.revisionFeedbackMaxLength ?? DEFAULT_REVISION_FEEDBACK_MAX_LENGTH;
   const onVeto = config.onVeto;
+  const randomFn = config.judge?.randomFn ?? Math.random;
+  const maxContentLength = config.judge?.maxContentLength;
 
   // let: mutable judge rubric — updated via handle.setRubric()
   let currentRubric = config.judge?.rubric ?? "";
@@ -103,6 +113,26 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
   };
 
   // ---------------------------------------------------------------------------
+  // Stats helpers (#8)
+  // ---------------------------------------------------------------------------
+
+  function recordDeterministicVeto(): void {
+    stats.deterministicVetoes++;
+  }
+  function recordJudgeVeto(): void {
+    stats.judgeVetoes++;
+  }
+  function recordWarn(): void {
+    stats.warned++;
+  }
+  function recordVetoed(): void {
+    stats.vetoed++;
+  }
+  function recordJudgeRun(): void {
+    stats.judgedChecks++;
+  }
+
+  // ---------------------------------------------------------------------------
   // Stage 2 helpers
   // ---------------------------------------------------------------------------
 
@@ -111,16 +141,14 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
     if (judge === undefined) return { kind: "skip" };
 
     const samplingRate = judge.samplingRate ?? DEFAULT_SAMPLING_RATE;
-    if (Math.random() > samplingRate) return { kind: "skip" };
+    if (randomFn() > samplingRate) return { kind: "skip" };
 
-    stats.judgedChecks++;
+    recordJudgeRun();
 
     const vetoThreshold = judge.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
     const judgeAction = judge.action ?? "block";
-    const feedbackMaxLength =
-      judge.revisionFeedbackMaxLength ?? DEFAULT_REVISION_FEEDBACK_MAX_LENGTH;
 
-    const prompt = buildJudgePrompt(currentRubric, content);
+    const prompt = buildJudgePrompt(currentRubric, content, maxContentLength);
 
     let score = 0;
     let reasoning = "";
@@ -175,12 +203,7 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
     return `Check "${checkName}" failed: ${reason}. Please revise your output.`;
   }
 
-  function judgeRevisionFeedback(
-    score: number,
-    vetoThreshold: number,
-    reasoning: string,
-    feedbackMaxLength: number,
-  ): string {
+  function judgeRevisionFeedback(score: number, vetoThreshold: number, reasoning: string): string {
     const reasonPart = reasoning.slice(0, feedbackMaxLength);
     return [
       `Your output was rejected by the quality judge (score: ${score.toFixed(2)}, required: ≥${vetoThreshold}).`,
@@ -193,6 +216,40 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
   }
 
   // ---------------------------------------------------------------------------
+  // Revision helper (#5)
+  // ---------------------------------------------------------------------------
+
+  function attemptRevision(
+    revision: number,
+    feedback: string,
+    source: string,
+    currentRequest: ModelRequest,
+  ): { readonly request: ModelRequest; readonly revision: number } {
+    if (revision >= maxRevisions) {
+      throw KoiRuntimeError.from(
+        "VALIDATION",
+        `Output verifier: ${source} failed after ${String(maxRevisions)} revision(s)`,
+      );
+    }
+    return {
+      request: injectRevisionMessage(currentRequest, feedback),
+      revision: revision + 1,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Veto event helper (#3 — wrapped in try/catch)
+  // ---------------------------------------------------------------------------
+
+  function fireVeto(event: VerifierVetoEvent): void {
+    try {
+      onVeto?.(event);
+    } catch (_e: unknown) {
+      // Observer errors must never affect verification correctness
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Core verification loop (iterative)
   // ---------------------------------------------------------------------------
 
@@ -201,10 +258,7 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
     next: ModelHandler,
     ctx: TurnContext,
   ): Promise<ModelResponse> {
-    const maxRevisions = config.judge?.maxRevisions ?? DEFAULT_MAX_REVISIONS;
     const vetoThreshold = config.judge?.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
-    const feedbackMaxLength =
-      config.judge?.revisionFeedbackMaxLength ?? DEFAULT_REVISION_FEEDBACK_MAX_LENGTH;
 
     // let justified: current request may change across revision attempts
     let currentRequest = request;
@@ -229,7 +283,14 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
         // let justified: tracks whether a revise was triggered this iteration
         let deterministicRevised = false;
         for (const check of config.deterministic ?? []) {
-          const result = check.check(content);
+          // #7 — wrap check.check() in try/catch (fail-closed)
+          let result: boolean | string;
+          try {
+            result = check.check(content);
+          } catch (e: unknown) {
+            const errorMsg = e instanceof Error ? e.message : "Unknown error";
+            result = `Check "${check.name}" threw: ${errorMsg}`;
+          }
           if (result === true) continue;
 
           const reason = typeof result === "string" ? result : `Check "${check.name}" failed`;
@@ -271,18 +332,14 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
             checkReason: reason,
             action: "revise",
           });
-          if (revision >= maxRevisions) {
-            throw KoiRuntimeError.from(
-              "VALIDATION",
-              `Output verifier: deterministic check "${check.name}" failed after ${maxRevisions} revision(s): ${reason}`,
-              { context: { checkName: check.name, reason, revision } },
-            );
-          }
-          revision++;
-          currentRequest = injectRevisionMessage(
-            currentRequest,
+          const revised = attemptRevision(
+            revision,
             deterministicRevisionFeedback(check.name, reason),
+            `deterministic check "${check.name}"`,
+            currentRequest,
           );
+          currentRequest = revised.request;
+          revision = revised.revision;
           deterministicRevised = true;
           break; // Inject feedback for first revise; restart loop
         }
@@ -319,7 +376,7 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
           });
           throw KoiRuntimeError.from(
             "VALIDATION",
-            `Output verifier: judge blocked output (score ${judge.score.toFixed(2)} < ${vetoThreshold})${judge.reasoning ? `: ${judge.reasoning.slice(0, 200)}` : ""}`,
+            `Output verifier: judge blocked output (score ${judge.score.toFixed(2)} < ${String(vetoThreshold)})${judge.reasoning ? `: ${judge.reasoning.slice(0, 200)}` : ""}`,
             { context: { score: judge.score, vetoThreshold } },
           );
         }
@@ -334,33 +391,21 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
           reasoning: judge.reasoning || undefined,
           ...(judge.judgeError !== undefined ? { judgeError: judge.judgeError } : {}),
         });
-        if (revision >= maxRevisions) {
-          throw KoiRuntimeError.from(
-            "VALIDATION",
-            `Output verifier: judge blocked output after ${maxRevisions} revision(s) (score ${judge.score.toFixed(2)} < ${vetoThreshold})`,
-            { context: { score: judge.score, vetoThreshold, revision } },
-          );
-        }
-        revision++;
-        currentRequest = injectRevisionMessage(
+        const revised = attemptRevision(
+          revision,
+          judgeRevisionFeedback(judge.score, vetoThreshold, judge.reasoning),
+          "judge",
           currentRequest,
-          judgeRevisionFeedback(judge.score, vetoThreshold, judge.reasoning, feedbackMaxLength),
         );
+        currentRequest = revised.request;
+        revision = revised.revision;
       }
     } finally {
-      if (callVetoed) stats.vetoed++;
-      if (callWarned) stats.warned++;
-      if (callDeterministicVeto) stats.deterministicVetoes++;
-      if (callJudgeVeto) stats.judgeVetoes++;
+      if (callVetoed) recordVetoed();
+      if (callWarned) recordWarn();
+      if (callDeterministicVeto) recordDeterministicVeto();
+      if (callJudgeVeto) recordJudgeVeto();
     }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Veto event helper
-  // ---------------------------------------------------------------------------
-
-  function fireVeto(event: VerifierVetoEvent): void {
-    onVeto?.(event);
   }
 
   // ---------------------------------------------------------------------------
@@ -370,15 +415,22 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
   async function verifyStream(content: string, ctx: TurnContext): Promise<void> {
     // Stage 1: deterministic (streaming: ALL actions degrade to warn — content already yielded)
     for (const check of config.deterministic ?? []) {
-      const result = check.check(content);
+      // #7 — wrap check.check() in try/catch (fail-closed)
+      let result: boolean | string;
+      try {
+        result = check.check(content);
+      } catch (e: unknown) {
+        const errorMsg = e instanceof Error ? e.message : "Unknown error";
+        result = `Check "${check.name}" threw: ${errorMsg}`;
+      }
       if (result === true) continue;
 
       const reason = typeof result === "string" ? result : `Check "${check.name}" failed`;
       const action = check.action;
       const degraded = action === "block" || action === "revise";
 
-      stats.deterministicVetoes++;
-      stats.warned++;
+      recordDeterministicVeto();
+      recordWarn();
       fireVeto({
         source: "deterministic",
         checkName: check.name,
@@ -392,8 +444,8 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
     // Stage 2: judge (streaming: revise/block degrade to warn)
     const judge = await runJudge(content, ctx.signal);
     if (judge.kind === "warn") {
-      stats.judgeVetoes++;
-      stats.warned++;
+      recordJudgeVeto();
+      recordWarn();
       fireVeto({
         source: "judge",
         action: "warn",
@@ -401,8 +453,8 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
         reasoning: judge.reasoning || undefined,
       });
     } else if (judge.kind === "block" || judge.kind === "revise") {
-      stats.judgeVetoes++;
-      stats.warned++; // degraded
+      recordJudgeVeto();
+      recordWarn(); // degraded
       fireVeto({
         source: "judge",
         action: judge.kind,
@@ -415,22 +467,22 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
   }
 
   // ---------------------------------------------------------------------------
-  // Capability fragment
+  // Capability fragment (#15 — cache static prefix)
   // ---------------------------------------------------------------------------
 
+  const stages: readonly string[] = [
+    ...(hasDeterministic ? ["deterministic checks"] : []),
+    ...(hasJudge
+      ? [`judge (score ≥${String(config.judge?.vetoThreshold ?? DEFAULT_VETO_THRESHOLD)})`]
+      : []),
+  ];
+  const revisionNote = maxRevisions > 0 ? `, up to ${String(maxRevisions)} revision(s)` : "";
+  const capabilityPrefix = `Output gate: ${stages.join(" + ")}${revisionNote}. `;
+
   function buildCapabilityFragment(): CapabilityFragment {
-    const { totalChecks, vetoed } = stats;
-    const maxRevisions = config.judge?.maxRevisions ?? DEFAULT_MAX_REVISIONS;
-    const stages: string[] = [];
-    if (hasDeterministic) stages.push("deterministic checks");
-    if (hasJudge) {
-      const threshold = config.judge?.vetoThreshold ?? DEFAULT_VETO_THRESHOLD;
-      stages.push(`judge (score ≥${String(threshold)})`);
-    }
-    const revisionNote = maxRevisions > 0 ? `, up to ${String(maxRevisions)} revision(s)` : "";
     return {
       label: "output-gate",
-      description: `Output gate: ${stages.join(" + ")}${revisionNote}. ${String(vetoed)}/${String(totalChecks)} vetoed this session.`,
+      description: `${capabilityPrefix}${String(stats.vetoed)}/${String(stats.totalChecks)} vetoed this session.`,
     };
   }
 
@@ -459,25 +511,30 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
       next: ModelStreamHandler,
     ): AsyncIterable<ModelChunk> {
       stats.totalChecks++;
-      // let justified: buffer grows across stream chunks
-      let buffer = "";
+      // #13 — Array + join for streaming buffer
+      // Mutation justified: local buffer accumulates stream chunks in a hot loop;
+      // immutable pattern (spread) would cause O(n²) allocations per chunk.
+      const bufferChunks: string[] = [];
+      // let justified: tracks total buffer length for overflow checks
+      let bufferLength = 0;
       // let justified: tracks buffer overflow state
       let overflowed = false;
 
       for await (const chunk of next(request)) {
         if (chunk.kind === "text_delta") {
           if (!overflowed) {
-            if (buffer.length + chunk.delta.length > maxBufferSize) {
+            if (bufferLength + chunk.delta.length > maxBufferSize) {
               overflowed = true;
               fireVeto({
                 source: "deterministic",
                 checkName: "stream-buffer-overflow",
-                checkReason: `Stream buffer exceeded ${maxBufferSize} characters; validation skipped`,
+                checkReason: `Stream buffer exceeded ${String(maxBufferSize)} characters; validation skipped`,
                 action: "warn",
                 degraded: true,
               });
             } else {
-              buffer += chunk.delta;
+              bufferChunks.push(chunk.delta);
+              bufferLength += chunk.delta.length;
             }
           }
           yield chunk;
@@ -485,12 +542,12 @@ export function createOutputVerifierMiddleware(config: VerifierConfig): Verifier
         }
 
         if (chunk.kind === "done") {
-          if (!overflowed && buffer.length > 0) {
-            const content = buffer;
-            buffer = ""; // Release memory before async work
+          if (!overflowed && bufferLength > 0) {
+            const content = bufferChunks.join("");
+            bufferChunks.length = 0; // Release memory before async work
             await verifyStream(content, ctx);
           } else {
-            buffer = ""; // Release memory
+            bufferChunks.length = 0; // Release memory
           }
           yield chunk;
           continue;

--- a/packages/middleware-output-verifier/src/types.ts
+++ b/packages/middleware-output-verifier/src/types.ts
@@ -67,13 +67,18 @@ export interface JudgeConfig {
    * Deterministic checks always run regardless of this setting.
    */
   readonly samplingRate?: number | undefined;
-  /** Maximum revision attempts before throwing. Default: 1. */
-  readonly maxRevisions?: number | undefined;
   /**
-   * Maximum characters of judge reasoning injected during revise.
-   * Prevents context bloat from verbose judge explanations. Default: 400.
+   * Maximum characters of agent output sent to the judge prompt.
+   * Longer content is truncated (60% head + 40% tail) with an elision marker.
+   * Default: 16384 (16K chars).
    */
-  readonly revisionFeedbackMaxLength?: number | undefined;
+  readonly maxContentLength?: number | undefined;
+  /**
+   * Random number generator used for sampling decisions.
+   * Must return a value in [0, 1). Default: Math.random.
+   * Inject a deterministic function in tests for reproducibility.
+   */
+  readonly randomFn?: (() => number) | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +94,16 @@ export interface VerifierConfig {
   readonly deterministic?: readonly DeterministicCheck[] | undefined;
   /** Stage 2: LLM-as-judge. Skipped if Stage 1 produced a "block". */
   readonly judge?: JudgeConfig | undefined;
+  /**
+   * Maximum revision attempts before throwing. Default: 1.
+   * Governs both deterministic revise and judge revise.
+   */
+  readonly maxRevisions?: number | undefined;
+  /**
+   * Maximum characters of judge reasoning injected during revise.
+   * Prevents context bloat from verbose judge explanations. Default: 400.
+   */
+  readonly revisionFeedbackMaxLength?: number | undefined;
   /** Called whenever a veto or warn is triggered. */
   readonly onVeto?: ((event: VerifierVetoEvent) => void) | undefined;
   /**


### PR DESCRIPTION
## Summary

Addresses all 16 issues from the 4-section interactive review of `@koi/middleware-output-verifier`.

Closes #518

### Architecture
- **#1**: Add `validateVerifierConfig()` + `BrickDescriptor` for manifest resolution
- **#2**: Switch judge to 1–5 integer scale with `normalizeScore()` (normalized to 0.0–1.0)
- **#3**: Wrap `fireVeto` in try/catch — observer errors never affect verification correctness
- **#4**: Keep post-hoc streaming (KISS, revisit per Rule of Three)

### Code Quality
- **#5**: Extract `attemptRevision()` helper for DRY revision logic
- **#6**: Move `maxRevisions` to `VerifierConfig` top level (governs whole loop, not just judge)
- **#7**: Wrap `check.check()` in try/catch — fail-closed on thrown errors
- **#8**: Centralize stats helpers (`recordVetoed()`, `recordWarn()`, etc.)

### Tests
- **#9**: Boolean `false` return tests for deterministic checks
- **#10**: Multi-revision tests (`maxRevisions: 2`, message accumulation)
- **#11**: Streaming `setRubric` test
- **#12**: Config validation tests + API surface snapshot

### Performance
- **#13**: Array + join for streaming buffer (O(n) vs O(n²) allocations)
- **#14**: Add `maxContentLength` with `truncateContent()` for judge prompt
- **#15**: Cache static capability fragment prefix at factory time
- **#16**: Add `randomFn` injection for deterministic judge sampling in tests

### Additional
- Default `samplingRate` changed from 1.0 → 0.3 (judge runs ~30% of turns by default)
- New files: `config.ts`, `descriptor.ts`, `config.test.ts`, `api-surface.test.ts`, `e2e-real-llm.test.ts`
- **118 unit tests** (99.47% line coverage), **13 E2E tests** with real Anthropic API via `createKoi` + `createPiAdapter`

## Test plan

- [x] `bun test packages/middleware-output-verifier/` — 118 unit tests pass
- [x] `E2E_TESTS=1 bun test src/__tests__/e2e-real-llm.test.ts` — 13 E2E tests pass with real LLM
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] Biome lint — clean
- [ ] CI passes