### PR TITLE
feat: SkillComponent for tools-github + BrickDescriptor for filesystem

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -611,6 +611,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "@koi/resolve": "workspace:*",
         "@koi/scope": "workspace:*",
       },
       "devDependencies": {

--- a/docs/L2/filesystem.md
+++ b/docs/L2/filesystem.md
@@ -1,0 +1,411 @@
+# @koi/filesystem — Cross-Engine Filesystem Abstraction
+
+Wraps a `FileSystemBackend` as 5 Koi Tool components: read, write, edit, list, and search. One factory call attaches all tools to any agent via ECS — both `engine-claude` and `engine-pi` discover them with `agent.query<Tool>("tool:")` and zero engine changes.
+
+Exports a `BrickDescriptor` for manifest auto-resolution: the resolve layer validates filesystem options (operations, prefix, trustTier) from `koi.yaml` at startup.
+
+---
+
+## Why It Exists
+
+Agents that work with code need filesystem access: read files, write changes, edit in place, list directories, search for patterns. Each engine adapter would need its own filesystem integration, leading to duplicated tool schemas, inconsistent error handling, and no middleware interception.
+
+`@koi/filesystem` solves this by defining a `FileSystemBackend` interface (in L0) and wrapping it as Koi `Tool` components (in L2). The `ComponentProvider` pattern means any engine adapter discovers these tools automatically. The `BrickDescriptor` enables manifest-driven validation and discovery.
+
+---
+
+## What This Enables
+
+### Agent-Driven File Operations
+
+```
+                      ┌──────────────────────────────────────────────┐
+                      │           Your Koi Agent (YAML)              │
+                      │  name: "code-assistant"                      │
+                      │  model: anthropic:claude-sonnet              │
+                      │  tools: ["@koi/filesystem"]                  │
+                      └──────────────────┬───────────────────────────┘
+                                         │
+                    ┌────────────────────▼─────────────────────────┐
+                    │           createKoi() — L1 Engine             │
+                    │  ┌──────────────────────────────────────────┐ │
+                    │  │ Middleware Chain                          │ │
+                    │  │  audit → permissions → sandbox → ...     │ │
+                    │  └──────────────────────────────────────────┘ │
+                    │  ┌──────────────────────────────────────────┐ │
+                    │  │ Engine Adapter (Loop / Pi / Claude)      │ │
+                    │  │  → LLM calls with tool schemas           │ │
+                    │  └──────────────────────────────────────────┘ │
+                    └────────────────────┬─────────────────────────┘
+                                         │
+              ┌──────────────────────────▼──────────────────────────────┐
+              │         createFileSystemProvider() — THIS PACKAGE       │
+              │                                                         │
+              │  ONE factory → 5 Tool components → ECS-attached         │
+              │                                                         │
+              │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+              │  │ fs_read  │ │ fs_write │ │ fs_edit  │ │ fs_list  │  │
+              │  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘  │
+              │       │            │             │             │        │
+              │  ┌────▼────────────▼─────────────▼─────────────▼─────┐ │
+              │  │  fs_search                                        │ │
+              │  └───────────────────────┬───────────────────────────┘ │
+              │                          │                             │
+              │  ┌───────────────────────▼───────────────────────────┐ │
+              │  │  FileSystemBackend (injected interface)           │ │
+              │  │  ● read(), write(), edit(), list(), search()     │ │
+              │  │  ● Concrete impls: local disk, S3, in-memory...  │ │
+              │  │  ● Mockable for tests (inject via interface)     │ │
+              │  └───────────────────────────────────────────────────┘ │
+              └──────────────────────────────────────────────────────────┘
+```
+
+### Before vs After (BrickDescriptor)
+
+```
+BEFORE: filesystem in koi.yaml — no validation, not discoverable
+═══════════════════════════════════════════════════════════════
+
+  koi.yaml:
+  ┌─────────────────────────────────────────────────────┐
+  │ tools:                                               │
+  │   - name: "@koi/filesystem"                          │
+  │     trustTier: "sandbo"   ← typo, silently ignored   │
+  │     operations: ["reed"]  ← typo, silently ignored   │
+  └─────────────────────────────────────────────────────┘
+
+  resolve layer:
+    "@koi/filesystem" → no descriptor found → skip validation
+
+
+AFTER: filesystem has BrickDescriptor — validated at startup
+════════════════════════════════════════════════════════════
+
+  koi.yaml:
+  ┌─────────────────────────────────────────────────────┐
+  │ tools:                                               │
+  │   - name: "@koi/filesystem"                          │
+  │     trustTier: "sandbo"   ← VALIDATION error!        │
+  │     operations: ["reed"]  ← VALIDATION error!        │
+  └─────────────────────────────────────────────────────┘
+
+  resolve layer:
+    "@koi/filesystem" → descriptor found
+    → aliases: ["filesystem", "fs"]
+    → optionsValidator: checks operations, prefix, trustTier
+    → error: 'filesystem.trustTier must be one of: sandbox, verified, promoted'
+```
+
+---
+
+## Architecture
+
+`@koi/filesystem` is an **L2 feature package**.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  @koi/filesystem  (L2)                                │
+│                                                       │
+│  constants.ts              ← operations, SDK mappings │
+│  descriptor.ts             ← BrickDescriptor          │
+│  fs-component-provider.ts  ← ComponentProvider        │
+│  index.ts                  ← public API surface       │
+│                                                       │
+│  tools/                                               │
+│    read.ts                 ← fs_read                  │
+│    write.ts                ← fs_write                 │
+│    edit.ts                 ← fs_edit                  │
+│    list.ts                 ← fs_list                  │
+│    search.ts               ← fs_search                │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  External deps: NONE                                  │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  Internal deps                                        │
+│  ● @koi/core (L0) — Tool, ComponentProvider, types    │
+│  ● @koi/scope (L0u) — scoped filesystem wrapper       │
+│  ● @koi/resolve (L0u) — BrickDescriptor type          │
+│                                                       │
+│  Dev-only                                             │
+│  ● @koi/test-utils — mock backends                    │
+└───────────────────────────────────────────────────────┘
+```
+
+### Layer Position
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    Tool, ComponentProvider, FileSystemBackend,         │
+    KoiError, Result, TrustTier                         │
+                                                        │
+L0u @koi/scope ───────────────────────────────────────┤
+    createScopedFileSystem                              │
+                                                        │
+L0u @koi/resolve ─────────────────────────────────────┤
+    BrickDescriptor                                     │
+                                                        │
+                                                        ▼
+L2  @koi/filesystem ◄──────────────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ All interface properties readonly
+```
+
+### Internal Structure
+
+```
+createFileSystemProvider(config)
+│
+├── config.backend       → FileSystemBackend (injected)
+├── config.prefix        → "fs" (default)
+├── config.trustTier     → "verified" (default)
+├── config.operations    → all 5 (default)
+├── config.scope?        → FileSystemScope (optional root + readOnly)
+│
+└── attach(agent) → Map<SubsystemToken, Tool>
+    │
+    ├── toolToken("fs_read")    → createFsReadTool(backend, prefix, trustTier)
+    ├── toolToken("fs_write")   → createFsWriteTool(backend, prefix, trustTier)
+    ├── toolToken("fs_edit")    → createFsEditTool(backend, prefix, trustTier)
+    ├── toolToken("fs_list")    → createFsListTool(backend, prefix, trustTier)
+    ├── toolToken("fs_search")  → createFsSearchTool(backend, prefix, trustTier)
+    └── FILESYSTEM token        → backend (service singleton for middleware access)
+
+
+descriptor (BrickDescriptor<ComponentProvider>)
+│
+├── kind: "tool"
+├── name: "@koi/filesystem"
+├── aliases: ["filesystem", "fs"]
+├── optionsValidator:
+│     ├── operations? → array of valid ops (read, write, edit, list, search)
+│     ├── prefix?     → string
+│     └── trustTier?  → "sandbox" | "verified" | "promoted"
+│
+└── factory: always throws (FileSystemBackend cannot be created from YAML)
+```
+
+---
+
+## Tools Reference
+
+### 5 Tools
+
+```
+╔════════════════╦═══════════╦══════════════════════════════════════════════════╗
+║ Tool           ║ Trust     ║ Purpose                                          ║
+╠════════════════╬═══════════╬══════════════════════════════════════════════════╣
+║ fs_read        ║ verified  ║ Read file contents (with optional offset/limit) ║
+║ fs_write       ║ verified  ║ Write or create a file                          ║
+║ fs_edit        ║ verified  ║ Apply edits to a file (search/replace)          ║
+║ fs_list        ║ verified  ║ List directory entries (files, dirs, symlinks)   ║
+║ fs_search      ║ verified  ║ Search file contents by pattern (regex)         ║
+╚════════════════╩═══════════╩══════════════════════════════════════════════════╝
+```
+
+### Input Schemas
+
+```
+fs_read
+  ├── path          string    (required) File path to read
+  ├── offset?       number    Line offset to start reading
+  └── limit?        number    Max lines to return
+
+fs_write
+  ├── path          string    (required) File path to write
+  └── content       string    (required) File content
+
+fs_edit
+  ├── path          string    (required) File path to edit
+  ├── edits         array     (required) Array of { oldText, newText } pairs
+  └── dryRun?       boolean   Preview changes without writing
+
+fs_list
+  ├── path          string    (required) Directory path to list
+  ├── recursive?    boolean   List recursively
+  └── pattern?      string    Glob filter pattern
+
+fs_search
+  ├── pattern       string    (required) Search pattern (regex)
+  ├── path?         string    Directory to search in
+  ├── include?      string    File glob to include
+  └── maxResults?   number    Max matches to return
+```
+
+---
+
+## BrickDescriptor
+
+The `descriptor` enables manifest auto-resolution from `koi.yaml`:
+
+```yaml
+# koi.yaml — filesystem options are validated at startup
+tools:
+  - name: "@koi/filesystem"    # or alias: "filesystem" or "fs"
+    operations: [read, list, search]   # subset of ops
+    prefix: "file"                      # → file_read, file_list, file_search
+    trustTier: "sandbox"                # override default
+```
+
+### What the descriptor validates
+
+| Field | Type | Valid values |
+|-------|------|-------------|
+| `operations` | `string[]` | `["read", "write", "edit", "list", "search"]` |
+| `prefix` | `string` | Any string (tool name prefix) |
+| `trustTier` | `string` | `"sandbox"`, `"verified"`, `"promoted"` |
+
+All fields are optional. Empty/null/undefined options are valid (defaults apply).
+
+### Why the factory throws
+
+`FileSystemBackend` is a runtime interface — it could be backed by local disk, S3, or an in-memory mock. This cannot be constructed from YAML alone. The descriptor participates in **validation and discovery** but delegates construction to `createFileSystemProvider({ backend })`.
+
+```
+koi.yaml:
+  tools:
+    - name: "@koi/filesystem"
+      trustTier: "sandbox"
+
+resolve layer:
+  1. Find descriptor     → ✓ (kind: "tool", name: "@koi/filesystem")
+  2. Validate options    → ✓ (trustTier is valid)
+  3. Call factory        → throws: "Use createFileSystemProvider({ backend }) directly"
+  4. Runtime must wire   → createFileSystemProvider({ backend: myBackend, trustTier: "sandbox" })
+```
+
+---
+
+## Usage
+
+### With Full L1 Runtime
+
+```typescript
+import { createFileSystemProvider } from "@koi/filesystem";
+import { createKoi } from "@koi/engine";
+
+const provider = createFileSystemProvider({
+  backend: myFileSystemBackend,
+  trustTier: "verified",
+});
+
+const runtime = await createKoi({
+  manifest: { name: "code-bot", version: "1.0.0", model: { name: "anthropic:claude-sonnet" } },
+  adapter,
+  providers: [provider],
+});
+
+// Tools are discoverable
+runtime.agent.has(toolToken("fs_read"));   // true
+runtime.agent.has(toolToken("fs_write"));  // true
+```
+
+### Scoped Filesystem (sandboxed)
+
+```typescript
+import { createFileSystemProvider } from "@koi/filesystem";
+
+const provider = createFileSystemProvider({
+  backend: myBackend,
+  scope: {
+    root: "/workspace/project",  // restrict to this directory
+    readOnly: false,
+  },
+});
+// All paths are resolved relative to root; escapes are blocked
+```
+
+### Read-Only Subset
+
+```typescript
+const provider = createFileSystemProvider({
+  backend: myBackend,
+  operations: ["read", "list", "search"],  // no write/edit
+  prefix: "code",                            // → code_read, code_list, code_search
+});
+```
+
+### Claude SDK Integration
+
+```typescript
+import { CLAUDE_SDK_FILE_TOOLS } from "@koi/filesystem";
+
+// Block Claude SDK's built-in file tools when using Koi filesystem
+const adapter = createClaudeAdapter({
+  disallowedTools: CLAUDE_SDK_FILE_TOOLS,  // ["Read", "Write", "Edit", "Glob", "Grep"]
+});
+```
+
+---
+
+## Testing
+
+### Test Structure
+
+```
+packages/filesystem/src/
+  tools/
+    read.test.ts        Read: happy path, options passthrough, validation errors
+    write.test.ts       Write: creation, options, validation errors
+    edit.test.ts        Edit: single/multi edits, dryRun, validation
+    list.test.ts        List: happy path, options, validation errors
+    search.test.ts      Search: matches, options, validation errors
+  fs-component-provider.test.ts   Provider: attach, prefix, trust tier, detach
+  descriptor.test.ts              Descriptor: validation, aliases, factory error
+```
+
+### Coverage
+
+61 tests total, 0 failures. Includes 10 descriptor tests covering all validation paths.
+
+```bash
+# Run all filesystem tests
+bun turbo test --filter=@koi/filesystem
+
+# Type-check
+bun turbo typecheck --filter=@koi/filesystem
+```
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `FileSystemBackend` interface (L0) | Backend is defined in core — any package can provide an implementation (local, S3, mock) |
+| ComponentProvider + `createServiceProvider` | Attaches tools via ECS with singleton FILESYSTEM token for middleware access |
+| BrickDescriptor with throwing factory | Enables YAML validation and discovery without needing to construct a backend from config |
+| Aliases `["filesystem", "fs"]` | Short-hand for `koi.yaml` — `tools: [fs]` resolves to `@koi/filesystem` |
+| Scoped filesystem via `@koi/scope` | Optional root containment and read-only mode, composable via config |
+| `CLAUDE_SDK_FILE_TOOLS` export | Blocks SDK built-in tools when Koi filesystem replaces them |
+| No external dependencies | Everything uses `@koi/core` types; backend implementations are injected |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    Tool, ToolDescriptor, ComponentProvider,            │
+    FileSystemBackend, KoiError, Result, TrustTier      │
+                                                        │
+L0u @koi/scope ───────────────────────────────────────┤
+    createScopedFileSystem, FileSystemScope              │
+                                                        │
+L0u @koi/resolve ─────────────────────────────────────┤
+    BrickDescriptor, OptionsValidator                    │
+                                                        │
+                                                        ▼
+L2  @koi/filesystem ◄──────────────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ FileSystemBackend is a plain interface (no vendor types)
+    ✓ All interface properties readonly
+    ✓ Tool execute returns Result-shaped objects (never throws)
+    ✓ Engine adapter agnostic (works with loop, Pi, Claude)
+```

--- a/docs/L2/tools-github.md
+++ b/docs/L2/tools-github.md
@@ -1,6 +1,6 @@
 # @koi/tools-github — GitHub PR Lifecycle Tools
 
-Wraps the GitHub CLI (`gh`) as 5 Koi Tool components for PR lifecycle management: create, status, review, merge, and CI wait. One factory call attaches all tools to any agent via ECS — engines discover them with zero engine changes.
+Wraps the GitHub CLI (`gh`) as 5 Koi Tool components for PR lifecycle management: create, status, review, merge, and CI wait. One factory call attaches all tools plus a `SkillComponent` with PR best-practice guidance to any agent via ECS — engines discover them with zero engine changes.
 
 ---
 
@@ -39,7 +39,7 @@ Agents that manage code need to interact with GitHub pull requests: check CI sta
               ┌──────────────────────────▼──────────────────────────────┐
               │         createGithubProvider() — THIS PACKAGE           │
               │                                                         │
-              │  ONE factory → 5 Tool components → ECS-attached         │
+              │  ONE factory → 5 Tool components + 1 Skill → ECS-attached│
               │                                                         │
               │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
               │  │pr_create │ │pr_status │ │pr_review │ │pr_merge  │  │
@@ -278,13 +278,14 @@ createGithubProvider(config)
 ├── config.trustTier     → "verified" (default)
 ├── config.operations    → all 5 (default)
 │
-└── attach(agent) → Map<SubsystemToken, Tool>
+└── attach(agent) → Map<SubsystemToken, Tool | SkillComponent>
     │
     ├── toolToken("github_pr_create")  → createGithubPrCreateTool(executor, prefix, "promoted")
     ├── toolToken("github_pr_status")  → createGithubPrStatusTool(executor, prefix, "verified")
     ├── toolToken("github_pr_review")  → createGithubPrReviewTool(executor, prefix, "promoted")
     ├── toolToken("github_pr_merge")   → createGithubPrMergeTool(executor, prefix, "promoted")
-    └── toolToken("github_ci_wait")    → createGithubCiWaitTool(executor, prefix, "verified")
+    ├── toolToken("github_ci_wait")    → createGithubCiWaitTool(executor, prefix, "verified")
+    └── skillToken("github")           → SkillComponent { name, description, content, tags }
 
 Trust tiers:
   Read operations  (pr_status, ci_wait)   → configTier (default: "verified")
@@ -492,7 +493,7 @@ Tier 3: Real LLM E2E (opt-in, needs ANTHROPIC_API_KEY)
 
 ### Coverage
 
-110 tests total, 0 failures. Unit + CI-safe E2E run on every build. Real LLM tests gated behind `E2E_TESTS=1`.
+113 tests total, 0 failures. Unit + CI-safe E2E run on every build. Real LLM tests gated behind `E2E_TESTS=1`.
 
 ```bash
 # Unit + CI-safe E2E (default)
@@ -517,7 +518,7 @@ bun turbo run build typecheck lint test --filter=@koi/tools-github
 | Pre-validation in `pr_merge` | Checks draft status, CI, merge conflicts BEFORE attempting merge — avoids partial failures |
 | `parseGhError` maps stderr patterns | Structured `KoiError` codes enable LLM-driven error handling ("rate limited → wait and retry") |
 | No external dependencies | `gh` CLI is the only external dependency; zero npm packages beyond `@koi/core` |
-| `GITHUB_SYSTEM_PROMPT` exported | Agents can include PR lifecycle best practices in their system prompt |
+| Auto-attached `SkillComponent` | Provider attaches `skill:github` with PR best practices — engines inject it into the system prompt automatically. `GITHUB_SYSTEM_PROMPT` is deprecated; no manual wiring needed |
 | Configurable prefix and operation subset | Same provider works for `github_*`, `gh_*`, or read-only subsets |
 | CI-safe E2E via scripted model | Validates full assembly pipeline without API keys — catches integration regressions in CI |
 | Sequential mock executor (queue) | Deterministic test ordering; routing executor for non-deterministic LLM tests |
@@ -529,6 +530,7 @@ bun turbo run build typecheck lint test --filter=@koi/tools-github
 ```
 L0  @koi/core ────────────────────────────────────────┐
     Tool, ToolDescriptor, ComponentProvider,            │
+    SkillComponent, skillToken,                         │
     KoiError, Result, JsonObject, TrustTier,            │
     toolToken, agentId                                  │
                                                         │

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@koi/core": "workspace:*",
+    "@koi/resolve": "workspace:*",
     "@koi/scope": "workspace:*"
   },
   "devDependencies": {

--- a/packages/filesystem/src/descriptor.test.ts
+++ b/packages/filesystem/src/descriptor.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentManifest } from "@koi/core";
+import type { ResolutionContext } from "@koi/resolve";
+import { descriptor } from "./descriptor.js";
+
+/** Minimal context — factory throws before using it. */
+const STUB_CONTEXT: ResolutionContext = {
+  manifestDir: "/tmp",
+  manifest: { name: "test" } as AgentManifest,
+  env: {},
+};
+
+describe("filesystem descriptor", () => {
+  test("has correct kind and name", () => {
+    expect(descriptor.kind).toBe("tool");
+    expect(descriptor.name).toBe("@koi/filesystem");
+  });
+
+  test("has aliases", () => {
+    expect(descriptor.aliases).toEqual(["filesystem", "fs"]);
+  });
+
+  test("validates empty options as valid", () => {
+    const result = descriptor.optionsValidator({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("validates null/undefined options as valid", () => {
+    expect(descriptor.optionsValidator(null).ok).toBe(true);
+    expect(descriptor.optionsValidator(undefined).ok).toBe(true);
+  });
+
+  test("rejects non-object options", () => {
+    const stringResult = descriptor.optionsValidator("bad");
+    expect(stringResult.ok).toBe(false);
+    if (!stringResult.ok) {
+      expect(stringResult.error.code).toBe("VALIDATION");
+    }
+
+    const numberResult = descriptor.optionsValidator(42);
+    expect(numberResult.ok).toBe(false);
+  });
+
+  test("validates operations as array of valid ops", () => {
+    const valid = descriptor.optionsValidator({ operations: ["read", "write"] });
+    expect(valid.ok).toBe(true);
+
+    const invalid = descriptor.optionsValidator({ operations: ["invalid"] });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.error.message).toContain("invalid");
+    }
+
+    const notArray = descriptor.optionsValidator({ operations: "not-array" });
+    expect(notArray.ok).toBe(false);
+    if (!notArray.ok) {
+      expect(notArray.error.message).toContain("array");
+    }
+  });
+
+  test("validates prefix as string", () => {
+    const valid = descriptor.optionsValidator({ prefix: "s3" });
+    expect(valid.ok).toBe(true);
+
+    const invalid = descriptor.optionsValidator({ prefix: 123 });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.error.message).toContain("prefix");
+    }
+  });
+
+  test("validates trustTier as enum", () => {
+    for (const tier of ["sandbox", "verified", "promoted"]) {
+      expect(descriptor.optionsValidator({ trustTier: tier }).ok).toBe(true);
+    }
+
+    const invalid = descriptor.optionsValidator({ trustTier: "invalid" });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.error.message).toContain("trustTier");
+    }
+  });
+
+  test("accepts all valid options combined", () => {
+    const result = descriptor.optionsValidator({
+      operations: ["read", "write", "edit", "list", "search"],
+      prefix: "s3",
+      trustTier: "sandbox",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("factory throws with helpful message", () => {
+    expect(() => descriptor.factory({}, STUB_CONTEXT)).toThrow("FileSystemBackend");
+  });
+});

--- a/packages/filesystem/src/descriptor.ts
+++ b/packages/filesystem/src/descriptor.ts
@@ -1,0 +1,107 @@
+/**
+ * BrickDescriptor for @koi/filesystem.
+ *
+ * Enables manifest auto-resolution: the resolve layer looks up this
+ * descriptor, validates filesystem options, and calls the factory.
+ *
+ * The factory always throws because @koi/filesystem requires a
+ * FileSystemBackend instance that cannot be constructed from YAML alone.
+ */
+
+import type { ComponentProvider, KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BrickDescriptor } from "@koi/resolve";
+import { OPERATIONS } from "./constants.js";
+
+const TRUST_TIERS = ["sandbox", "verified", "promoted"] as const;
+
+function validateFilesystemDescriptorOptions(input: unknown): Result<unknown, KoiError> {
+  if (input === null || input === undefined) {
+    return { ok: true, value: {} };
+  }
+
+  if (typeof input !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Filesystem options must be an object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const opts = input as Record<string, unknown>;
+
+  // Validate operations
+  if (opts.operations !== undefined) {
+    if (!Array.isArray(opts.operations)) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "filesystem.operations must be an array",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+    for (const op of opts.operations) {
+      if (!(OPERATIONS as readonly string[]).includes(op as string)) {
+        return {
+          ok: false,
+          error: {
+            code: "VALIDATION",
+            message: `filesystem.operations contains invalid operation "${String(op)}". Valid: ${OPERATIONS.join(", ")}`,
+            retryable: RETRYABLE_DEFAULTS.VALIDATION,
+          },
+        };
+      }
+    }
+  }
+
+  // Validate prefix
+  if (opts.prefix !== undefined && typeof opts.prefix !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "filesystem.prefix must be a string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  // Validate trustTier
+  if (opts.trustTier !== undefined) {
+    if (!(TRUST_TIERS as readonly string[]).includes(opts.trustTier as string)) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `filesystem.trustTier must be one of: ${TRUST_TIERS.join(", ")}`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+  }
+
+  return { ok: true, value: input };
+}
+
+/**
+ * Descriptor for filesystem provider.
+ *
+ * The factory always throws because a FileSystemBackend instance is
+ * required — use `createFileSystemProvider({ backend })` directly.
+ */
+export const descriptor: BrickDescriptor<ComponentProvider> = {
+  kind: "tool",
+  name: "@koi/filesystem",
+  aliases: ["filesystem", "fs"],
+  optionsValidator: validateFilesystemDescriptorOptions,
+  factory(_options, _context): ComponentProvider {
+    throw new Error(
+      "@koi/filesystem requires a FileSystemBackend. Use createFileSystemProvider({ backend }) directly.",
+    );
+  },
+};

--- a/packages/filesystem/src/index.ts
+++ b/packages/filesystem/src/index.ts
@@ -30,6 +30,9 @@ export type { FileSystemOperation } from "./constants.js";
 // constants
 export { CLAUDE_SDK_FILE_TOOLS, DEFAULT_PREFIX, OPERATIONS } from "./constants.js";
 
+// descriptor
+export { descriptor } from "./descriptor.js";
+
 // provider
 export type { FileSystemProviderConfig } from "./fs-component-provider.js";
 export { createFileSystemProvider } from "./fs-component-provider.js";

--- a/packages/tools-github/src/__tests__/github-component-provider.test.ts
+++ b/packages/tools-github/src/__tests__/github-component-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { AttachResult, Tool } from "@koi/core";
+import type { AttachResult, SkillComponent, Tool } from "@koi/core";
 import { isAttachResult } from "@koi/core";
+import { GITHUB_SYSTEM_PROMPT } from "../constants.js";
 import { createGithubProvider } from "../github-component-provider.js";
 import { createMockAgent, createMockGhExecutor } from "../test-helpers.js";
 
@@ -11,19 +12,20 @@ function extractMap(
 }
 
 describe("createGithubProvider", () => {
-  test("attaches all 5 tools by default", async () => {
+  test("attaches all 5 tools and skill by default", async () => {
     const executor = createMockGhExecutor([]);
     const provider = createGithubProvider({ executor });
     const agent = createMockAgent();
     const components = extractMap(await provider.attach(agent));
 
-    expect(components.size).toBe(5);
+    expect(components.size).toBe(6);
     const keys = [...components.keys()];
     expect(keys).toContain("tool:github_pr_create");
     expect(keys).toContain("tool:github_pr_status");
     expect(keys).toContain("tool:github_pr_review");
     expect(keys).toContain("tool:github_pr_merge");
     expect(keys).toContain("tool:github_ci_wait");
+    expect(keys).toContain("skill:github");
   });
 
   test("uses custom prefix", async () => {
@@ -82,11 +84,12 @@ describe("createGithubProvider", () => {
     const agent = createMockAgent();
     const components = extractMap(await provider.attach(agent));
 
-    expect(components.size).toBe(2);
+    expect(components.size).toBe(3);
     const keys = [...components.keys()];
     expect(keys).toContain("tool:github_pr_create");
     expect(keys).toContain("tool:github_pr_status");
     expect(keys).not.toContain("tool:github_pr_merge");
+    expect(keys).toContain("skill:github");
   });
 
   test("provider has correct name", () => {
@@ -107,12 +110,49 @@ describe("createGithubProvider", () => {
     const agent = createMockAgent();
     const components = extractMap(await provider.attach(agent));
 
-    for (const [_key, value] of components) {
+    for (const [key, value] of components) {
+      if (!key.startsWith("tool:")) continue;
       const tool = value as Tool;
       expect(tool.descriptor.name).toBeTruthy();
       expect(tool.descriptor.description).toBeTruthy();
       expect(tool.descriptor.inputSchema).toBeTruthy();
       expect(typeof tool.execute).toBe("function");
     }
+  });
+
+  test("attaches github skill with correct metadata", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = extractMap(await provider.attach(agent));
+
+    const skill = components.get("skill:github") as SkillComponent;
+    expect(skill.name).toBe("github");
+    expect(skill.description).toBe(
+      "GitHub PR lifecycle best practices and error handling guidance",
+    );
+    expect(skill.tags).toEqual(["github", "pr"]);
+  });
+
+  test("skill content matches GITHUB_SYSTEM_PROMPT", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({ executor });
+    const agent = createMockAgent();
+    const components = extractMap(await provider.attach(agent));
+
+    const skill = components.get("skill:github") as SkillComponent;
+    expect(skill.content).toBe(GITHUB_SYSTEM_PROMPT);
+  });
+
+  test("skill is attached regardless of operations filter", async () => {
+    const executor = createMockGhExecutor([]);
+    const provider = createGithubProvider({
+      executor,
+      operations: ["pr_status"],
+    });
+    const agent = createMockAgent();
+    const components = extractMap(await provider.attach(agent));
+
+    expect(components.has("skill:github")).toBe(true);
   });
 });

--- a/packages/tools-github/src/constants.ts
+++ b/packages/tools-github/src/constants.ts
@@ -57,8 +57,9 @@ export const CI_WAIT_FIELDS = "statusCheckRollup" as const;
 /**
  * System prompt guidance for agents using GitHub tools.
  *
- * Include this in your agent's system prompt or koi.yaml `instructions` field
- * to prime the agent with PR lifecycle best practices.
+ * @deprecated Use `createGithubProvider()` instead — it auto-attaches this
+ * content as a `SkillComponent` (keyed `"skill:github"`). Manual wiring is
+ * no longer necessary.
  */
 export const GITHUB_SYSTEM_PROMPT: string = `
 ## GitHub PR lifecycle — best practices

--- a/packages/tools-github/src/github-component-provider.ts
+++ b/packages/tools-github/src/github-component-provider.ts
@@ -6,9 +6,14 @@
  * available to any engine with zero engine changes.
  */
 
-import type { Agent, ComponentProvider, Tool, TrustTier } from "@koi/core";
-import { toolToken } from "@koi/core";
-import { type GithubOperation, OPERATIONS, trustTierForOperation } from "./constants.js";
+import type { Agent, ComponentProvider, SkillComponent, Tool, TrustTier } from "@koi/core";
+import { skillToken, toolToken } from "@koi/core";
+import {
+  GITHUB_SYSTEM_PROMPT,
+  type GithubOperation,
+  OPERATIONS,
+  trustTierForOperation,
+} from "./constants.js";
 import type { GhExecutor } from "./gh-executor.js";
 import { createGithubCiWaitTool } from "./tools/ci-wait.js";
 import { createGithubPrCreateTool } from "./tools/pr-create.js";
@@ -43,17 +48,22 @@ export function createGithubProvider(config: GithubProviderConfig): ComponentPro
     name: `github:${prefix}`,
 
     attach: async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
-      const entries: ReadonlyMap<string, unknown> = new Map(
-        operations.map((op) => {
-          const tier = trustTierForOperation(op, trustTier);
-          const factory = TOOL_FACTORIES[op];
-          const tool = factory(executor, prefix, tier);
-          // SubsystemToken<T> extends string — safe to use as Map key directly
-          const key: string = toolToken(tool.descriptor.name);
-          return [key, tool] as const;
-        }),
-      );
-      return entries;
+      const toolEntries: ReadonlyArray<readonly [string, unknown]> = operations.map((op) => {
+        const tier = trustTierForOperation(op, trustTier);
+        const factory = TOOL_FACTORIES[op];
+        const tool = factory(executor, prefix, tier);
+        return [toolToken(tool.descriptor.name) as string, tool] as const;
+      });
+
+      const skill: SkillComponent = {
+        name: "github",
+        description: "GitHub PR lifecycle best practices and error handling guidance",
+        content: GITHUB_SYSTEM_PROMPT,
+        tags: ["github", "pr"],
+      };
+      const skillEntry: readonly [string, unknown] = [skillToken("github") as string, skill];
+
+      return new Map([...toolEntries, skillEntry]);
     },
   };
 }


### PR DESCRIPTION
## Summary

- **Issue #533**: `GITHUB_SYSTEM_PROMPT` is now auto-attached as a `SkillComponent` (`skill:github`) by `createGithubProvider()`. Engines discover it via `agent.query<SkillComponent>("skill:")` and inject it into the system prompt — no manual wiring needed. The constant is deprecated with `@deprecated` JSDoc.

- **Issue #536**: `@koi/filesystem` now exports a `BrickDescriptor` (`kind: "tool"`, aliases `["filesystem", "fs"]`) enabling manifest auto-resolution. The descriptor validates `operations`, `prefix`, and `trustTier` from `koi.yaml` at startup. The factory throws with a helpful message since `FileSystemBackend` requires runtime injection.

- Documentation added/updated under `docs/L2/` for both packages.

Closes #533
Closes #536

## Changes

| File | Change |
|------|--------|
| `packages/tools-github/src/constants.ts` | `@deprecated` JSDoc on `GITHUB_SYSTEM_PROMPT` |
| `packages/tools-github/src/github-component-provider.ts` | Import `SkillComponent`/`skillToken`, attach `skill:github` in `attach()` |
| `packages/tools-github/src/__tests__/github-component-provider.test.ts` | Update size expectations, fix iterator test, add 3 skill tests |
| `packages/filesystem/package.json` | Add `@koi/resolve` dependency (L0u) |
| `packages/filesystem/src/descriptor.ts` | **New** — BrickDescriptor with validation |
| `packages/filesystem/src/descriptor.test.ts` | **New** — 10 comprehensive tests |
| `packages/filesystem/src/index.ts` | Export `descriptor` |
| `docs/L2/tools-github.md` | Document SkillComponent attachment |
| `docs/L2/filesystem.md` | **New** — full package documentation |

## Test plan

- [x] `bunx turbo test --filter=@koi/tools-github` — 105 pass, 8 skip, 0 fail
- [x] `bunx turbo test --filter=@koi/filesystem` — 61 pass, 0 fail
- [x] `bunx turbo typecheck --filter=@koi/tools-github --filter=@koi/filesystem` — clean
- [x] Biome lint/format — clean
- [ ] Verify `skill:github` is injected into system prompt in a real agent run
- [ ] Verify `koi.yaml` with `tools: [fs]` alias resolves correctly