### PR TITLE
feat: add SkillComponent to @koi/filesystem and @koi/tool-browser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1707,6 +1707,7 @@
       "name": "@koi/e2e-contracts",
       "version": "0.0.0",
       "devDependencies": {
+        "@koi/browser-playwright": "workspace:*",
         "@koi/canvas": "workspace:*",
         "@koi/channel-canvas-fallback": "workspace:*",
         "@koi/core": "workspace:*",
@@ -1715,6 +1716,7 @@
         "@koi/engine-external": "workspace:*",
         "@koi/engine-loop": "workspace:*",
         "@koi/engine-pi": "workspace:*",
+        "@koi/filesystem": "workspace:*",
         "@koi/forge": "workspace:*",
         "@koi/gateway": "workspace:*",
         "@koi/git-utils": "workspace:*",
@@ -1743,6 +1745,7 @@
         "@koi/sandbox-executor": "workspace:*",
         "@koi/soul": "workspace:*",
         "@koi/test-utils": "workspace:*",
+        "@koi/tool-browser": "workspace:*",
         "@koi/worktree-merge": "workspace:*",
       },
     },

--- a/docs/L2/filesystem.md
+++ b/docs/L2/filesystem.md
@@ -409,3 +409,44 @@ L2  @koi/filesystem ◄───────────────────
     ✓ Tool execute returns Result-shaped objects (never throws)
     ✓ Engine adapter agnostic (works with loop, Pi, Claude)
 ```
+
+---
+
+## SkillComponent (skill:filesystem)
+
+`createFileSystemProvider` automatically attaches a `SkillComponent` to the agent under the token `skill:filesystem`. This is pure ECS data — a structured object the middleware stack and orchestrator can read to inject behavioral guidance into the system prompt.
+
+### What the skill teaches
+
+The `FS_SKILL_CONTENT` markdown covers four areas:
+
+| Area | Guidance |
+|------|----------|
+| **fs_edit vs fs_write** | Use `fs_edit` for targeted changes to existing files; `fs_write` only for new files or full replacements |
+| **fs_search vs fs_list** | `fs_search` for content lookup by pattern; `fs_list` for directory structure |
+| **Read before edit** | Always `fs_read` first to confirm `oldText` before calling `fs_edit` |
+| **Path safety** | Always use absolute paths; never construct paths from untrusted input |
+
+### Accessing the skill
+
+```typescript
+import type { SkillComponent } from "@koi/core";
+import { skillToken } from "@koi/core";
+import { FS_SKILL_NAME } from "@koi/filesystem";
+
+const skill = runtime.agent.component<SkillComponent>(skillToken(FS_SKILL_NAME));
+// skill.name     → "filesystem"
+// skill.content  → markdown guidance string
+// skill.tags     → ["filesystem", "best-practices"]
+```
+
+### Using standalone
+
+The `FS_SKILL` constant is exported for use in custom providers:
+
+```typescript
+import { FS_SKILL, FS_SKILL_NAME } from "@koi/filesystem";
+import { skillToken } from "@koi/core";
+
+customTools: () => [[skillToken(FS_SKILL_NAME) as string, FS_SKILL]],
+```

--- a/docs/L2/tool-browser.md
+++ b/docs/L2/tool-browser.md
@@ -1,0 +1,276 @@
+# @koi/tool-browser — Browser Tool Provider
+
+Gives Koi agents the ability to control a web browser through a pluggable `BrowserDriver`. Attaches `browser_*` tools to the agent component map, enforces trust-tier access control, and injects a `SkillComponent` that teaches agents the snapshot-first workflow, form filling, wait strategies, tab management, and token-cost awareness.
+
+---
+
+## Why It Exists
+
+Browser automation with LLMs breaks in predictable ways unless the agent follows a strict loop: snapshot the page, reference elements by their `[ref=eN]` markers, act, then re-snapshot. Without explicit behavioral guidance the agent tends to:
+
+- Act on stale element references, causing `STALE_REF` errors
+- Use `browser_screenshot` (base64 images, ~100× more tokens) when `browser_snapshot` would suffice
+- Fill fields one-at-a-time instead of using `browser_fill_form` for atomic multi-field submission
+- Open tabs without closing them, leaking browser resources
+- Use `browser_evaluate` (JavaScript injection) without realizing it requires elevated `promoted` trust tier
+
+This package solves both sides of the problem — it wires the tools with correct trust-tier defaults, and it wires the behavioral instructions as a `SkillComponent` that travels with the tools through the ECS component map.
+
+---
+
+## What This Enables
+
+### The Snapshot-Act-Re-snapshot Loop
+
+```
+                    ┌──────────────────────────────────────────────┐
+                    │               KOI AGENT                      │
+                    │                                              │
+                    │  "I need to log in. Let me see the page."    │
+                    │                                              │
+                    └──────────────┬───────────────────────────────┘
+                                   │
+                    ┌──────────────▼───────────────────────────────┐
+                    │  STEP 1: browser_snapshot                    │
+                    │                                              │
+                    │  Output:                                     │
+                    │    snapshotId: "snap-tab-1-3"                │
+                    │    elements:                                 │
+                    │      textbox "Email"    [ref=e1]             │
+                    │      textbox "Password" [ref=e2]             │
+                    │      button  "Log In"   [ref=e3]             │
+                    │                                              │
+                    └──────────────┬───────────────────────────────┘
+                                   │
+                    ┌──────────────▼───────────────────────────────┐
+                    │  STEP 2: browser_fill_form                   │
+                    │                                              │
+                    │  Input:                                      │
+                    │    snapshotId: "snap-tab-1-3"  ← required   │
+                    │    fields: [                                 │
+                    │      { ref: "e1", value: "me@example.com" } │
+                    │      { ref: "e2", value: "••••••" }         │
+                    │    ]                                         │
+                    │                                              │
+                    └──────────────┬───────────────────────────────┘
+                                   │
+                    ┌──────────────▼───────────────────────────────┐
+                    │  STEP 3: browser_click                       │
+                    │                                              │
+                    │  Input: { snapshotId: "snap-tab-1-3",        │
+                    │           ref: "e3" }                        │
+                    │                                              │
+                    └──────────────┬───────────────────────────────┘
+                                   │
+                    ┌──────────────▼───────────────────────────────┐
+                    │  STEP 4: browser_snapshot (re-snapshot)      │
+                    │                                              │
+                    │  Output: new snapshotId + dashboard elements │
+                    │  → DOM changed: always re-snapshot after act │
+                    │                                              │
+                    └──────────────────────────────────────────────┘
+```
+
+---
+
+## Installation
+
+```bash
+bun add --cwd packages/my-agent @koi/tool-browser
+bun add --cwd packages/my-agent @koi/browser-playwright  # for real browsers
+```
+
+---
+
+## Quick Start
+
+```typescript
+import { createKoi } from "@koi/engine";
+import { createBrowserProvider } from "@koi/tool-browser";
+import { createPlaywrightBrowserDriver } from "@koi/browser-playwright";
+
+const browserProvider = createBrowserProvider({
+  backend: createPlaywrightBrowserDriver({ headless: true }),
+});
+
+const runtime = await createKoi({
+  manifest: { name: "my-agent", version: "0.0.1", model: { name: "claude-haiku-4-5-20251001" } },
+  adapter,
+  providers: [browserProvider],
+});
+```
+
+The agent now has all 12 default `browser_*` tools in its tool list and `skill:browser` in its component map.
+
+---
+
+## Configuration
+
+```typescript
+createBrowserProvider({
+  backend,        // required — BrowserDriver implementation
+  operations,     // optional — subset of operations (default: OPERATIONS, excludes "evaluate")
+  prefix,         // optional — tool name prefix (default: "browser")
+  scope,          // optional — ScopeChecker for URL-level access control
+  trustTier,      // optional — default trust tier (default: "verified")
+})
+```
+
+### Enable browser_evaluate (JavaScript injection)
+
+`browser_evaluate` is excluded from the default operations because it runs arbitrary JavaScript and requires `promoted` trust tier. Opt in explicitly:
+
+```typescript
+import { OPERATIONS } from "@koi/tool-browser";
+
+createBrowserProvider({
+  backend,
+  operations: [...OPERATIONS, "evaluate"],
+  // evaluate is automatically pinned to "promoted" regardless of trustTier config
+})
+```
+
+### Custom prefix
+
+```typescript
+createBrowserProvider({ backend, prefix: "web" })
+// Registers: web_snapshot, web_navigate, web_click, web_type, ...
+```
+
+### URL scope restrictions
+
+```typescript
+import { createScope } from "@koi/scope";
+
+createBrowserProvider({
+  backend,
+  scope: createScope({
+    allow: ["https://app.example.com/**"],
+    deny: ["https://app.example.com/admin/**"],
+  }),
+})
+```
+
+---
+
+## Default Operations
+
+| Operation | Tool name | Trust tier | Purpose |
+|-----------|-----------|------------|---------|
+| snapshot | browser_snapshot | verified | Capture accessibility tree + element refs |
+| navigate | browser_navigate | verified | Navigate to a URL |
+| click | browser_click | verified | Click an element by ref |
+| type | browser_type | verified | Type text into a field |
+| fill_form | browser_fill_form | verified | Fill multiple fields atomically |
+| select | browser_select | verified | Choose a dropdown option |
+| scroll | browser_scroll | verified | Scroll the page |
+| wait | browser_wait | verified | Wait for element/timeout |
+| tab_new | browser_tab_new | verified | Open a new tab |
+| tab_focus | browser_tab_focus | verified | Switch to a tab |
+| tab_close | browser_tab_close | verified | Close a tab |
+| screenshot | browser_screenshot | verified | Capture base64 screenshot |
+| *(opt-in)* | browser_evaluate | **promoted** | Execute JavaScript |
+
+---
+
+## SkillComponent
+
+`createBrowserProvider` automatically attaches a `SkillComponent` to the agent under the token `skill:browser`. This component is pure ECS data — a structured object the middleware stack and orchestrator can read to inject behavioral guidance into the system prompt or pass to other components.
+
+### Relationship to BROWSER_SYSTEM_PROMPT
+
+`BROWSER_SYSTEM_PROMPT` is an older raw string constant used by system-prompt middleware. `FS_SKILL` / `BROWSER_SKILL` are the ECS-native replacements. They carry the same guidance in a structured `SkillComponent` that can be queried, filtered by tag, and composed without string concatenation.
+
+### What the skill teaches
+
+The `BROWSER_SKILL_CONTENT` markdown covers five areas:
+
+| Area | Guidance |
+|------|----------|
+| **Snapshot loop** | Always snapshot before acting; always re-snapshot after DOM changes; pass `snapshotId` to every action |
+| **Form filling** | `browser_fill_form` for multi-field forms; `browser_type` for single fields; `browser_select` for dropdowns |
+| **Wait strategies** | `browser_wait` with `selector` preferred over fixed timeouts; re-snapshot after navigate |
+| **Tab management** | `browser_tab_focus` before acting on a tab; always close tabs you open |
+| **Trust tier awareness** | `browser_evaluate` is `promoted` only; prefer `browser_snapshot` over `browser_screenshot` (100× cheaper) |
+
+The skill also includes an **error code quick reference** table (`STALE_REF`, `TIMEOUT`, `NOT_FOUND`, `EXTERNAL`, `INTERNAL`, `PERMISSION`, `VALIDATION`) with recommended recovery actions.
+
+### Accessing the skill
+
+```typescript
+import type { SkillComponent } from "@koi/core";
+import { skillToken } from "@koi/core";
+import { BROWSER_SKILL_NAME } from "@koi/tool-browser";
+
+const skill = runtime.agent.component<SkillComponent>(skillToken(BROWSER_SKILL_NAME));
+// skill.name     → "browser"
+// skill.content  → markdown guidance string
+// skill.tags     → ["browser", "best-practices"]
+```
+
+### Using standalone
+
+The `BROWSER_SKILL` constant is exported so you can attach it to a custom provider:
+
+```typescript
+import { BROWSER_SKILL, BROWSER_SKILL_NAME } from "@koi/tool-browser";
+import { skillToken } from "@koi/core";
+
+customTools: () => [[skillToken(BROWSER_SKILL_NAME) as string, BROWSER_SKILL]],
+```
+
+---
+
+## BrowserDriver Interface
+
+Implement this interface to connect any browser backend:
+
+```typescript
+interface BrowserDriver {
+  snapshot(params?): Promise<BrowserSnapshotResult>;
+  navigate(params): Promise<BrowserNavigateResult>;
+  click(params): Promise<BrowserActionResult>;
+  type(params): Promise<BrowserActionResult>;
+  // ... one method per operation
+  dispose?(): void | Promise<void>;
+}
+```
+
+See `@koi/browser-playwright` for the Playwright implementation, or implement your own (e.g., Puppeteer, CDP-based, headless Chrome via shell).
+
+---
+
+## Architecture
+
+```
+@koi/tool-browser (L2)
+└── createBrowserProvider
+    ├── createServiceProvider<BrowserDriver, BrowserOperation>()
+    │   └── attaches: BROWSER token, browser_snapshot, browser_navigate, ...
+    └── customTools hook
+        ├── createCustomToolEntries()  ← evaluate pinned to "promoted"
+        └── skill:browser              ← SkillComponent (ECS component, pure data)
+```
+
+`@koi/tool-browser` depends only on `@koi/core` (L0). The `BrowserDriver` is injected at construction time — swapping backends requires zero code changes in the provider.
+
+---
+
+## Exports
+
+```typescript
+// Provider factory
+export { createBrowserProvider } from "./browser-component-provider.js";
+
+// Skill
+export { BROWSER_SKILL, BROWSER_SKILL_CONTENT, BROWSER_SKILL_NAME } from "./constants.js";
+
+// Constants
+export { BROWSER_SYSTEM_PROMPT, DEFAULT_PREFIX, OPERATIONS } from "./constants.js";
+
+// Test helpers
+export { createMockAgent, createMockDriver } from "./test-helpers.js";
+
+// Types
+export type { BrowserOperation } from "./constants.js";
+```

--- a/packages/filesystem/src/constants.ts
+++ b/packages/filesystem/src/constants.ts
@@ -2,6 +2,8 @@
  * Constants for @koi/filesystem — tool names and SDK mappings.
  */
 
+import type { SkillComponent } from "@koi/core";
+
 /** Default tool name prefix for filesystem tools. */
 export const DEFAULT_PREFIX = "fs" as const;
 
@@ -16,3 +18,72 @@ export type FileSystemOperation = (typeof OPERATIONS)[number];
  * from exposing its own file tools alongside the Koi ones.
  */
 export const CLAUDE_SDK_FILE_TOOLS = ["Read", "Write", "Edit", "Glob", "Grep"] as const;
+
+/** Skill component name for filesystem behavioral guidance. */
+export const FS_SKILL_NAME = "filesystem" as const;
+
+/**
+ * Markdown content for the filesystem skill component.
+ * Teaches agents when to use each filesystem tool and how to do so safely.
+ *
+ * References the default prefix (`fs_*`). Agents using a custom prefix
+ * should substitute the appropriate tool names when applying this guidance.
+ */
+export const FS_SKILL_CONTENT: string = `
+# Filesystem — tool selection and safety
+
+## Tool selection guide
+
+### fs_edit vs fs_write
+
+- **fs_edit** — in-place modification of an *existing* file using search-and-replace hunks.
+  - Use when: you know the exact text to replace and the file already exists.
+  - Supports multiple \`{ oldText, newText }\` hunks in a single call.
+  - Fails with NOT_FOUND if \`oldText\` is not present — prevents silent overwrites.
+  - Prefer \`dryRun: true\` to preview changes before committing.
+
+- **fs_write** — full content replacement of a file.
+  - Use when: creating a new file, or replacing the entire content of an existing file.
+  - Creates the file (and parent directories with \`createDirectories: true\`) if it does not exist.
+  - Overwrites without confirmation by default — set \`overwrite: false\` to guard existing files.
+  - Do NOT use fs_write to make small edits to large files; use fs_edit instead.
+
+### fs_search vs fs_list
+
+- **fs_search** — content search within files using a text or regex pattern.
+  - Use when: "find all occurrences of X", "which files contain Y", "show me where Z is used".
+  - Returns matching file paths and the matching lines.
+  - Much faster than reading every file when you know what you are looking for.
+
+- **fs_list** — directory structure exploration.
+  - Use when: "what files exist here", "show me the directory tree", "list contents of a folder".
+  - Does not read file content — use fs_read or fs_search for that.
+
+## Read before edit
+
+Always call **fs_read** before **fs_edit**. Confirm the exact \`oldText\` exists in the
+current file before submitting an edit hunk. If the file has changed since your last read,
+the edit will fail with NOT_FOUND. Reading first also reveals context that may change your edit.
+
+## Path safety
+
+- Always use **absolute paths**. Relative paths behave differently across backends and working
+  directories and are a common source of bugs.
+- Before \`fs_write\` (which overwrites by default), read the existing file to confirm you
+  intend to replace its entire content.
+- Never construct file paths via string concatenation from untrusted input — pass path values
+  only through the tool's \`path\` parameter.
+`.trim();
+
+/**
+ * Pre-built SkillComponent for filesystem behavioral guidance.
+ * Attached automatically by createFileSystemProvider.
+ * Can also be used standalone with a custom ComponentProvider.
+ */
+export const FS_SKILL: SkillComponent = {
+  name: FS_SKILL_NAME,
+  description:
+    "When to use fs_edit vs fs_write, fs_search vs fs_list, read-before-edit, and path safety",
+  content: FS_SKILL_CONTENT,
+  tags: ["filesystem", "best-practices"],
+} as const satisfies SkillComponent;

--- a/packages/filesystem/src/fs-component-provider.test.ts
+++ b/packages/filesystem/src/fs-component-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { AttachResult, FileSystemBackend, Tool } from "@koi/core";
-import { FILESYSTEM, isAttachResult, toolToken } from "@koi/core";
+import type { AttachResult, FileSystemBackend, SkillComponent, Tool } from "@koi/core";
+import { FILESYSTEM, isAttachResult, skillToken, toolToken } from "@koi/core";
 
 function extractMap(
   result: AttachResult | ReadonlyMap<string, unknown>,
@@ -8,6 +8,7 @@ function extractMap(
   return isAttachResult(result) ? result.components : result;
 }
 
+import { FS_SKILL_NAME } from "./constants.js";
 import { createFileSystemProvider } from "./fs-component-provider.js";
 import { createMockAgent, createMockBackend } from "./test-helpers.js";
 
@@ -27,7 +28,7 @@ describe("createFileSystemProvider", () => {
     const provider = createFileSystemProvider({ backend });
     const components = extractMap(await provider.attach(createMockAgent()));
 
-    expect(components.size).toBe(6); // 5 tools + FILESYSTEM token
+    expect(components.size).toBe(7); // 5 tools + FILESYSTEM token + 1 skill
     expect(components.has(toolToken("fs_read") as string)).toBe(true);
     expect(components.has(toolToken("fs_write") as string)).toBe(true);
     expect(components.has(toolToken("fs_edit") as string)).toBe(true);
@@ -79,8 +80,8 @@ describe("createFileSystemProvider", () => {
     });
     const components = extractMap(await provider.attach(createMockAgent()));
 
-    // 2 tools + FILESYSTEM token
-    expect(components.size).toBe(3);
+    // 2 tools + FILESYSTEM token + 1 skill (skill always attaches regardless of operations)
+    expect(components.size).toBe(4);
     expect(components.has(toolToken("fs_read") as string)).toBe(true);
     expect(components.has(toolToken("fs_list") as string)).toBe(true);
     expect(components.has(toolToken("fs_write") as string)).toBe(false);
@@ -169,5 +170,51 @@ describe("tool descriptors", () => {
       expect(schema.type).toBe("object");
       expect(schema.required).toBeDefined();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SkillComponent
+// ---------------------------------------------------------------------------
+
+describe("SkillComponent", () => {
+  test("attaches filesystem skill component", async () => {
+    const backend = createMockBackend("local");
+    const provider = createFileSystemProvider({ backend });
+    const components = extractMap(await provider.attach(createMockAgent()));
+
+    expect(components.has(skillToken(FS_SKILL_NAME) as string)).toBe(true);
+  });
+
+  test("skill has name, description, and non-empty content", async () => {
+    const backend = createMockBackend("local");
+    const provider = createFileSystemProvider({ backend });
+    const components = extractMap(await provider.attach(createMockAgent()));
+
+    const skill = components.get(skillToken(FS_SKILL_NAME) as string) as SkillComponent;
+    expect(skill.name).toBe(FS_SKILL_NAME);
+    expect(skill.description.length).toBeGreaterThan(0);
+    expect(skill.content.length).toBeGreaterThan(0);
+  });
+
+  test("skill content covers edit vs write and search vs list guidance", async () => {
+    const backend = createMockBackend("local");
+    const provider = createFileSystemProvider({ backend });
+    const components = extractMap(await provider.attach(createMockAgent()));
+
+    const skill = components.get(skillToken(FS_SKILL_NAME) as string) as SkillComponent;
+    expect(skill.content).toContain("fs_edit");
+    expect(skill.content).toContain("fs_write");
+    expect(skill.content).toContain("fs_search");
+    expect(skill.content).toContain("fs_list");
+    expect(skill.content).toContain("fs_read");
+  });
+
+  test("skill attaches even when operations are filtered", async () => {
+    const backend = createMockBackend("local");
+    const provider = createFileSystemProvider({ backend, operations: ["read"] });
+    const components = extractMap(await provider.attach(createMockAgent()));
+
+    expect(components.has(skillToken(FS_SKILL_NAME) as string)).toBe(true);
   });
 });

--- a/packages/filesystem/src/fs-component-provider.ts
+++ b/packages/filesystem/src/fs-component-provider.ts
@@ -7,11 +7,11 @@
  */
 
 import type { ComponentProvider, FileSystemBackend, Tool, TrustTier } from "@koi/core";
-import { createServiceProvider, FILESYSTEM } from "@koi/core";
+import { createServiceProvider, FILESYSTEM, skillToken } from "@koi/core";
 import type { FileSystemScope } from "@koi/scope";
 import { createScopedFileSystem } from "@koi/scope";
 import type { FileSystemOperation } from "./constants.js";
-import { DEFAULT_PREFIX, OPERATIONS } from "./constants.js";
+import { DEFAULT_PREFIX, FS_SKILL, FS_SKILL_NAME, OPERATIONS } from "./constants.js";
 import { createFsEditTool } from "./tools/edit.js";
 import { createFsListTool } from "./tools/list.js";
 import { createFsReadTool } from "./tools/read.js";
@@ -59,6 +59,7 @@ export function createFileSystemProvider(config: FileSystemProviderConfig): Comp
     factories: TOOL_FACTORIES,
     trustTier,
     prefix,
+    customTools: () => [[skillToken(FS_SKILL_NAME) as string, FS_SKILL]],
     detach: async (b) => {
       if (b.dispose) {
         await b.dispose();

--- a/packages/filesystem/src/index.ts
+++ b/packages/filesystem/src/index.ts
@@ -28,7 +28,14 @@ export type {
 } from "@koi/core";
 export type { FileSystemOperation } from "./constants.js";
 // constants
-export { CLAUDE_SDK_FILE_TOOLS, DEFAULT_PREFIX, OPERATIONS } from "./constants.js";
+export {
+  CLAUDE_SDK_FILE_TOOLS,
+  DEFAULT_PREFIX,
+  FS_SKILL,
+  FS_SKILL_CONTENT,
+  FS_SKILL_NAME,
+  OPERATIONS,
+} from "./constants.js";
 
 // descriptor
 export { descriptor } from "./descriptor.js";

--- a/packages/tool-browser/src/__tests__/browser.integration.test.ts
+++ b/packages/tool-browser/src/__tests__/browser.integration.test.ts
@@ -8,9 +8,15 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { AttachResult } from "@koi/core";
-import { BROWSER, isAttachResult, toolToken } from "@koi/core";
-import { createBrowserProvider, createMockAgent, createMockDriver, OPERATIONS } from "../index.js";
+import type { AttachResult, SkillComponent } from "@koi/core";
+import { BROWSER, isAttachResult, skillToken, toolToken } from "@koi/core";
+import {
+  BROWSER_SKILL_NAME,
+  createBrowserProvider,
+  createMockAgent,
+  createMockDriver,
+  OPERATIONS,
+} from "../index.js";
 
 function extractMap(
   result: AttachResult | ReadonlyMap<string, unknown>,
@@ -84,5 +90,17 @@ describe("createBrowserProvider (integration)", () => {
     await provider.attach(agent);
     await provider.detach?.(agent);
     expect(disposed).toBe(true);
+  });
+
+  test("attaches browser skill component with name and content", async () => {
+    const driver = createMockDriver();
+    const provider = createBrowserProvider({ backend: driver });
+    const agent = createMockAgent();
+    const components = extractMap(await provider.attach(agent));
+
+    expect(components.has(skillToken(BROWSER_SKILL_NAME) as string)).toBe(true);
+    const skill = components.get(skillToken(BROWSER_SKILL_NAME) as string) as SkillComponent;
+    expect(skill.name).toBe(BROWSER_SKILL_NAME);
+    expect(skill.content).toContain("browser_snapshot");
   });
 });

--- a/packages/tool-browser/src/browser-component-provider.ts
+++ b/packages/tool-browser/src/browser-component-provider.ts
@@ -7,10 +7,12 @@
  */
 
 import type { BrowserDriver, ComponentProvider, Tool, TrustTier } from "@koi/core";
-import { BROWSER, createServiceProvider, toolToken } from "@koi/core";
+import { BROWSER, createServiceProvider, skillToken, toolToken } from "@koi/core";
 import type { BrowserScope } from "@koi/scope";
 import { createScopedBrowser } from "@koi/scope";
 import {
+  BROWSER_SKILL,
+  BROWSER_SKILL_NAME,
   type BrowserOperation,
   EVALUATE_OPERATION,
   EVALUATE_TRUST_TIER,
@@ -204,7 +206,12 @@ export function createBrowserProvider(config: BrowserProviderConfig): ComponentP
       trustTier,
       compiledSecurity,
     );
-    const components = new Map<string, unknown>([[BROWSER as string, backend], ...customEntries]);
+    const skillEntry = [skillToken(BROWSER_SKILL_NAME) as string, BROWSER_SKILL] as const;
+    const components = new Map<string, unknown>([
+      [BROWSER as string, backend],
+      ...customEntries,
+      skillEntry,
+    ]);
     return {
       name: `browser:${backend.name}`,
       attach: async () => components,
@@ -222,7 +229,10 @@ export function createBrowserProvider(config: BrowserProviderConfig): ComponentP
     factories: TOOL_FACTORIES,
     trustTier,
     prefix,
-    customTools: (b) => createCustomToolEntries(operations, b, prefix, trustTier, compiledSecurity),
+    customTools: (b) => [
+      ...createCustomToolEntries(operations, b, prefix, trustTier, compiledSecurity),
+      [skillToken(BROWSER_SKILL_NAME) as string, BROWSER_SKILL],
+    ],
     detach: async (b) => {
       if (b.dispose) await b.dispose();
     },

--- a/packages/tool-browser/src/constants.test.ts
+++ b/packages/tool-browser/src/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { BROWSER_SYSTEM_PROMPT } from "./constants.js";
+import { BROWSER_SKILL, BROWSER_SKILL_NAME, BROWSER_SYSTEM_PROMPT } from "./constants.js";
 
 describe("BROWSER_SYSTEM_PROMPT", () => {
   test("is a non-empty string", () => {
@@ -25,5 +25,45 @@ describe("BROWSER_SYSTEM_PROMPT", () => {
 
   test("contains snapshot-act-snapshot loop guidance", () => {
     expect(BROWSER_SYSTEM_PROMPT).toContain("Re-snapshot");
+  });
+});
+
+describe("BROWSER_SKILL", () => {
+  test("has correct name", () => {
+    expect(BROWSER_SKILL.name).toBe(BROWSER_SKILL_NAME);
+  });
+
+  test("has non-empty description and content", () => {
+    expect(BROWSER_SKILL.description.length).toBeGreaterThan(0);
+    expect(BROWSER_SKILL.content.length).toBeGreaterThan(0);
+  });
+
+  test("content covers snapshot-first workflow", () => {
+    expect(BROWSER_SKILL.content).toContain("browser_snapshot");
+    expect(BROWSER_SKILL.content).toContain("snapshotId");
+  });
+
+  test("content covers form filling guidance", () => {
+    expect(BROWSER_SKILL.content).toContain("browser_fill_form");
+    expect(BROWSER_SKILL.content).toContain("browser_type");
+  });
+
+  test("content covers wait strategies", () => {
+    expect(BROWSER_SKILL.content).toContain("browser_wait");
+  });
+
+  test("content covers tab management", () => {
+    expect(BROWSER_SKILL.content).toContain("browser_tab_focus");
+    expect(BROWSER_SKILL.content).toContain("browser_tab_close");
+  });
+
+  test("content covers trust tier awareness for evaluate", () => {
+    expect(BROWSER_SKILL.content).toContain("browser_evaluate");
+    expect(BROWSER_SKILL.content).toContain("promoted");
+  });
+
+  test("has browser and best-practices tags", () => {
+    expect(BROWSER_SKILL.tags).toContain("browser");
+    expect(BROWSER_SKILL.tags).toContain("best-practices");
   });
 });

--- a/packages/tool-browser/src/constants.ts
+++ b/packages/tool-browser/src/constants.ts
@@ -2,6 +2,8 @@
  * Constants for @koi/tool-browser — tool names, operations, and SDK mappings.
  */
 
+import type { SkillComponent } from "@koi/core";
+
 /** Default tool name prefix for browser tools. */
 export const DEFAULT_PREFIX = "browser" as const;
 
@@ -139,3 +141,95 @@ export const UPLOAD_OPERATION = "upload" as const;
  */
 export const TRACE_OPERATION_START = "trace_start" as const;
 export const TRACE_OPERATION_STOP = "trace_stop" as const;
+
+/** Skill component name for browser automation behavioral guidance. */
+export const BROWSER_SKILL_NAME = "browser" as const;
+
+/**
+ * Markdown content for the browser skill component.
+ * Teaches agents the snapshot-first workflow, form filling, wait strategies,
+ * tab management, and trust tier awareness.
+ *
+ * References the default prefix (`browser_*`). Agents using a custom prefix
+ * should substitute the appropriate tool names when applying this guidance.
+ */
+export const BROWSER_SKILL_CONTENT: string = `
+# Browser automation — snapshot-first workflow
+
+## Core loop: snapshot → act → re-snapshot
+
+Always follow this loop when operating the browser:
+
+1. **browser_snapshot** — call before every action.
+   Returns \`snapshotId\` and a list of interactive elements with \`[ref=eN]\` markers
+   (e.g., \`[button] Submit [ref=e3]\`).
+
+2. **Pass \`snapshotId\` to every action** — include the \`snapshotId\` from the latest
+   snapshot in every interaction call (browser_click, browser_type, browser_fill_form, etc.).
+   Stale IDs cause STALE_REF errors immediately rather than acting on wrong elements.
+
+3. **Re-snapshot after DOM changes** — after clicking, submitting a form, or navigating,
+   always call browser_snapshot again before performing further interactions.
+
+4. **Ref format** — refs are strings like "e1", "e42". Only use refs from the most recent
+   browser_snapshot output.
+
+## Form filling
+
+- **Multi-field forms**: use **browser_fill_form** — submits all fields atomically with a
+  single call. Pass a \`fields\` array: \`[{ ref: "e5", value: "user@example.com" }, ...]\`
+- **Single field**: use **browser_type** — then snapshot to confirm the value was accepted.
+- **Dropdowns / select elements**: use **browser_select** with the option *value* (not label).
+- **File upload**: use **browser_upload** (requires the \`upload\` operation to be enabled).
+- After submitting a form, always re-snapshot to confirm navigation or a success indicator.
+
+## Wait strategies
+
+- After **browser_navigate**: re-snapshot; use **browser_wait** if expected elements are absent.
+- **browser_wait with \`selector\`**: waits for a specific element to appear — prefer this over
+  fixed time delays.
+- **browser_wait with \`timeout\`**: maximum ms to wait. Keep under 10 000 to avoid hanging.
+- Do not retry actions in a tight loop without a wait or snapshot in between.
+
+## Tab management
+
+- **browser_tab_new** — opens a new tab at a URL; returns a tab ID.
+- **browser_tab_focus(tabId)** — switch to a specific tab before acting on it.
+  Snapshots are tab-scoped: after browser_tab_focus, always call browser_snapshot.
+- **browser_tab_close(tabId)** — close a tab when done. Always close tabs you open.
+
+## Trust tier awareness
+
+- Most browser tools run at **verified** trust tier (the default).
+- **browser_evaluate** runs at **promoted** trust tier — requires explicit opt-in in the
+  provider config. Use it only when no other browser tool achieves the goal; prefer
+  browser_click, browser_type, and browser_fill_form over browser_evaluate.
+- **browser_screenshot** returns base64 image data and is token-expensive.
+  Prefer **browser_snapshot** (accessibility tree text) — roughly 100× cheaper in tokens.
+  Use browser_screenshot only for visual debugging or when image content is necessary.
+
+## Error code quick reference
+
+| Code       | Meaning                              | What to do                              |
+|------------|--------------------------------------|-----------------------------------------|
+| STALE_REF  | Ref or snapshot is outdated          | Call browser_snapshot, retry action     |
+| TIMEOUT    | Element/navigation timed out         | Call browser_wait or browser_snapshot   |
+| NOT_FOUND  | Element was never in the snapshot    | Call browser_snapshot to see the page   |
+| EXTERNAL   | Network/JS error on the page         | Check the URL, retry or investigate     |
+| INTERNAL   | Page closed/crashed unexpectedly     | Report error; re-navigate if needed     |
+| PERMISSION | Blocked by CORS or browser policy    | Check allowed domains in config         |
+| VALIDATION | Bad argument (wrong ref format, etc.)| Fix the argument and retry              |
+`.trim();
+
+/**
+ * Pre-built SkillComponent for browser automation behavioral guidance.
+ * Attached automatically by createBrowserProvider.
+ * Can also be used standalone with a custom ComponentProvider.
+ */
+export const BROWSER_SKILL: SkillComponent = {
+  name: BROWSER_SKILL_NAME,
+  description:
+    "Snapshot-first workflow, form filling, wait strategies, tab management, and trust tier awareness for browser automation",
+  content: BROWSER_SKILL_CONTENT,
+  tags: ["browser", "best-practices"],
+} as const satisfies SkillComponent;

--- a/packages/tool-browser/src/index.ts
+++ b/packages/tool-browser/src/index.ts
@@ -63,6 +63,9 @@ export { createBrowserProvider } from "./browser-component-provider.js";
 export type { BrowserOperation } from "./constants.js";
 export {
   ALL_OPERATIONS,
+  BROWSER_SKILL,
+  BROWSER_SKILL_CONTENT,
+  BROWSER_SKILL_NAME,
   BROWSER_SYSTEM_PROMPT,
   DEFAULT_PREFIX,
   EVALUATE_OPERATION,

--- a/tests/e2e/browser-skill.e2e.test.ts
+++ b/tests/e2e/browser-skill.e2e.test.ts
@@ -1,0 +1,289 @@
+/**
+ * E2E: @koi/tool-browser SkillComponent with a real Playwright driver through
+ * the full createKoi runtime.
+ *
+ * Verifies that:
+ * 1. skill:browser is attached to the agent's component map when using a real
+ *    Playwright-backed BrowserProvider.
+ * 2. The skill content covers snapshot-first workflow, form filling, wait
+ *    strategies, tab management, and trust tier awareness.
+ * 3. The snapshot-act-re-snapshot pattern (browser_snapshot → browser_navigate
+ *    → browser_snapshot) executes correctly through the full middleware stack
+ *    against a real Chromium browser.
+ *
+ * Gated by TEST_BROWSER=1 environment variable.
+ * Requires: bunx playwright install chromium
+ *
+ * Run: TEST_BROWSER=1 bun test tests/e2e/browser-skill.e2e.test.ts
+ */
+
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { createPlaywrightBrowserDriver } from "@koi/browser-playwright";
+import type {
+  BrowserDriver,
+  EngineEvent,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  SkillComponent,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { skillToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { BROWSER_SKILL_NAME, createBrowserProvider } from "@koi/tool-browser";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const SKIP = !process.env.TEST_BROWSER;
+
+const MODEL_NAME = "claude-haiku-4-5-20251001";
+const TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(SKIP)(
+  "e2e: @koi/tool-browser SkillComponent with real Playwright through full createKoi runtime",
+  () => {
+    let driver: BrowserDriver;
+    let runtime: Awaited<ReturnType<typeof createKoi>> | undefined; // let justified: set per test
+
+    beforeAll(async () => {
+      driver = createPlaywrightBrowserDriver({ headless: true });
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose?.();
+      runtime = undefined;
+    });
+
+    // afterAll: driver is shared — dispose after all tests complete
+    // (browser-playwright integration tests share this pattern)
+
+    test(
+      "skill:browser is attached to agent component map alongside browser tools",
+      async () => {
+        const browserProvider = createBrowserProvider({ backend: driver });
+
+        let _modelCallCount = 0; // let justified: tracks phase
+        const modelCall = async (_request: ModelRequest): Promise<ModelResponse> => {
+          _modelCallCount++;
+          // Single phase: done immediately
+          return {
+            content: "Skill component verified.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 5, outputTokens: 5 },
+          };
+        };
+
+        const { createLoopAdapter } = await import("@koi/engine-loop");
+        const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+
+        runtime = await createKoi({
+          manifest: {
+            name: "e2e-browser-skill-presence",
+            version: "0.0.1",
+            model: { name: MODEL_NAME },
+          },
+          adapter,
+          providers: [browserProvider],
+        });
+
+        // Verify the skill is attached to the agent's component map
+        const skill = runtime.agent.component<SkillComponent>(skillToken(BROWSER_SKILL_NAME));
+        expect(skill).toBeDefined();
+        expect(skill?.name).toBe(BROWSER_SKILL_NAME);
+        expect(skill?.description.length).toBeGreaterThan(0);
+        expect(skill?.content.length).toBeGreaterThan(0);
+
+        // Verify skill covers all key guidance areas
+        expect(skill?.content).toContain("browser_snapshot");
+        expect(skill?.content).toContain("snapshotId");
+        expect(skill?.content).toContain("browser_fill_form");
+        expect(skill?.content).toContain("browser_wait");
+        expect(skill?.content).toContain("browser_tab_focus");
+        expect(skill?.content).toContain("browser_evaluate");
+        expect(skill?.content).toContain("promoted");
+
+        // Agent completes without errors
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Check browser component map." }),
+        );
+        expect(events.find((e) => e.kind === "done")).toBeDefined();
+      },
+      TIMEOUT_MS,
+    );
+
+    test(
+      "snapshot-act-snapshot workflow: navigate → snapshot → navigate → re-snapshot executes correctly",
+      async () => {
+        const browserProvider = createBrowserProvider({ backend: driver });
+
+        const calledTools: string[] = []; // let justified: ordered call log
+        const snapshotIds: string[] = []; // let justified: tracks snapshot IDs across phases
+        let modelCallCount = 0; // let justified: tracks phase
+
+        const toolObserver: KoiMiddleware = {
+          name: "e2e-browser-skill-observer",
+          wrapToolCall: async (
+            _ctx,
+            request: ToolRequest,
+            next: ToolHandler,
+          ): Promise<ToolResponse> => {
+            calledTools.push(request.toolId);
+            const result = await next(request);
+            // Capture snapshotIds returned by successful browser_snapshot calls
+            if (request.toolId === "browser_snapshot") {
+              const output = result.output as { snapshotId?: string };
+              if (output.snapshotId !== undefined) {
+                snapshotIds.push(output.snapshotId);
+              }
+            }
+            return result;
+          },
+        };
+
+        const PAGE_A = "data:text/html,<h1>Page%20A</h1><button>Continue</button>";
+        const PAGE_B = "data:text/html,<h1>Page%20B</h1><button>Submit</button>";
+
+        const modelCall = async (_request: ModelRequest): Promise<ModelResponse> => {
+          modelCallCount++;
+
+          if (modelCallCount === 1) {
+            // Phase 1: navigate to starting page (browser needs a loaded page before snapshot)
+            return {
+              content: "Navigating to the starting page.",
+              model: MODEL_NAME,
+              usage: { inputTokens: 10, outputTokens: 10 },
+              metadata: {
+                toolCalls: [
+                  { toolName: "browser_navigate", callId: "call-nav-1", input: { url: PAGE_A } },
+                ],
+              },
+            };
+          }
+
+          if (modelCallCount === 2) {
+            // Phase 2: snapshot first (skill says: always snapshot before acting)
+            return {
+              content: "Taking a snapshot to see the current page state.",
+              model: MODEL_NAME,
+              usage: { inputTokens: 20, outputTokens: 10 },
+              metadata: {
+                toolCalls: [{ toolName: "browser_snapshot", callId: "call-snap-1", input: {} }],
+              },
+            };
+          }
+
+          if (modelCallCount === 3) {
+            // Phase 3: act — navigate to second page (DOM change)
+            const latestSnapshotId = snapshotIds.at(-1);
+            return {
+              content: "Navigating to the next page.",
+              model: MODEL_NAME,
+              usage: { inputTokens: 40, outputTokens: 10 },
+              metadata: {
+                toolCalls: [
+                  {
+                    toolName: "browser_navigate",
+                    callId: "call-nav-2",
+                    input: {
+                      url: PAGE_B,
+                      ...(latestSnapshotId !== undefined ? { snapshotId: latestSnapshotId } : {}),
+                    },
+                  },
+                ],
+              },
+            };
+          }
+
+          if (modelCallCount === 4) {
+            // Phase 4: re-snapshot after DOM change (skill says: re-snapshot after navigation)
+            return {
+              content: "Re-taking snapshot after navigation to see the new page.",
+              model: MODEL_NAME,
+              usage: { inputTokens: 60, outputTokens: 10 },
+              metadata: {
+                toolCalls: [{ toolName: "browser_snapshot", callId: "call-snap-2", input: {} }],
+              },
+            };
+          }
+
+          // Phase 5: done
+          return {
+            content: "Snapshot-act-snapshot workflow completed successfully.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 80, outputTokens: 10 },
+          };
+        };
+
+        const { createLoopAdapter } = await import("@koi/engine-loop");
+        const adapter = createLoopAdapter({ modelCall, maxTurns: 7 });
+
+        runtime = await createKoi({
+          manifest: {
+            name: "e2e-browser-snapshot-workflow",
+            version: "0.0.1",
+            model: { name: MODEL_NAME },
+          },
+          adapter,
+          middleware: [toolObserver],
+          providers: [browserProvider],
+        });
+
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Navigate to the test page and interact with it." }),
+        );
+
+        // Agent completed
+        const doneEvent = events.find((e) => e.kind === "done");
+        expect(doneEvent).toBeDefined();
+        if (doneEvent?.kind === "done") {
+          expect(doneEvent.output.stopReason).toBe("completed");
+        }
+
+        // Full workflow: navigate → snapshot → navigate → re-snapshot
+        expect(calledTools).toEqual([
+          "browser_navigate",
+          "browser_snapshot",
+          "browser_navigate",
+          "browser_snapshot",
+        ]);
+
+        // Both snapshots returned valid snapshotIds
+        expect(snapshotIds).toHaveLength(2);
+        expect(snapshotIds[0]).toMatch(/^snap-tab-\d+-\d+$/);
+        expect(snapshotIds[1]).toMatch(/^snap-tab-\d+-\d+$/);
+        // snapshotIds may repeat after navigation (counter resets per tab) — that is correct
+        // behavior; what matters is that both calls succeeded and the pattern was followed.
+
+        // Skill is present on the agent
+        const skill = runtime.agent.component<SkillComponent>(skillToken(BROWSER_SKILL_NAME));
+        expect(skill).toBeDefined();
+        expect(skill?.content).toContain("browser_snapshot");
+
+        await driver.dispose?.();
+      },
+      TIMEOUT_MS,
+    );
+  },
+);

--- a/tests/e2e/fs-skill.e2e.test.ts
+++ b/tests/e2e/fs-skill.e2e.test.ts
@@ -1,0 +1,374 @@
+/**
+ * E2E: @koi/filesystem SkillComponent through the full createKoi runtime.
+ *
+ * Verifies that:
+ * 1. skill:filesystem is attached to the agent's component map alongside fs tools.
+ * 2. The skill content covers the key guidance (edit vs write, search vs list,
+ *    read-before-edit, path safety).
+ * 3. fs_read and fs_edit execute correctly through the full middleware stack
+ *    against a stateful in-memory backend.
+ * 4. The read-before-edit pattern (fs_read → fs_edit, not fs_write) completes
+ *    successfully when forced via a deterministic model handler.
+ *
+ * Fully deterministic — no ANTHROPIC_API_KEY needed.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  EngineEvent,
+  FileEditResult,
+  FileListResult,
+  FileReadResult,
+  FileSearchResult,
+  FileSystemBackend,
+  FileWriteResult,
+  KoiError,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  Result,
+  SkillComponent,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { skillToken } from "@koi/core";
+import { createKoi } from "@koi/engine";
+import { createFileSystemProvider, FS_SKILL_NAME } from "@koi/filesystem";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MODEL_NAME = "claude-haiku-4-5-20251001";
+const TIMEOUT_MS = 30_000;
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const result: EngineEvent[] = []; // let justified: accumulator
+  for await (const event of iterable) {
+    result.push(event);
+  }
+  return result;
+}
+
+/**
+ * Stateful in-memory FileSystemBackend.
+ * Files are stored in a Map so edits persist across tool calls within a run.
+ */
+function createStatefulBackend(
+  initialFiles: Record<string, string>,
+): FileSystemBackend & { getFile: (path: string) => string | undefined } {
+  const files = new Map(Object.entries(initialFiles));
+
+  return {
+    name: "e2e-in-memory",
+
+    read: (path): Result<FileReadResult, KoiError> => {
+      const content = files.get(path);
+      if (content === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `File not found: ${path}`, retryable: false },
+        };
+      }
+      return { ok: true, value: { content, path, size: content.length } };
+    },
+
+    write: (path, content): Result<FileWriteResult, KoiError> => {
+      files.set(path, content);
+      return { ok: true, value: { path, bytesWritten: content.length } };
+    },
+
+    edit: (path, edits): Result<FileEditResult, KoiError> => {
+      let content = files.get(path);
+      if (content === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `File not found: ${path}`, retryable: false },
+        };
+      }
+      let hunksApplied = 0;
+      for (const edit of edits) {
+        if (content.includes(edit.oldText)) {
+          content = content.replace(edit.oldText, edit.newText);
+          hunksApplied++;
+        }
+      }
+      files.set(path, content);
+      return { ok: true, value: { path, hunksApplied } };
+    },
+
+    list: (_path): Result<FileListResult, KoiError> => ({
+      ok: true,
+      value: { entries: [], truncated: false },
+    }),
+
+    search: (_pattern): Result<FileSearchResult, KoiError> => ({
+      ok: true,
+      value: { matches: [], truncated: false },
+    }),
+
+    getFile: (path) => files.get(path),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: @koi/filesystem SkillComponent through full createKoi runtime", () => {
+  let runtime: Awaited<ReturnType<typeof createKoi>> | undefined; // let justified: set per test, disposed in afterEach
+
+  afterEach(async () => {
+    await runtime?.dispose?.();
+    runtime = undefined;
+  });
+
+  test(
+    "skill:filesystem is attached to agent component map alongside fs tools",
+    async () => {
+      const backend = createStatefulBackend({ "/config.json": '{ "port": 3000 }' });
+      const fsProvider = createFileSystemProvider({ backend });
+
+      let _modelCallCount = 0; // let justified: tracks phase
+      const modelCall = async (_request: ModelRequest): Promise<ModelResponse> => {
+        _modelCallCount++;
+        // Single phase: agent says done immediately (no tool calls needed)
+        return {
+          content: "Skill component verified.",
+          model: MODEL_NAME,
+          usage: { inputTokens: 5, outputTokens: 5 },
+        };
+      };
+
+      const { createLoopAdapter } = await import("@koi/engine-loop");
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 3 });
+
+      runtime = await createKoi({
+        manifest: {
+          name: "e2e-fs-skill-presence",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        providers: [fsProvider],
+      });
+
+      // Verify the skill is attached to the agent's component map
+      const skill = runtime.agent.component<SkillComponent>(skillToken(FS_SKILL_NAME));
+      expect(skill).toBeDefined();
+      expect(skill?.name).toBe(FS_SKILL_NAME);
+      expect(skill?.description.length).toBeGreaterThan(0);
+      expect(skill?.content.length).toBeGreaterThan(0);
+
+      // Verify skill covers all key guidance areas
+      expect(skill?.content).toContain("fs_edit");
+      expect(skill?.content).toContain("fs_write");
+      expect(skill?.content).toContain("fs_search");
+      expect(skill?.content).toContain("fs_list");
+      expect(skill?.content).toContain("fs_read");
+
+      // Run to verify assembly is valid (agent completes without errors)
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Check component map." }),
+      );
+      expect(events.find((e) => e.kind === "done")).toBeDefined();
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "fs_read executes through full runtime and returns file content",
+    async () => {
+      const initialContent = '{ "port": 3000, "host": "localhost" }';
+      const backend = createStatefulBackend({ "/app/config.json": initialContent });
+      const fsProvider = createFileSystemProvider({ backend });
+
+      let toolResult: ToolResponse | undefined; // let justified: captured by middleware
+      let modelCallCount = 0; // let justified: tracks phase
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-fs-read-observer",
+        wrapToolCall: async (
+          _ctx,
+          request: ToolRequest,
+          next: ToolHandler,
+        ): Promise<ToolResponse> => {
+          const result = await next(request);
+          if (request.toolId === "fs_read") {
+            toolResult = result;
+          }
+          return result;
+        },
+      };
+
+      const modelCall = async (_request: ModelRequest): Promise<ModelResponse> => {
+        modelCallCount++;
+        if (modelCallCount === 1) {
+          // Phase 1: force fs_read
+          return {
+            content: "Let me read the config file first.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 10, outputTokens: 10 },
+            metadata: {
+              toolCalls: [
+                {
+                  toolName: "fs_read",
+                  callId: "call-read-1",
+                  input: { path: "/app/config.json" },
+                },
+              ],
+            },
+          };
+        }
+        // Phase 2: done
+        return {
+          content: "File read successfully.",
+          model: MODEL_NAME,
+          usage: { inputTokens: 20, outputTokens: 5 },
+        };
+      };
+
+      const { createLoopAdapter } = await import("@koi/engine-loop");
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      runtime = await createKoi({
+        manifest: {
+          name: "e2e-fs-read",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        middleware: [toolObserver],
+        providers: [fsProvider],
+      });
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Read the config file." }),
+      );
+
+      // Agent completed
+      const doneEvent = events.find((e) => e.kind === "done");
+      expect(doneEvent).toBeDefined();
+
+      // fs_read was called and returned the file content
+      expect(toolResult).toBeDefined();
+      const output = toolResult?.output as { content: string; path: string };
+      expect(output.content).toBe(initialContent);
+      expect(output.path).toBe("/app/config.json");
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "read-before-edit pattern: fs_read then fs_edit modifies the file correctly",
+    async () => {
+      const initialContent = '{ "port": 3000 }';
+      const backend = createStatefulBackend({ "/app/config.json": initialContent });
+      const fsProvider = createFileSystemProvider({ backend });
+
+      const calledTools: string[] = []; // let justified: ordered call log
+      let modelCallCount = 0; // let justified: tracks phase
+
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-fs-skill-observer",
+        wrapToolCall: async (
+          _ctx,
+          request: ToolRequest,
+          next: ToolHandler,
+        ): Promise<ToolResponse> => {
+          calledTools.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      const modelCall = async (_request: ModelRequest): Promise<ModelResponse> => {
+        modelCallCount++;
+        if (modelCallCount === 1) {
+          // Phase 1: read first (skill says: always read before edit)
+          return {
+            content: "I will read the file first to confirm the exact text.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 10, outputTokens: 10 },
+            metadata: {
+              toolCalls: [
+                {
+                  toolName: "fs_read",
+                  callId: "call-read-1",
+                  input: { path: "/app/config.json" },
+                },
+              ],
+            },
+          };
+        }
+        if (modelCallCount === 2) {
+          // Phase 2: edit using exact text seen in phase 1
+          // (skill says: use fs_edit for small changes, not fs_write)
+          return {
+            content: "Now I will apply the targeted edit.",
+            model: MODEL_NAME,
+            usage: { inputTokens: 30, outputTokens: 10 },
+            metadata: {
+              toolCalls: [
+                {
+                  toolName: "fs_edit",
+                  callId: "call-edit-1",
+                  input: {
+                    path: "/app/config.json",
+                    edits: [{ oldText: '"port": 3000', newText: '"port": 8080' }],
+                  },
+                },
+              ],
+            },
+          };
+        }
+        // Phase 3: done
+        return {
+          content: "Updated port to 8080.",
+          model: MODEL_NAME,
+          usage: { inputTokens: 50, outputTokens: 10 },
+        };
+      };
+
+      const { createLoopAdapter } = await import("@koi/engine-loop");
+      const adapter = createLoopAdapter({ modelCall, maxTurns: 5 });
+
+      runtime = await createKoi({
+        manifest: {
+          name: "e2e-fs-read-before-edit",
+          version: "0.0.1",
+          model: { name: MODEL_NAME },
+        },
+        adapter,
+        middleware: [toolObserver],
+        providers: [fsProvider],
+      });
+
+      const events = await collectEvents(
+        runtime.run({ kind: "text", text: "Update the port to 8080 in /app/config.json." }),
+      );
+
+      // Agent completed
+      const doneEvent = events.find((e) => e.kind === "done");
+      expect(doneEvent).toBeDefined();
+      if (doneEvent?.kind === "done") {
+        expect(doneEvent.output.stopReason).toBe("completed");
+      }
+
+      // read-before-edit pattern: fs_read came before fs_edit (not fs_write)
+      expect(calledTools).toEqual(["fs_read", "fs_edit"]);
+      expect(calledTools).not.toContain("fs_write");
+
+      // File was actually modified in the in-memory backend
+      expect(backend.getFile("/app/config.json")).toBe('{ "port": 8080 }');
+
+      // Skill is present on the agent
+      const skill = runtime.agent.component<SkillComponent>(skillToken(FS_SKILL_NAME));
+      expect(skill).toBeDefined();
+      expect(skill?.content).toContain("fs_edit");
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -40,7 +40,10 @@
     "@koi/orchestrator": "workspace:*",
     "@koi/test-utils": "workspace:*",
     "@koi/git-utils": "workspace:*",
-    "@koi/worktree-merge": "workspace:*"
+    "@koi/worktree-merge": "workspace:*",
+    "@koi/filesystem": "workspace:*",
+    "@koi/tool-browser": "workspace:*",
+    "@koi/browser-playwright": "workspace:*"
   },
   "scripts": {
     "test": "bun test",


### PR DESCRIPTION
## Summary

Closes #530 — SkillComponent for `@koi/filesystem`
Closes #531 — SkillComponent for `@koi/tool-browser`

Each provider now attaches a `skill:<name>` SkillComponent to the agent component map via the `customTools` hook in `createServiceProvider`. No changes to `@koi/core` or `@koi/engine`.

### `@koi/filesystem` — `skill:filesystem`

Teaches agents:
- **fs_edit vs fs_write**: targeted edits vs full file replacement
- **fs_search vs fs_list**: content search vs directory exploration
- **Read before edit**: always `fs_read` first to confirm `oldText` exists
- **Path safety**: absolute paths only, never construct from untrusted input

New exports: `FS_SKILL`, `FS_SKILL_CONTENT`, `FS_SKILL_NAME`

### `@koi/tool-browser` — `skill:browser`

Teaches agents:
- **Snapshot loop**: snapshot → act → re-snapshot; pass `snapshotId` to every action
- **Form filling**: `browser_fill_form` for multi-field forms (atomic), `browser_type` for single fields
- **Wait strategies**: `browser_wait` with `selector` over fixed timeouts
- **Tab management**: `browser_tab_focus` before acting; always close opened tabs
- **Trust tier**: `browser_evaluate` = `promoted` only; prefer `browser_snapshot` over `browser_screenshot` (100× cheaper)
- **Error quick reference**: `STALE_REF`, `TIMEOUT`, `NOT_FOUND`, `EXTERNAL`, `INTERNAL`, `PERMISSION`, `VALIDATION`

New exports: `BROWSER_SKILL`, `BROWSER_SKILL_CONTENT`, `BROWSER_SKILL_NAME`

### How it works

```
ComponentProvider.attach()
  └── createServiceProvider({ customTools })
       └── customTools hook returns:
            └── [ [skillToken("filesystem"), FS_SKILL], ... ]
                      ↓
                  skill:filesystem  (SkillComponent ECS component)
                  discoverable via agent.component<SkillComponent>(skillToken("filesystem"))
```

## Test plan

- [x] Unit: `constants.test.ts` — `BROWSER_SKILL` and `FS_SKILL` shape, name, description, content, tags
- [x] Unit: `fs-component-provider.test.ts` — provider attaches `skill:filesystem`; size assertions updated
- [x] Integration: `browser.integration.test.ts` — provider attaches `skill:browser`
- [x] E2E (deterministic): `tests/e2e/fs-skill.e2e.test.ts` — skill presence, `fs_read`, read-before-edit pattern
- [x] E2E (Playwright, `TEST_BROWSER=1`): `tests/e2e/browser-skill.e2e.test.ts` — skill presence, navigate→snapshot→navigate→re-snapshot workflow
- [x] Docs: `docs/L2/filesystem.md` updated with SkillComponent section; `docs/L2/tool-browser.md` added