### PR TITLE
feat: add @koi/tool-squash — agent-initiated context compression

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1599,6 +1599,19 @@
         "@koi/scope": "workspace:*",
       },
     },
+    "packages/tool-squash": {
+      "name": "@koi/tool-squash",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/engine": "workspace:*",
+        "@koi/engine-pi": "workspace:*",
+        "@koi/snapshot-chain-store": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/tools-github": {
       "name": "@koi/tools-github",
       "version": "0.0.0",
@@ -2413,6 +2426,8 @@
     "@koi/tool-ask-user": ["@koi/tool-ask-user@workspace:packages/tool-ask-user"],
 
     "@koi/tool-browser": ["@koi/tool-browser@workspace:packages/tool-browser"],
+
+    "@koi/tool-squash": ["@koi/tool-squash@workspace:packages/tool-squash"],
 
     "@koi/tools-github": ["@koi/tools-github@workspace:packages/tools-github"],
 

--- a/docs/L2/tool-squash.md
+++ b/docs/L2/tool-squash.md
@@ -1,0 +1,427 @@
+# @koi/tool-squash — Agent-Initiated Phase-Boundary Compression
+
+Gives agents a `squash` tool to compress their own conversation history at natural phase boundaries. Old messages are replaced with the agent's summary (zero LLM cost), originals are archived to `SnapshotChainStore` for retrieval, and optionally facts are extracted to long-term memory. Includes a companion middleware that applies the compression before the next model call.
+
+---
+
+## Why It Exists
+
+Agents accumulate large conversation histories — file reads, search results, planning discussions — that eventually hit context window limits. The existing system compactor (`@koi/middleware-compactor`) is reactive and blind: it fires when token thresholds are crossed and requires an LLM call to summarize.
+
+The agent IS the LLM — it knows what's signal and what's noise. `@koi/tool-squash` lets the agent compress proactively at phase boundaries ("done planning, starting implementation"), producing higher-quality summaries at zero additional LLM cost.
+
+This is the Layer A complement to the system compactor (Layer B):
+
+| | Layer A (squash) | Layer B (compactor) |
+|---|---|---|
+| **Trigger** | Agent calls `squash(phase, summary)` | Token threshold crossed |
+| **Summarizer** | Agent's own summary (free) | LLM call ($) |
+| **Quality** | Agent knows what matters | Generic blind summarization |
+| **Timing** | Phase boundaries | Reactive, may interrupt |
+
+---
+
+## What This Enables
+
+```
+BEFORE SQUASH (context filling up)
+══════════════════════════════════
+
+┌─────────────────────────────────────────────┐
+│ [System prompt]                              │
+│ USER: "Build me a todo app"                  │
+│ AGENT: reads package.json (200 lines)        │
+│ AGENT: reads src/app.tsx (500 lines)         │
+│ USER: "Use SQLite for storage"               │
+│ AGENT: searches "bun sqlite" (3 pages)       │  ← stale planning
+│ AGENT: "Here's my plan: ..."                 │     phase eating
+│ USER: "Go ahead"                             │     tokens
+│ AGENT: writes schema.sql, db.ts, routes.ts   │
+│ ...                                          │
+│ ████████████████████████████████████░░ 95%    │
+│ ⚠️  Context almost full                       │
+└─────────────────────────────────────────────┘
+
+Agent calls: squash(phase="implementation", summary="...", facts=["Uses SQLite"])
+                            │
+                            ▼
+
+AFTER SQUASH (room to work)
+═══════════════════════════
+
+┌─────────────────────────────────────────────┐
+│ [System prompt]                              │
+│                                              │
+│ [PINNED] USER: "Build me a todo app"         │
+│                                              │
+│ ┌─────────────────────────────────────────┐  │
+│ │ 📋 SQUASH SUMMARY (phase: impl)        │  │
+│ │ Built todo app with SQLite:             │  │
+│ │ • Schema: todos table (id, title, done) │  │
+│ │ • DB layer: db.ts with CRUD ops         │  │
+│ │ • API: REST endpoints at /api/todos     │  │
+│ └─────────────────────────────────────────┘  │
+│                                              │
+│ [Recent 4 messages preserved]                │
+│                                              │
+│ ████████░░░░░░░░░░░░░░░░░░░░░░░░░░░ 25%     │
+│ ✅ 75% freed                                  │
+└─────────────────────────────────────────────┘
+
+Archived originals → SnapshotChainStore (retrievable)
+Facts → Memory store (persisted across sessions)
+```
+
+---
+
+## Quick Start
+
+```typescript
+import { createKoi } from "@koi/engine";
+import { createSquashProvider } from "@koi/tool-squash";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+
+// Mutable message list — the runtime updates this as messages flow in
+const messages: InboundMessage[] = [];
+
+const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+const { provider, middleware } = createSquashProvider(
+  { archiver, sessionId: "session-1" as SessionId },
+  () => messages,
+);
+
+const runtime = await createKoi({
+  manifest: { name: "my-agent", model: { name: "claude-sonnet-4-5-20250514" } },
+  adapter,
+  providers: [provider],
+  middleware: [middleware],
+});
+```
+
+The agent now has `tool:squash` and `skill:squash` in its component map.
+
+---
+
+## Configuration
+
+```typescript
+createSquashProvider({
+  archiver,         // required — SnapshotChainStore for archiving originals
+  sessionId,        // required — SessionId for archive chain naming
+  memory,           // optional — MemoryComponent for fact extraction
+  tokenEstimator,   // optional — TokenEstimator (default: 4 chars/token heuristic)
+  preserveRecent,   // optional — number of recent messages to keep (default: 4)
+  maxPendingSquashes, // optional — queue overflow cap (default: 3)
+}, getMessages)
+```
+
+### SquashConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `archiver` | `SnapshotChainStore<InboundMessage[]>` | *(required)* | Archive store for snapshotting squashed messages |
+| `sessionId` | `SessionId` | *(required)* | Session ID for archive chain naming |
+| `memory` | `MemoryComponent` | `undefined` | Memory component for fact extraction |
+| `tokenEstimator` | `TokenEstimator` | heuristic (4 chars/tok) | Custom token estimator |
+| `preserveRecent` | `number` | `4` | Most recent messages to preserve |
+| `maxPendingSquashes` | `number` | `3` | Max pending squashes before oldest dropped |
+
+### With Memory (fact extraction)
+
+```typescript
+import { createFsMemory } from "@koi/memory-fs";
+
+const memory = createFsMemory({ dataDir: "./memory" });
+
+const { provider, middleware } = createSquashProvider(
+  {
+    archiver,
+    sessionId,
+    memory: memory.component, // enables fact extraction
+  },
+  () => messages,
+);
+```
+
+---
+
+## Architecture
+
+```
+@koi/tool-squash (L2)
+├── types.ts               ← config, constants, tool descriptor, PendingQueue
+├── estimator.ts           ← heuristic token estimator (4 chars/token)
+├── skill.ts               ← SkillComponent teaching agents when/how to squash
+├── squash-tool.ts         ← tool factory: validate → archive → extract → queue
+├── squash-middleware.ts   ← middleware: drain pending → replace messages
+├── provider.ts            ← bundle factory: tool + skill + middleware
+└── index.ts               ← public API
+
+Dependencies:
+  ● @koi/core (L0) — types, interfaces, branded IDs
+  ✗ @koi/engine (L1) — never imported in production
+  ✗ peer L2 — never imported in production
+```
+
+### How Tool + Middleware Cooperate
+
+```
+  Agent calls squash tool
+         │
+         ▼
+  ┌──────────────┐    ┌──────────────────┐    ┌──────────────────┐
+  │  squash-tool  │───▶│  pending queue   │───▶│ squash-middleware │
+  │  (priority: -)│    │  (closure-shared)│    │  (priority: 220)  │
+  │               │    │                  │    │                   │
+  │ • validate    │    │ CompactionResult │    │ • drain queue     │
+  │ • archive     │    │ waiting to apply │    │ • replace msgs    │
+  │ • extract     │    │                  │    │ • pass to next    │
+  │   facts       │    └──────────────────┘    └────────┬──────────┘
+  │ • enqueue     │                                     │
+  └──────────────┘                                      ▼
+                                               ┌──────────────────┐
+                                               │    compactor      │
+                                               │  (priority: 225)  │
+                                               │                   │
+                                               │ sees SMALLER       │
+                                               │ context — may      │
+                                               │ skip its LLM call  │
+                                               └────────┬──────────┘
+                                                        │
+                                                        ▼
+                                                   LLM call
+                                               (with room to think)
+```
+
+The middleware runs at priority **220**, before the compactor at **225**. When no squash is pending, the middleware is zero-cost (early return on empty queue check).
+
+---
+
+## Tool Descriptor (exposed to model)
+
+| Field | Value |
+|-------|-------|
+| `name` | `"squash"` |
+| `trustTier` | `"verified"` |
+| **required input** | `phase` (string), `summary` (string) |
+| **optional input** | `facts` (string array) |
+
+The `phase` labels the completed phase (e.g., "planning", "research"). The `summary` replaces old messages. The `facts` array stores durable knowledge to memory.
+
+---
+
+## SkillComponent
+
+`createSquashProvider` automatically attaches `skill:squash` alongside the tool. The skill teaches agents:
+
+| Area | Guidance |
+|------|----------|
+| **When to squash** | Phase transitions, after 10+ tool calls, large intermediate output, before complex next steps |
+| **When NOT to squash** | Mid-task, too early (<8 messages), right before finishing |
+| **Summary quality** | Key decisions, files changed, current state, unresolved issues |
+| **Fact extraction** | Cross-session durable truths only (preferences, conventions, environment) |
+
+### Accessing the skill standalone
+
+```typescript
+import { SQUASH_SKILL, SQUASH_SKILL_NAME } from "@koi/tool-squash";
+import { skillToken } from "@koi/core";
+
+const skill = agent.component(skillToken(SQUASH_SKILL_NAME));
+// skill.content → markdown guidance string
+// skill.tags   → ["context-management", "compression"]
+```
+
+---
+
+## Data Flow
+
+```
+  LLM generates: squash({ phase: "planning", summary: "...", facts: [...] })
+         │
+         ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 1. Validate input                                │
+  │    phase: string (required), summary: string     │
+  │    facts: string[] (optional)                    │
+  │                                                  │
+  │    ✗ Bad input → { ok: false, code: "VALIDATION"}│
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 2. Partition messages                            │
+  │    pinned: msg.pinned === true (always kept)     │
+  │    squashable: everything else                   │
+  │                                                  │
+  │    ≤ preserveRecent squashable? → noop           │
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 3. Split squashable                              │
+  │    head = squashable[0 .. -preserveRecent]       │
+  │    tail = squashable[-preserveRecent ..]          │
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 4. Archive head to SnapshotChainStore            │
+  │    chain: "squash:{sessionId}"                   │
+  │    metadata: { phase, timestamp }                │
+  │    option: skipIfUnchanged: true                 │
+  │                                                  │
+  │    ✗ Failure → { ok: false, code: "ARCHIVE_FAILED"}│
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 5. Extract facts (best-effort)                   │
+  │    memory.store(fact, { category: phase })        │
+  │    Failures silently tracked in factsStored count │
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 6. Build CompactionResult                        │
+  │    messages: [...pinned, summaryMsg, ...tail]     │
+  │    strategy: "squash"                            │
+  │    → queued for companion middleware              │
+  └──────────────────┬───────────────────────────────┘
+                     │
+                     ▼
+  ┌─────────────────────────────────────────────────┐
+  │ 7. Return metrics to agent                       │
+  │    { ok, phase, originalMessages, originalTokens,│
+  │      compactedTokens, archivedNodeId, factsStored}│
+  └─────────────────────────────────────────────────┘
+```
+
+---
+
+## Error Handling
+
+| Condition | Returns | Code |
+|-----------|---------|------|
+| Missing/empty `phase` or `summary` | `{ ok: false, error, code }` | `VALIDATION` |
+| Invalid `facts` (not string array) | `{ ok: false, error, code }` | `VALIDATION` |
+| Abort signal already fired | `{ ok: false, error, code }` | `ABORTED` |
+| Archive store failure | `{ ok: false, error, code }` | `ARCHIVE_FAILED` |
+| Memory store throws | Squash succeeds, `factsStored` reflects partial count | *(best-effort)* |
+| Too few messages | Noop result (`originalMessages: 0`) | *(success)* |
+
+Archive is **fail-fast** — if the archive can't store originals, the squash aborts (no message replacement). Facts are **best-effort** — failures never block the squash.
+
+---
+
+## Testing
+
+```
+squash-tool.test.ts — 12 tests
+  Happy path:
+  ● Squash with summary: archive called, CompactionResult queued
+  ● With facts: memory.store called for each fact
+  ● Summary with special characters stored verbatim
+
+  Edge cases:
+  ● Empty message history → noop
+  ● Fewer than preserveRecent → noop
+  ● All messages pinned → noop
+  ● Mixed pinned + normal → pinned preserved in output
+
+  Error handling:
+  ● Archive failure → ARCHIVE_FAILED
+  ● Memory not provided, facts given → silently dropped
+  ● Memory store throws → squash still succeeds
+  ● Abort signal already aborted → ABORTED
+  ● Missing phase/summary → VALIDATION
+
+squash-middleware.test.ts — 6 tests
+  ● No pending squash → passthrough (zero-cost)
+  ● Single pending squash → messages replaced
+  ● Multiple pending → most recent wins
+  ● Queue overflow → oldest dropped
+  ● onSessionEnd → queue cleared
+  ● describeCapabilities → correct label/description
+
+e2e.test.ts — 5 tests
+  ● Full flow: tool → middleware replaces messages
+  ● Archive retrievable via real SnapshotChainStore
+  ● Facts stored via memory.store
+  ● Skill component attached alongside tool
+  ● Detach clears cached components
+
+e2e-real-llm.test.ts — 7 tests (gated on E2E_TESTS=1 + API key)
+  ● LLM calls squash tool through full Pi adapter stack
+  ● Archive populated with correct metadata
+  ● Middleware replaces messages before next model call
+  ● Facts stored to memory when LLM provides them
+  ● Multi-tool agent uses squash alongside other tools
+  ● Session lifecycle hooks fire correctly
+  ● Pinned messages preserved through squash
+```
+
+```bash
+# Unit + integration tests
+bun --cwd packages/tool-squash test
+
+# E2E with real LLM
+E2E_TESTS=1 bun --cwd packages/tool-squash test src/__tests__/e2e-real-llm.test.ts
+```
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Tool + middleware in one package | They share a closure-scoped pending queue. Splitting would require a shared state package — unnecessary complexity |
+| Phase as archive label, not region marker | Simpler than start/end markers. The agent names the phase after it's done, not before |
+| Agent-provided summary (no LLM call) | The agent IS the LLM. It already knows what matters. Zero additional cost |
+| Agent-provided facts (not auto-extracted) | Auto-extraction requires an LLM call. Agent can select durable facts during its normal reasoning |
+| Archive-or-fail, facts best-effort | Losing originals is unrecoverable. Losing a fact just means it won't be recalled later |
+| Bounded queue (max 3) | Multiple rapid squashes can queue up. Oldest are dropped to prevent memory growth |
+| Priority 220 (before compactor at 225) | Squash reduces context first, so the compactor sees smaller input and may skip its LLM call |
+| Skill bundled in provider | No separate manifest entry needed. Tool + behavioral guidance travel together |
+| `detach()` clears cache | Prevents stale closures if agent is re-assembled during hot-reload |
+| Zero-cost middleware passthrough | Empty queue check (`length === 0`) returns original request unchanged. No allocation on the hot path |
+| `skipIfUnchanged: true` on archive put | Prevents duplicate archives if the same messages are squashed twice |
+
+---
+
+## Exports
+
+```typescript
+// Provider factory
+export { createSquashProvider } from "./provider.js";
+export type { SquashProviderBundle } from "./provider.js";
+
+// Skill
+export { SQUASH_SKILL, SQUASH_SKILL_NAME } from "./skill.js";
+
+// Types + constants
+export type { SquashConfig, SquashResult } from "./types.js";
+export { SQUASH_DEFAULTS, SQUASH_TOOL_DESCRIPTOR } from "./types.js";
+```
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    SnapshotChainStore, CompactionResult, TokenEstimator, │
+    MemoryComponent, ToolDescriptor, Tool, InboundMessage, │
+    SkillComponent, skillToken, chainId, SessionId         │
+                                                           │
+L2  @koi/tool-squash ◄─────────────────────────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✓ All interface properties readonly
+    ✓ Returns error objects (never throws for expected failures)
+    ✓ import type for type-only imports
+    ✓ .js extensions on all local imports
+    ✓ No enum, any, namespace, as Type, ! in production code
+```

--- a/packages/tool-squash/package.json
+++ b/packages/tool-squash/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koi/tool-squash",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/engine": "workspace:*",
+    "@koi/engine-pi": "workspace:*",
+    "@koi/snapshot-chain-store": "workspace:*",
+    "@koi/test-utils": "workspace:*"
+  }
+}

--- a/packages/tool-squash/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/tool-squash/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,90 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/tool-squash API surface . has stable type surface 1`] = `
+"import { ToolDescriptor, MemoryComponent, SessionId, ComponentProvider } from '@koi/core/ecs';
+import { InboundMessage } from '@koi/core/message';
+import { KoiMiddleware } from '@koi/core/middleware';
+import { SnapshotChainStore, SkillComponent } from '@koi/core';
+import { TokenEstimator } from '@koi/core/context';
+
+/**
+ * Configuration, constants, and tool descriptor for @koi/tool-squash.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+/** User-facing configuration for createSquashProvider. */
+interface SquashConfig {
+    /** Required: archive store for snapshotting squashed messages. */
+    readonly archiver: SnapshotChainStore<readonly InboundMessage[]>;
+    /** Optional: memory component for fact extraction. */
+    readonly memory?: MemoryComponent | undefined;
+    /** Optional: token estimator override. Defaults to 4 chars/token heuristic. */
+    readonly tokenEstimator?: TokenEstimator | undefined;
+    /** Number of most recent messages to preserve. Default: 4. */
+    readonly preserveRecent?: number | undefined;
+    /** Maximum pending squashes before oldest is dropped. Default: 3. */
+    readonly maxPendingSquashes?: number | undefined;
+    /** Session ID for archive chain naming. */
+    readonly sessionId: SessionId;
+}
+/** Structured metrics returned to the agent after a squash call. */
+type SquashResult = {
+    readonly ok: true;
+    readonly phase: string;
+    readonly originalMessages: number;
+    readonly originalTokens: number;
+    readonly compactedTokens: number;
+    readonly archivedNodeId: string | undefined;
+    readonly factsStored: number;
+} | {
+    readonly ok: false;
+    readonly error: string;
+    readonly code: string;
+};
+interface SquashDefaults {
+    readonly preserveRecent: number;
+    readonly maxPendingSquashes: number;
+}
+declare const SQUASH_DEFAULTS: Readonly<SquashDefaults>;
+/** Tool descriptor exposed to the model for the squash tool. */
+declare const SQUASH_TOOL_DESCRIPTOR: ToolDescriptor;
+
+/**
+ * Bundle factory — creates the squash tool provider + companion middleware.
+ *
+ * Both share a closure-scoped pending queue. The caller registers:
+ * - The ComponentProvider via assembly (attaches tool:squash)
+ * - The KoiMiddleware via middleware chain (applies squashes before model calls)
+ */
+
+/** Return value of createSquashProvider — both must be registered. */
+interface SquashProviderBundle {
+    readonly provider: ComponentProvider;
+    readonly middleware: KoiMiddleware;
+}
+/**
+ * Creates a ComponentProvider + KoiMiddleware bundle for the squash tool.
+ *
+ * @param config - User-facing configuration
+ * @param getMessages - Returns current conversation messages for the tool to partition
+ */
+declare function createSquashProvider(config: SquashConfig, getMessages: () => readonly InboundMessage[]): SquashProviderBundle;
+
+/**
+ * Skill component for the squash tool — teaches agents when and how to compress context.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+/** Skill component name. */
+declare const SQUASH_SKILL_NAME: "squash";
+/**
+ * Pre-built SkillComponent for squash behavioral guidance.
+ * Attached automatically by createSquashProvider alongside the tool.
+ */
+declare const SQUASH_SKILL: SkillComponent;
+
+export { SQUASH_DEFAULTS, SQUASH_SKILL, SQUASH_SKILL_NAME, SQUASH_TOOL_DESCRIPTOR, type SquashConfig, type SquashProviderBundle, type SquashResult, createSquashProvider };
+"
+`;

--- a/packages/tool-squash/src/__tests__/api-surface.test.ts
+++ b/packages/tool-squash/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/tool-squash/src/__tests__/e2e-real-llm.test.ts
+++ b/packages/tool-squash/src/__tests__/e2e-real-llm.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Full-stack E2E: createKoi + createPiAdapter + @koi/tool-squash.
+ *
+ * Validates the squash tool + companion middleware with real LLM calls
+ * through the full L1 runtime assembly:
+ *   - LLM discovers the squash tool and calls it with correct arguments
+ *   - Archived messages are stored in a real SnapshotChainStore
+ *   - Companion middleware replaces messages on the next model call
+ *   - Facts are stored to memory when provided
+ *   - Squash tool works alongside other tools in a multi-tool agent
+ *   - Full conversation continuity after squash
+ *
+ * Run:
+ *   E2E_TESTS=1 bun test src/__tests__/e2e-real-llm.test.ts
+ *
+ * Cost: ~$0.03-0.08 per run (haiku model, minimal prompts).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  AgentManifest,
+  ComponentProvider,
+  EngineEvent,
+  EngineOutput,
+  KoiMiddleware,
+  ModelRequest,
+  ModelStreamHandler,
+  Tool,
+} from "@koi/core";
+import { chainId, toolToken } from "@koi/core";
+import type { MemoryComponent, SessionId } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import { createKoi } from "@koi/engine";
+import { createPiAdapter } from "@koi/engine-pi";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { createSquashProvider } from "../provider.js";
+
+// ---------------------------------------------------------------------------
+// Environment gate
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const HAS_KEY = ANTHROPIC_KEY.length > 0;
+const E2E_OPTED_IN = process.env.E2E_TESTS === "1";
+const describeE2E = HAS_KEY && E2E_OPTED_IN ? describe : describe.skip;
+
+const TIMEOUT_MS = 120_000;
+const E2E_MODEL = "anthropic:claude-haiku-4-5-20251001";
+const MODEL_NAME = "claude-haiku-4-5";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function collectEvents(
+  iterable: AsyncIterable<EngineEvent>,
+): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = []; // let justified: test accumulator
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function findDoneOutput(events: readonly EngineEvent[]): EngineOutput | undefined {
+  const done = events.find((e): e is EngineEvent & { readonly kind: "done" } => e.kind === "done");
+  return done?.output;
+}
+
+function testManifest(): AgentManifest {
+  return {
+    name: "E2E Squash Agent",
+    version: "0.1.0",
+    model: { name: MODEL_NAME },
+  };
+}
+
+function makeMessage(text: string, opts?: { readonly pinned?: boolean }): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "user",
+    timestamp: Date.now(),
+    ...(opts?.pinned === true ? { pinned: true } : {}),
+  };
+}
+
+function createAdapter(systemPrompt: string): ReturnType<typeof createPiAdapter> {
+  return createPiAdapter({
+    model: E2E_MODEL,
+    systemPrompt,
+    getApiKey: async () => ANTHROPIC_KEY,
+    thinkingLevel: "off",
+  });
+}
+
+/** Creates a ComponentProvider that registers additional tools alongside squash. */
+function createToolProvider(tools: readonly Tool[]): ComponentProvider {
+  return {
+    name: "e2e-extra-tools",
+    attach: async () => new Map(tools.map((t) => [toolToken(t.descriptor.name) as string, t])),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Seeded conversation history — simulates multi-turn conversation
+// ---------------------------------------------------------------------------
+
+function createSeededMessages(): InboundMessage[] {
+  return [
+    makeMessage("User: I need help building a REST API for a todo app."),
+    makeMessage("Assistant: I can help with that. Let me start by planning the architecture."),
+    makeMessage("User: Use Express.js and PostgreSQL."),
+    makeMessage(
+      "Assistant: Got it. I'll design the schema with tasks table and use Express routes.",
+    ),
+    makeMessage("User: Add authentication with JWT."),
+    makeMessage(
+      "Assistant: I'll add a users table, bcrypt for passwords, and JWT middleware for auth.",
+    ),
+    makeMessage("User: What about input validation?"),
+    makeMessage("Assistant: I'll use Zod for request body validation on all endpoints."),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describeE2E("e2e: squash tool through full createKoi + Pi stack", () => {
+  // ── Test 1: LLM discovers and calls squash tool ──────────────────────
+
+  test(
+    "LLM calls squash tool with correct phase and summary",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const { provider, middleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId: "e2e-session-1" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      // Track tool calls via middleware
+      const toolCallNames: string[] = []; // let justified: test accumulator
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-squash-tool-observer",
+        describeCapabilities: () => undefined,
+        wrapToolCall: async (_ctx, request, next) => {
+          toolCallNames.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      const adapter = createAdapter(
+        "You MUST call the squash tool with phase 'planning' and summary 'Planning done.' — nothing else. " +
+          "After calling it, say 'Done.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [middleware, toolObserver],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Please squash the conversation now." }),
+        );
+
+        // Agent completed
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Squash tool was called
+        expect(toolCallNames).toContain("squash");
+
+        // Tool call events were emitted
+        const toolStarts = events.filter((e) => e.kind === "tool_call_start");
+        const toolEnds = events.filter((e) => e.kind === "tool_call_end");
+        expect(toolStarts.length).toBeGreaterThanOrEqual(1);
+        expect(toolEnds.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 2: Archive populated with real SnapshotChainStore ──────────
+
+  test(
+    "archived messages stored in real SnapshotChainStore after squash",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+      const sessionId = "e2e-session-archive" as SessionId;
+
+      const { provider, middleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      const adapter = createAdapter(
+        "You MUST call the squash tool with phase 'research' and summary 'Research complete.' — nothing else. " +
+          "After calling it, say 'Done.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [middleware],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        await collectEvents(runtime.run({ kind: "text", text: "Squash now." }));
+
+        // Verify archive has data
+        const archiveChainId = chainId(`squash:${sessionId}`);
+        const headResult = await archiver.head(archiveChainId);
+        expect(headResult.ok).toBe(true);
+
+        if (headResult.ok && headResult.value !== undefined) {
+          // Archived data should contain the older messages (seeded - preserveRecent)
+          const archivedData = headResult.value.data;
+          expect(archivedData.length).toBe(4); // 8 seeded - 4 preserveRecent = 4 archived
+          // First archived message should be the first seeded message
+          expect(archivedData[0]?.content[0]).toMatchObject({
+            kind: "text",
+            text: "User: I need help building a REST API for a todo app.",
+          });
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 3: Middleware applies squash on next model call ────────────
+
+  test(
+    "companion middleware replaces messages on the model call after squash",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const { provider, middleware: squashMiddleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId: "e2e-session-mw" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      // Capture messages from each model call to detect replacement
+      const modelCallMessageCounts: number[] = []; // let justified: test accumulator
+      let sawSquashSummaryMessage = false; // let justified: toggled in observer
+
+      const streamObserver: KoiMiddleware = {
+        name: "e2e-squash-stream-observer",
+        // Priority lower than squash middleware (220) so we see post-squash messages
+        priority: 230,
+        describeCapabilities: () => undefined,
+        wrapModelStream: async function* (_ctx, request: ModelRequest, next: ModelStreamHandler) {
+          modelCallMessageCounts.push(request.messages.length);
+
+          // Check if any message has senderId "system:squash" (injected by squash tool)
+          const hasSquashMessage = request.messages.some((m) => m.senderId === "system:squash");
+          if (hasSquashMessage) {
+            sawSquashSummaryMessage = true;
+          }
+
+          yield* next(request);
+        },
+      };
+
+      const adapter = createAdapter(
+        "You MUST call the squash tool with phase 'implementation' and summary 'Implementation done.' " +
+          "After calling it, say 'Squash applied.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [squashMiddleware, streamObserver],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        const events = await collectEvents(runtime.run({ kind: "text", text: "Squash now." }));
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // There should be at least 2 model calls (1st triggers tool call, 2nd after tool result)
+        expect(modelCallMessageCounts.length).toBeGreaterThanOrEqual(2);
+
+        // The second model call should have the squash summary message
+        // (squash middleware fires at priority 220, observer at 230 sees post-replacement)
+        expect(sawSquashSummaryMessage).toBe(true);
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 4: Facts stored to memory ─────────────────────────────────
+
+  test(
+    "squash with memory: archive populated, facts stored if LLM includes them",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const storeMock = mock(() => Promise.resolve());
+      const mockMemory: MemoryComponent = {
+        recall: mock(() => Promise.resolve([])),
+        store: storeMock,
+      };
+
+      const { provider, middleware } = createSquashProvider(
+        {
+          archiver,
+          memory: mockMemory,
+          sessionId: "e2e-session-facts" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      const adapter = createAdapter(
+        "You MUST call the squash tool with these EXACT arguments:\n" +
+          '- phase: "planning"\n' +
+          '- summary: "Planning complete."\n' +
+          '- facts: ["User wants Express.js", "Database is PostgreSQL"]\n' +
+          "After calling it, say 'Done.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [middleware],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        await collectEvents(runtime.run({ kind: "text", text: "Squash with facts now." }));
+
+        // Verify archive was populated (squash tool was called)
+        const archiveChainId = chainId("squash:e2e-session-facts");
+        const headResult = await archiver.head(archiveChainId);
+        expect(headResult.ok).toBe(true);
+
+        // If the LLM included the optional facts array, memory.store was called
+        // (LLMs sometimes omit optional params, so this is a soft check)
+        if (storeMock.mock.calls.length > 0) {
+          const firstCallArgs = storeMock.mock.calls[0] as
+            | [string, { category: string }]
+            | undefined;
+          if (firstCallArgs !== undefined) {
+            expect(firstCallArgs[1]?.category).toBe("planning");
+          }
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 5: Multi-tool agent with squash ───────────────────────────
+
+  test(
+    "squash tool works alongside other tools in the same agent",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const { provider: squashProvider, middleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId: "e2e-session-multi" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      // A second tool alongside squash
+      const multiplyTool: Tool = {
+        descriptor: {
+          name: "multiply",
+          description: "Multiplies two numbers and returns the product.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              a: { type: "number", description: "First number" },
+              b: { type: "number", description: "Second number" },
+            },
+            required: ["a", "b"],
+          },
+        },
+        trustTier: "sandbox",
+        execute: async (input) => String(Number(input.a ?? 0) * Number(input.b ?? 0)),
+      };
+
+      const toolCallNames: string[] = []; // let justified: test accumulator
+      const toolObserver: KoiMiddleware = {
+        name: "e2e-multi-tool-observer",
+        describeCapabilities: () => undefined,
+        wrapToolCall: async (_ctx, request, next) => {
+          toolCallNames.push(request.toolId);
+          return next(request);
+        },
+      };
+
+      const adapter = createAdapter(
+        "You have two tools: multiply and squash. You MUST:\n" +
+          "1. First, use the multiply tool to compute 7 * 6.\n" +
+          '2. Then, call the squash tool with phase "calculation" and ' +
+          'summary "Calculated 7 * 6 = 42."\n' +
+          "3. Report both results briefly.",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [middleware, toolObserver],
+        providers: [squashProvider, createToolProvider([multiplyTool])],
+        loopDetection: false,
+        limits: { maxTurns: 8 },
+      });
+
+      try {
+        const events = await collectEvents(
+          runtime.run({ kind: "text", text: "Do the math and squash." }),
+        );
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Both tools should have been called
+        expect(toolCallNames).toContain("multiply");
+        expect(toolCallNames).toContain("squash");
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 6: Lifecycle: onSessionEnd clears pending queue ───────────
+
+  test(
+    "session end disposes cleanly with no pending squash leaks",
+    async () => {
+      const seededMessages = createSeededMessages();
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const { provider, middleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId: "e2e-session-dispose" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      let sessionEndFired = false; // let justified: toggled in hook
+
+      const lifecycleObserver: KoiMiddleware = {
+        name: "e2e-lifecycle-observer",
+        priority: 300,
+        describeCapabilities: () => undefined,
+        onSessionEnd: async () => {
+          sessionEndFired = true;
+        },
+      };
+
+      const adapter = createAdapter(
+        "You MUST call the squash tool with phase 'cleanup' and summary 'Cleanup done.' " +
+          "After calling it, say 'Complete.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [middleware, lifecycleObserver],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        const events = await collectEvents(runtime.run({ kind: "text", text: "Clean up." }));
+
+        const output = findDoneOutput(events);
+        expect(output).toBeDefined();
+
+        // Session lifecycle completed — middleware onSessionEnd fired
+        expect(sessionEndFired).toBe(true);
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  // ── Test 7: Pinned messages survive squash ─────────────────────────
+
+  test(
+    "pinned messages preserved through squash in the compacted output",
+    async () => {
+      const seededMessages: InboundMessage[] = [
+        makeMessage("SYSTEM INSTRUCTION: Always be helpful.", { pinned: true }),
+        ...createSeededMessages(),
+      ];
+      const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+
+      const { provider, middleware: squashMiddleware } = createSquashProvider(
+        {
+          archiver,
+          sessionId: "e2e-session-pinned" as SessionId,
+          preserveRecent: 4,
+        },
+        () => seededMessages,
+      );
+
+      // Capture the replaced messages to verify pinned message is preserved
+      let replacedMessages: readonly InboundMessage[] | undefined; // let justified: captured in observer
+
+      const streamObserver: KoiMiddleware = {
+        name: "e2e-pinned-observer",
+        priority: 230, // After squash middleware (220)
+        describeCapabilities: () => undefined,
+        wrapModelStream: async function* (_ctx, request: ModelRequest, next: ModelStreamHandler) {
+          const hasSquashMsg = request.messages.some((m) => m.senderId === "system:squash");
+          if (hasSquashMsg) {
+            replacedMessages = request.messages;
+          }
+          yield* next(request);
+        },
+      };
+
+      const adapter = createAdapter(
+        "Call the squash tool with phase 'review' and summary 'Review done.' " + "Then say 'OK.'",
+      );
+
+      const runtime = await createKoi({
+        manifest: testManifest(),
+        adapter,
+        middleware: [squashMiddleware, streamObserver],
+        providers: [provider],
+        loopDetection: false,
+        limits: { maxTurns: 5 },
+      });
+
+      try {
+        await collectEvents(runtime.run({ kind: "text", text: "Squash now." }));
+
+        // Replaced messages should include the pinned message
+        expect(replacedMessages).toBeDefined();
+        if (replacedMessages !== undefined) {
+          const pinnedMsg = replacedMessages.find((m) => m.pinned === true);
+          expect(pinnedMsg).toBeDefined();
+          expect(pinnedMsg?.content[0]).toMatchObject({
+            kind: "text",
+            text: "SYSTEM INSTRUCTION: Always be helpful.",
+          });
+
+          // Should also have the squash summary
+          const squashMsg = replacedMessages.find((m) => m.senderId === "system:squash");
+          expect(squashMsg).toBeDefined();
+        }
+      } finally {
+        await runtime.dispose();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});

--- a/packages/tool-squash/src/__tests__/e2e.test.ts
+++ b/packages/tool-squash/src/__tests__/e2e.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration tests — tool → middleware flow with real stores.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { chainId, skillToken } from "@koi/core";
+import type { MemoryComponent, SessionId, SkillComponent } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelRequest, TurnContext } from "@koi/core/middleware";
+import { createInMemorySnapshotChainStore } from "@koi/snapshot-chain-store";
+import { createSquashProvider } from "../provider.js";
+import { SQUASH_SKILL_NAME } from "../skill.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessage(text: string, opts?: { readonly pinned?: boolean }): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "user",
+    timestamp: Date.now(),
+    ...(opts?.pinned === true ? { pinned: true } : {}),
+  };
+}
+
+function makeTurnContext(): TurnContext {
+  return {
+    session: {
+      agentId: "agent-1",
+      sessionId: "session-1" as SessionId,
+      runId: "run-1" as TurnContext["session"]["runId"],
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "run-1:t0" as TurnContext["turnId"],
+    messages: [],
+    metadata: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tool-squash e2e", () => {
+  // let justified: reset per test
+  let messages: InboundMessage[];
+
+  beforeEach(() => {
+    messages = [];
+  });
+
+  test("full flow: tool → middleware replaces messages", async () => {
+    const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+    const sid = "session-e2e-1" as SessionId;
+    messages = Array.from({ length: 8 }, (_, i) => makeMessage(`message ${String(i)}`));
+
+    const { provider, middleware } = createSquashProvider(
+      { archiver, sessionId: sid },
+      () => messages,
+    );
+
+    // Attach provider to get the tool
+    const components = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+
+    // Get tool from components
+    const toolEntry =
+      components instanceof Map
+        ? components
+        : (components as { readonly components: ReadonlyMap<string, unknown> }).components;
+    const tool = toolEntry.get("tool:squash") as {
+      readonly execute: (args: Record<string, unknown>) => Promise<unknown>;
+    };
+    expect(tool).toBeDefined();
+
+    // Execute squash
+    const result = (await tool.execute({
+      phase: "planning",
+      summary: "Planning phase complete. Key decisions: use TypeScript, target Node 22.",
+    })) as { readonly ok: boolean; readonly originalMessages: number };
+
+    expect(result.ok).toBe(true);
+    expect(result.originalMessages).toBe(4); // 8 - 4 preserveRecent
+
+    // Now apply via middleware
+    const originalRequest: ModelRequest = {
+      messages: [makeMessage("this should be replaced")],
+    };
+    const next = mock(async (_req: ModelRequest) => ({
+      content: "response",
+      model: "test",
+      metadata: {},
+    }));
+
+    await middleware.wrapModelCall?.(makeTurnContext(), originalRequest, next);
+
+    // Verify middleware replaced the messages
+    const passedRequest = next.mock.calls[0]?.[0] as ModelRequest;
+    expect(passedRequest.messages).not.toBe(originalRequest.messages);
+    // Should contain the summary message
+    const summaryMsg = passedRequest.messages.find((m) => m.senderId === "system:squash");
+    expect(summaryMsg).toBeDefined();
+    expect(summaryMsg?.content[0]).toMatchObject({ kind: "text" });
+  });
+
+  test("full flow with real snapshot store: archive retrievable", async () => {
+    const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+    const sid = "session-e2e-2" as SessionId;
+    messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg ${String(i)}`));
+
+    const { provider } = createSquashProvider({ archiver, sessionId: sid }, () => messages);
+
+    const components = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+
+    const toolEntry =
+      components instanceof Map
+        ? components
+        : (components as { readonly components: ReadonlyMap<string, unknown> }).components;
+    const tool = toolEntry.get("tool:squash") as {
+      readonly execute: (args: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    await tool.execute({
+      phase: "research",
+      summary: "Research complete.",
+    });
+
+    // Verify archive is retrievable
+    const archiveChainId = chainId(`squash:${sid}`);
+    const headResult = await archiver.head(archiveChainId);
+    expect(headResult.ok).toBe(true);
+    if (headResult.ok && headResult.value !== undefined) {
+      expect(headResult.value.data.length).toBe(2); // 6 - 4 preserveRecent
+      expect(headResult.value.metadata).toMatchObject({ phase: "research" });
+    }
+  });
+
+  test("full flow with facts: memory.store called", async () => {
+    const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+    const sid = "session-e2e-3" as SessionId;
+    const storeMock = mock(() => Promise.resolve());
+    const memory: MemoryComponent = {
+      recall: mock(() => Promise.resolve([])),
+      store: storeMock,
+    };
+    messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg ${String(i)}`));
+
+    const { provider } = createSquashProvider({ archiver, sessionId: sid, memory }, () => messages);
+
+    const components = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+
+    const toolEntry =
+      components instanceof Map
+        ? components
+        : (components as { readonly components: ReadonlyMap<string, unknown> }).components;
+    const tool = toolEntry.get("tool:squash") as {
+      readonly execute: (args: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    const result = (await tool.execute({
+      phase: "implementation",
+      summary: "Implemented the feature.",
+      facts: ["Uses TypeScript strict mode", "Target is Node 22"],
+    })) as { readonly ok: boolean; readonly factsStored: number };
+
+    expect(result.ok).toBe(true);
+    expect(result.factsStored).toBe(2);
+    expect(storeMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("attaches squash skill component alongside tool", async () => {
+    const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+    const sid = "session-e2e-skill" as SessionId;
+
+    const { provider } = createSquashProvider({ archiver, sessionId: sid }, () => []);
+
+    const components = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+
+    const componentMap =
+      components instanceof Map
+        ? components
+        : (components as { readonly components: ReadonlyMap<string, unknown> }).components;
+
+    // Both tool and skill are attached
+    expect(componentMap.has("tool:squash")).toBe(true);
+    expect(componentMap.has(skillToken(SQUASH_SKILL_NAME) as string)).toBe(true);
+
+    // Skill has meaningful content
+    const skill = componentMap.get(skillToken(SQUASH_SKILL_NAME) as string) as SkillComponent;
+    expect(skill.name).toBe("squash");
+    expect(skill.content).toContain("phase boundaries");
+    expect(skill.content).toContain("When NOT to call squash");
+    expect(skill.content).toContain("How to write a good summary");
+  });
+
+  test("detach clears cached components and pending queue", async () => {
+    const archiver = createInMemorySnapshotChainStore<readonly InboundMessage[]>();
+    const sid = "session-e2e-detach" as SessionId;
+    messages = Array.from({ length: 8 }, (_, i) => makeMessage(`msg ${String(i)}`));
+
+    const { provider } = createSquashProvider({ archiver, sessionId: sid }, () => messages);
+
+    // Attach, execute tool, then detach
+    const components1 = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+    const toolEntry1 =
+      components1 instanceof Map
+        ? components1
+        : (components1 as { readonly components: ReadonlyMap<string, unknown> }).components;
+    const tool = toolEntry1.get("tool:squash") as {
+      readonly execute: (args: Record<string, unknown>) => Promise<unknown>;
+    };
+    await tool.execute({ phase: "test", summary: "Test." });
+
+    // Detach clears state
+    await provider.detach?.({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+
+    // Re-attach returns fresh components (not stale cache)
+    const components2 = await provider.attach({
+      pid: { id: "agent-1" as never, name: "test", type: "copilot", depth: 0 },
+      manifest: {} as never,
+      state: "running",
+      component: () => undefined,
+      has: () => false,
+      hasAll: () => false,
+      query: () => new Map(),
+      components: () => new Map(),
+    });
+    expect(components2).not.toBe(components1);
+  });
+});

--- a/packages/tool-squash/src/estimator.ts
+++ b/packages/tool-squash/src/estimator.ts
@@ -1,0 +1,23 @@
+/**
+ * Inline heuristic token estimator — 4 chars per token.
+ *
+ * Used as the default when no TokenEstimator is injected.
+ */
+
+import type { TokenEstimator } from "@koi/core/context";
+import type { InboundMessage } from "@koi/core/message";
+
+export const heuristicTokenEstimator: TokenEstimator = {
+  estimateText: (text: string): number => Math.ceil(text.length / 4),
+
+  estimateMessages: (messages: readonly InboundMessage[]): number =>
+    messages.reduce(
+      (sum, msg) =>
+        sum +
+        msg.content.reduce(
+          (s, block) => s + (block.kind === "text" ? Math.ceil(block.text.length / 4) : 0),
+          0,
+        ),
+      0,
+    ),
+};

--- a/packages/tool-squash/src/index.ts
+++ b/packages/tool-squash/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @koi/tool-squash — Agent-initiated phase-boundary compression (Layer 2)
+ *
+ * The agent calls `squash(phase, summary)` at natural phase boundaries.
+ * Old messages are replaced with the agent's own summary (no LLM call),
+ * originals are archived to SnapshotChainStore, and optionally facts are
+ * extracted to memory.
+ */
+
+export type { SquashProviderBundle } from "./provider.js";
+export { createSquashProvider } from "./provider.js";
+export { SQUASH_SKILL, SQUASH_SKILL_NAME } from "./skill.js";
+export type { SquashConfig, SquashResult } from "./types.js";
+export { SQUASH_DEFAULTS, SQUASH_TOOL_DESCRIPTOR } from "./types.js";

--- a/packages/tool-squash/src/provider.ts
+++ b/packages/tool-squash/src/provider.ts
@@ -1,0 +1,90 @@
+/**
+ * Bundle factory — creates the squash tool provider + companion middleware.
+ *
+ * Both share a closure-scoped pending queue. The caller registers:
+ * - The ComponentProvider via assembly (attaches tool:squash)
+ * - The KoiMiddleware via middleware chain (applies squashes before model calls)
+ */
+
+import { skillToken } from "@koi/core";
+import type { Agent, ComponentProvider } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { KoiMiddleware } from "@koi/core/middleware";
+import { heuristicTokenEstimator } from "./estimator.js";
+import { SQUASH_SKILL, SQUASH_SKILL_NAME } from "./skill.js";
+import { createSquashMiddleware } from "./squash-middleware.js";
+import { createSquashTool } from "./squash-tool.js";
+import type { ResolvedSquashConfig, SquashConfig } from "./types.js";
+import { createPendingQueue, SQUASH_DEFAULTS } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+function validatePositiveInt(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`Invalid ${name}: expected a positive integer, got ${String(value)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Return value of createSquashProvider — both must be registered. */
+export interface SquashProviderBundle {
+  readonly provider: ComponentProvider;
+  readonly middleware: KoiMiddleware;
+}
+
+/**
+ * Creates a ComponentProvider + KoiMiddleware bundle for the squash tool.
+ *
+ * @param config - User-facing configuration
+ * @param getMessages - Returns current conversation messages for the tool to partition
+ */
+export function createSquashProvider(
+  config: SquashConfig,
+  getMessages: () => readonly InboundMessage[],
+): SquashProviderBundle {
+  const pendingQueue = createPendingQueue();
+
+  const resolved: ResolvedSquashConfig = {
+    archiver: config.archiver,
+    memory: config.memory,
+    tokenEstimator: config.tokenEstimator ?? heuristicTokenEstimator,
+    preserveRecent: config.preserveRecent ?? SQUASH_DEFAULTS.preserveRecent,
+    maxPendingSquashes: config.maxPendingSquashes ?? SQUASH_DEFAULTS.maxPendingSquashes,
+    sessionId: config.sessionId,
+  };
+
+  validatePositiveInt(resolved.preserveRecent, "preserveRecent");
+  validatePositiveInt(resolved.maxPendingSquashes, "maxPendingSquashes");
+
+  // let justified: mutable cache (set once on first attach, reused thereafter)
+  let cached: ReadonlyMap<string, unknown> | undefined;
+
+  const provider: ComponentProvider = {
+    name: "squash",
+
+    async attach(_agent: Agent): Promise<ReadonlyMap<string, unknown>> {
+      if (cached !== undefined) return cached;
+
+      const tool = createSquashTool(resolved, pendingQueue, getMessages);
+      cached = new Map<string, unknown>([
+        ["tool:squash", tool],
+        [skillToken(SQUASH_SKILL_NAME) as string, SQUASH_SKILL],
+      ]);
+      return cached;
+    },
+
+    async detach(_agent: Agent): Promise<void> {
+      cached = undefined;
+      pendingQueue.clear();
+    },
+  };
+
+  const middleware = createSquashMiddleware(pendingQueue);
+
+  return { provider, middleware };
+}

--- a/packages/tool-squash/src/skill.ts
+++ b/packages/tool-squash/src/skill.ts
@@ -1,0 +1,75 @@
+/**
+ * Skill component for the squash tool — teaches agents when and how to compress context.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+import type { SkillComponent } from "@koi/core";
+
+/** Skill component name. */
+export const SQUASH_SKILL_NAME = "squash" as const;
+
+/**
+ * Markdown content teaching agents the squash strategy.
+ * Injected into the agent's context alongside the tool descriptor.
+ */
+export const SQUASH_SKILL_CONTENT: string = `
+# Squash — context compression strategy
+
+## When to call squash
+
+Call \`squash\` at **natural phase boundaries** — moments where one logical phase ends
+and a new one begins. Good triggers:
+
+- **Phase transitions**: done planning → starting implementation, done researching → starting coding
+- **High tool-call density**: after 10+ tool calls (file reads, searches, writes) since your last squash
+- **Large intermediate output**: after reading multiple large files or receiving verbose tool results that you have already processed
+- **Before a complex next step**: if the upcoming work needs room to think, compress first
+
+## When NOT to call squash
+
+- **Mid-task**: do not squash while actively debugging, editing, or iterating on a single file
+- **Too early**: if you have fewer than ~8 messages, there is nothing meaningful to compress
+- **Right before finishing**: if you are about to deliver the final answer, compression is wasted effort
+
+## How to write a good summary
+
+The summary **replaces** all old messages — it is the only record the model will see going forward.
+Include:
+
+1. **Key decisions made** and their rationale ("chose SQLite because user requested it")
+2. **Files created or modified** with a brief note on what changed
+3. **Current state** — what is done, what is next
+4. **Unresolved issues** or open questions, if any
+
+Do NOT include:
+- Verbose file contents (they are archived and retrievable)
+- Step-by-step narration of what you did (focus on outcomes)
+- Temporary debug output or intermediate reasoning
+
+## How to use facts
+
+Facts are optional durable knowledge stored to long-term memory. Use them for truths
+that matter **across sessions**, not just the current conversation:
+
+- User preferences: "User prefers TypeScript strict mode", "User uses Bun, not Node"
+- Project conventions: "API uses REST with JSON responses", "Tests use bun:test"
+- Environmental info: "API key stored in .env", "Deploy target is Cloudflare Workers"
+
+Do NOT store as facts:
+- Temporary state ("currently editing foo.ts")
+- Obvious information ("the project has a package.json")
+- Anything specific to the current task that will not be relevant later
+`.trim();
+
+/**
+ * Pre-built SkillComponent for squash behavioral guidance.
+ * Attached automatically by createSquashProvider alongside the tool.
+ */
+export const SQUASH_SKILL: SkillComponent = {
+  name: SQUASH_SKILL_NAME,
+  description:
+    "When to compress context with squash, how to write effective summaries, and how to extract durable facts",
+  content: SQUASH_SKILL_CONTENT,
+  tags: ["context-management", "compression"],
+} as const satisfies SkillComponent;

--- a/packages/tool-squash/src/squash-middleware.test.ts
+++ b/packages/tool-squash/src/squash-middleware.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for squash companion middleware.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CompactionResult } from "@koi/core/context";
+import type { SessionId } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelRequest, SessionContext, TurnContext } from "@koi/core/middleware";
+import { createSquashMiddleware } from "./squash-middleware.js";
+import type { PendingQueue, PendingSquash } from "./types.js";
+import { createPendingQueue } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessage(text: string): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "user",
+    timestamp: Date.now(),
+  };
+}
+
+function makeTurnContext(): TurnContext {
+  return {
+    session: {
+      agentId: "agent-1",
+      sessionId: "session-1" as SessionId,
+      runId: "run-1" as TurnContext["session"]["runId"],
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "run-1:t0" as TurnContext["turnId"],
+    messages: [],
+    metadata: {},
+  };
+}
+
+function makeModelRequest(messages: readonly InboundMessage[]): ModelRequest {
+  return { messages };
+}
+
+function makeCompactionResult(messages: readonly InboundMessage[]): CompactionResult {
+  return {
+    messages,
+    originalTokens: 100,
+    compactedTokens: 20,
+    strategy: "squash",
+  };
+}
+
+function makePending(messages: readonly InboundMessage[]): PendingSquash {
+  return { result: makeCompactionResult(messages) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createSquashMiddleware", () => {
+  // let justified: reset per test
+  let pendingQueue: PendingQueue;
+
+  beforeEach(() => {
+    pendingQueue = createPendingQueue();
+  });
+
+  test("no pending squash: next receives original request unchanged", async () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    const originalMessages = [makeMessage("hello")];
+    const request = makeModelRequest(originalMessages);
+    const next = mock(async (_req: ModelRequest) => ({
+      content: "response",
+      model: "test",
+      metadata: {},
+    }));
+
+    await middleware.wrapModelCall?.(makeTurnContext(), request, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const passedRequest = next.mock.calls[0]?.[0] as ModelRequest;
+    expect(passedRequest.messages).toBe(originalMessages);
+  });
+
+  test("single pending squash: next receives replaced messages, queue emptied", async () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    const squashedMessages = [makeMessage("squashed summary")];
+    pendingQueue.enqueue(makePending(squashedMessages));
+    const request = makeModelRequest([makeMessage("original")]);
+    const next = mock(async (_req: ModelRequest) => ({
+      content: "response",
+      model: "test",
+      metadata: {},
+    }));
+
+    await middleware.wrapModelCall?.(makeTurnContext(), request, next);
+
+    expect(pendingQueue.length).toBe(0);
+    const passedRequest = next.mock.calls[0]?.[0] as ModelRequest;
+    expect(passedRequest.messages).toBe(squashedMessages);
+  });
+
+  test("multiple pending squashes: last squash's messages applied", async () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    const firstMessages = [makeMessage("first squash")];
+    const secondMessages = [makeMessage("second squash")];
+    pendingQueue.enqueue(makePending(firstMessages));
+    pendingQueue.enqueue(makePending(secondMessages));
+    const request = makeModelRequest([makeMessage("original")]);
+    const next = mock(async (_req: ModelRequest) => ({
+      content: "response",
+      model: "test",
+      metadata: {},
+    }));
+
+    await middleware.wrapModelCall?.(makeTurnContext(), request, next);
+
+    expect(pendingQueue.length).toBe(0);
+    const passedRequest = next.mock.calls[0]?.[0] as ModelRequest;
+    expect(passedRequest.messages).toBe(secondMessages);
+  });
+
+  test("wrapModelStream: applies pending squash", async () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    const squashedMessages = [makeMessage("squashed")];
+    pendingQueue.enqueue(makePending(squashedMessages));
+    const request = makeModelRequest([makeMessage("original")]);
+    // let justified: captures the request received by next
+    let capturedRequest: ModelRequest | undefined;
+    const next = async function* (req: ModelRequest) {
+      capturedRequest = req;
+      yield { kind: "done" as const, response: { content: "done", model: "test" } };
+    };
+
+    const chunks: unknown[] = [];
+    const stream = middleware.wrapModelStream;
+    expect(stream).toBeDefined();
+    if (stream !== undefined) {
+      for await (const chunk of stream(makeTurnContext(), request, next)) {
+        chunks.push(chunk);
+      }
+    }
+
+    expect(pendingQueue.length).toBe(0);
+    expect(capturedRequest?.messages).toBe(squashedMessages);
+    expect(chunks).toHaveLength(1);
+  });
+
+  test("onSessionEnd clears queue", async () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    pendingQueue.enqueue(makePending([makeMessage("leftover")]));
+    pendingQueue.enqueue(makePending([makeMessage("leftover2")]));
+    expect(pendingQueue.length).toBe(2);
+
+    const sessionCtx: SessionContext = {
+      agentId: "agent-1",
+      sessionId: "session-1" as SessionId,
+      runId: "run-1" as SessionContext["runId"],
+      metadata: {},
+    };
+    await middleware.onSessionEnd?.(sessionCtx);
+
+    expect(pendingQueue.length).toBe(0);
+  });
+
+  test("describeCapabilities: returns correct label", () => {
+    const middleware = createSquashMiddleware(pendingQueue);
+    const cap = middleware.describeCapabilities(makeTurnContext());
+    expect(cap).toBeDefined();
+    expect(cap?.label).toBe("squash");
+    expect(cap?.description).toContain("squash tool");
+  });
+});

--- a/packages/tool-squash/src/squash-middleware.ts
+++ b/packages/tool-squash/src/squash-middleware.ts
@@ -1,0 +1,70 @@
+/**
+ * Squash companion middleware — applies pending squashes before model calls.
+ *
+ * Priority 220: runs before compactor (225), so squash applies first
+ * and the compactor sees the already-reduced context.
+ */
+
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  ModelHandler,
+  ModelRequest,
+  ModelStreamHandler,
+  SessionContext,
+  TurnContext,
+} from "@koi/core/middleware";
+import type { PendingQueue } from "./types.js";
+
+/**
+ * Creates the companion middleware that drains pending squashes before model calls.
+ *
+ * @param pendingQueue - Encapsulated queue shared with the squash tool
+ */
+export function createSquashMiddleware(pendingQueue: PendingQueue): KoiMiddleware {
+  function drainAndReplace(request: ModelRequest): ModelRequest {
+    if (pendingQueue.length === 0) {
+      return request;
+    }
+
+    // Drain all pending — most recent squash wins for message array
+    const pending = pendingQueue.drain();
+    const last = pending[pending.length - 1];
+    if (last === undefined) {
+      return request;
+    }
+
+    return { ...request, messages: last.result.messages };
+  }
+
+  return {
+    name: "koi:squash",
+    priority: 220,
+
+    describeCapabilities(_ctx: TurnContext): CapabilityFragment | undefined {
+      return {
+        label: "squash",
+        description:
+          pendingQueue.length > 0
+            ? `Phase-boundary compression: ${String(pendingQueue.length)} pending squash(es)`
+            : "Phase-boundary compression available via squash tool",
+      };
+    },
+
+    wrapModelCall(_ctx: TurnContext, request: ModelRequest, next: ModelHandler) {
+      return next(drainAndReplace(request));
+    },
+
+    async *wrapModelStream(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelStreamHandler,
+    ): ReturnType<ModelStreamHandler> {
+      yield* next(drainAndReplace(request));
+    },
+
+    async onSessionEnd(_ctx: SessionContext): Promise<void> {
+      pendingQueue.clear();
+    },
+  };
+}

--- a/packages/tool-squash/src/squash-tool.test.ts
+++ b/packages/tool-squash/src/squash-tool.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for squash tool logic.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { KoiError, NodeId, SnapshotChainStore } from "@koi/core";
+import { chainId, nodeId } from "@koi/core";
+import type { MemoryComponent, MemoryStoreOptions } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import { heuristicTokenEstimator } from "./estimator.js";
+import { createSquashTool } from "./squash-tool.js";
+import type { PendingQueue, ResolvedSquashConfig } from "./types.js";
+import { createPendingQueue, SQUASH_DEFAULTS } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMessage(text: string, opts?: { readonly pinned?: boolean }): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "user",
+    timestamp: Date.now(),
+    ...(opts?.pinned === true ? { pinned: true } : {}),
+  };
+}
+
+function createMockArchiver(): SnapshotChainStore<readonly InboundMessage[]> & {
+  readonly putMock: ReturnType<typeof mock>;
+  readonly headMock: ReturnType<typeof mock>;
+} {
+  const mockNodeId = nodeId("node-123");
+  const mockChainId = chainId("test-chain");
+
+  const putMock = mock(() => ({
+    ok: true as const,
+    value: {
+      nodeId: mockNodeId,
+      chainId: mockChainId,
+      parentIds: [] as readonly NodeId[],
+      contentHash: "abc",
+      data: [] as readonly InboundMessage[],
+      createdAt: Date.now(),
+      metadata: {} as Readonly<Record<string, unknown>>,
+    },
+  }));
+
+  const headMock = mock(() => ({ ok: true as const, value: undefined }));
+
+  const notFoundError: KoiError = {
+    code: "NOT_FOUND",
+    message: "not found",
+    retryable: false,
+  };
+
+  return {
+    put: putMock,
+    get: mock(() => ({ ok: false as const, error: notFoundError })),
+    head: headMock,
+    list: mock(() => ({ ok: true as const, value: [] as readonly never[] })),
+    ancestors: mock(() => ({ ok: true as const, value: [] as readonly never[] })),
+    fork: mock(() => ({ ok: true as const, value: { parentNodeId: nodeId("n"), label: "l" } })),
+    prune: mock(() => ({ ok: true as const, value: 0 })),
+    close: mock(() => undefined),
+    putMock,
+    headMock,
+  };
+}
+
+function createMockMemory(): MemoryComponent & {
+  readonly storeMock: ReturnType<typeof mock>;
+} {
+  const storeMock = mock(() => Promise.resolve());
+  return {
+    recall: mock(() => Promise.resolve([])),
+    store: storeMock,
+    storeMock,
+  };
+}
+
+function makeConfig(overrides?: Partial<ResolvedSquashConfig>): ResolvedSquashConfig {
+  const archiver = createMockArchiver();
+  return {
+    archiver,
+    memory: undefined,
+    tokenEstimator: heuristicTokenEstimator,
+    preserveRecent: SQUASH_DEFAULTS.preserveRecent,
+    maxPendingSquashes: SQUASH_DEFAULTS.maxPendingSquashes,
+    sessionId: "session-1" as ResolvedSquashConfig["sessionId"],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createSquashTool", () => {
+  // let justified: reset per test
+  let pendingQueue: PendingQueue;
+
+  beforeEach(() => {
+    pendingQueue = createPendingQueue();
+  });
+
+  test("happy path: squash with summary", async () => {
+    const archiver = createMockArchiver();
+    const config = makeConfig({ archiver });
+    const messages = [
+      makeMessage("msg1"),
+      makeMessage("msg2"),
+      makeMessage("msg3"),
+      makeMessage("msg4"),
+      makeMessage("msg5"),
+      makeMessage("msg6"),
+    ];
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "planning", summary: "We planned stuff." });
+
+    expect(result).toMatchObject({
+      ok: true,
+      phase: "planning",
+      originalMessages: 2,
+      archivedNodeId: "node-123",
+      factsStored: 0,
+    });
+    expect(archiver.putMock).toHaveBeenCalledTimes(1);
+    expect(pendingQueue.length).toBe(1);
+    const drained = pendingQueue.drain();
+    expect(drained[0]?.result.strategy).toBe("squash");
+  });
+
+  test("with facts: stores to memory", async () => {
+    const memory = createMockMemory();
+    const config = makeConfig({ memory });
+    const messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg${String(i)}`));
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({
+      phase: "research",
+      summary: "Research complete.",
+      facts: ["fact1", "fact2"],
+    });
+
+    expect(result).toMatchObject({ ok: true, factsStored: 2 });
+    expect(memory.storeMock).toHaveBeenCalledTimes(2);
+    // Verify category is the phase
+    const firstCallArgs = memory.storeMock.mock.calls[0] as [string, MemoryStoreOptions];
+    expect(firstCallArgs[0]).toBe("fact1");
+    expect(firstCallArgs[1]).toMatchObject({ category: "research" });
+  });
+
+  test("empty message history: noop result", async () => {
+    const config = makeConfig();
+    const tool = createSquashTool(config, pendingQueue, () => []);
+
+    const result = await tool.execute({ phase: "test", summary: "No messages." });
+
+    expect(result).toMatchObject({
+      ok: true,
+      originalMessages: 0,
+      originalTokens: 0,
+      compactedTokens: 0,
+    });
+    expect(pendingQueue.length).toBe(0);
+  });
+
+  test("fewer than preserveRecent messages: noop result", async () => {
+    const config = makeConfig({ preserveRecent: 4 });
+    const messages = [makeMessage("msg1"), makeMessage("msg2"), makeMessage("msg3")];
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "test", summary: "Too few." });
+
+    expect(result).toMatchObject({ ok: true, originalMessages: 0 });
+    expect(pendingQueue.length).toBe(0);
+  });
+
+  test("all messages pinned: noop result", async () => {
+    const config = makeConfig({ preserveRecent: 2 });
+    const messages = Array.from({ length: 5 }, (_, i) =>
+      makeMessage(`pinned${String(i)}`, { pinned: true }),
+    );
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "test", summary: "All pinned." });
+
+    expect(result).toMatchObject({ ok: true, originalMessages: 0 });
+    expect(pendingQueue.length).toBe(0);
+  });
+
+  test("mixed pinned + normal: pinned preserved in output", async () => {
+    const config = makeConfig({ preserveRecent: 2 });
+    const messages = [
+      makeMessage("pinned1", { pinned: true }),
+      makeMessage("normal1"),
+      makeMessage("normal2"),
+      makeMessage("normal3"),
+      makeMessage("normal4"),
+    ];
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "impl", summary: "Implementation done." });
+
+    expect(result).toMatchObject({ ok: true, originalMessages: 2 });
+    expect(pendingQueue.length).toBe(1);
+    // Verify pinned message is preserved in the compacted messages
+    const drained = pendingQueue.drain();
+    const compactedMessages = drained[0]?.result.messages;
+    expect(compactedMessages?.[0]?.pinned).toBe(true);
+    // Summary message is second
+    expect(compactedMessages?.[1]?.senderId).toBe("system:squash");
+  });
+
+  test("archive failure: returns ARCHIVE_FAILED", async () => {
+    const archiver = createMockArchiver();
+    (archiver as { put: unknown }).put = mock(() => ({
+      ok: false,
+      error: { code: "STORAGE", message: "disk full", retryable: false },
+    }));
+    const config = makeConfig({ archiver });
+    const messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg${String(i)}`));
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "test", summary: "Will fail." });
+
+    expect(result).toMatchObject({ ok: false, code: "ARCHIVE_FAILED" });
+    expect(pendingQueue.length).toBe(0);
+  });
+
+  test("memory not provided, facts given: facts silently dropped", async () => {
+    const config = makeConfig({ memory: undefined });
+    const messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg${String(i)}`));
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({
+      phase: "test",
+      summary: "Summary.",
+      facts: ["fact1"],
+    });
+
+    expect(result).toMatchObject({ ok: true, factsStored: 0 });
+  });
+
+  test("memory store throws: squash still succeeds (best-effort)", async () => {
+    const memory = createMockMemory();
+    (memory as { store: unknown }).store = mock(() => Promise.reject(new Error("store boom")));
+    const config = makeConfig({ memory });
+    const messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg${String(i)}`));
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({
+      phase: "test",
+      summary: "Summary.",
+      facts: ["fact1", "fact2"],
+    });
+
+    expect(result).toMatchObject({ ok: true, factsStored: 0 });
+    expect(pendingQueue.length).toBe(1);
+  });
+
+  test("abort signal already aborted: returns ABORTED", async () => {
+    const config = makeConfig();
+    const tool = createSquashTool(config, pendingQueue, () => []);
+
+    const result = await tool.execute(
+      { phase: "test", summary: "Aborted." },
+      { signal: AbortSignal.abort() },
+    );
+
+    expect(result).toMatchObject({ ok: false, code: "ABORTED" });
+  });
+
+  test("invalid args: missing phase", async () => {
+    const config = makeConfig();
+    const tool = createSquashTool(config, pendingQueue, () => []);
+
+    const result = await tool.execute({ summary: "No phase." });
+
+    expect(result).toMatchObject({ ok: false, code: "VALIDATION" });
+  });
+
+  test("invalid args: missing summary", async () => {
+    const config = makeConfig();
+    const tool = createSquashTool(config, pendingQueue, () => []);
+
+    const result = await tool.execute({ phase: "test" });
+
+    expect(result).toMatchObject({ ok: false, code: "VALIDATION" });
+  });
+
+  test("summary with special characters: stored verbatim", async () => {
+    const config = makeConfig();
+    const specialSummary = 'Special chars: <script>alert("xss")</script> & "quotes" \n newlines';
+    const messages = Array.from({ length: 6 }, (_, i) => makeMessage(`msg${String(i)}`));
+    const tool = createSquashTool(config, pendingQueue, () => messages);
+
+    const result = await tool.execute({ phase: "test", summary: specialSummary });
+
+    expect(result).toMatchObject({ ok: true });
+    const drained = pendingQueue.drain();
+    const summaryMsg = drained[0]?.result.messages.find((m) => m.senderId === "system:squash");
+    expect(summaryMsg?.content[0]).toMatchObject({ kind: "text", text: specialSummary });
+  });
+});

--- a/packages/tool-squash/src/squash-tool.ts
+++ b/packages/tool-squash/src/squash-tool.ts
@@ -1,0 +1,226 @@
+/**
+ * Squash tool factory — creates a Tool that compresses conversation history
+ * at agent-initiated phase boundaries.
+ *
+ * Flow:
+ * 1. Validate args (phase, summary, optional facts)
+ * 2. Partition messages into pinned + squashable
+ * 3. Split squashable into head (to archive) + tail (to preserve)
+ * 4. Archive head messages to SnapshotChainStore
+ * 5. Extract facts to memory (best-effort)
+ * 6. Queue CompactionResult for the companion middleware
+ * 7. Return structured metrics
+ */
+
+import { chainId } from "@koi/core";
+import type { JsonObject } from "@koi/core/common";
+import type { Tool, ToolExecuteOptions } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { PendingQueue, ResolvedSquashConfig, SquashResult } from "./types.js";
+import { SQUASH_TOOL_DESCRIPTOR } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+interface ValidatedArgs {
+  readonly phase: string;
+  readonly summary: string;
+  readonly facts: readonly string[];
+}
+
+function validateArgs(
+  args: JsonObject,
+):
+  | { readonly ok: true; readonly value: ValidatedArgs }
+  | { readonly ok: false; readonly result: SquashResult } {
+  const phase: unknown = args.phase;
+  const summary: unknown = args.summary;
+  const facts: unknown = args.facts;
+
+  if (typeof phase !== "string" || phase.length === 0) {
+    return {
+      ok: false,
+      result: { ok: false, error: "Missing or empty 'phase' string", code: "VALIDATION" },
+    };
+  }
+
+  if (typeof summary !== "string" || summary.length === 0) {
+    return {
+      ok: false,
+      result: { ok: false, error: "Missing or empty 'summary' string", code: "VALIDATION" },
+    };
+  }
+
+  if (facts !== undefined && facts !== null) {
+    if (!Array.isArray(facts) || !facts.every((f): f is string => typeof f === "string")) {
+      return {
+        ok: false,
+        result: { ok: false, error: "'facts' must be an array of strings", code: "VALIDATION" },
+      };
+    }
+    return { ok: true, value: { phase, summary, facts } };
+  }
+
+  return { ok: true, value: { phase, summary, facts: [] } };
+}
+
+// ---------------------------------------------------------------------------
+// Message partitioning
+// ---------------------------------------------------------------------------
+
+interface Partitioned {
+  readonly pinned: readonly InboundMessage[];
+  readonly squashable: readonly InboundMessage[];
+}
+
+function partitionMessages(messages: readonly InboundMessage[]): Partitioned {
+  return {
+    pinned: messages.filter((msg) => msg.pinned === true),
+    squashable: messages.filter((msg) => msg.pinned !== true),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the `squash` tool for agent-initiated phase-boundary compression.
+ *
+ * @param config - Resolved config with all defaults applied
+ * @param pendingQueue - Encapsulated queue shared with the companion middleware
+ * @param getMessages - Returns current conversation messages
+ */
+export function createSquashTool(
+  config: ResolvedSquashConfig,
+  pendingQueue: PendingQueue,
+  getMessages: () => readonly InboundMessage[],
+): Tool {
+  return {
+    descriptor: SQUASH_TOOL_DESCRIPTOR,
+    trustTier: "verified",
+
+    async execute(args: JsonObject, options?: ToolExecuteOptions): Promise<SquashResult> {
+      // 1. Validate input
+      const validation = validateArgs(args);
+      if (!validation.ok) {
+        return validation.result;
+      }
+      const { phase, summary, facts } = validation.value;
+
+      // 2. Check abort signal
+      if (options?.signal?.aborted === true) {
+        return { ok: false, error: "Aborted before execution", code: "ABORTED" };
+      }
+
+      // 3. Partition messages
+      const messages = getMessages();
+      const { pinned, squashable } = partitionMessages(messages);
+
+      // 4. Early exit: not enough messages to squash
+      if (squashable.length <= config.preserveRecent) {
+        return {
+          ok: true,
+          phase,
+          originalMessages: 0,
+          originalTokens: 0,
+          compactedTokens: 0,
+          archivedNodeId: undefined,
+          factsStored: 0,
+        };
+      }
+
+      // 5. Split: head (to archive) + tail (to preserve)
+      const headMessages = squashable.slice(0, -config.preserveRecent);
+      const tailMessages = squashable.slice(-config.preserveRecent);
+
+      // 6. Estimate tokens for head
+      const originalTokens = await config.tokenEstimator.estimateMessages(headMessages);
+
+      // 7. Archive head messages
+      const archiveChainId = chainId(`squash:${config.sessionId}`);
+      const headNodeResult = await config.archiver.head(archiveChainId);
+      const parentIds =
+        headNodeResult.ok && headNodeResult.value !== undefined
+          ? [headNodeResult.value.nodeId]
+          : [];
+
+      const putResult = await config.archiver.put(
+        archiveChainId,
+        headMessages,
+        parentIds,
+        { phase, timestamp: Date.now() },
+        { skipIfUnchanged: true },
+      );
+
+      if (!putResult.ok) {
+        return {
+          ok: false,
+          error: `Archive failed: ${putResult.error.message}`,
+          code: "ARCHIVE_FAILED",
+        };
+      }
+
+      const archivedNodeId =
+        putResult.value !== undefined ? String(putResult.value.nodeId) : undefined;
+
+      // 8. Extract facts (best-effort — failures are silent, tracked via factsStored count)
+      // let justified: tracks successful fact storage count
+      let factsStored = 0;
+      if (config.memory !== undefined && facts.length > 0) {
+        for (const fact of facts) {
+          try {
+            await config.memory.store(fact, {
+              category: phase,
+              relatedEntities: [config.sessionId],
+            });
+            factsStored += 1;
+          } catch (_e: unknown) {
+            // Best-effort: caller sees partial count in factsStored
+          }
+        }
+      }
+
+      // 9. Build summary message
+      const summaryMessage: InboundMessage = {
+        content: [{ kind: "text", text: summary }],
+        senderId: "system:squash",
+        timestamp: Date.now(),
+        metadata: { squashed: true, phase },
+      };
+
+      // 10. Estimate compacted tokens
+      const compactedMessages: readonly InboundMessage[] = [
+        ...pinned,
+        summaryMessage,
+        ...tailMessages,
+      ];
+      const compactedTokens = await config.tokenEstimator.estimateMessages(compactedMessages);
+
+      // 11. Queue overflow guard: drop oldest if at capacity
+      pendingQueue.trimTo(config.maxPendingSquashes);
+
+      // 12. Enqueue CompactionResult for the middleware
+      pendingQueue.enqueue({
+        result: {
+          messages: compactedMessages,
+          originalTokens,
+          compactedTokens,
+          strategy: "squash",
+        },
+      });
+
+      // 13. Return metrics
+      return {
+        ok: true,
+        phase,
+        originalMessages: headMessages.length,
+        originalTokens,
+        compactedTokens,
+        archivedNodeId,
+        factsStored,
+      };
+    },
+  };
+}

--- a/packages/tool-squash/src/types.ts
+++ b/packages/tool-squash/src/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Configuration, constants, and tool descriptor for @koi/tool-squash.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+import type { SnapshotChainStore } from "@koi/core";
+import type { CompactionResult, TokenEstimator } from "@koi/core/context";
+import type { MemoryComponent, SessionId, ToolDescriptor } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** User-facing configuration for createSquashProvider. */
+export interface SquashConfig {
+  /** Required: archive store for snapshotting squashed messages. */
+  readonly archiver: SnapshotChainStore<readonly InboundMessage[]>;
+  /** Optional: memory component for fact extraction. */
+  readonly memory?: MemoryComponent | undefined;
+  /** Optional: token estimator override. Defaults to 4 chars/token heuristic. */
+  readonly tokenEstimator?: TokenEstimator | undefined;
+  /** Number of most recent messages to preserve. Default: 4. */
+  readonly preserveRecent?: number | undefined;
+  /** Maximum pending squashes before oldest is dropped. Default: 3. */
+  readonly maxPendingSquashes?: number | undefined;
+  /** Session ID for archive chain naming. */
+  readonly sessionId: SessionId;
+}
+
+/** Fully resolved config with defaults applied. Internal only. */
+export interface ResolvedSquashConfig {
+  readonly archiver: SnapshotChainStore<readonly InboundMessage[]>;
+  readonly memory: MemoryComponent | undefined;
+  readonly tokenEstimator: TokenEstimator;
+  readonly preserveRecent: number;
+  readonly maxPendingSquashes: number;
+  readonly sessionId: SessionId;
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/** Structured metrics returned to the agent after a squash call. */
+export type SquashResult =
+  | {
+      readonly ok: true;
+      readonly phase: string;
+      readonly originalMessages: number;
+      readonly originalTokens: number;
+      readonly compactedTokens: number;
+      readonly archivedNodeId: string | undefined;
+      readonly factsStored: number;
+    }
+  | {
+      readonly ok: false;
+      readonly error: string;
+      readonly code: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Pending queue — encapsulated mutable channel between tool and middleware
+// ---------------------------------------------------------------------------
+
+/** A pending squash queued for the middleware to apply. */
+export interface PendingSquash {
+  readonly result: CompactionResult;
+}
+
+/** Encapsulated mutable queue shared between the squash tool and middleware. */
+export interface PendingQueue {
+  /** Current number of pending squashes. */
+  readonly length: number;
+  /** Drain all pending items, returning them. Queue becomes empty. */
+  readonly drain: () => readonly PendingSquash[];
+  /** Add a new pending squash to the queue. */
+  readonly enqueue: (item: PendingSquash) => void;
+  /** Remove all items from the queue. */
+  readonly clear: () => void;
+  /** Drop oldest items to stay within the given max size. */
+  readonly trimTo: (maxSize: number) => void;
+}
+
+/** Creates an encapsulated mutable pending queue. */
+export function createPendingQueue(): PendingQueue {
+  // Mutable array encapsulated — not exposed directly
+  const items: PendingSquash[] = [];
+  return {
+    get length(): number {
+      return items.length;
+    },
+    drain(): readonly PendingSquash[] {
+      return items.splice(0);
+    },
+    enqueue(item: PendingSquash): void {
+      items.push(item);
+    },
+    clear(): void {
+      items.splice(0);
+    },
+    trimTo(maxSize: number): void {
+      if (items.length >= maxSize) {
+        items.splice(0, items.length - maxSize + 1);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+interface SquashDefaults {
+  readonly preserveRecent: number;
+  readonly maxPendingSquashes: number;
+}
+
+export const SQUASH_DEFAULTS: Readonly<SquashDefaults> = Object.freeze({
+  preserveRecent: 4,
+  maxPendingSquashes: 3,
+});
+
+/** Tool descriptor exposed to the model for the squash tool. */
+export const SQUASH_TOOL_DESCRIPTOR: ToolDescriptor = {
+  name: "squash",
+  description:
+    "Compress conversation history at a phase boundary. Replaces old messages with your summary, archives originals for retrieval, and optionally stores facts to memory. Call at natural transitions (e.g., done planning, starting implementation) to free context space.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      phase: {
+        type: "string",
+        description:
+          "Label for the completed phase (e.g., 'planning', 'research', 'implementation'). Used as the archive category.",
+      },
+      summary: {
+        type: "string",
+        description:
+          "Your summary of the completed phase. This replaces the old messages in context. Be thorough — include key decisions, outcomes, and any state needed for the next phase.",
+      },
+      facts: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Optional list of discrete facts to persist to long-term memory (e.g., 'User prefers TypeScript', 'API key stored in .env'). Each fact is stored independently.",
+      },
+    },
+    required: ["phase", "summary"],
+  },
+};

--- a/packages/tool-squash/tsconfig.json
+++ b/packages/tool-squash/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/tool-squash/tsup.config.ts
+++ b/packages/tool-squash/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements **Issue #524** — agent-initiated phase-boundary compression (Layer A).

- **squash tool**: Agent calls `squash(phase, summary, facts?)` at natural phase boundaries. Old messages replaced with agent's own summary (zero LLM cost), originals archived to `SnapshotChainStore`, facts optionally extracted to memory.
- **companion middleware** (priority 220): Drains pending squashes before model calls. Zero-cost passthrough when queue empty. Runs before compactor (225) so it sees already-reduced context.
- **bundled SkillComponent**: Teaches agents when/how to use squash — phase transitions, summary quality, fact extraction strategy. Auto-loaded with the tool, no separate manifest entry needed.
- **docs**: Full L2 package documentation at `docs/L2/tool-squash.md`

## Package Structure

```
packages/tool-squash/
├── src/
│   ├── types.ts              — config, PendingQueue, tool descriptor
│   ├── estimator.ts          — heuristic token estimator (4 chars/tok)
│   ├── skill.ts              — SkillComponent (when/how to squash)
│   ├── squash-tool.ts        — validate → archive → extract → queue
│   ├── squash-middleware.ts   — drain queue → replace messages
│   ├── provider.ts           — bundle factory (tool + skill + middleware)
│   ├── index.ts              — public API
│   ├── squash-tool.test.ts   — 12 unit tests
│   ├── squash-middleware.test.ts — 6 unit tests
│   └── __tests__/
│       ├── e2e.test.ts       — 5 integration tests
│       ├── e2e-real-llm.test.ts — 7 E2E tests (real Pi adapter + Anthropic API)
│       └── api-surface.test.ts  — snapshot stability
└── docs/L2/tool-squash.md    — full documentation
```

## Layer Compliance

- [x] Production code imports only `@koi/core` (L0)
- [x] No `@koi/engine` or peer L2 imports in production
- [x] All interface properties `readonly`
- [x] No `enum`, `any`, `class`, `as Type`, `!` in production
- [x] `detach()` clears cache + queue on agent re-assembly

## Test plan

- [x] 12 unit tests for tool logic (happy path, edge cases, errors)
- [x] 6 unit tests for middleware (passthrough, replace, overflow, cleanup)
- [x] 5 integration tests (tool → middleware flow, archive retrieval, skill attachment)
- [x] 7 E2E tests with real LLM via Pi adapter (gated on `E2E_TESTS=1`)
- [x] API surface snapshot stability
- [x] Typecheck passes
- [x] Build passes (tsup ESM + dts)
- [x] Biome lint passes

Closes #524