### PR TITLE
feat: delegation exhaustion escalation middleware

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1022,6 +1022,16 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-delegation-escalation": {
+      "name": "@koi/middleware-delegation-escalation",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-event-trace": {
       "name": "@koi/middleware-event-trace",
       "version": "0.0.0",
@@ -1358,7 +1368,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
-        "@koi/errors": "workspace:*",
         "@koi/nexus-client": "workspace:*",
       },
       "devDependencies": {
@@ -2502,6 +2511,8 @@
     "@koi/middleware-compactor": ["@koi/middleware-compactor@workspace:packages/middleware-compactor"],
 
     "@koi/middleware-context-editing": ["@koi/middleware-context-editing@workspace:packages/middleware-context-editing"],
+
+    "@koi/middleware-delegation-escalation": ["@koi/middleware-delegation-escalation@workspace:packages/middleware-delegation-escalation"],
 
     "@koi/middleware-event-trace": ["@koi/middleware-event-trace@workspace:packages/middleware-event-trace"],
 

--- a/docs/L2/middleware-delegation-escalation.md
+++ b/docs/L2/middleware-delegation-escalation.md
@@ -1,0 +1,517 @@
+# @koi/middleware-delegation-escalation — Human Escalation When All Delegatees Are Down
+
+When every delegatee's circuit breaker is open, pauses the engine loop and asks a human for instructions via the bidirectional channel contract. The human can resume with guidance or abort cleanly. Connects three existing building blocks — delegation circuit breakers, the channel contract, and the `hitl_pause` lifecycle state — into a single escalation path.
+
+---
+
+## Why It Exists
+
+When a supervisor agent delegates to multiple workers and all of them fail past their circuit breaker thresholds, the system has a dead end:
+
+1. **No fallback path.** The supervisor cannot delegate work — all circuits are open. Without escalation, it either aborts silently or enters an infinite retry loop.
+2. **Humans are not in the loop.** The `hitl_pause` and `human_approval` lifecycle states exist in L0, but nothing wires them to the delegation subsystem. A human operator has no way to know the system is stuck.
+3. **Context is lost on abort.** If the supervisor self-terminates, the human has to restart from scratch. By pausing instead of aborting, the in-flight state is preserved and the human can steer the agent forward.
+
+This middleware closes the gap:
+
+- **Detects exhaustion** — checks if all monitored delegatees have open circuit breakers
+- **Sends a human-readable message** — via the channel (Slack, CLI, Discord, etc.) with the list of failed workers and optional task summary
+- **Pauses the engine** — the `for await` loop naturally suspends while `wrapModelCall` awaits the human response
+- **Resumes or aborts** — based on the human's reply, injects instructions into the next model call or throws to halt the engine
+
+---
+
+## Architecture
+
+`@koi/middleware-delegation-escalation` is an **L2 feature package** — it depends only on L0 (`@koi/core`). It does NOT import from `@koi/delegation` (peer L2). Instead, the consumer wires a `() => boolean` callback for the exhaustion check.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  @koi/middleware-delegation-escalation  (L2)                  │
+│                                                              │
+│  types.ts              ← Config, EscalationDecision, consts  │
+│  escalation-message.ts ← Pure message formatter              │
+│  escalation-gate.ts    ← Promise-based pause mechanism       │
+│  middleware.ts         ← Middleware factory + state           │
+│  index.ts              ← Public API surface                  │
+│                                                              │
+├──────────────────────────────────────────────────────────────┤
+│  Dependencies                                                │
+│                                                              │
+│  @koi/core   (L0)   KoiMiddleware, ChannelAdapter,           │
+│                      OutboundMessage, InboundMessage,         │
+│                      AgentId, DelegationEvent, TurnContext    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Layer Decoupling
+
+The middleware never imports `@koi/delegation`. The exhaustion check is a callback:
+
+```
+┌─────────────────┐         ┌──────────────────────────────┐
+│ @koi/delegation  │         │ @koi/middleware-delegation-   │
+│ (peer L2)        │         │ escalation (this package)    │
+│                  │         │                              │
+│ manager          │         │ config.isExhausted           │
+│  .isExhausted()──┼────────▶│  = () => boolean             │
+│                  │  wired  │                              │
+│                  │  by     │ config.onExhausted           │
+│ manager          │  consumer│  = (event) => void          │
+│  .onEvent?.()   ◀┼─────────│                              │
+└─────────────────┘         └──────────────────────────────┘
+```
+
+No L2-to-L2 import. The consumer (L3 or application code) wires the two packages together.
+
+---
+
+## How It Works
+
+### Full Escalation Flow
+
+```
+     Engine loop (for await)
+            │
+            ▼
+   ┌────────────────────┐
+   │    onAfterTurn()    │
+   │                     │
+   │  isExhausted()?     │
+   │    no  → return     │
+   │    yes → arm gate   │
+   └────────┬───────────┘
+            │
+            ▼
+   ┌────────────────────┐        ┌─────────────────┐
+   │  Emit delegation:   │        │                 │
+   │  exhausted event    │        │  Channel        │
+   │                     │────────▶  (Slack/CLI/    │
+   │  Send escalation    │        │   Discord)      │
+   │  message via channel│        │                 │
+   └────────┬───────────┘        └────────┬────────┘
+            │                             │
+            ▼                             │
+   ┌────────────────────┐                 │
+   │  wrapModelCall()    │                 ▼
+   │                     │        ┌─────────────────┐
+   │  Gate is pending    │        │  Human Operator  │
+   │  → await gate       │        │                 │
+   │                     │        │  Sees message:  │
+   │     ⏸ PAUSED        │        │  "All workers   │
+   │                     │        │   exhausted"    │
+   │                     │◀───────│                 │
+   │  Decision received  │        │  Types reply    │
+   └────────┬───────────┘        └─────────────────┘
+            │
+       ┌────┴────┐
+       │         │
+   "abort"    anything else
+       │         │
+       ▼         ▼
+   ┌────────┐ ┌──────────────────┐
+   │ throws │ │ Inject instruction│
+   │ Error  │ │ into ModelRequest │
+   │        │ │ messages[]        │
+   │ Engine │ │                  │
+   │ halts  │ │ next(modified)   │
+   └────────┘ │ Engine resumes   │
+              └──────────────────┘
+```
+
+### Suspension Mechanism
+
+The engine's `for await` loop is **naturally paused** while `wrapModelCall` awaits the gate promise. No external lifecycle mutations — no registry transitions, no timers polling for state. The middleware simply holds the promise until:
+
+1. A human message arrives on the channel → resolves as `resume`
+2. The timeout expires (default: 10 minutes) → resolves as `abort`
+3. The AbortSignal fires → resolves as `abort`
+4. `handle.cancel()` is called → resolves as `abort`
+
+### Middleware Position (Onion)
+
+```
+               Incoming Model Call
+                      │
+                      ▼
+          ┌───────────────────────┐
+          │   middleware-audit     │  priority: 450
+          ├───────────────────────┤
+          │  middleware-guided-    │  priority: 425
+          │  retry                │
+          ├───────────────────────┤
+          │  middleware-semantic-  │  priority: 420
+          │  retry                │
+          ├───────────────────────┤
+          │  middleware-permissions│  priority: 400
+          ├───────────────────────┤
+       ┌──│  middleware-delegation-│──┐  priority: 300
+       │  │  escalation (THIS)    │  │
+       │  ├───────────────────────┤  │
+       │  │  engine adapter       │  │
+       │  │  → LLM API call       │  │
+       │  └───────────┬───────────┘  │
+       │         Response            │
+       │              │              │
+       │   ┌──────────▼──────────┐   │
+       └──▶│ If gate pending:    │◀──┘
+           │  await human reply  │
+           │  inject instruction │
+           └─────────────────────┘
+```
+
+Priority 300 places it **before** semantic-retry (420) in the onion. This means:
+
+- On the way **in**, the escalation middleware wraps first — if the gate is pending, it pauses before the model call reaches the retry layer
+- On the way **out**, retries happen before escalation is checked — the system exhausts retry budgets before escalating to a human
+
+---
+
+## Escalation Gate
+
+The gate is a promise-based pause mechanism that races three signals:
+
+```
+┌──────────────────────────────────────────┐
+│  EscalationGate                          │
+│                                          │
+│  ┌──────────────┐  ┌──────────────────┐  │
+│  │ channel       │  │ setTimeout       │  │
+│  │ .onMessage()  │  │ (10 min default) │  │
+│  └──────┬───────┘  └───────┬──────────┘  │
+│         │                  │             │
+│         │  ┌───────────────┤             │
+│         │  │ AbortSignal   │             │
+│         │  └───────┬───────┘             │
+│         │          │                     │
+│         ▼          ▼                     │
+│     Promise.race (first to resolve wins) │
+│         │                                │
+│         ▼                                │
+│   EscalationDecision                     │
+│   { kind: "resume", instruction? }       │
+│   { kind: "abort", reason }              │
+└──────────────────────────────────────────┘
+```
+
+Cleanup is thorough: on resolution, the channel listener is unsubscribed, the timer is cleared, and the AbortSignal listener is removed. No resource leaks.
+
+### Response Parsing
+
+| Human types | Decision |
+|-------------|----------|
+| `abort` (case-insensitive, trimmed) | `{ kind: "abort", reason: "Human operator requested abort" }` |
+| Anything else | `{ kind: "resume", instruction: "<their text>" }` |
+| (no text blocks in message) | `{ kind: "resume" }` (no instruction) |
+| (timeout expires) | `{ kind: "abort", reason: "Escalation timed out after 600000ms" }` |
+
+---
+
+## Hot Path Performance
+
+The middleware adds near-zero overhead when delegatees are healthy:
+
+```
+onAfterTurn(ctx):
+  │
+  ├── isExhausted()?         ← 1 callback (sync)
+  │     false → return       ← fast path, zero allocations
+  │     true  → arm gate     ← only on exhaustion
+
+wrapModelCall(ctx, request, next):
+  │
+  ├── gate pending?          ← 1 undefined check
+  │     no  → next(request)  ← straight through
+  │     yes → await gate     ← only when escalating
+```
+
+**Success path:** 1 boolean check per turn + 1 undefined check per model call. Zero allocations, zero async operations.
+
+**Escalation path:** 1 channel.send() + 1 promise allocation + 1 channel listener. Bounded by a single gate (double-arm prevention ensures only one gate exists at a time).
+
+---
+
+## API Reference
+
+### Factory Functions
+
+#### `createDelegationEscalationMiddleware(config)`
+
+Creates the middleware with escalation state management.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `config.channel` | `ChannelAdapter` | (required) | Bidirectional channel for human communication |
+| `config.isExhausted` | `() => boolean` | (required) | Returns true when all delegates are exhausted |
+| `config.issuerId` | `AgentId` | (required) | The owning agent's ID |
+| `config.monitoredDelegateeIds` | `readonly AgentId[]` | (required) | Delegatee IDs for the event payload |
+| `config.taskSummary` | `string` | — | Optional context for the escalation message |
+| `config.escalationTimeoutMs` | `number` | `600_000` | Timeout waiting for human response (10 min) |
+| `config.onEscalation` | `(decision) => void` | — | Fires when a human decision is received |
+| `config.onExhausted` | `(event) => void` | — | Fires when exhaustion is detected (emits event) |
+
+**Returns:** `DelegationEscalationHandle`
+
+```typescript
+interface DelegationEscalationHandle {
+  readonly middleware: KoiMiddleware    // Register in your agent
+  readonly isPending: () => boolean    // True while awaiting human
+  readonly cancel: () => void          // Force-abort the pending gate
+}
+```
+
+#### `createEscalationGate(channel, signal?, timeoutMs?)`
+
+Low-level: creates a promise that resolves on the next channel message, timeout, or signal abort. Used internally by the middleware, exposed for advanced use cases.
+
+#### `generateEscalationMessage(ctx)`
+
+Pure function that formats a human-readable `OutboundMessage` from an `EscalationContext`. Includes delegatee list and optional task summary.
+
+#### `parseHumanResponse(message)`
+
+Pure function that maps an `InboundMessage` to an `EscalationDecision`. `"abort"` (case-insensitive) → abort, anything else → resume.
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `EscalationContext` | `{ issuerId, exhaustedDelegateeIds, detectedAt, taskSummary? }` |
+| `EscalationDecision` | `{ kind: "resume", instruction? } \| { kind: "abort", reason }` |
+| `DelegationEscalationConfig` | Configuration for the middleware factory |
+| `DelegationEscalationHandle` | Return type with middleware + state accessors |
+| `EscalationGate` | `{ promise, isPending(), cancel() }` |
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_ESCALATION_TIMEOUT_MS` | `600_000` | 10 minutes |
+
+---
+
+## Examples
+
+### Basic Usage
+
+```typescript
+import { createDelegationEscalationMiddleware } from "@koi/middleware-delegation-escalation";
+import { createDelegationManager } from "@koi/delegation";
+
+const manager = createDelegationManager({ config });
+
+const { middleware } = createDelegationEscalationMiddleware({
+  channel: mySlackChannel,
+  isExhausted: () => manager.isExhausted([agentId("w1"), agentId("w2")]),
+  issuerId: agentId("orchestrator"),
+  monitoredDelegateeIds: [agentId("w1"), agentId("w2")],
+});
+
+// Register in your Koi agent assembly:
+const agent = await createKoi({
+  manifest,
+  middleware: [middleware],
+});
+```
+
+### With Observability and Event Emission
+
+```typescript
+const { middleware, isPending } = createDelegationEscalationMiddleware({
+  channel: myChannel,
+  isExhausted: () => manager.isExhausted(workerIds),
+  issuerId: agentId("orchestrator"),
+  monitoredDelegateeIds: workerIds,
+  taskSummary: "Processing batch import of 10k user records",
+  escalationTimeoutMs: 300_000,  // 5 minutes
+
+  onExhausted(event) {
+    // Feed event to the delegation manager's event bus
+    manager.onEvent?.(event);
+    // Log for monitoring
+    logger.warn("delegation-exhausted", { event });
+  },
+
+  onEscalation(decision) {
+    metrics.increment("escalation.decision", { kind: decision.kind });
+    if (decision.kind === "resume") {
+      logger.info("human-resumed", { instruction: decision.instruction });
+    }
+  },
+});
+
+// Check escalation status from a health endpoint:
+app.get("/health", () => ({
+  escalationPending: isPending(),
+}));
+```
+
+### With Lifecycle Transitions
+
+```typescript
+const { middleware } = createDelegationEscalationMiddleware({
+  channel: myChannel,
+  isExhausted: () => manager.isExhausted(workerIds),
+  issuerId: agentId("orchestrator"),
+  monitoredDelegateeIds: workerIds,
+
+  onExhausted(event) {
+    // Transition agent to suspended state for dashboard visibility
+    registry.transition(
+      agentId("orchestrator"),
+      "suspended",
+      currentGeneration,
+      { kind: "hitl_pause" },
+    );
+  },
+
+  onEscalation(decision) {
+    if (decision.kind === "resume") {
+      // Transition back to running
+      registry.transition(
+        agentId("orchestrator"),
+        "running",
+        currentGeneration,
+        { kind: "human_approval" },
+      );
+    }
+  },
+});
+```
+
+### With Other Middleware
+
+```typescript
+import { createSemanticRetryMiddleware } from "@koi/middleware-semantic-retry";
+import { createDelegationEscalationMiddleware } from "@koi/middleware-delegation-escalation";
+import { createAuditMiddleware } from "@koi/middleware-audit";
+
+const agent = await createKoi({
+  manifest,
+  middleware: [
+    createAuditMiddleware({ ... }),                          // priority: 450
+    createSemanticRetryMiddleware({ ... }).middleware,        // priority: 420
+    createDelegationEscalationMiddleware({ ... }).middleware, // priority: 300
+  ],
+});
+// Retries exhaust first → then escalation pauses → human decides
+```
+
+### Cancel from External Code
+
+```typescript
+const handle = createDelegationEscalationMiddleware({ ... });
+
+// If the supervisor is being shut down externally:
+process.on("SIGTERM", () => {
+  handle.cancel();  // Resolves the gate as abort
+});
+```
+
+---
+
+## End-to-End Flow Example
+
+```
+User: "Deploy v2 to all 3 regions"
+         │
+         ▼
+┌────────────────────────┐
+│  Supervisor Agent       │
+│  Delegates to 3 workers │
+└────────┬───────────────┘
+         │
+    ┌────┴────┬──────────┐
+    ▼         ▼          ▼
+ Worker     Worker     Worker
+ us-east    eu-west    ap-south
+    │         │          │
+  ✓ OK     ✗ FAIL     ✗ FAIL
+            (5x)       (5x)
+              │          │
+              ▼          ▼
+         [circuit]  [circuit]
+         [  open ]  [  open ]
+
+         (isExhausted? → partial: false)
+         │
+         ▼
+  us-east completes, but fails on retry for eu-west
+         │
+       ✗ FAIL (5x)
+         │
+         ▼
+    [circuit open]
+
+    isExhausted([eu-west, ap-south]) → true
+         │
+    ┌────▼───────────────────────────────┐
+    │  Escalation Middleware              │
+    │                                    │
+    │  1. Emit delegation:exhausted      │
+    │  2. Send to Slack:                 │
+    │                                    │
+    │  ┌────────────────────────────┐    │
+    │  │ :warning: All delegatees   │    │
+    │  │ for "supervisor" exhausted │    │
+    │  │                            │    │
+    │  │ Exhausted:                 │    │
+    │  │   - eu-west                │    │
+    │  │   - ap-south               │    │
+    │  │                            │    │
+    │  │ Task: Deploy v2 to all     │    │
+    │  │ 3 regions                  │    │
+    │  │                            │    │
+    │  │ Reply to resume or         │    │
+    │  │ type "abort"               │    │
+    │  └────────────────────────────┘    │
+    │                                    │
+    │  3. Engine PAUSED (awaiting)       │
+    └────────────────────┬───────────────┘
+                         │
+                         ▼
+    ┌────────────────────────────────────┐
+    │  DevOps Engineer (in Slack):       │
+    │                                    │
+    │  "eu-west had a region outage,     │
+    │   skip it and deploy ap-south      │
+    │   using the backup endpoint"       │
+    └────────────────────┬───────────────┘
+                         │
+                         ▼
+    ┌────────────────────────────────────┐
+    │  Engine RESUMES                    │
+    │                                    │
+    │  Next model call includes:         │
+    │  "[Human escalation instruction]   │
+    │   eu-west had a region outage,     │
+    │   skip it and deploy ap-south      │
+    │   using the backup endpoint"       │
+    │                                    │
+    │  Supervisor adjusts strategy →     │
+    │  deploys ap-south via backup →     │
+    │  reports success                   │
+    └────────────────────────────────────┘
+```
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────────┐
+    KoiMiddleware, ChannelAdapter, AgentId,                  │
+    DelegationEvent, OutboundMessage, InboundMessage,        │
+    TurnContext, CapabilityFragment                           │
+                                                              │
+                                                              ▼
+L2  @koi/middleware-delegation-escalation ◄──────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports @koi/delegation (peer L2)
+    ✗ zero external dependencies
+```
+
+**Dev-only dependency** (`@koi/test-utils`) is used in tests but is not a runtime import.
+
+The consumer wires `@koi/delegation` to this middleware via the `isExhausted` callback — composition at the application layer, not a compile-time dependency.

--- a/packages/core/src/delegation.ts
+++ b/packages/core/src/delegation.ts
@@ -204,7 +204,13 @@ export type DelegationEvent =
       readonly delegateeId: AgentId;
       readonly failureCount: number;
     }
-  | { readonly kind: "delegation:circuit_closed"; readonly delegateeId: AgentId };
+  | { readonly kind: "delegation:circuit_closed"; readonly delegateeId: AgentId }
+  | {
+      readonly kind: "delegation:exhausted";
+      readonly delegateeIds: readonly AgentId[];
+      readonly issuerId: AgentId;
+      readonly detectedAt: number;
+    };
 
 // ---------------------------------------------------------------------------
 // Circuit breaker configuration

--- a/packages/delegation/src/delegation-manager-is-exhausted.test.ts
+++ b/packages/delegation/src/delegation-manager-is-exhausted.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for DelegationManager.isExhausted().
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { agentId, DEFAULT_CIRCUIT_BREAKER_CONFIG } from "@koi/core";
+import { createDelegationManager } from "./delegation-manager.js";
+
+const SECRET = "test-secret-key-32-bytes-minimum";
+const DEFAULT_CONFIG = {
+  secret: SECRET,
+  maxChainDepth: 3,
+  defaultTtlMs: 3600000,
+  circuitBreaker: {
+    ...DEFAULT_CIRCUIT_BREAKER_CONFIG,
+    failureThreshold: 2,
+  },
+} as const;
+
+describe("DelegationManager.isExhausted", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanups) {
+      fn();
+    }
+    cleanups.length = 0;
+  });
+
+  function createManager(): ReturnType<typeof createDelegationManager> {
+    const manager = createDelegationManager({ config: DEFAULT_CONFIG });
+    cleanups.push(manager.dispose);
+    return manager;
+  }
+
+  test("returns false for empty delegatee list", () => {
+    const manager = createManager();
+    expect(manager.isExhausted([])).toBe(false);
+  });
+
+  test("returns false when all circuits are closed", () => {
+    const manager = createManager();
+    const ids = [agentId("w1"), agentId("w2")];
+    expect(manager.isExhausted(ids)).toBe(false);
+  });
+
+  test("returns false when only some circuits are open", () => {
+    const manager = createManager();
+    const ids = [agentId("w1"), agentId("w2")];
+
+    // Open w1's circuit (2 failures = threshold)
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w1"));
+    expect(manager.circuitState(agentId("w1"))).toBe("open");
+    expect(manager.circuitState(agentId("w2"))).toBe("closed");
+
+    expect(manager.isExhausted(ids)).toBe(false);
+  });
+
+  test("returns true when all circuits are open", () => {
+    const manager = createManager();
+    const ids = [agentId("w1"), agentId("w2")];
+
+    // Open both circuits
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w2"));
+    manager.recordFailure(agentId("w2"));
+
+    expect(manager.circuitState(agentId("w1"))).toBe("open");
+    expect(manager.circuitState(agentId("w2"))).toBe("open");
+    expect(manager.isExhausted(ids)).toBe(true);
+  });
+
+  test("reports exhausted for subset when all in subset are open", () => {
+    const manager = createManager();
+    const ids = [agentId("w1"), agentId("w2")];
+
+    // Open both circuits
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w2"));
+    manager.recordFailure(agentId("w2"));
+    expect(manager.isExhausted(ids)).toBe(true);
+
+    // A single-element subset of open circuits is also exhausted
+    expect(manager.isExhausted([agentId("w1")])).toBe(true);
+  });
+
+  test("works with a single delegatee", () => {
+    const manager = createManager();
+
+    expect(manager.isExhausted([agentId("w1")])).toBe(false);
+
+    manager.recordFailure(agentId("w1"));
+    manager.recordFailure(agentId("w1"));
+
+    expect(manager.isExhausted([agentId("w1")])).toBe(true);
+  });
+});

--- a/packages/delegation/src/delegation-manager.ts
+++ b/packages/delegation/src/delegation-manager.ts
@@ -65,6 +65,7 @@ export interface DelegationManager {
   readonly recordFailure: (delegateeId: AgentId) => void;
   readonly canDelegate: (delegateeId: AgentId) => boolean;
   readonly circuitState: (delegateeId: AgentId) => CircuitState;
+  readonly isExhausted: (delegateeIds: readonly AgentId[]) => boolean;
 
   // Cleanup
   readonly dispose: () => void;
@@ -302,6 +303,11 @@ export function createDelegationManager(params: CreateDelegationManagerParams): 
     return circuitBreaker.getState(delegateeId);
   }
 
+  function isExhausted(delegateeIds: readonly AgentId[]): boolean {
+    if (delegateeIds.length === 0) return false;
+    return delegateeIds.every((id) => circuitBreaker.getState(id) === "open");
+  }
+
   // ---------------------------------------------------------------------------
   // Cleanup
   // ---------------------------------------------------------------------------
@@ -324,6 +330,7 @@ export function createDelegationManager(params: CreateDelegationManagerParams): 
     recordFailure,
     canDelegate,
     circuitState,
+    isExhausted,
     dispose,
   };
 }

--- a/packages/middleware-delegation-escalation/package.json
+++ b/packages/middleware-delegation-escalation/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/middleware-delegation-escalation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-delegation-escalation/src/__tests__/e2e.test.ts
+++ b/packages/middleware-delegation-escalation/src/__tests__/e2e.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration tests for the delegation-escalation middleware.
+ *
+ * Tests the full escalation flow: exhaustion detection → channel message →
+ * human response → decision handling.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  ChannelAdapter,
+  InboundMessage,
+  MessageHandler,
+  ModelRequest,
+  ModelResponse,
+  OutboundMessage,
+  SessionId,
+  TurnContext,
+  TurnId,
+} from "@koi/core";
+import { agentId, runId } from "@koi/core";
+import { createDelegationEscalationMiddleware } from "../middleware.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createMockChannel(): ChannelAdapter & {
+  readonly simulateMessage: (msg: InboundMessage) => Promise<void>;
+  readonly sentMessages: OutboundMessage[];
+} {
+  const handlers: MessageHandler[] = [];
+  const sentMessages: OutboundMessage[] = [];
+
+  return {
+    name: "test-channel",
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: false,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async (msg: OutboundMessage) => {
+      sentMessages.push(msg);
+    },
+    onMessage: (handler: MessageHandler) => {
+      handlers.push(handler);
+      return () => {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      };
+    },
+    simulateMessage: async (msg: InboundMessage) => {
+      for (const handler of [...handlers]) {
+        await handler(msg);
+      }
+    },
+    sentMessages,
+  };
+}
+
+function createCtx(): TurnContext {
+  return {
+    session: {
+      agentId: "test-agent",
+      sessionId: "s1" as SessionId,
+      runId: runId("r1"),
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "t1" as TurnId,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function createRequest(): ModelRequest {
+  return {
+    messages: [
+      {
+        content: [{ kind: "text", text: "Process data" }],
+        senderId: "user",
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+function textMsg(text: string): InboundMessage {
+  return { content: [{ kind: "text", text }], senderId: "human", timestamp: Date.now() };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("delegation-escalation e2e", () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanups) {
+      fn();
+    }
+    cleanups.length = 0;
+  });
+
+  test("full escalation flow: exhausted → message → resume with instruction", async () => {
+    const channel = createMockChannel();
+    // let: mutable — simulates exhaustion state change
+    let exhausted = false;
+
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => exhausted,
+      issuerId: agentId("supervisor"),
+      monitoredDelegateeIds: [agentId("worker-1"), agentId("worker-2")],
+      taskSummary: "Batch data processing job",
+    });
+    cleanups.push(() => handle.cancel());
+
+    const ctx = createCtx();
+    const response: ModelResponse = { content: "Done", model: "test" };
+    const next = async (req: ModelRequest): Promise<ModelResponse> => {
+      // Verify instruction injected
+      const lastMsg = req.messages[req.messages.length - 1];
+      if (lastMsg?.content[0]?.kind === "text") {
+        expect(lastMsg.content[0].text).toContain("Switch to backup workers");
+      }
+      return response;
+    };
+
+    // Phase 1: Normal operation — no exhaustion
+    const normalResult = await handle.middleware.wrapModelCall?.(
+      ctx,
+      createRequest(),
+      async () => response,
+    );
+    expect(normalResult).toBe(response);
+
+    // Phase 2: All delegatees exhausted
+    exhausted = true;
+    await handle.middleware.onAfterTurn?.(ctx);
+
+    // Verify channel received escalation message
+    expect(channel.sentMessages).toHaveLength(1);
+    const sentMsg = channel.sentMessages[0];
+    if (sentMsg?.content[0]?.kind === "text") {
+      expect(sentMsg.content[0].text).toContain("worker-1");
+      expect(sentMsg.content[0].text).toContain("worker-2");
+      expect(sentMsg.content[0].text).toContain("Batch data processing job");
+    }
+
+    // Phase 3: Human responds with instruction
+    const callPromise = handle.middleware.wrapModelCall?.(ctx, createRequest(), next);
+    await channel.simulateMessage(textMsg("Switch to backup workers"));
+
+    const result = await callPromise;
+    expect(result).toBe(response);
+    expect(handle.isPending()).toBe(false);
+  });
+
+  test("timeout flow: exhausted → message → timeout → abort", async () => {
+    const channel = createMockChannel();
+
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => true,
+      issuerId: agentId("supervisor"),
+      monitoredDelegateeIds: [agentId("worker-1")],
+      escalationTimeoutMs: 50, // Short timeout for testing
+    });
+    cleanups.push(() => handle.cancel());
+
+    const ctx = createCtx();
+    await handle.middleware.onAfterTurn?.(ctx);
+    expect(handle.isPending()).toBe(true);
+
+    // Model call should eventually throw due to timeout
+    await expect(
+      handle.middleware.wrapModelCall?.(ctx, createRequest(), async () => ({
+        content: "ignored",
+        model: "test",
+      })),
+    ).rejects.toThrow("Delegation escalation aborted");
+  });
+
+  test("re-escalation after resume: can escalate again on subsequent exhaustion", async () => {
+    const channel = createMockChannel();
+    // let: mutable — simulates toggling exhaustion state
+    let exhausted = false;
+
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => exhausted,
+      issuerId: agentId("supervisor"),
+      monitoredDelegateeIds: [agentId("worker-1")],
+    });
+    cleanups.push(() => handle.cancel());
+
+    const ctx = createCtx();
+    const response: ModelResponse = { content: "OK", model: "test" };
+
+    // First escalation
+    exhausted = true;
+    await handle.middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(1);
+
+    const call1 = handle.middleware.wrapModelCall?.(ctx, createRequest(), async () => response);
+    await channel.simulateMessage(textMsg("try again"));
+    await call1;
+    expect(handle.isPending()).toBe(false);
+
+    // Second escalation — exhaustion detected again on next turn
+    await handle.middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(2);
+    expect(handle.isPending()).toBe(true);
+
+    const call2 = handle.middleware.wrapModelCall?.(ctx, createRequest(), async () => response);
+    await channel.simulateMessage(textMsg("abort"));
+    await expect(call2).rejects.toThrow("aborted");
+  });
+});

--- a/packages/middleware-delegation-escalation/src/escalation-gate.test.ts
+++ b/packages/middleware-delegation-escalation/src/escalation-gate.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for createEscalationGate and parseHumanResponse.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ChannelAdapter, InboundMessage, MessageHandler } from "@koi/core";
+import { createEscalationGate, parseHumanResponse } from "./escalation-gate.js";
+
+// ---------------------------------------------------------------------------
+// Mock channel
+// ---------------------------------------------------------------------------
+
+function createMockChannel(): ChannelAdapter & {
+  readonly simulateMessage: (msg: InboundMessage) => Promise<void>;
+} {
+  const handlers: MessageHandler[] = [];
+
+  return {
+    name: "test-channel",
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: false,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async () => {},
+    onMessage: (handler: MessageHandler) => {
+      handlers.push(handler);
+      return () => {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      };
+    },
+    simulateMessage: async (msg: InboundMessage) => {
+      for (const handler of [...handlers]) {
+        await handler(msg);
+      }
+    },
+  };
+}
+
+function createTextMessage(text: string): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "human",
+    timestamp: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseHumanResponse
+// ---------------------------------------------------------------------------
+
+describe("parseHumanResponse", () => {
+  test("parses 'abort' as abort decision", () => {
+    const result = parseHumanResponse(createTextMessage("abort"));
+    expect(result.kind).toBe("abort");
+    if (result.kind === "abort") {
+      expect(result.reason).toContain("Human operator");
+    }
+  });
+
+  test("parses 'ABORT' (case-insensitive) as abort decision", () => {
+    const result = parseHumanResponse(createTextMessage("  ABORT  "));
+    expect(result.kind).toBe("abort");
+  });
+
+  test("parses any other text as resume with instruction", () => {
+    const result = parseHumanResponse(createTextMessage("Try using a different API endpoint"));
+    expect(result.kind).toBe("resume");
+    if (result.kind === "resume") {
+      expect(result.instruction).toBe("Try using a different API endpoint");
+    }
+  });
+
+  test("parses message with no text blocks as resume without instruction", () => {
+    const msg: InboundMessage = {
+      content: [{ kind: "image", url: "https://example.com/img.png" }],
+      senderId: "human",
+      timestamp: Date.now(),
+    };
+    const result = parseHumanResponse(msg);
+    expect(result.kind).toBe("resume");
+    if (result.kind === "resume") {
+      expect(result.instruction).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEscalationGate
+// ---------------------------------------------------------------------------
+
+describe("createEscalationGate", () => {
+  const channels: Array<ReturnType<typeof createMockChannel>> = [];
+
+  afterEach(() => {
+    channels.length = 0;
+  });
+
+  function channel(): ReturnType<typeof createMockChannel> {
+    const ch = createMockChannel();
+    channels.push(ch);
+    return ch;
+  }
+
+  test("resolves on human message response", async () => {
+    const ch = channel();
+    const gate = createEscalationGate(ch);
+
+    expect(gate.isPending()).toBe(true);
+
+    await ch.simulateMessage(createTextMessage("Continue with plan B"));
+
+    const decision = await gate.promise;
+    expect(decision.kind).toBe("resume");
+    if (decision.kind === "resume") {
+      expect(decision.instruction).toBe("Continue with plan B");
+    }
+    expect(gate.isPending()).toBe(false);
+  });
+
+  test("resolves as abort on timeout", async () => {
+    const ch = channel();
+    const gate = createEscalationGate(ch, undefined, 50);
+
+    const decision = await gate.promise;
+    expect(decision.kind).toBe("abort");
+    if (decision.kind === "abort") {
+      expect(decision.reason).toContain("timed out");
+    }
+    expect(gate.isPending()).toBe(false);
+  });
+
+  test("resolves as abort on AbortSignal", async () => {
+    const ch = channel();
+    const controller = new AbortController();
+    const gate = createEscalationGate(ch, controller.signal);
+
+    expect(gate.isPending()).toBe(true);
+    controller.abort();
+
+    const decision = await gate.promise;
+    expect(decision.kind).toBe("abort");
+    if (decision.kind === "abort") {
+      expect(decision.reason).toContain("aborted via signal");
+    }
+  });
+
+  test("resolves as abort on already-aborted signal", async () => {
+    const ch = channel();
+    const controller = new AbortController();
+    controller.abort();
+
+    const gate = createEscalationGate(ch, controller.signal);
+    const decision = await gate.promise;
+
+    expect(decision.kind).toBe("abort");
+    expect(gate.isPending()).toBe(false);
+  });
+
+  test("cancel resolves as abort", async () => {
+    const ch = channel();
+    const gate = createEscalationGate(ch);
+
+    expect(gate.isPending()).toBe(true);
+    gate.cancel();
+
+    const decision = await gate.promise;
+    expect(decision.kind).toBe("abort");
+    if (decision.kind === "abort") {
+      expect(decision.reason).toContain("cancelled");
+    }
+  });
+
+  test("second message after resolution is ignored", async () => {
+    const ch = channel();
+    const gate = createEscalationGate(ch);
+
+    await ch.simulateMessage(createTextMessage("first instruction"));
+    const decision = await gate.promise;
+    expect(decision.kind).toBe("resume");
+
+    // Second message should not cause issues
+    await ch.simulateMessage(createTextMessage("second instruction"));
+    // Still resolved to first
+    expect(gate.isPending()).toBe(false);
+  });
+
+  test("cleanup removes listener from channel", async () => {
+    const ch = channel();
+    const gate = createEscalationGate(ch);
+
+    gate.cancel();
+    await gate.promise;
+
+    // After cancellation, the channel should have no listeners left.
+    // Sending a message should not throw.
+    await ch.simulateMessage(createTextMessage("should be ignored"));
+    expect(gate.isPending()).toBe(false);
+  });
+});

--- a/packages/middleware-delegation-escalation/src/escalation-gate.ts
+++ b/packages/middleware-delegation-escalation/src/escalation-gate.ts
@@ -1,0 +1,127 @@
+/**
+ * Promise-based pause mechanism that awaits a human response via channel.
+ *
+ * Registers a one-time channel.onMessage() listener and races against
+ * an AbortSignal and a timeout. The resolved value is an EscalationDecision.
+ */
+
+import type { ChannelAdapter, InboundMessage } from "@koi/core";
+import type { EscalationDecision } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+export interface EscalationGate {
+  /** Promise that resolves to the human's decision. */
+  readonly promise: Promise<EscalationDecision>;
+  /** Returns true if the gate has not yet resolved. */
+  readonly isPending: () => boolean;
+  /** Cancel the gate (resolves as abort). */
+  readonly cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a human's inbound message into an EscalationDecision.
+ * - Text containing only "abort" (case-insensitive, trimmed) → abort
+ * - Anything else → resume with the text as instruction
+ */
+export function parseHumanResponse(message: InboundMessage): EscalationDecision {
+  const firstText = message.content.find((block) => block.kind === "text");
+  if (firstText === undefined) {
+    return { kind: "resume" };
+  }
+
+  const text = firstText.text.trim();
+
+  if (text.toLowerCase() === "abort") {
+    return { kind: "abort", reason: "Human operator requested abort" };
+  }
+
+  return { kind: "resume", instruction: text };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createEscalationGate(
+  channel: ChannelAdapter,
+  signal?: AbortSignal,
+  timeoutMs?: number,
+): EscalationGate {
+  // let: mutable — gate state is inherently stateful (pending → resolved)
+  let pending = true;
+  // let: mutable — cleanup references cleared on resolution
+  let unsubscribe: (() => void) | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // let: mutable — abort listener reference cleared on resolution to prevent leak
+  let abortListener: (() => void) | undefined;
+  // let: mutable — cancel function wired to resolve
+  let cancelFn: (() => void) | undefined;
+
+  function cleanup(): void {
+    pending = false;
+    unsubscribe?.();
+    unsubscribe = undefined;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (abortListener !== undefined && signal !== undefined) {
+      signal.removeEventListener("abort", abortListener);
+      abortListener = undefined;
+    }
+  }
+
+  const promise = new Promise<EscalationDecision>((resolve) => {
+    // Wire cancel to resolve as abort
+    cancelFn = () => {
+      if (!pending) return;
+      cleanup();
+      resolve({ kind: "abort", reason: "Escalation cancelled" });
+    };
+
+    // Listen for human response
+    unsubscribe = channel.onMessage(async (message: InboundMessage) => {
+      if (!pending) return;
+      const decision = parseHumanResponse(message);
+      cleanup();
+      resolve(decision);
+    });
+
+    // Timeout race
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        if (!pending) return;
+        cleanup();
+        resolve({ kind: "abort", reason: `Escalation timed out after ${String(timeoutMs)}ms` });
+      }, timeoutMs);
+    }
+
+    // AbortSignal race
+    if (signal !== undefined) {
+      if (signal.aborted) {
+        cleanup();
+        resolve({ kind: "abort", reason: "Escalation aborted via signal" });
+        return;
+      }
+      abortListener = () => {
+        if (!pending) return;
+        cleanup();
+        resolve({ kind: "abort", reason: "Escalation aborted via signal" });
+      };
+      signal.addEventListener("abort", abortListener, { once: true });
+    }
+  });
+
+  return {
+    promise,
+    isPending: () => pending,
+    cancel: () => cancelFn?.(),
+  };
+}

--- a/packages/middleware-delegation-escalation/src/escalation-message.test.ts
+++ b/packages/middleware-delegation-escalation/src/escalation-message.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for generateEscalationMessage().
+ */
+
+import { describe, expect, test } from "bun:test";
+import { agentId } from "@koi/core";
+import { generateEscalationMessage } from "./escalation-message.js";
+import type { EscalationContext } from "./types.js";
+
+describe("generateEscalationMessage", () => {
+  const baseCtx: EscalationContext = {
+    issuerId: agentId("orchestrator"),
+    exhaustedDelegateeIds: [agentId("w1"), agentId("w2")],
+    detectedAt: 1700000000000,
+  };
+
+  test("generates message with delegatee list", () => {
+    const msg = generateEscalationMessage(baseCtx);
+
+    expect(msg.content).toHaveLength(1);
+    const textBlock = msg.content[0];
+    expect(textBlock?.kind).toBe("text");
+    if (textBlock?.kind !== "text") return;
+
+    expect(textBlock.text).toContain("orchestrator");
+    expect(textBlock.text).toContain("w1");
+    expect(textBlock.text).toContain("w2");
+    expect(textBlock.text).toContain("abort");
+  });
+
+  test("includes task summary when provided", () => {
+    const ctx: EscalationContext = {
+      ...baseCtx,
+      taskSummary: "Processing batch import of user records",
+    };
+    const msg = generateEscalationMessage(ctx);
+
+    const textBlock = msg.content[0];
+    if (textBlock?.kind !== "text") return;
+
+    expect(textBlock.text).toContain("Processing batch import of user records");
+    expect(textBlock.text).toContain("Task summary:");
+  });
+
+  test("omits task summary section when not provided", () => {
+    const msg = generateEscalationMessage(baseCtx);
+
+    const textBlock = msg.content[0];
+    if (textBlock?.kind !== "text") return;
+
+    expect(textBlock.text).not.toContain("Task summary:");
+  });
+
+  test("sets escalation metadata on the message", () => {
+    const msg = generateEscalationMessage(baseCtx);
+
+    expect(msg.metadata).toBeDefined();
+    expect(msg.metadata?.escalation).toBe(true);
+    expect(msg.metadata?.issuerId).toBe("orchestrator");
+    expect(msg.metadata?.detectedAt).toBe(1700000000000);
+    expect(msg.metadata?.delegateeCount).toBe(2);
+  });
+});

--- a/packages/middleware-delegation-escalation/src/escalation-message.ts
+++ b/packages/middleware-delegation-escalation/src/escalation-message.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure function to generate a human-readable escalation message
+ * sent via the channel when all delegatees are exhausted.
+ */
+
+import type { OutboundMessage } from "@koi/core";
+import type { EscalationContext } from "./types.js";
+
+/**
+ * Generates an OutboundMessage describing the exhaustion condition
+ * for a human operator. Includes delegatee list and optional task summary.
+ */
+export function generateEscalationMessage(ctx: EscalationContext): OutboundMessage {
+  const delegateeList = ctx.exhaustedDelegateeIds.map((id) => `  - ${id}`).join("\n");
+
+  const summarySection =
+    ctx.taskSummary !== undefined ? `\n\nTask summary:\n${ctx.taskSummary}` : "";
+
+  const text = [
+    `[Escalation] All delegatees for agent "${ctx.issuerId}" have exhausted their circuit breakers.`,
+    "",
+    `Exhausted delegatees:\n${delegateeList}`,
+    summarySection,
+    "",
+    'Please reply with instructions to resume, or type "abort" to stop the agent.',
+  ].join("\n");
+
+  return {
+    content: [{ kind: "text", text }],
+    metadata: {
+      escalation: true,
+      issuerId: ctx.issuerId,
+      detectedAt: ctx.detectedAt,
+      delegateeCount: ctx.exhaustedDelegateeIds.length,
+    },
+  };
+}

--- a/packages/middleware-delegation-escalation/src/index.ts
+++ b/packages/middleware-delegation-escalation/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @koi/middleware-delegation-escalation — Human escalation on delegation exhaustion (Layer 2)
+ *
+ * When all delegatee circuit breakers are open, pauses the engine loop
+ * and asks a human for instructions via the bidirectional channel contract.
+ */
+
+// escalation gate
+export type { EscalationGate } from "./escalation-gate.js";
+export { createEscalationGate, parseHumanResponse } from "./escalation-gate.js";
+
+// escalation message
+export { generateEscalationMessage } from "./escalation-message.js";
+// middleware factory
+export { createDelegationEscalationMiddleware } from "./middleware.js";
+// types
+export type {
+  DelegationEscalationConfig,
+  DelegationEscalationHandle,
+  EscalationContext,
+  EscalationDecision,
+} from "./types.js";
+export { DEFAULT_ESCALATION_TIMEOUT_MS } from "./types.js";

--- a/packages/middleware-delegation-escalation/src/middleware.test.ts
+++ b/packages/middleware-delegation-escalation/src/middleware.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for createDelegationEscalationMiddleware().
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type {
+  ChannelAdapter,
+  DelegationEvent,
+  InboundMessage,
+  MessageHandler,
+  ModelRequest,
+  ModelResponse,
+  OutboundMessage,
+  SessionId,
+  TurnContext,
+  TurnId,
+} from "@koi/core";
+import { agentId, runId } from "@koi/core";
+import { createDelegationEscalationMiddleware } from "./middleware.js";
+import type { DelegationEscalationConfig, EscalationDecision } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function createMockChannel(): ChannelAdapter & {
+  readonly simulateMessage: (msg: InboundMessage) => Promise<void>;
+  readonly sentMessages: OutboundMessage[];
+} {
+  const handlers: MessageHandler[] = [];
+  const sentMessages: OutboundMessage[] = [];
+
+  return {
+    name: "test-channel",
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: false,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async (msg: OutboundMessage) => {
+      sentMessages.push(msg);
+    },
+    onMessage: (handler: MessageHandler) => {
+      handlers.push(handler);
+      return () => {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      };
+    },
+    simulateMessage: async (msg: InboundMessage) => {
+      for (const handler of [...handlers]) {
+        await handler(msg);
+      }
+    },
+    sentMessages,
+  };
+}
+
+function createMockTurnContext(overrides?: Partial<TurnContext>): TurnContext {
+  return {
+    session: {
+      agentId: "test-agent",
+      sessionId: "test-session" as SessionId,
+      runId: runId("test-run"),
+      metadata: {},
+    },
+    turnIndex: 0,
+    turnId: "test-turn" as TurnId,
+    messages: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function createMockModelRequest(): ModelRequest {
+  return {
+    messages: [
+      {
+        content: [{ kind: "text", text: "Hello" }],
+        senderId: "user",
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+function createMockModelResponse(): ModelResponse {
+  return {
+    content: "Response text",
+    model: "test-model",
+  };
+}
+
+function createTextMessage(text: string): InboundMessage {
+  return {
+    content: [{ kind: "text", text }],
+    senderId: "human",
+    timestamp: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createDelegationEscalationMiddleware", () => {
+  const handles: Array<ReturnType<typeof createDelegationEscalationMiddleware>> = [];
+
+  afterEach(() => {
+    for (const handle of handles) {
+      handle.cancel();
+    }
+    handles.length = 0;
+  });
+
+  function createHandle(overrides?: Partial<DelegationEscalationConfig>): ReturnType<
+    typeof createDelegationEscalationMiddleware
+  > & {
+    readonly channel: ReturnType<typeof createMockChannel>;
+  } {
+    const channel = createMockChannel();
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => false,
+      issuerId: agentId("orchestrator"),
+      monitoredDelegateeIds: [agentId("w1"), agentId("w2")],
+      ...overrides,
+      // Override channel if provided in overrides
+      ...(overrides?.channel !== undefined ? {} : { channel }),
+    });
+    handles.push(handle);
+    return { ...handle, channel };
+  }
+
+  test("passes through model call when not exhausted", async () => {
+    const { middleware } = createHandle();
+    const ctx = createMockTurnContext();
+    const request = createMockModelRequest();
+    const response = createMockModelResponse();
+    const next = mock(async () => response);
+
+    const result = await middleware.wrapModelCall?.(ctx, request, next);
+    expect(result).toBe(response);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not arm escalation in onAfterTurn when not exhausted", async () => {
+    const { middleware, channel } = createHandle();
+    const ctx = createMockTurnContext();
+
+    await middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(0);
+  });
+
+  test("arms escalation in onAfterTurn when exhausted", async () => {
+    const { middleware, channel } = createHandle({ isExhausted: () => true });
+    const ctx = createMockTurnContext();
+
+    await middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(1);
+    const msg = channel.sentMessages[0];
+    if (msg?.content[0]?.kind === "text") {
+      expect(msg.content[0].text).toContain("orchestrator");
+    }
+  });
+
+  test("wrapModelCall pauses and resumes on human instruction", async () => {
+    const channel = createMockChannel();
+    // let: mutable — tracks exhaustion state for testing
+    let exhausted = false;
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => exhausted,
+      issuerId: agentId("orchestrator"),
+      monitoredDelegateeIds: [agentId("w1"), agentId("w2")],
+    });
+    handles.push(handle);
+
+    const ctx = createMockTurnContext();
+    const request = createMockModelRequest();
+    const response = createMockModelResponse();
+    const next = mock(async (req: ModelRequest) => {
+      // Verify instruction was injected
+      if (req.messages.length > request.messages.length) {
+        const lastMsg = req.messages[req.messages.length - 1];
+        if (lastMsg?.content[0]?.kind === "text") {
+          expect(lastMsg.content[0].text).toContain("Try plan B");
+        }
+      }
+      return response;
+    });
+
+    // Trigger exhaustion
+    exhausted = true;
+    await handle.middleware.onAfterTurn?.(ctx);
+    expect(handle.isPending()).toBe(true);
+
+    // Start model call (will block on gate)
+    const callPromise = handle.middleware.wrapModelCall?.(ctx, request, next);
+
+    // Simulate human response
+    await channel.simulateMessage(createTextMessage("Try plan B"));
+
+    const result = await callPromise;
+    expect(result).toBe(response);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(handle.isPending()).toBe(false);
+  });
+
+  test("wrapModelCall throws on abort decision", async () => {
+    const channel = createMockChannel();
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => true,
+      issuerId: agentId("orchestrator"),
+      monitoredDelegateeIds: [agentId("w1")],
+    });
+    handles.push(handle);
+
+    const ctx = createMockTurnContext();
+    await handle.middleware.onAfterTurn?.(ctx);
+
+    const callPromise = handle.middleware.wrapModelCall?.(ctx, createMockModelRequest(), async () =>
+      createMockModelResponse(),
+    );
+
+    await channel.simulateMessage(createTextMessage("abort"));
+
+    await expect(callPromise).rejects.toThrow("Delegation escalation aborted");
+  });
+
+  test("prevents double-arming when gate is already pending", async () => {
+    const { middleware, channel } = createHandle({ isExhausted: () => true });
+    const ctx = createMockTurnContext();
+
+    await middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(1);
+
+    // Second call should not arm again
+    await middleware.onAfterTurn?.(ctx);
+    expect(channel.sentMessages).toHaveLength(1);
+  });
+
+  test("isPending reflects gate state", async () => {
+    const channel = createMockChannel();
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => true,
+      issuerId: agentId("orchestrator"),
+      monitoredDelegateeIds: [agentId("w1")],
+    });
+    handles.push(handle);
+
+    expect(handle.isPending()).toBe(false);
+
+    const ctx = createMockTurnContext();
+    await handle.middleware.onAfterTurn?.(ctx);
+    expect(handle.isPending()).toBe(true);
+
+    handle.cancel();
+    // Give the cancel a tick to resolve
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handle.isPending()).toBe(false);
+  });
+
+  test("fires onEscalation callback with decision", async () => {
+    const decisions: EscalationDecision[] = [];
+    const channel = createMockChannel();
+    const handle = createDelegationEscalationMiddleware({
+      channel,
+      isExhausted: () => true,
+      issuerId: agentId("orchestrator"),
+      monitoredDelegateeIds: [agentId("w1")],
+      onEscalation: (d) => decisions.push(d),
+    });
+    handles.push(handle);
+
+    const ctx = createMockTurnContext();
+    await handle.middleware.onAfterTurn?.(ctx);
+
+    // Start wrapModelCall to drive the decision path
+    const callPromise = handle.middleware.wrapModelCall?.(ctx, createMockModelRequest(), async () =>
+      createMockModelResponse(),
+    );
+    await channel.simulateMessage(createTextMessage("resume with instructions"));
+    await callPromise;
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.kind).toBe("resume");
+  });
+
+  test("fires onExhausted callback with delegation:exhausted event", async () => {
+    const events: DelegationEvent[] = [];
+    const { middleware } = createHandle({
+      isExhausted: () => true,
+      onExhausted: (e) => events.push(e),
+    });
+
+    const ctx = createMockTurnContext();
+    await middleware.onAfterTurn?.(ctx);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("delegation:exhausted");
+    if (events[0]?.kind === "delegation:exhausted") {
+      expect(events[0].issuerId).toBe(agentId("orchestrator"));
+      expect(events[0].delegateeIds).toEqual([agentId("w1"), agentId("w2")]);
+    }
+  });
+
+  test("describeCapabilities reflects monitoring state", () => {
+    const { middleware } = createHandle();
+    const ctx = createMockTurnContext();
+
+    const cap = middleware.describeCapabilities(ctx);
+    expect(cap?.label).toBe("delegation-escalation");
+    expect(cap?.description).toContain("monitoring 2 delegatees");
+  });
+
+  test("describeCapabilities reflects pending state", async () => {
+    const { middleware } = createHandle({ isExhausted: () => true });
+    const ctx = createMockTurnContext();
+
+    await middleware.onAfterTurn?.(ctx);
+
+    const cap = middleware.describeCapabilities(ctx);
+    expect(cap?.description).toContain("awaiting human response");
+  });
+});

--- a/packages/middleware-delegation-escalation/src/middleware.ts
+++ b/packages/middleware-delegation-escalation/src/middleware.ts
@@ -1,0 +1,169 @@
+/**
+ * Delegation-escalation middleware factory.
+ *
+ * Monitors delegatee circuit breakers via a callback and, when all are
+ * exhausted, pauses the engine loop by awaiting a human response through
+ * the channel. On "resume", injects the human's instruction as a system
+ * message. On "abort", throws to halt the engine.
+ */
+
+import type {
+  CapabilityFragment,
+  DelegationEvent,
+  InboundMessage,
+  KoiMiddleware,
+  ModelRequest,
+  ModelResponse,
+  TurnContext,
+} from "@koi/core";
+import type { EscalationGate } from "./escalation-gate.js";
+import { createEscalationGate } from "./escalation-gate.js";
+import { generateEscalationMessage } from "./escalation-message.js";
+import type {
+  DelegationEscalationConfig,
+  DelegationEscalationHandle,
+  EscalationContext,
+  EscalationDecision,
+} from "./types.js";
+import { DEFAULT_ESCALATION_TIMEOUT_MS } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIDDLEWARE_NAME = "koi:delegation-escalation";
+
+/** Priority 300: runs before semantic-retry (420). Lower = outer layer. */
+const MIDDLEWARE_PRIORITY = 300;
+
+const ESCALATION_SENDER_ID = "human-escalation";
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createDelegationEscalationMiddleware(
+  config: DelegationEscalationConfig,
+): DelegationEscalationHandle {
+  const {
+    channel,
+    isExhausted,
+    issuerId,
+    monitoredDelegateeIds,
+    taskSummary,
+    onEscalation,
+    onExhausted,
+  } = config;
+  const timeoutMs = config.escalationTimeoutMs ?? DEFAULT_ESCALATION_TIMEOUT_MS;
+
+  // let: mutable — gate is created on exhaustion and cleared on resolution
+  let gate: EscalationGate | undefined;
+
+  function emitExhaustedEvent(): void {
+    if (onExhausted === undefined) return;
+
+    const event: DelegationEvent = {
+      kind: "delegation:exhausted",
+      delegateeIds: monitoredDelegateeIds,
+      issuerId,
+      detectedAt: Date.now(),
+    };
+    onExhausted(event);
+  }
+
+  async function armEscalation(signal?: AbortSignal): Promise<void> {
+    // Double-arm prevention: don't create a second gate if one is pending
+    if (gate?.isPending()) return;
+
+    emitExhaustedEvent();
+
+    const ctx: EscalationContext = {
+      issuerId,
+      exhaustedDelegateeIds: monitoredDelegateeIds,
+      detectedAt: Date.now(),
+      taskSummary,
+    };
+
+    const message = generateEscalationMessage(ctx);
+    await channel.send(message);
+
+    gate = createEscalationGate(channel, signal, timeoutMs);
+  }
+
+  async function awaitDecision(): Promise<EscalationDecision> {
+    if (gate === undefined) {
+      return { kind: "resume" };
+    }
+
+    const decision = await gate.promise;
+    onEscalation?.(decision);
+    gate = undefined;
+    return decision;
+  }
+
+  function injectInstruction(request: ModelRequest, instruction: string): ModelRequest {
+    const systemMessage: InboundMessage = {
+      content: [{ kind: "text", text: `[Human escalation instruction] ${instruction}` }],
+      senderId: ESCALATION_SENDER_ID,
+      timestamp: Date.now(),
+    };
+    return {
+      ...request,
+      messages: [...request.messages, systemMessage],
+    };
+  }
+
+  const middleware: KoiMiddleware = {
+    name: MIDDLEWARE_NAME,
+    priority: MIDDLEWARE_PRIORITY,
+
+    async onAfterTurn(ctx: TurnContext): Promise<void> {
+      if (!isExhausted()) return;
+      if (gate?.isPending()) return;
+
+      await armEscalation(ctx.signal);
+    },
+
+    async wrapModelCall(
+      _ctx: TurnContext,
+      request: ModelRequest,
+      next: (request: ModelRequest) => Promise<ModelResponse>,
+    ): Promise<ModelResponse> {
+      // If no gate is pending, pass through
+      if (gate === undefined || !gate.isPending()) {
+        return next(request);
+      }
+
+      // Await the human decision
+      const decision = await awaitDecision();
+
+      if (decision.kind === "abort") {
+        throw new Error(`Delegation escalation aborted: ${decision.reason}`);
+      }
+
+      // Resume — optionally inject human instruction
+      const finalRequest =
+        decision.instruction !== undefined
+          ? injectInstruction(request, decision.instruction)
+          : request;
+
+      return next(finalRequest);
+    },
+
+    describeCapabilities(_ctx: TurnContext): CapabilityFragment {
+      const isPending = gate?.isPending();
+      return {
+        label: "delegation-escalation",
+        description: isPending
+          ? "Delegation escalation: awaiting human response"
+          : `Delegation escalation: monitoring ${String(monitoredDelegateeIds.length)} delegatees`,
+      };
+    },
+  };
+
+  return {
+    middleware,
+    isPending: () => gate?.isPending() ?? false,
+    cancel: () => gate?.cancel(),
+  };
+}

--- a/packages/middleware-delegation-escalation/src/types.ts
+++ b/packages/middleware-delegation-escalation/src/types.ts
@@ -1,0 +1,77 @@
+/**
+ * Types for the delegation-escalation middleware.
+ *
+ * Defines the escalation context, decision union, configuration,
+ * and the handle returned by the factory.
+ */
+
+import type { AgentId, ChannelAdapter, DelegationEvent, KoiMiddleware } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default timeout waiting for human response (10 minutes). */
+export const DEFAULT_ESCALATION_TIMEOUT_MS = 600_000;
+
+// ---------------------------------------------------------------------------
+// Escalation Context
+// ---------------------------------------------------------------------------
+
+/** Context describing the exhaustion condition passed to message formatters. */
+export interface EscalationContext {
+  readonly issuerId: AgentId;
+  readonly exhaustedDelegateeIds: readonly AgentId[];
+  readonly detectedAt: number;
+  readonly taskSummary?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Escalation Decision
+// ---------------------------------------------------------------------------
+
+/** Human's response to an escalation: resume with optional instruction or abort. */
+export type EscalationDecision =
+  | { readonly kind: "resume"; readonly instruction?: string | undefined }
+  | { readonly kind: "abort"; readonly reason: string };
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Configuration for the delegation-escalation middleware. */
+export interface DelegationEscalationConfig {
+  /** Bidirectional channel for human communication. */
+  readonly channel: ChannelAdapter;
+  /**
+   * Callback that returns true when all monitored delegatees are exhausted.
+   * Consumer wires this to `manager.isExhausted(ids)`.
+   */
+  readonly isExhausted: () => boolean;
+  /** The owning agent's ID. */
+  readonly issuerId: AgentId;
+  /** Delegatee IDs to include in the exhaustion event payload. */
+  readonly monitoredDelegateeIds: readonly AgentId[];
+  /** Optional task summary for the escalation message. */
+  readonly taskSummary?: string | undefined;
+  /** Timeout in ms waiting for human response (default: 600_000). */
+  readonly escalationTimeoutMs?: number | undefined;
+  /** Observability callback invoked when a human decision is received. */
+  readonly onEscalation?: ((decision: EscalationDecision) => void) | undefined;
+  /** Callback to emit the delegation:exhausted event to the event bus. */
+  readonly onExhausted?: ((event: DelegationEvent) => void) | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Handle
+// ---------------------------------------------------------------------------
+
+/** Handle returned by createDelegationEscalationMiddleware(). */
+export interface DelegationEscalationHandle {
+  /** The KoiMiddleware instance to register in the middleware chain. */
+  readonly middleware: KoiMiddleware;
+  /** Returns true if an escalation is currently awaiting human response. */
+  readonly isPending: () => boolean;
+  /** Cancels any pending escalation gate (resolves as abort). */
+  readonly cancel: () => void;
+}

--- a/packages/middleware-delegation-escalation/tsconfig.json
+++ b/packages/middleware-delegation-escalation/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/middleware-delegation-escalation/tsup.config.ts
+++ b/packages/middleware-delegation-escalation/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     { "path": "packages/mcp" },
     { "path": "packages/memory-fs" },
     { "path": "packages/middleware-audit" },
+    { "path": "packages/middleware-delegation-escalation" },
     { "path": "packages/middleware-event-trace" },
     { "path": "packages/middleware-feedback-loop" },
     { "path": "packages/middleware-fs-rollback" },


### PR DESCRIPTION
## Summary

When all delegatee circuit breakers are open, the system currently has no mechanism to pause and ask a human for help. This PR connects three existing building blocks — delegation circuit breakers, the bidirectional channel contract, and the `hitl_pause`/`human_approval` lifecycle states — into a coherent escalation path.

- **L0 `@koi/core`**: Add `delegation:exhausted` event variant to `DelegationEvent` union
- **L2 `@koi/delegation`**: Add `isExhausted(delegateeIds)` method to `DelegationManager`
- **L2 (new) `@koi/middleware-delegation-escalation`**: Escalation middleware that monitors circuit breakers, sends human-readable messages via the channel, and pauses the engine loop awaiting a human decision (resume with instruction or abort)

### How it works

```
All circuits open → middleware detects exhaustion
  → sends message via channel (Slack/CLI/Discord)
  → engine loop PAUSES (wrapModelCall awaits gate promise)
  → human replies with instruction or "abort"
  → engine RESUMES with injected instruction, or throws to halt
```

### Anti-leak compliance

- New L2 package imports only from `@koi/core` (L0)
- Does NOT import from `@koi/delegation` (peer L2) — consumer wires via callback
- All interface properties `readonly`
- Zero external dependencies

Closes #50

## Test plan

- [x] `@koi/core` typecheck passes with new event variant
- [x] `@koi/delegation` — 121 tests pass (6 new `isExhausted` tests)
- [x] `@koi/middleware-delegation-escalation` — 29 tests pass:
  - Escalation gate: immediate resolve, timeout, abort signal, cancel, listener cleanup, parse "abort", parse instruction
  - Escalation message: format with/without summary, metadata shape
  - Middleware: passthrough, gate creation, resume injection, abort throw, pending state, double-arm prevention, capabilities, callback firing
  - E2E: full flow, timeout flow, re-escalation after resume
- [x] Full dependency chain builds (`turbo run build --filter=...`)
- [x] Biome lint clean