### PR TITLE
fix: rebuild memory summaries on agent detach

### DIFF
--- a/packages/memory-fs/src/provider/memory-component-provider.test.ts
+++ b/packages/memory-fs/src/provider/memory-component-provider.test.ts
@@ -102,13 +102,14 @@ describe("createMemoryProvider — attach", () => {
 });
 
 describe("createMemoryProvider — detach", () => {
-  test("detach calls memory.close()", async () => {
+  test("detach rebuilds summaries then closes", async () => {
     const memory = createMockFsMemory();
     const provider = createMemoryProvider({ memory });
     await provider.detach?.(createMockAgent());
 
-    expect(memory.calls).toHaveLength(1);
-    expect(memory.calls[0]?.method).toBe("close");
+    expect(memory.calls).toHaveLength(2);
+    expect(memory.calls[0]?.method).toBe("rebuildSummaries");
+    expect(memory.calls[1]?.method).toBe("close");
   });
 });
 

--- a/packages/memory-fs/src/provider/memory-component-provider.ts
+++ b/packages/memory-fs/src/provider/memory-component-provider.ts
@@ -91,6 +91,7 @@ export function createMemoryProvider(config: MemoryProviderConfig): ComponentPro
     },
 
     detach: async (_agent: Agent): Promise<void> => {
+      await memory.rebuildSummaries();
       await memory.close();
     },
   };


### PR DESCRIPTION
## Summary

- `detach()` in `@koi/memory-fs` now calls `rebuildSummaries()` before `close()`, ensuring dirty entity summaries (`summary.md`) are regenerated when an agent session ends
- Previously, summaries were never rebuilt automatically — dirty entities lost their summary updates unless the application triggered a manual rebuild

## Test plan

- [x] Updated detach test to verify `rebuildSummaries` is called before `close`
- [x] Full `@koi/memory-fs` test suite passes (121 pass, 0 fail)
- [x] Full monorepo build + typecheck passes (245/245)