### PR TITLE
feat: add Codex MCP integration recipe

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1980,6 +1980,15 @@
         "@koi/git-utils": "workspace:*",
       },
     },
+    "recipes/codex-mcp": {
+      "name": "@koi/recipe-codex-mcp",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/manifest": "workspace:*",
+        "@koi/mcp": "workspace:*",
+      },
+    },
     "tests/e2e": {
       "name": "@koi/e2e-contracts",
       "version": "0.0.0",
@@ -2655,6 +2664,8 @@
     "@koi/pay-nexus": ["@koi/pay-nexus@workspace:packages/pay-nexus"],
 
     "@koi/permissions-nexus": ["@koi/permissions-nexus@workspace:packages/permissions-nexus"],
+
+    "@koi/recipe-codex-mcp": ["@koi/recipe-codex-mcp@workspace:recipes/codex-mcp"],
 
     "@koi/redaction": ["@koi/redaction@workspace:packages/redaction"],
 

--- a/docs/recipes/codex-mcp.md
+++ b/docs/recipes/codex-mcp.md
@@ -1,0 +1,158 @@
+# Recipe: Codex MCP Integration
+
+Run OpenAI Codex as a governed MCP tool server inside a Koi agent — zero code, just YAML.
+
+---
+
+## Why It Exists
+
+Codex exposes an MCP-compatible server (`codex mcp-server`) that provides code generation and editing tools over stdio. This recipe shows how to wire it into a Koi agent with full governance: permission rules control which tools are allowed, a budget middleware caps daily spend, and an audit middleware logs every call.
+
+```
+WITHOUT governance:
+  Agent ──► codex mcp-server ──► unrestricted code edits
+
+WITH this recipe:
+  Agent ──► permissions ──► pay ($500/day) ──► audit ──► codex mcp-server
+            │                                             │
+            deny production/**                            sandboxed execution
+```
+
+---
+
+## Data Flow
+
+```
+koi.yaml
+  │
+  ▼
+loadManifest()          ← validates YAML, returns LoadedManifest
+  │
+  ├─ tools.mcp[0]      ← { name: "codex", options: { command: "codex mcp-server", ... } }
+  ├─ middleware[0..2]   ← permissions → pay → audit
+  └─ permissions        ← allow / deny / ask rules
+  │
+  ▼
+createMcpComponentProvider()   ← connects to Codex via stdio, discovers tools
+  │
+  ▼
+mcp/codex/codex_generate       ← namespaced tool components
+mcp/codex/codex_edit           ← attached to agent via ECS
+```
+
+All tool calls flow through the middleware stack before reaching the MCP transport.
+
+---
+
+## Manifest Anatomy
+
+### MCP Tool Declaration
+
+```yaml
+tools:
+  mcp:
+    - name: codex
+      options:
+        command: "codex mcp-server"
+        transport: stdio
+        env:
+          CODEX_SANDBOX: "true"
+```
+
+The `tools.mcp` section declares MCP servers. Each entry becomes a set of `mcp/<server>/<tool>` components after discovery. The `options.env` map is passed to the child process — `CODEX_SANDBOX=true` tells Codex to run file operations in a sandboxed environment.
+
+### Governance Middleware
+
+```yaml
+middleware:
+  - name: "@koi/middleware-permissions"
+  - name: "@koi/middleware-pay"
+    options:
+      dailyBudget: 500
+  - name: "@koi/middleware-audit"
+```
+
+Middleware runs in declaration order. The permissions middleware evaluates allow/deny/ask rules before each tool call. The pay middleware tracks token spend against a daily budget. The audit middleware logs every call for compliance review.
+
+### Permission Rules
+
+```yaml
+permissions:
+  allow:
+    - "mcp/codex/codex_generate"        # Always allowed — no approval needed
+  deny:
+    - "mcp/codex/*:production/**"       # Block all Codex tools on production paths
+  ask:
+    - "mcp/codex/codex_edit"            # Requires human approval each time
+```
+
+Rules are evaluated in order: deny > ask > allow. The glob pattern `mcp/codex/*:production/**` matches any Codex tool when the argument contains a production path.
+
+---
+
+## Layer Position
+
+```
+L0   @koi/core         ← Agent, Tool, toolToken (types + branded constructors)
+L0u  @koi/manifest     ← loadManifest() validates koi.yaml
+L2   @koi/mcp          ← createMcpComponentProvider() wires MCP servers
+     recipes/codex-mcp ← this recipe (private, test-only workspace)
+```
+
+The recipe imports from L0 and L2 only. No L1 (`@koi/engine`) dependency — it validates the manifest and MCP wiring without running the kernel.
+
+---
+
+## Test Coverage
+
+| Test | Validates |
+|------|-----------|
+| `koi.yaml loads without errors` | Manifest parses with zero warnings |
+| `manifest has codex MCP tool config` | `tools[0].name === "codex"` with correct command in options |
+| `manifest declares governance middleware` | permissions + pay ($500) + audit all present |
+| `codex tools wrap as mcp/codex/*` | Mock MCP server tools namespaced correctly |
+| `wrapped tool executes via mock` | End-to-end tool call through mock transport |
+
+Tests use the same mock factory DI pattern as `@koi/mcp`'s own test suite — no real Codex installation needed.
+
+---
+
+## Extending This Recipe
+
+**Add more MCP servers** — append entries to `tools.mcp`:
+
+```yaml
+tools:
+  mcp:
+    - name: codex
+      options:
+        command: "codex mcp-server"
+        transport: stdio
+        env:
+          CODEX_SANDBOX: "true"
+    - name: filesystem
+      options:
+        command: "npx @anthropic/mcp-server-filesystem /workspace"
+        transport: stdio
+```
+
+**Adjust budget** — change `dailyBudget` in the pay middleware options.
+
+**Add retry logic** — append `@koi/middleware-semantic-retry` to the middleware stack.
+
+**Switch to HTTP transport** — for remote Codex servers, use `transport: http` with a `url` field instead of `command`.
+
+---
+
+## Running
+
+```bash
+# Tests (mocked — no Codex install needed)
+bun test recipes/codex-mcp/
+
+# Type check
+bunx tsc --noEmit -p recipes/codex-mcp/tsconfig.json
+
+# Lint
+bunx biome check recipes/codex-mcp/
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": [
     "packages/*",
     "apps/*",
-    "tests/e2e"
+    "tests/e2e",
+    "recipes/*"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/recipes/codex-mcp/README.md
+++ b/recipes/codex-mcp/README.md
@@ -1,0 +1,116 @@
+# Codex MCP Recipe
+
+Run [OpenAI Codex](https://github.com/openai/codex) as a governed MCP tool server inside a Koi agent — zero code, just YAML.
+
+## Prerequisites
+
+- Bun 1.3.x installed
+- `codex` CLI installed and on PATH (`npm install -g @openai/codex`)
+- `OPENAI_API_KEY` environment variable set
+
+## Quick Start
+
+```bash
+# From the repo root
+bun install
+
+# Run the recipe tests (no Codex install needed — tests use mocks)
+bun test recipes/codex-mcp/
+
+# Use the manifest with koi (when running a real agent)
+koi run recipes/codex-mcp/koi.yaml
+```
+
+## What This Recipe Does
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Koi Agent                            │
+│                                                         │
+│  koi.yaml ──► Manifest Loader                          │
+│                   │                                     │
+│                   ▼                                     │
+│  ┌─────────────────────────────────┐                   │
+│  │   Middleware Stack (in order)   │                   │
+│  │  1. permissions — allow/deny    │                   │
+│  │  2. pay — $500/day budget cap   │                   │
+│  │  3. audit — full call logging   │                   │
+│  └───────────────┬─────────────────┘                   │
+│                  │                                      │
+│                  ▼                                      │
+│  ┌─────────────────────────────────┐                   │
+│  │  MCP Component Provider         │                   │
+│  │  tools: mcp/codex/codex_*      │                   │
+│  └───────────────┬─────────────────┘                   │
+│                  │ stdio                                │
+│                  ▼                                      │
+│  ┌─────────────────────────────────┐                   │
+│  │  codex mcp-server               │                   │
+│  │  (CODEX_SANDBOX=true)           │                   │
+│  └─────────────────────────────────┘                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+All Codex tools are namespaced as `mcp/codex/<tool_name>` and pass through the governance middleware stack before execution.
+
+## Customization
+
+### Permissions
+
+Edit the `permissions` section in `koi.yaml`:
+
+```yaml
+permissions:
+  allow:
+    - "mcp/codex/codex_generate"          # Always allowed
+  deny:
+    - "mcp/codex/*:production/**"         # Block production paths
+  ask:
+    - "mcp/codex/codex_edit"              # Requires human approval
+```
+
+### Budget
+
+Adjust the daily budget in the middleware options:
+
+```yaml
+middleware:
+  - name: "@koi/middleware-pay"
+    options:
+      dailyBudget: 1000   # Raise to $1000/day
+```
+
+### Additional Middleware
+
+Add more middleware to the stack (order matters — first in the list runs first):
+
+```yaml
+middleware:
+  - name: "@koi/middleware-permissions"
+  - name: "@koi/middleware-pay"
+    options:
+      dailyBudget: 500
+  - name: "@koi/middleware-audit"
+  - name: "@koi/middleware-semantic-retry"  # Add retry logic
+```
+
+## Security Considerations
+
+- **Sandbox mode**: `CODEX_SANDBOX=true` is set by default — Codex runs file operations in a sandboxed environment
+- **Permission rules**: The deny rule `mcp/codex/*:production/**` blocks any Codex tool from operating on production paths
+- **Human-in-the-loop**: `codex_edit` requires explicit approval via the `ask` permission
+- **Budget cap**: The pay middleware enforces a $500/day spending limit by default
+- **Audit trail**: All tool calls are logged by the audit middleware
+
+## Running Tests
+
+```bash
+# Run recipe tests only
+bun test recipes/codex-mcp/
+
+# Type-check
+bunx tsc --noEmit -p recipes/codex-mcp/tsconfig.json
+
+# Lint
+biome check recipes/codex-mcp/
+```

--- a/recipes/codex-mcp/codex-mcp-recipe.test.ts
+++ b/recipes/codex-mcp/codex-mcp-recipe.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for the Codex MCP recipe.
+ *
+ * Validates that the koi.yaml manifest loads correctly, declares the expected
+ * MCP tool config and governance middleware, and that Codex tools are correctly
+ * namespaced when wired through the MCP component provider.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import type { Agent, AttachResult, Tool } from "@koi/core";
+import { agentId, isAttachResult, toolToken } from "@koi/core";
+import { loadManifest } from "@koi/manifest";
+import type { McpClientManager, McpProviderConfig, ResolvedMcpServerConfig } from "@koi/mcp";
+import { createMcpComponentProvider } from "@koi/mcp";
+
+// ---------------------------------------------------------------------------
+// Helpers (same patterns as packages/mcp/src/component-provider-mock.test.ts)
+// ---------------------------------------------------------------------------
+
+const MANIFEST_PATH = resolve(import.meta.dirname, "koi.yaml");
+
+function extractMap(
+  result: AttachResult | ReadonlyMap<string, unknown>,
+): ReadonlyMap<string, unknown> {
+  return isAttachResult(result) ? result.components : result;
+}
+
+function createMockAgent(): Agent {
+  return {
+    pid: { id: agentId("codex-test-1"), name: "codex-test", type: "worker", depth: 0 },
+    manifest: {
+      name: "codex-test-agent",
+      version: "1.0.0",
+      model: { name: "test-model" },
+      tools: [],
+      channels: [],
+      middleware: [],
+    },
+    state: "running",
+    component: () => undefined,
+    has: () => false,
+    hasAll: () => false,
+    query: () => new Map(),
+    components: () => new Map(),
+  };
+}
+
+function createCodexMockManager(
+  callResults: Readonly<Record<string, unknown>> = {},
+): McpClientManager {
+  let connected = false;
+  return {
+    connect: async () => {
+      connected = true;
+      return { ok: true as const, value: undefined };
+    },
+    listTools: async () => ({
+      ok: true as const,
+      value: [
+        { name: "codex_generate", description: "Generate code", inputSchema: { type: "object" } },
+        { name: "codex_edit", description: "Edit code", inputSchema: { type: "object" } },
+      ],
+    }),
+    callTool: async (toolName, _args) => {
+      const result = callResults[toolName];
+      if (result === undefined) {
+        return {
+          ok: false as const,
+          error: {
+            code: "NOT_FOUND" as const,
+            message: `Tool "${toolName}" not found`,
+            retryable: false,
+          },
+        };
+      }
+      return { ok: true as const, value: result };
+    },
+    close: async () => {
+      connected = false;
+    },
+    isConnected: () => connected,
+    serverName: () => "codex",
+  };
+}
+
+function createMockFactory(
+  registry: ReadonlyMap<string, McpClientManager>,
+): (
+  config: ResolvedMcpServerConfig,
+  connectTimeoutMs: number,
+  maxReconnectAttempts: number,
+) => McpClientManager {
+  return (config) => {
+    const manager = registry.get(config.name);
+    if (manager === undefined) {
+      throw new Error(`No mock manager registered for "${config.name}"`);
+    }
+    return manager;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Codex MCP recipe", () => {
+  test("koi.yaml loads without errors", async () => {
+    const result = await loadManifest(MANIFEST_PATH);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.warnings).toHaveLength(0);
+  });
+
+  test("manifest has codex MCP tool config", async () => {
+    const result = await loadManifest(MANIFEST_PATH);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { manifest } = result.value;
+    expect(manifest.tools).toBeDefined();
+
+    const codexTool = manifest.tools?.find((t) => t.name === "codex");
+    expect(codexTool).toBeDefined();
+    expect(codexTool?.options).toMatchObject({
+      command: "codex mcp-server",
+      section: "mcp",
+    });
+  });
+
+  test("manifest declares governance middleware", async () => {
+    const result = await loadManifest(MANIFEST_PATH);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { manifest } = result.value;
+    const names = manifest.middleware?.map((m) => m.name) ?? [];
+    expect(names).toContain("@koi/middleware-permissions");
+    expect(names).toContain("@koi/middleware-pay");
+    expect(names).toContain("@koi/middleware-audit");
+
+    const pay = manifest.middleware?.find((m) => m.name === "@koi/middleware-pay");
+    expect(pay?.options).toMatchObject({ dailyBudget: 500 });
+  });
+
+  test("codex tools wrap as mcp/codex/*", async () => {
+    const registry = new Map<string, McpClientManager>([["codex", createCodexMockManager()]]);
+
+    const config: McpProviderConfig = {
+      servers: [{ name: "codex", transport: "stdio", command: "echo", mode: "tools" }],
+    };
+
+    const result = await createMcpComponentProvider(config, createMockFactory(registry));
+    expect(result.failures).toHaveLength(0);
+    expect(result.clients).toHaveLength(1);
+
+    const agent = createMockAgent();
+    const components = extractMap(await result.provider.attach(agent));
+    expect(components.has(toolToken("mcp/codex/codex_generate") as string)).toBe(true);
+    expect(components.has(toolToken("mcp/codex/codex_edit") as string)).toBe(true);
+  });
+
+  test("wrapped tool executes via mock", async () => {
+    const registry = new Map<string, McpClientManager>([
+      [
+        "codex",
+        createCodexMockManager({
+          codex_generate: [{ type: "text", text: "function hello() { return 'world'; }" }],
+        }),
+      ],
+    ]);
+
+    const config: McpProviderConfig = {
+      servers: [{ name: "codex", transport: "stdio", command: "echo", mode: "tools" }],
+    };
+
+    const result = await createMcpComponentProvider(config, createMockFactory(registry));
+    const agent = createMockAgent();
+    const components = extractMap(await result.provider.attach(agent));
+
+    const tool = components.get(toolToken("mcp/codex/codex_generate") as string) as Tool;
+    expect(tool).toBeDefined();
+
+    const execResult = await tool.execute({ prompt: "hello world function" });
+    expect(execResult).toEqual([{ type: "text", text: "function hello() { return 'world'; }" }]);
+  });
+});

--- a/recipes/codex-mcp/koi.yaml
+++ b/recipes/codex-mcp/koi.yaml
@@ -1,0 +1,30 @@
+name: "codex-mcp-assistant"
+version: "1.0.0"
+description: "Koi agent with OpenAI Codex as MCP tool server — governed by permissions, budget, and audit"
+
+model:
+  name: "anthropic:claude-sonnet-4-5-20250929"
+
+tools:
+  mcp:
+    - name: codex
+      options:
+        command: "codex mcp-server"
+        transport: stdio
+        env:
+          CODEX_SANDBOX: "true"
+
+middleware:
+  - name: "@koi/middleware-permissions"
+  - name: "@koi/middleware-pay"
+    options:
+      dailyBudget: 500
+  - name: "@koi/middleware-audit"
+
+permissions:
+  allow:
+    - "mcp/codex/codex_generate"
+  deny:
+    - "mcp/codex/*:production/**"
+  ask:
+    - "mcp/codex/codex_edit"

--- a/recipes/codex-mcp/package.json
+++ b/recipes/codex-mcp/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@koi/recipe-codex-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/manifest": "workspace:*",
+    "@koi/mcp": "workspace:*"
+  }
+}

--- a/recipes/codex-mcp/tsconfig.json
+++ b/recipes/codex-mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/manifest" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,6 +71,7 @@
     { "path": "packages/store-sqlite" },
     { "path": "packages/test-utils" },
     { "path": "packages/tools-web" },
-    { "path": "packages/validation" }
+    { "path": "packages/validation" },
+    { "path": "recipes/codex-mcp" }
   ]
 }


### PR DESCRIPTION
## Summary

- Establish `recipes/` directory convention for integration examples
- Add Codex MCP recipe: run OpenAI Codex as a governed MCP tool server — zero code, just YAML
- `koi.yaml` declares Codex MCP server (stdio, sandboxed), governance middleware (permissions + pay $500/day + audit), and permission rules (allow/deny/ask)
- 5 integration tests using mock MCP factory DI pattern from `@koi/mcp`
- Documentation under `docs/recipes/codex-mcp.md`

Closes #499

## Files

**Modified:**
- `package.json` — add `"recipes/*"` to workspaces
- `tsconfig.json` — add recipe tsconfig reference
- `bun.lock` — auto-updated

**Created:**
- `recipes/codex-mcp/package.json` — private workspace package
- `recipes/codex-mcp/tsconfig.json` — extends tsconfig.base
- `recipes/codex-mcp/koi.yaml` — the star deliverable
- `recipes/codex-mcp/codex-mcp-recipe.test.ts` — 5 tests, ~100 LOC
- `recipes/codex-mcp/README.md` — setup guide + security notes
- `docs/recipes/codex-mcp.md` — architecture doc with data flow diagram

## Test plan

- [x] `bun install` — workspace resolves
- [x] `bun test recipes/codex-mcp/` — 5/5 pass, 17 assertions
- [x] `bunx tsc --noEmit -p recipes/codex-mcp/tsconfig.json` — clean
- [x] `bunx biome check recipes/codex-mcp/` — clean
- [x] Pre-commit hooks pass (biome-check)
- [x] No layer violations — recipe imports L0 + L0u + L2 only, no L1