### PR TITLE
feat: add ipc_discover tool to @koi/ipc-nexus

### DIFF
--- a/docs/L2/ipc-nexus.md
+++ b/docs/L2/ipc-nexus.md
@@ -1,6 +1,6 @@
 # @koi/ipc-nexus — Agent-to-Agent Messaging via Nexus IPC
 
-Agent-to-agent messaging through a central REST mailbox. Any Koi agent can send messages to any other agent — the LLM decides when to communicate using `ipc_send` and `ipc_list` tools.
+Agent-to-agent messaging through a central REST mailbox. Any Koi agent can send messages to any other agent — the LLM decides when to communicate using `ipc_send`, `ipc_list`, and `ipc_discover` tools.
 
 ## Why
 
@@ -136,22 +136,23 @@ L0  @koi/core          MailboxComponent + MAILBOX token + AgentMessage types
 L2  @koi/ipc-nexus     NexusClient + MailboxAdapter + ComponentProvider + tools
 ```
 
-The mailbox is an **ECS component** attached to agents via a `ComponentProvider`. The provider also registers `ipc_send` and `ipc_list` as agent-facing tools — the LLM calls them autonomously.
+The mailbox is an **ECS component** attached to agents via a `ComponentProvider`. The provider registers `ipc_send` and `ipc_list` as agent-facing tools — the LLM calls them autonomously. When an `AgentRegistry` is provided, `ipc_discover` is also attached, enabling agents to find each other without hardcoded IDs.
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│                     createKoi()                          │
-│   providers: [createIpcNexusProvider({ agentId, ... })]  │
-└────────────────────────┬─────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│                     createKoi()                               │
+│   providers: [createIpcNexusProvider({ agentId, registry })]  │
+└────────────────────────┬──────────────────────────────────────┘
                          │ attach()
                          ▼
-                  ┌──────────────┐
-                  │   Agent      │
-                  │              │
-                  │  MAILBOX     │◄── MailboxComponent (send/onMessage/list)
-                  │  tool:ipc_send  │◄── LLM-callable tool
-                  │  tool:ipc_list  │◄── LLM-callable tool
-                  └──────┬───────┘
+                  ┌─────────────────────┐
+                  │   Agent             │
+                  │                     │
+                  │  MAILBOX            │◄── MailboxComponent (send/onMessage/list)
+                  │  tool:ipc_send      │◄── LLM-callable tool
+                  │  tool:ipc_list      │◄── LLM-callable tool
+                  │  tool:ipc_discover  │◄── LLM-callable tool (when registry provided)
+                  └──────┬──────────────┘
                          │ HTTP
                          ▼
                   ┌──────────────┐
@@ -167,11 +168,14 @@ import { createKoi } from "@koi/engine";
 import { createLoopAdapter } from "@koi/engine-loop";
 import { createIpcNexusProvider } from "@koi/ipc-nexus";
 import { agentId } from "@koi/core";
+import type { AgentRegistry } from "@koi/core";
 
 // 1. Create provider — attaches MAILBOX + tools
+//    Pass registry to also enable ipc_discover
 const provider = createIpcNexusProvider({
   agentId: agentId("my-agent"),
   nexusBaseUrl: "http://localhost:2026",
+  registry,  // optional — enables ipc_discover tool
 });
 
 // 2. Wire into runtime
@@ -354,6 +358,7 @@ const provider = createIpcNexusProvider({
   pageLimit: 50,                       // messages per page
   timeoutMs: 10_000,                   // HTTP timeout
   operations: ["send", "list"],        // which tools to register (default: both)
+  registry,                            // optional — enables ipc_discover tool
 });
 ```
 
@@ -369,6 +374,7 @@ const provider = createIpcNexusProvider({
 | `pageLimit` | `50` | Messages fetched per poll cycle |
 | `timeoutMs` | `10000` | HTTP request timeout |
 | `operations` | `["send", "list"]` | Which tools to expose |
+| `registry` | `undefined` | `AgentRegistry` instance — enables `ipc_discover` tool |
 
 ## Nexus REST API
 
@@ -457,6 +463,32 @@ Lists messages in the agent's inbox with optional filtering.
 | `from` | string | no | Filter by sender |
 | `limit` | number | no | Maximum messages to return |
 
+### `ipc_discover`
+
+Lists live agents available for messaging. Only attached when `registry` is provided in the provider config. Enables agents to discover each other dynamically instead of relying on hardcoded agent IDs.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agentType` | string | no | Filter by agent type: `"copilot"` or `"worker"` |
+| `phase` | string | no | Filter by process state: `"created"`, `"running"`, `"waiting"`, `"suspended"`, or `"terminated"`. Defaults to `"running"` |
+
+Returns `{ agents: [{ agentId, agentType, phase, registeredAt }] }`.
+
+```
+  Agent: "Who can I send a code review to?"
+         │
+         ▼  ipc_discover({ agentType: "worker" })
+  ┌──────────────┐
+  │ AgentRegistry│  list({ phase: "running", agentType: "worker" })
+  │              │  → [{ agentId: "reviewer-1", ... }]
+  └──────────────┘
+         │
+         ▼
+  Agent: "Found reviewer-1. Sending review request."
+         │
+         ▼  ipc_send({ to: "reviewer-1", kind: "request", ... })
+```
+
 ## L0 Types (in @koi/core)
 
 ```typescript
@@ -500,6 +532,7 @@ const MAILBOX: SubsystemToken<MailboxComponent>;
 |--------|------|---------|
 | `createNexusMailbox` | Factory | Creates a `MailboxComponent` backed by Nexus REST |
 | `createIpcNexusProvider` | Factory | Creates a `ComponentProvider` (MAILBOX + tools) |
+| `createDiscoverTool` | Factory | Creates `ipc_discover` tool (advanced usage) |
 | `createSendTool` | Factory | Creates `ipc_send` tool (advanced usage) |
 | `createListTool` | Factory | Creates `ipc_list` tool (advanced usage) |
 | `NexusMailboxConfig` | Interface | Config for `createNexusMailbox` |
@@ -511,6 +544,7 @@ const MAILBOX: SubsystemToken<MailboxComponent>;
 ## Related
 
 - Issue #192 — Original implementation issue
+- Issue #608 — `ipc_discover` tool for agent discovery
 - Issue #193 — `@koi/registry-nexus` (agent discovery)
 - Issue #397 — `@koi/events-nexus` (event sourcing)
 - `@koi/core` `mailbox.ts` — L0 types

--- a/packages/ipc-nexus/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/ipc-nexus/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/ipc-nexus API surface . has stable type surface 1`] = `
-"import { AgentId, MailboxComponent, TrustTier, ComponentProvider, Tool } from '@koi/core';
+"import { AgentId, MailboxComponent, TrustTier, AgentRegistry, ComponentProvider, Tool } from '@koi/core';
 export { AgentMessage, AgentMessageInput, MailboxComponent, MessageFilter, MessageId, MessageKind } from '@koi/core';
 
 /** Default tool name prefix. */
@@ -51,9 +51,16 @@ interface IpcNexusProviderConfig {
     readonly pageLimit?: number | undefined;
     readonly timeoutMs?: number | undefined;
     readonly operations?: readonly IpcOperation[] | undefined;
+    readonly registry?: AgentRegistry | undefined;
 }
 /** Create a ComponentProvider that attaches a MailboxComponent + IPC tools. */
 declare function createIpcNexusProvider(config: IpcNexusProviderConfig): ComponentProvider;
+
+/**
+ * Tool factory for ipc_discover — list live agents available for messaging.
+ */
+
+declare function createDiscoverTool(registry: AgentRegistry, prefix: string, trustTier: TrustTier): Tool;
 
 /**
  * Tool factory for ipc_list — list messages in the agent's inbox.
@@ -67,6 +74,6 @@ declare function createListTool(component: MailboxComponent, prefix: string, tru
 
 declare function createSendTool(component: MailboxComponent, prefix: string, trustTier: TrustTier): Tool;
 
-export { DEFAULT_PREFIX, type IpcNexusProviderConfig, type IpcOperation, type NexusMailboxConfig, OPERATIONS, createIpcNexusProvider, createListTool, createNexusMailbox, createSendTool };
+export { DEFAULT_PREFIX, type IpcNexusProviderConfig, type IpcOperation, type NexusMailboxConfig, OPERATIONS, createDiscoverTool, createIpcNexusProvider, createListTool, createNexusMailbox, createSendTool };
 "
 `;

--- a/packages/ipc-nexus/src/index.ts
+++ b/packages/ipc-nexus/src/index.ts
@@ -29,6 +29,7 @@ export { createNexusMailbox } from "./mailbox-adapter.js";
 // provider
 export type { IpcNexusProviderConfig } from "./mailbox-provider.js";
 export { createIpcNexusProvider } from "./mailbox-provider.js";
-export { createListTool } from "./tools/list.js";
 // tool factories — for advanced usage (custom tool composition)
+export { createDiscoverTool } from "./tools/discover.js";
+export { createListTool } from "./tools/list.js";
 export { createSendTool } from "./tools/send.js";

--- a/packages/ipc-nexus/src/mailbox-provider.test.ts
+++ b/packages/ipc-nexus/src/mailbox-provider.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { agentId, isAttachResult, MAILBOX, toolToken } from "@koi/core";
 import { createMockAgent } from "@koi/test-utils";
 import { createIpcNexusProvider } from "./mailbox-provider.js";
+import { createMockRegistry } from "./test-helpers.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -74,5 +75,53 @@ describe("createIpcNexusProvider", () => {
     // Should not throw
     await provider.detach?.(agent);
     expect(true).toBe(true);
+  });
+
+  test("attaches ipc_discover tool when registry provided", async () => {
+    const provider = createIpcNexusProvider({
+      agentId: agentId("test-agent"),
+      registry: createMockRegistry(),
+    });
+    const agent = createMockAgent();
+    const result = await provider.attach(agent);
+
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has(toolToken("ipc_discover") as string)).toBe(true);
+  });
+
+  test("does NOT attach ipc_discover when registry omitted", async () => {
+    const provider = createIpcNexusProvider({ agentId: agentId("test-agent") });
+    const agent = createMockAgent();
+    const result = await provider.attach(agent);
+
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has(toolToken("ipc_discover") as string)).toBe(false);
+  });
+
+  test("respects custom prefix for discover tool", async () => {
+    const provider = createIpcNexusProvider({
+      agentId: agentId("test-agent"),
+      prefix: "msg",
+      registry: createMockRegistry(),
+    });
+    const agent = createMockAgent();
+    const result = await provider.attach(agent);
+
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has(toolToken("msg_discover") as string)).toBe(true);
+  });
+
+  test("send and list tools still work when registry is also provided", async () => {
+    const provider = createIpcNexusProvider({
+      agentId: agentId("test-agent"),
+      registry: createMockRegistry(),
+    });
+    const agent = createMockAgent();
+    const result = await provider.attach(agent);
+
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has(toolToken("ipc_send") as string)).toBe(true);
+    expect(components.has(toolToken("ipc_list") as string)).toBe(true);
+    expect(components.has(toolToken("ipc_discover") as string)).toBe(true);
   });
 });

--- a/packages/ipc-nexus/src/mailbox-provider.ts
+++ b/packages/ipc-nexus/src/mailbox-provider.ts
@@ -5,11 +5,18 @@
  * send/list as agent-facing tools via createServiceProvider.
  */
 
-import type { AgentId, ComponentProvider, MailboxComponent, TrustTier } from "@koi/core";
-import { createServiceProvider, MAILBOX } from "@koi/core";
+import type {
+  AgentId,
+  AgentRegistry,
+  ComponentProvider,
+  MailboxComponent,
+  TrustTier,
+} from "@koi/core";
+import { createServiceProvider, MAILBOX, toolToken } from "@koi/core";
 import type { IpcOperation } from "./constants.js";
 import { DEFAULT_PREFIX, OPERATIONS } from "./constants.js";
 import { createNexusMailbox } from "./mailbox-adapter.js";
+import { createDiscoverTool } from "./tools/discover.js";
 import { createListTool } from "./tools/list.js";
 import { createSendTool } from "./tools/send.js";
 
@@ -28,6 +35,7 @@ export interface IpcNexusProviderConfig {
   readonly pageLimit?: number | undefined;
   readonly timeoutMs?: number | undefined;
   readonly operations?: readonly IpcOperation[] | undefined;
+  readonly registry?: AgentRegistry | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +73,7 @@ export function createIpcNexusProvider(config: IpcNexusProviderConfig): Componen
     pageLimit,
     timeoutMs,
     operations = OPERATIONS,
+    registry,
   } = config;
 
   const mailbox = createNexusMailbox({
@@ -85,6 +94,14 @@ export function createIpcNexusProvider(config: IpcNexusProviderConfig): Componen
     factories: TOOL_FACTORIES,
     trustTier,
     prefix,
+    ...(registry !== undefined
+      ? {
+          customTools: (_backend, _agent) => {
+            const tool = createDiscoverTool(registry, prefix, trustTier);
+            return [[toolToken(tool.descriptor.name) as string, tool]];
+          },
+        }
+      : {}),
     detach: async () => {
       mailbox[Symbol.dispose]();
     },

--- a/packages/ipc-nexus/src/test-helpers.ts
+++ b/packages/ipc-nexus/src/test-helpers.ts
@@ -1,16 +1,19 @@
 /**
- * Test helpers for @koi/ipc-nexus — mock MailboxComponent for downstream consumers.
+ * Test helpers for @koi/ipc-nexus — mock MailboxComponent and AgentRegistry
+ * for downstream consumers.
  */
 
 import type {
   AgentMessage,
   AgentMessageInput,
+  AgentRegistry,
   KoiError,
   MailboxComponent,
   MessageFilter,
+  RegistryEntry,
   Result,
 } from "@koi/core";
-import { agentId, messageId } from "@koi/core";
+import { agentId, matchesFilter, messageId } from "@koi/core";
 
 export { createMockAgent } from "@koi/test-utils";
 
@@ -76,5 +79,76 @@ export function createMockMailboxComponent(options?: {
         })
         .slice(0, filter.limit ?? messages.length);
     },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock AgentRegistry
+// ---------------------------------------------------------------------------
+
+const DEFAULT_REGISTRY_ENTRIES: readonly RegistryEntry[] = [
+  {
+    agentId: agentId("copilot-1"),
+    status: {
+      phase: "running",
+      generation: 1,
+      conditions: [],
+      lastTransitionAt: 1_700_000_000_000,
+    },
+    agentType: "copilot",
+    metadata: {},
+    registeredAt: 1_700_000_000_000,
+  },
+  {
+    agentId: agentId("worker-1"),
+    status: {
+      phase: "running",
+      generation: 1,
+      conditions: [],
+      lastTransitionAt: 1_700_000_001_000,
+    },
+    agentType: "worker",
+    metadata: {},
+    registeredAt: 1_700_000_001_000,
+  },
+  {
+    agentId: agentId("worker-2"),
+    status: {
+      phase: "suspended",
+      generation: 2,
+      conditions: [],
+      lastTransitionAt: 1_700_000_002_000,
+    },
+    agentType: "worker",
+    metadata: {},
+    registeredAt: 1_700_000_002_000,
+  },
+];
+
+/** Create a mock AgentRegistry backed by an in-memory array. */
+export function createMockRegistry(options?: {
+  readonly entries?: readonly RegistryEntry[];
+}): AgentRegistry {
+  const entries = options?.entries ?? DEFAULT_REGISTRY_ENTRIES;
+
+  return {
+    register: async (entry) => entry,
+    deregister: async () => true,
+    lookup: async (id) => entries.find((e) => e.agentId === id),
+    list: async (filter) => {
+      if (filter === undefined) return entries;
+      return entries.filter((e) => matchesFilter(e, filter));
+    },
+    transition: async (_id, _target, _gen, _reason) => ({
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "mock: transition not implemented",
+        retryable: false,
+        context: {},
+      },
+    }),
+    watch: () => () => {},
+    [Symbol.asyncDispose]: async () => {},
   };
 }

--- a/packages/ipc-nexus/src/tools/discover.test.ts
+++ b/packages/ipc-nexus/src/tools/discover.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { agentId } from "@koi/core";
+import { createMockRegistry } from "../test-helpers.js";
+import { createDiscoverTool } from "./discover.js";
+
+describe("createDiscoverTool", () => {
+  test("has correct descriptor", () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    expect(tool.descriptor.name).toBe("ipc_discover");
+    expect(tool.descriptor.description).toBeTruthy();
+    expect(tool.trustTier).toBe("verified");
+  });
+
+  test("respects custom prefix", () => {
+    const tool = createDiscoverTool(createMockRegistry(), "msg", "promoted");
+    expect(tool.descriptor.name).toBe("msg_discover");
+    expect(tool.trustTier).toBe("promoted");
+  });
+
+  test("returns running agents by default (no args)", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({})) as {
+      agents: readonly { agentId: string; phase: string }[];
+    };
+
+    expect(result.agents).toHaveLength(2);
+    for (const agent of result.agents) {
+      expect(agent.phase).toBe("running");
+    }
+  });
+
+  test("filters by agentType", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ agentType: "worker" })) as {
+      agents: readonly { agentId: string; agentType: string }[];
+    };
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]?.agentType).toBe("worker");
+  });
+
+  test("filters by phase", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ phase: "suspended" })) as {
+      agents: readonly { agentId: string; phase: string }[];
+    };
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]?.phase).toBe("suspended");
+  });
+
+  test("filters by both agentType and phase", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ agentType: "worker", phase: "running" })) as {
+      agents: readonly { agentId: string; agentType: string; phase: string }[];
+    };
+
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0]?.agentType).toBe("worker");
+    expect(result.agents[0]?.phase).toBe("running");
+  });
+
+  test("returns simplified shape with agentId, agentType, phase, registeredAt", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ agentType: "copilot" })) as {
+      agents: readonly Record<string, unknown>[];
+    };
+
+    expect(result.agents).toHaveLength(1);
+    const agent = result.agents[0];
+    expect(agent).toEqual({
+      agentId: agentId("copilot-1"),
+      agentType: "copilot",
+      phase: "running",
+      registeredAt: 1_700_000_000_000,
+    });
+  });
+
+  test("returns empty agents array when no matches", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ phase: "terminated" })) as {
+      agents: readonly unknown[];
+    };
+
+    expect(result.agents).toEqual([]);
+  });
+
+  test("returns validation error for invalid agentType", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ agentType: "manager" })) as {
+      error: string;
+      code: string;
+    };
+
+    expect(result.code).toBe("VALIDATION");
+    expect(result.error).toContain("Invalid agentType");
+    expect(result.error).toContain("manager");
+  });
+
+  test("returns validation error for invalid phase", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ phase: "paused" })) as {
+      error: string;
+      code: string;
+    };
+
+    expect(result.code).toBe("VALIDATION");
+    expect(result.error).toContain("Invalid phase");
+    expect(result.error).toContain("paused");
+  });
+
+  test("returns validation error for non-string agentType", async () => {
+    const tool = createDiscoverTool(createMockRegistry(), "ipc", "verified");
+    const result = (await tool.execute({ agentType: 42 })) as {
+      error: string;
+      code: string;
+    };
+
+    expect(result.code).toBe("VALIDATION");
+    expect(result.error).toContain("Invalid agentType");
+  });
+
+  test("returns internal error when registry throws", async () => {
+    const registry = createMockRegistry();
+    const failingRegistry = {
+      ...registry,
+      list: () => {
+        throw new Error("registry unavailable");
+      },
+    };
+
+    const tool = createDiscoverTool(failingRegistry, "ipc", "verified");
+    const result = (await tool.execute({})) as { error: string; code: string };
+
+    expect(result.code).toBe("INTERNAL");
+    expect(result.error).toContain("registry unavailable");
+  });
+});

--- a/packages/ipc-nexus/src/tools/discover.ts
+++ b/packages/ipc-nexus/src/tools/discover.ts
@@ -1,0 +1,85 @@
+/**
+ * Tool factory for ipc_discover — list live agents available for messaging.
+ */
+
+import type {
+  AgentRegistry,
+  JsonObject,
+  ProcessState,
+  RegistryFilter,
+  Tool,
+  TrustTier,
+} from "@koi/core";
+import { isProcessState } from "@koi/core";
+
+const VALID_AGENT_TYPES: ReadonlySet<string> = new Set(["copilot", "worker"]);
+
+export function createDiscoverTool(
+  registry: AgentRegistry,
+  prefix: string,
+  trustTier: TrustTier,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_discover`,
+      description: "List live agents available for messaging.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          agentType: {
+            type: "string",
+            description: "Filter by agent type: copilot or worker",
+          },
+          phase: {
+            type: "string",
+            description:
+              "Filter by process state: created, running, waiting, suspended, or terminated. Defaults to running.",
+          },
+        },
+        required: [],
+      } as JsonObject,
+    },
+    trustTier,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const rawType = args.agentType;
+      const rawPhase = args.phase;
+
+      if (
+        rawType !== undefined &&
+        (typeof rawType !== "string" || !VALID_AGENT_TYPES.has(rawType))
+      ) {
+        return {
+          error: `Invalid agentType: ${String(rawType)}. Must be one of: copilot, worker`,
+          code: "VALIDATION",
+        };
+      }
+
+      if (rawPhase !== undefined && (typeof rawPhase !== "string" || !isProcessState(rawPhase))) {
+        return {
+          error: `Invalid phase: ${String(rawPhase)}. Must be one of: created, running, waiting, suspended, terminated`,
+          code: "VALIDATION",
+        };
+      }
+
+      const phase: ProcessState = rawPhase !== undefined ? (rawPhase as ProcessState) : "running";
+
+      const filter: RegistryFilter = {
+        phase,
+        ...(rawType !== undefined ? { agentType: rawType as "copilot" | "worker" } : {}),
+      };
+
+      try {
+        const entries = await registry.list(filter);
+        const agents = entries.map((e) => ({
+          agentId: e.agentId,
+          agentType: e.agentType,
+          phase: e.status.phase,
+          registeredAt: e.registeredAt,
+        }));
+        return { agents };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e), code: "INTERNAL" };
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `ipc_discover` tool that queries `AgentRegistry` to let agents discover other live agents dynamically, instead of relying on hardcoded agent IDs
- Tool is conditionally attached via `createServiceProvider`'s `customTools` escape hatch — only when `registry` is provided in config (backward compatible)
- Add shared `createMockRegistry` test helper for DRY test setup across test files
- Update `docs/L2/ipc-nexus.md` with discover tool documentation, architecture diagrams, and config reference

## Design

- **No caching** — thin wrapper delegating directly to `registry.list()`, perf is the registry implementation's responsibility
- **Strict validation** — returns `{ error, code: "VALIDATION" }` for invalid `agentType` or `phase` values
- **Defaults to `phase: "running"`** — most useful default for agent discovery
- **Simplified output** — maps full `RegistryEntry` to `{ agentId, agentType, phase, registeredAt }` to minimize token usage

## Anti-Leak Checklist

- [x] `@koi/core` has zero changes
- [x] No vendor types in any file
- [x] L2 imports only from `@koi/core` (L0) and `@koi/test-utils` (L0u)
- [x] All interface properties `readonly`
- [x] Tool returns `Promise<unknown>` — async-compatible

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (`biome check`)
- [x] Build passes (`tsup`)
- [x] All 70 tests pass (12 new: discover tool unit tests + provider integration tests)
- [x] API surface snapshot updated
- [x] Pre-push hooks (typecheck + build) pass

Closes #608