### PR TITLE
feat: wire forge fitness decay, registry sync, and catalog ranking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "@koi/validation": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",

--- a/docs/L2/forge.md
+++ b/docs/L2/forge.md
@@ -1465,6 +1465,184 @@ with a real LLM.
 
 ---
 
+## Trust decay at discovery time (Issue #251)
+
+Fitness scores are recorded by `forge-usage-middleware` and ranked by `search_forge` — but
+previously, a brick promoted to `"promoted"` trust tier could stay there forever, even after
+its fitness score collapsed. Trust decay closes this loop: bricks with terrible runtime
+performance are automatically demoted at discovery time.
+
+### How it works
+
+`createForgeResolver()` evaluates `evaluateTrustDecay()` on every brick it returns:
+
+```
+  resolver.discover()
+      │
+      ├── store.search({})
+      ├── filterByAgentScope(results, agentId)
+      │
+      ├── for each visible brick:
+      │     │
+      │     ├── evaluateTrustDecay(brick, nowMs)
+      │     │     ├── brick.fitness undefined? → skip (no evidence)
+      │     │     ├── totalCalls === 0? → skip (no evidence)
+      │     │     ├── computeBrickFitness(brick.fitness, nowMs)
+      │     │     │
+      │     │     ├── promoted + score < 0.3 → demote to "verified"
+      │     │     ├── verified + score < 0.1 → demote to "sandbox"
+      │     │     └── sandbox → floor, never demote further
+      │     │
+      │     └── if demotion needed:
+      │           void store.update(id, { trustTier, lastDemotedAt })
+      │                 .then(() => onDecayDemotion(id, from, to))
+      │                 .catch(onError)              ← fire-and-forget
+      │
+      └── return visible bricks (unchanged, demotion is async)
+```
+
+The same check runs on `resolver.load(id)` for single-brick lookups.
+
+### Design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| **Where** | `discover()` + `load()` | Lazy eval at the point where bricks become visible |
+| **Blocking?** | Fire-and-forget | Discovery latency is not gated on store writes |
+| **Cap** | 5 async demotions per `discover()` | Prevents thundering herd on large stores |
+| **Sandbox floor** | Never demote below sandbox | Sandbox is the minimum trust tier |
+| **No data = no action** | Skip undefined fitness | Absence of evidence ≠ evidence of failure |
+| **Error handling** | `onDecayDemotion` + `onError` callbacks | Caller controls observability |
+
+### Configuration
+
+Decay thresholds are configurable via `DecayThresholds` (from `@koi/validation`):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `promotedDemotionThreshold` | `0.3` | Fitness below this demotes promoted → verified |
+| `verifiedDemotionThreshold` | `0.1` | Fitness below this demotes verified → sandbox |
+
+### Extended context
+
+```typescript
+const resolver = createForgeResolver(store, {
+  agentId: "agent-1",
+  onDecayDemotion: (brickId, from, to) => {
+    logger.info(`Brick ${brickId} demoted: ${from} → ${to}`);
+  },
+  onError: (error) => {
+    logger.warn("Decay demotion failed", { error });
+  },
+});
+```
+
+---
+
+## Forge → Registry sync
+
+When a brick is promoted (e.g., `agent → global` scope), it should become discoverable through
+the `BrickRegistryBackend` — not just the `ForgeStore`. `createForgeRegistrySync()` bridges
+this gap by listening for `"promoted"` store change events and auto-publishing to a registry.
+
+### How it works
+
+```
+  ForgeStore.watch()
+      │
+      ├── event.kind === "promoted"?
+      │     ├── no → ignore
+      │     └── yes:
+      │           ├── store.load(event.brickId)
+      │           ├── registry.register(brick)
+      │           ├── onPublished(brickId, name)     ← success callback
+      │           └── catch → onError(brickId, err)  ← fire-and-forget
+      │
+      └── returns unsubscribe function
+```
+
+### Usage
+
+```typescript
+const unsubscribe = createForgeRegistrySync({
+  forgeStore: store,
+  registry: brickRegistry,
+  onPublished: (id, name) => {
+    logger.info(`Published ${name} (${id}) to registry`);
+  },
+  onError: (id, error) => {
+    logger.warn(`Failed to publish ${id}`, { error });
+  },
+});
+
+// Later, to stop syncing:
+unsubscribe();
+```
+
+### Design decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| **Trigger** | `StoreChangeEvent` with `kind: "promoted"` | Only promotion events matter |
+| **Blocking?** | Fire-and-forget | Promotion response time is not gated on registry writes |
+| **Opt-in** | Caller creates the sync explicitly | Not all deployments need a registry |
+| **Cleanup** | Returns `() => void` unsubscribe | Standard teardown pattern |
+| **Requires watch** | Throws if `store.watch` undefined | Explicit contract requirement |
+
+---
+
+## Catalog fitness ranking
+
+The `CatalogEntry` interface in `@koi/core` now includes an optional `fitnessScore` field,
+allowing agents to rank and filter discovery results by runtime performance across all
+catalog sources.
+
+### The field
+
+```typescript
+interface CatalogEntry {
+  // ... existing fields ...
+  /** Composite fitness score in [0, 1]. Undefined if brick has no usage data. */
+  readonly fitnessScore?: number;
+}
+```
+
+### How it's computed
+
+The forge adapter in `@koi/catalog` computes fitness at search time:
+
+```
+  createForgeAdapter(store).search(query)
+      │
+      ├── nowMs = Date.now()      ← captured once per search call
+      ├── store.search(query)
+      │
+      └── for each brick:
+            mapBrickToEntry(brick, nowMs)
+              │
+              ├── brick.fitness defined + totalCalls > 0?
+              │     └── fitnessScore = computeBrickFitness(fitness, nowMs)
+              │
+              └── no fitness data → fitnessScore omitted (undefined)
+```
+
+### Why `Date.now()` once per call
+
+All bricks in a single search result are scored against the same timestamp. This ensures
+consistent relative ranking — brick A always compares to brick B at the same "now". The
+cost of `Date.now()` is ~2ns; the consistency benefit is worth it.
+
+### Source availability
+
+| Source | `fitnessScore` | Reason |
+|--------|---------------|--------|
+| `forged` | Yes (when brick has usage data) | Forge bricks track `BrickFitnessMetrics` |
+| `bundled` | No | Static entries, no runtime metrics |
+| `mcp` | No | External tools, no forge metrics |
+| `skill-registry` | No | Skills don't have forge fitness data |
+
+---
+
 ## Related
 
 - [Koi Architecture](../architecture/Koi.md) — system overview and layer rules
@@ -1474,3 +1652,4 @@ with a real LLM.
 - [#72](https://github.com/windoliver/koi/issues/72) — OS-level sandbox isolation (Seatbelt/bubblewrap/gVisor)
 - [#394](https://github.com/windoliver/koi/issues/394) — cross-device workspace sync via Nexus
 - [#151](https://github.com/windoliver/koi/issues/151) — fitness-scored brick discovery (runtime natural selection)
+- [#251](https://github.com/windoliver/koi/issues/251) — fitness signals in ForgeStore (natural selection for bricks)

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -10,7 +10,8 @@
     }
   },
   "dependencies": {
-    "@koi/core": "workspace:*"
+    "@koi/core": "workspace:*",
+    "@koi/validation": "workspace:*"
   },
   "devDependencies": {
     "@koi/engine": "workspace:*",

--- a/packages/catalog/src/adapters.test.ts
+++ b/packages/catalog/src/adapters.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { CatalogEntry, Resolver, Tool, ToolDescriptor } from "@koi/core";
+import type { BrickFitnessMetrics, CatalogEntry, Resolver, Tool, ToolDescriptor } from "@koi/core";
 import { skillId } from "@koi/core";
 import {
   createInMemoryBrickRegistry,
@@ -36,6 +36,66 @@ describe("createForgeAdapter", () => {
     expect(results[0]?.kind).toBe("tool");
     expect(results[0]?.source).toBe("forged");
     expect(results[0]?.description).toBe("A tool");
+  });
+
+  test("populates fitnessScore for brick with fitness data", async () => {
+    const registry = createInMemoryBrickRegistry();
+    const fitness: BrickFitnessMetrics = {
+      successCount: 10,
+      errorCount: 0,
+      latency: { samples: [100], count: 1, cap: 100 },
+      lastUsedAt: Date.now(),
+    };
+    const tool = createTestToolArtifact({
+      name: "fit-tool",
+      description: "A fit tool",
+      fitness,
+    });
+    registry.register(tool);
+
+    const adapter = createForgeAdapter(registry);
+    const results = await adapter.search({});
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.fitnessScore).toBeDefined();
+    expect(results[0]?.fitnessScore).toBeGreaterThan(0);
+  });
+
+  test("omits fitnessScore when brick has no fitness data", async () => {
+    const registry = createInMemoryBrickRegistry();
+    const tool = createTestToolArtifact({ name: "no-fitness", description: "No fitness" });
+    registry.register(tool);
+
+    const adapter = createForgeAdapter(registry);
+    const results = await adapter.search({});
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.fitnessScore).toBeUndefined();
+  });
+
+  test("fitnessScore is in [0, 1] range", async () => {
+    const registry = createInMemoryBrickRegistry();
+    const fitness: BrickFitnessMetrics = {
+      successCount: 50,
+      errorCount: 50,
+      latency: { samples: [200, 300, 500], count: 3, cap: 100 },
+      lastUsedAt: Date.now(),
+    };
+    const tool = createTestToolArtifact({
+      name: "bounded-tool",
+      description: "Bounded fitness",
+      fitness,
+    });
+    registry.register(tool);
+
+    const adapter = createForgeAdapter(registry);
+    const results = await adapter.search({});
+
+    expect(results).toHaveLength(1);
+    const score = results[0]?.fitnessScore;
+    expect(score).toBeDefined();
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
   });
 });
 

--- a/packages/catalog/src/adapters.ts
+++ b/packages/catalog/src/adapters.ts
@@ -17,6 +17,7 @@ import type {
   Tool,
   ToolDescriptor,
 } from "@koi/core";
+import { computeBrickFitness } from "@koi/validation";
 
 import type { CatalogSourceAdapter } from "./types.js";
 
@@ -63,7 +64,10 @@ function filterEntries(
 // Forge adapter
 // ---------------------------------------------------------------------------
 
-function mapBrickToEntry(brick: BrickArtifact): CatalogEntry {
+function mapBrickToEntry(brick: BrickArtifact, nowMs: number): CatalogEntry {
+  const fitness = brick.fitness;
+  const hasFitnessData = fitness !== undefined && fitness.successCount + fitness.errorCount > 0;
+
   return {
     name: prefixName("forged", brick.name),
     kind: brick.kind,
@@ -72,17 +76,19 @@ function mapBrickToEntry(brick: BrickArtifact): CatalogEntry {
     ...(brick.trustTier !== undefined ? { trustTier: brick.trustTier } : {}),
     ...(brick.tags.length > 0 ? { tags: brick.tags } : {}),
     ...(brick.version !== undefined ? { version: brick.version } : {}),
+    ...(hasFitnessData ? { fitnessScore: computeBrickFitness(fitness, nowMs) } : {}),
   };
 }
 
 export function createForgeAdapter(store: BrickRegistryReader): CatalogSourceAdapter {
   const search = async (query: CatalogQuery): Promise<readonly CatalogEntry[]> => {
+    const nowMs = Date.now();
     const page = await store.search({
       ...(query.kind !== undefined ? { kind: query.kind } : {}),
       ...(query.text !== undefined ? { text: query.text } : {}),
       ...(query.tags !== undefined ? { tags: [...query.tags] } : {}),
     });
-    return page.items.map(mapBrickToEntry);
+    return page.items.map((brick) => mapBrickToEntry(brick, nowMs));
   };
 
   const storeOnChange = store.onChange;

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -571,6 +571,8 @@ interface CatalogEntry {
     readonly trustTier?: "sandbox" | "verified" | "promoted";
     readonly version?: string;
     readonly tags?: readonly string[];
+    /** Composite fitness score in [0, 1]. Undefined if brick has no usage data. */
+    readonly fitnessScore?: number;
 }
 interface CatalogQuery {
     readonly kind?: BrickKind;

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -38,6 +38,8 @@ export interface CatalogEntry {
   readonly trustTier?: "sandbox" | "verified" | "promoted";
   readonly version?: string;
   readonly tags?: readonly string[];
+  /** Composite fitness score in [0, 1]. Undefined if brick has no usage data. */
+  readonly fitnessScore?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/forge/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/forge API surface . has stable type surface 1`] = `
-"import { BrickRequires, DataClassification, ContentMarker, TestCase, TrustTier, BrickId, BrickKind, ToolDescriptor, ForgeScope, BrickLifecycle, SandboxExecutor, BrickArtifact, ForgeStore, Result, KoiError, ForgeProvenance, SigningBackend, ToolArtifact, Tool, TieredSandboxExecutor, StoreChangeNotifier, ComponentProvider, DiagnosticProvider, SubsystemToken, GovernanceVariableContributor, Resolver, StoreChangeEvent, BrickComponentMap, KoiMiddleware, GovernanceController, SandboxErrorCode, SandboxError, InTotoStatementV1, AgentArtifact, ExecutionContext } from '@koi/core';
+"import { BrickRequires, DataClassification, ContentMarker, TestCase, TrustTier, BrickId, BrickKind, ToolDescriptor, ForgeScope, BrickLifecycle, SandboxExecutor, BrickArtifact, ForgeStore, Result, KoiError, ForgeProvenance, SigningBackend, ToolArtifact, Tool, TieredSandboxExecutor, StoreChangeNotifier, ComponentProvider, DiagnosticProvider, SubsystemToken, GovernanceVariableContributor, BrickRegistryWriter, Resolver, StoreChangeEvent, BrickComponentMap, KoiMiddleware, GovernanceController, SandboxErrorCode, SandboxError, InTotoStatementV1, AgentArtifact, ExecutionContext } from '@koi/core';
 export { AdvisoryLock, AgentArtifact, BrickArtifact, BrickArtifactBase, BrickRequires, BrickUpdate, ContentMarker, DataClassification, ForgeAttestationSignature, ForgeBuildDefinition, ForgeBuilder, ForgeProvenance, ForgeQuery, ForgeResourceRef, ForgeRunMetadata, ForgeStageDigest, ForgeStore, ForgeVerificationSummary, LockHandle, LockMode, LockRequest, SandboxError, SandboxErrorCode, SandboxExecutor, SandboxResult, SigningBackend, SkillArtifact, StoreChangeEvent, StoreChangeKind, StoreChangeNotifier, TestCase, TierResolution, TieredSandboxExecutor, ToolArtifact } from '@koi/core';
 import { BrickDescriptor } from '@koi/resolve';
 
@@ -599,12 +599,39 @@ declare const FORGE_GOVERNANCE: SubsystemToken<GovernanceVariableContributor>;
 declare function createForgeGovernanceContributor(config: ForgeConfig, readDepth: () => number, readForgeCount: () => number): GovernanceVariableContributor;
 
 /**
+ * Forge → Registry sync — publishes promoted bricks to a BrickRegistryWriter.
+ *
+ * Subscribes to ForgeStore.watch() for "promoted" events and fires
+ * registry.register() in a fire-and-forget pattern. Opt-in via factory.
+ */
+
+interface ForgeRegistrySyncConfig {
+    readonly forgeStore: ForgeStore;
+    readonly registry: BrickRegistryWriter;
+    /** Called after a brick is successfully published to the registry. */
+    readonly onPublished?: (brickId: string, name: string) => void;
+    /** Called when loading or registering a promoted brick fails. */
+    readonly onError?: (brickId: string, error: unknown) => void;
+}
+/**
+ * Creates a sync listener that auto-publishes promoted bricks to a registry.
+ *
+ * Returns an unsubscribe function. Call it to stop listening.
+ * Requires \`forgeStore.watch\` to be defined — throws otherwise.
+ */
+declare function createForgeRegistrySync(config: ForgeRegistrySyncConfig): () => void;
+
+/**
  * ForgeResolver — Resolver adapter backed by a ForgeStore.
  * Implements the L0 Resolver<BrickArtifact, BrickArtifact> interface.
  */
 
 interface ForgeResolverContext {
     readonly agentId: string;
+    /** Called when a brick is demoted due to fitness decay. */
+    readonly onDecayDemotion?: (brickId: string, from: TrustTier, to: TrustTier) => void;
+    /** Called when a decay-related store update or callback throws. */
+    readonly onError?: (error: unknown) => void;
 }
 declare function createForgeResolver(store: ForgeStore, context: ForgeResolverContext): Resolver<BrickArtifact, BrickArtifact>;
 
@@ -1261,6 +1288,6 @@ interface ScanResult {
  */
 declare function scanWorkspaceCode(workspacePath: string, _config: DependencyConfig): Promise<Result<ScanResult, ForgeError>>;
 
-export { type AssembleManifestOptions, type AssembleManifestResult, type AttestationCache, type AutoPromotionConfig, type CodeSnippet, type CreateForgeRuntimeOptions, type CreateProvenanceOptions, DEFAULT_REVERIFICATION_CONFIG, type DependencyConfig, type DiagnosticVerifierConfig, type EnrichedSandboxError, FORGE_GOVERNANCE, type ForgeAgentInput, type ForgeAgentInputWithBricks, type ForgeAgentInputWithManifest, type ForgeChannelInput, type ForgeComponentProviderConfig, type ForgeComponentProviderInstance, type ForgeConfig, type ForgeContext, type ForgeDeps, type ForgeError, type ForgeInput, type ForgeInputBase, type ForgeMiddlewareInput, type ForgeResolverContext, type ForgeResult, type ForgeResultMetadata, type ForgeRuntimeInstance, type ForgeSkillInput, type ForgeToolConfig, type ForgeToolInput, type ForgeUsageMiddlewareConfig, type ForgeVerifier, type FormatConfig, type FormatStageReport, type GovernanceResult, type IntegrityAttestationFailed, type IntegrityContentMismatch, type IntegrityOk, type IntegrityResult, type ManifestParseResult, type ManifestParser, type NetworkPolicy, type OnForgeAgentSpawn, type PromoteChange, type PromoteResult, type RequiresCheckResult, type ResolveStageReport, type ReverificationConfig, type ReverificationHandler, type ReverificationQueue, type ScanFinding, type ScanResult, type ScopePromotionConfig, type SkillMdInput, type SlsaBuildDefinition, type SlsaBuildMetadata, type SlsaBuilder, type SlsaKoiExtensions, type SlsaProvenanceV1, type SlsaProvenanceV1WithExtensions, type SlsaResourceDescriptor, type SlsaRunDetails, type StageReport, type TestFailure, type TrustStageReport, type UsagePromotedResult, type UsageRecordedResult, type UsageResult, type VerificationConfig, type VerificationReport, type VerificationStage, type VerifierResult, type WorkspaceResult, assembleManifest, assignTrust, auditDependencies, auditTransitiveDependencies, brickToTool, canonicalJsonSerialize, checkBrickRequires, checkGovernance, checkScopePromotion, cleanupStaleWorkspaces, computeAutoPromotion, computeDependencyHash, computeRemediation, computeTtl, createAdversarialVerifiers, createAttestationCache, createBrickWorkspace, createComposeForge, createContentScanningVerifier, createDefaultForgeConfig, createDiagnosticVerifier, createExfiltrationVerifier, createForgeAgentTool, createForgeChannelTool, createForgeComponentProvider, createForgeEditTool, createForgeGovernanceContributor, createForgeMiddlewareTool, createForgeProvenance, createForgeResolver, createForgeRuntime, createForgeSkillTool, createForgeTool, createForgeToolTool, createForgeUsageMiddleware, createInMemoryForgeStore, createInjectionVerifier, createMemoryStoreChangeNotifier, createPromoteForgeTool, createResourceExhaustionVerifier, createReverificationQueue, createSearchForgeTool, createStructuralHidingVerifier, descriptor, enrichSandboxError, extractBrickContent, extractSnippet, filterByAgentScope, formatError, generateSkillMd, governanceError, isStale, isVisibleToAgent, loadAndVerify, mapProvenanceToSlsa, mapProvenanceToStatement, recordBrickUsage, resolveError, resolveWorkspacePath, sandboxError, sanitizeInput, scanWorkspaceCode, selfTestError, signAttestation, staticError, storeError, trustError, typeError, validateForgeConfig, verify, verifyAttestation, verifyBrickAttestation, verifyBrickIntegrity, verifyFormat, verifyInstallIntegrity, verifyResolve, verifySandbox, verifySelfTest, verifyStatic, writeBrickEntry };
+export { type AssembleManifestOptions, type AssembleManifestResult, type AttestationCache, type AutoPromotionConfig, type CodeSnippet, type CreateForgeRuntimeOptions, type CreateProvenanceOptions, DEFAULT_REVERIFICATION_CONFIG, type DependencyConfig, type DiagnosticVerifierConfig, type EnrichedSandboxError, FORGE_GOVERNANCE, type ForgeAgentInput, type ForgeAgentInputWithBricks, type ForgeAgentInputWithManifest, type ForgeChannelInput, type ForgeComponentProviderConfig, type ForgeComponentProviderInstance, type ForgeConfig, type ForgeContext, type ForgeDeps, type ForgeError, type ForgeInput, type ForgeInputBase, type ForgeMiddlewareInput, type ForgeRegistrySyncConfig, type ForgeResolverContext, type ForgeResult, type ForgeResultMetadata, type ForgeRuntimeInstance, type ForgeSkillInput, type ForgeToolConfig, type ForgeToolInput, type ForgeUsageMiddlewareConfig, type ForgeVerifier, type FormatConfig, type FormatStageReport, type GovernanceResult, type IntegrityAttestationFailed, type IntegrityContentMismatch, type IntegrityOk, type IntegrityResult, type ManifestParseResult, type ManifestParser, type NetworkPolicy, type OnForgeAgentSpawn, type PromoteChange, type PromoteResult, type RequiresCheckResult, type ResolveStageReport, type ReverificationConfig, type ReverificationHandler, type ReverificationQueue, type ScanFinding, type ScanResult, type ScopePromotionConfig, type SkillMdInput, type SlsaBuildDefinition, type SlsaBuildMetadata, type SlsaBuilder, type SlsaKoiExtensions, type SlsaProvenanceV1, type SlsaProvenanceV1WithExtensions, type SlsaResourceDescriptor, type SlsaRunDetails, type StageReport, type TestFailure, type TrustStageReport, type UsagePromotedResult, type UsageRecordedResult, type UsageResult, type VerificationConfig, type VerificationReport, type VerificationStage, type VerifierResult, type WorkspaceResult, assembleManifest, assignTrust, auditDependencies, auditTransitiveDependencies, brickToTool, canonicalJsonSerialize, checkBrickRequires, checkGovernance, checkScopePromotion, cleanupStaleWorkspaces, computeAutoPromotion, computeDependencyHash, computeRemediation, computeTtl, createAdversarialVerifiers, createAttestationCache, createBrickWorkspace, createComposeForge, createContentScanningVerifier, createDefaultForgeConfig, createDiagnosticVerifier, createExfiltrationVerifier, createForgeAgentTool, createForgeChannelTool, createForgeComponentProvider, createForgeEditTool, createForgeGovernanceContributor, createForgeMiddlewareTool, createForgeProvenance, createForgeRegistrySync, createForgeResolver, createForgeRuntime, createForgeSkillTool, createForgeTool, createForgeToolTool, createForgeUsageMiddleware, createInMemoryForgeStore, createInjectionVerifier, createMemoryStoreChangeNotifier, createPromoteForgeTool, createResourceExhaustionVerifier, createReverificationQueue, createSearchForgeTool, createStructuralHidingVerifier, descriptor, enrichSandboxError, extractBrickContent, extractSnippet, filterByAgentScope, formatError, generateSkillMd, governanceError, isStale, isVisibleToAgent, loadAndVerify, mapProvenanceToSlsa, mapProvenanceToStatement, recordBrickUsage, resolveError, resolveWorkspacePath, sandboxError, sanitizeInput, scanWorkspaceCode, selfTestError, signAttestation, staticError, storeError, trustError, typeError, validateForgeConfig, verify, verifyAttestation, verifyBrickAttestation, verifyBrickIntegrity, verifyFormat, verifyInstallIntegrity, verifyResolve, verifySandbox, verifySelfTest, verifyStatic, writeBrickEntry };
 "
 `;

--- a/packages/forge/src/forge-registry-sync.test.ts
+++ b/packages/forge/src/forge-registry-sync.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifact, BrickRegistryWriter, KoiError, Result } from "@koi/core";
+import { brickId } from "@koi/core";
+import { DEFAULT_PROVENANCE } from "@koi/test-utils";
+import { createForgeRegistrySync } from "./forge-registry-sync.js";
+import { createInMemoryForgeStore } from "./memory-store.js";
+import type { ToolArtifact } from "./types.js";
+
+function createBrick(overrides?: Partial<ToolArtifact>): ToolArtifact {
+  return {
+    id: brickId(`brick_${Math.random().toString(36).slice(2, 10)}`),
+    kind: "tool",
+    name: "test-brick",
+    description: "A test brick",
+    scope: "agent",
+    trustTier: "promoted",
+    lifecycle: "active",
+    provenance: DEFAULT_PROVENANCE,
+    version: "0.0.1",
+    tags: [],
+    usageCount: 0,
+    implementation: "return 1;",
+    inputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+function createMockRegistry(
+  registerFn?: (brick: BrickArtifact) => Result<void, KoiError> | Promise<Result<void, KoiError>>,
+): BrickRegistryWriter {
+  return {
+    register: registerFn ?? (async () => ({ ok: true as const, value: undefined })),
+    unregister: async () => ({ ok: true as const, value: undefined }),
+  };
+}
+
+describe("createForgeRegistrySync", () => {
+  test("publishes brick to registry on promoted event", async () => {
+    const store = createInMemoryForgeStore();
+    const brick = createBrick({ id: brickId("b1"), name: "promoted-tool" });
+    await store.save(brick);
+
+    const registered: string[] = [];
+    const registry = createMockRegistry(async (b) => {
+      registered.push(b.name);
+      return { ok: true, value: undefined };
+    });
+
+    const published: Array<{ brickId: string; name: string }> = [];
+    createForgeRegistrySync({
+      forgeStore: store,
+      registry,
+      onPublished: (id, name) => {
+        published.push({ brickId: id, name });
+      },
+    });
+
+    // Trigger a promotion event by calling promoteAndUpdate
+    await store.promoteAndUpdate?.(brickId("b1"), "global", { trustTier: "promoted" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0]).toBe("promoted-tool");
+    expect(published).toHaveLength(1);
+    expect(published[0]?.name).toBe("promoted-tool");
+  });
+
+  test("ignores non-promotion events (saved, updated, removed)", async () => {
+    const store = createInMemoryForgeStore();
+    const brick = createBrick({ id: brickId("b1") });
+
+    const registered: string[] = [];
+    const registry = createMockRegistry(async (b) => {
+      registered.push(b.name);
+      return { ok: true, value: undefined };
+    });
+
+    createForgeRegistrySync({ forgeStore: store, registry });
+
+    // save → "saved" event
+    await store.save(brick);
+    // update → "updated" event
+    await store.update(brickId("b1"), { usageCount: 5 });
+    // remove → "removed" event
+    await store.remove(brickId("b1"));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(registered).toHaveLength(0);
+  });
+
+  test("calls onError when registry.register fails", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: brickId("b1") }));
+
+    const registry = createMockRegistry(async () => {
+      throw new Error("registry unavailable");
+    });
+
+    const errors: Array<{ brickId: string; error: unknown }> = [];
+    createForgeRegistrySync({
+      forgeStore: store,
+      registry,
+      onError: (id, err) => {
+        errors.push({ brickId: id, error: err });
+      },
+    });
+
+    await store.promoteAndUpdate?.(brickId("b1"), "global", { trustTier: "promoted" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.brickId).toBe(brickId("b1"));
+    expect(errors[0]?.error).toBeInstanceOf(Error);
+    if (errors[0]?.error instanceof Error) {
+      expect(errors[0].error.message).toBe("registry unavailable");
+    }
+  });
+
+  test("calls onPublished on success", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: brickId("b1"), name: "my-tool" }));
+
+    const registry = createMockRegistry();
+    const published: Array<{ brickId: string; name: string }> = [];
+
+    createForgeRegistrySync({
+      forgeStore: store,
+      registry,
+      onPublished: (id, name) => {
+        published.push({ brickId: id, name });
+      },
+    });
+
+    await store.promoteAndUpdate?.(brickId("b1"), "global", { trustTier: "promoted" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.brickId).toBe(brickId("b1"));
+    expect(published[0]?.name).toBe("my-tool");
+  });
+
+  test("unsubscribe stops listening", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(createBrick({ id: brickId("b1") }));
+
+    const registered: string[] = [];
+    const registry = createMockRegistry(async (b) => {
+      registered.push(b.name);
+      return { ok: true, value: undefined };
+    });
+
+    const unsubscribe = createForgeRegistrySync({ forgeStore: store, registry });
+
+    // Unsubscribe before triggering promotion
+    unsubscribe();
+
+    await store.promoteAndUpdate?.(brickId("b1"), "global", { trustTier: "promoted" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(registered).toHaveLength(0);
+  });
+});

--- a/packages/forge/src/forge-registry-sync.ts
+++ b/packages/forge/src/forge-registry-sync.ts
@@ -1,0 +1,68 @@
+/**
+ * Forge → Registry sync — publishes promoted bricks to a BrickRegistryWriter.
+ *
+ * Subscribes to ForgeStore.watch() for "promoted" events and fires
+ * registry.register() in a fire-and-forget pattern. Opt-in via factory.
+ */
+
+import type { BrickRegistryWriter, ForgeStore } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface ForgeRegistrySyncConfig {
+  readonly forgeStore: ForgeStore;
+  readonly registry: BrickRegistryWriter;
+  /** Called after a brick is successfully published to the registry. */
+  readonly onPublished?: (brickId: string, name: string) => void;
+  /** Called when loading or registering a promoted brick fails. */
+  readonly onError?: (brickId: string, error: unknown) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a sync listener that auto-publishes promoted bricks to a registry.
+ *
+ * Returns an unsubscribe function. Call it to stop listening.
+ * Requires `forgeStore.watch` to be defined — throws otherwise.
+ */
+export function createForgeRegistrySync(config: ForgeRegistrySyncConfig): () => void {
+  const { forgeStore, registry, onPublished, onError } = config;
+
+  if (forgeStore.watch === undefined) {
+    throw new Error(
+      "ForgeRegistrySync requires a ForgeStore with watch() support. " +
+        "The provided store does not implement watch().",
+    );
+  }
+
+  const unsubscribe = forgeStore.watch((event) => {
+    if (event.kind !== "promoted") return;
+
+    const { brickId } = event;
+
+    void (async () => {
+      const loadResult = await forgeStore.load(brickId);
+      if (!loadResult.ok) {
+        onError?.(brickId, new Error(`Failed to load promoted brick: ${loadResult.error.message}`));
+        return;
+      }
+
+      const registerResult = await registry.register(loadResult.value);
+      if (!registerResult.ok) {
+        onError?.(brickId, new Error(`Failed to register brick: ${registerResult.error.message}`));
+        return;
+      }
+
+      onPublished?.(brickId, loadResult.value.name);
+    })().catch((e: unknown) => {
+      onError?.(brickId, e);
+    });
+  });
+
+  return unsubscribe;
+}

--- a/packages/forge/src/forge-resolver.test.ts
+++ b/packages/forge/src/forge-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { BrickFitnessMetrics, TrustTier } from "@koi/core";
 import { brickId } from "@koi/core";
 import { DEFAULT_PROVENANCE } from "@koi/test-utils";
 import { createForgeResolver, extractSource } from "./forge-resolver.js";
@@ -228,6 +229,192 @@ describe("createForgeResolver", () => {
     expect(result).toBeDefined();
     if (result === undefined) return;
     expect(result.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust decay in discover / load
+// ---------------------------------------------------------------------------
+
+/** Creates a fitness metrics object with a given success rate. */
+function createFitness(
+  successCount: number,
+  errorCount: number,
+  lastUsedAt?: number,
+): BrickFitnessMetrics {
+  return {
+    successCount,
+    errorCount,
+    latency: { samples: [100], count: 1, cap: 100 },
+    lastUsedAt: lastUsedAt ?? Date.now(),
+  };
+}
+
+describe("trust decay in discover", () => {
+  test("demotes brick with low fitness score", async () => {
+    const store = createInMemoryForgeStore();
+    // 0% success rate → score 0 → below promoted demotion threshold (0.3)
+    await store.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "promoted",
+        fitness: createFitness(0, 100),
+      }),
+    );
+
+    const demotions: Array<{ brickId: string; from: TrustTier; to: TrustTier }> = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onDecayDemotion: (id, from, to) => {
+        demotions.push({ brickId: id, from, to });
+      },
+    });
+
+    await resolver.discover();
+    // Fire-and-forget — wait a tick for the async update to complete
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(demotions).toHaveLength(1);
+    expect(demotions[0]?.brickId).toBe(brickId("b1"));
+    expect(demotions[0]?.from).toBe("promoted");
+    expect(demotions[0]?.to).toBe("verified");
+  });
+
+  test("does not demote brick with high fitness", async () => {
+    const store = createInMemoryForgeStore();
+    // 100% success rate, recently used → high score
+    await store.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "promoted",
+        fitness: createFitness(100, 0),
+      }),
+    );
+
+    const demotions: string[] = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onDecayDemotion: (id) => {
+        demotions.push(id);
+      },
+    });
+
+    await resolver.discover();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(demotions).toHaveLength(0);
+  });
+
+  test("does not demote brick with no fitness data", async () => {
+    const store = createInMemoryForgeStore();
+    await store.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "promoted",
+        // no fitness field → undefined → no demotion
+      }),
+    );
+
+    const demotions: string[] = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onDecayDemotion: (id) => {
+        demotions.push(id);
+      },
+    });
+
+    await resolver.discover();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(demotions).toHaveLength(0);
+  });
+
+  test("fires onDecayDemotion callback with correct from/to tiers", async () => {
+    const store = createInMemoryForgeStore();
+    // verified brick with 0% success → below verified demotion threshold (0.1) → sandbox
+    await store.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "verified",
+        fitness: createFitness(0, 50),
+      }),
+    );
+
+    const demotions: Array<{ from: TrustTier; to: TrustTier }> = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onDecayDemotion: (_id, from, to) => {
+        demotions.push({ from, to });
+      },
+    });
+
+    await resolver.discover();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(demotions).toHaveLength(1);
+    expect(demotions[0]?.from).toBe("verified");
+    expect(demotions[0]?.to).toBe("sandbox");
+  });
+
+  test("handles store.update failure via onError", async () => {
+    const inner = createInMemoryForgeStore();
+    await inner.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "promoted",
+        fitness: createFitness(0, 100),
+      }),
+    );
+
+    // Wrap store with a failing update method
+    const store = {
+      ...inner,
+      update: async () => {
+        throw new Error("store update failed");
+      },
+    };
+
+    const errors: unknown[] = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onError: (e) => {
+        errors.push(e);
+      },
+    });
+
+    await resolver.discover();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    if (errors[0] instanceof Error) {
+      expect(errors[0].message).toBe("store update failed");
+    }
+  });
+
+  test("never demotes sandbox bricks (floor)", async () => {
+    const store = createInMemoryForgeStore();
+    // Sandbox brick with terrible fitness — should NOT be demoted further
+    await store.save(
+      createBrick({
+        id: brickId("b1"),
+        trustTier: "sandbox",
+        fitness: createFitness(0, 100),
+      }),
+    );
+
+    const demotions: string[] = [];
+    const resolver = createForgeResolver(store, {
+      agentId: "agent-1",
+      onDecayDemotion: (id) => {
+        demotions.push(id);
+      },
+    });
+
+    await resolver.discover();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(demotions).toHaveLength(0);
   });
 });
 

--- a/packages/forge/src/forge-resolver.ts
+++ b/packages/forge/src/forge-resolver.ts
@@ -10,8 +10,10 @@ import type {
   Resolver,
   Result,
   SourceBundle,
+  TrustTier,
 } from "@koi/core";
 import { brickId } from "@koi/core";
+import { evaluateTrustDecay } from "@koi/validation";
 import { filterByAgentScope, isVisibleToAgent } from "./scope-filter.js";
 
 // ---------------------------------------------------------------------------
@@ -36,8 +38,15 @@ export function extractSource(brick: BrickArtifact): SourceBundle {
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Maximum number of async demotion updates per discover() call. */
+const MAX_DECAY_DEMOTIONS_PER_DISCOVER = 5;
+
 export interface ForgeResolverContext {
   readonly agentId: string;
+  /** Called when a brick is demoted due to fitness decay. */
+  readonly onDecayDemotion?: (brickId: string, from: TrustTier, to: TrustTier) => void;
+  /** Called when a decay-related store update or callback throws. */
+  readonly onError?: (error: unknown) => void;
 }
 
 /**
@@ -49,6 +58,27 @@ function notFoundError(id: string): Result<never, KoiError> {
     ok: false,
     error: { code: "NOT_FOUND", message: `Brick not found: ${id}`, retryable: false },
   };
+}
+
+/**
+ * Fires an async store.update() to demote a brick, capped by the demotion counter.
+ * Errors are routed to `onError`, never thrown.
+ */
+function fireDemotion(
+  store: ForgeStore,
+  brick: BrickArtifact,
+  targetTier: TrustTier,
+  nowMs: number,
+  context: ForgeResolverContext,
+): void {
+  void store
+    .update(brick.id, { trustTier: targetTier, lastDemotedAt: nowMs })
+    .then(() => {
+      context.onDecayDemotion?.(brick.id, brick.trustTier, targetTier);
+    })
+    .catch((e: unknown) => {
+      context.onError?.(e);
+    });
 }
 
 export function createForgeResolver(
@@ -67,13 +97,35 @@ export function createForgeResolver(
         cause: result.error,
       });
     }
-    return filterByAgentScope(result.value, agentId);
+    const visible = filterByAgentScope(result.value, agentId);
+
+    // Lazy trust decay — evaluate fitness on each visible brick
+    const nowMs = Date.now();
+    let demotionCount = 0; // let: incremented per demotion in loop
+    for (const brick of visible) {
+      if (demotionCount >= MAX_DECAY_DEMOTIONS_PER_DISCOVER) break;
+      const targetTier = evaluateTrustDecay(brick, nowMs);
+      if (targetTier !== undefined) {
+        demotionCount++;
+        fireDemotion(store, brick, targetTier, nowMs, context);
+      }
+    }
+
+    return visible;
   };
 
   const load = async (id: string): Promise<Result<BrickArtifact, KoiError>> => {
     const result = await store.load(brickId(id));
     if (!result.ok) return result;
     if (!isVisibleToAgent(result.value, agentId)) return notFoundError(id);
+
+    // Lazy trust decay on load
+    const nowMs = Date.now();
+    const targetTier = evaluateTrustDecay(result.value, nowMs);
+    if (targetTier !== undefined) {
+      fireDemotion(store, result.value, targetTier, nowMs, context);
+    }
+
     return result;
   };
 

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -105,6 +105,8 @@ export {
   createForgeGovernanceContributor,
   FORGE_GOVERNANCE,
 } from "./forge-governance-contributor.js";
+export type { ForgeRegistrySyncConfig } from "./forge-registry-sync.js";
+export { createForgeRegistrySync } from "./forge-registry-sync.js";
 export type { ForgeResolverContext } from "./forge-resolver.js";
 export { createForgeResolver } from "./forge-resolver.js";
 export type { CreateForgeRuntimeOptions, ForgeRuntimeInstance } from "./forge-runtime.js";

--- a/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/validation API surface . has stable type surface 1`] = `
-"import { BrickArtifactBase, BrickUpdate, Result, BrickArtifact, KoiError, BrickFitnessMetrics, LatencySampler, ForgeQuery } from '@koi/core';
+"import { BrickArtifactBase, BrickUpdate, Result, BrickArtifact, KoiError, BrickFitnessMetrics, TrustTier, LatencySampler, ForgeQuery } from '@koi/core';
 import { z } from 'zod';
 
 /**
@@ -69,6 +69,23 @@ declare const DEFAULT_FITNESS_SCORING_CONFIG: FitnessScoringConfig;
  * @param config - Optional partial config (merged with defaults).
  */
 declare function computeBrickFitness(metrics: BrickFitnessMetrics, nowMs: number, config?: Partial<FitnessScoringConfig>): number;
+/** Thresholds for fitness-based trust decay. */
+interface DecayThresholds {
+    /** Fitness score below which a promoted brick should be demoted to verified. Default: 0.3. */
+    readonly promotedDemotionThreshold: number;
+    /** Fitness score below which a verified brick should be demoted to sandbox. Default: 0.1. */
+    readonly verifiedDemotionThreshold: number;
+}
+declare const DEFAULT_DECAY_THRESHOLDS: DecayThresholds;
+/**
+ * Evaluates whether a brick's fitness has decayed enough to warrant trust demotion.
+ *
+ * Returns the target tier if demotion is needed, \`undefined\` if no change.
+ * This is a pure scoring function — callers are responsible for executing the demotion.
+ *
+ * Does NOT demote bricks with zero usage (no evidence = no demotion).
+ */
+declare function evaluateTrustDecay(brick: BrickArtifactBase, nowMs: number, config?: Partial<FitnessScoringConfig>, thresholds?: Partial<DecayThresholds>): TrustTier | undefined;
 
 /**
  * Bounded sorted-sample buffer for percentile estimation.
@@ -186,6 +203,6 @@ declare function zodToKoiError(zodError: z.core.$ZodError, prefix?: string): Koi
  */
 declare function validateWith<T>(schema: z.ZodType<T>, raw: unknown, prefix?: string): Result<T, KoiError>;
 
-export { DEFAULT_FITNESS_SCORING_CONFIG, type FitnessScoringConfig, SEVERITY_ORDER, type Severity, type SortBricksOptions, applyBrickUpdate, computeBrickFitness, computePercentile, createLatencySampler, levenshteinDistance, matchesBrickQuery, mergeSamplers, recordLatency, severityAtOrAbove, sortBricks, validateBrickArtifact, validateWith, zodToKoiError };
+export { DEFAULT_DECAY_THRESHOLDS, DEFAULT_FITNESS_SCORING_CONFIG, type DecayThresholds, type FitnessScoringConfig, SEVERITY_ORDER, type Severity, type SortBricksOptions, applyBrickUpdate, computeBrickFitness, computePercentile, createLatencySampler, evaluateTrustDecay, levenshteinDistance, matchesBrickQuery, mergeSamplers, recordLatency, severityAtOrAbove, sortBricks, validateBrickArtifact, validateWith, zodToKoiError };
 "
 `;

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -10,7 +10,10 @@ export { applyBrickUpdate } from "./apply-brick-update.js";
 export { validateBrickArtifact } from "./brick-validation.js";
 export {
   computeBrickFitness,
+  DEFAULT_DECAY_THRESHOLDS,
   DEFAULT_FITNESS_SCORING_CONFIG,
+  type DecayThresholds,
+  evaluateTrustDecay,
   type FitnessScoringConfig,
 } from "./fitness-scoring.js";
 export {


### PR DESCRIPTION
## Summary

Closes the three remaining integration gaps in **Forge Phase 3 (Crystallization + Trust Promotion)** and **Phase 5 (Ecosystem)**:

- **Trust decay in ForgeResolver** — `evaluateTrustDecay()` is now called lazily in `discover()` and `load()`. Bricks with collapsed fitness are async-demoted via fire-and-forget `store.update()`, capped at 5 per discover call. Callbacks: `onDecayDemotion` + `onError`.
- **Forge → Registry sync** — `createForgeRegistrySync()` subscribes to `ForgeStore.watch()` for `"promoted"` events and auto-publishes to `BrickRegistryWriter`. Fire-and-forget with error callback. Returns unsubscribe function.
- **Catalog fitness ranking** — `CatalogEntry` gains optional `fitnessScore` field (`[0, 1]`). The forge adapter computes it via `computeBrickFitness()` at search time with a single `Date.now()` per call for consistency.

Also exports `evaluateTrustDecay`, `DecayThresholds`, `DEFAULT_DECAY_THRESHOLDS` from `@koi/validation`, and adds documentation for all three features in `docs/L2/forge.md`.

## Files changed (15)

| File | Change |
|------|--------|
| `packages/forge/src/forge-resolver.ts` | Trust decay wiring in discover/load |
| `packages/forge/src/forge-resolver.test.ts` | +6 trust decay tests |
| `packages/forge/src/forge-registry-sync.ts` | **New**: promotion → registry sync |
| `packages/forge/src/forge-registry-sync.test.ts` | **New**: 5 sync tests |
| `packages/forge/src/index.ts` | Export new factory + type |
| `packages/core/src/catalog.ts` | +1 optional `fitnessScore` field |
| `packages/catalog/src/adapters.ts` | Compute fitness in forge adapter |
| `packages/catalog/src/adapters.test.ts` | +3 fitness score tests |
| `packages/catalog/package.json` | Add `@koi/validation` dependency |
| `packages/validation/src/index.ts` | Export `evaluateTrustDecay` + types |
| `docs/L2/forge.md` | +3 sections: decay, sync, catalog fitness |
| API surface snapshots (×3) | Updated for new exports |

## Anti-leak checklist

- [x] `@koi/core` has zero new imports (only adds 1 optional field)
- [x] `@koi/forge` (L2) only imports from `@koi/core` (L0) and `@koi/validation` (L0u)
- [x] `@koi/catalog` (L2) only imports from `@koi/core` (L0) and `@koi/validation` (L0u)
- [x] All new interface properties are `readonly`
- [x] No `class`, no `enum`, no `any`, no `as Type` assertions
- [x] Fire-and-forget uses `void promise.catch(onError)` pattern
- [x] All catch blocks use `catch (e: unknown)` or `catch (_: unknown)`

## Test plan

- [x] 6 trust decay tests (demote low fitness, skip high fitness, skip no data, correct tiers, error handling, sandbox floor)
- [x] 5 registry sync tests (publish on promote, ignore other events, error callback, success callback, unsubscribe)
- [x] 3 catalog fitness tests (score populated, omitted when no data, bounded [0,1])
- [x] All 1790 tests pass across core/forge/validation/catalog
- [x] Full build (159 packages) + typecheck + biome lint pass

Relates to #251