### PR TITLE
feat: add L0 anti-leak audit to check-layers

### DIFF
--- a/docs/architecture/ci-enforcement.md
+++ b/docs/architecture/ci-enforcement.md
@@ -25,12 +25,14 @@ scripts/check-layers.ts    ← enforcement (package.json deps + source-file impo
 scripts/check-layers.test.ts
 ```
 
-**`scripts/check-layers.ts`** runs two kinds of checks:
+**`scripts/check-layers.ts`** runs four kinds of checks:
 
-| Check | What it validates |
-|-------|------------------|
-| `package.json` dep check | Each package's declared deps obey the layer rules below |
-| Source-file import scan | L0 source never imports an external module; L2 source never imports from L1 |
+| # | Check | What it validates |
+|---|-------|------------------|
+| 1 | `package.json` dep check | Each package's declared deps obey the layer rules below |
+| 2 | L0 source import scan | `@koi/core` source never imports an external module |
+| 3 | L2 source import scan | L2 non-test source never imports from L1 (`@koi/engine`) |
+| 4 | L0 anti-leak audit | `@koi/core` has zero class declarations and no unlisted function bodies |
 
 #### Layer dependency rules (package.json)
 
@@ -51,6 +53,34 @@ scripts/check-layers.test.ts
 
 The scanner uses **`Bun.Transpiler` AST** (not regex) so commented-out imports are never
 flagged. A regex supplement captures `import type` statements that the transpiler elides.
+
+#### L0 anti-leak audit (class & function body enforcement)
+
+`@koi/core` is an interfaces-only kernel. The anti-leak audit enforces two rules on every
+non-test `.ts` file in `packages/core/src/`:
+
+| Rule | Policy | Exceptions |
+|------|--------|------------|
+| **No class declarations** | `class`, `export class`, `abstract class` — all forbidden | None |
+| **No function bodies** | `function`, `export function`, `export const x = (` — all forbidden | Files listed in `L0_RUNTIME_ALLOWLIST` |
+
+**`L0_RUNTIME_ALLOWLIST`** is a `ReadonlySet<string>` of 24 files that legitimately contain
+function bodies. Every function in these files falls into one of the architecture doc's L0
+exceptions:
+
+- Branded type constructors (identity casts like `agentId()`, `sessionId()`)
+- Pure type guards (`isProcessState()`, `isAgentStateEvent()`)
+- Validation helpers (`validateNonEmpty()`)
+- Error factories (`notFound()`, `timeout()`, etc.)
+- Pure mapping functions (`mapStopReasonToOutcome()`)
+- ComponentProvider factories (`createServiceProvider()`, `createSingleToolProvider()`)
+
+**Adding a new file to the allowlist** requires a PR review to confirm all functions meet
+L0 criteria (pure, side-effect-free, operating only on L0 types).
+
+**Detection**: Line-level regex on trimmed, non-comment lines. Comment lines (`//`, `*`,
+`/*`) are skipped. The scan short-circuits once both flags (class found, function found)
+are set for a given file.
 
 ### Running the check
 

--- a/scripts/check-layers.test.ts
+++ b/scripts/check-layers.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { extractImportSpecifiers, isL0Violation, isL2Violation } from "./check-layers.js";
+import {
+  extractImportSpecifiers,
+  isClassDeclaration,
+  isFunctionBody,
+  isL0Violation,
+  isL2Violation,
+  L0_RUNTIME_ALLOWLIST,
+} from "./check-layers.js";
 
 // ---------------------------------------------------------------------------
 // isL0Violation — L0 source import predicate
@@ -125,5 +132,97 @@ describe("extractImportSpecifiers", () => {
   test("extracts @koi/engine specifier (L2 violation regression)", () => {
     const source = `import { createEngine } from "@koi/engine";`;
     expect(extractImportSpecifiers(source)).toContain("@koi/engine");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isClassDeclaration — L0 class detection
+// ---------------------------------------------------------------------------
+
+describe("isClassDeclaration", () => {
+  test("detects export class", () => {
+    expect(isClassDeclaration("export class Foo {")).toBe(true);
+  });
+
+  test("detects non-exported class", () => {
+    expect(isClassDeclaration("class Bar {")).toBe(true);
+  });
+
+  test("ignores interface declarations", () => {
+    expect(isClassDeclaration("export interface Baz {")).toBe(false);
+  });
+
+  test("ignores type alias", () => {
+    expect(isClassDeclaration("export type Qux = string;")).toBe(false);
+  });
+
+  test("detects abstract class", () => {
+    expect(isClassDeclaration("abstract class Baz {")).toBe(true);
+  });
+
+  test("detects export abstract class", () => {
+    expect(isClassDeclaration("export abstract class Qux {")).toBe(true);
+  });
+
+  test("ignores class reference in string", () => {
+    expect(isClassDeclaration('const x = "class Foo";')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFunctionBody — L0 exported function detection
+// ---------------------------------------------------------------------------
+
+describe("isFunctionBody", () => {
+  test("detects export function", () => {
+    expect(isFunctionBody("export function foo(): void {")).toBe(true);
+  });
+
+  test("detects export async function", () => {
+    expect(isFunctionBody("export async function bar(): Promise<void> {")).toBe(true);
+  });
+
+  test("detects exported arrow function", () => {
+    expect(isFunctionBody("export const baz = (x: number): number => x;")).toBe(true);
+  });
+
+  test("detects exported async arrow function", () => {
+    expect(isFunctionBody("export const qux = async (x: string): Promise<string> => x;")).toBe(
+      true,
+    );
+  });
+
+  test("ignores type declarations", () => {
+    expect(isFunctionBody("export type Fn = () => void;")).toBe(false);
+  });
+
+  test("ignores interface method signatures", () => {
+    expect(isFunctionBody("  send(msg: Message): void;")).toBe(false);
+  });
+
+  test("detects non-exported function", () => {
+    expect(isFunctionBody("function helper(): void {")).toBe(true);
+  });
+
+  test("detects non-exported async function", () => {
+    expect(isFunctionBody("async function compute(): Promise<void> {")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L0_RUNTIME_ALLOWLIST — sanity checks
+// ---------------------------------------------------------------------------
+
+describe("L0_RUNTIME_ALLOWLIST", () => {
+  test("contains known allowlisted files", () => {
+    expect(L0_RUNTIME_ALLOWLIST.has("ecs.ts")).toBe(true);
+    expect(L0_RUNTIME_ALLOWLIST.has("error-factories.ts")).toBe(true);
+    expect(L0_RUNTIME_ALLOWLIST.has("validation-utils.ts")).toBe(true);
+  });
+
+  test("does not contain type-only files", () => {
+    expect(L0_RUNTIME_ALLOWLIST.has("middleware.ts")).toBe(false);
+    expect(L0_RUNTIME_ALLOWLIST.has("channel.ts")).toBe(false);
+    expect(L0_RUNTIME_ALLOWLIST.has("message.ts")).toBe(false);
   });
 });

--- a/scripts/check-layers.ts
+++ b/scripts/check-layers.ts
@@ -28,6 +28,47 @@ interface Violation {
   readonly message: string;
 }
 
+// --- L0 runtime code allowlist ---
+
+/**
+ * Files in @koi/core (L0) permitted to have function bodies.
+ * Each entry is a relative path from packages/core/src/.
+ *
+ * All functions in these files are either branded type constructors,
+ * pure type guards, validation helpers, error factories, or
+ * pure data constructors — side-effect-free operations permitted
+ * per the architecture doc's L0 exceptions.
+ *
+ * Adding a new file here requires PR review to confirm it meets L0 criteria.
+ */
+export const L0_RUNTIME_ALLOWLIST: ReadonlySet<string> = new Set([
+  "ecs.ts",
+  "error-factories.ts",
+  "validation-utils.ts",
+  "capability-registry.ts",
+  "capability.ts",
+  "handoff.ts",
+  "harness.ts",
+  "engine.ts",
+  "intent-capsule.ts",
+  "lifecycle.ts",
+  "task-board.ts",
+  "scheduler.ts",
+  "version-types.ts",
+  "mailbox.ts",
+  "proposal.ts",
+  "snapshot-chain.ts",
+  "skill-registry.ts",
+  "agent-state-event.ts",
+  "bundle-types.ts",
+  "brick-snapshot.ts",
+  "delegation.ts",
+  "governance.ts",
+  "create-service-provider.ts",
+  "create-single-tool-provider.ts",
+  "zone.ts",
+]);
+
 // --- Predicates (exported for testing) ---
 
 /**
@@ -113,6 +154,76 @@ export async function scanFilesForViolations(
         const relPath = file.startsWith(dir) ? `src${file.slice(dir.length)}` : file;
         violations.push({ pkg: pkgName, message: makeMessage(specifier, relPath) });
       }
+    }
+  }
+
+  return violations;
+}
+
+// --- L0 anti-leak scan ---
+
+const CLASS_RE = /^\s*(export\s+)?(abstract\s+)?class\s+/;
+const FUNCTION_RE = /^\s*(export\s+)?(async\s+)?function\s+/;
+const EXPORTED_ARROW_RE = /^\s*export\s+const\s+\w+\s*=\s*(async\s*)?\(/;
+
+/**
+ * Returns true if a trimmed, non-comment line declares a class.
+ */
+export function isClassDeclaration(line: string): boolean {
+  return CLASS_RE.test(line);
+}
+
+/**
+ * Returns true if a trimmed, non-comment line declares a function body
+ * (`function`, `export function`, or `export const x = (`).
+ */
+export function isFunctionBody(line: string): boolean {
+  return FUNCTION_RE.test(line) || EXPORTED_ARROW_RE.test(line);
+}
+
+/**
+ * Scans @koi/core source for class declarations and unlisted function bodies.
+ *
+ * Rules:
+ *   - Class declarations are always forbidden in L0 (no exceptions)
+ *   - Function bodies are forbidden unless the file is in L0_RUNTIME_ALLOWLIST
+ */
+export async function scanL0ForRuntimeCode(dir: string): Promise<readonly Violation[]> {
+  const violations: Violation[] = [];
+  const glob = new Bun.Glob("**/*.ts");
+
+  for await (const file of glob.scan({ cwd: dir, absolute: true })) {
+    if (isTestFile(file)) continue;
+
+    const source = await Bun.file(file).text();
+    const lines = source.split("\n");
+    const relPath = file.startsWith(dir) ? file.slice(dir.length + 1) : file;
+
+    let hasClass = false;
+    let hasFunctionBody = false;
+
+    for (const line of lines) {
+      if (hasClass && hasFunctionBody) break;
+      const trimmed = line.trimStart();
+      // Skip comment lines
+      if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+
+      if (!hasClass && isClassDeclaration(trimmed)) hasClass = true;
+      if (!hasFunctionBody && isFunctionBody(trimmed)) hasFunctionBody = true;
+    }
+
+    if (hasClass) {
+      violations.push({
+        pkg: "@koi/core",
+        message: `L0 must not contain class declarations: ${relPath}`,
+      });
+    }
+
+    if (hasFunctionBody && !L0_RUNTIME_ALLOWLIST.has(relPath)) {
+      violations.push({
+        pkg: "@koi/core",
+        message: `L0 file has function bodies but is not in L0_RUNTIME_ALLOWLIST: ${relPath}`,
+      });
     }
   }
 
@@ -247,6 +358,13 @@ async function main(): Promise<void> {
       (_specifier, relPath) => `L2 source imports from L1 (@koi/engine) at ${relPath}`,
     );
     violations.push(...l2Violations);
+  }
+
+  // ── 4. L0 anti-leak: no classes, no unlisted function bodies ───────────────
+
+  if (await Bun.file(`${PACKAGES_DIR}core/package.json`).exists()) {
+    const l0RuntimeViolations = await scanL0ForRuntimeCode(coreSrcDir);
+    violations.push(...l0RuntimeViolations);
   }
 
   // ── Report ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add CI enforcement that `@koi/core` has zero class declarations (`class`, `export class`, `abstract class`) and no unlisted function bodies
- 25-file `L0_RUNTIME_ALLOWLIST` covers the permitted exceptions (branded constructors, type guards, error factories, pure mappers, ComponentProvider factories)
- New exported predicates (`isClassDeclaration`, `isFunctionBody`) and `scanL0ForRuntimeCode` scanner function
- 13 new test cases covering all detection patterns and allowlist sanity
- Updated `docs/architecture/ci-enforcement.md` with L0 anti-leak audit documentation

Closes #77

## Test plan

- [x] `bun test scripts/check-layers.test.ts` — 40 tests pass (13 new)
- [x] `bun scripts/check-layers.ts` — passes with current codebase (zero violations)
- [x] Biome lint/format clean
- [x] Pre-push build and typecheck pass