### PR TITLE
feat: middleware graceful degradation via required flag

### DIFF
--- a/docs/architecture/manifest-resolution.md
+++ b/docs/architecture/manifest-resolution.md
@@ -20,7 +20,7 @@ Koi agents are defined declaratively in YAML manifests. Manifest resolution is t
                                     │
                                     ▼
                             ResolvedManifest
-                            { model, middleware[], channels?, engine? }
+                            { model, middleware[], warnings[], channels?, engine? }
 ```
 
 ## The Pipeline
@@ -229,11 +229,22 @@ The soul descriptor creates a middleware with `wrapModelCall` that injects perso
 
 ### Middleware Resolution
 
-Explicit middleware entries are resolved in order, then merged with soul + permissions:
+Explicit middleware entries are resolved in order, then merged with soul + permissions.
+
+Each middleware entry supports a `required` flag that controls failure behavior:
+
+- `required: true` (default) — resolution failure aborts agent startup
+- `required: false` — resolution failure produces a warning, middleware is skipped
+
+This enables graceful degradation for edge/local deployments where non-critical
+middleware (telemetry, audit) may be unavailable.
 
 ```
   middleware:
+    - name: "@koi/middleware-permissions"
+      # required: true (default — omitted)
     - name: "@koi/middleware-audit"
+      required: false          ← skip if audit backend is unavailable
       options: { level: "verbose" }
     - name: "@koi/middleware-call-limits"
       options: { maxModelCalls: 50 }
@@ -244,13 +255,21 @@ Explicit middleware entries are resolved in order, then merged with soul + permi
        ├── resolve each entry via resolveOne()
        │   (registry lookup → validate → factory)
        │
-       └── KoiMiddleware[]
+       ├── 3-bucket partitioning:
+       │   ├── resolved[]           — successfully resolved middleware
+       │   ├── requiredFailures[]   — failures where required !== false
+       │   └── optionalWarnings[]   — warning strings where required === false
+       │
+       ├── requiredFailures.length > 0 → { ok: false, error }
+       └── otherwise → MiddlewareResolutionResult { middleware[], warnings[] }
 
   Final merge:
     [explicit...] + [soul?] + [permissions?]
        │
        ▼
   sort by priority (lower number = outer layer = runs first)
+
+  ResolvedManifest includes warnings[] for caller logging
 ```
 
 ### Channel and Engine Resolution
@@ -287,6 +306,27 @@ Resolution failures are aggregated — all sections run even if some fail, provi
        ▼
   formatResolutionError(error) → human-readable stderr output
 ```
+
+### Graceful Degradation
+
+Middleware entries with `required: false` degrade gracefully — they are skipped with a warning instead of aborting startup. This is resolution-time only (no runtime hook changes).
+
+```
+  middleware:
+    - name: "@koi/middleware-audit"
+      required: false                ← optional: skip on failure
+
+  If audit backend is unavailable:
+    ├── middleware is omitted from the chain
+    ├── warning: 'Optional middleware "@koi/middleware-audit" skipped: ...'
+    └── agent starts successfully with remaining middleware
+
+  ResolvedManifest.warnings contains all skipped-middleware messages.
+  The CLI or caller is responsible for logging these warnings.
+```
+
+The `required` flag defaults to `true` for backward compatibility — existing manifests
+without the flag behave identically to before (all-or-nothing resolution).
 
 ## Example Manifests
 
@@ -332,6 +372,23 @@ engine:
 
 Resolves to: `{ model: ModelHandler, middleware: [], engine: PiEngineAdapter }`.
 
+### Edge deployment with graceful degradation
+
+```yaml
+name: edge-agent
+version: "1.0"
+model: anthropic:claude-haiku-4-5-20251001
+middleware:
+  - name: "@koi/middleware-permissions"
+    # required: true (default) — agent won't start without permissions
+  - name: "@koi/middleware-audit"
+    required: false  # skip if audit backend is unavailable
+  - name: "@koi/middleware-pii"
+    required: false  # skip if PII detection service is offline
+```
+
+Resolves to: `{ model: ModelHandler, middleware: [permissions], warnings: ["...audit...", "...pii..."] }` when audit and PII backends are unreachable. Agent starts with permissions middleware only.
+
 ## Package Map
 
 ```
@@ -341,7 +398,8 @@ Resolves to: `{ model: ModelHandler, middleware: [], engine: PiEngineAdapter }`.
 
   @koi/resolve (L0u)
   ├── types: BrickDescriptor, ResolveRegistry,     (types.ts)
-  │          ResolutionContext, ResolvedManifest
+  │          ResolutionContext, ResolvedManifest,
+  │          MiddlewareResolutionResult
   ├── createRegistry()                             (registry.ts)
   ├── resolveManifest()                            (resolve-manifest.ts)
   ├── resolveMiddleware()                          (resolve-middleware.ts)

--- a/packages/core/src/assembly.ts
+++ b/packages/core/src/assembly.ts
@@ -50,6 +50,8 @@ export interface MiddlewareConfig {
   readonly options?: JsonObject;
   readonly version?: string;
   readonly publisher?: string;
+  /** When false, resolution failure produces a warning instead of aborting. Defaults to true. */
+  readonly required?: boolean | undefined;
 }
 
 export interface SearchConfig {

--- a/packages/manifest/src/__tests__/schema.test.ts
+++ b/packages/manifest/src/__tests__/schema.test.ts
@@ -624,6 +624,34 @@ describe("rawManifestSchema — skills", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Middleware required flag
+// ---------------------------------------------------------------------------
+
+describe("rawManifestSchema — middleware required flag", () => {
+  test("accepts middleware with required: false in explicit form", () => {
+    const result = parse({
+      middleware: [{ name: "@koi/middleware-audit", required: false }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { middleware?: readonly Record<string, unknown>[] };
+      expect(data.middleware?.[0]?.required).toBe(false);
+    }
+  });
+
+  test("accepts middleware without required field (optional, defaults absent)", () => {
+    const result = parse({
+      middleware: [{ name: "@koi/middleware-permissions" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { middleware?: readonly Record<string, unknown>[] };
+      expect(data.middleware?.[0]?.required).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Template expression rejection
 // ---------------------------------------------------------------------------
 

--- a/packages/manifest/src/__tests__/transform.test.ts
+++ b/packages/manifest/src/__tests__/transform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   normalizeChannelConfig,
   normalizeConfigItem,
+  normalizeMiddlewareConfig,
   normalizeModelConfig,
   transformToLoadedManifest,
 } from "../transform.js";
@@ -54,6 +55,38 @@ describe("normalizeConfigItem", () => {
     const result = normalizeConfigItem(input);
     expect("version" in result).toBe(false);
     expect("publisher" in result).toBe(false);
+  });
+});
+
+describe("normalizeMiddlewareConfig", () => {
+  test("passes through required: false", () => {
+    const input = { name: "@koi/middleware-audit", required: false };
+    const result = normalizeMiddlewareConfig(input);
+    expect(result.name).toBe("@koi/middleware-audit");
+    expect(result.required).toBe(false);
+  });
+
+  test("omits required when absent", () => {
+    const input = { name: "@koi/middleware-permissions" };
+    const result = normalizeMiddlewareConfig(input);
+    expect(result.name).toBe("@koi/middleware-permissions");
+    expect("required" in result).toBe(false);
+  });
+
+  test("preserves options alongside required", () => {
+    const input = { name: "@koi/middleware-audit", options: { level: "verbose" }, required: false };
+    const result = normalizeMiddlewareConfig(input);
+    expect(result.name).toBe("@koi/middleware-audit");
+    expect(result.options).toEqual({ level: "verbose" });
+    expect(result.required).toBe(false);
+  });
+
+  test("handles key-value shorthand (no required support)", () => {
+    const input = { "@koi/middleware-memory": { scope: "agent" } };
+    const result = normalizeMiddlewareConfig(input);
+    expect(result.name).toBe("@koi/middleware-memory");
+    expect(result.options).toEqual({ scope: "agent" });
+    expect("required" in result).toBe(false);
   });
 });
 
@@ -288,6 +321,28 @@ describe("transformToLoadedManifest", () => {
     const result = transformToLoadedManifest(raw);
     expect(result.middleware?.[0]?.version).toBe("3.0.0");
     expect(result.middleware?.[0]?.publisher).toBe("koi-team");
+  });
+
+  test("passes through required: false on middleware", () => {
+    const raw = {
+      name: "my-agent",
+      version: "1.0.0",
+      model: "anthropic:claude-sonnet-4-5-20250929",
+      middleware: [{ name: "@koi/middleware-audit", required: false }],
+    };
+    const result = transformToLoadedManifest(raw);
+    expect(result.middleware?.[0]?.required).toBe(false);
+  });
+
+  test("omits required on middleware when absent in raw", () => {
+    const raw = {
+      name: "my-agent",
+      version: "1.0.0",
+      model: "anthropic:claude-sonnet-4-5-20250929",
+      middleware: [{ name: "@koi/middleware-permissions" }],
+    };
+    const result = transformToLoadedManifest(raw);
+    expect("required" in (result.middleware?.[0] ?? {})).toBe(false);
   });
 
   test("passes through version and publisher on channels", () => {

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -165,6 +165,22 @@ const channelIdentitySchema = z
   .optional();
 
 /**
+ * Middleware config item — same as namedConfigSchema but also supports `required` flag.
+ * Accepts either `{ name: string, options?: object, required?: boolean }` or a
+ * key-value map `{ "@koi/pkg": { ... } }` (required not supported in shorthand form).
+ */
+const middlewareConfigSchema = z.union([
+  z.object({
+    name: noTemplateExpressions(z.string()),
+    options: jsonObjectSchema.optional(),
+    version: z.string().optional(),
+    publisher: z.string().optional(),
+    required: z.boolean().optional(),
+  }),
+  jsonObjectSchema,
+]);
+
+/**
  * Channel config item — same as namedConfigSchema but also supports `identity` block.
  * Accepts either `{ name: string, options?: object, identity?: ChannelIdentity }` or a
  * key-value map `{ "@koi/pkg": { ... } }` (identity not supported in shorthand form).
@@ -351,7 +367,7 @@ export const rawManifestSchema: z.ZodType<RawManifest> = z
     model: modelSchema,
     tools: toolsSchema.optional(),
     channels: z.array(rawChannelSchema).optional(),
-    middleware: z.array(namedConfigSchema).optional(),
+    middleware: z.array(middlewareConfigSchema).optional(),
     skills: z.array(skillConfigSchema).optional(),
     permissions: permissionsSchema.optional(),
     metadata: jsonObjectSchema.optional(),

--- a/packages/manifest/src/transform.ts
+++ b/packages/manifest/src/transform.ts
@@ -112,6 +112,20 @@ export function normalizeConfigItem(raw: Readonly<Record<string, unknown>>): Nor
 }
 
 /**
+ * Normalizes a middleware config item, preserving the `required` flag if present.
+ * Extends `normalizeConfigItem` with required passthrough.
+ */
+export function normalizeMiddlewareConfig(
+  raw: Readonly<Record<string, unknown>>,
+): MiddlewareConfig {
+  const base = normalizeConfigItem(raw);
+  if (typeof raw.required === "boolean") {
+    return { ...base, required: raw.required };
+  }
+  return base;
+}
+
+/**
  * Normalizes a channel config item, preserving the `identity` block if present.
  * Extends `normalizeConfigItem` with identity passthrough.
  */
@@ -202,9 +216,9 @@ export function transformToLoadedManifest(raw: RawManifest): LoadedManifest {
     }
   }
 
-  // Transform middleware
+  // Transform middleware — preserves `required` flag when present
   const middleware: readonly MiddlewareConfig[] | undefined = raw.middleware?.map(
-    (m): MiddlewareConfig => normalizeConfigItem(m),
+    (m): MiddlewareConfig => normalizeMiddlewareConfig(m),
   );
 
   // Transform channels — preserve identity block if present

--- a/packages/resolve/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/resolve/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -72,6 +72,11 @@ interface ResolveRegistry {
     /** List all descriptors of a given kind. */
     readonly list: (kind: ResolveKind) => readonly BrickDescriptor<unknown>[];
 }
+/** Result of resolving the middleware section — includes warnings for skipped optional middleware. */
+interface MiddlewareResolutionResult {
+    readonly middleware: readonly KoiMiddleware[];
+    readonly warnings: readonly string[];
+}
 /** What resolveManifest() returns on success. */
 interface ResolvedManifest {
     /** Merged and priority-sorted middleware (explicit + soul + permissions). */
@@ -84,6 +89,8 @@ interface ResolvedManifest {
     readonly engine?: EngineAdapter | undefined;
     /** Resolved search provider (undefined → no web search capability). */
     readonly search?: SearchProvider | undefined;
+    /** Warnings from optional middleware that failed to resolve. */
+    readonly warnings: readonly string[];
 }
 /** A single resolution failure within a section. */
 interface ResolutionFailure {
@@ -185,6 +192,7 @@ interface ManifestInput {
     readonly middleware?: readonly {
         readonly name: string;
         readonly options?: Record<string, unknown>;
+        readonly required?: boolean | undefined;
     }[];
     readonly model: {
         readonly name: string;
@@ -227,10 +235,11 @@ declare function resolveManifest(manifest: ManifestInput, registry: ResolveRegis
  *
  * - Checks for duplicate names
  * - Resolves all in parallel via Promise.allSettled
- * - Aggregates all failures
+ * - Optional middleware (required === false) degrade gracefully with warnings
+ * - Required middleware failures abort resolution
  * - Returns sorted by priority (lower = outer onion layer = runs first)
  */
-declare function resolveMiddleware(configs: readonly MiddlewareConfig[], registry: ResolveRegistry, context: ResolutionContext): Promise<Result<readonly KoiMiddleware[], KoiError>>;
+declare function resolveMiddleware(configs: readonly MiddlewareConfig[], registry: ResolveRegistry, context: ResolutionContext): Promise<Result<MiddlewareResolutionResult, KoiError>>;
 
 /**
  * Model section resolver.
@@ -329,6 +338,6 @@ interface SoulManifestSlice {
  */
 declare function resolveSoul(manifest: SoulManifestSlice, registry: ResolveRegistry, context: ResolutionContext): Promise<Result<KoiMiddleware | undefined, KoiError>>;
 
-export { type BrickDescriptor, type BrickFactory, type OptionsValidator, type ResolutionContext, type ResolutionFailure, type ResolveApprovalHandler, type ResolveKind, type ResolveRegistry, type ResolvedManifest, aggregateErrors, createRegistry, discoverDescriptors, formatResolutionError, parseModelName, resolveChannels, resolveEngine, resolveManifest, resolveMiddleware, resolveModel, resolveOne, resolvePermissions, resolveSearch, resolveSoul };
+export { type BrickDescriptor, type BrickFactory, type MiddlewareResolutionResult, type OptionsValidator, type ResolutionContext, type ResolutionFailure, type ResolveApprovalHandler, type ResolveKind, type ResolveRegistry, type ResolvedManifest, aggregateErrors, createRegistry, discoverDescriptors, formatResolutionError, parseModelName, resolveChannels, resolveEngine, resolveManifest, resolveMiddleware, resolveModel, resolveOne, resolvePermissions, resolveSearch, resolveSoul };
 "
 `;

--- a/packages/resolve/src/index.ts
+++ b/packages/resolve/src/index.ts
@@ -27,6 +27,7 @@ export { resolveSoul } from "./resolve-soul.js";
 export type {
   BrickDescriptor,
   BrickFactory,
+  MiddlewareResolutionResult,
   OptionsValidator,
   ResolutionContext,
   ResolutionFailure,

--- a/packages/resolve/src/resolve-manifest.ts
+++ b/packages/resolve/src/resolve-manifest.ts
@@ -26,6 +26,7 @@ interface ManifestInput {
   readonly middleware?: readonly {
     readonly name: string;
     readonly options?: Record<string, unknown>;
+    readonly required?: boolean | undefined;
   }[];
   readonly model: { readonly name: string; readonly options?: Record<string, unknown> };
   readonly permissions?: {
@@ -170,16 +171,17 @@ export async function resolveManifest(
     return { ok: false, error: aggregateErrors(failures) };
   }
 
+  // Extract middleware and warnings from resolution result
+  const explicitMiddleware = middlewareResult.value.middleware;
+  const middlewareWarnings = middlewareResult.value.warnings;
+
   // Merge middleware: explicit + soul + permissions (immutable)
   const optionalMiddleware: readonly KoiMiddleware[] = [
     soulResult.value,
     permissionsResult.value,
   ].filter((mw): mw is KoiMiddleware => mw !== undefined);
 
-  const allMiddleware: readonly KoiMiddleware[] = [
-    ...middlewareResult.value,
-    ...optionalMiddleware,
-  ];
+  const allMiddleware: readonly KoiMiddleware[] = [...explicitMiddleware, ...optionalMiddleware];
 
   // Sort by priority (lower = outer onion layer = runs first)
   const DEFAULT_PRIORITY = 500;
@@ -191,6 +193,7 @@ export async function resolveManifest(
   const resolved: ResolvedManifest = {
     middleware: sorted,
     model: modelResult.value,
+    warnings: middlewareWarnings,
     ...(channelsResult.value !== undefined ? { channels: channelsResult.value } : {}),
     ...(engineResult.value !== undefined ? { engine: engineResult.value } : {}),
     ...(searchResult.value !== undefined ? { search: searchResult.value } : {}),

--- a/packages/resolve/src/resolve-middleware.test.ts
+++ b/packages/resolve/src/resolve-middleware.test.ts
@@ -49,7 +49,7 @@ function makeFailingDescriptor(name: string): BrickDescriptor<KoiMiddleware> {
 // ---------------------------------------------------------------------------
 
 describe("resolveMiddleware", () => {
-  test("returns empty array for empty configs", async () => {
+  test("returns empty middleware and warnings for empty configs", async () => {
     const regResult = createRegistry([]);
     if (!regResult.ok) throw new Error("Registry failed");
 
@@ -57,7 +57,8 @@ describe("resolveMiddleware", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("Expected ok");
-    expect(result.value).toEqual([]);
+    expect(result.value.middleware).toEqual([]);
+    expect(result.value.warnings).toEqual([]);
   });
 
   test("resolves multiple middleware sorted by priority", async () => {
@@ -76,10 +77,11 @@ describe("resolveMiddleware", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("Expected ok");
-    expect(result.value).toHaveLength(3);
-    expect(result.value[0]?.name).toBe("mw-low");
-    expect(result.value[1]?.name).toBe("mw-mid");
-    expect(result.value[2]?.name).toBe("mw-high");
+    expect(result.value.middleware).toHaveLength(3);
+    expect(result.value.middleware[0]?.name).toBe("mw-low");
+    expect(result.value.middleware[1]?.name).toBe("mw-mid");
+    expect(result.value.middleware[2]?.name).toBe("mw-high");
+    expect(result.value.warnings).toEqual([]);
   });
 
   test("returns VALIDATION error for duplicate names", async () => {
@@ -98,7 +100,7 @@ describe("resolveMiddleware", () => {
     expect(result.error.message).toContain("Duplicate middleware name");
   });
 
-  test("aggregates errors when some middleware fail", async () => {
+  test("aggregates errors when some required middleware fail", async () => {
     const regResult = createRegistry([
       makeMwDescriptor("mw-good", 500),
       makeFailingDescriptor("mw-bad"),
@@ -117,7 +119,7 @@ describe("resolveMiddleware", () => {
     expect(result.error.message).toContain("mw-bad");
   });
 
-  test("aggregates errors when all middleware fail", async () => {
+  test("aggregates errors when all required middleware fail", async () => {
     const regResult = createRegistry([
       makeFailingDescriptor("mw-a"),
       makeFailingDescriptor("mw-b"),
@@ -137,7 +139,7 @@ describe("resolveMiddleware", () => {
     expect(result.error.message).toContain("mw-b");
   });
 
-  test("returns NOT_FOUND for unregistered middleware", async () => {
+  test("returns NOT_FOUND for unregistered required middleware", async () => {
     const regResult = createRegistry([]);
     if (!regResult.ok) throw new Error("Registry failed");
 
@@ -146,5 +148,126 @@ describe("resolveMiddleware", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("Expected error");
     expect(result.error.message).toContain("not found");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Graceful degradation (required flag)
+  // ---------------------------------------------------------------------------
+
+  test("skips all optional middleware with warnings when all fail", async () => {
+    const regResult = createRegistry([
+      makeFailingDescriptor("mw-opt-a"),
+      makeFailingDescriptor("mw-opt-b"),
+    ]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware(
+      [
+        { name: "mw-opt-a", required: false },
+        { name: "mw-opt-b", required: false },
+      ],
+      regResult.value,
+      MOCK_CONTEXT,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.middleware).toEqual([]);
+    expect(result.value.warnings).toHaveLength(2);
+    expect(result.value.warnings[0]).toContain("mw-opt-a");
+    expect(result.value.warnings[1]).toContain("mw-opt-b");
+  });
+
+  test("returns required middleware and warnings when only optional fails", async () => {
+    const regResult = createRegistry([
+      makeMwDescriptor("mw-required", 100),
+      makeFailingDescriptor("mw-optional"),
+    ]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware(
+      [{ name: "mw-required" }, { name: "mw-optional", required: false }],
+      regResult.value,
+      MOCK_CONTEXT,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.middleware).toHaveLength(1);
+    expect(result.value.middleware[0]?.name).toBe("mw-required");
+    expect(result.value.warnings).toHaveLength(1);
+    expect(result.value.warnings[0]).toContain("mw-optional");
+  });
+
+  test("fails when required middleware fails alongside optional failure", async () => {
+    const regResult = createRegistry([
+      makeFailingDescriptor("mw-required"),
+      makeFailingDescriptor("mw-optional"),
+    ]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware(
+      [{ name: "mw-required" }, { name: "mw-optional", required: false }],
+      regResult.value,
+      MOCK_CONTEXT,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.message).toContain("mw-required");
+  });
+
+  test("returns all middleware with empty warnings when optional succeeds", async () => {
+    const regResult = createRegistry([
+      makeMwDescriptor("mw-opt-a", 200),
+      makeMwDescriptor("mw-opt-b", 400),
+    ]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware(
+      [
+        { name: "mw-opt-a", required: false },
+        { name: "mw-opt-b", required: false },
+      ],
+      regResult.value,
+      MOCK_CONTEXT,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.middleware).toHaveLength(2);
+    expect(result.value.warnings).toEqual([]);
+  });
+
+  test("treats missing required field as required (backward compat)", async () => {
+    const regResult = createRegistry([makeFailingDescriptor("mw-default")]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware([{ name: "mw-default" }], regResult.value, MOCK_CONTEXT);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error");
+    expect(result.error.message).toContain("mw-default");
+  });
+
+  test("returns both required and optional middleware when all succeed", async () => {
+    const regResult = createRegistry([
+      makeMwDescriptor("mw-req", 100),
+      makeMwDescriptor("mw-opt", 200),
+    ]);
+    if (!regResult.ok) throw new Error("Registry failed");
+
+    const result = await resolveMiddleware(
+      [{ name: "mw-req" }, { name: "mw-opt", required: false }],
+      regResult.value,
+      MOCK_CONTEXT,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok");
+    expect(result.value.middleware).toHaveLength(2);
+    expect(result.value.middleware[0]?.name).toBe("mw-req");
+    expect(result.value.middleware[1]?.name).toBe("mw-opt");
+    expect(result.value.warnings).toEqual([]);
   });
 });

--- a/packages/resolve/src/resolve-middleware.ts
+++ b/packages/resolve/src/resolve-middleware.ts
@@ -9,23 +9,29 @@ import type { KoiError, KoiMiddleware, MiddlewareConfig, Result } from "@koi/cor
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import { aggregateErrors } from "./errors.js";
 import { resolveOne } from "./resolve-one.js";
-import type { ResolutionContext, ResolutionFailure, ResolveRegistry } from "./types.js";
+import type {
+  MiddlewareResolutionResult,
+  ResolutionContext,
+  ResolutionFailure,
+  ResolveRegistry,
+} from "./types.js";
 
 /**
  * Resolves all middleware entries from the manifest.
  *
  * - Checks for duplicate names
  * - Resolves all in parallel via Promise.allSettled
- * - Aggregates all failures
+ * - Optional middleware (required === false) degrade gracefully with warnings
+ * - Required middleware failures abort resolution
  * - Returns sorted by priority (lower = outer onion layer = runs first)
  */
 export async function resolveMiddleware(
   configs: readonly MiddlewareConfig[],
   registry: ResolveRegistry,
   context: ResolutionContext,
-): Promise<Result<readonly KoiMiddleware[], KoiError>> {
+): Promise<Result<MiddlewareResolutionResult, KoiError>> {
   if (configs.length === 0) {
-    return { ok: true, value: [] };
+    return { ok: true, value: { middleware: [], warnings: [] } };
   }
 
   // Check for duplicate names
@@ -47,40 +53,65 @@ export async function resolveMiddleware(
     configs.map((config) => resolveOne<KoiMiddleware>("middleware", config, registry, context)),
   );
 
-  // Partition results into successes and failures (immutable)
-  const { middleware, failures } = results.reduce<{
+  // Partition results into 3 buckets (immutable)
+  const { middleware, requiredFailures, optionalWarnings } = results.reduce<{
     readonly middleware: readonly KoiMiddleware[];
-    readonly failures: readonly ResolutionFailure[];
+    readonly requiredFailures: readonly ResolutionFailure[];
+    readonly optionalWarnings: readonly string[];
   }>(
     (acc, result, i) => {
       const config = configs[i];
       if (config === undefined) return acc;
 
+      const isOptional = config.required === false;
+
       if (result.status === "rejected") {
+        const message =
+          result.reason instanceof Error ? result.reason.message : String(result.reason);
+        if (isOptional) {
+          return {
+            middleware: acc.middleware,
+            requiredFailures: acc.requiredFailures,
+            optionalWarnings: [
+              ...acc.optionalWarnings,
+              `Optional middleware "${config.name}" skipped: ${message}`,
+            ],
+          };
+        }
         return {
           middleware: acc.middleware,
-          failures: [
-            ...acc.failures,
+          requiredFailures: [
+            ...acc.requiredFailures,
             {
               section: "middleware" as const,
               index: i,
               name: config.name,
               error: {
                 code: "INTERNAL" as const,
-                message:
-                  result.reason instanceof Error ? result.reason.message : String(result.reason),
+                message,
                 retryable: RETRYABLE_DEFAULTS.INTERNAL,
                 cause: result.reason,
               },
             },
           ],
+          optionalWarnings: acc.optionalWarnings,
         };
       }
       if (!result.value.ok) {
+        if (isOptional) {
+          return {
+            middleware: acc.middleware,
+            requiredFailures: acc.requiredFailures,
+            optionalWarnings: [
+              ...acc.optionalWarnings,
+              `Optional middleware "${config.name}" skipped: ${result.value.error.message}`,
+            ],
+          };
+        }
         return {
           middleware: acc.middleware,
-          failures: [
-            ...acc.failures,
+          requiredFailures: [
+            ...acc.requiredFailures,
             {
               section: "middleware" as const,
               index: i,
@@ -88,18 +119,20 @@ export async function resolveMiddleware(
               error: result.value.error,
             },
           ],
+          optionalWarnings: acc.optionalWarnings,
         };
       }
       return {
         middleware: [...acc.middleware, result.value.value],
-        failures: acc.failures,
+        requiredFailures: acc.requiredFailures,
+        optionalWarnings: acc.optionalWarnings,
       };
     },
-    { middleware: [], failures: [] },
+    { middleware: [], requiredFailures: [], optionalWarnings: [] },
   );
 
-  if (failures.length > 0) {
-    return { ok: false, error: aggregateErrors(failures) };
+  if (requiredFailures.length > 0) {
+    return { ok: false, error: aggregateErrors(requiredFailures) };
   }
 
   // Sort by priority (default 500, lower = runs first)
@@ -108,5 +141,5 @@ export async function resolveMiddleware(
     (a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY),
   );
 
-  return { ok: true, value: sorted };
+  return { ok: true, value: { middleware: sorted, warnings: optionalWarnings } };
 }

--- a/packages/resolve/src/types.ts
+++ b/packages/resolve/src/types.ts
@@ -119,6 +119,12 @@ export interface ResolveRegistry {
 // Resolution results
 // ---------------------------------------------------------------------------
 
+/** Result of resolving the middleware section — includes warnings for skipped optional middleware. */
+export interface MiddlewareResolutionResult {
+  readonly middleware: readonly KoiMiddleware[];
+  readonly warnings: readonly string[];
+}
+
 /** What resolveManifest() returns on success. */
 export interface ResolvedManifest {
   /** Merged and priority-sorted middleware (explicit + soul + permissions). */
@@ -131,6 +137,8 @@ export interface ResolvedManifest {
   readonly engine?: EngineAdapter | undefined;
   /** Resolved search provider (undefined → no web search capability). */
   readonly search?: SearchProvider | undefined;
+  /** Warnings from optional middleware that failed to resolve. */
+  readonly warnings: readonly string[];
 }
 
 /** A single resolution failure within a section. */


### PR DESCRIPTION
## Summary

- Adds `required?: boolean` field to `MiddlewareConfig` (L0) — when `false`, resolution failure produces a warning instead of aborting agent startup
- Introduces `MiddlewareResolutionResult` type with `middleware` + `warnings` fields, and propagates warnings through `ResolvedManifest`
- Updates `@koi/manifest` schema and transform to validate and normalize the new field
- Documents the feature in `docs/architecture/manifest-resolution.md`

Closes #43

## Changes by layer

| Layer | Package | Change |
|-------|---------|--------|
| L0 | `@koi/core` | +1 line: `readonly required?: boolean \| undefined` on `MiddlewareConfig` |
| L0u | `@koi/manifest` | New `middlewareConfigSchema` with `required` field; `normalizeMiddlewareConfig()` transform |
| L0u | `@koi/resolve` | 3-bucket reduce in `resolveMiddleware`; `MiddlewareResolutionResult` type; warnings propagation in `resolveManifest` |
| Docs | `docs/architecture/` | Updated manifest-resolution.md with graceful degradation section |

## Test plan

- [x] 6 new tests in `resolve-middleware.test.ts` covering all degradation paths
- [x] 2 new schema tests for `required` field acceptance
- [x] 4 new transform tests for `normalizeMiddlewareConfig`
- [x] 2 integration tests for required passthrough in `transformToLoadedManifest`
- [x] API surface snapshots updated
- [x] `bun run build` — 160/160 tasks pass
- [x] `bun test packages/resolve` — 94 tests pass
- [x] `bun test packages/manifest` — 189 tests pass
- [x] `bun test packages/core` — 509 tests pass
- [x] Biome lint clean on all changed files
- [x] `bun run check:layers` passes (no layer violations)