### PR TITLE
feat: add @koi/reputation — in-memory reputation backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1504,6 +1504,16 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/reputation": {
+      "name": "@koi/reputation",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/resolve": {
       "name": "@koi/resolve",
       "version": "0.0.0",
@@ -2701,6 +2711,8 @@
     "@koi/registry-nexus": ["@koi/registry-nexus@workspace:packages/registry-nexus"],
 
     "@koi/registry-store": ["@koi/registry-store@workspace:packages/registry-store"],
+
+    "@koi/reputation": ["@koi/reputation@workspace:packages/reputation"],
 
     "@koi/resolve": ["@koi/resolve@workspace:packages/resolve"],
 

--- a/docs/L2/reputation.md
+++ b/docs/L2/reputation.md
@@ -1,0 +1,318 @@
+# @koi/reputation — In-Memory Reputation Backend
+
+In-memory implementation of the `ReputationBackend` contract for recording agent interaction feedback and computing trust scores. Uses a weighted-average algorithm with per-agent ring-buffer storage. Sync operations, zero external dependencies — suitable for dev, test, and single-node deployments.
+
+---
+
+## Why It Exists
+
+The L0 contract (`ReputationBackend` in `@koi/core`) defines the interface but has no implementations. Without a concrete backend, trust-aware routing, governance guards, and middleware feedback loops have nothing to write to or read from.
+
+This package provides the simplest conforming backend:
+
+```
+Without @koi/reputation               With @koi/reputation
+───────────────────────                ─────────────────────
+
+No backend → contract is dead letter   In-memory backend → contract works
+Routing has no trust signal            getScores() → filter candidates
+Governance cannot check levels         getScore() → deny below threshold
+Middleware cannot record feedback      record() → per-turn signal stored
+```
+
+---
+
+## Architecture
+
+`@koi/reputation` is an **L2 feature package** — depends on `@koi/core` (L0) only.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  @koi/core (L0) — reputation-backend.ts                             │
+│                                                                     │
+│  Types: ReputationBackend, ReputationFeedback, ReputationScore,    │
+│         ReputationQuery, ReputationQueryResult                      │
+│  Enums: ReputationLevel, FeedbackKind                              │
+│  Constants: REPUTATION_LEVEL_ORDER, DEFAULT_REPUTATION_QUERY_LIMIT │
+│  ECS token: REPUTATION: SubsystemToken<ReputationBackend>          │
+├─────────────────────────────────────────────────────────────────────┤
+│  @koi/reputation (L2)                                               │
+│                                                                     │
+│  ┌──────────────────────┐  ┌────────────────────────────────────┐  │
+│  │ compute-score.ts     │  │ in-memory-backend.ts               │  │
+│  │                      │  │                                    │  │
+│  │ computeScore()       │  │ createInMemoryReputationBackend()  │  │
+│  │ weighted average     │  │   → ReputationBackend              │  │
+│  │ level thresholds     │  │                                    │  │
+│  │ configurable weights │  │ Map<AgentId, feedback[]>           │  │
+│  └──────────────────────┘  │ ring buffer (default 1000/agent)   │  │
+│                             │ idempotent record                  │  │
+│                             │ sync Result returns                │  │
+│                             └────────────────────────────────────┘  │
+│                                                                     │
+│  ┌──────────────────────────┐                                      │
+│  │ component-provider.ts    │                                      │
+│  │                          │                                      │
+│  │ createReputationProvider │                                      │
+│  │   (backend)              │                                      │
+│  │   → ComponentProvider    │                                      │
+│  │   REPUTATION token       │                                      │
+│  └──────────────────────────┘                                      │
+│                                                                     │
+├─────────────────────────────────────────────────────────────────────┤
+│  Dependencies                                                       │
+│  @koi/core (L0) only — zero L0u, zero external                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Score Algorithm
+
+Weighted average of all feedback entries for an agent, mapped to a categorical level:
+
+```
+Input:  feedback[] for agent X
+        weights: { positive: 1.0, neutral: 0.5, negative: 0.0 }
+
+Score = sum(weight[entry.kind] for each entry) / count(entries)
+
+Level thresholds:
+  score >= 0.6  →  "high"
+  score >= 0.4  →  "medium"
+  score >= 0.2  →  "low"
+  score <  0.2  →  "untrusted"
+  no entries    →  undefined (callers treat as "unknown")
+
+"verified" is never auto-assigned — requires external attestation.
+```
+
+Example:
+
+```
+Agent received: 8 positive, 1 neutral, 1 negative
+Score = (8×1.0 + 1×0.5 + 1×0.0) / 10 = 0.85
+Level = "high"
+```
+
+Weights are configurable at backend creation time.
+
+---
+
+## Quick Start
+
+```typescript
+import { createInMemoryReputationBackend, createReputationProvider } from "@koi/reputation";
+import { agentId } from "@koi/core";
+
+// 1. Create backend
+const backend = createInMemoryReputationBackend();
+
+// 2. Record feedback
+await backend.record({
+  sourceId: agentId("observer-agent"),
+  targetId: agentId("worker-agent"),
+  kind: "positive",
+  timestamp: Date.now(),
+});
+
+// 3. Query score
+const result = await backend.getScore(agentId("worker-agent"));
+if (result.ok && result.value !== undefined) {
+  console.log(result.value.level);  // "high"
+  console.log(result.value.score);  // 1.0
+}
+
+// 4. Wire into agent assembly via ECS
+const provider = createReputationProvider(backend);
+// Pass provider to createKoi({ providers: [provider, ...] })
+```
+
+---
+
+## Configuration
+
+```typescript
+interface InMemoryReputationConfig {
+  /** Max feedback entries per agent (ring buffer cap). Default: 1000. */
+  readonly maxEntriesPerAgent?: number | undefined;
+  /** Custom weights per FeedbackKind. Default: positive=1.0, neutral=0.5, negative=0.0. */
+  readonly weights?: Readonly<Record<FeedbackKind, number>> | undefined;
+}
+```
+
+```typescript
+// Custom configuration
+const backend = createInMemoryReputationBackend({
+  maxEntriesPerAgent: 500,
+  weights: { positive: 1.0, neutral: 0.3, negative: 0.0 },
+});
+```
+
+---
+
+## API Reference
+
+### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `createInMemoryReputationBackend` | factory | Creates an in-memory `ReputationBackend` |
+| `createReputationProvider` | factory | Creates a `ComponentProvider` that attaches backend on `REPUTATION` token |
+| `computeScore` | pure function | `feedback[] → ReputationScore \| undefined` |
+| `DEFAULT_FEEDBACK_WEIGHTS` | const | `{ positive: 1.0, neutral: 0.5, negative: 0.0 }` |
+| `InMemoryReputationConfig` | type | Configuration for `createInMemoryReputationBackend` |
+
+### Backend Methods (from L0 contract)
+
+| Method | Required | Returns |
+|--------|----------|---------|
+| `record` | yes | `Result<void, KoiError>` — sync |
+| `getScore` | yes | `Result<ReputationScore \| undefined, KoiError>` — sync |
+| `getScores` | optional | `Result<ReadonlyMap<AgentId, Score \| undefined>, KoiError>` — sync |
+| `query` | yes | `Result<ReputationQueryResult, KoiError>` — sync |
+| `dispose` | optional | `void` — clears all data, marks backend as disposed |
+
+All methods return synchronously (no async overhead) but callers must `await` per the L0 contract.
+
+---
+
+## Examples
+
+### Trust-Aware Routing
+
+```typescript
+const candidates = [agentId("a"), agentId("b"), agentId("c")];
+const result = await backend.getScores(candidates);
+
+if (result.ok) {
+  const eligible = candidates.filter((id) => {
+    const score = result.value.get(id);
+    // Fail-closed: undefined (unknown) is excluded
+    return score !== undefined && score.level !== "untrusted" && score.level !== "unknown";
+  });
+  // Route to highest-scoring eligible agent
+}
+```
+
+### Middleware Feedback Loop
+
+```typescript
+const feedbackMiddleware: KoiMiddleware = {
+  name: "reputation-feedback",
+  onAfterTurn: async (ctx) => {
+    // Record positive signal for successful turns
+    await backend.record({
+      sourceId: agentId("system"),
+      targetId: ctx.agent.pid.id,
+      kind: ctx.output.stopReason === "error" ? "negative" : "positive",
+      timestamp: Date.now(),
+    });
+  },
+};
+```
+
+### Query Feedback History
+
+```typescript
+// Get recent negative feedback for an agent
+const result = await backend.query({
+  targetId: agentId("suspect-agent"),
+  kinds: ["negative"],
+  limit: 20,
+});
+
+if (result.ok) {
+  for (const entry of result.value.entries) {
+    console.log(`${entry.sourceId} reported negative at ${entry.timestamp}`);
+  }
+  if (result.value.hasMore) {
+    // Paginate with before: entries[entries.length-1].timestamp
+  }
+}
+```
+
+---
+
+## Performance
+
+### Storage: O(k) per agent, O(n * k) total
+
+Ring buffer caps entries at `maxEntriesPerAgent` (default 1000). Oldest entries are evicted when capacity is reached — no unbounded memory growth.
+
+```
+1000 agents × 1000 entries × ~100 bytes/entry ≈ 100 MB
+Typical dev/test: 10-50 agents × 100-500 entries ≈ < 5 MB
+```
+
+### Operations
+
+| Operation | Complexity | Notes |
+|-----------|-----------|-------|
+| `record` | O(n) | Dedup scan of agent's feedback bucket |
+| `getScore` | O(n) | Weighted average over agent's entries |
+| `getScores` | O(m * n) | m agents, n entries each |
+| `query` | O(N) | Scans all entries across all agents, sorts result |
+
+Where n = entries per agent, N = total entries across all agents, m = number of queried agents.
+
+For production workloads with high throughput, use a dedicated backend (e.g., `@koi/reputation-nexus` with EigenTrust).
+
+---
+
+## Error Handling
+
+| Scenario | Error Code | Retryable |
+|----------|-----------|-----------|
+| Backend disposed | `INTERNAL` | No |
+
+All other operations succeed — there are no validation, permission, or rate-limit errors in the in-memory backend. The backend follows the fail-closed contract: `getScore()` returns `undefined` for unknown agents, which callers must treat as `"unknown"` trust level.
+
+---
+
+## Ring Buffer Behavior
+
+```
+maxEntriesPerAgent = 3
+
+record(feedback_1)  →  [1]
+record(feedback_2)  →  [1, 2]
+record(feedback_3)  →  [1, 2, 3]      ← full
+record(feedback_4)  →  [2, 3, 4]      ← feedback_1 evicted (FIFO)
+record(feedback_4)  →  [2, 3, 4]      ← duplicate, no-op (idempotent)
+```
+
+Deduplication key: `(sourceId, targetId, kind, timestamp)` tuple.
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ────────────────────────────────────────────┐
+    reputation-backend.ts — types + interfaces only        │
+    ecs.ts — REPUTATION: SubsystemToken<ReputationBackend> │
+                                                           │
+L2  @koi/reputation ◄─────────────────────────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ never imports L0u packages
+    ✓ @koi/core is the sole workspace dependency
+```
+
+---
+
+## Testing
+
+```bash
+cd packages/reputation && bun test
+```
+
+36 tests across 3 files:
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `compute-score.test.ts` | 14 | Level thresholds, weighted average, custom weights, edge cases |
+| `in-memory-backend.test.ts` | 17 | record/getScore, getScores batch, query filters, ring buffer, idempotency, dispose |
+| `component-provider.test.ts` | 5 | Provider shape, REPUTATION key, stable reference, detach |

--- a/docs/architecture/reputation-backend.md
+++ b/docs/architecture/reputation-backend.md
@@ -41,9 +41,10 @@ L0  @koi/core
         REPUTATION_LEVEL_ORDER     ← frozen ordered array
         DEFAULT_REPUTATION_QUERY_LIMIT  ← 100
 
-L2  @koi/reputation-memory (future)
+L2  @koi/reputation
     └── implements ReputationBackend
     └── in-memory ring buffer, sync, dev/test
+    └── see docs/L2/reputation.md
 
 L2  @koi/reputation-nexus (future)
     └── implements ReputationBackend
@@ -332,10 +333,10 @@ Key implementation rules:
 @koi/core (L0)
 └── ReputationBackend ← this contract
 
-@koi/reputation-memory (L2, planned)
+@koi/reputation (L2, implemented)
 └── in-memory ring buffer
-└── FIFO eviction (configurable cap)
-└── simple weighted average scoring
+└── FIFO eviction (configurable cap, default 1000/agent)
+└── weighted average scoring (configurable weights)
 └── sync — zero async overhead
 └── use for: dev, test, single-node
 

--- a/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "import { A as AgentId, E as EngineState, P as ProcessState, B as BrickRef, T as Tool, S as SkillComponent, a as AgentDescriptor, I as ImplementationArtifact, b as BrickArtifact, D as DelegationDenyReason, c as PermissionConfig, d as SessionId, C as CapabilityProof, e as BrickKind, f as SubsystemToken, g as TrustTier, h as Agent, i as ComponentProvider, j as AgentManifest, K as KoiMiddleware, k as ToolCallId } from './assembly-HASH.js';
-export { l as ALL_BRICK_KINDS, m as ANS_SCOPE_PRIORITY, n as AbortReason, o as AdvisoryLock, p as AgentArtifact, q as AgentMessage, r as AgentMessageInput, s as AnsConfig, t as ApprovalDecision, u as ApprovalHandler, v as ApprovalRequest, w as ArtifactRef, x as AttachResult, y as BROWSER, z as BrickArtifactBase, F as BrickFitnessMetrics, G as BrickId, H as BrickLifecycle, J as BrickPage, L as BrickRegistryBackend, M as BrickRegistryChangeEvent, N as BrickRegistryChangeKind, O as BrickRegistryReader, Q as BrickRegistryWriter, R as BrickRequires, U as BrickSearchQuery, V as BrickSnapshot, W as BrickSource, X as BrickUpdate, Y as BrowserActionOptions, Z as BrowserConsoleEntry, _ as BrowserConsoleLevel, $ as BrowserConsoleOptions, a0 as BrowserConsoleResult, a1 as BrowserDriver, a2 as BrowserEvaluateOptions, a3 as BrowserEvaluateResult, a4 as BrowserFormField, a5 as BrowserNavigateOptions, a6 as BrowserNavigateResult, a7 as BrowserRefInfo, a8 as BrowserScreenshotOptions, a9 as BrowserScreenshotResult, aa as BrowserScrollOptions, ab as BrowserSnapshotOptions, ac as BrowserSnapshotResult, ad as BrowserTabCloseOptions, ae as BrowserTabFocusOptions, af as BrowserTabInfo, ag as BrowserTabNewOptions, ah as BrowserTraceOptions, ai as BrowserTraceResult, aj as BrowserTypeOptions, ak as BrowserUploadFile, al as BrowserUploadOptions, am as BrowserWaitOptions, an as BrowserWaitUntil, ao as COMPONENT_PRIORITY, ap as CREDENTIALS, aq as CapabilityConfig, ar as CapabilityFragment, as as ChannelConfig, at as ChannelIdentity, au as ChildHandle, av as ChildLifecycleEvent, aw as ChildSpec, ax as CircuitBreakerConfig, ay as CompanionSkillDefinition, az as ComplianceRecord, aA as ComplianceRecorder, aB as ComponentEvent, aC as ComponentEventKind, aD as ComposedCallHandlers, aE as ConstraintChecker, aF as ConstraintQuery, aG as ContentMarker, aH as ContextPressureTrend, aI as CorrelationIds, aJ as CredentialComponent, aK as CronSchedule, aL as DEFAULT_ANS_CONFIG, aM as DEFAULT_BRICK_FITNESS, aN as DEFAULT_BRICK_SEARCH_LIMIT, aO as DEFAULT_CIRCUIT_BREAKER_CONFIG, aP as DEFAULT_DEMOTION_CRITERIA, aQ as DEFAULT_SCHEDULER_CONFIG, aR as DEFAULT_SKILL_SEARCH_LIMIT, aS as DEFAULT_SUPERVISION_CONFIG, aT as DEFAULT_VIOLATION_QUERY_LIMIT, aU as DELEGATION, aV as DataClassification, aW as DecisionRecord, aX as DelegationComponent, aY as DelegationConfig, aZ as DelegationEvent, a_ as DelegationGrant, a$ as DelegationId, b0 as DelegationManagerConfig, b1 as DelegationScope, b2 as DelegationVerifyResult, b3 as DemotionCriteria, b4 as EVENTS, b5 as EXTERNAL_AGENTS, b6 as EngineAdapter, b7 as EngineEvent, b8 as EngineInput, b9 as EngineInputBase, ba as EngineMetrics, bb as EngineOutput, bc as EngineStopReason, bd as EventComponent, be as ExternalAgentDescriptor, bf as ExternalAgentSource, bg as ExternalAgentTransport, bh as FILESYSTEM, bi as ForgeAttestationSignature, bj as ForgeBuildDefinition, bk as ForgeBuilder, bl as ForgeProvenance, bm as ForgeQuery, bn as ForgeResourceRef, bo as ForgeRunMetadata, bp as ForgeScope, bq as ForgeStageDigest, br as ForgeStore, bs as ForgeVerificationSummary, bt as GOVERNANCE, bu as GOVERNANCE_ALLOW, bv as GOVERNANCE_BACKEND, bw as GOVERNANCE_VARIABLES, bx as GovernanceBackend, by as GovernanceCheck, bz as GovernanceController, bA as GovernanceEvent, bB as GovernanceSnapshot, bC as GovernanceVariable, bD as GovernanceVariableContributor, bE as GovernanceVerdict, bF as HANDOFF, bG as HandoffAcceptError, bH as HandoffAcceptResult, bI as HandoffComponent, bJ as HandoffEnvelope, bK as HandoffEvent, bL as HandoffId, bM as HandoffStatus, bN as InTotoStatementV1, bO as InTotoSubject, bP as LatencySampler, bQ as LockHandle, bR as LockMode, bS as LockRequest, bT as MAILBOX, bU as MEMORY, bV as MIN_TRUST_BY_KIND, bW as MailboxComponent, bX as MemoryComponent, bY as MemoryRecallOptions, bZ as MemoryResult, b_ as MemoryStoreOptions, b$ as MemoryTier, c0 as MessageFilter, c1 as MessageId, c2 as MessageKind, c3 as MiddlewareBundle, c4 as MiddlewareConfig, c5 as ModelChunk, c6 as ModelConfig, c7 as ModelHandler, c8 as ModelRequest, c9 as ModelResponse, ca as ModelStreamHandler, cb as NAME_SERVICE, cc as NameBinding, cd as NameChangeEvent, ce as NameChangeKind, cf as NameQuery, cg as NameRecord, ch as NameRegistration, ci as NameResolution, cj as NameServiceBackend, ck as NameServiceReader, cl as NameServiceWriter, cm as NameSuggestion, cn as PolicyEvaluator, co as PolicyRequest, cp as PolicyRequestKind, cq as ProcessAccounter, cr as ProcessId, cs as PublisherId, ct as REGISTRY, cu as RegistryComponent, cv as RestartType, cw as RevocationRegistry, cx as RunId, cy as SCHEDULER, cz as ScheduleId, cA as ScheduleStore, cB as ScheduledTask, cC as SchedulerComponent, cD as SchedulerConfig, cE as SchedulerEvent, cF as SchedulerStats, cG as ScopeChecker, cH as SearchConfig, cI as SensorReading, cJ as SessionContext, cK as ShadowWarning, cL as SigningBackend, cM as SkillArtifact, cN as SkillConfig, cO as SkillId, cP as SkillMetadata, cQ as SkillPage, cR as SkillPublishRequest, cS as SkillRegistryBackend, cT as SkillRegistryChangeEvent, cU as SkillRegistryChangeKind, cV as SkillRegistryEntry, cW as SkillRegistryReader, cX as SkillRegistryWriter, cY as SkillSearchQuery, cZ as SkillVersion, c_ as SkippedComponent, c$ as SnapshotEvent, d0 as SnapshotId, d1 as SnapshotQuery, d2 as SnapshotStore, d3 as SpawnLedger, d4 as StoreChangeEvent, d5 as StoreChangeKind, d6 as StoreChangeNotifier, d7 as SupervisionConfig, d8 as SupervisionStrategy, d9 as TaskFilter, da as TaskHistoryFilter, db as TaskId, dc as TaskOptions, dd as TaskRunRecord, de as TaskScheduler, df as TaskStatus, dg as TaskStore, dh as TerminationOutcome, di as TestCase, dj as ToolArtifact, dk as ToolConfig, dl as ToolDescriptor, dm as ToolExecuteOptions, dn as ToolHandler, dp as ToolRequest, dq as ToolResponse, dr as TrustTransitionCaller, ds as TurnContext, dt as TurnId, du as VALID_LIFECYCLE_TRANSITIONS, dv as VIOLATION_SEVERITY_ORDER, dw as VersionChangeEvent, dx as VersionChangeKind, dy as VersionEntry, dz as VersionIndexBackend, dA as VersionIndexReader, dB as VersionIndexWriter, dC as VersionedBrickRef, dD as Violation, dE as ViolationFilter, dF as ViolationPage, dG as ViolationSeverity, dH as ViolationStore, dI as WEBHOOK, dJ as WORKSPACE, dK as WorkspaceComponent, dL as ZONE_REGISTRY, dM as agentId, dN as agentToken, dO as brickId, dP as channelToken, dQ as delegationId, dR as governanceContributorToken, dS as handoffId, dT as isAttachResult, dU as mapStopReasonToOutcome, dV as messageId, dW as middlewareToken, dX as publisherId, dY as runId, dZ as scheduleId, d_ as sessionId, d$ as skillId, e0 as skillToken, e1 as snapshotId, e2 as taskId, e3 as token, e4 as toolCallId, e5 as toolToken, e6 as turnId } from './assembly-HASH.js';
+export { l as ALL_BRICK_KINDS, m as ANS_SCOPE_PRIORITY, n as AbortReason, o as AdvisoryLock, p as AgentArtifact, q as AgentMessage, r as AgentMessageInput, s as AnsConfig, t as ApprovalDecision, u as ApprovalHandler, v as ApprovalRequest, w as ArtifactRef, x as AttachResult, y as BROWSER, z as BrickArtifactBase, F as BrickFitnessMetrics, G as BrickId, H as BrickLifecycle, J as BrickPage, L as BrickRegistryBackend, M as BrickRegistryChangeEvent, N as BrickRegistryChangeKind, O as BrickRegistryReader, Q as BrickRegistryWriter, R as BrickRequires, U as BrickSearchQuery, V as BrickSnapshot, W as BrickSource, X as BrickUpdate, Y as BrowserActionOptions, Z as BrowserConsoleEntry, _ as BrowserConsoleLevel, $ as BrowserConsoleOptions, a0 as BrowserConsoleResult, a1 as BrowserDriver, a2 as BrowserEvaluateOptions, a3 as BrowserEvaluateResult, a4 as BrowserFormField, a5 as BrowserNavigateOptions, a6 as BrowserNavigateResult, a7 as BrowserRefInfo, a8 as BrowserScreenshotOptions, a9 as BrowserScreenshotResult, aa as BrowserScrollOptions, ab as BrowserSnapshotOptions, ac as BrowserSnapshotResult, ad as BrowserTabCloseOptions, ae as BrowserTabFocusOptions, af as BrowserTabInfo, ag as BrowserTabNewOptions, ah as BrowserTraceOptions, ai as BrowserTraceResult, aj as BrowserTypeOptions, ak as BrowserUploadFile, al as BrowserUploadOptions, am as BrowserWaitOptions, an as BrowserWaitUntil, ao as COMPONENT_PRIORITY, ap as CREDENTIALS, aq as CapabilityConfig, ar as CapabilityFragment, as as ChannelConfig, at as ChannelIdentity, au as ChildHandle, av as ChildLifecycleEvent, aw as ChildSpec, ax as CircuitBreakerConfig, ay as CompanionSkillDefinition, az as ComplianceRecord, aA as ComplianceRecorder, aB as ComponentEvent, aC as ComponentEventKind, aD as ComposedCallHandlers, aE as ConstraintChecker, aF as ConstraintQuery, aG as ContentMarker, aH as ContextPressureTrend, aI as CorrelationIds, aJ as CredentialComponent, aK as CronSchedule, aL as DEFAULT_ANS_CONFIG, aM as DEFAULT_BRICK_FITNESS, aN as DEFAULT_BRICK_SEARCH_LIMIT, aO as DEFAULT_CIRCUIT_BREAKER_CONFIG, aP as DEFAULT_DEMOTION_CRITERIA, aQ as DEFAULT_REPUTATION_QUERY_LIMIT, aR as DEFAULT_SCHEDULER_CONFIG, aS as DEFAULT_SKILL_SEARCH_LIMIT, aT as DEFAULT_SUPERVISION_CONFIG, aU as DEFAULT_VIOLATION_QUERY_LIMIT, aV as DELEGATION, aW as DataClassification, aX as DecisionRecord, aY as DelegationComponent, aZ as DelegationConfig, a_ as DelegationEvent, a$ as DelegationGrant, b0 as DelegationId, b1 as DelegationManagerConfig, b2 as DelegationScope, b3 as DelegationVerifyResult, b4 as DemotionCriteria, b5 as EVENTS, b6 as EXTERNAL_AGENTS, b7 as EngineAdapter, b8 as EngineEvent, b9 as EngineInput, ba as EngineInputBase, bb as EngineMetrics, bc as EngineOutput, bd as EngineStopReason, be as EventComponent, bf as ExternalAgentDescriptor, bg as ExternalAgentSource, bh as ExternalAgentTransport, bi as FILESYSTEM, bj as FeedbackKind, bk as ForgeAttestationSignature, bl as ForgeBuildDefinition, bm as ForgeBuilder, bn as ForgeProvenance, bo as ForgeQuery, bp as ForgeResourceRef, bq as ForgeRunMetadata, br as ForgeScope, bs as ForgeStageDigest, bt as ForgeStore, bu as ForgeVerificationSummary, bv as GOVERNANCE, bw as GOVERNANCE_ALLOW, bx as GOVERNANCE_BACKEND, by as GOVERNANCE_VARIABLES, bz as GovernanceBackend, bA as GovernanceCheck, bB as GovernanceController, bC as GovernanceEvent, bD as GovernanceSnapshot, bE as GovernanceVariable, bF as GovernanceVariableContributor, bG as GovernanceVerdict, bH as HANDOFF, bI as HandoffAcceptError, bJ as HandoffAcceptResult, bK as HandoffComponent, bL as HandoffEnvelope, bM as HandoffEvent, bN as HandoffId, bO as HandoffStatus, bP as InTotoStatementV1, bQ as InTotoSubject, bR as LatencySampler, bS as LockHandle, bT as LockMode, bU as LockRequest, bV as MAILBOX, bW as MEMORY, bX as MIN_TRUST_BY_KIND, bY as MailboxComponent, bZ as MemoryComponent, b_ as MemoryRecallOptions, b$ as MemoryResult, c0 as MemoryStoreOptions, c1 as MemoryTier, c2 as MessageFilter, c3 as MessageId, c4 as MessageKind, c5 as MiddlewareBundle, c6 as MiddlewareConfig, c7 as ModelChunk, c8 as ModelConfig, c9 as ModelHandler, ca as ModelRequest, cb as ModelResponse, cc as ModelStreamHandler, cd as NAME_SERVICE, ce as NameBinding, cf as NameChangeEvent, cg as NameChangeKind, ch as NameQuery, ci as NameRecord, cj as NameRegistration, ck as NameResolution, cl as NameServiceBackend, cm as NameServiceReader, cn as NameServiceWriter, co as NameSuggestion, cp as PolicyEvaluator, cq as PolicyRequest, cr as PolicyRequestKind, cs as ProcessAccounter, ct as ProcessId, cu as PublisherId, cv as REGISTRY, cw as REPUTATION, cx as REPUTATION_LEVEL_ORDER, cy as RegistryComponent, cz as ReputationBackend, cA as ReputationFeedback, cB as ReputationLevel, cC as ReputationQuery, cD as ReputationQueryResult, cE as ReputationScore, cF as RestartType, cG as RevocationRegistry, cH as RunId, cI as SCHEDULER, cJ as ScheduleId, cK as ScheduleStore, cL as ScheduledTask, cM as SchedulerComponent, cN as SchedulerConfig, cO as SchedulerEvent, cP as SchedulerStats, cQ as ScopeChecker, cR as SearchConfig, cS as SensorReading, cT as SessionContext, cU as ShadowWarning, cV as SigningBackend, cW as SkillArtifact, cX as SkillConfig, cY as SkillId, cZ as SkillMetadata, c_ as SkillPage, c$ as SkillPublishRequest, d0 as SkillRegistryBackend, d1 as SkillRegistryChangeEvent, d2 as SkillRegistryChangeKind, d3 as SkillRegistryEntry, d4 as SkillRegistryReader, d5 as SkillRegistryWriter, d6 as SkillSearchQuery, d7 as SkillVersion, d8 as SkippedComponent, d9 as SnapshotEvent, da as SnapshotId, db as SnapshotQuery, dc as SnapshotStore, dd as SpawnLedger, de as StoreChangeEvent, df as StoreChangeKind, dg as StoreChangeNotifier, dh as SupervisionConfig, di as SupervisionStrategy, dj as TaskFilter, dk as TaskHistoryFilter, dl as TaskId, dm as TaskOptions, dn as TaskRunRecord, dp as TaskScheduler, dq as TaskStatus, dr as TaskStore, ds as TerminationOutcome, dt as TestCase, du as ToolArtifact, dv as ToolConfig, dw as ToolDescriptor, dx as ToolExecuteOptions, dy as ToolHandler, dz as ToolRequest, dA as ToolResponse, dB as TrustTransitionCaller, dC as TurnContext, dD as TurnId, dE as VALID_LIFECYCLE_TRANSITIONS, dF as VIOLATION_SEVERITY_ORDER, dG as VersionChangeEvent, dH as VersionChangeKind, dI as VersionEntry, dJ as VersionIndexBackend, dK as VersionIndexReader, dL as VersionIndexWriter, dM as VersionedBrickRef, dN as Violation, dO as ViolationFilter, dP as ViolationPage, dQ as ViolationSeverity, dR as ViolationStore, dS as WEBHOOK, dT as WORKSPACE, dU as WorkspaceComponent, dV as ZONE_REGISTRY, dW as agentId, dX as agentToken, dY as brickId, dZ as channelToken, d_ as delegationId, d$ as governanceContributorToken, e0 as handoffId, e1 as isAttachResult, e2 as mapStopReasonToOutcome, e3 as messageId, e4 as middlewareToken, e5 as publisherId, e6 as runId, e7 as scheduleId, e8 as sessionId, e9 as skillId, ea as skillToken, eb as snapshotId, ec as taskId, ed as token, ee as toolCallId, ef as toolToken, eg as turnId } from './assembly-HASH.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
 import { TransitionReason, AgentCondition, AgentStatus, RegistryEntry, AgentRegistry } from './lifecycle.js';
@@ -1286,164 +1286,6 @@ interface ReconcileRunnerConfig {
 declare const DEFAULT_RECONCILE_RUNNER_CONFIG: ReconcileRunnerConfig;
 
 /**
- * Reputation backend — pluggable trust scoring and feedback contract (Layer 0).
- *
- * Defines the shapes for recording interaction feedback, querying computed trust
- * scores, and filtering feedback history. L2 packages implement ReputationBackend
- * for specific backends (in-memory ring buffer, Nexus/EigenTrust, etc.).
- *
- * Fail-closed contract: callers MUST treat a missing score (undefined from
- * getScore) as "unknown" trust level — never as implicitly trusted.
- */
-
-/**
- * Discrete trust level derived from a computed reputation score.
- * Ordered from least to most trusted — see REPUTATION_LEVEL_ORDER for
- * the canonical sequence.
- */
-type ReputationLevel = "unknown" | "untrusted" | "low" | "medium" | "high" | "verified";
-/**
- * Canonical ordering of ReputationLevel values from least to most trusted.
- * Use this to avoid hardcoding the sequence in consumers:
- *
- * \`\`\`typescript
- * const idx = REPUTATION_LEVEL_ORDER.indexOf(score.level);
- * if (idx >= REPUTATION_LEVEL_ORDER.indexOf("medium")) { ... }
- * \`\`\`
- */
-declare const REPUTATION_LEVEL_ORDER: readonly ReputationLevel[];
-/**
- * Categorical feedback signal. Backends map these to numeric weights
- * using their own algorithm (e.g., EigenTrust normalizes to [0,1]).
- *
- * Start minimal: "positive" | "negative" | "neutral" only.
- * Retraction and dispute kinds (with entry IDs) will be added when
- * the dispute resolution workflow is designed.
- */
-type FeedbackKind = "positive" | "negative" | "neutral";
-/**
- * A single trust signal from one agent about another.
- *
- * No numeric score on input — backends derive weights from \`kind\` using
- * their own algorithm. This avoids the ambiguity of \`kind: "positive"\` with
- * \`score: -0.5\`. \`kind\` is the authoritative semantic signal.
- */
-interface ReputationFeedback {
-    /** The agent providing feedback (the observer). */
-    readonly sourceId: AgentId;
-    /** The agent being evaluated (the subject). */
-    readonly targetId: AgentId;
-    /** The semantic nature of the trust signal. */
-    readonly kind: FeedbackKind;
-    /**
-     * Optional structured context for the interaction.
-     * Useful for domain-specific metadata (session ID, task ID, domain tag).
-     * Backends may use context fields for domain-scoped scoring.
-     */
-    readonly context?: JsonObject | undefined;
-    /** Unix timestamp (ms) when the interaction occurred. */
-    readonly timestamp: number;
-}
-/**
- * The computed trust score for an agent.
- *
- * \`score\` is the continuous value in [0, 1] — backends derive this from
- * their own algorithm (e.g., EigenTrust eigenvector value, weighted average).
- * \`level\` is the categorical bucket derived from \`score\`.
- */
-interface ReputationScore {
-    /** The agent this score belongs to. */
-    readonly agentId: AgentId;
-    /**
-     * Continuous trust score in [0, 1].
-     * Higher = more trusted. Backends define the specific mapping.
-     */
-    readonly score: number;
-    /** Categorical trust level derived from \`score\`. */
-    readonly level: ReputationLevel;
-    /** Total number of feedback entries that contributed to this score. */
-    readonly feedbackCount: number;
-    /** Unix timestamp (ms) when this score was last computed. */
-    readonly computedAt: number;
-}
-/**
- * Default maximum number of feedback entries returned by a single \`query()\` call.
- * Implementations SHOULD apply this when the caller omits \`limit\`.
- */
-declare const DEFAULT_REPUTATION_QUERY_LIMIT = 100;
-/**
- * Filter for querying raw feedback entries.
- * All fields are optional — omitting a field means "no constraint on that dimension".
- * Providing no fields (empty filter) returns ALL entries up to \`limit\` — use with care.
- */
-interface ReputationQuery {
-    /** Filter to feedback where this agent is the subject being evaluated. */
-    readonly targetId?: AgentId | undefined;
-    /** Filter to feedback originating from this agent. */
-    readonly sourceId?: AgentId | undefined;
-    /** Filter to entries matching any of these kinds. */
-    readonly kinds?: readonly FeedbackKind[] | undefined;
-    /** Include only entries at or after this Unix timestamp (ms). */
-    readonly after?: number | undefined;
-    /** Include only entries before this Unix timestamp (ms). */
-    readonly before?: number | undefined;
-    /** Maximum number of entries to return. */
-    readonly limit?: number | undefined;
-}
-interface ReputationQueryResult {
-    /** Feedback entries matching the query filter. */
-    readonly entries: readonly ReputationFeedback[];
-    /** True if more entries exist beyond the returned batch (use limit + before/after to paginate). */
-    readonly hasMore: boolean;
-}
-/**
- * Pluggable trust scoring and feedback backend.
- *
- * All fallible operations return \`Result<T, KoiError>\`.
- * All methods return \`T | Promise<T>\` — in-memory implementations are sync,
- * database/network implementations are async. Callers must always \`await\`.
- *
- * **Fail-closed contract**: \`getScore()\` returns \`undefined\` for agents with
- * no feedback history. Callers MUST treat \`undefined\` as \`"unknown"\` trust
- * level and restrict access accordingly — never treat absence of data as
- * implicit trust.
- */
-interface ReputationBackend {
-    /**
-     * Record a trust signal from one agent about another.
-     * Implementations SHOULD be idempotent for identical (sourceId, targetId, kind, timestamp)
-     * tuples to handle retry scenarios.
-     */
-    readonly record: (feedback: ReputationFeedback) => Result<void, KoiError> | Promise<Result<void, KoiError>>;
-    /**
-     * Get the current computed trust score for a single agent.
-     *
-     * Returns \`undefined\` when no feedback exists for this agent.
-     * Callers MUST treat \`undefined\` as \`"unknown"\` level — fail closed.
-     */
-    readonly getScore: (targetId: AgentId) => Result<ReputationScore | undefined, KoiError> | Promise<Result<ReputationScore | undefined, KoiError>>;
-    /**
-     * Get computed trust scores for multiple agents in a single call.
-     *
-     * Optional — in-memory backends implement this trivially; network backends
-     * use batch requests to avoid N+1 roundtrips (e.g., for trust-aware routing).
-     * Callers SHOULD use this when scoring multiple agents simultaneously.
-     *
-     * Missing entries in the returned map mean no feedback exists for that agent.
-     */
-    readonly getScores?: (targetIds: readonly AgentId[]) => Result<ReadonlyMap<AgentId, ReputationScore | undefined>, KoiError> | Promise<Result<ReadonlyMap<AgentId, ReputationScore | undefined>, KoiError>>;
-    /**
-     * Query raw feedback entries matching the filter.
-     *
-     * Returns entries ordered by \`timestamp\` descending (most recent first).
-     * Check \`hasMore\` to determine if results were truncated.
-     */
-    readonly query: (filter: ReputationQuery) => Result<ReputationQueryResult, KoiError> | Promise<Result<ReputationQueryResult, KoiError>>;
-    /** Close the backend and release resources. */
-    readonly dispose?: () => void | Promise<void>;
-}
-
-/**
  * Scope enforcement — pluggable policy backend for subsystem access checks.
  *
  * Default enforcement lives in \`@koi/scope\` (local compiled patterns).
@@ -1738,7 +1580,7 @@ declare function isProcessState(value: string): value is ProcessState;
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CompensatingOp, ComponentProvider, type ContextSummary, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_REPUTATION_QUERY_LIMIT, DEFAULT_TASK_BOARD_CONFIG, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineState, type EventCursor, type FeedbackKind, type FileOpKind, type FileOpRecord, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, type NodeCapability, type NodeId, PROPOSAL_GATE_REQUIREMENTS, type PendingFrame, PermissionConfig, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, REPUTATION_LEVEL_ORDER, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, type ReputationBackend, type ReputationFeedback, type ReputationLevel, type ReputationQuery, type ReputationQueryResult, type ReputationScore, Result, type ReviewDecision, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, SubsystemToken, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskResult, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, TrustTier, type TurnTrace, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isProcessState, isToolCallPayload, nodeId, notFound, permission, proposalId, rateLimit, staleRef, taskItemId, timeout, validateNonEmpty, validation };
+export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentId, AgentManifest, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CompensatingOp, ComponentProvider, type ContextSummary, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_TASK_BOARD_CONFIG, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineState, type EventCursor, type FileOpKind, type FileOpRecord, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, type NodeCapability, type NodeId, PROPOSAL_GATE_REQUIREMENTS, type PendingFrame, PermissionConfig, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionCheckpoint, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SnapshotChainStore, type SnapshotNode, SubsystemToken, type TaskBoard, type TaskBoardConfig, type TaskBoardEvent, type TaskBoardSnapshot, type TaskItem, type TaskItemId, type TaskItemInput, type TaskItemPatch, type TaskItemStatus, type TaskResult, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TransitionContext, TransitionReason, TrustTier, type TurnTrace, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isProcessState, isToolCallPayload, nodeId, notFound, permission, proposalId, rateLimit, staleRef, taskItemId, timeout, validateNonEmpty, validation };
 "
 `;
 
@@ -1836,7 +1678,7 @@ export type { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, Feat
 
 exports[`@koi/core API surface ./assembly has stable type surface 1`] = `
 "import './common.js';
-export { j as AgentManifest, aq as CapabilityConfig, as as ChannelConfig, at as ChannelIdentity, c4 as MiddlewareConfig, c6 as ModelConfig, c as PermissionConfig, cH as SearchConfig, cN as SkillConfig, dk as ToolConfig } from './assembly-HASH.js';
+export { j as AgentManifest, aq as CapabilityConfig, as as ChannelConfig, at as ChannelIdentity, c6 as MiddlewareConfig, c8 as ModelConfig, c as PermissionConfig, cR as SearchConfig, cX as SkillConfig, dv as ToolConfig } from './assembly-HASH.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -1946,7 +1788,7 @@ export type { CompactionResult, ContextCompactor, TokenEstimator };
 `;
 
 exports[`@koi/core API surface ./delegation has stable type surface 1`] = `
-"export { C as CapabilityProof, ax as CircuitBreakerConfig, aO as DEFAULT_CIRCUIT_BREAKER_CONFIG, aX as DelegationComponent, aY as DelegationConfig, D as DelegationDenyReason, aZ as DelegationEvent, a_ as DelegationGrant, a$ as DelegationId, b0 as DelegationManagerConfig, b1 as DelegationScope, b2 as DelegationVerifyResult, cw as RevocationRegistry, cG as ScopeChecker, dQ as delegationId } from './assembly-HASH.js';
+"export { C as CapabilityProof, ax as CircuitBreakerConfig, aO as DEFAULT_CIRCUIT_BREAKER_CONFIG, aY as DelegationComponent, aZ as DelegationConfig, D as DelegationDenyReason, a_ as DelegationEvent, a$ as DelegationGrant, b0 as DelegationId, b1 as DelegationManagerConfig, b2 as DelegationScope, b3 as DelegationVerifyResult, cG as RevocationRegistry, cQ as ScopeChecker, d_ as delegationId } from './assembly-HASH.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -1958,7 +1800,7 @@ import './zone.js';
 `;
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
-"export { h as Agent, a as AgentDescriptor, A as AgentId, x as AttachResult, y as BROWSER, ao as COMPONENT_PRIORITY, ap as CREDENTIALS, au as ChildHandle, av as ChildLifecycleEvent, ay as CompanionSkillDefinition, aB as ComponentEvent, aC as ComponentEventKind, i as ComponentProvider, aJ as CredentialComponent, aU as DELEGATION, b4 as EVENTS, b5 as EXTERNAL_AGENTS, bd as EventComponent, bh as FILESYSTEM, bt as GOVERNANCE, bv as GOVERNANCE_BACKEND, bF as HANDOFF, bT as MAILBOX, bU as MEMORY, bX as MemoryComponent, bY as MemoryRecallOptions, bZ as MemoryResult, b_ as MemoryStoreOptions, b$ as MemoryTier, cb as NAME_SERVICE, cq as ProcessAccounter, cr as ProcessId, P as ProcessState, ct as REGISTRY, cu as RegistryComponent, cx as RunId, cy as SCHEDULER, d as SessionId, S as SkillComponent, cP as SkillMetadata, c_ as SkippedComponent, d3 as SpawnLedger, f as SubsystemToken, T as Tool, k as ToolCallId, dl as ToolDescriptor, dm as ToolExecuteOptions, g as TrustTier, dt as TurnId, dI as WEBHOOK, dJ as WORKSPACE, dK as WorkspaceComponent, dL as ZONE_REGISTRY, dM as agentId, dN as agentToken, dP as channelToken, dT as isAttachResult, dW as middlewareToken, dY as runId, d_ as sessionId, e0 as skillToken, e3 as token, e4 as toolCallId, e5 as toolToken, e6 as turnId } from './assembly-HASH.js';
+"export { h as Agent, a as AgentDescriptor, A as AgentId, x as AttachResult, y as BROWSER, ao as COMPONENT_PRIORITY, ap as CREDENTIALS, au as ChildHandle, av as ChildLifecycleEvent, ay as CompanionSkillDefinition, aB as ComponentEvent, aC as ComponentEventKind, i as ComponentProvider, aJ as CredentialComponent, aV as DELEGATION, b5 as EVENTS, b6 as EXTERNAL_AGENTS, be as EventComponent, bi as FILESYSTEM, bv as GOVERNANCE, bx as GOVERNANCE_BACKEND, bH as HANDOFF, bV as MAILBOX, bW as MEMORY, bZ as MemoryComponent, b_ as MemoryRecallOptions, b$ as MemoryResult, c0 as MemoryStoreOptions, c1 as MemoryTier, cd as NAME_SERVICE, cs as ProcessAccounter, ct as ProcessId, P as ProcessState, cv as REGISTRY, cw as REPUTATION, cy as RegistryComponent, cH as RunId, cI as SCHEDULER, d as SessionId, S as SkillComponent, cZ as SkillMetadata, d8 as SkippedComponent, dd as SpawnLedger, f as SubsystemToken, T as Tool, k as ToolCallId, dw as ToolDescriptor, dx as ToolExecuteOptions, g as TrustTier, dD as TurnId, dS as WEBHOOK, dT as WORKSPACE, dU as WorkspaceComponent, dV as ZONE_REGISTRY, dW as agentId, dX as agentToken, dZ as channelToken, e1 as isAttachResult, e4 as middlewareToken, e6 as runId, e8 as sessionId, ea as skillToken, ed as token, ee as toolCallId, ef as toolToken, eg as turnId } from './assembly-HASH.js';
 import './channel.js';
 import './common.js';
 import './filesystem-HASH.js';
@@ -1971,7 +1813,7 @@ import './message.js';
 
 exports[`@koi/core API surface ./handoff has stable type surface 1`] = `
 "import './common.js';
-export { w as ArtifactRef, aW as DecisionRecord, bG as HandoffAcceptError, bH as HandoffAcceptResult, bI as HandoffComponent, bJ as HandoffEnvelope, bK as HandoffEvent, bL as HandoffId, bM as HandoffStatus, dS as handoffId } from './assembly-HASH.js';
+export { w as ArtifactRef, aX as DecisionRecord, bI as HandoffAcceptError, bJ as HandoffAcceptResult, bK as HandoffComponent, bL as HandoffEnvelope, bM as HandoffEvent, bN as HandoffId, bO as HandoffStatus, e0 as handoffId } from './assembly-HASH.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -1983,7 +1825,7 @@ import './zone.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { n as AbortReason, aD as ComposedCallHandlers, b6 as EngineAdapter, b7 as EngineEvent, b8 as EngineInput, b9 as EngineInputBase, ba as EngineMetrics, bb as EngineOutput, E as EngineState, bc as EngineStopReason, dh as TerminationOutcome, dU as mapStopReasonToOutcome } from './assembly-HASH.js';
+export { n as AbortReason, aD as ComposedCallHandlers, b7 as EngineAdapter, b8 as EngineEvent, b9 as EngineInput, ba as EngineInputBase, bb as EngineMetrics, bc as EngineOutput, E as EngineState, bd as EngineStopReason, ds as TerminationOutcome, e2 as mapStopReasonToOutcome } from './assembly-HASH.js';
 import './message.js';
 import './webhook.js';
 import './errors.js';
@@ -2145,7 +1987,7 @@ export type { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfi
 
 exports[`@koi/core API surface ./governance-backend has stable type surface 1`] = `
 "import './common.js';
-export { az as ComplianceRecord, aA as ComplianceRecorder, aE as ConstraintChecker, aF as ConstraintQuery, aT as DEFAULT_VIOLATION_QUERY_LIMIT, bu as GOVERNANCE_ALLOW, bx as GovernanceBackend, bE as GovernanceVerdict, cn as PolicyEvaluator, co as PolicyRequest, cp as PolicyRequestKind, dv as VIOLATION_SEVERITY_ORDER, dD as Violation, dE as ViolationFilter, dF as ViolationPage, dG as ViolationSeverity, dH as ViolationStore } from './assembly-HASH.js';
+export { az as ComplianceRecord, aA as ComplianceRecorder, aE as ConstraintChecker, aF as ConstraintQuery, aU as DEFAULT_VIOLATION_QUERY_LIMIT, bw as GOVERNANCE_ALLOW, bz as GovernanceBackend, bG as GovernanceVerdict, cp as PolicyEvaluator, cq as PolicyRequest, cr as PolicyRequestKind, dF as VIOLATION_SEVERITY_ORDER, dN as Violation, dO as ViolationFilter, dP as ViolationPage, dQ as ViolationSeverity, dR as ViolationStore } from './assembly-HASH.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -2400,7 +2242,7 @@ export type { ButtonBlock, ContentBlock, CustomBlock, FileBlock, ImageBlock, Inb
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import './channel.js';
 import './common.js';
-export { t as ApprovalDecision, u as ApprovalHandler, v as ApprovalRequest, ar as CapabilityFragment, K as KoiMiddleware, c3 as MiddlewareBundle, c5 as ModelChunk, c7 as ModelHandler, c8 as ModelRequest, c9 as ModelResponse, ca as ModelStreamHandler, cJ as SessionContext, dn as ToolHandler, dp as ToolRequest, dq as ToolResponse, ds as TurnContext } from './assembly-HASH.js';
+export { t as ApprovalDecision, u as ApprovalHandler, v as ApprovalRequest, ar as CapabilityFragment, K as KoiMiddleware, c5 as MiddlewareBundle, c7 as ModelChunk, c9 as ModelHandler, ca as ModelRequest, cb as ModelResponse, cc as ModelStreamHandler, cT as SessionContext, dy as ToolHandler, dz as ToolRequest, dA as ToolResponse, dC as TurnContext } from './assembly-HASH.js';
 import './message.js';
 import './webhook.js';
 import './errors.js';
@@ -2788,7 +2630,7 @@ export type { Resolver, SourceBundle, SourceLanguage };
 
 exports[`@koi/core API surface ./brick-snapshot has stable type surface 1`] = `
 "import './errors.js';
-export { G as BrickId, B as BrickRef, V as BrickSnapshot, W as BrickSource, c$ as SnapshotEvent, d0 as SnapshotId, d1 as SnapshotQuery, d2 as SnapshotStore, dO as brickId, e1 as snapshotId } from './assembly-HASH.js';
+export { G as BrickId, B as BrickRef, V as BrickSnapshot, W as BrickSource, d9 as SnapshotEvent, da as SnapshotId, db as SnapshotQuery, dc as SnapshotStore, dY as brickId, eb as snapshotId } from './assembly-HASH.js';
 import './common.js';
 import './webhook.js';
 import './channel.js';
@@ -2799,7 +2641,7 @@ import './zone.js';
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"export { o as AdvisoryLock, p as AgentArtifact, b as BrickArtifact, z as BrickArtifactBase, F as BrickFitnessMetrics, R as BrickRequires, X as BrickUpdate, aM as DEFAULT_BRICK_FITNESS, bm as ForgeQuery, br as ForgeStore, I as ImplementationArtifact, bP as LatencySampler, bQ as LockHandle, bR as LockMode, bS as LockRequest, cM as SkillArtifact, d4 as StoreChangeEvent, d5 as StoreChangeKind, d6 as StoreChangeNotifier, di as TestCase, dj as ToolArtifact } from './assembly-HASH.js';
+"export { o as AdvisoryLock, p as AgentArtifact, b as BrickArtifact, z as BrickArtifactBase, F as BrickFitnessMetrics, R as BrickRequires, X as BrickUpdate, aM as DEFAULT_BRICK_FITNESS, bo as ForgeQuery, bt as ForgeStore, I as ImplementationArtifact, bR as LatencySampler, bS as LockHandle, bT as LockMode, bU as LockRequest, cW as SkillArtifact, de as StoreChangeEvent, df as StoreChangeKind, dg as StoreChangeNotifier, dt as TestCase, du as ToolArtifact } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './webhook.js';
@@ -3020,7 +2862,7 @@ export type { FilesystemPolicy, NetworkPolicy, ResourceLimits, SandboxProfile };
 `;
 
 exports[`@koi/core API surface ./skill-registry has stable type surface 1`] = `
-"export { aR as DEFAULT_SKILL_SEARCH_LIMIT, cO as SkillId, cQ as SkillPage, cR as SkillPublishRequest, cS as SkillRegistryBackend, cT as SkillRegistryChangeEvent, cU as SkillRegistryChangeKind, cV as SkillRegistryEntry, cW as SkillRegistryReader, cX as SkillRegistryWriter, cY as SkillSearchQuery, cZ as SkillVersion, d$ as skillId } from './assembly-HASH.js';
+"export { aS as DEFAULT_SKILL_SEARCH_LIMIT, cY as SkillId, c_ as SkillPage, c$ as SkillPublishRequest, d0 as SkillRegistryBackend, d1 as SkillRegistryChangeEvent, d2 as SkillRegistryChangeKind, d3 as SkillRegistryEntry, d4 as SkillRegistryReader, d5 as SkillRegistryWriter, d6 as SkillSearchQuery, d7 as SkillVersion, e9 as skillId } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './webhook.js';
@@ -3067,7 +2909,7 @@ export type { PermissionBackend, PermissionDecision, PermissionQuery };
 `;
 
 exports[`@koi/core API surface ./version-index has stable type surface 1`] = `
-"export { dz as VersionIndexBackend, dA as VersionIndexReader, dB as VersionIndexWriter } from './assembly-HASH.js';
+"export { dJ as VersionIndexBackend, dK as VersionIndexReader, dL as VersionIndexWriter } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './webhook.js';
@@ -3079,7 +2921,7 @@ import './zone.js';
 `;
 
 exports[`@koi/core API surface ./version-types has stable type surface 1`] = `
-"export { cs as PublisherId, cK as ShadowWarning, dw as VersionChangeEvent, dx as VersionChangeKind, dy as VersionEntry, dC as VersionedBrickRef, dX as publisherId } from './assembly-HASH.js';
+"export { cu as PublisherId, cU as ShadowWarning, dG as VersionChangeEvent, dH as VersionChangeKind, dI as VersionEntry, dM as VersionedBrickRef, e5 as publisherId } from './assembly-HASH.js';
 import './common.js';
 import './webhook.js';
 import './errors.js';
@@ -3092,7 +2934,7 @@ import './zone.js';
 
 exports[`@koi/core API surface ./run-report has stable type surface 1`] = `
 "import { JsonObject } from './common.js';
-import { A as AgentId, d as SessionId, cx as RunId, w as ArtifactRef } from './assembly-HASH.js';
+import { A as AgentId, d as SessionId, cH as RunId, w as ArtifactRef } from './assembly-HASH.js';
 import './webhook.js';
 import './errors.js';
 import './channel.js';
@@ -3215,7 +3057,7 @@ export type { ElicitationOption, ElicitationQuestion, ElicitationResult };
 
 exports[`@koi/core API surface ./mailbox has stable type surface 1`] = `
 "import './common.js';
-export { q as AgentMessage, r as AgentMessageInput, bW as MailboxComponent, c0 as MessageFilter, c1 as MessageId, c2 as MessageKind, dV as messageId } from './assembly-HASH.js';
+export { q as AgentMessage, r as AgentMessageInput, bY as MailboxComponent, c2 as MessageFilter, c3 as MessageId, c4 as MessageKind, e3 as messageId } from './assembly-HASH.js';
 import './errors.js';
 import './webhook.js';
 import './channel.js';

--- a/packages/core/src/ecs.ts
+++ b/packages/core/src/ecs.ts
@@ -22,6 +22,7 @@ import type { GovernanceBackend } from "./governance-backend.js";
 import type { HandoffComponent } from "./handoff.js";
 import type { MailboxComponent } from "./mailbox.js";
 import type { NameServiceReader } from "./name-service.js";
+import type { ReputationBackend } from "./reputation-backend.js";
 import type { SchedulerComponent } from "./scheduler.js";
 import type { SkillRegistryReader } from "./skill-registry.js";
 import type { VersionIndexReader } from "./version-index.js";
@@ -495,6 +496,7 @@ export const WEBHOOK: SubsystemToken<WebhookComponent> = token<WebhookComponent>
 export const EXTERNAL_AGENTS: SubsystemToken<readonly ExternalAgentDescriptor[]> =
   token<readonly ExternalAgentDescriptor[]>("external-agents");
 export const REGISTRY: SubsystemToken<RegistryComponent> = token<RegistryComponent>("registry");
+export const REPUTATION: SubsystemToken<ReputationBackend> = token<ReputationBackend>("reputation");
 export const MAILBOX: SubsystemToken<MailboxComponent> = token<MailboxComponent>("mailbox");
 export const NAME_SERVICE: SubsystemToken<NameServiceReader> =
   token<NameServiceReader>("name-service");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -272,6 +272,7 @@ export {
   middlewareToken,
   NAME_SERVICE,
   REGISTRY,
+  REPUTATION,
   runId,
   SCHEDULER,
   sessionId,

--- a/packages/reputation/package.json
+++ b/packages/reputation/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/reputation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  }
+}

--- a/packages/reputation/src/component-provider.test.ts
+++ b/packages/reputation/src/component-provider.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import type { Agent, ReputationBackend } from "@koi/core";
+import { REPUTATION } from "@koi/core";
+
+import { createReputationProvider } from "./component-provider.js";
+import { createInMemoryReputationBackend } from "./in-memory-backend.js";
+
+describe("createReputationProvider", () => {
+  test("returns a provider with name 'reputation'", () => {
+    const backend = createInMemoryReputationBackend();
+    const provider = createReputationProvider(backend);
+    expect(provider.name).toBe("reputation");
+  });
+
+  test("attach returns REPUTATION token in components map", async () => {
+    const backend = createInMemoryReputationBackend();
+    const provider = createReputationProvider(backend);
+    const result = await provider.attach({} as Agent);
+
+    expect("components" in result).toBe(true);
+    if ("components" in result) {
+      expect(result.components.has(REPUTATION as string)).toBe(true);
+      expect(result.skipped).toHaveLength(0);
+    }
+  });
+
+  test("attached component is the same backend instance", async () => {
+    const backend = createInMemoryReputationBackend();
+    const provider = createReputationProvider(backend);
+    const result = await provider.attach({} as Agent);
+
+    if ("components" in result) {
+      const attached = result.components.get(REPUTATION as string) as ReputationBackend;
+      expect(attached).toBe(backend);
+    }
+  });
+
+  test("attach returns stable reference on repeated calls", async () => {
+    const backend = createInMemoryReputationBackend();
+    const provider = createReputationProvider(backend);
+    const result1 = await provider.attach({} as Agent);
+    const result2 = await provider.attach({} as Agent);
+    expect(result1).toBe(result2);
+  });
+
+  test("detach calls backend dispose", async () => {
+    let disposed = false;
+    const mockBackend: ReputationBackend = {
+      record: () => ({ ok: true, value: undefined }),
+      getScore: () => ({ ok: true, value: undefined }),
+      query: () => ({ ok: true, value: { entries: [], hasMore: false } }),
+      dispose: () => {
+        disposed = true;
+      },
+    };
+
+    const provider = createReputationProvider(mockBackend);
+    await provider.detach?.({} as Agent);
+    expect(disposed).toBe(true);
+  });
+});

--- a/packages/reputation/src/component-provider.ts
+++ b/packages/reputation/src/component-provider.ts
@@ -1,0 +1,27 @@
+/**
+ * ComponentProvider that attaches a full ReputationBackend on the REPUTATION token.
+ *
+ * Agents receive both read and write access — they can record feedback and
+ * query scores through the same component.
+ */
+
+import type { AttachResult, ComponentProvider, ReputationBackend } from "@koi/core";
+import { COMPONENT_PRIORITY, REPUTATION } from "@koi/core";
+
+/**
+ * Create a ComponentProvider that attaches the given ReputationBackend
+ * to every agent under the REPUTATION token.
+ */
+export function createReputationProvider(backend: ReputationBackend): ComponentProvider {
+  const components: ReadonlyMap<string, unknown> = new Map([[REPUTATION as string, backend]]);
+  const result: AttachResult = { components, skipped: [] };
+
+  return {
+    name: "reputation",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    attach: async () => result,
+    detach: async () => {
+      await backend.dispose?.();
+    },
+  };
+}

--- a/packages/reputation/src/compute-score.test.ts
+++ b/packages/reputation/src/compute-score.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedbackKind, ReputationFeedback, ReputationScore } from "@koi/core";
+import { agentId } from "@koi/core";
+
+import { computeScore, DEFAULT_FEEDBACK_WEIGHTS } from "./compute-score.js";
+
+const AGENT_A = agentId("agent-a");
+const AGENT_B = agentId("agent-b");
+
+function makeFeedback(kind: FeedbackKind, timestamp = Date.now()): ReputationFeedback {
+  return { sourceId: AGENT_B, targetId: AGENT_A, kind, timestamp };
+}
+
+/** Narrow undefined away so subsequent expects don't need `!`. */
+function assertDefined(value: ReputationScore | undefined): asserts value is ReputationScore {
+  expect(value).toBeDefined();
+}
+
+describe("computeScore", () => {
+  test("returns undefined for empty entries", () => {
+    expect(computeScore(AGENT_A, [])).toBeUndefined();
+  });
+
+  test("returns score=1.0, level=high for all-positive feedback", () => {
+    const entries = [makeFeedback("positive"), makeFeedback("positive"), makeFeedback("positive")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(1.0);
+    expect(result.level).toBe("high");
+    expect(result.feedbackCount).toBe(3);
+    expect(result.agentId).toBe(AGENT_A);
+  });
+
+  test("returns score=0.0, level=untrusted for all-negative feedback", () => {
+    const entries = [makeFeedback("negative"), makeFeedback("negative")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.0);
+    expect(result.level).toBe("untrusted");
+  });
+
+  test("returns score=0.5, level=medium for all-neutral feedback", () => {
+    const entries = [makeFeedback("neutral"), makeFeedback("neutral")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.5);
+    expect(result.level).toBe("medium");
+  });
+
+  test("computes weighted average for mixed feedback", () => {
+    // 1 positive (1.0), 1 neutral (0.5), 1 negative (0.0) → avg = 0.5
+    const entries = [makeFeedback("positive"), makeFeedback("neutral"), makeFeedback("negative")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.5);
+    expect(result.level).toBe("medium");
+  });
+
+  test("level=untrusted when score < 0.2", () => {
+    // 1 neutral (0.5), 4 negative (0.0) → avg = 0.1
+    const entries = [
+      makeFeedback("neutral"),
+      makeFeedback("negative"),
+      makeFeedback("negative"),
+      makeFeedback("negative"),
+      makeFeedback("negative"),
+    ];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.1);
+    expect(result.level).toBe("untrusted");
+  });
+
+  test("level=low when 0.2 <= score < 0.4", () => {
+    // 3 negative (0.0), 1 positive (1.0) → avg = 0.25
+    const entries = [
+      makeFeedback("negative"),
+      makeFeedback("negative"),
+      makeFeedback("negative"),
+      makeFeedback("positive"),
+    ];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.25);
+    expect(result.level).toBe("low");
+  });
+
+  test("level=medium when 0.4 <= score < 0.6", () => {
+    // 1 positive (1.0), 1 negative (0.0) → avg = 0.5
+    const entries = [makeFeedback("positive"), makeFeedback("negative")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBe(0.5);
+    expect(result.level).toBe("medium");
+  });
+
+  test("level=high when score >= 0.6", () => {
+    // 2 positive (1.0), 1 negative (0.0) → avg = 0.666...
+    const entries = [makeFeedback("positive"), makeFeedback("positive"), makeFeedback("negative")];
+    const result = computeScore(AGENT_A, entries);
+    assertDefined(result);
+    expect(result.score).toBeCloseTo(0.6667, 3);
+    expect(result.level).toBe("high");
+  });
+
+  test("never assigns 'verified' level", () => {
+    const result = computeScore(AGENT_A, [makeFeedback("positive")]);
+    assertDefined(result);
+    expect(result.level).not.toBe("verified");
+  });
+
+  test("respects custom weights", () => {
+    const customWeights: Record<FeedbackKind, number> = {
+      positive: 1.0,
+      neutral: 0.8,
+      negative: 0.2,
+    };
+    // 1 negative with weight 0.2 → avg = 0.2 → level = low
+    const entries = [makeFeedback("negative")];
+    const result = computeScore(AGENT_A, entries, customWeights);
+    assertDefined(result);
+    expect(result.score).toBe(0.2);
+    expect(result.level).toBe("low");
+  });
+
+  test("DEFAULT_FEEDBACK_WEIGHTS has expected values", () => {
+    expect(DEFAULT_FEEDBACK_WEIGHTS.positive).toBe(1.0);
+    expect(DEFAULT_FEEDBACK_WEIGHTS.neutral).toBe(0.5);
+    expect(DEFAULT_FEEDBACK_WEIGHTS.negative).toBe(0.0);
+  });
+
+  test("populates computedAt timestamp", () => {
+    const before = Date.now();
+    const result = computeScore(AGENT_A, [makeFeedback("positive")]);
+    const after = Date.now();
+    assertDefined(result);
+    expect(result.computedAt).toBeGreaterThanOrEqual(before);
+    expect(result.computedAt).toBeLessThanOrEqual(after);
+  });
+});

--- a/packages/reputation/src/compute-score.ts
+++ b/packages/reputation/src/compute-score.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure score computation: feedback entries → ReputationScore.
+ *
+ * Weighted average with configurable weights per FeedbackKind.
+ * Level thresholds: <0.2 untrusted, <0.4 low, <0.6 medium, >=0.6 high.
+ * "verified" is never auto-assigned — it requires external attestation.
+ */
+
+import type {
+  AgentId,
+  FeedbackKind,
+  ReputationFeedback,
+  ReputationLevel,
+  ReputationScore,
+} from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Weight configuration
+// ---------------------------------------------------------------------------
+
+/** Default numeric weights for each FeedbackKind. */
+export const DEFAULT_FEEDBACK_WEIGHTS: Readonly<Record<FeedbackKind, number>> = Object.freeze({
+  positive: 1.0,
+  neutral: 0.5,
+  negative: 0.0,
+} as const);
+
+/** Thresholds for mapping a continuous score to a ReputationLevel. */
+const LEVEL_THRESHOLDS: readonly { readonly min: number; readonly level: ReputationLevel }[] =
+  Object.freeze([
+    { min: 0.6, level: "high" },
+    { min: 0.4, level: "medium" },
+    { min: 0.2, level: "low" },
+    { min: 0, level: "untrusted" },
+  ] as const);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a ReputationScore from a set of feedback entries.
+ *
+ * Returns `undefined` when `entries` is empty (no data → unknown trust).
+ * Callers should treat `undefined` as `"unknown"` level (fail-closed).
+ */
+export function computeScore(
+  targetId: AgentId,
+  entries: readonly ReputationFeedback[],
+  weights?: Readonly<Record<FeedbackKind, number>>,
+): ReputationScore | undefined {
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const w = weights ?? DEFAULT_FEEDBACK_WEIGHTS;
+
+  let sum = 0;
+  for (const entry of entries) {
+    const weight = w[entry.kind];
+    sum += weight ?? 0;
+  }
+  const score = sum / entries.length;
+
+  return {
+    agentId: targetId,
+    score,
+    level: scoreToLevel(score),
+    feedbackCount: entries.length,
+    computedAt: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function scoreToLevel(score: number): ReputationLevel {
+  for (const threshold of LEVEL_THRESHOLDS) {
+    if (score >= threshold.min) {
+      return threshold.level;
+    }
+  }
+  return "untrusted";
+}

--- a/packages/reputation/src/in-memory-backend.test.ts
+++ b/packages/reputation/src/in-memory-backend.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { ReputationBackend, ReputationFeedback } from "@koi/core";
+import { agentId } from "@koi/core";
+
+import { createInMemoryReputationBackend } from "./in-memory-backend.js";
+
+const AGENT_A = agentId("agent-a");
+const AGENT_B = agentId("agent-b");
+const AGENT_C = agentId("agent-c");
+
+function feedback(overrides?: Partial<ReputationFeedback>): ReputationFeedback {
+  return {
+    sourceId: AGENT_B,
+    targetId: AGENT_A,
+    kind: "positive",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+/** Narrow undefined away so subsequent expects don't need `!`. */
+function assertDefined<T>(value: T | undefined): asserts value is T {
+  expect(value).toBeDefined();
+}
+
+describe("createInMemoryReputationBackend", () => {
+  // let is justified: reset in beforeEach
+  let backend: ReputationBackend;
+
+  beforeEach(() => {
+    backend = createInMemoryReputationBackend();
+  });
+
+  // -- record ----------------------------------------------------------------
+
+  describe("record", () => {
+    test("records feedback successfully", async () => {
+      const result = await backend.record(feedback());
+      expect(result).toEqual({ ok: true, value: undefined });
+    });
+
+    test("is idempotent for identical tuples", async () => {
+      const fb = feedback({ timestamp: 1000 });
+      await backend.record(fb);
+      await backend.record(fb);
+
+      const scoreResult = await backend.getScore(AGENT_A);
+      expect(scoreResult).toMatchObject({ ok: true });
+      if (scoreResult.ok) {
+        assertDefined(scoreResult.value);
+        expect(scoreResult.value.feedbackCount).toBe(1);
+      }
+    });
+
+    test("records different feedback from same source", async () => {
+      await backend.record(feedback({ kind: "positive", timestamp: 1000 }));
+      await backend.record(feedback({ kind: "negative", timestamp: 2000 }));
+
+      const scoreResult = await backend.getScore(AGENT_A);
+      expect(scoreResult).toMatchObject({ ok: true });
+      if (scoreResult.ok) {
+        assertDefined(scoreResult.value);
+        expect(scoreResult.value.feedbackCount).toBe(2);
+      }
+    });
+  });
+
+  // -- getScore --------------------------------------------------------------
+
+  describe("getScore", () => {
+    test("returns undefined for unknown agent", async () => {
+      const result = await backend.getScore(agentId("unknown"));
+      expect(result).toEqual({ ok: true, value: undefined });
+    });
+
+    test("returns computed score after recording", async () => {
+      await backend.record(feedback({ kind: "positive", timestamp: 1 }));
+      await backend.record(feedback({ kind: "positive", timestamp: 2 }));
+
+      const result = await backend.getScore(AGENT_A);
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        assertDefined(result.value);
+        expect(result.value.score).toBe(1.0);
+        expect(result.value.level).toBe("high");
+        expect(result.value.agentId).toBe(AGENT_A);
+      }
+    });
+  });
+
+  // -- getScores (batch) -----------------------------------------------------
+
+  describe("getScores", () => {
+    test("returns scores for multiple agents", async () => {
+      await backend.record(feedback({ targetId: AGENT_A, kind: "positive", timestamp: 1 }));
+      await backend.record(feedback({ targetId: AGENT_B, kind: "negative", timestamp: 2 }));
+
+      assertDefined(backend.getScores);
+      const result = await backend.getScores([AGENT_A, AGENT_B, AGENT_C]);
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        const scores = result.value;
+        const scoreA = scores.get(AGENT_A);
+        assertDefined(scoreA);
+        expect(scoreA.level).toBe("high");
+
+        const scoreB = scores.get(AGENT_B);
+        assertDefined(scoreB);
+        expect(scoreB.level).toBe("untrusted");
+
+        expect(scores.get(AGENT_C)).toBeUndefined();
+      }
+    });
+  });
+
+  // -- query -----------------------------------------------------------------
+
+  describe("query", () => {
+    test("returns empty for no matching entries", async () => {
+      const result = await backend.query({ targetId: agentId("nonexistent") });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(0);
+        expect(result.value.hasMore).toBe(false);
+      }
+    });
+
+    test("filters by targetId", async () => {
+      await backend.record(feedback({ targetId: AGENT_A, timestamp: 1 }));
+      await backend.record(feedback({ targetId: AGENT_B, timestamp: 2 }));
+
+      const result = await backend.query({ targetId: AGENT_A });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(1);
+        const first = result.value.entries[0];
+        assertDefined(first);
+        expect(first.targetId).toBe(AGENT_A);
+      }
+    });
+
+    test("filters by sourceId", async () => {
+      await backend.record(feedback({ sourceId: AGENT_B, timestamp: 1 }));
+      await backend.record(feedback({ sourceId: AGENT_C, timestamp: 2 }));
+
+      const result = await backend.query({ sourceId: AGENT_C });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(1);
+        const first = result.value.entries[0];
+        assertDefined(first);
+        expect(first.sourceId).toBe(AGENT_C);
+      }
+    });
+
+    test("filters by kinds", async () => {
+      await backend.record(feedback({ kind: "positive", timestamp: 1 }));
+      await backend.record(feedback({ kind: "negative", timestamp: 2 }));
+      await backend.record(feedback({ kind: "neutral", timestamp: 3 }));
+
+      const result = await backend.query({ kinds: ["positive", "neutral"] });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(2);
+      }
+    });
+
+    test("filters by time range (after/before)", async () => {
+      await backend.record(feedback({ timestamp: 100 }));
+      await backend.record(feedback({ timestamp: 200, kind: "neutral" }));
+      await backend.record(feedback({ timestamp: 300, kind: "negative" }));
+
+      const result = await backend.query({ after: 150, before: 250 });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(1);
+        const first = result.value.entries[0];
+        assertDefined(first);
+        expect(first.timestamp).toBe(200);
+      }
+    });
+
+    test("returns entries sorted by timestamp descending", async () => {
+      await backend.record(feedback({ timestamp: 100 }));
+      await backend.record(feedback({ timestamp: 300, kind: "neutral" }));
+      await backend.record(feedback({ timestamp: 200, kind: "negative" }));
+
+      const result = await backend.query({});
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        const timestamps = result.value.entries.map((e: ReputationFeedback) => e.timestamp);
+        expect(timestamps).toEqual([300, 200, 100]);
+      }
+    });
+
+    test("respects limit and reports hasMore", async () => {
+      await backend.record(feedback({ timestamp: 1 }));
+      await backend.record(feedback({ timestamp: 2, kind: "neutral" }));
+      await backend.record(feedback({ timestamp: 3, kind: "negative" }));
+
+      const result = await backend.query({ limit: 2 });
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.value.entries).toHaveLength(2);
+        expect(result.value.hasMore).toBe(true);
+      }
+    });
+  });
+
+  // -- ring buffer -----------------------------------------------------------
+
+  describe("ring buffer", () => {
+    test("evicts oldest entries when capacity is reached", async () => {
+      const small = createInMemoryReputationBackend({ maxEntriesPerAgent: 3 });
+
+      await small.record(feedback({ kind: "negative", timestamp: 1 }));
+      await small.record(feedback({ kind: "negative", timestamp: 2 }));
+      await small.record(feedback({ kind: "negative", timestamp: 3 }));
+      // This should evict timestamp=1
+      await small.record(feedback({ kind: "positive", timestamp: 4 }));
+
+      const queryResult = await small.query({ targetId: AGENT_A });
+      expect(queryResult).toMatchObject({ ok: true });
+      if (queryResult.ok) {
+        expect(queryResult.value.entries).toHaveLength(3);
+        const timestamps = queryResult.value.entries.map((e: ReputationFeedback) => e.timestamp);
+        expect(timestamps).toEqual([4, 3, 2]);
+      }
+    });
+  });
+
+  // -- dispose ---------------------------------------------------------------
+
+  describe("dispose", () => {
+    test("clears all data", async () => {
+      await backend.record(feedback({ timestamp: 1 }));
+      assertDefined(backend.dispose);
+      await backend.dispose();
+
+      const result = await backend.getScore(AGENT_A);
+      expect(result).toMatchObject({ ok: false });
+    });
+
+    test("returns error on record after dispose", async () => {
+      assertDefined(backend.dispose);
+      await backend.dispose();
+      const result = await backend.record(feedback());
+      expect(result).toMatchObject({ ok: false });
+      if (!result.ok) {
+        expect(result.error.code).toBe("INTERNAL");
+      }
+    });
+
+    test("returns error on query after dispose", async () => {
+      assertDefined(backend.dispose);
+      await backend.dispose();
+      const result = await backend.query({});
+      expect(result).toMatchObject({ ok: false });
+    });
+  });
+
+  // -- custom weights --------------------------------------------------------
+
+  describe("custom weights", () => {
+    test("uses custom weights for score computation", async () => {
+      const weighted = createInMemoryReputationBackend({
+        weights: { positive: 1.0, neutral: 0.8, negative: 0.2 },
+      });
+
+      await weighted.record(feedback({ kind: "negative", timestamp: 1 }));
+      const result = await weighted.getScore(AGENT_A);
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        assertDefined(result.value);
+        expect(result.value.score).toBe(0.2);
+      }
+    });
+  });
+});

--- a/packages/reputation/src/in-memory-backend.ts
+++ b/packages/reputation/src/in-memory-backend.ts
@@ -1,0 +1,198 @@
+/**
+ * In-memory reputation backend with ring-buffer storage.
+ *
+ * Closure-private Map<AgentId, feedback[]> with configurable per-agent
+ * capacity. Idempotent record (duplicate sourceId+targetId+kind+timestamp
+ * tuples are silently accepted). All operations are synchronous.
+ */
+
+import type {
+  AgentId,
+  FeedbackKind,
+  ReputationBackend,
+  ReputationFeedback,
+  ReputationQuery,
+  ReputationQueryResult,
+  ReputationScore,
+  Result,
+} from "@koi/core";
+import { DEFAULT_REPUTATION_QUERY_LIMIT } from "@koi/core";
+
+import { computeScore, DEFAULT_FEEDBACK_WEIGHTS } from "./compute-score.js";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Default maximum feedback entries stored per agent. */
+const DEFAULT_MAX_ENTRIES_PER_AGENT = 1000;
+
+export interface InMemoryReputationConfig {
+  /** Maximum feedback entries per agent (ring buffer cap). Defaults to 1000. */
+  readonly maxEntriesPerAgent?: number | undefined;
+  /** Custom weights for score computation. */
+  readonly weights?: Readonly<Record<FeedbackKind, number>> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an in-memory ReputationBackend.
+ *
+ * All data lives in a closure-private Map. Entries are stored in
+ * insertion order per agent, with a ring buffer that evicts the oldest
+ * entry when capacity is reached.
+ */
+export function createInMemoryReputationBackend(
+  config?: InMemoryReputationConfig,
+): ReputationBackend {
+  const maxPerAgent = config?.maxEntriesPerAgent ?? DEFAULT_MAX_ENTRIES_PER_AGENT;
+  const weights = config?.weights ?? DEFAULT_FEEDBACK_WEIGHTS;
+
+  // Mutable internal state — hidden behind closure
+  const store = new Map<AgentId, ReputationFeedback[]>();
+  let disposed = false;
+
+  // -- helpers ---------------------------------------------------------------
+
+  function getOrCreateBucket(targetId: AgentId): ReputationFeedback[] {
+    let bucket = store.get(targetId);
+    if (bucket === undefined) {
+      bucket = [];
+      store.set(targetId, bucket);
+    }
+    return bucket;
+  }
+
+  function isDuplicate(
+    bucket: readonly ReputationFeedback[],
+    feedback: ReputationFeedback,
+  ): boolean {
+    return bucket.some(
+      (existing) =>
+        existing.sourceId === feedback.sourceId &&
+        existing.targetId === feedback.targetId &&
+        existing.kind === feedback.kind &&
+        existing.timestamp === feedback.timestamp,
+    );
+  }
+
+  function matchesFilter(entry: ReputationFeedback, filter: ReputationQuery): boolean {
+    if (filter.targetId !== undefined && entry.targetId !== filter.targetId) {
+      return false;
+    }
+    if (filter.sourceId !== undefined && entry.sourceId !== filter.sourceId) {
+      return false;
+    }
+    if (
+      filter.kinds !== undefined &&
+      filter.kinds.length > 0 &&
+      !filter.kinds.includes(entry.kind)
+    ) {
+      return false;
+    }
+    if (filter.after !== undefined && entry.timestamp < filter.after) {
+      return false;
+    }
+    if (filter.before !== undefined && entry.timestamp >= filter.before) {
+      return false;
+    }
+    return true;
+  }
+
+  // -- backend methods -------------------------------------------------------
+
+  const record: ReputationBackend["record"] = (feedback) => {
+    if (disposed) {
+      return {
+        ok: false,
+        error: { code: "INTERNAL", message: "Backend is disposed", retryable: false },
+      };
+    }
+
+    const bucket = getOrCreateBucket(feedback.targetId);
+
+    // Idempotent: silently accept duplicates
+    if (isDuplicate(bucket, feedback)) {
+      return { ok: true, value: undefined };
+    }
+
+    // Ring buffer: evict oldest when at capacity
+    if (bucket.length >= maxPerAgent) {
+      bucket.shift();
+    }
+    bucket.push(feedback);
+
+    return { ok: true, value: undefined };
+  };
+
+  const getScore: ReputationBackend["getScore"] = (targetId) => {
+    if (disposed) {
+      return {
+        ok: false,
+        error: { code: "INTERNAL", message: "Backend is disposed", retryable: false },
+      };
+    }
+
+    const bucket = store.get(targetId);
+    if (bucket === undefined || bucket.length === 0) {
+      return { ok: true, value: undefined };
+    }
+
+    return { ok: true, value: computeScore(targetId, bucket, weights) };
+  };
+
+  const getScores: ReputationBackend["getScores"] = (targetIds) => {
+    if (disposed) {
+      return {
+        ok: false,
+        error: { code: "INTERNAL", message: "Backend is disposed", retryable: false },
+      };
+    }
+
+    const results = new Map<AgentId, ReputationScore | undefined>();
+    for (const id of targetIds) {
+      const bucket = store.get(id);
+      if (bucket === undefined || bucket.length === 0) {
+        results.set(id, undefined);
+      } else {
+        results.set(id, computeScore(id, bucket, weights));
+      }
+    }
+
+    return { ok: true, value: results } satisfies Result<
+      ReadonlyMap<AgentId, ReputationScore | undefined>
+    >;
+  };
+
+  const query: ReputationBackend["query"] = (filter) => {
+    if (disposed) {
+      return {
+        ok: false,
+        error: { code: "INTERNAL", message: "Backend is disposed", retryable: false },
+      };
+    }
+
+    const limit = filter.limit ?? DEFAULT_REPUTATION_QUERY_LIMIT;
+
+    // Collect matching entries from all buckets, sort descending by timestamp
+    const matched = [...store.values()]
+      .flatMap((bucket) => bucket.filter((entry) => matchesFilter(entry, filter)))
+      .toSorted((a, b) => b.timestamp - a.timestamp);
+
+    // Apply limit + hasMore
+    const hasMore = matched.length > limit;
+    const entries = matched.slice(0, limit);
+
+    return { ok: true, value: { entries, hasMore } satisfies ReputationQueryResult };
+  };
+
+  const dispose: ReputationBackend["dispose"] = () => {
+    disposed = true;
+    store.clear();
+  };
+
+  return { record, getScore, getScores, query, dispose };
+}

--- a/packages/reputation/src/index.ts
+++ b/packages/reputation/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @koi/reputation — In-memory reputation backend (Layer 2).
+ *
+ * Pluggable trust scoring using weighted feedback averages.
+ * Depends on @koi/core (L0) only.
+ */
+
+export { createReputationProvider } from "./component-provider.js";
+export { computeScore, DEFAULT_FEEDBACK_WEIGHTS } from "./compute-score.js";
+export type { InMemoryReputationConfig } from "./in-memory-backend.js";
+export { createInMemoryReputationBackend } from "./in-memory-backend.js";

--- a/packages/reputation/tsconfig.json
+++ b/packages/reputation/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/reputation/tsup.config.ts
+++ b/packages/reputation/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Implement the first `ReputationBackend` (L2) for recording agent interaction feedback and computing trust scores
- Add `REPUTATION` ECS token to `@koi/core` so agents can access the backend via component lookup
- Weighted-average scoring with configurable weights (positive=1.0, neutral=0.5, negative=0.0) and level thresholds (untrusted/low/medium/high)
- Per-agent ring-buffer storage (default 1000 entries) with FIFO eviction and idempotent record

## What's included

| File | Purpose |
|------|---------|
| `packages/reputation/src/compute-score.ts` | Pure `computeScore()` — weighted average, level mapping |
| `packages/reputation/src/in-memory-backend.ts` | `createInMemoryReputationBackend()` — Map + ring buffer |
| `packages/reputation/src/component-provider.ts` | `createReputationProvider()` — ECS REPUTATION token |
| `packages/core/src/ecs.ts` | `REPUTATION` token + import |
| `docs/L2/reputation.md` | Package documentation |
| `docs/architecture/reputation-backend.md` | Updated L0 doc (no longer "future") |

## Layer compliance

- L2 package — imports from `@koi/core` (L0) only
- Zero L0u, zero external dependencies
- All interface properties `readonly`, no `any`, no `enum`
- Follows established naming conventions (`create*`, `compute*`, `DEFAULT_*`)

## Test plan

- [x] 36 tests across 3 colocated test files (all passing)
- [x] `compute-score.test.ts` — level thresholds, weighted average, custom weights, edge cases
- [x] `in-memory-backend.test.ts` — record/getScore, getScores batch, query filters, ring buffer eviction, idempotency, dispose
- [x] `component-provider.test.ts` — provider shape, REPUTATION key, stable reference, detach
- [x] `bun run --filter @koi/core typecheck` passes
- [x] `bun run --filter @koi/reputation typecheck` passes
- [x] Core API surface snapshots updated
- [x] Biome lint/format clean

Closes #112