### PR TITLE
feat: evolve @koi/governance into full security bundle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -891,6 +891,7 @@
         "@koi/core": "workspace:*",
         "@koi/delegation": "workspace:*",
         "@koi/exec-approvals": "workspace:*",
+        "@koi/filesystem": "workspace:*",
         "@koi/middleware-audit": "workspace:*",
         "@koi/middleware-governance-backend": "workspace:*",
         "@koi/middleware-guardrails": "workspace:*",
@@ -898,6 +899,8 @@
         "@koi/middleware-permissions": "workspace:*",
         "@koi/middleware-pii": "workspace:*",
         "@koi/middleware-sanitize": "workspace:*",
+        "@koi/scope": "workspace:*",
+        "@koi/tool-browser": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",

--- a/docs/L3/governance.md
+++ b/docs/L3/governance.md
@@ -1,0 +1,152 @@
+# @koi/governance — Enterprise Compliance Bundle
+
+Layer 3 meta-package that assembles up to 9 middleware and 4 scope providers
+into a single `createGovernanceStack()` call.
+
+## What This Enables
+
+**One-line enterprise compliance.** Instead of manually importing, configuring,
+and ordering 9 separate middleware packages, callers get:
+
+- **Deployment presets** (`open`, `standard`, `strict`) with sensible defaults
+- **3-layer config merge**: defaults → preset → user overrides
+- **Scope enforcement**: filesystem, browser, credentials, memory — each wrapped
+  with enforcer + scoping + audit
+- **Pattern-based permissions shorthand**: `permissionRules: { allow: [...] }`
+  instead of constructing a full `PermissionBackend`
+- **Pay deprecation path**: `pay` still works but emits `console.warn`
+
+## Quick Start
+
+```typescript
+import { createGovernanceStack } from "@koi/governance";
+import { createKoi } from "@koi/engine";
+
+// Minimal — open preset, all tools allowed
+const { middlewares, providers, config } = createGovernanceStack({});
+
+// Standard — PII masking, sanitization, filesystem + browser scope
+const stack = createGovernanceStack({
+  preset: "standard",
+  backends: { filesystem: myFsBackend, browser: myBrowserDriver },
+});
+
+// Strict — PII redaction, guardrails, read-only filesystem, HTTPS-only browser
+const strict = createGovernanceStack({
+  preset: "strict",
+  audit: { sink: myAuditSink },
+  backends: { filesystem: myFsBackend },
+});
+
+const runtime = await createKoi({
+  manifest,
+  adapter,
+  middleware: stack.middlewares,
+  providers: stack.providers,
+});
+```
+
+## Middleware Priority Order
+
+| Priority | Middleware | Description |
+|----------|-----------|-------------|
+| 100 | permissions | Coarse-grained tool allow/deny/ask |
+| 110 | exec-approvals | Progressive command allowlisting |
+| 120 | delegation | Delegation grant verification |
+| 150 | governance-backend | Pluggable policy evaluation gate |
+| 200 | pay | Token budget enforcement (deprecated) |
+| 300 | audit | Compliance audit logging |
+| 340 | pii | PII detection and redaction |
+| 350 | sanitize | Content sanitization |
+| 375 | guardrails | Output schema validation |
+
+## Deployment Presets
+
+### `open` (default)
+
+- Permissions: allow all (`["*"]`)
+- No middleware beyond permissions
+- No scope enforcement
+
+### `standard`
+
+- Permissions: allow fs_read, web, browser, lsp; deny fs_delete; ask runtime
+- PII: mask strategy
+- Sanitize: enabled (empty rules)
+- Scope: filesystem (rw) + browser (block private addresses)
+
+### `strict`
+
+- Permissions: allow fs_read only; deny runtime, fs_delete, db_write
+- PII: redact strategy
+- Sanitize: enabled
+- Guardrails: enabled
+- Scope: filesystem (ro) + browser (HTTPS only, block private) + credentials + memory
+
+## Config Resolution
+
+The 3-layer merge works as follows:
+
+1. **Defaults**: base config (empty)
+2. **Preset**: `GOVERNANCE_PRESET_SPECS[preset]` fills in unset fields
+3. **User overrides**: explicit config fields always win
+
+### Validation Rules
+
+- `permissions` and `permissionRules` are mutually exclusive (throws)
+- `execApprovals` requires an `onAsk` handler (throws)
+- `pay` emits a deprecation warning via `console.warn`
+
+## Scope Wiring
+
+When `scope` and `backends` are both provided, the factory wires
+`ComponentProvider`s for each configured subsystem:
+
+| Subsystem | Scope Config | Backend |
+|-----------|-------------|---------|
+| Filesystem | `scope.filesystem` | `backends.filesystem` |
+| Browser | `scope.browser` | `backends.browser` |
+| Credentials | `scope.credentials` | `backends.credentials` |
+| Memory | `scope.memory` | `backends.memory` |
+
+Each backend is optionally wrapped with:
+1. **Enforcer** (`ScopeEnforcer`) — pluggable policy (ReBAC, ABAC)
+2. **Scoping** — local checks (path containment, pattern matching)
+3. **Audit** — when `backends.auditSink` is available
+
+Missing backends for a configured scope are gracefully skipped.
+
+## Return Shape
+
+```typescript
+interface GovernanceBundle {
+  readonly middlewares: readonly KoiMiddleware[];
+  readonly providers: readonly ComponentProvider[];
+  readonly config: ResolvedGovernanceMeta;
+}
+
+interface ResolvedGovernanceMeta {
+  readonly preset: GovernancePreset;
+  readonly middlewareCount: number;
+  readonly providerCount: number;
+  readonly payDeprecated: boolean;
+  readonly scopeEnabled: boolean;
+}
+```
+
+## Architecture
+
+```
+@koi/governance (L3)
+  ├── types.ts              — GovernanceStackConfig, presets, bundle types
+  ├── presets.ts             — GOVERNANCE_PRESET_SPECS (frozen)
+  ├── config-resolution.ts   — 3-layer merge + validation
+  ├── scope-wiring.ts        — scope config → ComponentProviders
+  ├── governance-stack.ts     — createGovernanceStack() factory
+  └── index.ts               — public API surface
+```
+
+Dependencies:
+- L0: `@koi/core` (types)
+- L0u: `@koi/scope` (enforcer, scoping)
+- L2: `@koi/filesystem`, `@koi/tool-browser`, 9 middleware packages

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -11,15 +11,18 @@
   },
   "dependencies": {
     "@koi/core": "workspace:*",
-    "@koi/middleware-audit": "workspace:*",
-    "@koi/middleware-permissions": "workspace:*",
-    "@koi/middleware-pay": "workspace:*",
-    "@koi/middleware-pii": "workspace:*",
-    "@koi/middleware-sanitize": "workspace:*",
-    "@koi/middleware-guardrails": "workspace:*",
     "@koi/delegation": "workspace:*",
     "@koi/exec-approvals": "workspace:*",
-    "@koi/middleware-governance-backend": "workspace:*"
+    "@koi/filesystem": "workspace:*",
+    "@koi/middleware-audit": "workspace:*",
+    "@koi/middleware-governance-backend": "workspace:*",
+    "@koi/middleware-guardrails": "workspace:*",
+    "@koi/middleware-pay": "workspace:*",
+    "@koi/middleware-permissions": "workspace:*",
+    "@koi/middleware-pii": "workspace:*",
+    "@koi/middleware-sanitize": "workspace:*",
+    "@koi/scope": "workspace:*",
+    "@koi/tool-browser": "workspace:*"
   },
   "devDependencies": {
     "@koi/engine": "workspace:*",

--- a/packages/governance/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/governance/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -13,13 +13,125 @@ import { GuardrailsConfig } from '@koi/middleware-guardrails';
 export { GuardrailsConfig } from '@koi/middleware-guardrails';
 import { PayMiddlewareConfig } from '@koi/middleware-pay';
 export { PayMiddlewareConfig } from '@koi/middleware-pay';
-import { PermissionsMiddlewareConfig } from '@koi/middleware-permissions';
-export { PermissionsMiddlewareConfig } from '@koi/middleware-permissions';
+import { PermissionRules, PermissionsMiddlewareConfig } from '@koi/middleware-permissions';
+export { PatternBackendConfig, PermissionRules, PermissionsMiddlewareConfig } from '@koi/middleware-permissions';
 import { PIIConfig } from '@koi/middleware-pii';
 export { PIIConfig } from '@koi/middleware-pii';
 import { SanitizeMiddlewareConfig } from '@koi/middleware-sanitize';
 export { SanitizeMiddlewareConfig } from '@koi/middleware-sanitize';
-import { KoiMiddleware } from '@koi/core/middleware';
+import { FileSystemBackend, CredentialComponent, MemoryComponent, AuditSink, ScopeEnforcer, KoiMiddleware, ComponentProvider } from '@koi/core';
+import { BrowserDriver } from '@koi/tool-browser';
+
+/**
+ * Types for the governance compliance bundle.
+ *
+ * Defines the full GovernanceStackConfig (preset + scope + middleware fields),
+ * deployment presets, scope configuration, and the GovernanceBundle return shape.
+ */
+
+/** Deployment preset levels for governance stacks. */
+type GovernancePreset = "open" | "standard" | "strict";
+/** Scope configuration for governed capabilities. */
+interface GovernanceScopeConfig {
+    readonly filesystem?: {
+        readonly root: string;
+        readonly mode?: "rw" | "ro" | undefined;
+    } | undefined;
+    readonly browser?: {
+        readonly allowedProtocols?: readonly string[] | undefined;
+        readonly allowedDomains?: readonly string[] | undefined;
+        readonly blockPrivateAddresses?: boolean | undefined;
+        readonly trustTier?: "sandbox" | "verified" | "promoted" | undefined;
+    } | undefined;
+    readonly credentials?: {
+        readonly keyPattern: string;
+    } | undefined;
+    readonly memory?: {
+        readonly namespace: string;
+    } | undefined;
+}
+/** Backend implementations for scope wiring. */
+interface GovernanceScopeBackends {
+    readonly filesystem?: FileSystemBackend | undefined;
+    readonly browser?: BrowserDriver | undefined;
+    readonly credentials?: CredentialComponent | undefined;
+    readonly memory?: MemoryComponent | undefined;
+    readonly auditSink?: AuditSink | undefined;
+}
+/**
+ * Configuration for the governance compliance stack.
+ *
+ * All fields are optional. Include only the middleware you need.
+ * When \`preset\` is specified, its defaults are merged under user overrides.
+ */
+interface GovernanceStackConfig {
+    /** Deployment preset. Defaults to "open". */
+    readonly preset?: GovernancePreset | undefined;
+    /** Scope enforcement configuration. */
+    readonly scope?: GovernanceScopeConfig | undefined;
+    /** Backend implementations for scope wiring. */
+    readonly backends?: GovernanceScopeBackends | undefined;
+    /** Pluggable scope enforcer (ReBAC, ABAC, etc.). */
+    readonly enforcer?: ScopeEnforcer | undefined;
+    /**
+     * Pattern-based permission rules shorthand. Mutually exclusive with \`permissions\`.
+     * Creates a pattern permission backend automatically.
+     */
+    readonly permissionRules?: PermissionRules | undefined;
+    /** Coarse-grained tool allow/deny/ask rules. Priority 100. */
+    readonly permissions?: PermissionsMiddlewareConfig | undefined;
+    /** Progressive command allowlisting. Priority 110 (overridden from default). */
+    readonly execApprovals?: ExecApprovalsConfig | undefined;
+    /** Delegation grant verification. Priority 120 (overridden from default). */
+    readonly delegation?: DelegationMiddlewareConfig | undefined;
+    /** Pluggable policy evaluation gate. Priority 150. */
+    readonly governanceBackend?: GovernanceBackendMiddlewareConfig | undefined;
+    /** @deprecated Use @koi/middleware-pay directly. Will be removed next major. */
+    readonly pay?: PayMiddlewareConfig | undefined;
+    /** Compliance audit logging. Priority 300. */
+    readonly audit?: AuditMiddlewareConfig | undefined;
+    /** PII detection and redaction. Priority 340. */
+    readonly pii?: PIIConfig | undefined;
+    /** Content sanitization. Priority 350. */
+    readonly sanitize?: SanitizeMiddlewareConfig | undefined;
+    /** Output schema validation. Priority 375. */
+    readonly guardrails?: GuardrailsConfig | undefined;
+}
+/**
+ * Partial config without meta-fields, used for preset definitions.
+ * Presets cannot specify preset, backends, enforcer, or pay.
+ */
+type GovernancePresetSpec = Partial<Omit<GovernanceStackConfig, "preset" | "backends" | "enforcer" | "pay">>;
+/** Metadata about the resolved governance stack for inspection. */
+interface ResolvedGovernanceMeta {
+    readonly preset: GovernancePreset;
+    readonly middlewareCount: number;
+    readonly providerCount: number;
+    readonly payDeprecated: boolean;
+    readonly scopeEnabled: boolean;
+}
+/** Return value of createGovernanceStack(). */
+interface GovernanceBundle {
+    readonly middlewares: readonly KoiMiddleware[];
+    readonly providers: readonly ComponentProvider[];
+    readonly config: ResolvedGovernanceMeta;
+}
+
+/**
+ * Config resolution: 3-layer merge (defaults -> preset -> user overrides).
+ *
+ * Validates mutual exclusion constraints and emits deprecation warnings.
+ */
+
+/**
+ * Resolve governance config by merging preset defaults under user overrides.
+ *
+ * Validation rules:
+ * - \`permissions\` and \`permissionRules\` are mutually exclusive (throws)
+ * - \`execApprovals\` requires an \`onAsk\` handler (throws)
+ * - \`pay\` emits a console.warn deprecation notice
+ */
+declare function resolveGovernanceConfig(config: GovernanceStackConfig): GovernanceStackConfig;
 
 /**
  * createGovernanceStack — enterprise compliance middleware assembly.
@@ -40,47 +152,33 @@ import { KoiMiddleware } from '@koi/core/middleware';
  */
 
 /**
- * Configuration for the governance compliance stack.
- * All fields are optional — include only the middleware you need.
- */
-interface GovernanceStackConfig {
-    /** Coarse-grained tool allow/deny/ask rules. Priority 100. */
-    readonly permissions?: PermissionsMiddlewareConfig;
-    /** Progressive command allowlisting. Priority 110 (overridden from default). */
-    readonly execApprovals?: ExecApprovalsConfig;
-    /** Delegation grant verification. Priority 120 (overridden from default). */
-    readonly delegation?: DelegationMiddlewareConfig;
-    /** Pluggable policy evaluation gate. Priority 150. */
-    readonly governanceBackend?: GovernanceBackendMiddlewareConfig;
-    /** Token budget enforcement. Priority 200. */
-    readonly pay?: PayMiddlewareConfig;
-    /** Compliance audit logging. Priority 300. */
-    readonly audit?: AuditMiddlewareConfig;
-    /** PII detection and redaction. Priority 340. */
-    readonly pii?: PIIConfig;
-    /** Content sanitization. Priority 350. */
-    readonly sanitize?: SanitizeMiddlewareConfig;
-    /** Output schema validation. Priority 375. */
-    readonly guardrails?: GuardrailsConfig;
-}
-/**
  * Assemble a governance compliance middleware stack.
  *
- * Returns an object with \`middlewares\` — pass it directly to createKoi():
+ * Returns a \`GovernanceBundle\` with \`middlewares\`, \`providers\`, and \`config\` metadata.
+ * Pass \`middlewares\` and \`providers\` directly to createKoi():
  *
  * \`\`\`typescript
- * const { middlewares } = createGovernanceStack({ audit: { sink: myAuditSink } });
- * const runtime = await createKoi({ ..., middleware: middlewares });
+ * const { middlewares, providers } = createGovernanceStack({ preset: "standard" });
+ * const runtime = await createKoi({ ..., middleware: middlewares, providers });
  * \`\`\`
  *
+ * Config resolution: defaults -> preset -> user overrides.
  * Middleware are ordered by priority. Priority overrides are applied for
  * exec-approvals (110) and delegation (120) so they slot correctly between
  * permissions (100) and governance-backend (150).
  */
-declare function createGovernanceStack(config: GovernanceStackConfig): {
-    readonly middlewares: readonly KoiMiddleware[];
-};
+declare function createGovernanceStack(config: GovernanceStackConfig): GovernanceBundle;
 
-export { type GovernanceStackConfig, createGovernanceStack };
+/**
+ * Governance deployment presets: open, standard, strict.
+ *
+ * Each preset provides sensible defaults for permission rules,
+ * middleware, and scope configuration. User overrides always win.
+ */
+
+/** Frozen registry of governance preset specs, keyed by preset name. */
+declare const GOVERNANCE_PRESET_SPECS: Readonly<Record<GovernancePreset, GovernancePresetSpec>>;
+
+export { GOVERNANCE_PRESET_SPECS, type GovernanceBundle, type GovernancePreset, type GovernancePresetSpec, type GovernanceScopeBackends, type GovernanceScopeConfig, type GovernanceStackConfig, type ResolvedGovernanceMeta, createGovernanceStack, resolveGovernanceConfig };
 "
 `;

--- a/packages/governance/src/__tests__/config-resolution.test.ts
+++ b/packages/governance/src/__tests__/config-resolution.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for config resolution (3-layer merge).
+ *
+ * Verifies:
+ *   - Empty config resolves to "open" preset defaults
+ *   - Explicit preset "strict" resolves strict defaults
+ *   - User override wins over preset
+ *   - permissionRules shorthand creates pattern backend
+ *   - permissions + permissionRules throws
+ *   - exec-approvals without onAsk throws
+ *   - pay triggers deprecation warning
+ *   - Scope merging: user scope overrides preset scope
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { PAY_DEPRECATION_WARNING, resolveGovernanceConfig } from "../config-resolution.js";
+
+// Spy on console.warn for pay deprecation tests
+const originalWarn = console.warn;
+let warnSpy: ReturnType<typeof mock>;
+
+beforeEach(() => {
+  warnSpy = mock(() => undefined);
+  console.warn = warnSpy;
+});
+
+afterEach(() => {
+  console.warn = originalWarn;
+});
+
+describe("resolveGovernanceConfig", () => {
+  // ── Preset resolution ─────────────────────────────────────────────────
+
+  test("empty config resolves open preset → has permissions", () => {
+    const resolved = resolveGovernanceConfig({});
+    expect(resolved.permissions).toBeDefined();
+  });
+
+  test("empty config defaults to open preset", () => {
+    const resolved = resolveGovernanceConfig({});
+    expect(resolved.preset ?? "open").toBe("open");
+  });
+
+  test("explicit preset strict resolves strict defaults", () => {
+    const resolved = resolveGovernanceConfig({ preset: "strict" });
+    expect(resolved.pii?.strategy).toBe("redact");
+    expect(resolved.guardrails).toBeDefined();
+    expect(resolved.scope?.filesystem?.mode).toBe("ro");
+  });
+
+  test("explicit preset standard resolves standard defaults", () => {
+    const resolved = resolveGovernanceConfig({ preset: "standard" });
+    expect(resolved.pii?.strategy).toBe("mask");
+    expect(resolved.sanitize).toBeDefined();
+    expect(resolved.scope?.filesystem?.mode).toBe("rw");
+  });
+
+  // ── User overrides ────────────────────────────────────────────────────
+
+  test("user pii override wins over preset", () => {
+    const resolved = resolveGovernanceConfig({
+      preset: "standard",
+      pii: { strategy: "redact" },
+    });
+    // User specified "redact", standard preset has "mask"
+    expect(resolved.pii?.strategy).toBe("redact");
+  });
+
+  test("user scope overrides preset scope", () => {
+    const resolved = resolveGovernanceConfig({
+      preset: "strict",
+      scope: { filesystem: { root: "/custom", mode: "rw" } },
+    });
+    expect(resolved.scope?.filesystem?.root).toBe("/custom");
+    expect(resolved.scope?.filesystem?.mode).toBe("rw");
+  });
+
+  // ── Permission rules shorthand ────────────────────────────────────────
+
+  test("permissionRules shorthand creates permissions backend", () => {
+    const resolved = resolveGovernanceConfig({
+      permissionRules: { allow: ["tool:read"], deny: [], ask: [] },
+    });
+    expect(resolved.permissions).toBeDefined();
+    expect(resolved.permissions?.backend).toBeDefined();
+  });
+
+  // ── Mutual exclusion ─────────────────────────────────────────────────
+
+  test("permissions + permissionRules throws", () => {
+    expect(() =>
+      resolveGovernanceConfig({
+        permissions: { backend: { check: () => ({ effect: "allow" as const }) } },
+        permissionRules: { allow: ["*"], deny: [], ask: [] },
+      }),
+    ).toThrow(/Cannot provide both/);
+  });
+
+  // ── Exec-approvals validation ─────────────────────────────────────────
+
+  test("exec-approvals without onAsk throws", () => {
+    expect(() =>
+      resolveGovernanceConfig({
+        execApprovals: {
+          rules: { allow: ["*"], deny: [], ask: [] },
+          // Missing onAsk
+        } as never,
+      }),
+    ).toThrow(/onAsk/);
+  });
+
+  // ── Pay deprecation ──────────────────────────────────────────────────
+
+  test("pay triggers deprecation console.warn", () => {
+    resolveGovernanceConfig({
+      pay: {
+        tracker: {
+          record: async () => undefined,
+          totalSpend: async () => 0,
+          remaining: async () => 1000,
+          breakdown: async () => ({ totalCostUsd: 0, byModel: [], byTool: [] }),
+        },
+        calculator: { calculate: () => 0 },
+        budget: 1000,
+      },
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toBe(PAY_DEPRECATION_WARNING);
+  });
+
+  test("no pay → no deprecation warning", () => {
+    resolveGovernanceConfig({});
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/governance/src/__tests__/governance-stack.test.ts
+++ b/packages/governance/src/__tests__/governance-stack.test.ts
@@ -2,17 +2,22 @@
  * Unit and integration tests for createGovernanceStack().
  *
  * Unit tests (black-box by name):
- *   - Empty config → 0 middlewares
+ *   - Empty config → open preset permissions middleware
  *   - Single middleware present and named correctly
  *   - All 9 configured → 9 middlewares in correct priority order
+ *   - All 8 configured (no pay) → 8 middlewares
  *   - exec-approvals priority overridden to 110
  *   - delegation priority overridden to 120
+ *   - Preset: standard → permissions + pii + sanitize
+ *   - Preset: strict → permissions + pii + sanitize + guardrails
+ *   - Return value includes providers and config metadata
+ *   - Pay deprecation warning + still functional
  *
  * Integration test:
  *   - createGovernanceStack({ audit }) → pass to createKoi + cooperating adapter
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
   AgentManifest,
   EngineAdapter,
@@ -78,33 +83,71 @@ const BASE_MANIFEST: AgentManifest = {
   model: { name: "test-model" },
 };
 
+function makePayTracker(): {
+  readonly record: () => Promise<undefined>;
+  readonly totalSpend: () => Promise<number>;
+  readonly remaining: () => Promise<number>;
+  readonly breakdown: () => Promise<{
+    readonly totalCostUsd: number;
+    readonly byModel: readonly [];
+    readonly byTool: readonly [];
+  }>;
+} {
+  return {
+    record: async () => undefined,
+    totalSpend: async () => 0,
+    remaining: async () => 1000,
+    breakdown: async () => ({ totalCostUsd: 0, byModel: [], byTool: [] }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests — createGovernanceStack composability
 // ---------------------------------------------------------------------------
 
 describe("createGovernanceStack", () => {
-  // ── Empty config ────────────────────────────────────────────────────────
+  // Capture console.warn for pay deprecation tests
+  const originalWarn = console.warn;
+  let warnSpy: ReturnType<typeof mock>;
 
-  test("empty config returns 0 middlewares", () => {
-    const { middlewares } = createGovernanceStack({});
-    expect(middlewares).toHaveLength(0);
+  beforeEach(() => {
+    warnSpy = mock(() => undefined);
+    console.warn = warnSpy;
   });
 
-  // ── Single middleware presence by name ──────────────────────────────────
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
 
-  test("audit only → 1 middleware named 'audit'", () => {
+  // ── Empty config (open preset) ────────────────────────────────────────
+
+  test("empty config resolves open preset → permissions middleware", () => {
+    const { middlewares } = createGovernanceStack({});
+    // Open preset creates permissions middleware from permissionRules: { allow: ["*"] }
+    expect(middlewares).toHaveLength(1);
+    expect(middlewares[0]?.name).toBe("permissions");
+  });
+
+  // ── Single middleware + open preset ──────────────────────────────────
+
+  test("audit only → permissions + audit middleware", () => {
     const sink = createInMemoryAuditSink();
     const { middlewares } = createGovernanceStack({ audit: { sink } });
-    expect(middlewares).toHaveLength(1);
-    expect(middlewares[0]?.name).toBe("audit");
+    // Open preset adds permissions, user adds audit
+    expect(middlewares).toHaveLength(2);
+    const names = middlewares.map((mw) => mw.name);
+    expect(names).toContain("permissions");
+    expect(names).toContain("audit");
   });
 
-  test("governanceBackend only → 1 middleware named 'koi:governance-backend'", () => {
+  test("governanceBackend only → permissions + governance-backend", () => {
     const { middlewares } = createGovernanceStack({
       governanceBackend: { backend: makeAllowGovernanceBackend() },
     });
-    expect(middlewares).toHaveLength(1);
-    expect(middlewares[0]?.name).toBe("koi:governance-backend");
+    expect(middlewares).toHaveLength(2);
+    const names = middlewares.map((mw) => mw.name);
+    expect(names).toContain("permissions");
+    expect(names).toContain("koi:governance-backend");
   });
 
   // ── Full 9-middleware stack ──────────────────────────────────────────────
@@ -131,27 +174,46 @@ describe("createGovernanceStack", () => {
       },
       governanceBackend: { backend: makeAllowGovernanceBackend() },
       pay: {
-        tracker: {
-          record: async () => undefined,
-          totalSpend: async () => 0,
-          remaining: async () => 1000,
-          breakdown: async () => ({ totalCostUsd: 0, byModel: [], byTool: [] }),
-        },
+        tracker: makePayTracker(),
         calculator: { calculate: () => 0 },
         budget: 1000,
       },
       audit: { sink },
-      pii: {
-        strategy: "redact",
-      },
-      sanitize: {
-        rules: [],
-      },
-      guardrails: {
-        rules: [],
-      },
+      pii: { strategy: "redact" },
+      sanitize: { rules: [] },
+      guardrails: { rules: [] },
     });
     expect(middlewares).toHaveLength(9);
+  });
+
+  test("all 8 configured without pay → 8 middlewares", () => {
+    const sink = createInMemoryAuditSink();
+    const { middlewares } = createGovernanceStack({
+      permissions: {
+        backend: {
+          check: () => ({ effect: "allow" as const }),
+        },
+      },
+      execApprovals: {
+        rules: { allow: ["*"], deny: [], ask: [] },
+        onAsk: async () => ({ kind: "allow_once" as const }),
+      },
+      delegation: {
+        secret: "test-secret",
+        registry: {
+          isRevoked: async () => false,
+          revoke: async () => undefined,
+        },
+        grantStore: new Map(),
+      },
+      governanceBackend: { backend: makeAllowGovernanceBackend() },
+      audit: { sink },
+      pii: { strategy: "redact" },
+      sanitize: { rules: [] },
+      guardrails: { rules: [] },
+    });
+    expect(middlewares).toHaveLength(8);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("all 9 ordered by priority ascending", () => {
@@ -176,12 +238,7 @@ describe("createGovernanceStack", () => {
       },
       governanceBackend: { backend: makeAllowGovernanceBackend() },
       pay: {
-        tracker: {
-          record: async () => undefined,
-          totalSpend: async () => 0,
-          remaining: async () => 1000,
-          breakdown: async () => ({ totalCostUsd: 0, byModel: [], byTool: [] }),
-        },
+        tracker: makePayTracker(),
         calculator: { calculate: () => 0 },
         budget: 1000,
       },
@@ -213,9 +270,9 @@ describe("createGovernanceStack", () => {
         onAsk: async () => ({ kind: "deny_once" as const, reason: "test" }),
       },
     });
-    expect(middlewares).toHaveLength(1);
-    expect(middlewares[0]?.name).toBe("exec-approvals");
-    expect(middlewares[0]?.priority).toBe(110);
+    const ea = middlewares.find((mw) => mw.name === "exec-approvals");
+    expect(ea).toBeDefined();
+    expect(ea?.priority).toBe(110);
   });
 
   test("delegation priority is overridden to 120", () => {
@@ -229,17 +286,102 @@ describe("createGovernanceStack", () => {
         grantStore: new Map(),
       },
     });
-    expect(middlewares).toHaveLength(1);
-    expect(middlewares[0]?.name).toBe("koi:delegation");
-    expect(middlewares[0]?.priority).toBe(120);
+    const del = middlewares.find((mw) => mw.name === "koi:delegation");
+    expect(del).toBeDefined();
+    expect(del?.priority).toBe(120);
   });
 
-  // ── Return value is immutable-shaped ────────────────────────────────────
+  // ── Return value shape ────────────────────────────────────────────────
 
-  test("returns object with 'middlewares' property", () => {
+  test("returns GovernanceBundle with middlewares, providers, and config", () => {
     const result = createGovernanceStack({});
     expect(result).toHaveProperty("middlewares");
+    expect(result).toHaveProperty("providers");
+    expect(result).toHaveProperty("config");
     expect(Array.isArray(result.middlewares)).toBe(true);
+    expect(Array.isArray(result.providers)).toBe(true);
+  });
+
+  test("config metadata reflects open preset", () => {
+    const { config } = createGovernanceStack({});
+    expect(config.preset).toBe("open");
+    expect(config.middlewareCount).toBe(1); // permissions from open
+    expect(config.providerCount).toBe(0);
+    expect(config.payDeprecated).toBe(false);
+    expect(config.scopeEnabled).toBe(false);
+  });
+
+  test("providers is empty when no backends provided", () => {
+    const { providers } = createGovernanceStack({ preset: "strict" });
+    expect(providers).toHaveLength(0);
+  });
+
+  // ── Preset tests ──────────────────────────────────────────────────────
+
+  test("preset: standard → permissions + pii + sanitize", () => {
+    const { middlewares, config } = createGovernanceStack({ preset: "standard" });
+    const names = middlewares.map((mw) => mw.name);
+    expect(names).toContain("permissions");
+    expect(names).toContain("pii");
+    expect(names).toContain("sanitize");
+    expect(config.preset).toBe("standard");
+    expect(config.scopeEnabled).toBe(true); // standard has scope config
+  });
+
+  test("preset: strict → permissions + pii + sanitize + guardrails", () => {
+    const { middlewares, config } = createGovernanceStack({ preset: "strict" });
+    const names = middlewares.map((mw) => mw.name);
+    expect(names).toContain("permissions");
+    expect(names).toContain("pii");
+    expect(names).toContain("sanitize");
+    expect(names).toContain("guardrails");
+    expect(config.preset).toBe("strict");
+    expect(config.scopeEnabled).toBe(true);
+  });
+
+  test("preset ordering invariant: open count ≤ standard count ≤ strict count", () => {
+    const openCount = createGovernanceStack({ preset: "open" }).middlewares.length;
+    const stdCount = createGovernanceStack({ preset: "standard" }).middlewares.length;
+    const strictCount = createGovernanceStack({ preset: "strict" }).middlewares.length;
+    expect(stdCount).toBeGreaterThanOrEqual(openCount);
+    expect(strictCount).toBeGreaterThanOrEqual(stdCount);
+  });
+
+  // ── Pay deprecation ─────────────────────────────────────────────────
+
+  test("pay deprecated but still functional → 9 middlewares + console.warn", () => {
+    const sink = createInMemoryAuditSink();
+    const { middlewares, config } = createGovernanceStack({
+      permissions: {
+        backend: { check: () => ({ effect: "allow" as const }) },
+      },
+      execApprovals: {
+        rules: { allow: ["*"], deny: [], ask: [] },
+        onAsk: async () => ({ kind: "allow_once" as const }),
+      },
+      delegation: {
+        secret: "test-secret",
+        registry: {
+          isRevoked: async () => false,
+          revoke: async () => undefined,
+        },
+        grantStore: new Map(),
+      },
+      governanceBackend: { backend: makeAllowGovernanceBackend() },
+      pay: {
+        tracker: makePayTracker(),
+        calculator: { calculate: () => 0 },
+        budget: 1000,
+      },
+      audit: { sink },
+      pii: { strategy: "redact" },
+      sanitize: { rules: [] },
+      guardrails: { rules: [] },
+    });
+    expect(middlewares).toHaveLength(9);
+    expect(config.payDeprecated).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("deprecated");
   });
 });
 

--- a/packages/governance/src/__tests__/presets.test.ts
+++ b/packages/governance/src/__tests__/presets.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for governance deployment presets.
+ *
+ * Verifies:
+ *   - All 3 presets are defined and frozen
+ *   - "open" has permissionRules.allow: ["*"]
+ *   - "standard" has pii, sanitize, scope with filesystem + browser
+ *   - "strict" has pii.strategy: "redact", guardrails, scope with all 4 subsystems
+ *   - Ordering invariant: open field count <= standard <= strict
+ */
+
+import { describe, expect, test } from "bun:test";
+import { GOVERNANCE_PRESET_SPECS } from "../presets.js";
+
+describe("GOVERNANCE_PRESET_SPECS", () => {
+  test("all 3 presets are defined", () => {
+    expect(GOVERNANCE_PRESET_SPECS).toHaveProperty("open");
+    expect(GOVERNANCE_PRESET_SPECS).toHaveProperty("standard");
+    expect(GOVERNANCE_PRESET_SPECS).toHaveProperty("strict");
+  });
+
+  test("registry is frozen", () => {
+    expect(Object.isFrozen(GOVERNANCE_PRESET_SPECS)).toBe(true);
+  });
+
+  test("each preset spec is frozen", () => {
+    expect(Object.isFrozen(GOVERNANCE_PRESET_SPECS.open)).toBe(true);
+    expect(Object.isFrozen(GOVERNANCE_PRESET_SPECS.standard)).toBe(true);
+    expect(Object.isFrozen(GOVERNANCE_PRESET_SPECS.strict)).toBe(true);
+  });
+
+  // ── Open preset ───────────────────────────────────────────────────────
+
+  test("open: permissionRules allows everything", () => {
+    const open = GOVERNANCE_PRESET_SPECS.open;
+    expect(open.permissionRules).toBeDefined();
+    expect(open.permissionRules?.allow).toEqual(["*"]);
+    expect(open.permissionRules?.deny).toEqual([]);
+    expect(open.permissionRules?.ask).toEqual([]);
+  });
+
+  test("open: no middleware beyond permissions", () => {
+    const open = GOVERNANCE_PRESET_SPECS.open;
+    expect(open.pii).toBeUndefined();
+    expect(open.sanitize).toBeUndefined();
+    expect(open.guardrails).toBeUndefined();
+    expect(open.scope).toBeUndefined();
+  });
+
+  // ── Standard preset ───────────────────────────────────────────────────
+
+  test("standard: has pii with mask strategy", () => {
+    expect(GOVERNANCE_PRESET_SPECS.standard.pii?.strategy).toBe("mask");
+  });
+
+  test("standard: has sanitize with empty rules", () => {
+    expect(GOVERNANCE_PRESET_SPECS.standard.sanitize).toBeDefined();
+    expect(GOVERNANCE_PRESET_SPECS.standard.sanitize?.rules).toEqual([]);
+  });
+
+  test("standard: scope has filesystem (rw) and browser", () => {
+    const scope = GOVERNANCE_PRESET_SPECS.standard.scope;
+    expect(scope?.filesystem?.root).toBe(".");
+    expect(scope?.filesystem?.mode).toBe("rw");
+    expect(scope?.browser?.blockPrivateAddresses).toBe(true);
+  });
+
+  test("standard: no guardrails", () => {
+    expect(GOVERNANCE_PRESET_SPECS.standard.guardrails).toBeUndefined();
+  });
+
+  // ── Strict preset ────────────────────────────────────────────────────
+
+  test("strict: pii uses redact strategy", () => {
+    expect(GOVERNANCE_PRESET_SPECS.strict.pii?.strategy).toBe("redact");
+  });
+
+  test("strict: has guardrails", () => {
+    expect(GOVERNANCE_PRESET_SPECS.strict.guardrails).toBeDefined();
+  });
+
+  test("strict: scope has all 4 subsystems", () => {
+    const scope = GOVERNANCE_PRESET_SPECS.strict.scope;
+    expect(scope?.filesystem).toBeDefined();
+    expect(scope?.browser).toBeDefined();
+    expect(scope?.credentials).toBeDefined();
+    expect(scope?.memory).toBeDefined();
+  });
+
+  test("strict: filesystem is read-only", () => {
+    expect(GOVERNANCE_PRESET_SPECS.strict.scope?.filesystem?.mode).toBe("ro");
+  });
+
+  test("strict: browser allows only https", () => {
+    expect(GOVERNANCE_PRESET_SPECS.strict.scope?.browser?.allowedProtocols).toEqual(["https:"]);
+  });
+
+  // ── Ordering invariant ────────────────────────────────────────────────
+
+  test("preset field count: open <= standard <= strict", () => {
+    const openKeys = Object.keys(GOVERNANCE_PRESET_SPECS.open).length;
+    const stdKeys = Object.keys(GOVERNANCE_PRESET_SPECS.standard).length;
+    const strictKeys = Object.keys(GOVERNANCE_PRESET_SPECS.strict).length;
+    expect(stdKeys).toBeGreaterThanOrEqual(openKeys);
+    expect(strictKeys).toBeGreaterThanOrEqual(stdKeys);
+  });
+});

--- a/packages/governance/src/__tests__/scope-wiring.test.ts
+++ b/packages/governance/src/__tests__/scope-wiring.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for scope wiring.
+ *
+ * Verifies:
+ *   - No backends -> empty providers
+ *   - Filesystem scope + backend -> filesystem provider
+ *   - Browser scope + backend -> browser provider
+ *   - Credentials scope + backend -> credentials provider
+ *   - Memory scope + backend -> memory provider
+ *   - All 4 scopes + backends -> 4 providers
+ *   - Enforcer is applied when provided
+ *   - Missing backend for a scope config -> graceful skip
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  CredentialComponent,
+  FileEditResult,
+  FileListResult,
+  FileReadResult,
+  FileSearchResult,
+  FileSystemBackend,
+  FileWriteResult,
+  KoiError,
+  MemoryComponent,
+  Result,
+  ScopeEnforcer,
+} from "@koi/core";
+import { createMockDriver as createMockBrowserDriver } from "@koi/tool-browser";
+import { wireGovernanceScope } from "../scope-wiring.js";
+import type { GovernanceScopeBackends, GovernanceScopeConfig } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function makeMockFileSystem(): FileSystemBackend {
+  return {
+    name: "mock-fs",
+    read: (_path, _options?) =>
+      ({
+        ok: true,
+        value: { content: "file content", path: _path, size: 12 },
+      }) satisfies Result<FileReadResult, KoiError>,
+    write: (_path, _content, _options?) =>
+      ({
+        ok: true,
+        value: { path: _path, bytesWritten: _content.length },
+      }) satisfies Result<FileWriteResult, KoiError>,
+    edit: (_path, edits, _options?) =>
+      ({
+        ok: true,
+        value: { path: _path, hunksApplied: edits.length },
+      }) satisfies Result<FileEditResult, KoiError>,
+    list: (_path, _options?) =>
+      ({
+        ok: true,
+        value: { entries: [], truncated: false },
+      }) satisfies Result<FileListResult, KoiError>,
+    search: (_pattern, _options?) =>
+      ({
+        ok: true,
+        value: { matches: [], truncated: false },
+      }) satisfies Result<FileSearchResult, KoiError>,
+  };
+}
+
+function makeMockCredentials(): CredentialComponent {
+  return {
+    get: async () => undefined,
+  };
+}
+
+function makeMockMemory(): MemoryComponent {
+  return {
+    recall: async () => [],
+    store: async () => undefined,
+  };
+}
+
+function makeMockEnforcer(): ScopeEnforcer {
+  return {
+    checkAccess: () => true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("wireGovernanceScope", () => {
+  test("empty scope config + empty backends -> 0 providers", () => {
+    const providers = wireGovernanceScope({}, {});
+    expect(providers).toHaveLength(0);
+  });
+
+  test("filesystem scope + backend -> 1 provider", () => {
+    const scope: GovernanceScopeConfig = { filesystem: { root: ".", mode: "rw" } };
+    const backends: GovernanceScopeBackends = { filesystem: makeMockFileSystem() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.name).toContain("filesystem");
+  });
+
+  test("browser scope + backend -> 1 provider", () => {
+    const scope: GovernanceScopeConfig = {
+      browser: { blockPrivateAddresses: true },
+    };
+    const backends: GovernanceScopeBackends = { browser: createMockBrowserDriver() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.name).toContain("browser");
+  });
+
+  test("credentials scope + backend -> 1 provider", () => {
+    const scope: GovernanceScopeConfig = { credentials: { keyPattern: "api:*" } };
+    const backends: GovernanceScopeBackends = { credentials: makeMockCredentials() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.name).toContain("credentials");
+  });
+
+  test("memory scope + backend -> 1 provider", () => {
+    const scope: GovernanceScopeConfig = { memory: { namespace: "test" } };
+    const backends: GovernanceScopeBackends = { memory: makeMockMemory() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+  });
+
+  test("all 4 scopes + backends -> 4 providers", () => {
+    const scope: GovernanceScopeConfig = {
+      filesystem: { root: ".", mode: "ro" },
+      browser: { blockPrivateAddresses: true, allowedProtocols: ["https:"] },
+      credentials: { keyPattern: "*" },
+      memory: { namespace: "default" },
+    };
+    const backends: GovernanceScopeBackends = {
+      filesystem: makeMockFileSystem(),
+      browser: createMockBrowserDriver(),
+      credentials: makeMockCredentials(),
+      memory: makeMockMemory(),
+    };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(4);
+  });
+
+  test("scope config without matching backend -> graceful skip", () => {
+    const scope: GovernanceScopeConfig = {
+      filesystem: { root: "." },
+      browser: { blockPrivateAddresses: true },
+    };
+    // Only provide filesystem backend, not browser
+    const backends: GovernanceScopeBackends = { filesystem: makeMockFileSystem() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.name).toContain("filesystem");
+  });
+
+  test("enforcer is applied when provided", () => {
+    const scope: GovernanceScopeConfig = { filesystem: { root: ".", mode: "rw" } };
+    const backends: GovernanceScopeBackends = { filesystem: makeMockFileSystem() };
+    const enforcer = makeMockEnforcer();
+
+    // Should not throw — enforcer wraps the backend
+    const providers = wireGovernanceScope(scope, backends, enforcer);
+    expect(providers).toHaveLength(1);
+  });
+
+  test("filesystem scope without mode defaults to rw", () => {
+    const scope: GovernanceScopeConfig = { filesystem: { root: "/tmp" } };
+    const backends: GovernanceScopeBackends = { filesystem: makeMockFileSystem() };
+    const providers = wireGovernanceScope(scope, backends);
+    expect(providers).toHaveLength(1);
+  });
+});

--- a/packages/governance/src/config-resolution.ts
+++ b/packages/governance/src/config-resolution.ts
@@ -1,0 +1,81 @@
+/**
+ * Config resolution: 3-layer merge (defaults -> preset -> user overrides).
+ *
+ * Validates mutual exclusion constraints and emits deprecation warnings.
+ */
+
+import { createPatternPermissionBackend } from "@koi/middleware-permissions";
+
+import { GOVERNANCE_PRESET_SPECS } from "./presets.js";
+import type { GovernanceStackConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Deprecation warning emitted when `pay` is provided. */
+export const PAY_DEPRECATION_WARNING: string =
+  "[@koi/governance] 'pay' is deprecated and will be removed in the next major release. " +
+  "Use @koi/middleware-pay directly instead.";
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve governance config by merging preset defaults under user overrides.
+ *
+ * Validation rules:
+ * - `permissions` and `permissionRules` are mutually exclusive (throws)
+ * - `execApprovals` requires an `onAsk` handler (throws)
+ * - `pay` emits a console.warn deprecation notice
+ */
+export function resolveGovernanceConfig(config: GovernanceStackConfig): GovernanceStackConfig {
+  // 1. Determine preset
+  const preset = config.preset ?? "open";
+  const spec = GOVERNANCE_PRESET_SPECS[preset];
+
+  // 2. Validate mutual exclusion: permissions XOR permissionRules
+  if (config.permissions !== undefined && config.permissionRules !== undefined) {
+    throw new Error(
+      "[@koi/governance] Cannot provide both 'permissions' and 'permissionRules'. " +
+        "Use 'permissionRules' for pattern-based rules, or 'permissions' for a custom backend.",
+    );
+  }
+
+  // 3. Validate exec-approvals has onAsk when present
+  const effectiveExecApprovals = config.execApprovals ?? spec.execApprovals;
+  if (effectiveExecApprovals !== undefined && effectiveExecApprovals.onAsk === undefined) {
+    throw new Error(
+      "[@koi/governance] exec-approvals requires an 'onAsk' handler. " +
+        "Presets cannot provide this — supply it explicitly via execApprovals.onAsk.",
+    );
+  }
+
+  // 4. Resolve permissions from rules shorthand or preset
+  const effectivePermissionRules = config.permissionRules ?? spec.permissionRules;
+  const effectivePermissions =
+    config.permissions ??
+    (effectivePermissionRules !== undefined
+      ? { backend: createPatternPermissionBackend({ rules: effectivePermissionRules }) }
+      : spec.permissions);
+
+  // 5. Pay deprecation warning
+  if (config.pay !== undefined) {
+    console.warn(PAY_DEPRECATION_WARNING);
+  }
+
+  // 6. Merge: user override ?? preset ?? undefined
+  return {
+    ...config,
+    permissions: effectivePermissions,
+    execApprovals: effectiveExecApprovals,
+    delegation: config.delegation ?? spec.delegation,
+    governanceBackend: config.governanceBackend ?? spec.governanceBackend,
+    audit: config.audit ?? spec.audit,
+    pii: config.pii ?? spec.pii,
+    sanitize: config.sanitize ?? spec.sanitize,
+    guardrails: config.guardrails ?? spec.guardrails,
+    scope: config.scope ?? spec.scope,
+  };
+}

--- a/packages/governance/src/governance-stack.ts
+++ b/packages/governance/src/governance-stack.ts
@@ -17,98 +17,92 @@
  */
 
 import type { KoiMiddleware } from "@koi/core/middleware";
-import type { DelegationMiddlewareConfig } from "@koi/delegation";
 import { createDelegationMiddleware } from "@koi/delegation";
-import type { ExecApprovalsConfig } from "@koi/exec-approvals";
 import { createExecApprovalsMiddleware } from "@koi/exec-approvals";
-import type { AuditMiddlewareConfig } from "@koi/middleware-audit";
 import { createAuditMiddleware } from "@koi/middleware-audit";
-import type { GovernanceBackendMiddlewareConfig } from "@koi/middleware-governance-backend";
 import { createGovernanceBackendMiddleware } from "@koi/middleware-governance-backend";
-import type { GuardrailsConfig } from "@koi/middleware-guardrails";
 import { createGuardrailsMiddleware } from "@koi/middleware-guardrails";
-import type { PayMiddlewareConfig } from "@koi/middleware-pay";
 import { createPayMiddleware } from "@koi/middleware-pay";
-import type { PermissionsMiddlewareConfig } from "@koi/middleware-permissions";
 import { createPermissionsMiddleware } from "@koi/middleware-permissions";
-import type { PIIConfig } from "@koi/middleware-pii";
 import { createPIIMiddleware } from "@koi/middleware-pii";
-import type { SanitizeMiddlewareConfig } from "@koi/middleware-sanitize";
 import { createSanitizeMiddleware } from "@koi/middleware-sanitize";
 
-/**
- * Configuration for the governance compliance stack.
- * All fields are optional — include only the middleware you need.
- */
-export interface GovernanceStackConfig {
-  /** Coarse-grained tool allow/deny/ask rules. Priority 100. */
-  readonly permissions?: PermissionsMiddlewareConfig;
-  /** Progressive command allowlisting. Priority 110 (overridden from default). */
-  readonly execApprovals?: ExecApprovalsConfig;
-  /** Delegation grant verification. Priority 120 (overridden from default). */
-  readonly delegation?: DelegationMiddlewareConfig;
-  /** Pluggable policy evaluation gate. Priority 150. */
-  readonly governanceBackend?: GovernanceBackendMiddlewareConfig;
-  /** Token budget enforcement. Priority 200. */
-  readonly pay?: PayMiddlewareConfig;
-  /** Compliance audit logging. Priority 300. */
-  readonly audit?: AuditMiddlewareConfig;
-  /** PII detection and redaction. Priority 340. */
-  readonly pii?: PIIConfig;
-  /** Content sanitization. Priority 350. */
-  readonly sanitize?: SanitizeMiddlewareConfig;
-  /** Output schema validation. Priority 375. */
-  readonly guardrails?: GuardrailsConfig;
-}
+import { resolveGovernanceConfig } from "./config-resolution.js";
+import { wireGovernanceScope } from "./scope-wiring.js";
+import type { GovernanceBundle, GovernanceStackConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
 
 /**
  * Assemble a governance compliance middleware stack.
  *
- * Returns an object with `middlewares` — pass it directly to createKoi():
+ * Returns a `GovernanceBundle` with `middlewares`, `providers`, and `config` metadata.
+ * Pass `middlewares` and `providers` directly to createKoi():
  *
  * ```typescript
- * const { middlewares } = createGovernanceStack({ audit: { sink: myAuditSink } });
- * const runtime = await createKoi({ ..., middleware: middlewares });
+ * const { middlewares, providers } = createGovernanceStack({ preset: "standard" });
+ * const runtime = await createKoi({ ..., middleware: middlewares, providers });
  * ```
  *
+ * Config resolution: defaults -> preset -> user overrides.
  * Middleware are ordered by priority. Priority overrides are applied for
  * exec-approvals (110) and delegation (120) so they slot correctly between
  * permissions (100) and governance-backend (150).
  */
-export function createGovernanceStack(config: GovernanceStackConfig): {
-  readonly middlewares: readonly KoiMiddleware[];
-} {
+export function createGovernanceStack(config: GovernanceStackConfig): GovernanceBundle {
+  const resolved = resolveGovernanceConfig(config);
+
   const candidates: ReadonlyArray<KoiMiddleware | undefined> = [
-    config.permissions !== undefined
-      ? createPermissionsMiddleware(config.permissions) // 100
+    resolved.permissions !== undefined
+      ? createPermissionsMiddleware(resolved.permissions) // 100
       : undefined,
-    config.execApprovals !== undefined
-      ? { ...createExecApprovalsMiddleware(config.execApprovals), priority: 110 } // override from 100
+    resolved.execApprovals !== undefined
+      ? { ...createExecApprovalsMiddleware(resolved.execApprovals), priority: 110 } // override
       : undefined,
-    config.delegation !== undefined
-      ? { ...createDelegationMiddleware(config.delegation), priority: 120 } // override from default
+    resolved.delegation !== undefined
+      ? { ...createDelegationMiddleware(resolved.delegation), priority: 120 } // override
       : undefined,
-    config.governanceBackend !== undefined
-      ? createGovernanceBackendMiddleware(config.governanceBackend) // 150
+    resolved.governanceBackend !== undefined
+      ? createGovernanceBackendMiddleware(resolved.governanceBackend) // 150
       : undefined,
-    config.pay !== undefined
-      ? createPayMiddleware(config.pay) // 200
+    resolved.pay !== undefined
+      ? createPayMiddleware(resolved.pay) // 200
       : undefined,
-    config.audit !== undefined
-      ? createAuditMiddleware(config.audit) // 300
+    resolved.audit !== undefined
+      ? createAuditMiddleware(resolved.audit) // 300
       : undefined,
-    config.pii !== undefined
-      ? createPIIMiddleware(config.pii) // 340
+    resolved.pii !== undefined
+      ? createPIIMiddleware(resolved.pii) // 340
       : undefined,
-    config.sanitize !== undefined
-      ? createSanitizeMiddleware(config.sanitize) // 350
+    resolved.sanitize !== undefined
+      ? createSanitizeMiddleware(resolved.sanitize) // 350
       : undefined,
-    config.guardrails !== undefined
-      ? createGuardrailsMiddleware(config.guardrails) // 375
+    resolved.guardrails !== undefined
+      ? createGuardrailsMiddleware(resolved.guardrails) // 375
       : undefined,
   ];
 
+  const middlewares = candidates.filter((mw): mw is KoiMiddleware => mw !== undefined);
+
+  // Wire scope providers when scope + backends are present
+  const providers =
+    resolved.scope !== undefined && resolved.backends !== undefined
+      ? wireGovernanceScope(resolved.scope, resolved.backends, resolved.enforcer)
+      : [];
+
+  const preset = resolved.preset ?? "open";
+
   return {
-    middlewares: candidates.filter((mw): mw is KoiMiddleware => mw !== undefined),
+    middlewares,
+    providers,
+    config: {
+      preset,
+      middlewareCount: middlewares.length,
+      providerCount: providers.length,
+      payDeprecated: resolved.pay !== undefined,
+      scopeEnabled: resolved.scope !== undefined,
+    },
   };
 }

--- a/packages/governance/src/index.ts
+++ b/packages/governance/src/index.ts
@@ -2,35 +2,52 @@
  * @koi/governance — Enterprise compliance meta-package (Layer 3)
  *
  * One-line enterprise compliance for AI agent deployments.
- * Composes 9 middleware into a single createGovernanceStack() factory:
+ * Composes up to 9 middleware + scope providers via createGovernanceStack():
  *
  *   permissions → exec-approvals → delegation → governance-backend →
  *   pay → audit → pii → sanitize → guardrails
  *
+ * Supports deployment presets: "open" (default), "standard", "strict".
+ *
  * Usage:
  * ```typescript
  * import { createGovernanceStack } from "@koi/governance";
- * import { createInMemoryAuditSink } from "@koi/middleware-audit";
  *
- * const { middlewares } = createGovernanceStack({
- *   audit: { sink: createInMemoryAuditSink() },
- *   // add more as needed
+ * const { middlewares, providers, config } = createGovernanceStack({
+ *   preset: "standard",
+ *   audit: { sink: myAuditSink },
  * });
- * const runtime = await createKoi({ ..., middleware: middlewares });
+ * const runtime = await createKoi({ ..., middleware: middlewares, providers });
  * ```
  */
 
+// ── Types: middleware sub-configs ────────────────────────────────────────
 export type { DelegationMiddlewareConfig } from "@koi/delegation";
 export type { ExecApprovalsConfig } from "@koi/exec-approvals";
-
-// Sub-config types for callers building the config
 export type { AuditMiddlewareConfig } from "@koi/middleware-audit";
 export type { GovernanceBackendMiddlewareConfig } from "@koi/middleware-governance-backend";
 export type { GuardrailsConfig } from "@koi/middleware-guardrails";
+/** @deprecated Use @koi/middleware-pay directly. */
 export type { PayMiddlewareConfig } from "@koi/middleware-pay";
-export type { PermissionsMiddlewareConfig } from "@koi/middleware-permissions";
+export type {
+  PatternBackendConfig,
+  PermissionRules,
+  PermissionsMiddlewareConfig,
+} from "@koi/middleware-permissions";
 export type { PIIConfig } from "@koi/middleware-pii";
 export type { SanitizeMiddlewareConfig } from "@koi/middleware-sanitize";
-export type { GovernanceStackConfig } from "./governance-stack.js";
-// Factory + config
+// ── Functions ───────────────────────────────────────────────────────────
+export { resolveGovernanceConfig } from "./config-resolution.js";
 export { createGovernanceStack } from "./governance-stack.js";
+// ── Constants ───────────────────────────────────────────────────────────
+export { GOVERNANCE_PRESET_SPECS } from "./presets.js";
+// ── Types: governance bundle ────────────────────────────────────────────
+export type {
+  GovernanceBundle,
+  GovernancePreset,
+  GovernancePresetSpec,
+  GovernanceScopeBackends,
+  GovernanceScopeConfig,
+  GovernanceStackConfig,
+  ResolvedGovernanceMeta,
+} from "./types.js";

--- a/packages/governance/src/presets.ts
+++ b/packages/governance/src/presets.ts
@@ -1,0 +1,62 @@
+/**
+ * Governance deployment presets: open, standard, strict.
+ *
+ * Each preset provides sensible defaults for permission rules,
+ * middleware, and scope configuration. User overrides always win.
+ */
+
+import type { GovernancePreset, GovernancePresetSpec } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Preset definitions (deeply frozen)
+// ---------------------------------------------------------------------------
+
+const OPEN: GovernancePresetSpec = Object.freeze({
+  permissionRules: Object.freeze({
+    allow: Object.freeze(["*"]),
+    deny: Object.freeze([] as readonly string[]),
+    ask: Object.freeze([] as readonly string[]),
+  }),
+});
+
+const STANDARD: GovernancePresetSpec = Object.freeze({
+  permissionRules: Object.freeze({
+    allow: Object.freeze(["group:fs_read", "group:web", "group:browser", "group:lsp"]),
+    deny: Object.freeze(["group:fs_delete"]),
+    ask: Object.freeze(["group:runtime"]),
+  }),
+  pii: Object.freeze({ strategy: "mask" as const }),
+  sanitize: Object.freeze({ rules: Object.freeze([] as readonly []) }),
+  scope: Object.freeze({
+    filesystem: Object.freeze({ root: ".", mode: "rw" as const }),
+    browser: Object.freeze({ blockPrivateAddresses: true }),
+  }),
+});
+
+const STRICT: GovernancePresetSpec = Object.freeze({
+  permissionRules: Object.freeze({
+    allow: Object.freeze(["group:fs_read"]),
+    deny: Object.freeze(["group:runtime", "group:fs_delete", "group:db_write"]),
+    ask: Object.freeze([] as readonly string[]),
+  }),
+  pii: Object.freeze({ strategy: "redact" as const }),
+  sanitize: Object.freeze({ rules: Object.freeze([] as readonly []) }),
+  guardrails: Object.freeze({ rules: Object.freeze([] as readonly []) }),
+  scope: Object.freeze({
+    filesystem: Object.freeze({ root: ".", mode: "ro" as const }),
+    browser: Object.freeze({
+      blockPrivateAddresses: true,
+      allowedProtocols: Object.freeze(["https:"]),
+    }),
+    credentials: Object.freeze({ keyPattern: "*" }),
+    memory: Object.freeze({ namespace: "default" }),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Exported registry
+// ---------------------------------------------------------------------------
+
+/** Frozen registry of governance preset specs, keyed by preset name. */
+export const GOVERNANCE_PRESET_SPECS: Readonly<Record<GovernancePreset, GovernancePresetSpec>> =
+  Object.freeze({ open: OPEN, standard: STANDARD, strict: STRICT });

--- a/packages/governance/src/scope-wiring.ts
+++ b/packages/governance/src/scope-wiring.ts
@@ -1,0 +1,114 @@
+/**
+ * Scope wiring: maps GovernanceScopeConfig + backends to ComponentProviders.
+ *
+ * Duplicates the pattern from @koi/starter/src/scope-resolver.ts (Rule of Three).
+ * Each subsystem: filesystem → browser → credentials → memory.
+ */
+
+import type { ComponentProvider, ScopeEnforcer } from "@koi/core";
+import { createFileSystemProvider } from "@koi/filesystem";
+import type { BrowserScope, NavigationSecurityConfig } from "@koi/scope";
+import {
+  createAuditedCredentials,
+  createEnforcedFileSystem,
+  createScopedCredentials,
+  createScopedMemoryProvider,
+} from "@koi/scope";
+import { createBrowserProvider } from "@koi/tool-browser";
+
+import type { GovernanceScopeBackends, GovernanceScopeConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Scope wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire scope configuration and backends into ComponentProviders.
+ *
+ * For each subsystem (filesystem, browser, credentials, memory):
+ * 1. Check if scope config AND backend are both present
+ * 2. Apply enforcer wrapping when provided
+ * 3. Apply scoping (local checks: path containment, pattern matching, etc.)
+ * 4. Apply audit wrapping when auditSink is available
+ * 5. Create the ComponentProvider
+ *
+ * Missing backends for a configured scope are gracefully skipped.
+ */
+export function wireGovernanceScope(
+  scopeConfig: GovernanceScopeConfig,
+  backends: GovernanceScopeBackends,
+  enforcer?: ScopeEnforcer,
+): readonly ComponentProvider[] {
+  const providers: ComponentProvider[] = [];
+
+  // ── Filesystem ──────────────────────────────────────────────────────
+  if (scopeConfig.filesystem !== undefined && backends.filesystem !== undefined) {
+    const raw = backends.filesystem;
+    const enforced = enforcer !== undefined ? createEnforcedFileSystem(raw, enforcer) : raw;
+
+    providers.push(
+      createFileSystemProvider({
+        backend: enforced,
+        scope: {
+          root: scopeConfig.filesystem.root,
+          mode: scopeConfig.filesystem.mode ?? "rw",
+        },
+      }),
+    );
+  }
+
+  // ── Browser ─────────────────────────────────────────────────────────
+  if (scopeConfig.browser !== undefined && backends.browser !== undefined) {
+    const raw = backends.browser;
+    const bc = scopeConfig.browser;
+
+    // Build NavigationSecurityConfig — only include defined properties
+    // to satisfy exactOptionalPropertyTypes
+    const nav: NavigationSecurityConfig = {
+      ...(bc.blockPrivateAddresses !== undefined
+        ? { blockPrivateAddresses: bc.blockPrivateAddresses }
+        : {}),
+      ...(bc.allowedProtocols !== undefined ? { allowedProtocols: bc.allowedProtocols } : {}),
+      ...(bc.allowedDomains !== undefined ? { allowedDomains: bc.allowedDomains } : {}),
+    };
+
+    const scope: BrowserScope = {
+      navigation: nav,
+      ...(bc.trustTier !== undefined ? { trustTier: bc.trustTier } : {}),
+    };
+
+    providers.push(createBrowserProvider({ backend: raw, scope }));
+  }
+
+  // ── Credentials ─────────────────────────────────────────────────────
+  if (scopeConfig.credentials !== undefined && backends.credentials !== undefined) {
+    const raw = backends.credentials;
+    const scoped = createScopedCredentials(raw, {
+      keyPattern: scopeConfig.credentials.keyPattern,
+    });
+
+    // Optionally wrap with audit
+    const audited =
+      backends.auditSink !== undefined
+        ? createAuditedCredentials(scoped, { sink: backends.auditSink })
+        : scoped;
+
+    providers.push({
+      name: "governance:credentials",
+      attach: async () => new Map([["credentials", audited]]),
+    });
+  }
+
+  // ── Memory ──────────────────────────────────────────────────────────
+  if (scopeConfig.memory !== undefined && backends.memory !== undefined) {
+    const raw = backends.memory;
+
+    providers.push(
+      createScopedMemoryProvider(raw, {
+        namespace: scopeConfig.memory.namespace,
+      }),
+    );
+  }
+
+  return providers;
+}

--- a/packages/governance/src/types.ts
+++ b/packages/governance/src/types.ts
@@ -1,0 +1,148 @@
+/**
+ * Types for the governance compliance bundle.
+ *
+ * Defines the full GovernanceStackConfig (preset + scope + middleware fields),
+ * deployment presets, scope configuration, and the GovernanceBundle return shape.
+ */
+
+import type {
+  AuditSink,
+  ComponentProvider,
+  CredentialComponent,
+  FileSystemBackend,
+  KoiMiddleware,
+  MemoryComponent,
+  ScopeEnforcer,
+} from "@koi/core";
+import type { DelegationMiddlewareConfig } from "@koi/delegation";
+import type { ExecApprovalsConfig } from "@koi/exec-approvals";
+import type { AuditMiddlewareConfig } from "@koi/middleware-audit";
+import type { GovernanceBackendMiddlewareConfig } from "@koi/middleware-governance-backend";
+import type { GuardrailsConfig } from "@koi/middleware-guardrails";
+import type { PayMiddlewareConfig } from "@koi/middleware-pay";
+import type { PermissionRules, PermissionsMiddlewareConfig } from "@koi/middleware-permissions";
+import type { PIIConfig } from "@koi/middleware-pii";
+import type { SanitizeMiddlewareConfig } from "@koi/middleware-sanitize";
+import type { BrowserDriver } from "@koi/tool-browser";
+
+// ---------------------------------------------------------------------------
+// Deployment presets
+// ---------------------------------------------------------------------------
+
+/** Deployment preset levels for governance stacks. */
+export type GovernancePreset = "open" | "standard" | "strict";
+
+// ---------------------------------------------------------------------------
+// Scope configuration
+// ---------------------------------------------------------------------------
+
+/** Scope configuration for governed capabilities. */
+export interface GovernanceScopeConfig {
+  readonly filesystem?:
+    | { readonly root: string; readonly mode?: "rw" | "ro" | undefined }
+    | undefined;
+  readonly browser?:
+    | {
+        readonly allowedProtocols?: readonly string[] | undefined;
+        readonly allowedDomains?: readonly string[] | undefined;
+        readonly blockPrivateAddresses?: boolean | undefined;
+        readonly trustTier?: "sandbox" | "verified" | "promoted" | undefined;
+      }
+    | undefined;
+  readonly credentials?: { readonly keyPattern: string } | undefined;
+  readonly memory?: { readonly namespace: string } | undefined;
+}
+
+/** Backend implementations for scope wiring. */
+export interface GovernanceScopeBackends {
+  readonly filesystem?: FileSystemBackend | undefined;
+  readonly browser?: BrowserDriver | undefined;
+  readonly credentials?: CredentialComponent | undefined;
+  readonly memory?: MemoryComponent | undefined;
+  readonly auditSink?: AuditSink | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Stack configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the governance compliance stack.
+ *
+ * All fields are optional. Include only the middleware you need.
+ * When `preset` is specified, its defaults are merged under user overrides.
+ */
+export interface GovernanceStackConfig {
+  // ── Meta ──────────────────────────────────────────────────────────────
+  /** Deployment preset. Defaults to "open". */
+  readonly preset?: GovernancePreset | undefined;
+  /** Scope enforcement configuration. */
+  readonly scope?: GovernanceScopeConfig | undefined;
+  /** Backend implementations for scope wiring. */
+  readonly backends?: GovernanceScopeBackends | undefined;
+  /** Pluggable scope enforcer (ReBAC, ABAC, etc.). */
+  readonly enforcer?: ScopeEnforcer | undefined;
+
+  // ── Permission shorthand ──────────────────────────────────────────────
+  /**
+   * Pattern-based permission rules shorthand. Mutually exclusive with `permissions`.
+   * Creates a pattern permission backend automatically.
+   */
+  readonly permissionRules?: PermissionRules | undefined;
+
+  // ── Middleware configs (all optional) ─────────────────────────────────
+  /** Coarse-grained tool allow/deny/ask rules. Priority 100. */
+  readonly permissions?: PermissionsMiddlewareConfig | undefined;
+  /** Progressive command allowlisting. Priority 110 (overridden from default). */
+  readonly execApprovals?: ExecApprovalsConfig | undefined;
+  /** Delegation grant verification. Priority 120 (overridden from default). */
+  readonly delegation?: DelegationMiddlewareConfig | undefined;
+  /** Pluggable policy evaluation gate. Priority 150. */
+  readonly governanceBackend?: GovernanceBackendMiddlewareConfig | undefined;
+  /** @deprecated Use @koi/middleware-pay directly. Will be removed next major. */
+  readonly pay?: PayMiddlewareConfig | undefined;
+  /** Compliance audit logging. Priority 300. */
+  readonly audit?: AuditMiddlewareConfig | undefined;
+  /** PII detection and redaction. Priority 340. */
+  readonly pii?: PIIConfig | undefined;
+  /** Content sanitization. Priority 350. */
+  readonly sanitize?: SanitizeMiddlewareConfig | undefined;
+  /** Output schema validation. Priority 375. */
+  readonly guardrails?: GuardrailsConfig | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Preset spec (DRY via Omit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Partial config without meta-fields, used for preset definitions.
+ * Presets cannot specify preset, backends, enforcer, or pay.
+ */
+export type GovernancePresetSpec = Partial<
+  Omit<GovernanceStackConfig, "preset" | "backends" | "enforcer" | "pay">
+>;
+
+// ---------------------------------------------------------------------------
+// Resolved metadata
+// ---------------------------------------------------------------------------
+
+/** Metadata about the resolved governance stack for inspection. */
+export interface ResolvedGovernanceMeta {
+  readonly preset: GovernancePreset;
+  readonly middlewareCount: number;
+  readonly providerCount: number;
+  readonly payDeprecated: boolean;
+  readonly scopeEnabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Bundle return value
+// ---------------------------------------------------------------------------
+
+/** Return value of createGovernanceStack(). */
+export interface GovernanceBundle {
+  readonly middlewares: readonly KoiMiddleware[];
+  readonly providers: readonly ComponentProvider[];
+  readonly config: ResolvedGovernanceMeta;
+}


### PR DESCRIPTION
## Summary

Evolves `@koi/governance` from a simple middleware assembler into a full enterprise compliance bundle with deployment presets, scope enforcement, and config resolution.

- **Deployment presets** (`open` / `standard` / `strict`) with sensible defaults for permissions, PII handling, sanitization, guardrails, and scope
- **3-layer config merge**: defaults → preset → user overrides via `resolveGovernanceConfig()`
- **Scope enforcement wiring**: filesystem, browser, credentials, memory — each wrapped with enforcer + scoping + audit
- **`permissionRules` shorthand**: pattern-based rules without constructing a custom `PermissionBackend`
- **Pay deprecation**: `console.warn` when `pay` field used, still functional for one release
- **Return shape**: `{ middlewares }` → `GovernanceBundle { middlewares, providers, config }`

### New files
| File | Purpose |
|------|---------|
| `types.ts` | `GovernanceStackConfig`, presets, scope config, bundle types |
| `presets.ts` | Frozen `GOVERNANCE_PRESET_SPECS` registry |
| `config-resolution.ts` | 3-layer merge + validation |
| `scope-wiring.ts` | Scope config + backends → `ComponentProvider[]` |
| `docs/L3/governance.md` | Package documentation |

### Modified files
| File | Change |
|------|--------|
| `governance-stack.ts` | Uses `resolveGovernanceConfig()` + `wireGovernanceScope()`, returns `GovernanceBundle` |
| `index.ts` | Exports new types, constants, functions |
| `package.json` | Added `@koi/scope`, `@koi/filesystem`, `@koi/tool-browser` deps |

## Test plan

- [x] 54 tests pass across 5 test files (presets, config-resolution, scope-wiring, governance-stack, api-surface)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Build clean (`tsup` ESM + .d.ts)
- [x] Layer check passes (`scripts/check-layers.ts`)
- [x] API surface snapshot updated
- [x] Biome lint/format clean

Closes #641