### PR TITLE
feat: fix personalization heuristics, pin injections, wire into context-arena

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -512,6 +512,7 @@
         "@koi/memory-fs": "workspace:*",
         "@koi/middleware-compactor": "workspace:*",
         "@koi/middleware-context-editing": "workspace:*",
+        "@koi/middleware-personalization": "workspace:*",
         "@koi/snapshot-chain-store": "workspace:*",
         "@koi/token-estimator": "workspace:*",
         "@koi/tool-squash": "workspace:*",
@@ -1317,6 +1318,18 @@
         "@koi/engine": "workspace:*",
         "@koi/engine-loop": "workspace:*",
         "@koi/engine-pi": "workspace:*",
+        "@koi/test-utils": "workspace:*",
+      },
+    },
+    "packages/middleware-personalization": {
+      "name": "@koi/middleware-personalization",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+        "@koi/token-estimator": "workspace:*",
+      },
+      "devDependencies": {
         "@koi/test-utils": "workspace:*",
       },
     },
@@ -2797,6 +2810,8 @@
     "@koi/middleware-pay": ["@koi/middleware-pay@workspace:packages/middleware-pay"],
 
     "@koi/middleware-permissions": ["@koi/middleware-permissions@workspace:packages/middleware-permissions"],
+
+    "@koi/middleware-personalization": ["@koi/middleware-personalization@workspace:packages/middleware-personalization"],
 
     "@koi/middleware-pii": ["@koi/middleware-pii@workspace:packages/middleware-pii"],
 

--- a/docs/L2/middleware-personalization.md
+++ b/docs/L2/middleware-personalization.md
@@ -1,0 +1,265 @@
+# @koi/middleware-personalization — Dual-Channel Preference Learning
+
+`@koi/middleware-personalization` is an L2 middleware package that closes the preference learning loop through two complementary feedback channels:
+
+1. **Pre-action clarification** — injects stored preferences or asks the user to clarify ambiguous instructions before the model acts
+2. **Post-action correction** — detects when the user corrects the model and stores the preference for future recall
+
+---
+
+## Why It Exists
+
+Without preference learning, agents repeat the same mistakes:
+
+```
+Without personalization:
+  User: "Format the output"     → Agent picks JSON (guess)
+  User: "No, use YAML"          → Agent switches to YAML
+  User: "Format the output"     → Agent picks JSON again (forgot)
+
+With personalization:
+  User: "Format the output"     → Agent picks JSON (guess)
+  User: "No, use YAML"          → Agent stores: "User prefers YAML"
+  User: "Format the output"     → Agent injects [User Preferences: YAML] → picks YAML
+```
+
+Based on [PAHF (Liang et al., 2025)](https://arxiv.org/abs/2602.16173): combining pre-action and post-action feedback is strictly better than either alone. Pre-action queries reduce ambiguity errors exponentially. Post-action corrections bound drift errors to O(K) where K = number of preference switches.
+
+---
+
+## Architecture
+
+### Layer Position
+
+```
+L0  @koi/core           ─ KoiMiddleware, MemoryComponent, InboundMessage (types only)
+L0u @koi/errors          ─ swallowError
+L0u @koi/token-estimator ─ estimateTokens
+L2  @koi/middleware-personalization ◄── this package (L0 + L0u only)
+```
+
+### Internal Module Map
+
+```
+index.ts                    ← public re-exports
+│
+├── config.ts               ← PersonalizationConfig, validation, resolveDefaults
+├── personalization.ts      ← createPersonalizationMiddleware() factory
+├── ambiguity-classifier.ts ← AmbiguityClassifier interface + default heuristic
+├── correction-detector.ts  ← CorrectionDetector interface + default heuristic
+├── preference-cache.ts     ← single-entry cache for memory recall results
+└── text-extractor.ts       ← extract text from InboundMessage content blocks
+```
+
+---
+
+## How It Works
+
+### Pre-Action Channel (every turn)
+
+```
+User message arrives
+       │
+       ▼
+  memory.recall(query)  ─── cached after first call
+       │
+       ├── preferences found (score ≥ 0.7)
+       │     └─► inject [User Preferences] message (pinned) → model sees them
+       │
+       └── no preferences
+             │
+             ▼
+        classifier.classify(instruction)
+             │
+             ├── ambiguous (question + alternative markers)
+             │     └─► inject clarification directive (pinned) → model asks user
+             │
+             └── clear
+                   └─► pass through unchanged
+```
+
+Key details:
+- Preference messages are `pinned: true` so compactor preserves them during aggressive compaction
+- The default classifier uses pure string matching (zero LLM cost)
+- Token budget (default 500) caps injected preference size
+- Relevance threshold (default 0.7) filters low-quality recall results
+
+### Post-Action Channel (turn > 0 only)
+
+```
+User message on turn N (N > 0)
+       │
+       ├── too short (< 5 words) AND no correction markers?
+       │     └─► skip (fast path)
+       │
+       └── long enough OR has markers ("no,", "actually,", "i prefer")
+             │
+             ▼
+        detector.detect(message)
+             │
+             ├── corrective + has preference update
+             │     └─► memory.store(update, namespace: "preferences")
+             │         cache.invalidate()
+             │
+             └── not corrective
+                   └─► pass through
+```
+
+Key details:
+- Skips turn 0 (nothing to correct yet)
+- Short-circuits messages under 5 words without correction markers
+- Filters false positives: "no problem", "no worries", "no thanks"
+- The default detector uses keyword heuristics (zero LLM cost)
+
+---
+
+## API
+
+### `createPersonalizationMiddleware(config)`
+
+Creates the middleware with both channels enabled by default.
+
+```typescript
+import { createPersonalizationMiddleware } from "@koi/middleware-personalization";
+
+const mw = createPersonalizationMiddleware({
+  memory: myMemoryComponent,      // required — MemoryComponent from ECS
+  relevanceThreshold: 0.7,        // default: 0.7
+  maxPreferenceTokens: 500,       // default: 500
+  preferenceNamespace: "preferences", // default: "preferences"
+});
+```
+
+Returns `KoiMiddleware` with:
+- `name: "personalization"`
+- `priority: 420`
+- `describeCapabilities()` — reports active channels
+- `wrapModelCall()` — pre-action injection + post-action detection
+
+### `PersonalizationConfig`
+
+```typescript
+interface PersonalizationConfig {
+  readonly memory: MemoryComponent;                // required
+  readonly preAction?: PreActionConfig;            // default: enabled
+  readonly postAction?: PostActionConfig;          // default: enabled
+  readonly relevanceThreshold?: number;            // default: 0.7
+  readonly maxPreferenceTokens?: number;           // default: 500
+  readonly preferenceNamespace?: string;           // default: "preferences"
+  readonly onError?: (error: unknown) => void;     // default: swallowError
+}
+
+interface PreActionConfig {
+  readonly enabled?: boolean;                      // default: true
+  readonly classifier?: AmbiguityClassifier;       // default: keyword heuristic
+  readonly maxQuestionTokens?: number;             // default: 100
+}
+
+interface PostActionConfig {
+  readonly enabled?: boolean;                      // default: true
+  readonly detector?: CorrectionDetector;          // default: keyword heuristic
+}
+```
+
+### Pluggable Classifiers
+
+Both `AmbiguityClassifier` and `CorrectionDetector` are strategy interfaces — swap in model-based implementations when you need higher accuracy:
+
+```typescript
+interface AmbiguityClassifier {
+  readonly classify: (
+    instruction: string,
+    relevantPreferences: readonly MemoryResult[],
+  ) => AmbiguityAssessment | Promise<AmbiguityAssessment>;
+}
+
+interface CorrectionDetector {
+  readonly detect: (
+    message: string,
+    recentContext: readonly InboundMessage[],
+  ) => CorrectionAssessment | Promise<CorrectionAssessment>;
+}
+```
+
+---
+
+## Context Arena Integration
+
+When using `@koi/context-arena`, personalization is an opt-in module that shares memory and budget allocation:
+
+```typescript
+import { createContextArena } from "@koi/context-arena";
+
+const bundle = await createContextArena({
+  summarizer: myModelHandler,
+  sessionId: mySessionId,
+  getMessages: () => messages,
+  memory: myMemoryComponent,
+  personalization: { enabled: true },  // opt-in
+});
+
+// bundle.middleware: [squash(220), compactor(225), context-editing(250), personalization(420)]
+```
+
+Configuration overrides:
+
+```typescript
+personalization: {
+  enabled: true,
+  relevanceThreshold: 0.5,      // lower threshold = more preferences injected
+  maxPreferenceTokens: 200,     // tighter budget
+}
+```
+
+Personalization requires `memory` — if no memory component is provided, the middleware is silently omitted even when `enabled: true`.
+
+---
+
+## Performance Properties
+
+| Operation | Cost | When |
+|-----------|------|------|
+| `memory.recall()` | 1 call, then cached | First turn only (per middleware instance) |
+| `filterByRelevance()` | O(n) array filter | Every turn with pre-action enabled |
+| `capByTokenBudget()` | O(n) with token estimation | Every turn with preferences found |
+| `classifier.classify()` | O(markers) string matching | Only when no preferences + pre-action |
+| `looksLikeCorrection()` | O(1) string prefix check | Every turn > 0 with post-action |
+| `detector.detect()` | O(markers) string matching | Only when message passes short-circuit |
+| `memory.store()` | 1 call | Only on detected corrections |
+
+**Zero LLM calls** with default classifiers. The only I/O is `memory.recall()` (cached) and `memory.store()` (rare).
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    KoiMiddleware, MemoryComponent, InboundMessage,      │
+    MemoryResult, CapabilityFragment                     │
+                                                          │
+L0u @koi/errors ────────────────────────────────────┐    │
+    swallowError                                    │    │
+                                                    │    │
+L0u @koi/token-estimator ──────────────────────┐    │    │
+    estimateTokens                              │    │    │
+                                                ▼    ▼    ▼
+L2  @koi/middleware-personalization ◄───────────┘────┘────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external runtime dependencies
+```
+
+---
+
+## What This Feature Enables
+
+Agents that **remember and adapt to individual users** without extra LLM calls:
+
+- **Cold start handling** — when the agent has no preferences, it asks before guessing
+- **Preference persistence** — corrections are stored and recalled in future sessions
+- **Compaction-safe** — pinned messages survive aggressive context compaction
+- **Zero-cost defaults** — keyword heuristics mean no extra API calls or latency
+- **Pluggable upgrade path** — swap in LLM-based classifiers when accuracy matters more than cost
+- **Coordinated budgets** — via context-arena, preferences share the token budget with squash, compactor, and context-editing

--- a/packages/context-arena/package.json
+++ b/packages/context-arena/package.json
@@ -15,6 +15,7 @@
     "@koi/memory-fs": "workspace:*",
     "@koi/middleware-compactor": "workspace:*",
     "@koi/middleware-context-editing": "workspace:*",
+    "@koi/middleware-personalization": "workspace:*",
     "@koi/snapshot-chain-store": "workspace:*",
     "@koi/token-estimator": "workspace:*",
     "@koi/tool-squash": "workspace:*"

--- a/packages/context-arena/src/arena-factory.test.ts
+++ b/packages/context-arena/src/arena-factory.test.ts
@@ -105,6 +105,54 @@ describe("createContextArena", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Personalization wiring
+// ---------------------------------------------------------------------------
+
+describe("createContextArena personalization", () => {
+  test("personalization not added when disabled (default)", async () => {
+    const bundle = await createContextArena(baseConfig());
+    expect(bundle.middleware).toHaveLength(3);
+  });
+
+  test("personalization not added when enabled but no memory", async () => {
+    const bundle = await createContextArena(baseConfig({ personalization: { enabled: true } }));
+    expect(bundle.middleware).toHaveLength(3);
+  });
+
+  test("personalization adds 4th middleware when enabled with memory", async () => {
+    const memory = {
+      recall: mock(() => Promise.resolve([])),
+      store: mock(() => Promise.resolve()),
+    } as unknown as MemoryComponent;
+    const bundle = await createContextArena(
+      baseConfig({ memory, personalization: { enabled: true } }),
+    );
+    expect(bundle.middleware).toHaveLength(4);
+    expect(bundle.middleware[3]?.name).toBe("personalization");
+  });
+
+  test("personalization middleware uses resolved config values", async () => {
+    const memory = {
+      recall: mock(() => Promise.resolve([])),
+      store: mock(() => Promise.resolve()),
+    } as unknown as MemoryComponent;
+    const bundle = await createContextArena(
+      baseConfig({
+        memory,
+        personalization: {
+          enabled: true,
+          relevanceThreshold: 0.5,
+          maxPreferenceTokens: 200,
+        },
+      }),
+    );
+    expect(bundle.config.personalizationEnabled).toBe(true);
+    expect(bundle.config.personalizationRelevanceThreshold).toBe(0.5);
+    expect(bundle.config.personalizationMaxPreferenceTokens).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Memory wiring — integration tests (no mock.module, real L2 factories)
 // ---------------------------------------------------------------------------
 

--- a/packages/context-arena/src/arena-factory.ts
+++ b/packages/context-arena/src/arena-factory.ts
@@ -11,6 +11,7 @@ import type { Agent } from "@koi/core/ecs";
 import { createFsMemory, createMemoryProvider } from "@koi/memory-fs";
 import { createCompactorMiddleware } from "@koi/middleware-compactor";
 import { createContextEditingMiddleware } from "@koi/middleware-context-editing";
+import { createPersonalizationMiddleware } from "@koi/middleware-personalization";
 import { createSquashProvider } from "@koi/tool-squash";
 import { resolveContextArenaConfig } from "./config-resolution.js";
 import type { ContextArenaBundle, ContextArenaConfig } from "./types.js";
@@ -18,7 +19,7 @@ import type { ContextArenaBundle, ContextArenaConfig } from "./types.js";
 /**
  * Creates a fully wired context arena bundle with coordinated budget allocation.
  *
- * Middleware ordering in the returned array: squash (220) → compactor (225) → context-editing (250).
+ * Middleware ordering in the returned array: squash (220) → compactor (225) → context-editing (250) → personalization (420, opt-in).
  * Priority is owned by L2 packages — arena just returns them in priority order.
  *
  * @param config - User-facing configuration with required summarizer, sessionId, and getMessages
@@ -75,8 +76,23 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
     tokenEstimator: resolved.tokenEstimator,
   });
 
+  // --- Opt-in: personalization middleware ---
+  const personalizationMiddleware =
+    resolved.personalizationEnabled && effectiveMemory !== undefined
+      ? createPersonalizationMiddleware({
+          memory: effectiveMemory,
+          relevanceThreshold: resolved.personalizationRelevanceThreshold,
+          maxPreferenceTokens: resolved.personalizationMaxPreferenceTokens,
+        })
+      : undefined;
+
   // --- Middleware in priority order ---
-  const middleware = [squashBundle.middleware, compactorMiddleware, contextEditingMiddleware];
+  const middleware = [
+    squashBundle.middleware,
+    compactorMiddleware,
+    contextEditingMiddleware,
+    ...(personalizationMiddleware !== undefined ? [personalizationMiddleware] : []),
+  ];
 
   // --- Opt-in: filesystem memory provider (reuses pre-created fsMemory) ---
   const memoryProvider =

--- a/packages/context-arena/src/config-resolution.test.ts
+++ b/packages/context-arena/src/config-resolution.test.ts
@@ -83,6 +83,36 @@ describe("resolveContextArenaConfig", () => {
     ).toThrow("contextWindowSize must be a finite positive number");
   });
 
+  test("personalizationEnabled defaults to false", () => {
+    const resolved = resolveContextArenaConfig(baseConfig());
+    expect(resolved.personalizationEnabled).toBe(false);
+  });
+
+  test("personalizationEnabled true when personalization.enabled is true", () => {
+    const resolved = resolveContextArenaConfig(baseConfig({ personalization: { enabled: true } }));
+    expect(resolved.personalizationEnabled).toBe(true);
+  });
+
+  test("personalization defaults resolve correctly", () => {
+    const resolved = resolveContextArenaConfig(baseConfig());
+    expect(resolved.personalizationRelevanceThreshold).toBe(0.7);
+    expect(resolved.personalizationMaxPreferenceTokens).toBe(500);
+  });
+
+  test("personalization overrides apply", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({
+        personalization: {
+          enabled: true,
+          relevanceThreshold: 0.5,
+          maxPreferenceTokens: 200,
+        },
+      }),
+    );
+    expect(resolved.personalizationRelevanceThreshold).toBe(0.5);
+    expect(resolved.personalizationMaxPreferenceTokens).toBe(200);
+  });
+
   test("hydratorEnabled and memoryFsEnabled flags derived correctly", () => {
     const withoutOpts = resolveContextArenaConfig(baseConfig());
     expect(withoutOpts.hydratorEnabled).toBe(false);

--- a/packages/context-arena/src/config-resolution.ts
+++ b/packages/context-arena/src/config-resolution.ts
@@ -58,6 +58,11 @@ export function resolveContextArenaConfig(config: ContextArenaConfig): ResolvedC
     squashPreserveRecent: config.squash?.preserveRecent ?? budget.squashPreserveRecent,
     squashMaxPendingSquashes: config.squash?.maxPendingSquashes ?? budget.squashMaxPendingSquashes,
 
+    // Personalization
+    personalizationEnabled: config.personalization?.enabled ?? false,
+    personalizationRelevanceThreshold: config.personalization?.relevanceThreshold ?? 0.7,
+    personalizationMaxPreferenceTokens: config.personalization?.maxPreferenceTokens ?? 500,
+
     // Feature flags
     hydratorEnabled: config.hydrator !== undefined,
     memoryFsEnabled: config.memoryFs !== undefined,

--- a/packages/context-arena/src/index.ts
+++ b/packages/context-arena/src/index.ts
@@ -39,6 +39,7 @@ export type {
   ContextArenaConfig,
   ContextArenaPreset,
   ContextEditingOverrides,
+  PersonalizationOverrides,
   PresetBudget,
   PresetSpec,
   ResolvedContextArenaConfig,

--- a/packages/context-arena/src/types.ts
+++ b/packages/context-arena/src/types.ts
@@ -47,6 +47,15 @@ export interface SquashOverrides {
   readonly maxPendingSquashes?: number | undefined;
 }
 
+export interface PersonalizationOverrides {
+  /** Enable personalization middleware. Default: false (opt-in). */
+  readonly enabled?: boolean | undefined;
+  /** Minimum relevance score for preference recall. Default: 0.7. */
+  readonly relevanceThreshold?: number | undefined;
+  /** Max tokens for injected preferences. Default: 500. */
+  readonly maxPreferenceTokens?: number | undefined;
+}
+
 /** User-facing configuration for createContextArena. */
 export interface ContextArenaConfig {
   // --- Required ---
@@ -78,6 +87,8 @@ export interface ContextArenaConfig {
   readonly contextEditing?: ContextEditingOverrides | undefined;
   /** Override squash-specific settings. */
   readonly squash?: SquashOverrides | undefined;
+  /** Override personalization-specific settings. */
+  readonly personalization?: PersonalizationOverrides | undefined;
 
   // --- Opt-in modules ---
   /** Enable context hydrator (deferred — requires Agent at creation time). */
@@ -125,6 +136,11 @@ export interface ResolvedContextArenaConfig {
   // Squash
   readonly squashPreserveRecent: number;
   readonly squashMaxPendingSquashes: number;
+
+  // Personalization
+  readonly personalizationEnabled: boolean;
+  readonly personalizationRelevanceThreshold: number;
+  readonly personalizationMaxPreferenceTokens: number;
 
   // Feature flags
   readonly hydratorEnabled: boolean;

--- a/packages/context-arena/tsconfig.json
+++ b/packages/context-arena/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../memory-fs" },
     { "path": "../middleware-compactor" },
     { "path": "../middleware-context-editing" },
+    { "path": "../middleware-personalization" },
     { "path": "../snapshot-chain-store" },
     { "path": "../token-estimator" },
     { "path": "../tool-squash" }

--- a/packages/middleware-personalization/package.json
+++ b/packages/middleware-personalization/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/middleware-personalization",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "@koi/token-estimator": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/middleware-personalization/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-personalization/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,98 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-personalization API surface . has stable type surface 1`] = `
+"import { MemoryResult, MemoryComponent } from '@koi/core/ecs';
+import { Result, KoiError } from '@koi/core/errors';
+import { InboundMessage } from '@koi/core/message';
+import { KoiMiddleware } from '@koi/core/middleware';
+
+/**
+ * Ambiguity classifier — detects when user instructions need clarification.
+ */
+
+interface AmbiguityAssessment {
+    readonly ambiguous: boolean;
+    readonly suggestedDirective?: string;
+}
+interface AmbiguityClassifier {
+    readonly classify: (instruction: string, relevantPreferences: readonly MemoryResult[]) => AmbiguityAssessment | Promise<AmbiguityAssessment>;
+}
+declare function createDefaultAmbiguityClassifier(): AmbiguityClassifier;
+
+/**
+ * Correction detector — identifies preference corrections in user messages.
+ */
+
+interface CorrectionAssessment {
+    readonly corrective: boolean;
+    readonly preferenceUpdate?: string;
+}
+interface CorrectionDetector {
+    readonly detect: (message: string, recentContext: readonly InboundMessage[]) => CorrectionAssessment | Promise<CorrectionAssessment>;
+}
+declare function createDefaultCorrectionDetector(): CorrectionDetector;
+
+/**
+ * Personalization middleware configuration and validation.
+ */
+
+interface PreActionConfig {
+    readonly enabled?: boolean;
+    readonly classifier?: AmbiguityClassifier;
+    readonly maxQuestionTokens?: number;
+}
+interface PostActionConfig {
+    readonly enabled?: boolean;
+    readonly detector?: CorrectionDetector;
+}
+interface PersonalizationConfig {
+    readonly memory: MemoryComponent;
+    readonly preAction?: PreActionConfig;
+    readonly postAction?: PostActionConfig;
+    readonly relevanceThreshold?: number;
+    readonly maxPreferenceTokens?: number;
+    readonly preferenceNamespace?: string;
+    readonly onError?: (error: unknown) => void;
+}
+/** Resolved config with all defaults applied. */
+interface ResolvedPersonalizationConfig {
+    readonly memory: MemoryComponent;
+    readonly preAction: {
+        readonly enabled: boolean;
+        readonly classifier: AmbiguityClassifier;
+        readonly maxQuestionTokens: number;
+    };
+    readonly postAction: {
+        readonly enabled: boolean;
+        readonly detector: CorrectionDetector;
+    };
+    readonly relevanceThreshold: number;
+    readonly maxPreferenceTokens: number;
+    readonly preferenceNamespace: string;
+    readonly onError?: ((error: unknown) => void) | undefined;
+}
+declare function validatePersonalizationConfig(config: unknown): Result<PersonalizationConfig, KoiError>;
+
+/**
+ * Personalization middleware factory — dual-channel preference learning.
+ *
+ * Pre-action: injects relevant preferences + clarification directives.
+ * Post-action: detects corrections and stores preference updates.
+ */
+
+declare function createPersonalizationMiddleware(config: PersonalizationConfig): KoiMiddleware;
+
+/**
+ * Per-session preference cache with invalidation.
+ */
+
+interface PreferenceCache {
+    readonly get: () => readonly MemoryResult[] | undefined;
+    readonly set: (preferences: readonly MemoryResult[]) => void;
+    readonly invalidate: () => void;
+}
+declare function createPreferenceCache(): PreferenceCache;
+
+export { type AmbiguityAssessment, type AmbiguityClassifier, type CorrectionAssessment, type CorrectionDetector, type PersonalizationConfig, type PostActionConfig, type PreActionConfig, type PreferenceCache, type ResolvedPersonalizationConfig, createDefaultAmbiguityClassifier, createDefaultCorrectionDetector, createPersonalizationMiddleware, createPreferenceCache, validatePersonalizationConfig };
+"
+`;

--- a/packages/middleware-personalization/src/__tests__/api-surface.test.ts
+++ b/packages/middleware-personalization/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware-personalization/src/__tests__/integration.test.ts
+++ b/packages/middleware-personalization/src/__tests__/integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration test — multi-turn preference learning loop.
+ *
+ * Uses a stateful mock memory to simulate the full lifecycle:
+ * cold start → preference recall → correction → corrected behavior.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { MemoryRecallOptions, MemoryResult, MemoryStoreOptions } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelRequest, ModelResponse, TurnContext } from "@koi/core/middleware";
+import { createPersonalizationMiddleware } from "../personalization.js";
+
+interface StoredEntry {
+  readonly content: string;
+  readonly namespace?: string | undefined;
+  readonly category?: string | undefined;
+}
+
+function createStatefulMemory(): {
+  readonly recall: (
+    query: string,
+    options?: MemoryRecallOptions,
+  ) => Promise<readonly MemoryResult[]>;
+  readonly store: (content: string, options?: MemoryStoreOptions) => Promise<void>;
+  readonly entries: StoredEntry[];
+} {
+  const entries: StoredEntry[] = [];
+
+  return {
+    entries,
+    async recall(_query: string, options?: MemoryRecallOptions): Promise<readonly MemoryResult[]> {
+      return entries
+        .filter((e) => !options?.namespace || e.namespace === options.namespace)
+        .map((e) => ({ content: e.content, score: 0.95 }));
+    },
+    async store(content: string, options?: MemoryStoreOptions): Promise<void> {
+      entries.push({
+        content,
+        namespace: options?.namespace,
+        category: options?.category,
+      });
+    },
+  };
+}
+
+function createTurnContext(turnIndex: number): TurnContext {
+  return {
+    session: {
+      agentId: "test-agent",
+      sessionId: "integration-session" as never,
+      runId: "integration-run" as never,
+      metadata: {},
+    },
+    turnIndex,
+    turnId: `turn-${turnIndex}` as never,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function createRequest(text: string): ModelRequest {
+  const msg: InboundMessage = {
+    senderId: "user",
+    timestamp: Date.now(),
+    content: [{ kind: "text", text }],
+  };
+  return { messages: [msg] };
+}
+
+function createNext(): ReturnType<typeof mock> & ((req: ModelRequest) => Promise<ModelResponse>) {
+  return mock(
+    async (_req: ModelRequest): Promise<ModelResponse> => ({
+      content: "ok",
+      model: "test-model",
+    }),
+  );
+}
+
+describe("multi-turn preference learning", () => {
+  test("cold start → preference recall → correction → corrected behavior", async () => {
+    const memory = createStatefulMemory();
+    const mw = createPersonalizationMiddleware({ memory });
+
+    // --- Turn 1: cold start, ambiguous instruction ---
+    const next1 = createNext();
+    await mw.wrapModelCall?.(
+      createTurnContext(0),
+      createRequest("How should I format dates — ISO or locale?"),
+      next1,
+    );
+
+    // Expect clarification directive (no preferences exist)
+    const call1 = next1.mock.calls[0]?.[0] as ModelRequest;
+    expect(call1.messages[0]).toBeDefined();
+    expect(call1.messages[0]?.content[0]).toEqual(
+      expect.objectContaining({ kind: "text", text: expect.stringContaining("ask the user") }),
+    );
+
+    // Simulate: user answered, middleware stores the preference externally
+    await memory.store("User prefers ISO-8601 format", {
+      namespace: "preferences",
+      category: "preference",
+    });
+
+    // --- Turn 2: preference recall (non-ambiguous instruction) ---
+    // Create a new middleware instance to reset cache (simulating real scenario)
+    const mw2 = createPersonalizationMiddleware({ memory });
+    const next2 = createNext();
+    await mw2.wrapModelCall?.(
+      createTurnContext(1),
+      createRequest("Format the timestamps in the report"),
+      next2,
+    );
+
+    // Expect [User Preferences] injected
+    const call2 = next2.mock.calls[0]?.[0] as ModelRequest;
+    expect(call2.messages[0]).toBeDefined();
+    expect(call2.messages[0]?.content[0]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        text: expect.stringContaining("[User Preferences]"),
+      }),
+    );
+    expect(call2.messages[0]?.content[0]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        text: expect.stringContaining("ISO-8601"),
+      }),
+    );
+
+    // --- Turn 3: preference correction ---
+    const mw3 = createPersonalizationMiddleware({ memory });
+    const next3 = createNext();
+    await mw3.wrapModelCall?.(
+      createTurnContext(2),
+      createRequest("Actually, I prefer US date format MM/DD/YYYY instead"),
+      next3,
+    );
+
+    // Correction should have been stored
+    const prefEntries = memory.entries.filter((e) => e.category === "preference");
+    expect(prefEntries.length).toBe(2); // original + correction
+    expect(prefEntries[1]?.content).toContain("MM/DD/YYYY");
+
+    // --- Turn 4: corrected behavior ---
+    const mw4 = createPersonalizationMiddleware({ memory });
+    const next4 = createNext();
+    await mw4.wrapModelCall?.(createTurnContext(3), createRequest("Display the dates"), next4);
+
+    // Expect [User Preferences] with both entries (new + old)
+    const call4 = next4.mock.calls[0]?.[0] as ModelRequest;
+    expect(call4.messages[0]).toBeDefined();
+    expect(call4.messages[0]?.content[0]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        text: expect.stringContaining("[User Preferences]"),
+      }),
+    );
+    expect(call4.messages[0]?.content[0]).toEqual(
+      expect.objectContaining({
+        kind: "text",
+        text: expect.stringContaining("MM/DD/YYYY"),
+      }),
+    );
+  });
+});

--- a/packages/middleware-personalization/src/ambiguity-classifier.test.ts
+++ b/packages/middleware-personalization/src/ambiguity-classifier.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import type { MemoryResult } from "@koi/core/ecs";
+import { createDefaultAmbiguityClassifier } from "./ambiguity-classifier.js";
+
+describe("createDefaultAmbiguityClassifier", () => {
+  const classifier = createDefaultAmbiguityClassifier();
+
+  test("returns ambiguous when question AND alternative markers present", async () => {
+    const result = await classifier.classify("should I use dark mode or light mode?", []);
+    expect(result).toEqual({
+      ambiguous: true,
+      suggestedDirective: expect.any(String),
+    });
+  });
+
+  test("returns not ambiguous for question marker alone", async () => {
+    const result = await classifier.classify("should I deploy?", []);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("returns not ambiguous for alternative marker alone", async () => {
+    const result = await classifier.classify("dark mode or light mode?", []);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("returns not ambiguous for vague qualifiers (removed)", async () => {
+    const result = await classifier.classify("pick some nice colors", []);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("returns not ambiguous when preferences exist", async () => {
+    const prefs: readonly MemoryResult[] = [{ content: "User prefers dark mode", score: 0.9 }];
+    const result = await classifier.classify("should I use dark mode or light mode?", prefs);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("returns not ambiguous for clear instructions", async () => {
+    const result = await classifier.classify("deploy to production", []);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("returns not ambiguous for empty string", async () => {
+    const result = await classifier.classify("", []);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  test("handles very long input without crashing", async () => {
+    const longInput = `should I use ${" or ".repeat(10_000)}`;
+    const result = await classifier.classify(longInput, []);
+    expect(result.ambiguous).toBe(true);
+  });
+
+  test("detects 'how should' + alternative", async () => {
+    const result = await classifier.classify("how should I format the dates — ISO or locale?", []);
+    expect(result.ambiguous).toBe(true);
+  });
+
+  test("detects 'what kind' + alternative", async () => {
+    const result = await classifier.classify("what kind of output do you prefer?", []);
+    expect(result.ambiguous).toBe(true);
+  });
+
+  test("detects 'which' + 'between'", async () => {
+    const result = await classifier.classify("which option between tabs and spaces?", []);
+    expect(result.ambiguous).toBe(true);
+  });
+
+  test("detects 'should I' + 'either'", async () => {
+    const result = await classifier.classify("should I use either TypeScript or JavaScript?", []);
+    expect(result.ambiguous).toBe(true);
+  });
+
+  test("suggested directive is actionable", async () => {
+    const result = await classifier.classify("which framework should I prefer?", []);
+    expect(result.suggestedDirective).toContain("ask the user");
+  });
+
+  test("good morning is not ambiguous", async () => {
+    const result = await classifier.classify("good morning", []);
+    expect(result.ambiguous).toBe(false);
+  });
+});

--- a/packages/middleware-personalization/src/ambiguity-classifier.ts
+++ b/packages/middleware-personalization/src/ambiguity-classifier.ts
@@ -1,0 +1,52 @@
+/**
+ * Ambiguity classifier — detects when user instructions need clarification.
+ */
+
+import type { MemoryResult } from "@koi/core/ecs";
+
+export interface AmbiguityAssessment {
+  readonly ambiguous: boolean;
+  readonly suggestedDirective?: string;
+}
+
+export interface AmbiguityClassifier {
+  readonly classify: (
+    instruction: string,
+    relevantPreferences: readonly MemoryResult[],
+  ) => AmbiguityAssessment | Promise<AmbiguityAssessment>;
+}
+
+const QUESTION_MARKERS: readonly string[] = ["should i", "which", "how should", "what kind"];
+
+const ALTERNATIVE_MARKERS: readonly string[] = [" or ", "either", "between", "prefer"];
+
+const DEFAULT_DIRECTIVE =
+  "Before proceeding, ask the user about their preference for this task. Limit to one concise question with 2-4 specific options.";
+
+export function createDefaultAmbiguityClassifier(): AmbiguityClassifier {
+  return {
+    classify(
+      instruction: string,
+      relevantPreferences: readonly MemoryResult[],
+    ): AmbiguityAssessment {
+      if (relevantPreferences.length > 0) {
+        return { ambiguous: false };
+      }
+
+      if (instruction.length === 0) {
+        return { ambiguous: false };
+      }
+
+      const lower = instruction.toLowerCase();
+
+      const hasQuestion = QUESTION_MARKERS.some((m) => lower.includes(m));
+      const hasAlternative = ALTERNATIVE_MARKERS.some((m) => lower.includes(m));
+
+      if (hasQuestion && hasAlternative) {
+        return { ambiguous: true, suggestedDirective: DEFAULT_DIRECTIVE };
+      }
+
+      return { ambiguous: false };
+    },
+  };
+}

--- a/packages/middleware-personalization/src/config.test.ts
+++ b/packages/middleware-personalization/src/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { validatePersonalizationConfig } from "./config.js";
+
+function createMockMemory(): { recall: () => Promise<readonly []>; store: () => Promise<void> } {
+  return {
+    async recall(): Promise<readonly []> {
+      return [];
+    },
+    async store(): Promise<void> {},
+  };
+}
+
+describe("validatePersonalizationConfig", () => {
+  const memory = createMockMemory();
+
+  test("accepts valid config with required fields", () => {
+    const result = validatePersonalizationConfig({ memory });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects null config", () => {
+    const result = validatePersonalizationConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects undefined config", () => {
+    const result = validatePersonalizationConfig(undefined);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects config without memory", () => {
+    const result = validatePersonalizationConfig({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("memory");
+  });
+
+  test("rejects memory without recall method", () => {
+    const result = validatePersonalizationConfig({ memory: { store: () => {} } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("memory");
+  });
+
+  test("rejects memory without store method", () => {
+    const result = validatePersonalizationConfig({ memory: { recall: () => {} } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("memory");
+  });
+
+  test("rejects negative relevanceThreshold", () => {
+    const result = validatePersonalizationConfig({ memory, relevanceThreshold: -0.1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("relevanceThreshold");
+  });
+
+  test("rejects relevanceThreshold greater than 1", () => {
+    const result = validatePersonalizationConfig({ memory, relevanceThreshold: 1.5 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts relevanceThreshold of 0", () => {
+    const result = validatePersonalizationConfig({ memory, relevanceThreshold: 0 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts relevanceThreshold of 1", () => {
+    const result = validatePersonalizationConfig({ memory, relevanceThreshold: 1 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects negative maxPreferenceTokens", () => {
+    const result = validatePersonalizationConfig({ memory, maxPreferenceTokens: -1 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects zero maxPreferenceTokens", () => {
+    const result = validatePersonalizationConfig({ memory, maxPreferenceTokens: 0 });
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts positive maxPreferenceTokens", () => {
+    const result = validatePersonalizationConfig({ memory, maxPreferenceTokens: 200 });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts config with all optional fields", () => {
+    const result = validatePersonalizationConfig({
+      memory,
+      relevanceThreshold: 0.8,
+      maxPreferenceTokens: 300,
+      preferenceNamespace: "user-prefs",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("all errors are non-retryable", () => {
+    const result = validatePersonalizationConfig(null);
+    if (!result.ok) expect(result.error.retryable).toBe(false);
+  });
+});

--- a/packages/middleware-personalization/src/config.ts
+++ b/packages/middleware-personalization/src/config.ts
@@ -1,0 +1,144 @@
+/**
+ * Personalization middleware configuration and validation.
+ */
+
+import type { MemoryComponent } from "@koi/core/ecs";
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { AmbiguityClassifier } from "./ambiguity-classifier.js";
+import type { CorrectionDetector } from "./correction-detector.js";
+
+export interface PreActionConfig {
+  readonly enabled?: boolean;
+  readonly classifier?: AmbiguityClassifier;
+  readonly maxQuestionTokens?: number;
+}
+
+export interface PostActionConfig {
+  readonly enabled?: boolean;
+  readonly detector?: CorrectionDetector;
+}
+
+export interface PersonalizationConfig {
+  readonly memory: MemoryComponent;
+  readonly preAction?: PreActionConfig;
+  readonly postAction?: PostActionConfig;
+  readonly relevanceThreshold?: number;
+  readonly maxPreferenceTokens?: number;
+  readonly preferenceNamespace?: string;
+  readonly onError?: (error: unknown) => void;
+}
+
+/** Resolved config with all defaults applied. */
+export interface ResolvedPersonalizationConfig {
+  readonly memory: MemoryComponent;
+  readonly preAction: {
+    readonly enabled: boolean;
+    readonly classifier: AmbiguityClassifier;
+    readonly maxQuestionTokens: number;
+  };
+  readonly postAction: { readonly enabled: boolean; readonly detector: CorrectionDetector };
+  readonly relevanceThreshold: number;
+  readonly maxPreferenceTokens: number;
+  readonly preferenceNamespace: string;
+  readonly onError?: ((error: unknown) => void) | undefined;
+}
+
+const DEFAULT_RELEVANCE_THRESHOLD = 0.7;
+const DEFAULT_MAX_PREFERENCE_TOKENS = 500;
+const DEFAULT_PREFERENCE_NAMESPACE = "preferences";
+
+export function validatePersonalizationConfig(
+  config: unknown,
+): Result<PersonalizationConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config must be a non-null object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (!c.memory || typeof c.memory !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config requires a 'memory' MemoryComponent with recall and store methods",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  const mem = c.memory as Record<string, unknown>;
+  if (typeof mem.recall !== "function" || typeof mem.store !== "function") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Config requires a 'memory' MemoryComponent with recall and store methods",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (c.relevanceThreshold !== undefined) {
+    if (
+      typeof c.relevanceThreshold !== "number" ||
+      c.relevanceThreshold < 0 ||
+      c.relevanceThreshold > 1
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "relevanceThreshold must be a number between 0 and 1",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+  }
+
+  if (c.maxPreferenceTokens !== undefined) {
+    if (typeof c.maxPreferenceTokens !== "number" || c.maxPreferenceTokens <= 0) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "maxPreferenceTokens must be a positive number",
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        },
+      };
+    }
+  }
+
+  return { ok: true, value: config as PersonalizationConfig };
+}
+
+export function resolveDefaults(
+  config: PersonalizationConfig,
+  defaultClassifier: AmbiguityClassifier,
+  defaultDetector: CorrectionDetector,
+): ResolvedPersonalizationConfig {
+  return {
+    memory: config.memory,
+    preAction: {
+      enabled: config.preAction?.enabled ?? true,
+      classifier: config.preAction?.classifier ?? defaultClassifier,
+      maxQuestionTokens: config.preAction?.maxQuestionTokens ?? 100,
+    },
+    postAction: {
+      enabled: config.postAction?.enabled ?? true,
+      detector: config.postAction?.detector ?? defaultDetector,
+    },
+    relevanceThreshold: config.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD,
+    maxPreferenceTokens: config.maxPreferenceTokens ?? DEFAULT_MAX_PREFERENCE_TOKENS,
+    preferenceNamespace: config.preferenceNamespace ?? DEFAULT_PREFERENCE_NAMESPACE,
+    onError: config.onError,
+  };
+}

--- a/packages/middleware-personalization/src/correction-detector.test.ts
+++ b/packages/middleware-personalization/src/correction-detector.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultCorrectionDetector } from "./correction-detector.js";
+
+describe("createDefaultCorrectionDetector", () => {
+  const detector = createDefaultCorrectionDetector();
+
+  test("detects 'No, I prefer' as correction", async () => {
+    const result = await detector.detect("No, I prefer dark mode", []);
+    expect(result.corrective).toBe(true);
+    expect(result.preferenceUpdate).toContain("dark mode");
+  });
+
+  test("detects 'Actually, use TypeScript'", async () => {
+    const result = await detector.detect("Actually, use TypeScript", []);
+    expect(result.corrective).toBe(true);
+    expect(result.preferenceUpdate).toContain("TypeScript");
+  });
+
+  test("detects 'I prefer' mid-sentence", async () => {
+    const result = await detector.detect("For this project I prefer tabs", []);
+    expect(result.corrective).toBe(true);
+    expect(result.preferenceUpdate).toContain("tabs");
+  });
+
+  test("detects 'I meant' correction", async () => {
+    const result = await detector.detect("I meant the other file", []);
+    expect(result.corrective).toBe(true);
+  });
+
+  test("detects 'please use' correction", async () => {
+    const result = await detector.detect("please use Bun instead", []);
+    expect(result.corrective).toBe(true);
+  });
+
+  test("detects 'change to' correction", async () => {
+    const result = await detector.detect("change to snake_case", []);
+    expect(result.corrective).toBe(true);
+  });
+
+  test("detects 'switch to' correction", async () => {
+    const result = await detector.detect("switch to dark mode", []);
+    expect(result.corrective).toBe(true);
+  });
+
+  test("does not detect plain request as correction", async () => {
+    const result = await detector.detect("Please refactor the auth module", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("does not detect question as correction", async () => {
+    const result = await detector.detect("Can you explain this?", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("does not detect empty string as correction", async () => {
+    const result = await detector.detect("", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("does not detect 'No problem' as correction", async () => {
+    const result = await detector.detect("No problem, continue", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("does not detect 'No worries' as correction", async () => {
+    const result = await detector.detect("No worries about that", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("does not detect 'No thanks' as correction", async () => {
+    const result = await detector.detect("No thanks, I'm good", []);
+    expect(result.corrective).toBe(false);
+  });
+
+  test("caps very long preference text", async () => {
+    const longText = `Actually, ${"x".repeat(500)}`;
+    const result = await detector.detect(longText, []);
+    expect(result.corrective).toBe(true);
+    expect((result.preferenceUpdate ?? "").length).toBeLessThanOrEqual(200);
+  });
+});

--- a/packages/middleware-personalization/src/correction-detector.ts
+++ b/packages/middleware-personalization/src/correction-detector.ts
@@ -1,0 +1,79 @@
+/**
+ * Correction detector — identifies preference corrections in user messages.
+ */
+
+import type { InboundMessage } from "@koi/core/message";
+
+export interface CorrectionAssessment {
+  readonly corrective: boolean;
+  readonly preferenceUpdate?: string;
+}
+
+export interface CorrectionDetector {
+  readonly detect: (
+    message: string,
+    recentContext: readonly InboundMessage[],
+  ) => CorrectionAssessment | Promise<CorrectionAssessment>;
+}
+
+/** Ordered by specificity — more specific markers first to prefer longer matches. */
+const CORRECTION_MARKERS: readonly string[] = [
+  "not what i",
+  "i meant",
+  "please use",
+  "change to",
+  "switch to",
+  "i prefer",
+  "don't do that",
+  "instead,",
+  "actually,",
+  "no,",
+  "wrong",
+];
+
+/** False-positive exclusions — phrases starting with "no" that aren't corrections. */
+const FALSE_POSITIVE_PREFIXES: readonly string[] = [
+  "no problem",
+  "no worries",
+  "no thanks",
+  "no need",
+  "no issue",
+];
+
+const MAX_PREFERENCE_LENGTH = 200;
+
+export function createDefaultCorrectionDetector(): CorrectionDetector {
+  return {
+    detect(message: string, _recentContext: readonly InboundMessage[]): CorrectionAssessment {
+      if (message.length === 0) {
+        return { corrective: false };
+      }
+
+      const lower = message.toLowerCase().trim();
+
+      // Check false-positive prefixes first
+      if (FALSE_POSITIVE_PREFIXES.some((fp) => lower.startsWith(fp))) {
+        return { corrective: false };
+      }
+
+      for (const marker of CORRECTION_MARKERS) {
+        const idx = lower.indexOf(marker);
+        if (idx !== -1) {
+          // Extract the preference text after the marker
+          const afterMarker = message.slice(idx + marker.length).trim();
+          const preferenceUpdate =
+            afterMarker.length > MAX_PREFERENCE_LENGTH
+              ? afterMarker.slice(0, MAX_PREFERENCE_LENGTH)
+              : afterMarker;
+
+          return {
+            corrective: true,
+            preferenceUpdate: preferenceUpdate.length > 0 ? preferenceUpdate : message,
+          };
+        }
+      }
+
+      return { corrective: false };
+    },
+  };
+}

--- a/packages/middleware-personalization/src/index.ts
+++ b/packages/middleware-personalization/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @koi/middleware-personalization — Dual-channel preference learning (Layer 2)
+ *
+ * Pre-action: detects ambiguity, injects clarification directives.
+ * Post-action: detects corrections, stores preference updates.
+ * Depends on @koi/core + L0u only.
+ */
+
+export type { AmbiguityAssessment, AmbiguityClassifier } from "./ambiguity-classifier.js";
+export { createDefaultAmbiguityClassifier } from "./ambiguity-classifier.js";
+export type {
+  PersonalizationConfig,
+  PostActionConfig,
+  PreActionConfig,
+  ResolvedPersonalizationConfig,
+} from "./config.js";
+export { validatePersonalizationConfig } from "./config.js";
+export type { CorrectionAssessment, CorrectionDetector } from "./correction-detector.js";
+export { createDefaultCorrectionDetector } from "./correction-detector.js";
+export { createPersonalizationMiddleware } from "./personalization.js";
+export type { PreferenceCache } from "./preference-cache.js";
+export { createPreferenceCache } from "./preference-cache.js";

--- a/packages/middleware-personalization/src/personalization.test.ts
+++ b/packages/middleware-personalization/src/personalization.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  MemoryComponent,
+  MemoryRecallOptions,
+  MemoryResult,
+  MemoryStoreOptions,
+} from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type { ModelRequest, ModelResponse, TurnContext } from "@koi/core/middleware";
+import type { AmbiguityClassifier } from "./ambiguity-classifier.js";
+import type { CorrectionDetector } from "./correction-detector.js";
+import { createPersonalizationMiddleware } from "./personalization.js";
+
+function createMockMemory(recallResult: readonly MemoryResult[] = []): MemoryComponent & {
+  readonly storeCalls: Array<{
+    readonly content: string;
+    readonly options?: MemoryStoreOptions | undefined;
+  }>;
+} {
+  const storeCalls: Array<{
+    readonly content: string;
+    readonly options?: MemoryStoreOptions | undefined;
+  }> = [];
+  return {
+    storeCalls,
+    async recall(_query: string, _options?: MemoryRecallOptions): Promise<readonly MemoryResult[]> {
+      return recallResult;
+    },
+    async store(content: string, options?: MemoryStoreOptions): Promise<void> {
+      storeCalls.push({ content, options });
+    },
+  };
+}
+
+function createTurnContext(turnIndex: number): TurnContext {
+  return {
+    session: {
+      agentId: "test-agent",
+      sessionId: "test-session" as never,
+      runId: "test-run" as never,
+      metadata: {},
+    },
+    turnIndex,
+    turnId: "test-turn" as never,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function createModelRequest(text: string): ModelRequest {
+  const message: InboundMessage = {
+    senderId: "user",
+    timestamp: Date.now(),
+    content: [{ kind: "text", text }],
+  };
+  return { messages: [message] };
+}
+
+function createMockNext(
+  response?: Partial<ModelResponse>,
+): ReturnType<typeof mock> & ((req: ModelRequest) => Promise<ModelResponse>) {
+  return mock(
+    async (_req: ModelRequest): Promise<ModelResponse> => ({
+      content: "test response",
+      model: "test-model",
+      ...response,
+    }),
+  );
+}
+
+describe("createPersonalizationMiddleware", () => {
+  test("has correct name and priority", () => {
+    const mw = createPersonalizationMiddleware({ memory: createMockMemory() });
+    expect(mw.name).toBe("personalization");
+    expect(mw.priority).toBe(420);
+  });
+
+  test("describeCapabilities returns fragment for both channels", () => {
+    const mw = createPersonalizationMiddleware({ memory: createMockMemory() });
+    const fragment = mw.describeCapabilities(createTurnContext(0));
+    expect(fragment?.label).toBe("personalization");
+    expect(fragment?.description).toContain("clarify + correct");
+  });
+
+  test("describeCapabilities for pre-action only", () => {
+    const mw = createPersonalizationMiddleware({
+      memory: createMockMemory(),
+      postAction: { enabled: false },
+    });
+    const fragment = mw.describeCapabilities(createTurnContext(0));
+    expect(fragment?.description).toContain("clarify only");
+  });
+
+  test("describeCapabilities for post-action only", () => {
+    const mw = createPersonalizationMiddleware({
+      memory: createMockMemory(),
+      preAction: { enabled: false },
+    });
+    const fragment = mw.describeCapabilities(createTurnContext(0));
+    expect(fragment?.description).toContain("correct only");
+  });
+
+  describe("pre-action channel", () => {
+    test("injects preferences when available", async () => {
+      const memory = createMockMemory([{ content: "User prefers dark mode", score: 0.9 }]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("format the output");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages[0]).toBeDefined();
+      expect(calledWith.messages[0]?.content[0]).toEqual(
+        expect.objectContaining({
+          kind: "text",
+          text: expect.stringContaining("[User Preferences]"),
+        }),
+      );
+    });
+
+    test("injects clarification when ambiguous and no preferences", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("should I use dark mode or light mode?");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages[0]).toBeDefined();
+      expect(calledWith.messages[0]?.content[0]).toEqual(
+        expect.objectContaining({ kind: "text", text: expect.stringContaining("ask the user") }),
+      );
+    });
+
+    test("does not inject anything for clear instructions with no preferences", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("deploy to production");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages).toEqual(request.messages);
+    });
+
+    test("filters by relevance threshold", async () => {
+      const memory = createMockMemory([{ content: "low relevance pref", score: 0.3 }]);
+      const mw = createPersonalizationMiddleware({ memory, relevanceThreshold: 0.7 });
+      const next = createMockNext();
+      const request = createModelRequest("should I format dates as ISO or locale?");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      // Low score filtered out → ambiguity check kicks in (question + alternative)
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages[0]).toBeDefined();
+      expect(calledWith.messages[0]?.content[0]).toEqual(
+        expect.objectContaining({ kind: "text", text: expect.stringContaining("ask the user") }),
+      );
+    });
+
+    test("caps injection by token budget", async () => {
+      const longPref = "x".repeat(3000); // ~750 tokens, exceeds 500 budget
+      const memory = createMockMemory([
+        { content: longPref, score: 0.9 },
+        { content: "second pref", score: 0.9 },
+      ]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        maxPreferenceTokens: 500,
+      });
+      const next = createMockNext();
+      const request = createModelRequest("format output");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      // Both excluded because first alone exceeds budget → falls through
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages).toEqual(request.messages);
+    });
+
+    test("uses custom classifier when provided", async () => {
+      const customClassifier: AmbiguityClassifier = {
+        classify: () => ({ ambiguous: true, suggestedDirective: "Custom directive" }),
+      };
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        preAction: { classifier: customClassifier },
+      });
+      const next = createMockNext();
+      const request = createModelRequest("do the thing");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith.messages[0]).toBeDefined();
+      expect(calledWith.messages[0]?.content[0]).toEqual(
+        expect.objectContaining({ kind: "text", text: "Custom directive" }),
+      );
+    });
+  });
+
+  describe("post-action channel", () => {
+    test("stores correction on turn > 0", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("No, I prefer dark mode please");
+
+      await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      expect(memory.storeCalls.length).toBe(1);
+      expect(memory.storeCalls[0]?.options?.category).toBe("preference");
+      expect(memory.storeCalls[0]?.options?.namespace).toBe("preferences");
+    });
+
+    test("skips correction on turn 0", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("No, I prefer dark mode");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      expect(memory.storeCalls.length).toBe(0);
+    });
+
+    test("does not store when no correction detected", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("Please refactor the auth module now");
+
+      await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      expect(memory.storeCalls.length).toBe(0);
+    });
+
+    test("uses custom detector when provided", async () => {
+      const customDetector: CorrectionDetector = {
+        detect: () => ({ corrective: true, preferenceUpdate: "custom preference" }),
+      };
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        postAction: { detector: customDetector },
+      });
+      const next = createMockNext();
+      const request = createModelRequest("this is a long enough message for detection");
+
+      await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      expect(memory.storeCalls.length).toBe(1);
+      expect(memory.storeCalls[0]?.content).toBe("custom preference");
+    });
+  });
+
+  describe("failure modes", () => {
+    test("memory recall throws → gracefully skips, calls next", async () => {
+      const memory: MemoryComponent = {
+        async recall(): Promise<readonly MemoryResult[]> {
+          throw new Error("recall failed");
+        },
+        async store(): Promise<void> {},
+      };
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("test message");
+
+      const response = await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(response?.content).toBe("test response");
+    });
+
+    test("memory store throws → logs error, continues", async () => {
+      const errors: unknown[] = [];
+      const memory: MemoryComponent = {
+        async recall(): Promise<readonly MemoryResult[]> {
+          return [];
+        },
+        async store(): Promise<void> {
+          throw new Error("store failed");
+        },
+      };
+      const mw = createPersonalizationMiddleware({
+        memory,
+        onError: (e) => errors.push(e),
+      });
+      const next = createMockNext();
+      const request = createModelRequest("No, I prefer dark mode instead");
+
+      const response = await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      expect(errors.length).toBe(1);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(response?.content).toBe("test response");
+    });
+
+    test("classifier false positive → directive injected, request not corrupted", async () => {
+      const alwaysAmbiguous: AmbiguityClassifier = {
+        classify: () => ({
+          ambiguous: true,
+          suggestedDirective: "Clarify please",
+        }),
+      };
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        preAction: { classifier: alwaysAmbiguous },
+      });
+      const next = createMockNext();
+      const request = createModelRequest("deploy now");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      // Original message still present
+      expect(calledWith.messages[calledWith.messages.length - 1]).toEqual(request.messages[0]);
+    });
+
+    test("detector false positive → preference stored, request passes through", async () => {
+      const alwaysCorrective: CorrectionDetector = {
+        detect: () => ({ corrective: true, preferenceUpdate: "false preference" }),
+      };
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        postAction: { detector: alwaysCorrective },
+      });
+      const next = createMockNext();
+      const request = createModelRequest("this is a long enough message for correction check");
+
+      await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      expect(memory.storeCalls.length).toBe(1);
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    test("empty message → no crash, passes through", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request: ModelRequest = { messages: [] };
+
+      const response = await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      expect(response?.content).toBe("test response");
+    });
+
+    test("message with no text blocks → passes through", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const msg: InboundMessage = {
+        senderId: "user",
+        timestamp: Date.now(),
+        content: [{ kind: "image", url: "https://example.com/img.png" }],
+      };
+      const request: ModelRequest = { messages: [msg] };
+
+      const response = await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      expect(response?.content).toBe("test response");
+    });
+
+    test("both channels disabled → pure pass-through", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({
+        memory,
+        preAction: { enabled: false },
+        postAction: { enabled: false },
+      });
+      const next = createMockNext();
+      const request = createModelRequest("No, I prefer dark mode");
+
+      await mw.wrapModelCall?.(createTurnContext(1), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      expect(calledWith).toEqual(request);
+      expect(memory.storeCalls.length).toBe(0);
+    });
+  });
+
+  describe("pinning", () => {
+    test("preference injection message has pinned: true", async () => {
+      const memory = createMockMemory([{ content: "User prefers dark mode", score: 0.9 }]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("format the output");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      const injected = calledWith.messages[0] as InboundMessage;
+      expect(injected.pinned).toBe(true);
+    });
+
+    test("clarification directive message has pinned: true", async () => {
+      const memory = createMockMemory([]);
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+      const request = createModelRequest("should I use dark mode or light mode?");
+
+      await mw.wrapModelCall?.(createTurnContext(0), request, next);
+
+      const calledWith = (next as ReturnType<typeof mock>).mock.calls[0]?.[0] as ModelRequest;
+      const injected = calledWith.messages[0] as InboundMessage;
+      expect(injected.pinned).toBe(true);
+    });
+  });
+
+  describe("caching", () => {
+    test("second call uses cached preferences", async () => {
+      const recallCount = { value: 0 };
+      const memory: MemoryComponent & { readonly storeCalls: Array<{ content: string }> } = {
+        storeCalls: [],
+        async recall(): Promise<readonly MemoryResult[]> {
+          recallCount.value++;
+          return [{ content: "cached pref", score: 0.9 }];
+        },
+        async store(): Promise<void> {},
+      };
+      const mw = createPersonalizationMiddleware({ memory });
+      const next = createMockNext();
+
+      await mw.wrapModelCall?.(createTurnContext(0), createModelRequest("first"), next);
+      await mw.wrapModelCall?.(createTurnContext(1), createModelRequest("second"), next);
+
+      // Only one recall — second call hits cache
+      expect(recallCount.value).toBe(1);
+    });
+  });
+});

--- a/packages/middleware-personalization/src/personalization.ts
+++ b/packages/middleware-personalization/src/personalization.ts
@@ -1,0 +1,191 @@
+/**
+ * Personalization middleware factory — dual-channel preference learning.
+ *
+ * Pre-action: injects relevant preferences + clarification directives.
+ * Post-action: detects corrections and stores preference updates.
+ */
+
+import type { MemoryResult } from "@koi/core/ecs";
+import type { InboundMessage } from "@koi/core/message";
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  ModelHandler,
+  ModelRequest,
+  ModelResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { swallowError } from "@koi/errors";
+import { estimateTokens } from "@koi/token-estimator";
+import { createDefaultAmbiguityClassifier } from "./ambiguity-classifier.js";
+import type { PersonalizationConfig, ResolvedPersonalizationConfig } from "./config.js";
+import { resolveDefaults } from "./config.js";
+import { createDefaultCorrectionDetector } from "./correction-detector.js";
+import { createPreferenceCache } from "./preference-cache.js";
+import { extractLastMessageText } from "./text-extractor.js";
+
+const MIN_WORDS_FOR_CORRECTION = 5;
+const PREFERENCE_CATEGORY = "preference";
+
+function computeCapabilityDescription(cfg: ResolvedPersonalizationConfig): string {
+  const pre = cfg.preAction.enabled;
+  const post = cfg.postAction.enabled;
+
+  if (pre && post) return "User preference learning active (clarify + correct)";
+  if (pre) return "User preference learning active (clarify only)";
+  if (post) return "User preference learning active (correct only)";
+  return "User preference learning inactive";
+}
+
+function filterByRelevance(
+  results: readonly MemoryResult[],
+  threshold: number,
+): readonly MemoryResult[] {
+  return results.filter((r) => (r.score ?? 1) >= threshold);
+}
+
+function capByTokenBudget(
+  results: readonly MemoryResult[],
+  maxTokens: number,
+): readonly MemoryResult[] {
+  const capped: MemoryResult[] = [];
+  let tokensUsed = 0; // let: accumulator for token budget
+
+  for (const r of results) {
+    const tokens = estimateTokens(r.content);
+    if (tokensUsed + tokens > maxTokens) break;
+    tokensUsed += tokens;
+    capped.push(r);
+  }
+
+  return capped;
+}
+
+function wordCount(text: string): number {
+  return text.trim().split(/\s+/).length;
+}
+
+export function createPersonalizationMiddleware(config: PersonalizationConfig): KoiMiddleware {
+  const cfg = resolveDefaults(
+    config,
+    createDefaultAmbiguityClassifier(),
+    createDefaultCorrectionDetector(),
+  );
+
+  const cache = createPreferenceCache();
+  const capabilityDescription = computeCapabilityDescription(cfg);
+
+  const capabilityFragment: CapabilityFragment = {
+    label: "personalization",
+    description: capabilityDescription,
+  };
+
+  async function recallPreferences(query: string): Promise<readonly MemoryResult[]> {
+    const cached = cache.get();
+    if (cached !== undefined) return cached;
+
+    const results = await cfg.memory.recall(query, {
+      namespace: cfg.preferenceNamespace,
+    });
+    cache.set(results);
+    return results;
+  }
+
+  function handleError(error: unknown): void {
+    if (cfg.onError) {
+      cfg.onError(error);
+    } else {
+      swallowError(error, {
+        package: "middleware-personalization",
+        operation: "preference-learning",
+      });
+    }
+  }
+
+  return {
+    name: "personalization",
+    priority: 420,
+
+    describeCapabilities: (_ctx: TurnContext) => capabilityFragment,
+
+    async wrapModelCall(
+      ctx: TurnContext,
+      request: ModelRequest,
+      next: ModelHandler,
+    ): Promise<ModelResponse> {
+      const messageText = extractLastMessageText(request.messages);
+
+      // --- Post-action channel: detect corrections from previous turn ---
+      if (cfg.postAction.enabled && ctx.turnIndex > 0 && messageText.length > 0) {
+        // Short-circuit: skip very short messages without correction markers
+        if (
+          wordCount(messageText) >= MIN_WORDS_FOR_CORRECTION ||
+          looksLikeCorrection(messageText)
+        ) {
+          try {
+            const assessment = await cfg.postAction.detector.detect(messageText, request.messages);
+
+            if (assessment.corrective && assessment.preferenceUpdate) {
+              await cfg.memory.store(assessment.preferenceUpdate, {
+                namespace: cfg.preferenceNamespace,
+                category: PREFERENCE_CATEGORY,
+              });
+              cache.invalidate();
+            }
+          } catch (error: unknown) {
+            handleError(error);
+          }
+        }
+      }
+
+      // --- Pre-action channel: inject preferences or clarification ---
+      if (cfg.preAction.enabled) {
+        try {
+          const preferences = await recallPreferences(messageText);
+          const relevant = filterByRelevance(preferences, cfg.relevanceThreshold);
+          const capped = capByTokenBudget(relevant, cfg.maxPreferenceTokens);
+
+          if (capped.length > 0) {
+            const prefText = capped.map((p) => p.content).join("\n");
+            const prefMessage: InboundMessage = {
+              senderId: "system:personalization",
+              timestamp: Date.now(),
+              content: [{ kind: "text", text: `[User Preferences]\n${prefText}` }],
+              pinned: true,
+            };
+            return next({ ...request, messages: [prefMessage, ...request.messages] });
+          }
+
+          // No relevant preferences — check ambiguity
+          const assessment = await cfg.preAction.classifier.classify(messageText, relevant);
+
+          if (assessment.ambiguous && assessment.suggestedDirective) {
+            const directiveMessage: InboundMessage = {
+              senderId: "system:personalization",
+              timestamp: Date.now(),
+              content: [{ kind: "text", text: assessment.suggestedDirective }],
+              pinned: true,
+            };
+            return next({ ...request, messages: [directiveMessage, ...request.messages] });
+          }
+        } catch (error: unknown) {
+          handleError(error);
+        }
+      }
+
+      return next(request);
+    },
+  };
+}
+
+/** Quick check for correction markers without running the full detector. */
+function looksLikeCorrection(text: string): boolean {
+  const lower = text.toLowerCase().trim();
+  return (
+    lower.startsWith("no,") ||
+    lower.startsWith("actually,") ||
+    lower.startsWith("instead,") ||
+    lower.includes("i prefer") ||
+    lower.includes("i meant")
+  );
+}

--- a/packages/middleware-personalization/src/preference-cache.test.ts
+++ b/packages/middleware-personalization/src/preference-cache.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import type { MemoryResult } from "@koi/core/ecs";
+import { createPreferenceCache } from "./preference-cache.js";
+
+describe("createPreferenceCache", () => {
+  test("initially returns undefined", () => {
+    const cache = createPreferenceCache();
+    expect(cache.get()).toBeUndefined();
+  });
+
+  test("returns cached value after set", () => {
+    const cache = createPreferenceCache();
+    const prefs: readonly MemoryResult[] = [{ content: "dark mode", score: 0.9 }];
+    cache.set(prefs);
+    expect(cache.get()).toEqual(prefs);
+  });
+
+  test("returns undefined after invalidate", () => {
+    const cache = createPreferenceCache();
+    cache.set([{ content: "dark mode", score: 0.9 }]);
+    cache.invalidate();
+    expect(cache.get()).toBeUndefined();
+  });
+
+  test("returns latest value after multiple sets", () => {
+    const cache = createPreferenceCache();
+    cache.set([{ content: "first", score: 0.5 }]);
+    const latest: readonly MemoryResult[] = [{ content: "second", score: 0.8 }];
+    cache.set(latest);
+    expect(cache.get()).toEqual(latest);
+  });
+
+  test("can set again after invalidate", () => {
+    const cache = createPreferenceCache();
+    cache.set([{ content: "first" }]);
+    cache.invalidate();
+    const newPrefs: readonly MemoryResult[] = [{ content: "after-invalidate" }];
+    cache.set(newPrefs);
+    expect(cache.get()).toEqual(newPrefs);
+  });
+});

--- a/packages/middleware-personalization/src/preference-cache.ts
+++ b/packages/middleware-personalization/src/preference-cache.ts
@@ -1,0 +1,27 @@
+/**
+ * Per-session preference cache with invalidation.
+ */
+
+import type { MemoryResult } from "@koi/core/ecs";
+
+export interface PreferenceCache {
+  readonly get: () => readonly MemoryResult[] | undefined;
+  readonly set: (preferences: readonly MemoryResult[]) => void;
+  readonly invalidate: () => void;
+}
+
+export function createPreferenceCache(): PreferenceCache {
+  let cached: readonly MemoryResult[] | undefined; // let: mutable cache slot
+
+  return {
+    get(): readonly MemoryResult[] | undefined {
+      return cached;
+    },
+    set(preferences: readonly MemoryResult[]): void {
+      cached = preferences;
+    },
+    invalidate(): void {
+      cached = undefined;
+    },
+  };
+}

--- a/packages/middleware-personalization/src/text-extractor.ts
+++ b/packages/middleware-personalization/src/text-extractor.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility to extract text from InboundMessage arrays.
+ */
+
+import type { InboundMessage } from "@koi/core/message";
+
+/**
+ * Extracts text from the last message's text content blocks.
+ * Scans backwards from the last message, returning the first text block found.
+ */
+export function extractLastMessageText(messages: readonly InboundMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg) {
+      for (const block of msg.content) {
+        if (block.kind === "text") {
+          return block.text;
+        }
+      }
+    }
+  }
+  return "";
+}

--- a/packages/middleware-personalization/tsconfig.json
+++ b/packages/middleware-personalization/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }, { "path": "../token-estimator" }]
+}

--- a/packages/middleware-personalization/tsup.config.ts
+++ b/packages/middleware-personalization/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Closes #652

- **Ambiguity classifier tightened** — removed vague markers ("some", "nice", "good") that triggered false positives on normal messages like "good morning". Now requires both a question marker AND an alternative marker (e.g. "should I use X or Y?")
- **Preference injections pinned** — added `pinned: true` to both `[User Preferences]` and clarification directive messages so compactor's `findFirstPinnedIndex()` preserves them during aggressive compaction
- **Wired into context-arena** — personalization is now an opt-in module (`personalization: { enabled: true }`) that shares `effectiveMemory` and gets coordinated budget allocation via `PersonalizationOverrides`
- **Documentation** — added `docs/L2/middleware-personalization.md` covering architecture, API, performance, and layer compliance

## Performance

Zero LLM calls with default classifiers — both `AmbiguityClassifier` and `CorrectionDetector` use pure string matching heuristics. The only I/O is `memory.recall()` (cached after first call) and `memory.store()` (only on detected corrections).

## Layer compliance

- `@koi/middleware-personalization` imports from L0 + L0u only (zero peer L2 deps)
- `@koi/context-arena` (L3) imports from the new L2 package
- `bun run check:layers` passes

## Test plan

- [x] `bun test` in `packages/middleware-personalization/` — 75 tests pass
- [x] `bun test` in `packages/context-arena/` — 44 tests pass
- [x] `bunx turbo run typecheck --filter=@koi/context-arena` — passes
- [x] `bunx turbo run build --filter=@koi/context-arena...` — passes
- [x] `bun run check:layers` — no violations
- [x] `bunx turbo run lint --filter=@koi/middleware-personalization --filter=@koi/context-arena` — passes