### PR TITLE
feat: add @koi/audit-sink-nexus — Nexus-backed persistent audit logging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,18 @@
         "@koi/nexus-client": "workspace:*",
       },
     },
+    "packages/audit-sink-nexus": {
+      "name": "@koi/audit-sink-nexus",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+        "@koi/nexus-client": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/autonomous": {
       "name": "@koi/autonomous",
       "version": "0.0.0",
@@ -2640,6 +2652,8 @@
     "@koi/agui": ["@koi/agui@workspace:packages/agui"],
 
     "@koi/artifact-client": ["@koi/artifact-client@workspace:packages/artifact-client"],
+
+    "@koi/audit-sink-nexus": ["@koi/audit-sink-nexus@workspace:packages/audit-sink-nexus"],
 
     "@koi/autonomous": ["@koi/autonomous@workspace:packages/autonomous"],
 

--- a/docs/L2/audit-sink-nexus.md
+++ b/docs/L2/audit-sink-nexus.md
@@ -1,0 +1,326 @@
+# @koi/audit-sink-nexus — Nexus-Backed Persistent Audit Logging
+
+Implements the `AuditSink` contract from `@koi/core`, persisting structured audit entries to a Nexus server via JSON-RPC. Supports configurable batch size, flush interval, and retry policy for compliance-grade audit logging.
+
+---
+
+## Why It Exists
+
+`@koi/middleware-audit` intercepts every model call, tool call, and session lifecycle event, then writes a structured `AuditEntry` to a pluggable `AuditSink`. The built-in sinks (console, in-memory) are fine for development, but production needs durable, queryable storage for compliance, debugging, and observability.
+
+Without this package, operators would need to build their own Nexus integration, handle batching, retries, and error policies from scratch.
+
+---
+
+## What This Enables
+
+### Before vs After
+
+```
+WITHOUT audit-sink-nexus: audit entries are ephemeral
+════════════════════════════════════════════════════
+
+  @koi/middleware-audit
+  ┌────────────────────────┐
+  │ intercepts model/tool  │
+  │ calls, writes entries  │───▶  console.log(entry)  💨 gone
+  └────────────────────────┘      or in-memory array   💨 gone on restart
+
+
+WITH audit-sink-nexus: durable, structured, queryable
+═════════════════════════════════════════════════════
+
+  @koi/middleware-audit
+  ┌────────────────────────┐     @koi/audit-sink-nexus
+  │ intercepts model/tool  │     ┌──────────────────────────┐
+  │ calls, writes entries  │────▶│ batches entries (50)      │
+  └────────────────────────┘     │ flushes every 5s or full  │
+                                 │ retries transient errors   │
+                                 └──────────┬───────────────┘
+                                            │ JSON-RPC "write"
+                                            ▼
+                                 ┌──────────────────────────┐
+                                 │  Nexus Server             │
+                                 │  /audit/{sessionId}/      │
+                                 │    1700000000000-0-       │
+                                 │      model_call.json      │
+                                 │    1700000000042-1-       │
+                                 │      tool_call.json       │
+                                 │    ...                     │
+                                 └──────────────────────────┘
+                                   persistent ✓ queryable ✓
+```
+
+### What You Can Do With Persistent Audit Logs
+
+- **Compliance**: prove what an agent did, when, and why
+- **Debugging**: replay a session's model/tool calls to reproduce issues
+- **Observability**: query `durationMs` to find slow model calls
+- **Cost tracking**: correlate `model_call` entries with token usage
+- **Security auditing**: review `secret_access` and `tool_call` entries for unauthorized actions
+
+---
+
+## Architecture
+
+`@koi/audit-sink-nexus` is a **Layer 2 (L2) feature package** — it imports from `@koi/core` (L0) and L0u utilities only.
+
+```
+┌───────────────────────────────────────────────┐
+│  @koi/audit-sink-nexus  (L2)                   │
+│                                                 │
+│  createNexusAuditSink(config) → AuditSink       │
+│  ● Batched writes (size + interval triggers)    │
+│  ● Retry with exponential backoff               │
+│  ● Failed entries re-enqueued (no data loss)    │
+│  ● Timer .unref() (won't hold process open)     │
+│  ● Path traversal protection on sessionId       │
+└────────────┬──────────────┬───────────────────┘
+             │              │
+             ▼              ▼
+   ┌─────────────┐  ┌──────────────┐
+   │ @koi/errors  │  │@koi/nexus-   │
+   │ (L0u)       │  │ client (L0u) │
+   │ withRetry   │  │ rpc("write") │
+   │ swallowError│  │              │
+   └──────┬──────┘  └──────┬───────┘
+          │                │
+          ▼                ▼
+   ┌──────────────────────────┐
+   │  @koi/core (L0)          │
+   │  AuditSink, AuditEntry,  │
+   │  Result, KoiError         │
+   └──────────────────────────┘
+```
+
+### File Organization
+
+```
+packages/audit-sink-nexus/
+├── package.json              # L2 deps: core, errors, nexus-client
+├── tsconfig.json             # References L0 + L0u deps
+├── tsup.config.ts            # ESM + dts build
+└── src/
+    ├── index.ts              # Public exports
+    ├── config.ts             # NexusAuditSinkConfig + validation
+    ├── nexus-sink.ts         # createNexusAuditSink() factory
+    └── __tests__/
+        ├── sink-contract.ts  # Reusable contract test suite
+        └── nexus-sink.test.ts # 21 unit + integration tests
+```
+
+---
+
+## How It Works
+
+### Batching Strategy
+
+Entries are buffered in memory and flushed on two triggers:
+
+```
+log(entry) called
+       │
+       ▼
+  ┌─────────────┐
+  │ append to    │
+  │ buffer       │
+  └──────┬──────┘
+         │
+    ┌────┴────┐
+    │ buffer  │──── YES ──▶ flushBuffer() fire-and-forget
+    │ >= 50?  │
+    └────┬────┘
+         │ NO
+    ┌────┴────────┐
+    │ interval    │──── fires every 5s ──▶ flushBuffer()
+    │ timer       │
+    └─────────────┘
+
+flush() called (session end)
+       │
+       ▼
+  clear timer → flushBuffer() awaited → errors propagate
+```
+
+### Error Handling Policy
+
+| Method | On error | Rationale |
+|--------|----------|-----------|
+| `log()` | Swallowed (fire-and-forget) | Never block the agent loop |
+| `flush()` | Thrown to caller | Middleware decides error policy |
+| Interval timer | Swallowed | Background; no caller to propagate to |
+
+Failed entries from `flushBuffer()` are **re-enqueued** in the buffer so they can be retried on the next flush. No data loss on partial failures.
+
+### File Path Convention
+
+Each entry is written to Nexus at:
+
+```
+{basePath}/{sessionId}/{timestamp}-{turnIndex}-{kind}.json
+```
+
+Example:
+```
+/audit/sess-abc123/1700000000000-0-session_start.json
+/audit/sess-abc123/1700000000042-1-model_call.json
+/audit/sess-abc123/1700000000100-2-tool_call.json
+/audit/sess-abc123/1700000000150-3-session_end.json
+```
+
+---
+
+## Configuration
+
+```typescript
+interface NexusAuditSinkConfig {
+  readonly baseUrl: string;                               // Nexus server URL
+  readonly apiKey: string;                                // Nexus API key
+  readonly basePath?: string | undefined;                 // Default: "/audit"
+  readonly batchSize?: number | undefined;                // Default: 50
+  readonly flushIntervalMs?: number | undefined;          // Default: 5_000
+  readonly retry?: Partial<RetryConfig> | undefined;      // Default: 3 retries, exp backoff
+  readonly fetch?: typeof globalThis.fetch | undefined;   // Injectable for testing
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `baseUrl` | (required) | Nexus server URL |
+| `apiKey` | (required) | Bearer token for Nexus auth |
+| `basePath` | `"/audit"` | Root path prefix in Nexus storage |
+| `batchSize` | `50` | Flush when buffer reaches this size |
+| `flushIntervalMs` | `5_000` | Flush at this interval (ms) regardless of buffer size |
+| `retry` | `{ maxRetries: 3, backoffMultiplier: 2, initialDelayMs: 1000 }` | Retry policy for transient Nexus errors |
+| `fetch` | `globalThis.fetch` | Override for testing with `createFakeNexusFetch()` |
+
+---
+
+## Examples
+
+### Minimal Setup
+
+```typescript
+import { createAuditMiddleware } from "@koi/middleware-audit";
+import { createNexusAuditSink } from "@koi/audit-sink-nexus";
+
+const sink = createNexusAuditSink({
+  baseUrl: "http://nexus.internal:2026",
+  apiKey: process.env.NEXUS_API_KEY!,
+});
+
+const audit = createAuditMiddleware({ sink });
+```
+
+### Full Configuration
+
+```typescript
+import { createAuditMiddleware } from "@koi/middleware-audit";
+import { createNexusAuditSink } from "@koi/audit-sink-nexus";
+
+const sink = createNexusAuditSink({
+  baseUrl: "http://nexus.internal:2026",
+  apiKey: process.env.NEXUS_API_KEY!,
+  basePath: "/audit/production",
+  batchSize: 100,          // larger batches for high-throughput agents
+  flushIntervalMs: 10_000, // flush every 10s
+  retry: {
+    maxRetries: 5,         // more retries for unreliable networks
+    initialDelayMs: 500,
+    maxBackoffMs: 60_000,
+  },
+});
+
+const audit = createAuditMiddleware({
+  sink,
+  redactRequestBodies: true,  // strip model prompts from logs
+  maxEntrySize: 20_000,       // truncate large entries
+  onError: (error, entry) => {
+    console.error("Audit write failed", { error, entryKind: entry.kind });
+  },
+});
+```
+
+### Testing With Fake Nexus
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { createFakeNexusFetch } from "@koi/test-utils";
+import { createNexusAuditSink } from "@koi/audit-sink-nexus";
+
+test("audit entries are persisted", async () => {
+  const sink = createNexusAuditSink({
+    baseUrl: "http://fake:2026",
+    apiKey: "test-key",
+    fetch: createFakeNexusFetch(), // in-memory Nexus
+    batchSize: 10,
+    flushIntervalMs: 60_000,
+    retry: { maxRetries: 0 },
+  });
+
+  await sink.log({
+    timestamp: Date.now(),
+    sessionId: "test-session",
+    agentId: "test-agent",
+    turnIndex: 0,
+    kind: "model_call",
+    durationMs: 42,
+  });
+
+  await sink.flush?.();
+  // entries now in fake Nexus storage
+});
+```
+
+---
+
+## API Reference
+
+### Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `createNexusAuditSink` | `(config: NexusAuditSinkConfig) => AuditSink` | Factory. Throws on invalid config. |
+| `validateNexusAuditSinkConfig` | `(config: NexusAuditSinkConfig) => Result<void, KoiError>` | Validate without creating. |
+
+### Types
+
+| Type | Description |
+|------|-------------|
+| `NexusAuditSinkConfig` | Configuration for the Nexus audit sink |
+| `AuditSink` | Re-exported from `@koi/core` — `{ log, flush? }` |
+| `AuditEntry` | Re-exported from `@koi/core` — structured audit event |
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_BATCH_SIZE` | `50` | Entries before size-triggered flush |
+| `DEFAULT_FLUSH_INTERVAL_MS` | `5_000` | Milliseconds between interval flushes |
+| `DEFAULT_BASE_PATH` | `"/audit"` | Root path in Nexus storage |
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Per-entry files (not append log) | Nexus is a KV store, not a log system. Individual files enable targeted reads and glob queries. |
+| Dual flush triggers (size + interval) | Size trigger handles burst traffic; interval trigger ensures low-traffic entries are persisted within bounded latency. |
+| `log()` never throws | Audit logging must never block the agent loop. Errors surface on `flush()` where the middleware can decide policy. |
+| Failed entries re-enqueued | Partial batch failures don't cause data loss. Failed entries stay in buffer for next flush attempt. |
+| `timer.unref()` | Prevents the interval timer from keeping the process alive if the consumer forgets to call `flush()`. |
+| SessionId sanitization | Defense-in-depth: `replace(/[^a-zA-Z0-9_-]/g, "_")` prevents path traversal via crafted session IDs. |
+| `Promise.allSettled` (not `Promise.all`) | Writes entries in parallel within a batch. One failing entry doesn't prevent others from succeeding. |
+| Injectable `fetch` | Enables testing with `createFakeNexusFetch()` without mocking globals. |
+
+---
+
+## Layer Compliance
+
+- [x] Only imports from `@koi/core` (L0) and L0u packages (`@koi/errors`, `@koi/nexus-client`)
+- [x] No imports from `@koi/engine` (L1) or peer L2 packages
+- [x] All interface properties `readonly`
+- [x] No vendor types in public API
+- [x] Injectable `fetch` — no global side effects
+- [x] `import type` used for type-only imports (`verbatimModuleSyntax`)

--- a/packages/audit-sink-nexus/package.json
+++ b/packages/audit-sink-nexus/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@koi/audit-sink-nexus",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "@koi/nexus-client": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  }
+}

--- a/packages/audit-sink-nexus/src/__tests__/nexus-sink.test.ts
+++ b/packages/audit-sink-nexus/src/__tests__/nexus-sink.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Nexus audit sink — unit tests with fake Nexus fetch.
+ *
+ * Tests batching, interval flushing, retry, file paths, and error handling.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { AuditEntry } from "@koi/core";
+import { createFakeNexusFetch } from "@koi/test-utils";
+import { validateNexusAuditSinkConfig } from "../config.js";
+import { createNexusAuditSink } from "../nexus-sink.js";
+import { runAuditSinkContractTests } from "./sink-contract.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_CONFIG = {
+  baseUrl: "http://fake-nexus:2026",
+  apiKey: "test-key",
+  basePath: "/audit",
+} as const;
+
+interface RpcBody {
+  readonly method: string;
+  readonly id: number;
+  readonly params: Record<string, unknown>;
+}
+
+/** Parse an RPC request body from a fetch init. Returns undefined if not parseable. */
+function parseRpcBody(init: RequestInit | undefined): RpcBody | undefined {
+  if (!init?.body || typeof init.body !== "string") return undefined;
+  const parsed: unknown = JSON.parse(init.body);
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.method !== "string" || typeof obj.id !== "number") return undefined;
+  return parsed satisfies unknown as RpcBody;
+}
+
+function makeEntry(overrides?: Partial<AuditEntry>): AuditEntry {
+  return {
+    timestamp: 1700000000000,
+    sessionId: "sess-abc",
+    agentId: "agent-1",
+    turnIndex: 0,
+    kind: "model_call",
+    durationMs: 42,
+    ...overrides,
+  };
+}
+
+/** Track all RPC write calls by intercepting the fake fetch. */
+function createTrackingFetch(): {
+  readonly fetch: typeof globalThis.fetch;
+  readonly writtenPaths: () => readonly string[];
+  readonly writtenEntries: () => readonly AuditEntry[];
+} {
+  const fakeFetch = createFakeNexusFetch();
+  const paths: string[] = [];
+  const entries: AuditEntry[] = [];
+
+  // @ts-expect-error — Bun's typeof fetch includes non-callable properties (preconnect)
+  const tracked: typeof globalThis.fetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const body = parseRpcBody(init);
+    if (body?.method === "write") {
+      paths.push(String(body.params.path));
+      const parsed: unknown = JSON.parse(String(body.params.content));
+      entries.push(parsed satisfies unknown as AuditEntry);
+    }
+    return fakeFetch(input, init);
+  };
+
+  return {
+    fetch: tracked,
+    writtenPaths: () => [...paths],
+    writtenEntries: () => [...entries],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract tests (reusable suite)
+// ---------------------------------------------------------------------------
+
+describe("NexusAuditSink", () => {
+  // let justified: reassigned per-test in beforeEach
+  let tracking: ReturnType<typeof createTrackingFetch>;
+
+  beforeEach(() => {
+    tracking = createTrackingFetch();
+  });
+
+  runAuditSinkContractTests(
+    () => {
+      tracking = createTrackingFetch();
+      return createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+    },
+    async () => tracking.writtenEntries(),
+  );
+
+  // -------------------------------------------------------------------------
+  // Batching — size trigger
+  // -------------------------------------------------------------------------
+
+  describe("batching", () => {
+    test("flushes automatically when buffer reaches batchSize", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 3,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry({ turnIndex: 0 }));
+      await sink.log(makeEntry({ turnIndex: 1 }));
+      expect(tracking.writtenPaths().length).toBe(0);
+
+      await sink.log(makeEntry({ turnIndex: 2 }));
+      // Give fire-and-forget flush a tick to complete
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(tracking.writtenPaths().length).toBe(3);
+      await sink.flush?.();
+    });
+
+    test("flush() drains entries below batchSize", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry({ turnIndex: 0 }));
+      await sink.log(makeEntry({ turnIndex: 1 }));
+
+      expect(tracking.writtenPaths().length).toBe(0);
+      await sink.flush?.();
+      expect(tracking.writtenPaths().length).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // File paths
+  // -------------------------------------------------------------------------
+
+  describe("file paths", () => {
+    test("writes entries to {basePath}/{sessionId}/{timestamp}-{turnIndex}-{kind}.json", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(
+        makeEntry({
+          sessionId: "sess-xyz",
+          timestamp: 1700000000000,
+          turnIndex: 5,
+          kind: "tool_call",
+        }),
+      );
+      await sink.flush?.();
+
+      expect(tracking.writtenPaths()).toEqual(["/audit/sess-xyz/1700000000000-5-tool_call.json"]);
+    });
+
+    test("uses custom basePath", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        basePath: "/custom/audit",
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry());
+      await sink.flush?.();
+
+      expect(tracking.writtenPaths()[0]).toStartWith("/custom/audit/");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Retry behavior
+  // -------------------------------------------------------------------------
+
+  describe("retry", () => {
+    test("retries on transient errors and eventually succeeds", async () => {
+      // let justified: counter incremented on each call
+      let callCount = 0;
+      // @ts-expect-error — Bun's typeof fetch includes non-callable properties (preconnect)
+      const failOnceFetch: typeof globalThis.fetch = async (
+        _input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const body = parseRpcBody(init);
+        if (body?.method === "write") {
+          callCount++;
+          if (callCount === 1) {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: body.id,
+                error: { code: -32000, message: "Temporary error" },
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }
+        return createFakeNexusFetch()(_input, init);
+      };
+
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: failOnceFetch,
+        retry: { maxRetries: 2, initialDelayMs: 1, maxBackoffMs: 5, jitter: false },
+      });
+
+      await sink.log(makeEntry());
+      await sink.flush?.();
+
+      expect(callCount).toBe(2);
+    });
+
+    test("flush() throws on permanent failure", async () => {
+      // @ts-expect-error — Bun's typeof fetch includes non-callable properties (preconnect)
+      const alwaysFailFetch: typeof globalThis.fetch = async (
+        _input: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        const body = parseRpcBody(init);
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body?.id ?? 0,
+            error: { code: -32003, message: "Unauthorized" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      };
+
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: alwaysFailFetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry());
+      await expect(sink.flush?.()).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Config validation
+  // -------------------------------------------------------------------------
+
+  describe("config validation", () => {
+    test("rejects empty baseUrl", () => {
+      const result = validateNexusAuditSinkConfig({ ...BASE_CONFIG, baseUrl: "" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION");
+        expect(result.error.message).toContain("baseUrl");
+      }
+    });
+
+    test("rejects empty apiKey", () => {
+      const result = validateNexusAuditSinkConfig({ ...BASE_CONFIG, apiKey: "" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION");
+        expect(result.error.message).toContain("apiKey");
+      }
+    });
+
+    test("rejects non-positive batchSize", () => {
+      const result = validateNexusAuditSinkConfig({ ...BASE_CONFIG, batchSize: 0 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION");
+      }
+    });
+
+    test("rejects non-positive flushIntervalMs", () => {
+      const result = validateNexusAuditSinkConfig({ ...BASE_CONFIG, flushIntervalMs: -1 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("VALIDATION");
+      }
+    });
+
+    test("accepts valid config", () => {
+      const result = validateNexusAuditSinkConfig(BASE_CONFIG);
+      expect(result.ok).toBe(true);
+    });
+
+    test("factory throws on invalid config", () => {
+      expect(() => createNexusAuditSink({ ...BASE_CONFIG, baseUrl: "" })).toThrow("baseUrl");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Concurrent flush safety
+  // -------------------------------------------------------------------------
+
+  describe("concurrency", () => {
+    test("concurrent flush does not duplicate writes", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry({ turnIndex: 0 }));
+      await sink.log(makeEntry({ turnIndex: 1 }));
+
+      // Trigger two flushes simultaneously
+      await Promise.all([sink.flush?.(), sink.flush?.()]);
+
+      expect(tracking.writtenPaths().length).toBe(2);
+    });
+
+    test("empty flush is a no-op", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 60_000,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.flush?.();
+      expect(tracking.writtenPaths().length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Interval flushing
+  // -------------------------------------------------------------------------
+
+  describe("interval flush", () => {
+    test("timer triggers flush after flushIntervalMs", async () => {
+      const sink = createNexusAuditSink({
+        ...BASE_CONFIG,
+        batchSize: 100,
+        flushIntervalMs: 50,
+        fetch: tracking.fetch,
+        retry: { maxRetries: 0 },
+      });
+
+      await sink.log(makeEntry());
+
+      // Wait for interval to fire
+      await new Promise((r) => setTimeout(r, 120));
+
+      expect(tracking.writtenPaths().length).toBeGreaterThanOrEqual(1);
+      await sink.flush?.();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (env-gated)
+// ---------------------------------------------------------------------------
+
+const NEXUS_URL = process.env.NEXUS_URL;
+const NEXUS_API_KEY = process.env.NEXUS_API_KEY;
+
+(NEXUS_URL && NEXUS_API_KEY ? describe : describe.skip)("Nexus integration", () => {
+  test("writes and reads back an audit entry", async () => {
+    if (!NEXUS_URL || !NEXUS_API_KEY) return;
+
+    const sink = createNexusAuditSink({
+      baseUrl: NEXUS_URL,
+      apiKey: NEXUS_API_KEY,
+      batchSize: 1,
+      flushIntervalMs: 60_000,
+    });
+
+    const entry = makeEntry({ sessionId: `integration-${Date.now()}` });
+    await sink.log(entry);
+    await sink.flush?.();
+  });
+});

--- a/packages/audit-sink-nexus/src/__tests__/sink-contract.ts
+++ b/packages/audit-sink-nexus/src/__tests__/sink-contract.ts
@@ -1,0 +1,93 @@
+/**
+ * Reusable contract test suite for any AuditSink implementation.
+ *
+ * Call `runAuditSinkContractTests(createSink, readEntries)` with a factory
+ * that creates a fresh sink per test group and an optional read-back function
+ * (since AuditSink is write-only, we need a side-channel for verification).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AuditEntry, AuditSink } from "@koi/core";
+
+const ENTRY_KINDS = [
+  "model_call",
+  "tool_call",
+  "session_start",
+  "session_end",
+  "secret_access",
+] as const;
+
+function makeEntry(overrides?: Partial<AuditEntry>): AuditEntry {
+  return {
+    timestamp: Date.now(),
+    sessionId: "session-1",
+    agentId: "agent-1",
+    turnIndex: 0,
+    kind: "model_call",
+    durationMs: 42,
+    ...overrides,
+  };
+}
+
+export function runAuditSinkContractTests(
+  createSink: () => AuditSink,
+  readEntries?: () => Promise<readonly AuditEntry[]>,
+): void {
+  describe("AuditSink contract", () => {
+    test("log() accepts a valid entry without throwing", async () => {
+      const sink = createSink();
+      await expect(sink.log(makeEntry())).resolves.toBeUndefined();
+      await sink.flush?.();
+    });
+
+    test("flush() resolves when buffer is empty", async () => {
+      const sink = createSink();
+      await expect(sink.flush?.() ?? Promise.resolve()).resolves.toBeUndefined();
+    });
+
+    test("log() + flush() persists entries", async () => {
+      if (!readEntries) return;
+
+      const sink = createSink();
+      const entry = makeEntry({ turnIndex: 1 });
+      await sink.log(entry);
+      await sink.flush?.();
+
+      const stored = await readEntries();
+      expect(stored.length).toBeGreaterThanOrEqual(1);
+      const found = stored.find((e) => e.turnIndex === 1);
+      expect(found).toBeDefined();
+      expect(found?.sessionId).toBe("session-1");
+    });
+
+    test("flush() is idempotent", async () => {
+      const sink = createSink();
+      await sink.log(makeEntry());
+      await sink.flush?.();
+      // Second flush should be a no-op, not throw
+      await expect(sink.flush?.() ?? Promise.resolve()).resolves.toBeUndefined();
+    });
+
+    test("entry ordering is preserved", async () => {
+      if (!readEntries) return;
+
+      const sink = createSink();
+      for (let i = 0; i < 5; i++) {
+        await sink.log(makeEntry({ turnIndex: i, timestamp: 1000 + i }));
+      }
+      await sink.flush?.();
+
+      const stored = await readEntries();
+      const turns = stored.map((e) => e.turnIndex);
+      expect(turns).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    test("all 5 entry kinds are accepted", async () => {
+      const sink = createSink();
+      for (const kind of ENTRY_KINDS) {
+        await expect(sink.log(makeEntry({ kind }))).resolves.toBeUndefined();
+      }
+      await sink.flush?.();
+    });
+  });
+}

--- a/packages/audit-sink-nexus/src/config.ts
+++ b/packages/audit-sink-nexus/src/config.ts
@@ -1,0 +1,76 @@
+/**
+ * Configuration, defaults, and validation for the Nexus audit sink.
+ */
+
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { RetryConfig } from "@koi/errors";
+
+export interface NexusAuditSinkConfig {
+  /** Nexus server base URL (e.g., "http://localhost:2026"). */
+  readonly baseUrl: string;
+  /** Nexus API key for authentication. */
+  readonly apiKey: string;
+  /** Base path prefix for audit entries in Nexus. Default: "/audit". */
+  readonly basePath?: string | undefined;
+  /** Number of entries before triggering a flush. Default: 50. */
+  readonly batchSize?: number | undefined;
+  /** Interval in ms between automatic flushes. Default: 5_000. */
+  readonly flushIntervalMs?: number | undefined;
+  /** Retry config for transient Nexus write failures. */
+  readonly retry?: Partial<RetryConfig> | undefined;
+  /** Injectable fetch for testing. Default: globalThis.fetch. */
+  readonly fetch?: typeof globalThis.fetch | undefined;
+}
+
+export const DEFAULT_BATCH_SIZE = 50;
+export const DEFAULT_FLUSH_INTERVAL_MS = 5_000;
+export const DEFAULT_BASE_PATH = "/audit";
+
+export function validateNexusAuditSinkConfig(config: NexusAuditSinkConfig): Result<void, KoiError> {
+  if (!config.baseUrl) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "baseUrl must be a non-empty string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (!config.apiKey) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "apiKey must be a non-empty string",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (config.batchSize !== undefined && config.batchSize <= 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "batchSize must be a positive number",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  if (config.flushIntervalMs !== undefined && config.flushIntervalMs <= 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "flushIntervalMs must be a positive number",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return { ok: true, value: undefined };
+}

--- a/packages/audit-sink-nexus/src/index.ts
+++ b/packages/audit-sink-nexus/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @koi/audit-sink-nexus — Nexus-backed AuditSink with batched writes (Layer 2).
+ *
+ * Implements the AuditSink contract from @koi/core, persisting structured
+ * audit entries to Nexus via JSON-RPC. Supports configurable batch size,
+ * flush interval, and retry policy.
+ */
+
+// Re-export core types for consumer convenience
+export type { AuditEntry, AuditSink } from "@koi/core";
+
+// Config
+export type { NexusAuditSinkConfig } from "./config.js";
+export {
+  DEFAULT_BASE_PATH,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_FLUSH_INTERVAL_MS,
+  validateNexusAuditSinkConfig,
+} from "./config.js";
+
+// Factory
+export { createNexusAuditSink } from "./nexus-sink.js";

--- a/packages/audit-sink-nexus/src/nexus-sink.ts
+++ b/packages/audit-sink-nexus/src/nexus-sink.ts
@@ -1,0 +1,139 @@
+/**
+ * Nexus-backed AuditSink — batched writes with interval + size triggers.
+ *
+ * Each audit entry is written to Nexus as a separate JSON file at:
+ *   {basePath}/{sessionId}/{timestamp}-{turnIndex}-{kind}.json
+ *
+ * Errors from `log()` are fire-and-forget (swallowed). Errors from `flush()`
+ * propagate to the caller so middleware can enforce its error policy.
+ */
+
+import type { AuditEntry, AuditSink } from "@koi/core";
+import type { RetryConfig } from "@koi/errors";
+import { DEFAULT_RETRY_CONFIG, swallowError, withRetry } from "@koi/errors";
+import type { NexusClient } from "@koi/nexus-client";
+import { createNexusClient } from "@koi/nexus-client";
+import type { NexusAuditSinkConfig } from "./config.js";
+import {
+  DEFAULT_BASE_PATH,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_FLUSH_INTERVAL_MS,
+  validateNexusAuditSinkConfig,
+} from "./config.js";
+
+/**
+ * Creates an AuditSink that writes entries to Nexus in batches.
+ *
+ * @throws On invalid config (VALIDATION error)
+ */
+export function createNexusAuditSink(config: NexusAuditSinkConfig): AuditSink {
+  const validation = validateNexusAuditSinkConfig(config);
+  if (!validation.ok) {
+    throw new Error(validation.error.message, { cause: validation.error });
+  }
+
+  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE;
+  const flushIntervalMs = config.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+  const retryConfig: RetryConfig = { ...DEFAULT_RETRY_CONFIG, ...config.retry };
+
+  const client: NexusClient = createNexusClient({
+    baseUrl: config.baseUrl,
+    apiKey: config.apiKey,
+    fetch: config.fetch,
+  });
+
+  // Internal mutable state — encapsulated in closure, never exposed.
+  // `let` justified: buffer is swapped atomically on flush; timer/flushing are lifecycle flags.
+  let buffer: AuditEntry[] = [];
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let flushing = false;
+
+  function computeEntryPath(entry: AuditEntry): string {
+    const safeSessionId = entry.sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return `${basePath}/${safeSessionId}/${entry.timestamp}-${entry.turnIndex}-${entry.kind}.json`;
+  }
+
+  async function writeEntry(entry: AuditEntry, path: string): Promise<void> {
+    const result = await client.rpc("write", {
+      path,
+      content: JSON.stringify(entry),
+    });
+    if (!result.ok) {
+      throw new Error(result.error.message, { cause: result.error });
+    }
+  }
+
+  async function flushBuffer(): Promise<void> {
+    if (buffer.length === 0 || flushing) return;
+
+    flushing = true;
+    const batch = buffer;
+    buffer = [];
+
+    try {
+      const results = await Promise.allSettled(
+        batch.map((entry) => {
+          const path = computeEntryPath(entry);
+          return withRetry(() => writeEntry(entry, path), retryConfig);
+        }),
+      );
+
+      // Re-enqueue failed entries so they can be retried on next flush
+      const failedEntries = batch.filter((_, i) => results[i]?.status === "rejected");
+      if (failedEntries.length > 0) {
+        buffer = [...failedEntries, ...buffer];
+      }
+
+      const firstRejected = results.find(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
+      if (firstRejected) {
+        throw new Error("Failed to write audit entry", { cause: firstRejected.reason });
+      }
+    } finally {
+      flushing = false;
+    }
+  }
+
+  function ensureTimer(): void {
+    if (timer !== undefined) return;
+    timer = setInterval(() => {
+      void flushBuffer().catch((error: unknown) => {
+        swallowError(error, {
+          package: "audit-sink-nexus",
+          operation: "interval-flush",
+        });
+      });
+    }, flushIntervalMs);
+    // Don't prevent process exit if consumer forgets to call flush()
+    if (typeof timer === "object" && "unref" in timer) {
+      timer.unref();
+    }
+  }
+
+  const log = async (entry: AuditEntry): Promise<void> => {
+    buffer = [...buffer, entry];
+    ensureTimer();
+
+    if (buffer.length >= batchSize) {
+      // Fire-and-forget — errors surface on flush()
+      void flushBuffer().catch((error: unknown) => {
+        swallowError(error, {
+          package: "audit-sink-nexus",
+          operation: "batch-flush",
+        });
+      });
+    }
+  };
+
+  const flush = async (): Promise<void> => {
+    if (timer !== undefined) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+    await flushBuffer();
+  };
+
+  return { log, flush };
+}

--- a/packages/audit-sink-nexus/tsconfig.json
+++ b/packages/audit-sink-nexus/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../errors" }, { "path": "../nexus-client" }]
+}

--- a/packages/audit-sink-nexus/tsup.config.ts
+++ b/packages/audit-sink-nexus/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Implements the `AuditSink` contract from `@koi/core`, backed by Nexus JSON-RPC
- New L2 package: `@koi/audit-sink-nexus` with batched writes, dual flush triggers (size + interval), retry with exponential backoff
- Enables persistent structured audit logging for compliance, debugging, and observability
- Includes reusable contract test suite (`runAuditSinkContractTests`) + 21 unit tests + env-gated integration test
- Documentation at `docs/L2/audit-sink-nexus.md`

### Key design decisions
- `log()` fire-and-forget (never blocks agent loop), `flush()` propagates errors
- Failed entries re-enqueued in buffer (no data loss on partial failure)
- `timer.unref()` prevents holding process open
- SessionId sanitized to prevent path traversal
- Injectable `fetch` for testing with `createFakeNexusFetch()`

### Layer compliance
- Only imports from `@koi/core` (L0) and L0u: `@koi/errors`, `@koi/nexus-client`
- No L1 or peer L2 imports
- All interface properties `readonly`
- Verified via `bun scripts/check-layers.ts`

Closes #305

## Test plan
- [x] `bun test --cwd packages/audit-sink-nexus` — 21 pass, 1 skip (env-gated)
- [x] `tsc --noEmit` — zero errors
- [x] `biome check` — zero issues
- [x] `tsup` build — clean (4.18 KB JS + 1.98 KB .d.ts)
- [x] Pre-push hooks pass (turborepo typecheck + build)
- [ ] CI pipeline