### PR TITLE
feat: convention survival + hot-tier memory injection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -524,6 +524,7 @@
         "@koi/memory-fs": "workspace:*",
         "@koi/middleware-compactor": "workspace:*",
         "@koi/middleware-context-editing": "workspace:*",
+        "@koi/middleware-hot-memory": "workspace:*",
         "@koi/middleware-personalization": "workspace:*",
         "@koi/middleware-preference": "workspace:*",
         "@koi/snapshot-chain-store": "workspace:*",
@@ -1266,6 +1267,17 @@
       "dependencies": {
         "@koi/core": "workspace:*",
         "@koi/resolve": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
+    "packages/middleware-hot-memory": {
+      "name": "@koi/middleware-hot-memory",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/token-estimator": "workspace:*",
       },
       "devDependencies": {
         "@koi/test-utils": "workspace:*",
@@ -2834,6 +2846,8 @@
     "@koi/middleware-guardrails": ["@koi/middleware-guardrails@workspace:packages/middleware-guardrails"],
 
     "@koi/middleware-guided-retry": ["@koi/middleware-guided-retry@workspace:packages/middleware-guided-retry"],
+
+    "@koi/middleware-hot-memory": ["@koi/middleware-hot-memory@workspace:packages/middleware-hot-memory"],
 
     "@koi/middleware-intent-capsule": ["@koi/middleware-intent-capsule@workspace:packages/middleware-intent-capsule"],
 

--- a/docs/L2/middleware-hot-memory.md
+++ b/docs/L2/middleware-hot-memory.md
@@ -1,0 +1,276 @@
+# @koi/middleware-hot-memory — Automatic Hot-Tier Memory Injection
+
+`@koi/middleware-hot-memory` is an L2 middleware package that automatically
+injects recently-accessed memories into every model call. The agent doesn't
+invoke tools or call `recall()` — hot memories appear in context transparently,
+giving the LLM ambient awareness of its most relevant knowledge.
+
+---
+
+## Why it exists
+
+Agent memory systems have a **cold start problem per turn**: the LLM sees only
+the conversation history, not the knowledge it stored in previous sessions or
+earlier in the current session. Without injection, the agent must explicitly
+decide to recall — but it can't decide to recall what it doesn't know it has.
+
+```
+Without hot-memory:
+  Agent has 50 stored facts from prior sessions
+  User asks: "Set up the project"
+  → Agent starts from scratch, ignores stored preferences and context
+
+With hot-memory:
+  [Hot Memories]
+  - User prefers Bun over Node.js
+  - Project uses ESM-only with .js extensions
+  - Dark mode preferred
+  → Agent applies stored knowledge without being asked
+```
+
+The middleware bridges the gap between **stored knowledge** and **active
+context** using the tier system already built into `@koi/memory-fs`.
+
+---
+
+## What this enables
+
+### For agent builders
+
+- **Zero-config ambient memory** — enable `memoryFs` in context-arena and hot
+  memories auto-inject. No tools, no explicit recall, no prompt engineering.
+- **Budget-controlled injection** — preset-driven token limits prevent memory
+  from crowding out conversation history.
+- **Turn-interval caching** — recall happens every N turns (default 5), not
+  every turn. 80% of turns have zero I/O cost.
+- **Graceful degradation** — recall errors are swallowed with a warning. The
+  agent continues without injection rather than crashing.
+
+### For users
+
+- Agents that **remember context** from prior sessions automatically
+- Recently-discussed facts stay visible without re-explaining them
+- No manual "remember this" — frequently-accessed knowledge stays hot
+
+### How it complements other memory middleware
+
+| Middleware | Strategy | Frequency | Purpose |
+|---|---|---|---|
+| **hot-memory** (310) | Wildcard + tier filter | Every 5 turns | Ambient awareness of recent knowledge |
+| **personalization** (420) | Semantic query | Every turn | Relevant preferences for current task |
+| **preference** (410) | Keyword detection | Every turn | Detect + store preference changes |
+
+Hot-memory uses **tier-based** recall (what's recent), personalization uses
+**relevance-based** recall (what's related to the current message). They inject
+different memories with minimal overlap.
+
+---
+
+## Architecture
+
+### Layer position
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    KoiMiddleware, MemoryComponent, MemoryRecallOptions, │
+    CapabilityFragment, TokenEstimator                    │
+                                                          ▼
+L2  @koi/middleware-hot-memory ◄────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    one L0u dependency: @koi/token-estimator
+```
+
+### Internal module map
+
+```
+index.ts                    ← public re-exports
+│
+├── types.ts                ← HotMemoryConfig, HotMemoryDefaults, HOT_MEMORY_DEFAULTS
+└── hot-memory-middleware.ts ← createHotMemoryMiddleware() factory
+```
+
+---
+
+## How it works
+
+### Per-turn flow
+
+```
+wrapModelCall / wrapModelStream
+│
+├─ First call ever?
+│  └─ Yes → synchronous fetchHotMemories() (initial load)
+│
+├─ cachedMessage exists?
+│  └─ Yes → prepend [Hot Memories] to request.messages
+│
+├─ Call next(request) → model executes
+│
+└─ Post-call: should refresh? (turnCount % refreshInterval === 0)
+   └─ Yes → async fetchHotMemories() (fire-and-forget for next turn)
+```
+
+### Recall strategy
+
+```typescript
+memory.recall("*", { tierFilter: "hot", limit: 20 })
+```
+
+- **Wildcard query** `"*"` — not searching for specific content, just
+  retrieving everything in the hot tier
+- **Tier filter** — `memory-fs` computes tiers dynamically from exponential
+  decay (`decayScore >= 0.7` = hot, roughly ≤10 days since last access)
+- **Limit 20** — cap on number of memories to prevent runaway injection
+- **Token budget** — results are formatted and truncated to fit the configured
+  `maxTokens` budget (default 4000)
+
+### Injected message format
+
+```
+[Hot Memories]
+- User prefers Bun over Node.js
+- Project uses ESM-only with .js extensions
+- Last session focused on auth module refactoring
+```
+
+Injected as a pinned system message with `senderId: "system:hot-memory"`,
+prepended before all conversation messages.
+
+### Tier calculation (handled by memory-fs)
+
+Tiers are **not manually assigned** — they're computed at recall time:
+
+```
+decayScore = e^(-λ × ageDays)     where λ = ln(2) / 30
+
+HOT:  decayScore >= 0.7  (~10 days or less since last access)
+WARM: decayScore >= 0.3  OR accessCount >= 10
+COLD: everything else
+```
+
+Each `recall()` hit updates `lastAccessed` and `accessCount`, keeping
+frequently-used facts hot. Unused facts naturally decay to warm → cold.
+
+---
+
+## API
+
+### `createHotMemoryMiddleware(config)`
+
+```typescript
+import { createHotMemoryMiddleware } from "@koi/middleware-hot-memory";
+
+const hotMemory = createHotMemoryMiddleware({
+  memory: memoryComponent,
+  maxTokens: 4000,        // optional, default from preset
+  refreshInterval: 5,     // optional, turns between recalls
+});
+```
+
+Returns a `KoiMiddleware` with `name: "koi:hot-memory"` and `priority: 310`.
+
+### `HotMemoryConfig`
+
+```typescript
+interface HotMemoryConfig {
+  /** Memory component for hot-tier recall. Required. */
+  readonly memory: MemoryComponent;
+  /** Max tokens for injected memories. Default: 4000. */
+  readonly maxTokens?: number | undefined;
+  /** Turns between recall refreshes. Default: 5. 0 = session start only. */
+  readonly refreshInterval?: number | undefined;
+  /** Override the default token estimator. */
+  readonly tokenEstimator?: TokenEstimator | undefined;
+}
+```
+
+### `describeCapabilities`
+
+Reports injection status and token usage:
+
+```
+"3 hot memories injected (850/4000 tokens)"
+```
+
+Returns `undefined` when no hot memories are available (no noise in capability
+descriptions).
+
+---
+
+## Context Arena integration
+
+`@koi/context-arena` (L3) wires hot memory automatically when `memoryFs` is
+configured. No extra config needed:
+
+```typescript
+const bundle = await createContextArena({
+  summarizer: myModelHandler,
+  sessionId: mySessionId,
+  getMessages: () => messages,
+  memoryFs: { config: { baseDir: "./memory" } },
+  // hot-memory middleware is enabled automatically
+});
+```
+
+To override budget or refresh interval:
+
+```typescript
+const bundle = await createContextArena({
+  // ...
+  hotMemory: { maxTokens: 2000, refreshInterval: 3 },
+});
+```
+
+To disable hot memory even with memoryFs:
+
+```typescript
+const bundle = await createContextArena({
+  // ...
+  hotMemory: { disabled: true },
+});
+```
+
+### Preset budgets
+
+| Preset | Token Budget | Refresh Interval |
+|---|---|---|
+| conservative | 1.5% of window (3000 tokens at 200K) | 8 turns |
+| balanced | 2% of window (4000 tokens at 200K) | 5 turns |
+| aggressive | 3% of window (6000 tokens at 200K) | 3 turns |
+
+---
+
+## Performance properties
+
+| Operation | Cost | Frequency |
+|---|---|---|
+| Hot memory recall | 1 `memory.recall()` call (file I/O) | Every N turns (default 5) |
+| Message formatting | String concatenation | Every turn (from cache) |
+| Token estimation | Heuristic `text.length / 4` | On refresh only |
+| LLM calls | **Zero** | Never |
+
+**80% of turns have zero I/O cost** — the cached message is reused between
+refresh intervals. On refresh, one `recall()` call reads from the filesystem.
+No LLM calls are ever made by this middleware.
+
+### Error handling
+
+| Scenario | Behavior |
+|---|---|
+| `recall()` throws | Warning logged, existing cache kept, injection continues |
+| `recall()` returns empty | No injection, `describeCapabilities` returns `undefined` |
+| Token budget exceeded | Memories truncated (earliest dropped first) |
+| First call before cache | Synchronous `await` (one-time initial load) |
+
+---
+
+## Related
+
+- [Issue #657](https://github.com/windoliver/koi/issues/657) — Convention
+  survival + tier-aware context injection
+- `docs/L2/middleware-preference.md` — Preference drift detection (store-side)
+- `docs/L2/middleware-personalization.md` — Preference injection (recall-side)
+- `docs/L2/memory-fs.md` — Memory backend with tier calculation
+- `docs/L3/context-arena.md` — Orchestrator that wires all memory middleware

--- a/packages/context-arena/package.json
+++ b/packages/context-arena/package.json
@@ -15,6 +15,7 @@
     "@koi/memory-fs": "workspace:*",
     "@koi/middleware-compactor": "workspace:*",
     "@koi/middleware-context-editing": "workspace:*",
+    "@koi/middleware-hot-memory": "workspace:*",
     "@koi/middleware-personalization": "workspace:*",
     "@koi/middleware-preference": "workspace:*",
     "@koi/snapshot-chain-store": "workspace:*",

--- a/packages/context-arena/src/arena-factory.test.ts
+++ b/packages/context-arena/src/arena-factory.test.ts
@@ -206,11 +206,11 @@ describe("createContextArena memory wiring", () => {
 
     // memoryFs provider still attaches even when config.memory overrides for extraction
     expect(bundle.providers).toHaveLength(2);
-    // 4 middleware: squash + compactor + context-editing + preference (memory available)
-    expect(bundle.middleware).toHaveLength(4);
+    // 3 base + hot memory + preference = 5 middleware
+    expect(bundle.middleware).toHaveLength(5);
   });
 
-  test("memoryFs adds preference middleware to bundle", async () => {
+  test("memoryFs adds hot memory and preference middleware", async () => {
     const dir = await makeTmpDir();
     const bundle = await createContextArena(
       baseConfig({
@@ -218,10 +218,10 @@ describe("createContextArena memory wiring", () => {
       }),
     );
 
-    // 4 middleware: squash + compactor + context-editing + preference (memory available)
-    expect(bundle.middleware).toHaveLength(4);
+    // squash (220) + compactor (225) + context-editing (250) + hot-memory (310) + preference (410)
+    expect(bundle.middleware).toHaveLength(5);
     const priorities = bundle.middleware.map((mw) => mw.priority);
-    expect(priorities).toEqual([220, 225, 250, 410]);
+    expect(priorities).toEqual([220, 225, 250, 310, 410]);
   });
 
   test("preference: false disables preference middleware even with memory", async () => {
@@ -233,7 +233,8 @@ describe("createContextArena memory wiring", () => {
       }),
     );
 
-    expect(bundle.middleware).toHaveLength(3);
+    // squash + compactor + context-editing + hot-memory = 4
+    expect(bundle.middleware).toHaveLength(4);
     const names = bundle.middleware.map((mw) => mw.name);
     expect(names).not.toContain("preference-drift");
   });
@@ -247,7 +248,8 @@ describe("createContextArena memory wiring", () => {
       }),
     );
 
-    expect(bundle.middleware).toHaveLength(4);
+    // squash + compactor + context-editing + hot-memory + preference = 5
+    expect(bundle.middleware).toHaveLength(5);
     const prefMw = bundle.middleware.find((mw) => mw.name === "preference-drift");
     expect(prefMw).toBeDefined();
   });
@@ -354,5 +356,75 @@ describe("createContextArena search wiring", () => {
     expect(bundle.providers).toHaveLength(2);
     // Indexer is deferred — not called during construction
     expect(indexSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature matrix — conventions + hot memory combinations
+// ---------------------------------------------------------------------------
+
+describe("createContextArena feature matrix", () => {
+  const tmpDirs: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(tmpDirs.map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  async function makeTmpDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "koi-arena-matrix-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  test("no features: 3 middleware, no conventions", async () => {
+    const bundle = await createContextArena(baseConfig());
+    expect(bundle.middleware).toHaveLength(3);
+    expect(bundle.config.conventions).toHaveLength(0);
+    expect(bundle.config.hotMemoryEnabled).toBe(false);
+  });
+
+  test("conventions only: 3 middleware, conventions resolved", async () => {
+    const bundle = await createContextArena(
+      baseConfig({ conventions: ["ESM-only", "No mutation"] }),
+    );
+    expect(bundle.middleware).toHaveLength(3);
+    expect(bundle.config.conventions).toHaveLength(2);
+    expect(bundle.config.conventions[0]?.label).toBe("convention");
+    expect(bundle.config.conventions[0]?.description).toBe("ESM-only");
+  });
+
+  test("memoryFs only: 5 middleware (includes hot memory + preference)", async () => {
+    const dir = await makeTmpDir();
+    const bundle = await createContextArena(baseConfig({ memoryFs: { config: { baseDir: dir } } }));
+    // squash + compactor + context-editing + hot-memory + preference
+    expect(bundle.middleware).toHaveLength(5);
+    expect(bundle.config.hotMemoryEnabled).toBe(true);
+  });
+
+  test("memoryFs + conventions: 5 middleware, conventions present", async () => {
+    const dir = await makeTmpDir();
+    const bundle = await createContextArena(
+      baseConfig({
+        memoryFs: { config: { baseDir: dir } },
+        conventions: ["ESM-only"],
+      }),
+    );
+    // squash + compactor + context-editing + hot-memory + preference
+    expect(bundle.middleware).toHaveLength(5);
+    expect(bundle.config.conventions).toHaveLength(1);
+    expect(bundle.config.hotMemoryEnabled).toBe(true);
+  });
+
+  test("memoryFs + disabled hot memory: 4 middleware (preference still on)", async () => {
+    const dir = await makeTmpDir();
+    const bundle = await createContextArena(
+      baseConfig({
+        memoryFs: { config: { baseDir: dir } },
+        hotMemory: { disabled: true },
+      }),
+    );
+    // squash + compactor + context-editing + preference (no hot-memory)
+    expect(bundle.middleware).toHaveLength(4);
+    expect(bundle.config.hotMemoryEnabled).toBe(false);
   });
 });

--- a/packages/context-arena/src/arena-factory.ts
+++ b/packages/context-arena/src/arena-factory.ts
@@ -17,6 +17,7 @@ import {
 } from "@koi/memory-fs";
 import { createCompactorMiddleware } from "@koi/middleware-compactor";
 import { createContextEditingMiddleware } from "@koi/middleware-context-editing";
+import { createHotMemoryMiddleware } from "@koi/middleware-hot-memory";
 import { createPersonalizationMiddleware } from "@koi/middleware-personalization";
 import { createPreferenceMiddleware } from "@koi/middleware-preference";
 import { createSquashProvider } from "@koi/tool-squash";
@@ -54,7 +55,7 @@ function createDefaultMergeHandler(summarizer: ModelHandler): MergeHandler {
 /**
  * Creates a fully wired context arena bundle with coordinated budget allocation.
  *
- * Middleware ordering in the returned array: squash (220) → compactor (225) → context-editing (250) → personalization (420, opt-in) → preference (410, default-on with memory).
+ * Middleware ordering in the returned array: squash (220) → compactor (225) → context-editing (250) → hot-memory (310, opt-in) → personalization (420, opt-in) → preference (410, default-on with memory).
  * Priority is owned by L2 packages — arena just returns them in priority order.
  *
  * @param config - User-facing configuration with required summarizer, sessionId, and getMessages
@@ -115,6 +116,7 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
     maxSummaryTokens: resolved.compactorMaxSummaryTokens,
     tokenEstimator: resolved.tokenEstimator,
     memory: effectiveMemory,
+    ...(resolved.conventions.length > 0 ? { conventions: resolved.conventions } : {}),
   });
 
   // --- Always-on: context-editing middleware ---
@@ -123,6 +125,17 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
     numRecentToKeep: resolved.editingNumRecentToKeep,
     tokenEstimator: resolved.tokenEstimator,
   });
+
+  // --- Opt-in: hot memory middleware (requires memoryFs) ---
+  const hotMemoryMiddleware =
+    resolved.hotMemoryEnabled && effectiveMemory !== undefined
+      ? createHotMemoryMiddleware({
+          memory: effectiveMemory,
+          maxTokens: resolved.hotMemoryMaxTokens,
+          refreshInterval: resolved.hotMemoryRefreshInterval,
+          tokenEstimator: resolved.tokenEstimator,
+        })
+      : undefined;
 
   // --- Opt-in: personalization middleware ---
   const personalizationMiddleware =
@@ -150,6 +163,7 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
     squashBundle.middleware,
     compactorMiddleware,
     contextEditingMiddleware,
+    ...(hotMemoryMiddleware !== undefined ? [hotMemoryMiddleware] : []),
     ...(personalizationMiddleware !== undefined ? [personalizationMiddleware] : []),
     ...(preferenceMiddleware !== undefined ? [preferenceMiddleware] : []),
   ];

--- a/packages/context-arena/src/config-resolution.test.ts
+++ b/packages/context-arena/src/config-resolution.test.ts
@@ -127,4 +127,57 @@ describe("resolveContextArenaConfig", () => {
     expect(withOpts.hydratorEnabled).toBe(true);
     expect(withOpts.memoryFsEnabled).toBe(true);
   });
+
+  test("conventions strings mapped to CapabilityFragment[]", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({ conventions: ["ESM-only", "No mutation"] }),
+    );
+    expect(resolved.conventions).toHaveLength(2);
+    expect(resolved.conventions[0]?.label).toBe("convention");
+    expect(resolved.conventions[0]?.description).toBe("ESM-only");
+    expect(resolved.conventions[1]?.description).toBe("No mutation");
+  });
+
+  test("empty conventions produces empty array", () => {
+    const resolved = resolveContextArenaConfig(baseConfig({ conventions: [] }));
+    expect(resolved.conventions).toHaveLength(0);
+  });
+
+  test("undefined conventions produces empty array", () => {
+    const resolved = resolveContextArenaConfig(baseConfig());
+    expect(resolved.conventions).toHaveLength(0);
+  });
+
+  test("hotMemoryEnabled is true when memoryFs present and not disabled", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({ memoryFs: { config: { baseDir: "/tmp/test" } } }),
+    );
+    expect(resolved.hotMemoryEnabled).toBe(true);
+  });
+
+  test("hotMemoryEnabled is false when memoryFs absent", () => {
+    const resolved = resolveContextArenaConfig(baseConfig());
+    expect(resolved.hotMemoryEnabled).toBe(false);
+  });
+
+  test("hotMemoryEnabled is false when explicitly disabled", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({
+        memoryFs: { config: { baseDir: "/tmp/test" } },
+        hotMemory: { disabled: true },
+      }),
+    );
+    expect(resolved.hotMemoryEnabled).toBe(false);
+  });
+
+  test("hotMemory overrides take precedence over preset", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({
+        memoryFs: { config: { baseDir: "/tmp/test" } },
+        hotMemory: { maxTokens: 8000, refreshInterval: 2 },
+      }),
+    );
+    expect(resolved.hotMemoryMaxTokens).toBe(8000);
+    expect(resolved.hotMemoryRefreshInterval).toBe(2);
+  });
 });

--- a/packages/context-arena/src/config-resolution.ts
+++ b/packages/context-arena/src/config-resolution.ts
@@ -63,6 +63,17 @@ export function resolveContextArenaConfig(config: ContextArenaConfig): ResolvedC
     personalizationRelevanceThreshold: config.personalization?.relevanceThreshold ?? 0.7,
     personalizationMaxPreferenceTokens: config.personalization?.maxPreferenceTokens ?? 500,
 
+    // Hot memory — user overrides → preset
+    hotMemoryMaxTokens: config.hotMemory?.maxTokens ?? budget.hotMemoryMaxTokens,
+    hotMemoryRefreshInterval: config.hotMemory?.refreshInterval ?? budget.hotMemoryRefreshInterval,
+    hotMemoryEnabled: config.memoryFs !== undefined && config.hotMemory?.disabled !== true,
+
+    // Conventions — map raw strings to CapabilityFragment[]
+    conventions:
+      config.conventions !== undefined && config.conventions.length > 0
+        ? config.conventions.map((s) => ({ label: "convention", description: s }))
+        : [],
+
     // Feature flags
     hydratorEnabled: config.hydrator !== undefined,
     memoryFsEnabled: config.memoryFs !== undefined,

--- a/packages/context-arena/src/index.ts
+++ b/packages/context-arena/src/index.ts
@@ -39,6 +39,7 @@ export type {
   ContextArenaConfig,
   ContextArenaPreset,
   ContextEditingOverrides,
+  HotMemoryOverrides,
   PersonalizationOverrides,
   PresetBudget,
   PresetSpec,

--- a/packages/context-arena/src/presets.test.ts
+++ b/packages/context-arena/src/presets.test.ts
@@ -32,6 +32,8 @@ describe("PRESET_SPECS", () => {
       expect(spec.editingTriggerFraction).toBeGreaterThan(0);
       expect(spec.editingRecentToKeep).toBeGreaterThan(0);
       expect(spec.maxPendingSquashes).toBeGreaterThan(0);
+      expect(spec.hotMemoryTokenFraction).toBeGreaterThan(0);
+      expect(spec.hotMemoryRefreshInterval).toBeGreaterThan(0);
     }
   });
 });
@@ -78,6 +80,8 @@ describe("computePresetBudget", () => {
         expect(budget.editingNumRecentToKeep).toBeGreaterThan(0);
         expect(budget.squashPreserveRecent).toBeGreaterThan(0);
         expect(budget.squashMaxPendingSquashes).toBeGreaterThan(0);
+        expect(budget.hotMemoryMaxTokens).toBeGreaterThan(0);
+        expect(budget.hotMemoryRefreshInterval).toBeGreaterThan(0);
       }
     }
   });
@@ -100,5 +104,24 @@ describe("computePresetBudget", () => {
     expect(budget.editingNumRecentToKeep).toBe(3);
     expect(budget.squashPreserveRecent).toBe(4);
     expect(budget.squashMaxPendingSquashes).toBe(3);
+    expect(budget.hotMemoryMaxTokens).toBe(4_000); // 200_000 * 0.02
+    expect(budget.hotMemoryRefreshInterval).toBe(5);
+  });
+
+  test("hot memory budget scales with window size", () => {
+    for (const name of PRESET_NAMES) {
+      const small = computePresetBudget(name, 50_000);
+      const large = computePresetBudget(name, 1_000_000);
+      expect(large.hotMemoryMaxTokens).toBeGreaterThan(small.hotMemoryMaxTokens);
+    }
+  });
+
+  test("conservative <= balanced <= aggressive hot memory fractions", () => {
+    expect(PRESET_SPECS.conservative.hotMemoryTokenFraction).toBeLessThanOrEqual(
+      PRESET_SPECS.balanced.hotMemoryTokenFraction,
+    );
+    expect(PRESET_SPECS.balanced.hotMemoryTokenFraction).toBeLessThanOrEqual(
+      PRESET_SPECS.aggressive.hotMemoryTokenFraction,
+    );
   });
 });

--- a/packages/context-arena/src/presets.ts
+++ b/packages/context-arena/src/presets.ts
@@ -20,6 +20,8 @@ const CONSERVATIVE: PresetSpec = Object.freeze({
   editingTriggerFraction: 0.4,
   editingRecentToKeep: 4,
   maxPendingSquashes: 2,
+  hotMemoryTokenFraction: 0.015,
+  hotMemoryRefreshInterval: 8,
 });
 
 const BALANCED: PresetSpec = Object.freeze({
@@ -30,6 +32,8 @@ const BALANCED: PresetSpec = Object.freeze({
   editingTriggerFraction: 0.5,
   editingRecentToKeep: 3,
   maxPendingSquashes: 3,
+  hotMemoryTokenFraction: 0.02,
+  hotMemoryRefreshInterval: 5,
 });
 
 const AGGRESSIVE: PresetSpec = Object.freeze({
@@ -40,6 +44,8 @@ const AGGRESSIVE: PresetSpec = Object.freeze({
   editingTriggerFraction: 0.6,
   editingRecentToKeep: 2,
   maxPendingSquashes: 4,
+  hotMemoryTokenFraction: 0.03,
+  hotMemoryRefreshInterval: 3,
 });
 
 /** All preset specifications keyed by name. */
@@ -73,5 +79,7 @@ export function computePresetBudget(
     editingNumRecentToKeep: spec.editingRecentToKeep,
     squashPreserveRecent: spec.preserveRecent,
     squashMaxPendingSquashes: spec.maxPendingSquashes,
+    hotMemoryMaxTokens: Math.round(contextWindowSize * spec.hotMemoryTokenFraction),
+    hotMemoryRefreshInterval: spec.hotMemoryRefreshInterval,
   };
 }

--- a/packages/context-arena/src/types.ts
+++ b/packages/context-arena/src/types.ts
@@ -8,7 +8,7 @@ import type { ContextHydratorMiddleware, ContextManifestConfig } from "@koi/cont
 import type { PruningPolicy, SnapshotChainStore, TokenEstimator } from "@koi/core";
 import type { Agent, ComponentProvider, MemoryComponent, SessionId } from "@koi/core/ecs";
 import type { InboundMessage } from "@koi/core/message";
-import type { KoiMiddleware, ModelHandler } from "@koi/core/middleware";
+import type { CapabilityFragment, KoiMiddleware, ModelHandler } from "@koi/core/middleware";
 import type { FsMemoryConfig, FsSearchIndexer, FsSearchRetriever } from "@koi/memory-fs";
 import type { CompactionTrigger } from "@koi/middleware-compactor";
 import type { LlmClassifier } from "@koi/middleware-preference";
@@ -57,6 +57,15 @@ export interface PersonalizationOverrides {
   readonly maxPreferenceTokens?: number | undefined;
 }
 
+export interface HotMemoryOverrides {
+  /** Override max tokens for hot memory injection. */
+  readonly maxTokens?: number | undefined;
+  /** Override turn refresh interval. */
+  readonly refreshInterval?: number | undefined;
+  /** Set true to disable hot memory even when memoryFs is configured. */
+  readonly disabled?: boolean | undefined;
+}
+
 /** User-facing configuration for createContextArena. */
 export interface ContextArenaConfig {
   // --- Required ---
@@ -92,6 +101,10 @@ export interface ContextArenaConfig {
   readonly personalization?: PersonalizationOverrides | undefined;
 
   // --- Opt-in modules ---
+  /** Project conventions preserved through compaction. Mapped to CapabilityFragment internally. */
+  readonly conventions?: readonly string[] | undefined;
+  /** Hot memory injection overrides. Requires memoryFs to be configured. */
+  readonly hotMemory?: HotMemoryOverrides | undefined;
   /** Enable context hydrator (deferred — requires Agent at creation time). */
   readonly hydrator?: { readonly config: ContextManifestConfig } | undefined;
   /** Enable filesystem memory. Async initialization. */
@@ -158,6 +171,14 @@ export interface ResolvedContextArenaConfig {
   readonly personalizationRelevanceThreshold: number;
   readonly personalizationMaxPreferenceTokens: number;
 
+  // Hot memory
+  readonly hotMemoryMaxTokens: number;
+  readonly hotMemoryRefreshInterval: number;
+  readonly hotMemoryEnabled: boolean;
+
+  // Conventions
+  readonly conventions: readonly CapabilityFragment[];
+
   // Feature flags
   readonly hydratorEnabled: boolean;
   readonly memoryFsEnabled: boolean;
@@ -200,6 +221,10 @@ export interface PresetSpec {
   readonly editingRecentToKeep: number;
   /** Squash queue depth. */
   readonly maxPendingSquashes: number;
+  /** Hot memory token budget as fraction of context window. */
+  readonly hotMemoryTokenFraction: number;
+  /** Hot memory turn refresh interval. */
+  readonly hotMemoryRefreshInterval: number;
 }
 
 /** Computed budget values from a preset + window size. */
@@ -212,4 +237,6 @@ export interface PresetBudget {
   readonly editingNumRecentToKeep: number;
   readonly squashPreserveRecent: number;
   readonly squashMaxPendingSquashes: number;
+  readonly hotMemoryMaxTokens: number;
+  readonly hotMemoryRefreshInterval: number;
 }

--- a/packages/context-arena/tsconfig.json
+++ b/packages/context-arena/tsconfig.json
@@ -11,7 +11,9 @@
     { "path": "../memory-fs" },
     { "path": "../middleware-compactor" },
     { "path": "../middleware-context-editing" },
+    { "path": "../middleware-hot-memory" },
     { "path": "../middleware-personalization" },
+    { "path": "../middleware-preference" },
     { "path": "../snapshot-chain-store" },
     { "path": "../token-estimator" },
     { "path": "../tool-squash" }

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -1102,6 +1102,27 @@ describe("AgentManifest delegation config", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AgentManifest conventions
+// ---------------------------------------------------------------------------
+
+describe("AgentManifest conventions", () => {
+  test("conventions is optional on AgentManifest", () => {
+    const without: AgentManifest = { name: "test", version: "0.0.0", model: { name: "gpt-4" } };
+    expect(without.conventions).toBeUndefined();
+  });
+
+  test("accepts readonly string array", () => {
+    const m: AgentManifest = {
+      name: "test",
+      version: "0.0.0",
+      model: { name: "gpt-4" },
+      conventions: ["ESM-only imports", "No mutation"],
+    };
+    expect(m.conventions).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Model provider types
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/assembly.ts
+++ b/packages/core/src/assembly.ts
@@ -109,6 +109,8 @@ export interface AgentManifest {
   readonly metadata?: JsonObject;
   /** Declared task objectives — used by goal drift detection and attention management middleware. */
   readonly objectives?: readonly string[];
+  /** Project conventions preserved through compaction — surfaced via middleware capabilities. */
+  readonly conventions?: readonly string[] | undefined;
   /** Search provider configuration — resolved to a SearchProvider at assembly time. */
   readonly search?: SearchConfig | undefined;
   /**

--- a/packages/middleware-compactor/src/compact.test.ts
+++ b/packages/middleware-compactor/src/compact.test.ts
@@ -644,3 +644,73 @@ describe("createLlmCompactor", () => {
     expect(forcedResult.messages[0]?.senderId).toBe("system:compactor");
   });
 });
+
+describe("convention preservation", () => {
+  test("convention block is prepended to summary message", async () => {
+    const compactor = createLlmCompactor({
+      summarizer: createMockSummarizer("LLM summary text"),
+      contextWindowSize: 1000,
+      trigger: { messageCount: 3 },
+      preserveRecent: 1,
+      maxSummaryTokens: 500,
+      conventions: [{ label: "immutability", description: "Never mutate shared state" }],
+    });
+
+    const msgs = [userMsg("a"), userMsg("b"), userMsg("c"), userMsg("d")];
+    const result = await compactor.compact(msgs, 1000);
+    expect(result.strategy).toBe("llm-summary");
+    const summaryText = result.messages[0]?.content[0];
+    expect(summaryText?.kind).toBe("text");
+    if (summaryText?.kind === "text") {
+      expect(summaryText.text).toContain("[Conventions]");
+      expect(summaryText.text).toContain("**immutability**");
+      expect(summaryText.text).toContain("LLM summary text");
+    }
+  });
+
+  test("conventions survive multi-cycle compaction", async () => {
+    const conventions = [{ label: "esm-only", description: "Use .js extensions" }] as const;
+    const compactor = createLlmCompactor({
+      summarizer: createMockSummarizer("Cycle summary"),
+      contextWindowSize: 1000,
+      trigger: { messageCount: 3 },
+      preserveRecent: 1,
+      maxSummaryTokens: 500,
+      conventions,
+    });
+
+    // First compaction cycle
+    const msgs1 = [userMsg("a"), userMsg("b"), userMsg("c"), userMsg("d")];
+    const result1 = await compactor.compact(msgs1, 1000);
+    expect(result1.strategy).toBe("llm-summary");
+
+    // Second compaction cycle — use output of first cycle + new messages
+    const msgs2 = [...result1.messages, userMsg("e"), userMsg("f"), userMsg("g")];
+    const result2 = await compactor.compact(msgs2, 1000);
+    expect(result2.strategy).toBe("llm-summary");
+    const text2 = result2.messages[0]?.content[0];
+    if (text2?.kind === "text") {
+      expect(text2.text).toContain("[Conventions]");
+      expect(text2.text).toContain("**esm-only**");
+    }
+  });
+
+  test("no convention block when conventions empty", async () => {
+    const compactor = createLlmCompactor({
+      summarizer: createMockSummarizer("Plain summary"),
+      contextWindowSize: 1000,
+      trigger: { messageCount: 3 },
+      preserveRecent: 1,
+      maxSummaryTokens: 500,
+      conventions: [],
+    });
+
+    const msgs = [userMsg("a"), userMsg("b"), userMsg("c"), userMsg("d")];
+    const result = await compactor.compact(msgs, 1000);
+    const text = result.messages[0]?.content[0];
+    if (text?.kind === "text") {
+      expect(text.text).not.toContain("[Conventions]");
+      expect(text.text).toBe("Plain summary");
+    }
+  });
+});

--- a/packages/middleware-compactor/src/compact.ts
+++ b/packages/middleware-compactor/src/compact.ts
@@ -11,7 +11,7 @@ import { HEURISTIC_ESTIMATOR } from "@koi/token-estimator";
 import { createFactExtractingArchiver } from "./fact-extracting-archiver.js";
 import { findOptimalSplit } from "./find-split.js";
 import { findValidSplitPoints } from "./pair-boundaries.js";
-import { buildSummaryPrompt } from "./prompt.js";
+import { buildSummaryPrompt, formatConventionBlock } from "./prompt.js";
 import type { CompactionTrigger, CompactorConfig, ResolvedCompactorConfig } from "./types.js";
 import { COMPACTOR_DEFAULTS } from "./types.js";
 
@@ -50,6 +50,7 @@ function resolveConfig(config: CompactorConfig): ResolvedCompactorConfig {
       config.archiver ??
       (config.memory !== undefined ? createFactExtractingArchiver(config.memory) : undefined),
     overflowRecovery: config.overflowRecovery ?? COMPACTOR_DEFAULTS.overflowRecovery,
+    conventions: config.conventions ?? COMPACTOR_DEFAULTS.conventions,
   };
 }
 
@@ -103,6 +104,19 @@ function noopResult(messages: readonly InboundMessage[], tokenCount: number): Co
 export function createLlmCompactor(config: CompactorConfig): LlmCompactor {
   const resolved = resolveConfig(config);
 
+  // Pre-format convention block text once at factory time (format once, reuse across cycles)
+  const conventionBlockText = formatConventionBlock(resolved.conventions);
+
+  // Budget warning: if convention block exceeds 20% of maxSummaryTokens
+  if (conventionBlockText.length > 0) {
+    const estimatedTokens = conventionBlockText.length / 4;
+    if (estimatedTokens > resolved.maxSummaryTokens * 0.2) {
+      console.warn(
+        `[middleware-compactor] Convention block (~${String(Math.round(estimatedTokens))} tokens) exceeds 20% of maxSummaryTokens (${String(resolved.maxSummaryTokens)})`,
+      );
+    }
+  }
+
   // let required: re-entrancy guard toggled within compact() to prevent concurrent summarizations
   let compacting = false;
 
@@ -135,7 +149,15 @@ export function createLlmCompactor(config: CompactorConfig): LlmCompactor {
       // Set guard before any async work
       compacting = true;
       try {
-        return await performCompaction(messages, maxTokens, model, resolved, false, epoch);
+        return await performCompaction(
+          messages,
+          maxTokens,
+          model,
+          resolved,
+          false,
+          epoch,
+          conventionBlockText,
+        );
       } catch (_e: unknown) {
         // Graceful degradation: return original messages on any failure.
         // L0 contract: "Always succeeds — worst case returns an empty message array."
@@ -151,7 +173,15 @@ export function createLlmCompactor(config: CompactorConfig): LlmCompactor {
       model?: string,
       epoch?: number,
     ): Promise<CompactionResult> {
-      return performCompaction(messages, maxTokens, model, resolved, true, epoch);
+      return performCompaction(
+        messages,
+        maxTokens,
+        model,
+        resolved,
+        true,
+        epoch,
+        conventionBlockText,
+      );
     },
   };
 }
@@ -164,6 +194,7 @@ async function performCompaction(
   resolved: ResolvedCompactorConfig,
   force = false,
   epoch?: number,
+  conventionBlockText = "",
 ): Promise<CompactionResult> {
   const contextWindowSize = Math.min(maxTokens, resolved.contextWindowSize);
 
@@ -204,7 +235,10 @@ async function performCompaction(
   // Build prompt from head messages (to be summarized)
   const headMessages = messages.slice(0, splitIndex);
   const tailMessages = messages.slice(splitIndex);
-  const prompt = resolved.promptBuilder(headMessages, resolved.maxSummaryTokens);
+  const prompt =
+    resolved.conventions.length > 0
+      ? resolved.promptBuilder(headMessages, resolved.maxSummaryTokens, resolved.conventions)
+      : resolved.promptBuilder(headMessages, resolved.maxSummaryTokens);
 
   // Resolve which model to use: explicit summarizerModel takes precedence
   const summarizerModel = resolved.summarizerModel ?? model;
@@ -221,9 +255,15 @@ async function performCompaction(
     maxTokens: resolved.maxSummaryTokens,
   });
 
+  // Prepend convention block to summary so conventions survive compaction
+  const summaryText =
+    conventionBlockText.length > 0
+      ? `${conventionBlockText}\n\n${response.content}`
+      : response.content;
+
   // Build summary message
   const summaryMessage: InboundMessage = {
-    content: [{ kind: "text", text: response.content }],
+    content: [{ kind: "text", text: summaryText }],
     senderId: "system:compactor",
     timestamp: Date.now(),
     metadata: { compacted: true, ...(epoch !== undefined ? { compactionEpoch: epoch } : {}) },

--- a/packages/middleware-compactor/src/compactor-middleware.test.ts
+++ b/packages/middleware-compactor/src/compactor-middleware.test.ts
@@ -636,6 +636,68 @@ describe("createCompactorMiddleware", () => {
       expect(passedMessages?.[0]?.metadata?.compactionEpoch).toBe(0);
     });
   });
+
+  describe("conventions in describeCapabilities", () => {
+    test("includes convention labels when conventions configured", () => {
+      const mw = createCompactorMiddleware({
+        summarizer: createMockSummarizer(),
+        conventions: [
+          { label: "immutability", description: "No mutation" },
+          { label: "esm-only", description: "Use .js extensions" },
+        ],
+      });
+      const result = mw.describeCapabilities?.(ctx);
+      expect(result?.description).toContain("Conventions:");
+      expect(result?.description).toContain("immutability: No mutation");
+      expect(result?.description).toContain("esm-only: Use .js extensions");
+    });
+
+    test("no convention suffix when conventions empty", () => {
+      const mw = createCompactorMiddleware({
+        summarizer: createMockSummarizer(),
+        conventions: [],
+      });
+      const result = mw.describeCapabilities?.(ctx);
+      expect(result?.description).not.toContain("Conventions:");
+    });
+
+    test("no convention suffix when conventions omitted", () => {
+      const mw = createCompactorMiddleware({
+        summarizer: createMockSummarizer(),
+      });
+      const result = mw.describeCapabilities?.(ctx);
+      expect(result?.description).not.toContain("Conventions:");
+    });
+
+    test("current config conventions always win over stale stored ones", async () => {
+      const storedMsg: InboundMessage = {
+        content: [{ kind: "text", text: "Old summary with old conventions" }],
+        senderId: "system:compactor",
+        timestamp: 1,
+        metadata: { compacted: true },
+      };
+      const store: CompactionStore = {
+        save: async () => {},
+        load: async () => ({
+          messages: [storedMsg],
+          originalTokens: 100,
+          compactedTokens: 20,
+          strategy: "llm-summary" as const,
+        }),
+      };
+
+      const mw = createCompactorMiddleware({
+        summarizer: createMockSummarizer(),
+        trigger: { messageCount: 100 },
+        store,
+        conventions: [{ label: "fresh-convention", description: "Latest rule" }],
+      });
+
+      await mw.onSessionStart?.(createMockSessionContext());
+      const result = mw.describeCapabilities?.(ctx);
+      expect(result?.description).toContain("fresh-convention: Latest rule");
+    });
+  });
 });
 
 /** Helper: create a message with exactly `n` tokens (n*4 chars). */

--- a/packages/middleware-compactor/src/compactor-middleware.ts
+++ b/packages/middleware-compactor/src/compactor-middleware.ts
@@ -77,6 +77,11 @@ export function createCompactorMiddleware(config: CompactorConfig): CompactorMid
   const compactionThreshold = contextWindowSize * triggerFraction;
 
   const hasToolEnabled = config.toolEnabled === true;
+  const conventions = config.conventions ?? [];
+  const conventionSuffix =
+    conventions.length > 0
+      ? `. Conventions: ${conventions.map((c) => `${c.label}: ${c.description}`).join("; ")}`
+      : "";
 
   // let required: single mutable state record — each mutation returns a new object
   let state: CompactorState = { epoch: 0, lastTokenFraction: 0, cachedRestore: undefined };
@@ -199,7 +204,8 @@ export function createCompactorMiddleware(config: CompactorConfig): CompactorMid
         `Compaction above ${String(contextWindowSize)} tokens` +
         (hasOverflowRecovery ? `, overflow recovery (${String(overflowMaxRetries)} retries)` : "") +
         (store !== undefined ? ", session restore enabled" : "") +
-        (hasToolEnabled ? ". Use compact_context tool to trigger early compaction" : "");
+        (hasToolEnabled ? ". Use compact_context tool to trigger early compaction" : "") +
+        conventionSuffix;
 
       // Soft trigger warning when above soft threshold
       if (softTriggerFraction !== undefined && state.lastTokenFraction >= softTriggerFraction) {

--- a/packages/middleware-compactor/src/index.ts
+++ b/packages/middleware-compactor/src/index.ts
@@ -29,6 +29,7 @@ export { DEFAULT_HEURISTIC_PATTERNS } from "./fact-extraction.js";
 export { createMemoryCompactionStore } from "./memory-compaction-store.js";
 export type { PressureTrendTracker } from "./pressure-trend.js";
 export { createPressureTrendTracker } from "./pressure-trend.js";
+export { formatConventionBlock } from "./prompt.js";
 export type {
   CompactionArchiver,
   CompactionStore,

--- a/packages/middleware-compactor/src/prompt.test.ts
+++ b/packages/middleware-compactor/src/prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { InboundMessage } from "@koi/core/message";
-import { buildSummaryPrompt } from "./prompt.js";
+import type { CapabilityFragment } from "@koi/core/middleware";
+import { buildSummaryPrompt, formatConventionBlock } from "./prompt.js";
 
 function userMsg(text: string): InboundMessage {
   return { content: [{ kind: "text", text }], senderId: "user", timestamp: 1 };
@@ -77,5 +78,51 @@ describe("buildSummaryPrompt", () => {
     const prompt = buildSummaryPrompt([msg], 500);
     expect(prompt).toContain("first block");
     expect(prompt).toContain("second block");
+  });
+
+  test("includes CONVENTIONS section when conventions provided", () => {
+    const conventions: readonly CapabilityFragment[] = [
+      { label: "immutability", description: "Never mutate shared state" },
+      { label: "esm-only", description: "Use .js extensions in imports" },
+    ];
+    const prompt = buildSummaryPrompt([userMsg("test")], 500, conventions);
+    expect(prompt).toContain("## CONVENTIONS (preserve verbatim)");
+    expect(prompt).toContain("**immutability**");
+    expect(prompt).toContain("Never mutate shared state");
+    expect(prompt).toContain("**esm-only**");
+  });
+
+  test("omits CONVENTIONS section when conventions empty", () => {
+    const prompt = buildSummaryPrompt([userMsg("test")], 500, []);
+    expect(prompt).not.toContain("CONVENTIONS");
+  });
+
+  test("omits CONVENTIONS section when conventions undefined", () => {
+    const prompt = buildSummaryPrompt([userMsg("test")], 500);
+    expect(prompt).not.toContain("CONVENTIONS");
+  });
+});
+
+describe("formatConventionBlock", () => {
+  test("formats conventions into labeled block", () => {
+    const conventions: readonly CapabilityFragment[] = [
+      { label: "immutability", description: "No mutation" },
+    ];
+    const block = formatConventionBlock(conventions);
+    expect(block).toBe("[Conventions]\n- **immutability**: No mutation");
+  });
+
+  test("returns empty string for empty array", () => {
+    expect(formatConventionBlock([])).toBe("");
+  });
+
+  test("formats multiple conventions", () => {
+    const conventions: readonly CapabilityFragment[] = [
+      { label: "a", description: "desc-a" },
+      { label: "b", description: "desc-b" },
+    ];
+    const block = formatConventionBlock(conventions);
+    expect(block).toContain("- **a**: desc-a");
+    expect(block).toContain("- **b**: desc-b");
   });
 });

--- a/packages/middleware-compactor/src/prompt.ts
+++ b/packages/middleware-compactor/src/prompt.ts
@@ -6,6 +6,7 @@
  */
 
 import type { InboundMessage } from "@koi/core/message";
+import type { CapabilityFragment } from "@koi/core/middleware";
 
 const MAX_MESSAGE_CHARS = 2000;
 
@@ -25,19 +26,41 @@ function serializeMessage(msg: InboundMessage): string {
 }
 
 /**
+ * Formats convention fragments into a text block for injection into summaries.
+ * Returns empty string when the array is empty.
+ */
+export function formatConventionBlock(conventions: readonly CapabilityFragment[]): string {
+  if (conventions.length === 0) return "";
+  const lines = conventions.map((c) => `- **${c.label}**: ${c.description}`);
+  return `[Conventions]\n${lines.join("\n")}`;
+}
+
+/**
  * Build a summary prompt from a sequence of messages.
  *
  * The prompt instructs the LLM to produce a structured summary with
  * sections for session intent, key events, artifacts, and next steps.
+ *
+ * When conventions are provided, a CONVENTIONS section is appended
+ * instructing the LLM to preserve them verbatim in the summary.
  */
-export function buildSummaryPrompt(messages: readonly InboundMessage[], maxTokens: number): string {
+export function buildSummaryPrompt(
+  messages: readonly InboundMessage[],
+  maxTokens: number,
+  conventions?: readonly CapabilityFragment[],
+): string {
   const serialized = messages.map(serializeMessage).join("\n");
+
+  const conventionSection =
+    conventions !== undefined && conventions.length > 0
+      ? `\n\n## CONVENTIONS (preserve verbatim)\n${conventions.map((c) => `- **${c.label}**: ${c.description}`).join("\n")}`
+      : "";
 
   return `You are a conversation summarizer. Summarize the following conversation history into a structured summary. Your summary must fit within ${String(maxTokens)} tokens.
 
 <conversation>
 ${serialized}
-</conversation>
+</conversation>${conventionSection}
 
 Produce your summary in the following format:
 

--- a/packages/middleware-compactor/src/types.ts
+++ b/packages/middleware-compactor/src/types.ts
@@ -5,7 +5,7 @@
 import type { MemoryComponent } from "@koi/core";
 import type { CompactionResult, TokenEstimator } from "@koi/core/context";
 import type { InboundMessage } from "@koi/core/message";
-import type { ModelHandler } from "@koi/core/middleware";
+import type { CapabilityFragment, ModelHandler } from "@koi/core/middleware";
 
 /**
  * Archives original messages before they are replaced by a summary.
@@ -68,7 +68,11 @@ export interface CompactorConfig {
   /** Override the default token estimator (4 chars/token heuristic). */
   readonly tokenEstimator?: TokenEstimator;
   /** Override the default summary prompt builder. */
-  readonly promptBuilder?: (messages: readonly InboundMessage[], maxTokens: number) => string;
+  readonly promptBuilder?: (
+    messages: readonly InboundMessage[],
+    maxTokens: number,
+    conventions?: readonly CapabilityFragment[],
+  ) => string;
   /** Memory component — auto-creates a fact-extracting archiver when set and `archiver` is omitted. */
   readonly memory?: MemoryComponent | undefined;
   /** Archive original messages before summarization. */
@@ -79,6 +83,8 @@ export interface CompactorConfig {
   readonly overflowRecovery?: OverflowRecoveryConfig;
   /** When true, describeCapabilities mentions the compact_context tool. */
   readonly toolEnabled?: boolean;
+  /** Convention fragments preserved through compaction cycles. */
+  readonly conventions?: readonly CapabilityFragment[] | undefined;
 }
 
 /**
@@ -92,9 +98,14 @@ export interface ResolvedCompactorConfig {
   readonly preserveRecent: number;
   readonly maxSummaryTokens: number;
   readonly tokenEstimator: TokenEstimator;
-  readonly promptBuilder: (messages: readonly InboundMessage[], maxTokens: number) => string;
+  readonly promptBuilder: (
+    messages: readonly InboundMessage[],
+    maxTokens: number,
+    conventions?: readonly CapabilityFragment[],
+  ) => string;
   readonly archiver: CompactionArchiver | undefined;
   readonly overflowRecovery: OverflowRecoveryConfig;
+  readonly conventions: readonly CapabilityFragment[];
 }
 
 interface CompactorDefaults {
@@ -103,6 +114,7 @@ interface CompactorDefaults {
   readonly preserveRecent: number;
   readonly maxSummaryTokens: number;
   readonly overflowRecovery: OverflowRecoveryConfig;
+  readonly conventions: readonly CapabilityFragment[];
 }
 
 export const COMPACTOR_DEFAULTS: CompactorDefaults = Object.freeze({
@@ -111,6 +123,7 @@ export const COMPACTOR_DEFAULTS: CompactorDefaults = Object.freeze({
   preserveRecent: 4,
   maxSummaryTokens: 1000,
   overflowRecovery: Object.freeze({ maxRetries: 1 }),
+  conventions: Object.freeze([]),
 });
 
 /** Named presets for common compactor configurations. */

--- a/packages/middleware-hot-memory/package.json
+++ b/packages/middleware-hot-memory/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/middleware-hot-memory",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/token-estimator": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/middleware-hot-memory/src/hot-memory-middleware.test.ts
+++ b/packages/middleware-hot-memory/src/hot-memory-middleware.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import type { MemoryComponent, MemoryResult } from "@koi/core";
+import type { InboundMessage } from "@koi/core/message";
+import { createMockTurnContext, createSpyModelHandler } from "@koi/test-utils";
+import { createHotMemoryMiddleware } from "./hot-memory-middleware.js";
+
+function userMsg(text: string): InboundMessage {
+  return { content: [{ kind: "text", text }], senderId: "user", timestamp: 1 };
+}
+
+function createMockMemory(results: readonly MemoryResult[] = []): MemoryComponent {
+  return {
+    recall: async () => results,
+    store: async () => {},
+  };
+}
+
+function createMemoryResult(content: string): MemoryResult {
+  return {
+    content,
+    score: 1.0,
+  };
+}
+
+describe("createHotMemoryMiddleware", () => {
+  const ctx = createMockTurnContext();
+
+  test("has name 'koi:hot-memory'", () => {
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(),
+    });
+    expect(mw.name).toBe("koi:hot-memory");
+  });
+
+  test("has priority 310", () => {
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(),
+    });
+    expect(mw.priority).toBe(310);
+  });
+
+  test("injects hot memories into model call", async () => {
+    const memories = [createMemoryResult("Remember: ESM only"), createMemoryResult("No mutation")];
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(memories),
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+
+    const passedMessages = spy.calls[0]?.messages;
+    expect(passedMessages).toBeDefined();
+    // Hot memory message should be prepended
+    expect(passedMessages?.[0]?.senderId).toBe("system:hot-memory");
+    expect(passedMessages?.[0]?.content[0]?.kind).toBe("text");
+    // Original messages preserved
+    expect(passedMessages?.[1]?.senderId).toBe("user");
+  });
+
+  test("injects hot memories into model stream", async () => {
+    const memories = [createMemoryResult("Hot fact")];
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(memories),
+    });
+
+    const messages = [userMsg("hello")];
+    let capturedMessages: readonly InboundMessage[] | undefined;
+    const handler = async function* (req: { readonly messages: readonly InboundMessage[] }) {
+      capturedMessages = req.messages;
+      yield { kind: "done" as const, response: { content: "ok", model: "test" } };
+    };
+
+    if (mw.wrapModelStream !== undefined) {
+      for await (const _chunk of mw.wrapModelStream(ctx, { messages }, handler)) {
+        /* drain */
+      }
+    }
+
+    expect(capturedMessages?.[0]?.senderId).toBe("system:hot-memory");
+    expect(capturedMessages?.[1]?.senderId).toBe("user");
+  });
+
+  test("no injection when recall returns empty", async () => {
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory([]),
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+
+    // Should pass through unmodified
+    expect(spy.calls[0]?.messages).toEqual(messages);
+  });
+
+  test("graceful degradation on recall error", async () => {
+    const failingMemory: MemoryComponent = {
+      recall: async () => {
+        throw new Error("recall failed");
+      },
+      store: async () => {},
+    };
+
+    const mw = createHotMemoryMiddleware({
+      memory: failingMemory,
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+    // Should not throw
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    // Should pass through unmodified (no cache after error)
+    expect(spy.calls[0]?.messages).toEqual(messages);
+  });
+
+  test("respects maxTokens budget", async () => {
+    // Create a memory that would exceed the budget
+    const longContent = "x".repeat(1000); // ~250 tokens
+    const memories = [createMemoryResult(longContent)];
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(memories),
+      maxTokens: 50, // 50 tokens = ~200 chars
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+
+    const hotMsg = spy.calls[0]?.messages?.[0];
+    expect(hotMsg?.senderId).toBe("system:hot-memory");
+    if (hotMsg?.content[0]?.kind === "text") {
+      // Should be truncated — length limited to ~200 chars + header
+      expect(hotMsg.content[0].text).toContain("...[truncated]");
+      expect(hotMsg.content[0].text.length).toBeLessThan(1000);
+    }
+  });
+
+  test("refreshes at correct interval", async () => {
+    let recallCount = 0;
+    const memory: MemoryComponent = {
+      recall: async () => {
+        recallCount++;
+        return [createMemoryResult("fact")];
+      },
+      store: async () => {},
+    };
+
+    const mw = createHotMemoryMiddleware({
+      memory,
+      refreshInterval: 3,
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+
+    // Turn 0: initial fetch (recallCount = 1) + refresh at turn 0 (but turn++ happens after)
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    expect(recallCount).toBe(1); // Initial fetch only
+
+    // Turns 1-2: no refresh
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+
+    // Wait for any fire-and-forget refreshes
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Turn 3 triggers refresh (turnCount=3, 3 % 3 === 0)
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Should have 1 (initial) + 1 (turn 3 refresh) = at least 2
+    expect(recallCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("describeCapabilities reports count and budget", async () => {
+    const memories = [createMemoryResult("fact A"), createMemoryResult("fact B")];
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory(memories),
+      maxTokens: 4000,
+    });
+
+    // Trigger initial fetch
+    const spy = createSpyModelHandler();
+    await mw.wrapModelCall?.(ctx, { messages: [userMsg("hello")] }, spy.handler);
+
+    const fragment = mw.describeCapabilities?.(ctx);
+    expect(fragment).toBeDefined();
+    expect(fragment?.label).toBe("hot-memory");
+    expect(fragment?.description).toContain("2 hot memories");
+    expect(fragment?.description).toContain("/4000 tokens");
+  });
+
+  test("describeCapabilities returns undefined when no hot memories", async () => {
+    const mw = createHotMemoryMiddleware({
+      memory: createMockMemory([]),
+    });
+
+    // Trigger initial fetch
+    const spy = createSpyModelHandler();
+    await mw.wrapModelCall?.(ctx, { messages: [userMsg("hello")] }, spy.handler);
+
+    const fragment = mw.describeCapabilities?.(ctx);
+    expect(fragment).toBeUndefined();
+  });
+
+  test("refreshInterval 0 means session start only", async () => {
+    let recallCount = 0;
+    const memory: MemoryComponent = {
+      recall: async () => {
+        recallCount++;
+        return [createMemoryResult("fact")];
+      },
+      store: async () => {},
+    };
+
+    const mw = createHotMemoryMiddleware({
+      memory,
+      refreshInterval: 0,
+    });
+
+    const messages = [userMsg("hello")];
+    const spy = createSpyModelHandler();
+
+    // Multiple turns — only initial fetch should happen
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+    await mw.wrapModelCall?.(ctx, { messages }, spy.handler);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(recallCount).toBe(1);
+  });
+});

--- a/packages/middleware-hot-memory/src/hot-memory-middleware.ts
+++ b/packages/middleware-hot-memory/src/hot-memory-middleware.ts
@@ -1,0 +1,156 @@
+/**
+ * Hot memory middleware — injects hot-tier memories into model calls.
+ *
+ * Priority 310: runs after context-editing (250) and context hydrator (300),
+ * so hot memories are the last system content injected before the model sees the request.
+ *
+ * Turn-interval caching: memories are fetched at session start and every N turns,
+ * avoiding redundant I/O on most turns.
+ */
+
+import type { MemoryResult } from "@koi/core";
+import type { InboundMessage } from "@koi/core/message";
+import type { CapabilityFragment, KoiMiddleware } from "@koi/core/middleware";
+import type { HotMemoryConfig } from "./types.js";
+import { HOT_MEMORY_DEFAULTS } from "./types.js";
+
+/** Format recalled memories into a single text block. */
+function formatMemories(memories: readonly MemoryResult[]): string {
+  return memories.map((m) => `- ${m.content}`).join("\n");
+}
+
+/** Heuristic token estimate: ~4 chars per token. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/** Truncate text to fit within a token budget using heuristic estimation. */
+function truncateToTokenBudget(text: string, maxTokens: number): string {
+  const maxChars = maxTokens * 4;
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}...[truncated]`;
+}
+
+/**
+ * Creates a middleware that injects hot-tier memories into model calls.
+ *
+ * On the first model call, hot memories are fetched synchronously (awaited).
+ * Subsequent refreshes happen at the configured turn interval.
+ * Errors during recall are logged and swallowed — the middleware never blocks model calls.
+ */
+export function createHotMemoryMiddleware(config: HotMemoryConfig): KoiMiddleware {
+  const memory = config.memory;
+  const maxTokens = config.maxTokens ?? HOT_MEMORY_DEFAULTS.maxTokens;
+  const refreshInterval = config.refreshInterval ?? HOT_MEMORY_DEFAULTS.refreshInterval;
+
+  // let justified: cached injection message, updated at refresh intervals
+  let cachedMessage: InboundMessage | undefined;
+  // let justified: turn counter since last refresh
+  let turnCount = 0;
+  // let justified: count of hot memories for capability reporting
+  let hotCount = 0;
+  // let justified: token count of current cached message for capability reporting
+  let cachedTokenCount = 0;
+  // let justified: tracks whether initial fetch has completed
+  let initialized = false;
+
+  async function fetchHotMemories(): Promise<void> {
+    try {
+      const results = await memory.recall("*", { tierFilter: "hot", limit: 20 });
+      if (results.length === 0) {
+        cachedMessage = undefined;
+        hotCount = 0;
+        cachedTokenCount = 0;
+        return;
+      }
+
+      const formatted = formatMemories(results);
+      const truncated = truncateToTokenBudget(formatted, maxTokens);
+      cachedTokenCount = estimateTokens(truncated);
+      hotCount = results.length;
+
+      cachedMessage = {
+        content: [
+          {
+            kind: "text",
+            text: `[Hot Memories]\n${truncated}`,
+          },
+        ],
+        senderId: "system:hot-memory",
+        timestamp: Date.now(),
+      };
+    } catch (_e: unknown) {
+      console.warn("[middleware-hot-memory] recall() failed (swallowed)");
+      // Keep existing cache on error — graceful degradation
+    }
+  }
+
+  function shouldRefresh(): boolean {
+    if (refreshInterval === 0) return false; // session start only
+    return turnCount % refreshInterval === 0;
+  }
+
+  return {
+    name: "koi:hot-memory",
+    priority: 310,
+
+    describeCapabilities(): CapabilityFragment | undefined {
+      if (hotCount === 0) return undefined;
+      return {
+        label: "hot-memory",
+        description: `${String(hotCount)} hot memories injected (${String(cachedTokenCount)}/${String(maxTokens)} tokens)`,
+      };
+    },
+
+    async wrapModelCall(_ctx, request, next) {
+      // Initial load on first call
+      if (!initialized) {
+        initialized = true;
+        await fetchHotMemories();
+      }
+
+      // Prepend cached hot memories if available
+      const effectiveRequest =
+        cachedMessage !== undefined
+          ? { ...request, messages: [cachedMessage, ...request.messages] }
+          : request;
+
+      const result = await next(effectiveRequest);
+
+      // Post-call: increment turn, schedule async refresh if needed
+      turnCount++;
+      if (shouldRefresh()) {
+        // Fire-and-forget refresh for next turn
+        fetchHotMemories().catch((_e: unknown) => {
+          console.warn("[middleware-hot-memory] background refresh failed (swallowed)");
+        });
+      }
+
+      return result;
+    },
+
+    async *wrapModelStream(_ctx, request, next) {
+      // Initial load on first call
+      if (!initialized) {
+        initialized = true;
+        await fetchHotMemories();
+      }
+
+      // Prepend cached hot memories if available
+      const effectiveRequest =
+        cachedMessage !== undefined
+          ? { ...request, messages: [cachedMessage, ...request.messages] }
+          : request;
+
+      yield* next(effectiveRequest);
+
+      // Post-stream: increment turn, schedule async refresh if needed
+      turnCount++;
+      if (shouldRefresh()) {
+        fetchHotMemories().catch((_e: unknown) => {
+          console.warn("[middleware-hot-memory] background refresh failed (swallowed)");
+        });
+      }
+    },
+  };
+}

--- a/packages/middleware-hot-memory/src/index.ts
+++ b/packages/middleware-hot-memory/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @koi/middleware-hot-memory — Hot-tier memory injection (Layer 2)
+ *
+ * Injects hot-tier memories into model calls at configurable intervals.
+ * Depends on @koi/core only.
+ */
+
+export { createHotMemoryMiddleware } from "./hot-memory-middleware.js";
+export type { HotMemoryConfig, HotMemoryDefaults } from "./types.js";
+export { HOT_MEMORY_DEFAULTS } from "./types.js";

--- a/packages/middleware-hot-memory/src/types.ts
+++ b/packages/middleware-hot-memory/src/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Configuration types for the middleware-hot-memory package.
+ */
+
+import type { TokenEstimator } from "@koi/core/context";
+import type { MemoryComponent } from "@koi/core/ecs";
+
+/** User-facing configuration for createHotMemoryMiddleware. */
+export interface HotMemoryConfig {
+  /** Memory component to recall hot-tier memories from. */
+  readonly memory: MemoryComponent;
+  /** Max tokens for the injected hot memory block. Default: 4000. */
+  readonly maxTokens?: number | undefined;
+  /** Turns between refreshes. Default: 5. 0 = session start only. */
+  readonly refreshInterval?: number | undefined;
+  /** Override the default token estimator. */
+  readonly tokenEstimator?: TokenEstimator | undefined;
+}
+
+export interface HotMemoryDefaults {
+  readonly maxTokens: number;
+  readonly refreshInterval: number;
+}
+
+export const HOT_MEMORY_DEFAULTS: HotMemoryDefaults = Object.freeze({
+  maxTokens: 4_000,
+  refreshInterval: 5,
+});

--- a/packages/middleware-hot-memory/tsconfig.json
+++ b/packages/middleware-hot-memory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../token-estimator" }]
+}

--- a/packages/middleware-hot-memory/tsup.config.ts
+++ b/packages/middleware-hot-memory/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements #657 — Convention Survival + Tier-Aware Context Injection.

- **Convention preservation**: Project conventions (ESM-only, no mutation, etc.) now survive LLM-based context compaction. Conventions are injected into the compaction prompt with "preserve verbatim" instructions and code-level prepended to every summary message as a belt-and-suspenders guarantee.
- **Hot-tier memory injection**: New `@koi/middleware-hot-memory` (L2, priority 310) automatically injects recently-accessed memories into model calls using `memory.recall("*", { tierFilter: "hot" })` with turn-interval caching. Zero LLM cost — pure file I/O on refresh, cached message reuse between intervals.
- **Arena wiring**: Both features wired into `@koi/context-arena` (L3) alongside existing preference (410) and personalization (420) middleware with preset-driven budget allocation.

### Changes by phase

| Phase | Package | What |
|-------|---------|------|
| 1 (L0) | `@koi/core` | Add `conventions` field to `AgentManifest` |
| 2 (L2) | `@koi/middleware-compactor` | `formatConventionBlock()`, convention-aware `buildSummaryPrompt()`, convention prepend to summaries, budget warning at 20% |
| 3 (L2) | `@koi/middleware-hot-memory` | **New package** — hot-tier recall, turn-interval caching, graceful degradation |
| 4 (L3) | `@koi/context-arena` | Wire hot-memory + conventions into arena factory, presets, config resolution |
| Docs | `docs/L2/` | `middleware-hot-memory.md` |

### New L2 package: `@koi/middleware-hot-memory`

- Priority 310, name `koi:hot-memory`
- Recall: `memory.recall("*", { tierFilter: "hot", limit: 20 })`
- Caches formatted message, refreshes every N turns (default 5)
- Preset budgets: conservative 3K/8 turns, balanced 4K/5 turns, aggressive 6K/3 turns
- Error handling: swallow + warn, keep stale cache

### Verification

- 767+ tests pass across core, compactor, hot-memory, arena
- Typecheck clean (270 packages)
- Layer check passed
- Lint clean on all affected packages

Closes #657

## Test plan

- [x] Convention block prepended to compaction summaries
- [x] Conventions survive 2+ compaction cycles (multi-cycle test)
- [x] `describeCapabilities` includes convention labels
- [x] Hot memories injected into model calls and streams
- [x] Graceful degradation on recall error (warning, no crash)
- [x] Token budget respected (memories truncated when over)
- [x] Refresh interval honored (recall at turns 0, 5, 10)
- [x] Arena feature matrix: all 5 combinations tested (no features, conventions only, memoryFs only, both, disabled hot memory)
- [x] Middleware counts correct with preference + personalization + hot-memory