### PR TITLE
feat: @koi/knowledge-vault — description, FileSystemBackend, scope integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1009,6 +1009,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/knowledge-vault": {
+      "name": "@koi/knowledge-vault",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/scope": "workspace:*",
+        "@koi/search-provider": "workspace:*",
+        "@koi/token-estimator": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/long-running": {
       "name": "@koi/long-running",
       "version": "0.0.0",
@@ -2804,6 +2817,8 @@
     "@koi/hash": ["@koi/hash@workspace:packages/hash"],
 
     "@koi/ipc-nexus": ["@koi/ipc-nexus@workspace:packages/ipc-nexus"],
+
+    "@koi/knowledge-vault": ["@koi/knowledge-vault@workspace:packages/knowledge-vault"],
 
     "@koi/long-running": ["@koi/long-running@workspace:packages/long-running"],
 

--- a/docs/L2/knowledge-vault.md
+++ b/docs/L2/knowledge-vault.md
@@ -1,0 +1,489 @@
+# @koi/knowledge-vault — Business Context Hydration from Structured Knowledge Bases
+
+Hydrates agent context from markdown directories, pre-built indexes, or Nexus endpoints using BM25 ranking and token-budget-aware selection. Attaches a `KNOWLEDGE` ECS component so agents can query domain knowledge at runtime.
+
+---
+
+## Why It Exists
+
+Specialized agents fail when they lack business context. An orchestrator reading from a knowledge base can inject targeted domain information into each agent's prompt — but this requires scanning, indexing, ranking, and budget-aware selection of documents. Without it, every agent integration reinvents document discovery, relevance scoring, and token budgeting.
+
+`@koi/knowledge-vault` solves this with a single `ComponentProvider` factory that:
+- Scans multiple knowledge sources (directories, indexes, Nexus endpoints)
+- Builds a BM25 search index with title/tag boosting
+- Selects results within a token budget with cross-source diversity guarantees
+- Exposes a `KNOWLEDGE` component for runtime queries
+
+---
+
+## What This Enables
+
+### Domain-Agnostic Context Hydration
+
+Any agent can be hydrated with business context from structured knowledge bases:
+
+```
+                  ┌───────────────────────────────────────────────────┐
+                  │           Your Koi Agent (YAML)                   │
+                  │  name: "billing-analyst"                          │
+                  │  model: anthropic:claude-sonnet                   │
+                  │  providers: [knowledge-vault]                     │
+                  └──────────────────┬────────────────────────────────┘
+                                     │
+                  ┌──────────────────▼──────────────────────────────┐
+                  │     createKnowledgeVaultProvider(config)         │
+                  │                                                  │
+                  │  1. Scan sources (directory, index, nexus)       │
+                  │  2. Parse frontmatter (title, tags)              │
+                  │  3. Build BM25 index                             │
+                  │  4. Expose KNOWLEDGE component                   │
+                  │                                                  │
+                  │  ┌────────────┐  ┌──────────┐  ┌──────────────┐ │
+                  │  │ Directory  │  │  Index   │  │    Nexus     │ │
+                  │  │  (local/   │  │ (search  │  │  (remote     │ │
+                  │  │  backend)  │  │  engine) │  │   endpoint)  │ │
+                  │  └────────────┘  └──────────┘  └──────────────┘ │
+                  └──────────────────┬──────────────────────────────┘
+                                     │
+                  ┌──────────────────▼──────────────────────────────┐
+                  │              Runtime Query                       │
+                  │                                                  │
+                  │  component.query("billing API rate limits")      │
+                  │    → BM25 search → budget selection → documents  │
+                  └─────────────────────────────────────────────────┘
+```
+
+### Domain Examples
+
+| Domain | Knowledge sources | Agent gets |
+|--------|-------------------|-----------|
+| **Coding** | Architecture docs, API contracts, style guides | Precise technical context for code generation |
+| **Support** | Product docs, escalation policies, FAQ | Domain knowledge for customer responses |
+| **Research** | Market reports, academic papers, prior findings | Background for analysis and synthesis |
+| **Legal** | Contract templates, regulatory requirements | Compliance context for document review |
+
+### Before vs After
+
+```
+BEFORE: Agent has no business context
+══════════════════════════════════════
+
+  Agent: "What are the billing API rate limits?"
+  → No knowledge source configured
+  → Agent hallucinates or asks the user
+
+AFTER: Agent queries knowledge vault
+═════════════════════════════════════
+
+  Agent: "What are the billing API rate limits?"
+  → KNOWLEDGE.query("billing API rate limits")
+  → BM25 ranks billing-api.md highest (score: 0.87)
+  → Returns: "Rate limits: 100 req/min for free tier, 1000 for pro..."
+  → Agent responds with accurate, sourced information
+```
+
+### FileSystemBackend Support
+
+Directory sources can use any `FileSystemBackend` implementation — not just local disk:
+
+```
+BEFORE: Local-only (Bun.file)
+═════════════════════════════
+
+  sources: [{ kind: "directory", path: "/docs" }]
+  → Bun.Glob scans local filesystem
+  → Only works on the machine where docs live
+
+AFTER: Any FileSystemBackend
+════════════════════════════
+
+  sources: [{ kind: "directory", path: "/docs", backend: nexusBackend }]
+  → backend.list() discovers files remotely
+  → backend.read() fetches content over network
+  → Works with Nexus, S3, in-memory mocks, etc.
+```
+
+### Scope Enforcement
+
+Path boundary enforcement prevents agents from reading outside their allowed root:
+
+```
+  config: {
+    sources: [{ kind: "directory", path: "/project/docs", backend }],
+    scope: { root: "/project/docs", mode: "ro" }
+  }
+
+  → backend is wrapped with createScopedFileSystem()
+  → Path traversal attempts are blocked
+  → Read-only mode prevents writes through the backend
+```
+
+---
+
+## Architecture
+
+`@koi/knowledge-vault` is an **L2 feature package**.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  @koi/knowledge-vault  (L2)                           │
+│                                                       │
+│  types.ts                ← config, component, tokens  │
+│  vault-service.ts        ← orchestration + BM25 index │
+│  component-provider.ts   ← ComponentProvider factory   │
+│  context-source-adapter.ts ← @koi/context integration │
+│                                                       │
+│  source-directory.ts     ← scan dirs (Bun or backend) │
+│  source-index.ts         ← query pre-built indexes    │
+│  source-nexus.ts         ← fetch from Nexus endpoints │
+│                                                       │
+│  bm25.ts                 ← BM25 ranking engine        │
+│  selector.ts             ← budget-aware selection      │
+│  frontmatter.ts          ← YAML frontmatter parser    │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  External deps: NONE                                  │
+│                                                       │
+├───────────────────────────────────────────────────────┤
+│  Internal deps                                        │
+│  ● @koi/core (L0) — SubsystemToken, TokenEstimator,  │
+│    FileSystemBackend, Result, KoiError                │
+│  ● @koi/scope (L0u) — createScopedFileSystem          │
+│  ● @koi/search-provider (L0u) — Retriever interface   │
+│  ● @koi/token-estimator (L0u) — HEURISTIC_ESTIMATOR  │
+│                                                       │
+│  Dev-only                                             │
+│  ● @koi/test-utils — test helpers                     │
+└───────────────────────────────────────────────────────┘
+```
+
+### Layer Position
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    SubsystemToken, TokenEstimator,                    │
+    FileSystemBackend, KoiError, Result                │
+                                                       │
+L0u @koi/scope ───────────────────────────────────────┤
+    createScopedFileSystem, FileSystemScope             │
+                                                       │
+L0u @koi/search-provider ────────────────────────────┤
+    Retriever                                          │
+                                                       │
+L0u @koi/token-estimator ────────────────────────────┤
+    HEURISTIC_ESTIMATOR                                │
+                                                       │
+                                                       ▼
+L2  @koi/knowledge-vault ◄────────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ All interface properties readonly
+    ✓ FileSystemBackend abstraction (not Bun-locked)
+    ✓ Scope enforcement via @koi/scope composition
+```
+
+### Internal Structure
+
+```
+createKnowledgeVaultProvider(config)
+│
+├── config.sources[]       → Knowledge source configs
+│     ├── directory        → Local or backend-based file scanning
+│     ├── index            → Pre-built search index (Retriever)
+│     └── nexus            → Remote Nexus endpoint
+│
+├── config.tokenBudget?    → 4000 (default)
+├── config.relevanceThreshold? → 0.0 (default)
+├── config.scope?          → FileSystemScope (optional boundary enforcement)
+│
+└── attach(agent) → Map<SubsystemToken, KnowledgeComponent>
+    │
+    └── KNOWLEDGE token → {
+          sources: KnowledgeSourceInfo[]     ← name, kind, description, docCount
+          query(q, limit?) → KnowledgeDocument[]  ← BM25 + budget selection
+          refresh() → RefreshResult               ← re-scan all sources
+        }
+```
+
+---
+
+## Pipeline
+
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│   Sources    │───>│   Parsing    │───>│   Indexing   │───>│   Querying   │
+│              │    │              │    │              │    │              │
+│ • Directory  │    │ • Frontmatter│    │ • BM25 index │    │ • BM25 search│
+│   (Bun/      │    │   extraction │    │ • Title boost│    │ • Budget     │
+│    Backend)  │    │ • Title/tags │    │ • Tag boost  │    │   selection  │
+│ • Index      │    │ • Truncation │    │              │    │ • Diversity  │
+│ • Nexus      │    │ • Token est. │    │              │    │   guarantee  │
+└──────────────┘    └──────────────┘    └──────────────┘    └──────────────┘
+```
+
+### BM25 Configuration
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| k1 | 1.5 | Term frequency saturation |
+| b | 0.75 | Document length normalization |
+| titleBoost | 3.0 | Weight multiplier for title matches |
+| tagBoost | 2.0 | Weight multiplier for tag matches |
+
+### Budget Selection
+
+The selector enforces two guarantees:
+1. **Token budget**: Total selected document tokens stay within `tokenBudget`
+2. **Source diversity**: At least one document from each source (if budget allows)
+
+---
+
+## Usage
+
+### Basic — Local Directory
+
+```typescript
+import { createKnowledgeVaultProvider } from "@koi/knowledge-vault";
+
+const provider = createKnowledgeVaultProvider({
+  sources: [
+    {
+      kind: "directory",
+      path: "/project/docs",
+      name: "project-docs",
+      description: "Internal engineering documentation",
+    },
+  ],
+  tokenBudget: 4000,
+});
+```
+
+### Remote Filesystem via Backend
+
+```typescript
+import { createKnowledgeVaultProvider } from "@koi/knowledge-vault";
+
+const provider = createKnowledgeVaultProvider({
+  sources: [
+    {
+      kind: "directory",
+      path: "/docs",
+      name: "remote-docs",
+      description: "Documentation stored on Nexus",
+      backend: nexusFileSystemBackend,  // any FileSystemBackend implementation
+    },
+  ],
+});
+```
+
+### Scoped + Backend (sandboxed remote access)
+
+```typescript
+import { createKnowledgeVaultProvider } from "@koi/knowledge-vault";
+
+const provider = createKnowledgeVaultProvider({
+  sources: [
+    {
+      kind: "directory",
+      path: "/project/docs",
+      backend: remoteBackend,
+      description: "Scoped engineering docs",
+    },
+  ],
+  scope: { root: "/project/docs", mode: "ro" },
+  // backend is wrapped with createScopedFileSystem() automatically
+});
+```
+
+### Multiple Sources
+
+```typescript
+const provider = createKnowledgeVaultProvider({
+  sources: [
+    {
+      kind: "directory",
+      path: "/docs/api",
+      name: "api-docs",
+      description: "API reference and contracts",
+    },
+    {
+      kind: "directory",
+      path: "/docs/arch",
+      name: "architecture",
+      description: "Architecture decisions and patterns",
+    },
+    {
+      kind: "nexus",
+      endpoint: "https://nexus.internal/knowledge",
+      name: "shared-knowledge",
+      description: "Organization-wide knowledge base",
+    },
+  ],
+  tokenBudget: 8000,
+  relevanceThreshold: 0.1,
+});
+```
+
+### Runtime Query
+
+```typescript
+import { KNOWLEDGE } from "@koi/knowledge-vault";
+
+// In middleware or agent code:
+const knowledge = agent.component(KNOWLEDGE);
+
+// Query for relevant documents
+const docs = await knowledge.query("authentication JWT tokens", 5);
+for (const doc of docs) {
+  console.log(`${doc.title} (score: ${doc.relevanceScore})`);
+  console.log(doc.content);
+}
+
+// Check source metadata
+for (const source of knowledge.sources) {
+  console.log(`${source.name}: ${source.documentCount} docs — ${source.description}`);
+}
+
+// Re-scan all sources
+const refreshResult = await knowledge.refresh();
+```
+
+### Context Source Adapter
+
+```typescript
+import { createKnowledgeSourceResolver, createVaultService } from "@koi/knowledge-vault";
+
+const result = await createVaultService(config);
+if (result.ok) {
+  const resolver = createKnowledgeSourceResolver(result.value);
+  // Register with @koi/context hydrator
+  resolvers.set("knowledge", resolver);
+}
+```
+
+---
+
+## Configuration Reference
+
+### KnowledgeVaultConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sources` | `KnowledgeSourceConfig[]` | (required) | Knowledge source configurations |
+| `tokenBudget` | `number` | 4000 | Max tokens for query results |
+| `relevanceThreshold` | `number` | 0.0 | Min BM25 score to include (0-1) |
+| `maxIndexCharsPerDoc` | `number` | 2000 | Max chars indexed per document |
+| `maxWarnings` | `number` | 50 | Max warnings before truncation |
+| `scope` | `FileSystemScope` | (none) | Path boundary enforcement for directory backends |
+
+### DirectorySourceConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `kind` | `"directory"` | (required) | Source type discriminator |
+| `name` | `string` | auto-generated | Human-readable source name |
+| `description` | `string` | (none) | What this source contains |
+| `path` | `string` | (required) | Root directory path |
+| `glob` | `string` | `"**/*.md"` | File discovery pattern |
+| `exclude` | `string[]` | (none) | Glob patterns to exclude |
+| `backend` | `FileSystemBackend` | (none) | Custom filesystem backend (default: Bun APIs) |
+
+### IndexSourceConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | `"index"` | Source type discriminator |
+| `name` | `string` | Human-readable source name |
+| `description` | `string` | What this source contains |
+| `backend` | `Retriever<unknown>` | Search backend implementing Retriever interface |
+
+### NexusSourceConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | `"nexus"` | Source type discriminator |
+| `name` | `string` | Human-readable source name |
+| `description` | `string` | What this source contains |
+| `endpoint` | `string` | Nexus knowledge endpoint URL |
+
+---
+
+## Testing
+
+### Test Structure
+
+```
+packages/knowledge-vault/src/
+  bm25.test.ts                   BM25: IDF, TF, normalization, edge cases
+  frontmatter.test.ts            Frontmatter: YAML parsing, edge cases
+  selector.test.ts               Selector: budget, diversity, edge cases
+  source-directory.test.ts       Directory: Bun path, backend path, errors
+  source-index.test.ts           Index: Retriever integration
+  source-nexus.test.ts           Nexus: HTTP endpoint with real server
+  vault-service.test.ts          Service: orchestration, description, scope
+  component-provider.test.ts     Provider: attach, refresh, descriptions
+  __tests__/e2e.test.ts          E2E: full pipeline, edge cases, backend
+```
+
+### Coverage
+
+80 tests total, 0 failures. Covers all source types, error paths, edge cases, and the full pipeline.
+
+```bash
+# Run all knowledge-vault tests
+bun test --cwd packages/knowledge-vault
+
+# Type-check
+bun run --cwd packages/knowledge-vault typecheck
+
+# Build
+bun run --cwd packages/knowledge-vault build
+```
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| BM25 over vector search | Zero dependencies, works offline, no embedding model needed. Semantic search can be layered via `IndexSourceConfig` + `@koi/search-nexus` |
+| Token budget selection | Prevents context window overflow — agents get the most relevant docs that fit |
+| Source diversity guarantee | When multiple sources exist, at least one doc from each prevents single-source dominance |
+| `FileSystemBackend` abstraction | Directory source works with local disk, Nexus FS, S3, or in-memory mocks |
+| Scope composition (not inheritance) | `createScopedFileSystem()` wraps the backend — same pattern as `@koi/filesystem` |
+| `description` on sources | Agents and orchestrators can understand what each source contains without reading its documents |
+| Frontmatter parsing | Compatible with Obsidian, Hugo, Jekyll, and any YAML-frontmatter markdown |
+| No refresh timer | v1 is pull-based (`refresh()`) — push-based watchers can be added later without API changes |
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ────────────────────────────────────────┐
+    SubsystemToken, TokenEstimator,                    │
+    FileSystemBackend, FileReadResult, FileListResult,  │
+    KoiError, Result                                   │
+                                                       │
+L0u @koi/scope ───────────────────────────────────────┤
+    createScopedFileSystem, FileSystemScope             │
+                                                       │
+L0u @koi/search-provider ────────────────────────────┤
+    Retriever                                          │
+                                                       │
+L0u @koi/token-estimator ────────────────────────────┤
+    HEURISTIC_ESTIMATOR                                │
+                                                       │
+                                                       ▼
+L2  @koi/knowledge-vault ◄────────────────────────────┘
+    imports from L0 + L0u only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ zero external npm dependencies
+    ✓ FileSystemBackend abstraction (not Bun-locked)
+    ✓ Scope enforcement via @koi/scope composition
+    ✓ All interface properties readonly
+    ✓ Immutable return values throughout
+```

--- a/packages/knowledge-vault/package.json
+++ b/packages/knowledge-vault/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/knowledge-vault",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/scope": "workspace:*",
+    "@koi/search-provider": "workspace:*",
+    "@koi/token-estimator": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/knowledge-vault/src/__tests__/e2e.test.ts
+++ b/packages/knowledge-vault/src/__tests__/e2e.test.ts
@@ -1,0 +1,512 @@
+/**
+ * End-to-end integration tests for the knowledge vault pipeline.
+ *
+ * Tests the full flow: scan → index → query → select using real
+ * temp directories with markdown files.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Agent, AttachResult, FileSystemBackend, KoiError, Result } from "@koi/core";
+import { isAttachResult } from "@koi/core";
+import { createKnowledgeVaultProvider } from "../component-provider.js";
+import { createKnowledgeSourceResolver } from "../context-source-adapter.js";
+import type { KnowledgeComponent, KnowledgeVaultConfig } from "../types.js";
+import { KNOWLEDGE } from "../types.js";
+import { createVaultService } from "../vault-service.js";
+
+interface TestDoc {
+  readonly path: string;
+  readonly frontmatter?: Readonly<Record<string, string | readonly string[]>>;
+  readonly body: string;
+}
+
+const tempDirs: string[] = [];
+
+async function createTestVault(docs: readonly TestDoc[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kv-e2e-"));
+  tempDirs.push(dir);
+
+  for (const doc of docs) {
+    const parts: string[] = [];
+    if (doc.frontmatter !== undefined) {
+      parts.push("---");
+      for (const [key, value] of Object.entries(doc.frontmatter)) {
+        if (Array.isArray(value)) {
+          parts.push(`${key}: [${value.join(", ")}]`);
+        } else {
+          parts.push(`${key}: ${value}`);
+        }
+      }
+      parts.push("---");
+    }
+    parts.push(doc.body);
+    await Bun.write(join(dir, doc.path), parts.join("\n"));
+  }
+
+  return dir;
+}
+
+// Agent stub — provider/resolver ignores the agent param, so cast is safe
+const stubAgent = {} as Agent;
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("e2e: full pipeline", () => {
+  test("happy path: 10-doc vault → provider → attach → query", async () => {
+    const dir = await createTestVault([
+      {
+        path: "auth/jwt.md",
+        frontmatter: { title: "JWT Authentication", tags: ["auth", "jwt", "security"] },
+        body: "JSON Web Tokens for stateless authentication. Access tokens, refresh tokens, signing algorithms.",
+      },
+      {
+        path: "auth/oauth.md",
+        frontmatter: { title: "OAuth2 Flows", tags: ["auth", "oauth"] },
+        body: "Authorization code flow, PKCE, client credentials grant, implicit flow deprecation.",
+      },
+      {
+        path: "api/rest.md",
+        frontmatter: { title: "REST API Design", tags: ["api", "rest"] },
+        body: "Resource naming, HTTP methods, pagination, filtering, error responses, HATEOAS.",
+      },
+      {
+        path: "api/graphql.md",
+        frontmatter: { title: "GraphQL Schema", tags: ["api", "graphql"] },
+        body: "Schema definition language, resolvers, mutations, subscriptions, N+1 problem.",
+      },
+      {
+        path: "db/postgres.md",
+        frontmatter: { title: "PostgreSQL Guide", tags: ["database", "postgres"] },
+        body: "Table design, indexes, CTEs, window functions, JSONB, full-text search.",
+      },
+      {
+        path: "db/migrations.md",
+        frontmatter: { title: "Database Migrations", tags: ["database", "migrations"] },
+        body: "Schema versioning, up/down migrations, data migrations, zero-downtime migrations.",
+      },
+      {
+        path: "deploy/docker.md",
+        frontmatter: { title: "Docker Setup", tags: ["deploy", "docker"] },
+        body: "Dockerfile best practices, multi-stage builds, compose files, health checks.",
+      },
+      {
+        path: "deploy/k8s.md",
+        frontmatter: { title: "Kubernetes Deployment", tags: ["deploy", "kubernetes"] },
+        body: "Pods, deployments, services, ingress, ConfigMaps, secrets, horizontal pod autoscaler.",
+      },
+      {
+        path: "arch/patterns.md",
+        frontmatter: { title: "Architecture Patterns", tags: ["architecture"] },
+        body: "Domain-driven design, hexagonal architecture, CQRS, event sourcing.",
+      },
+      {
+        path: "arch/testing.md",
+        frontmatter: { title: "Testing Strategy", tags: ["testing"] },
+        body: "Unit tests, integration tests, contract tests, test pyramid, TDD workflow.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir, name: "architecture-docs" }],
+      tokenBudget: 4000,
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+
+    expect(isAttachResult(result)).toBe(true);
+    const attachResult = result as AttachResult;
+    expect(attachResult.skipped).toHaveLength(0);
+
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+
+    expect(component).toBeDefined();
+    expect(component.sources).toHaveLength(1);
+    expect(component.sources[0]?.documentCount).toBe(10);
+
+    // Query for authentication
+    const authDocs = await component.query("authentication JWT tokens");
+    expect(authDocs.length).toBeGreaterThanOrEqual(1);
+
+    // First result should be the JWT doc (most relevant)
+    const topDoc = authDocs[0]!;
+    expect(topDoc.title).toBe("JWT Authentication");
+    expect(topDoc.relevanceScore).toBeGreaterThan(0);
+
+    // Query for database
+    const dbDocs = await component.query("PostgreSQL schema migrations");
+    expect(dbDocs.length).toBeGreaterThanOrEqual(1);
+    const dbTitles = dbDocs.map((d) => d.title);
+    expect(dbTitles.includes("PostgreSQL Guide") || dbTitles.includes("Database Migrations")).toBe(
+      true,
+    );
+  });
+
+  test("empty vault: attach succeeds, query returns empty", async () => {
+    const dir = await createTestVault([]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+
+    expect(isAttachResult(result)).toBe(true);
+    const attachResult = result as AttachResult;
+
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+
+    expect(component).toBeDefined();
+    const docs = await component.query("anything");
+    expect(docs).toHaveLength(0);
+  });
+
+  test("mixed failures: good md + binary → warnings collected", async () => {
+    const dir = await createTestVault([
+      {
+        path: "good1.md",
+        frontmatter: { title: "Good Doc 1" },
+        body: "Valid markdown content one.",
+      },
+      {
+        path: "good2.md",
+        frontmatter: { title: "Good Doc 2" },
+        body: "Valid markdown content two.",
+      },
+      {
+        path: "good3.md",
+        frontmatter: { title: "Good Doc 3" },
+        body: "Valid markdown content three.",
+      },
+      {
+        path: "good4.md",
+        frontmatter: { title: "Good Doc 4" },
+        body: "Valid markdown content four.",
+      },
+      {
+        path: "good5.md",
+        frontmatter: { title: "Good Doc 5" },
+        body: "Valid markdown content five.",
+      },
+    ]);
+
+    // Write binary files
+    await Bun.write(
+      join(dir, "binary1.md"),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x0d, 0x0a]),
+    );
+    await Bun.write(join(dir, "binary2.md"), Buffer.from([0x00, 0x01, 0x02, 0x03]));
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const service = result.value;
+    // 5 good docs indexed
+    expect(service.sources[0]?.documentCount).toBe(5);
+
+    // Refresh should report warnings about binary files
+    const refreshResult = await service.refresh();
+    expect(refreshResult.documentCount).toBe(5);
+    expect(refreshResult.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("context source adapter produces formatted output", async () => {
+    const dir = await createTestVault([
+      {
+        path: "doc1.md",
+        frontmatter: { title: "Auth Guide" },
+        body: "Authentication concepts and patterns.",
+      },
+      {
+        path: "doc2.md",
+        frontmatter: { title: "API Guide" },
+        body: "API design principles and patterns.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const resolver = createKnowledgeSourceResolver(result.value);
+    const sourceResult = await resolver({ kind: "knowledge", query: "authentication" }, stubAgent);
+
+    expect(sourceResult.label).toBe("Knowledge Vault");
+    expect(sourceResult.content).toContain("Auth Guide");
+    expect(sourceResult.tokens).toBeGreaterThan(0);
+  });
+
+  test("context source adapter handles empty query", async () => {
+    const dir = await createTestVault([{ path: "doc.md", body: "Some content." }]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const resolver = createKnowledgeSourceResolver(result.value);
+    const sourceResult = await resolver({ kind: "knowledge" }, stubAgent);
+
+    expect(sourceResult.content).toBe("");
+    expect(sourceResult.tokens).toBe(0);
+  });
+});
+
+describe("e2e: edge cases", () => {
+  test("single-file vault works correctly", async () => {
+    const dir = await createTestVault([
+      {
+        path: "only.md",
+        frontmatter: { title: "Only Doc" },
+        body: "The only document in this vault.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("document");
+    expect(docs).toHaveLength(1);
+    expect(docs[0]?.title).toBe("Only Doc");
+  });
+
+  test("no frontmatter documents work correctly", async () => {
+    const dir = await createTestVault([
+      { path: "bare.md", body: "Just plain markdown content without any frontmatter." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("markdown");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+    expect(docs[0]?.tags).toEqual([]);
+  });
+
+  test("unicode content handled correctly", async () => {
+    const dir = await createTestVault([
+      {
+        path: "unicode.md",
+        frontmatter: { title: "Unicode Document" },
+        body: "Documenting internationalization: 日本語, 한국어, العربية, emoji 🎉",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("internationalization");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+    expect(docs[0]?.content).toContain("日本語");
+  });
+
+  test("zero-match query returns empty array (not error)", async () => {
+    const dir = await createTestVault([
+      { path: "doc.md", body: "Content about completely unrelated topics." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("xylophone");
+    expect(docs).toHaveLength(0);
+  });
+
+  test("duplicate tags are preserved as-is", async () => {
+    const dir = await createTestVault([
+      {
+        path: "dup.md",
+        frontmatter: { title: "Dup Tags", tags: ["api", "api", "auth"] },
+        body: "Document with duplicate tags.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("api auth");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("budget=0 returns nothing even when docs match", async () => {
+    const dir = await createTestVault([
+      { path: "doc.md", body: "Relevant content about testing." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+      tokenBudget: 0,
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("testing");
+    expect(docs).toHaveLength(0);
+  });
+
+  test("full pipeline with mock FileSystemBackend", async () => {
+    const files = new Map([
+      [
+        "guides/auth.md",
+        "---\ntitle: Authentication Guide\ntags: [auth, security]\n---\nJWT tokens, OAuth2 flows, session management.",
+      ],
+      [
+        "guides/api.md",
+        "---\ntitle: API Design Guide\ntags: [api, rest]\n---\nREST endpoints, pagination, error handling.",
+      ],
+      [
+        "guides/db.md",
+        "---\ntitle: Database Guide\ntags: [database, sql]\n---\nPostgreSQL schema, migrations, indexing.",
+      ],
+    ]);
+
+    const mockBackend: FileSystemBackend = {
+      name: "e2e-mock",
+      list: (_path, options) => {
+        const entries = [...files.keys()]
+          .filter((p) => {
+            if (options?.glob === undefined) return true;
+            const glob = new Bun.Glob(options.glob);
+            return glob.match(p);
+          })
+          .map((p) => ({ path: p, kind: "file" as const }));
+        return { ok: true, value: { entries, truncated: false } };
+      },
+      read: (path) => {
+        const content = files.get(path);
+        if (content === undefined) {
+          return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: `Not found: ${path}`, retryable: false },
+          } satisfies Result<never, KoiError>;
+        }
+        return { ok: true, value: { content, path, size: content.length } };
+      },
+      write: () => {
+        throw new Error("Not implemented");
+      },
+      edit: () => {
+        throw new Error("Not implemented");
+      },
+      search: () => {
+        throw new Error("Not implemented");
+      },
+    };
+
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        {
+          kind: "directory",
+          path: "/virtual",
+          name: "guides",
+          description: "Engineering guides",
+          backend: mockBackend,
+        },
+      ],
+      tokenBudget: 4000,
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+
+    expect(isAttachResult(result)).toBe(true);
+    const attachResult = result as AttachResult;
+    expect(attachResult.skipped).toHaveLength(0);
+
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+    expect(component).toBeDefined();
+    expect(component.sources).toHaveLength(1);
+    expect(component.sources[0]?.documentCount).toBe(3);
+    expect(component.sources[0]?.description).toBe("Engineering guides");
+
+    // Query for authentication
+    const authDocs = await component.query("authentication JWT");
+    expect(authDocs.length).toBeGreaterThanOrEqual(1);
+    expect(authDocs[0]?.title).toBe("Authentication Guide");
+
+    // Query for database
+    const dbDocs = await component.query("PostgreSQL schema");
+    expect(dbDocs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("multiple directory sources with diversity guarantee", async () => {
+    const dir1 = await createTestVault([
+      {
+        path: "auth-guide.md",
+        frontmatter: { title: "Auth from Source 1" },
+        body: "Authentication details from the first vault.",
+      },
+    ]);
+    const dir2 = await createTestVault([
+      {
+        path: "auth-reference.md",
+        frontmatter: { title: "Auth from Source 2" },
+        body: "Authentication details from the second vault.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        { kind: "directory", path: dir1, name: "vault-1" },
+        { kind: "directory", path: dir2, name: "vault-2" },
+      ],
+      tokenBudget: 4000,
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.sources).toHaveLength(2);
+    const docs = await result.value.query("authentication");
+    expect(docs.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/knowledge-vault/src/bm25.test.ts
+++ b/packages/knowledge-vault/src/bm25.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { createBM25Index } from "./bm25.js";
+
+describe("createBM25Index", () => {
+  const corpus = [
+    {
+      id: "auth",
+      text: "authentication login password security tokens jwt",
+      titleText: "Authentication Guide",
+      tagText: "auth security",
+    },
+    {
+      id: "api",
+      text: "api rest endpoints http json request response",
+      titleText: "API Reference",
+      tagText: "api http",
+    },
+    {
+      id: "db",
+      text: "database sql query tables schema migration index",
+      titleText: "Database Guide",
+      tagText: "database sql",
+    },
+    {
+      id: "deploy",
+      text: "deploy production server docker containers kubernetes",
+      titleText: "Deployment Guide",
+      tagText: "deploy ops",
+    },
+    {
+      id: "general",
+      text: "the application uses authentication and api and database and deploy for everything",
+      titleText: "Overview",
+      tagText: "general",
+    },
+  ];
+
+  test("rare terms score higher than common terms (IDF property)", () => {
+    const index = createBM25Index(corpus);
+
+    // "kubernetes" appears in 1 doc, "authentication" appears in 2
+    const kubeResults = index.search("kubernetes");
+    const authResults = index.search("authentication");
+
+    const kubeScore = kubeResults.find((r) => r.id === "deploy")?.score ?? 0;
+    const authScore = authResults.find((r) => r.id === "auth")?.score ?? 0;
+
+    // Rare term in its own doc should score high
+    expect(kubeScore).toBeGreaterThan(0);
+    expect(authScore).toBeGreaterThan(0);
+  });
+
+  test("more occurrences score higher (TF property with saturation)", () => {
+    const docsWithRepeats = [
+      { id: "many", text: "api api api api api other words" },
+      { id: "few", text: "api other words here and more words" },
+    ];
+    const index = createBM25Index(docsWithRepeats);
+    const results = index.search("api");
+
+    const manyScore = results.find((r) => r.id === "many")?.score ?? 0;
+    const fewScore = results.find((r) => r.id === "few")?.score ?? 0;
+
+    expect(manyScore).toBeGreaterThan(fewScore);
+  });
+
+  test("shorter docs with same term count score >= longer docs (length normalization)", () => {
+    const docsWithLength = [
+      { id: "short", text: "api endpoint reference" },
+      {
+        id: "long",
+        text: "api endpoint reference plus lots of additional filler words that dilute the relevance of the matching terms significantly",
+      },
+    ];
+    const index = createBM25Index(docsWithLength);
+    const results = index.search("api");
+
+    const shortScore = results.find((r) => r.id === "short")?.score ?? 0;
+    const longScore = results.find((r) => r.id === "long")?.score ?? 0;
+
+    expect(shortScore).toBeGreaterThanOrEqual(longScore);
+  });
+
+  test("scores are always >= 0", () => {
+    const index = createBM25Index(corpus);
+    const results = index.search("authentication api database");
+
+    for (const result of results) {
+      expect(result.score).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("empty query returns empty results", () => {
+    const index = createBM25Index(corpus);
+    const results = index.search("");
+    expect(results).toEqual([]);
+  });
+
+  test("query term not in corpus returns no results", () => {
+    const index = createBM25Index(corpus);
+    const results = index.search("xylophone");
+    expect(results).toEqual([]);
+  });
+
+  test("single document corpus works correctly", () => {
+    const index = createBM25Index([{ id: "only", text: "hello world" }]);
+    const results = index.search("hello");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe("only");
+    expect(results[0]?.score).toBeGreaterThan(0);
+  });
+
+  test("title matches score higher than body-only matches", () => {
+    const docs = [
+      {
+        id: "title-match",
+        text: "some general content about various things",
+        titleText: "authentication",
+      },
+      {
+        id: "body-match",
+        text: "authentication is discussed here among other topics",
+        titleText: "General Document",
+      },
+    ];
+    const index = createBM25Index(docs);
+    const results = index.search("authentication");
+
+    const titleScore = results.find((r) => r.id === "title-match")?.score ?? 0;
+    const bodyScore = results.find((r) => r.id === "body-match")?.score ?? 0;
+
+    expect(titleScore).toBeGreaterThan(bodyScore);
+  });
+
+  test("tag matches boost score", () => {
+    const docs = [
+      {
+        id: "tagged",
+        text: "some content here",
+        tagText: "security authentication",
+      },
+      {
+        id: "untagged",
+        text: "some content here about security",
+      },
+    ];
+    const index = createBM25Index(docs);
+    const results = index.search("security");
+
+    const taggedScore = results.find((r) => r.id === "tagged")?.score ?? 0;
+    const untaggedScore = results.find((r) => r.id === "untagged")?.score ?? 0;
+
+    expect(taggedScore).toBeGreaterThan(untaggedScore);
+  });
+
+  test("limit parameter caps result count", () => {
+    const index = createBM25Index(corpus);
+    const results = index.search("authentication api database", 2);
+    expect(results.length).toBeLessThanOrEqual(2);
+  });
+
+  test("documentCount reflects indexed corpus size", () => {
+    const index = createBM25Index(corpus);
+    expect(index.documentCount).toBe(5);
+  });
+
+  test("empty corpus returns empty search results", () => {
+    const index = createBM25Index([]);
+    expect(index.documentCount).toBe(0);
+    expect(index.search("anything")).toEqual([]);
+  });
+});

--- a/packages/knowledge-vault/src/bm25.ts
+++ b/packages/knowledge-vault/src/bm25.ts
@@ -1,0 +1,182 @@
+/**
+ * BM25 full-text search scoring.
+ *
+ * Hand-rolled implementation (~80 lines of logic). Zero external deps.
+ * Supports weighted fields (title, tags get higher weight than body).
+ */
+
+/** Immutable search index built from a document corpus. */
+export interface BM25Index {
+  readonly search: (query: string, limit?: number) => readonly BM25Result[];
+  readonly documentCount: number;
+}
+
+/** A single scored search result. */
+export interface BM25Result {
+  readonly id: string;
+  readonly score: number;
+}
+
+/** Input document for indexing. */
+export interface BM25Document {
+  readonly id: string;
+  readonly text: string;
+  readonly titleText?: string | undefined;
+  readonly tagText?: string | undefined;
+}
+
+/** Tuning parameters for BM25 scoring. */
+export interface BM25Config {
+  readonly k1?: number | undefined;
+  readonly b?: number | undefined;
+  readonly titleWeight?: number | undefined;
+  readonly tagWeight?: number | undefined;
+}
+
+const DEFAULT_K1 = 1.5;
+const DEFAULT_B = 0.75;
+const DEFAULT_TITLE_WEIGHT = 3.0;
+const DEFAULT_TAG_WEIGHT = 2.0;
+
+interface DocEntry {
+  readonly id: string;
+  readonly termFreqs: ReadonlyMap<string, number>;
+  readonly length: number;
+}
+
+/**
+ * Build an immutable BM25 index from a set of documents.
+ *
+ * Returns an index with a `search()` method that scores documents against
+ * a query string using BM25 with field-weighted boosting.
+ */
+export function createBM25Index(
+  documents: readonly BM25Document[],
+  config?: BM25Config,
+): BM25Index {
+  const k1 = config?.k1 ?? DEFAULT_K1;
+  const b = config?.b ?? DEFAULT_B;
+  const titleWeight = config?.titleWeight ?? DEFAULT_TITLE_WEIGHT;
+  const tagWeight = config?.tagWeight ?? DEFAULT_TAG_WEIGHT;
+
+  const entries: readonly DocEntry[] = documents.map((doc) => {
+    const weightedText = buildWeightedText(
+      doc.text,
+      doc.titleText,
+      doc.tagText,
+      titleWeight,
+      tagWeight,
+    );
+    const terms = tokenize(weightedText);
+    return {
+      id: doc.id,
+      termFreqs: computeTermFreqs(terms),
+      length: terms.length,
+    };
+  });
+
+  const n = entries.length;
+  const avgDl = n === 0 ? 0 : entries.reduce((sum, e) => sum + e.length, 0) / n;
+
+  // Pre-compute document frequency for each term
+  const docFreqs = new Map<string, number>();
+  for (const entry of entries) {
+    for (const term of entry.termFreqs.keys()) {
+      docFreqs.set(term, (docFreqs.get(term) ?? 0) + 1);
+    }
+  }
+
+  function search(query: string, limit?: number): readonly BM25Result[] {
+    const queryTerms = tokenize(query);
+    if (queryTerms.length === 0 || n === 0) {
+      return [];
+    }
+
+    const results: BM25Result[] = [];
+    for (const entry of entries) {
+      const score = computeScore(queryTerms, entry, n, avgDl, docFreqs, k1, b);
+      if (score > 0) {
+        results.push({ id: entry.id, score });
+      }
+    }
+
+    results.sort((a, b) => b.score - a.score);
+    return limit !== undefined ? results.slice(0, limit) : results;
+  }
+
+  return { search, documentCount: n };
+}
+
+function computeScore(
+  queryTerms: readonly string[],
+  entry: DocEntry,
+  n: number,
+  avgDl: number,
+  docFreqs: ReadonlyMap<string, number>,
+  k1: number,
+  b: number,
+): number {
+  // let is required — accumulating score across terms
+  let score = 0;
+  for (const term of queryTerms) {
+    const tf = entry.termFreqs.get(term) ?? 0;
+    if (tf === 0) continue;
+
+    const df = docFreqs.get(term) ?? 0;
+    // IDF: log((N - df + 0.5) / (df + 0.5) + 1)
+    const idf = Math.log((n - df + 0.5) / (df + 0.5) + 1);
+    // TF saturation with length normalization
+    const tfNorm = (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (entry.length / (avgDl || 1))));
+    score += idf * tfNorm;
+  }
+  return score;
+}
+
+function buildWeightedText(
+  body: string,
+  title: string | undefined,
+  tags: string | undefined,
+  titleWeight: number,
+  tagWeight: number,
+): string {
+  const parts: string[] = [body];
+  if (title !== undefined && title !== "") {
+    // Repeat title text to increase its weight
+    const titleRepeat = Math.round(titleWeight);
+    for (
+      // let is required — loop counter
+      let r = 0;
+      r < titleRepeat;
+      r++
+    ) {
+      parts.push(title);
+    }
+  }
+  if (tags !== undefined && tags !== "") {
+    const tagRepeat = Math.round(tagWeight);
+    for (
+      // let is required — loop counter
+      let r = 0;
+      r < tagRepeat;
+      r++
+    ) {
+      parts.push(tags);
+    }
+  }
+  return parts.join(" ");
+}
+
+function tokenize(text: string): readonly string[] {
+  return text
+    .toLowerCase()
+    .split(/[\s\-_/.,;:!?()[\]{}<>"'`~@#$%^&*+=|\\]+/)
+    .filter((t) => t.length > 0);
+}
+
+function computeTermFreqs(terms: readonly string[]): ReadonlyMap<string, number> {
+  const freqs = new Map<string, number>();
+  for (const term of terms) {
+    freqs.set(term, (freqs.get(term) ?? 0) + 1);
+  }
+  return freqs;
+}

--- a/packages/knowledge-vault/src/component-provider.test.ts
+++ b/packages/knowledge-vault/src/component-provider.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Agent, AttachResult } from "@koi/core";
+import { isAttachResult } from "@koi/core";
+import { createKnowledgeVaultProvider } from "./component-provider.js";
+import type { KnowledgeComponent, KnowledgeVaultConfig } from "./types.js";
+import { KNOWLEDGE } from "./types.js";
+
+const tempDirs: string[] = [];
+
+async function createTestVault(
+  docs: readonly { readonly path: string; readonly content: string }[],
+): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kv-cp-"));
+  tempDirs.push(dir);
+  for (const doc of docs) {
+    await Bun.write(join(dir, doc.path), doc.content);
+  }
+  return dir;
+}
+
+// Agent stub — attach() ignores the agent param, so cast is safe
+const stubAgent = {} as Agent;
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("createKnowledgeVaultProvider", () => {
+  test("creates provider with correct name", () => {
+    const config: KnowledgeVaultConfig = { sources: [] };
+    const provider = createKnowledgeVaultProvider(config);
+    expect(provider.name).toBe("knowledge-vault");
+  });
+
+  test("attach returns KNOWLEDGE component with valid service", async () => {
+    const dir = await createTestVault([
+      {
+        path: "doc.md",
+        content: "---\ntitle: Test Doc\ntags: [test]\n---\nTest content about testing.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+
+    expect(isAttachResult(result)).toBe(true);
+    const attachResult = result as AttachResult;
+    expect(attachResult.skipped).toHaveLength(0);
+
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+    expect(component).toBeDefined();
+    expect(component.sources).toHaveLength(1);
+
+    // Verify query works
+    const docs = await component.query("testing");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("attach returns skipped component on failure", async () => {
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        {
+          kind: "directory",
+          path: "/nonexistent/path/that/does/not/exist",
+        },
+      ],
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+
+    // Even with a bad path, service creation succeeds (0 docs + warnings)
+    expect(isAttachResult(result)).toBe(true);
+    const attachResult = result as AttachResult;
+    // The directory scan may produce 0 docs but not fail entirely
+    expect(attachResult.components.has(KNOWLEDGE as string)).toBe(true);
+  });
+
+  test("detach is a no-op", async () => {
+    const config: KnowledgeVaultConfig = { sources: [] };
+    const provider = createKnowledgeVaultProvider(config);
+    // Should not throw
+    await provider.detach?.(stubAgent);
+  });
+
+  test("refresh rebuilds knowledge component state", async () => {
+    const dir = await createTestVault([
+      { path: "initial.md", content: "Initial content about auth." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+    const attachResult = result as AttachResult;
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+
+    expect(component.sources[0]?.documentCount).toBe(1);
+
+    // Add a file and refresh
+    await Bun.write(join(dir, "new.md"), "New content about deployment.");
+    const refreshResult = await component.refresh();
+    expect(refreshResult.documentCount).toBe(2);
+  });
+
+  test("provider surfaces source descriptions", async () => {
+    const dir = await createTestVault([
+      { path: "doc.md", content: "Test content about security." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        {
+          kind: "directory",
+          path: dir,
+          name: "security-docs",
+          description: "Security documentation for the platform",
+        },
+      ],
+    };
+
+    const provider = createKnowledgeVaultProvider(config);
+    const result = await provider.attach(stubAgent);
+    const attachResult = result as AttachResult;
+    const component = attachResult.components.get(KNOWLEDGE as string) as KnowledgeComponent;
+
+    expect(component).toBeDefined();
+    expect(component.sources).toHaveLength(1);
+    expect(component.sources[0]?.name).toBe("security-docs");
+    expect(component.sources[0]?.description).toBe("Security documentation for the platform");
+  });
+});

--- a/packages/knowledge-vault/src/component-provider.ts
+++ b/packages/knowledge-vault/src/component-provider.ts
@@ -1,0 +1,56 @@
+/**
+ * ComponentProvider factory for knowledge vault.
+ *
+ * Creates an ECS ComponentProvider that attaches a KNOWLEDGE component
+ * and optionally a `query_knowledge` tool to agents during assembly.
+ */
+
+import type { AttachResult, ComponentProvider } from "@koi/core";
+import type { KnowledgeComponent, KnowledgeVaultConfig } from "./types.js";
+import { KNOWLEDGE } from "./types.js";
+import type { VaultService } from "./vault-service.js";
+import { createVaultService } from "./vault-service.js";
+
+/**
+ * Create a ComponentProvider that hydrates agents with knowledge vault access.
+ *
+ * On `attach()`, scans configured sources, builds the BM25 index, and
+ * provides a `KNOWLEDGE` component for runtime queries.
+ */
+export function createKnowledgeVaultProvider(config: KnowledgeVaultConfig): ComponentProvider {
+  return {
+    name: "knowledge-vault",
+
+    attach: async (): Promise<AttachResult> => {
+      const result = await createVaultService(config);
+
+      if (!result.ok) {
+        return {
+          components: new Map<string, unknown>(),
+          skipped: [
+            {
+              name: "knowledge-vault",
+              reason: result.error.message,
+            },
+          ],
+        };
+      }
+
+      const service: VaultService = result.value;
+
+      const component: KnowledgeComponent = {
+        sources: service.sources,
+        query: service.query,
+        refresh: service.refresh,
+      };
+
+      const components = new Map<string, unknown>([[KNOWLEDGE as string, component]]);
+
+      return { components, skipped: [] };
+    },
+
+    detach: async (): Promise<void> => {
+      // No timers or watchers in v1 — no-op
+    },
+  };
+}

--- a/packages/knowledge-vault/src/context-source-adapter.ts
+++ b/packages/knowledge-vault/src/context-source-adapter.ts
@@ -1,0 +1,75 @@
+/**
+ * Context source adapter for @koi/context integration.
+ *
+ * Returns a SourceResolver function that can be registered with the
+ * context hydrator's `resolvers` Map under a custom source kind.
+ *
+ * Usage in L3 or application code:
+ * ```ts
+ * const resolvers = new Map([
+ *   ["knowledge", createKnowledgeSourceResolver(vaultService)],
+ * ]);
+ * ```
+ */
+
+import type { Agent } from "@koi/core";
+
+import type { VaultService } from "./vault-service.js";
+
+/**
+ * A SourceResolver-compatible function type.
+ *
+ * Matches the SourceResolver signature from @koi/context:
+ * `(source: ContextSource, agent: Agent) => SourceResult | Promise<SourceResult>`
+ *
+ * We define a local interface to avoid importing @koi/context (L2→L2 violation).
+ */
+export interface KnowledgeSourceResult {
+  readonly label: string;
+  readonly content: string;
+  readonly tokens: number;
+  readonly source: { readonly kind: string };
+}
+
+export type KnowledgeSourceResolver = (
+  source: { readonly kind: string; readonly query?: string; readonly label?: string },
+  agent: Agent,
+) => Promise<KnowledgeSourceResult>;
+
+/**
+ * Create a SourceResolver that queries the vault service.
+ *
+ * The resolver expects source objects with `kind: "knowledge"` and
+ * an optional `query` field. If no query is provided, it returns
+ * an empty result.
+ */
+export function createKnowledgeSourceResolver(service: VaultService): KnowledgeSourceResolver {
+  return async (
+    source: { readonly kind: string; readonly query?: string; readonly label?: string },
+    _agent: Agent,
+  ): Promise<KnowledgeSourceResult> => {
+    const query = source.query ?? "";
+    const label = source.label ?? "Knowledge Vault";
+
+    if (query === "") {
+      return {
+        label,
+        content: "",
+        tokens: 0,
+        source: { kind: source.kind },
+      };
+    }
+
+    const docs = await service.query(query);
+    const content = docs.map((doc) => `## ${doc.title}\n\n${doc.content}`).join("\n\n---\n\n");
+
+    const tokens = Math.ceil(content.length / 4);
+
+    return {
+      label,
+      content,
+      tokens,
+      source: { kind: source.kind },
+    };
+  };
+}

--- a/packages/knowledge-vault/src/frontmatter.test.ts
+++ b/packages/knowledge-vault/src/frontmatter.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { parseFrontmatter } from "./frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  test("returns empty metadata when no frontmatter present", () => {
+    const result = parseFrontmatter("Hello world\n\nSome content.");
+    expect(result.metadata).toEqual({});
+    expect(result.body).toBe("Hello world\n\nSome content.");
+  });
+
+  test("parses standard key-value pairs", () => {
+    const content = `---
+title: My Document
+author: Jane Doe
+---
+Body text here.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({
+      title: "My Document",
+      author: "Jane Doe",
+    });
+    expect(result.body).toBe("Body text here.");
+  });
+
+  test("parses inline tag list [a, b, c]", () => {
+    const content = `---
+tags: [api, auth, security]
+---
+Content.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({ tags: ["api", "auth", "security"] });
+  });
+
+  test("parses multi-line tag list", () => {
+    const content = `---
+tags:
+  - architecture
+  - design
+  - patterns
+---
+Content.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({
+      tags: ["architecture", "design", "patterns"],
+    });
+  });
+
+  test("strips # prefix from tags", () => {
+    const content = `---
+tags: [#api, #auth]
+---
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({ tags: ["api", "auth"] });
+  });
+
+  test("strips # prefix from multi-line tags", () => {
+    const content = `---
+tags:
+  - #api
+  - #auth
+---
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({ tags: ["api", "auth"] });
+  });
+
+  test("handles empty frontmatter block", () => {
+    const content = `---
+---
+Body content.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({});
+    expect(result.body).toBe("Body content.");
+  });
+
+  test("does not confuse --- in body with frontmatter delimiter", () => {
+    const content = `---
+title: Doc
+---
+Some text.
+
+---
+
+More text after horizontal rule.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({ title: "Doc" });
+    expect(result.body).toContain("---");
+    expect(result.body).toContain("More text after horizontal rule.");
+  });
+
+  test("parses boolean and number values", () => {
+    const content = `---
+draft: true
+published: false
+version: 42
+weight: 3.14
+---
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({
+      draft: true,
+      published: false,
+      version: 42,
+      weight: 3.14,
+    });
+  });
+
+  test("parses quoted strings", () => {
+    const content = `---
+title: "Hello: World"
+subtitle: 'Another: Value'
+---
+Body.`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({
+      title: "Hello: World",
+      subtitle: "Another: Value",
+    });
+  });
+
+  test("returns empty metadata for malformed YAML (no throw)", () => {
+    const content = `---
+: bad key
+---
+Body.`;
+    const result = parseFrontmatter(content);
+    // Should not throw, malformed key is skipped
+    expect(result.body).toBe("Body.");
+  });
+
+  test("handles empty file", () => {
+    const result = parseFrontmatter("");
+    expect(result.metadata).toEqual({});
+    expect(result.body).toBe("");
+  });
+
+  test("handles file with only frontmatter, no body", () => {
+    const content = `---
+title: Metadata Only
+---
+`;
+    const result = parseFrontmatter(content);
+    expect(result.metadata).toEqual({ title: "Metadata Only" });
+    expect(result.body).toBe("");
+  });
+});

--- a/packages/knowledge-vault/src/frontmatter.ts
+++ b/packages/knowledge-vault/src/frontmatter.ts
@@ -1,0 +1,140 @@
+/**
+ * Hand-rolled YAML frontmatter parser.
+ *
+ * Handles flat key-value pairs, inline/multi-line tag lists, and common
+ * value types (strings, numbers, booleans). Intentionally minimal —
+ * no nested objects, no multi-line strings. Malformed frontmatter
+ * yields empty metadata (no throw).
+ */
+
+/** Result of parsing a markdown file's frontmatter. */
+export interface FrontmatterResult {
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly body: string;
+}
+
+const FRONTMATTER_REGEX = /^---[ \t]*\r?\n([\s\S]*?\r?\n)?---[ \t]*\r?\n?/;
+const INLINE_LIST_REGEX = /^\[([^\]]*)\]$/;
+const HASH_PREFIX_REGEX = /^#\s*/;
+
+/**
+ * Parse YAML frontmatter from markdown content.
+ *
+ * Extracts `---`-delimited frontmatter block and parses flat key-value
+ * pairs. Returns empty metadata if no frontmatter or if parsing fails.
+ */
+export function parseFrontmatter(content: string): FrontmatterResult {
+  if (content === "") {
+    return { metadata: {}, body: "" };
+  }
+
+  const match = FRONTMATTER_REGEX.exec(content);
+  if (match === null) {
+    return { metadata: {}, body: content };
+  }
+
+  const rawYaml = match[1] ?? "";
+  const body = content.slice(match[0].length);
+  const metadata = parseYamlBlock(rawYaml);
+
+  return { metadata, body };
+}
+
+function parseYamlBlock(raw: string): Readonly<Record<string, unknown>> {
+  const result: Record<string, unknown> = {};
+  const lines = raw.split("\n");
+
+  // let is required here — we track index for multi-line list parsing
+  let i = 0; // mutable: iterating with lookahead for multi-line lists
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      i += 1;
+      continue;
+    }
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) {
+      i += 1;
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rawValue = trimmed.slice(colonIdx + 1).trim();
+
+    if (key === "") {
+      i += 1;
+      continue;
+    }
+
+    // Check for multi-line list (value empty, next lines start with "- ")
+    if (rawValue === "" && i + 1 < lines.length) {
+      const nextLine = lines[i + 1] ?? "";
+      if (/^\s+-\s/.test(nextLine)) {
+        const items: string[] = [];
+        i += 1;
+        while (i < lines.length) {
+          const listLine = lines[i] ?? "";
+          const listMatch = /^\s+-\s+(.*)$/.exec(listLine);
+          if (listMatch === null) break;
+          const item = stripHashPrefix(parseScalarValue(listMatch[1]?.trim() ?? ""));
+          items.push(typeof item === "string" ? item : String(item));
+          i += 1;
+        }
+        result[key] = items;
+        continue;
+      }
+    }
+
+    // Inline list: [a, b, c]
+    const inlineMatch = INLINE_LIST_REGEX.exec(rawValue);
+    if (inlineMatch !== null) {
+      const inner = inlineMatch[1] ?? "";
+      const items = inner
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s !== "")
+        .map((s) => {
+          const parsed = parseScalarValue(s);
+          return typeof parsed === "string" ? stripHashPrefix(parsed) : String(parsed);
+        });
+      result[key] = items;
+      i += 1;
+      continue;
+    }
+
+    result[key] = parseScalarValue(rawValue);
+    i += 1;
+  }
+
+  return result;
+}
+
+function parseScalarValue(raw: string): string | number | boolean {
+  // Quoted strings
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+
+  // Booleans
+  const lower = raw.toLowerCase();
+  if (lower === "true" || lower === "yes") return true;
+  if (lower === "false" || lower === "no") return false;
+
+  // Numbers
+  if (raw !== "" && !Number.isNaN(Number(raw))) {
+    return Number(raw);
+  }
+
+  return raw;
+}
+
+function stripHashPrefix(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(HASH_PREFIX_REGEX, "");
+  }
+  return value;
+}

--- a/packages/knowledge-vault/src/index.ts
+++ b/packages/knowledge-vault/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @koi/knowledge-vault — L2 ComponentProvider for business context hydration.
+ *
+ * Hydrates agent context from structured knowledge bases (Obsidian vaults,
+ * markdown directories, or indexed stores) using BM25 ranking and
+ * token-budget-aware selection.
+ */
+
+// Re-exports for consumer convenience (consumers can also import directly)
+export type { FileSystemBackend } from "@koi/core";
+export type { FileSystemScope } from "@koi/scope";
+// BM25 (exported for advanced usage / custom pipelines)
+export {
+  type BM25Config,
+  type BM25Document,
+  type BM25Index,
+  type BM25Result,
+  createBM25Index,
+} from "./bm25.js";
+// ComponentProvider factory
+export { createKnowledgeVaultProvider } from "./component-provider.js";
+// Context source adapter for @koi/context integration
+export { createKnowledgeSourceResolver } from "./context-source-adapter.js";
+// Frontmatter parser (exported for reuse)
+export { type FrontmatterResult, parseFrontmatter } from "./frontmatter.js";
+// Selector (exported for advanced usage)
+export { type SelectionResult, selectWithinBudget } from "./selector.js";
+// ECS component token + public types
+export {
+  DEFAULT_GLOB,
+  DEFAULT_MAX_INDEX_CHARS,
+  DEFAULT_MAX_WARNINGS,
+  DEFAULT_RELEVANCE_THRESHOLD,
+  DEFAULT_TOKEN_BUDGET,
+  type DirectorySourceConfig,
+  type IndexSourceConfig,
+  KNOWLEDGE,
+  type KnowledgeComponent,
+  type KnowledgeDocument,
+  type KnowledgeSourceConfig,
+  type KnowledgeSourceInfo,
+  type KnowledgeSourceKind,
+  type KnowledgeVaultConfig,
+  type NexusSourceConfig,
+  type RefreshResult,
+} from "./types.js";
+// Vault service (for advanced usage / context-source adapter)
+export { createVaultService, type VaultService } from "./vault-service.js";

--- a/packages/knowledge-vault/src/selector.test.ts
+++ b/packages/knowledge-vault/src/selector.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { HEURISTIC_ESTIMATOR } from "@koi/token-estimator";
+import { type ScoredDocument, selectWithinBudget } from "./selector.js";
+import type { KnowledgeDocument, KnowledgeSourceInfo } from "./types.js";
+
+function makeDoc(path: string, content: string, relevanceScore: number): KnowledgeDocument {
+  return {
+    path,
+    title: path,
+    content,
+    tags: [],
+    lastModified: Date.now(),
+    relevanceScore,
+  };
+}
+
+function makeScored(doc: KnowledgeDocument, sourceIndex: number): ScoredDocument {
+  return { document: doc, sourceIndex };
+}
+
+const sources: readonly KnowledgeSourceInfo[] = [
+  { name: "source-a", kind: "directory", documentCount: 3 },
+  { name: "source-b", kind: "directory", documentCount: 2 },
+];
+
+describe("selectWithinBudget", () => {
+  test("budget fits all docs - all selected", () => {
+    const docs = [
+      makeScored(makeDoc("a1", "short", 0.9), 0),
+      makeScored(makeDoc("a2", "text", 0.8), 0),
+      makeScored(makeDoc("b1", "word", 0.7), 1),
+    ];
+
+    const result = selectWithinBudget(docs, sources, 10000, HEURISTIC_ESTIMATOR);
+
+    expect(result.selected).toHaveLength(3);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  test("budget fits none - first doc still included", () => {
+    const docs = [makeScored(makeDoc("a1", "x".repeat(400), 0.9), 0)];
+
+    // Budget of 1 token can't fit 100-token doc, but we include it anyway
+    const result = selectWithinBudget(docs, [sources[0]!], 1, HEURISTIC_ESTIMATOR);
+
+    expect(result.selected).toHaveLength(1);
+    expect(result.selected[0]?.path).toBe("a1");
+  });
+
+  test("budget = 0 returns empty results", () => {
+    const docs = [makeScored(makeDoc("a1", "content", 0.9), 0)];
+
+    const result = selectWithinBudget(docs, sources, 0, HEURISTIC_ESTIMATOR);
+
+    expect(result.selected).toHaveLength(0);
+    expect(result.totalTokens).toBe(0);
+  });
+
+  test("diversity guarantee: each source gets at least 1 doc", () => {
+    // Source A has high-scoring docs, source B has lower
+    const docs = [
+      makeScored(makeDoc("a1", "x".repeat(40), 0.95), 0),
+      makeScored(makeDoc("a2", "x".repeat(40), 0.9), 0),
+      makeScored(makeDoc("a3", "x".repeat(40), 0.85), 0),
+      makeScored(makeDoc("b1", "x".repeat(40), 0.5), 1),
+      makeScored(makeDoc("b2", "x".repeat(40), 0.45), 1),
+    ];
+
+    // Budget fits ~3 docs (each ~10 tokens at 4 chars/token)
+    const result = selectWithinBudget(docs, sources, 30, HEURISTIC_ESTIMATOR);
+
+    const selectedPaths = result.selected.map((d) => d.path);
+    // Source B should be represented even though source A has higher scores
+    expect(selectedPaths).toContain("b1");
+    expect(selectedPaths).toContain("a1");
+  });
+
+  test("large source does not crowd out small source", () => {
+    const docs = [
+      makeScored(makeDoc("a1", "x".repeat(40), 0.95), 0),
+      makeScored(makeDoc("a2", "x".repeat(40), 0.9), 0),
+      makeScored(makeDoc("a3", "x".repeat(40), 0.85), 0),
+      makeScored(makeDoc("a4", "x".repeat(40), 0.8), 0),
+      makeScored(makeDoc("b1", "x".repeat(40), 0.5), 1),
+    ];
+
+    // Budget fits exactly 2 docs
+    const result = selectWithinBudget(docs, sources, 20, HEURISTIC_ESTIMATOR);
+
+    const selectedPaths = result.selected.map((d) => d.path);
+    expect(selectedPaths).toContain("b1");
+  });
+
+  test("documents ordered by relevance in output", () => {
+    const docs = [
+      makeScored(makeDoc("low", "word", 0.3), 0),
+      makeScored(makeDoc("high", "text", 0.9), 0),
+      makeScored(makeDoc("mid", "data", 0.6), 1),
+    ];
+
+    const result = selectWithinBudget(docs, sources, 10000, HEURISTIC_ESTIMATOR);
+
+    const scores = result.selected.map((d) => d.relevanceScore);
+    for (const [i, score] of scores.entries()) {
+      if (i > 0) {
+        expect(score).toBeLessThanOrEqual(scores[i - 1]!);
+      }
+    }
+  });
+
+  test("single source uses pure greedy behavior", () => {
+    const singleSource: readonly KnowledgeSourceInfo[] = [
+      { name: "only", kind: "directory", documentCount: 3 },
+    ];
+
+    const docs = [
+      makeScored(makeDoc("d1", "x".repeat(40), 0.9), 0),
+      makeScored(makeDoc("d2", "x".repeat(40), 0.8), 0),
+      makeScored(makeDoc("d3", "x".repeat(40), 0.7), 0),
+    ];
+
+    // Budget fits 2 docs
+    const result = selectWithinBudget(docs, singleSource, 20, HEURISTIC_ESTIMATOR);
+
+    expect(result.selected).toHaveLength(2);
+    expect(result.selected[0]?.path).toBe("d1");
+    expect(result.selected[1]?.path).toBe("d2");
+  });
+
+  test("exact budget boundary (doc tokens === remaining budget)", () => {
+    // 20 chars = 5 tokens with heuristic (4 chars/token)
+    const docs = [makeScored(makeDoc("exact", "x".repeat(20), 0.9), 0)];
+
+    const result = selectWithinBudget(docs, [sources[0]!], 5, HEURISTIC_ESTIMATOR);
+
+    expect(result.selected).toHaveLength(1);
+    expect(result.totalTokens).toBe(5);
+  });
+});

--- a/packages/knowledge-vault/src/selector.ts
+++ b/packages/knowledge-vault/src/selector.ts
@@ -1,0 +1,108 @@
+/**
+ * Token-budget-aware document selector.
+ *
+ * Greedy selection with diversity guarantee: each source gets at least
+ * 1 document (highest-scored), then remaining budget fills by global
+ * relevance score.
+ */
+
+import type { TokenEstimator } from "@koi/core";
+
+import type { KnowledgeDocument, KnowledgeSourceInfo } from "./types.js";
+
+/** Result of budget-aware selection. */
+export interface SelectionResult {
+  readonly selected: readonly KnowledgeDocument[];
+  readonly totalTokens: number;
+  readonly dropped: readonly string[];
+}
+
+/** Input document with source attribution for diversity guarantee. */
+export interface ScoredDocument {
+  readonly document: KnowledgeDocument;
+  readonly sourceIndex: number;
+}
+
+/**
+ * Select documents within a token budget.
+ *
+ * Algorithm:
+ * 1. First pass: guarantee 1 doc from each source (highest-scored per source).
+ * 2. Second pass: fill remaining budget by global relevance (greedy, skip-and-continue).
+ * 3. Return selected docs ordered by relevance score (descending).
+ */
+export function selectWithinBudget(
+  documents: readonly ScoredDocument[],
+  sources: readonly KnowledgeSourceInfo[],
+  budget: number,
+  estimator: TokenEstimator,
+): SelectionResult {
+  if (budget <= 0 || documents.length === 0) {
+    return { selected: [], totalTokens: 0, dropped: documents.map((d) => d.document.path) };
+  }
+
+  // Sort all documents by relevance descending
+  const sorted = [...documents].sort(
+    (a, b) => b.document.relevanceScore - a.document.relevanceScore,
+  );
+
+  const selectedSet = new Set<string>();
+  const selectedDocs: KnowledgeDocument[] = [];
+  // let is required — tracking running token total
+  let usedTokens = 0;
+
+  // Pass 1: diversity guarantee — best doc from each source
+  for (
+    // let is required — loop counter for source index
+    let sourceIdx = 0;
+    sourceIdx < sources.length;
+    sourceIdx++
+  ) {
+    const best = sorted.find(
+      (d) => d.sourceIndex === sourceIdx && !selectedSet.has(d.document.path),
+    );
+    if (best === undefined) continue;
+
+    const tokens = estimateDocTokens(best.document, estimator);
+    if (usedTokens + tokens <= budget) {
+      selectedSet.add(best.document.path);
+      selectedDocs.push(best.document);
+      usedTokens += tokens;
+    } else if (selectedDocs.length === 0) {
+      // Budget can't fit even the first doc — truncate concept:
+      // include it anyway so we always return at least something
+      selectedSet.add(best.document.path);
+      selectedDocs.push(best.document);
+      usedTokens += tokens;
+      break;
+    }
+  }
+
+  // Pass 2: fill remaining budget by global relevance (greedy)
+  for (const entry of sorted) {
+    if (selectedSet.has(entry.document.path)) continue;
+
+    const tokens = estimateDocTokens(entry.document, estimator);
+    if (usedTokens + tokens <= budget) {
+      selectedSet.add(entry.document.path);
+      selectedDocs.push(entry.document);
+      usedTokens += tokens;
+    }
+    // Skip-and-continue: try next doc even if this one didn't fit
+  }
+
+  // Sort final output by relevance descending
+  const selected = [...selectedDocs].sort((a, b) => b.relevanceScore - a.relevanceScore);
+
+  const dropped = sorted
+    .filter((d) => !selectedSet.has(d.document.path))
+    .map((d) => d.document.path);
+
+  return { selected, totalTokens: usedTokens, dropped };
+}
+
+function estimateDocTokens(doc: KnowledgeDocument, estimator: TokenEstimator): number {
+  // estimateText may return number | Promise<number>, but heuristic is sync
+  const result = estimator.estimateText(doc.content);
+  return typeof result === "number" ? result : 0;
+}

--- a/packages/knowledge-vault/src/source-directory.test.ts
+++ b/packages/knowledge-vault/src/source-directory.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileSystemBackend, KoiError, Result } from "@koi/core";
+import { HEURISTIC_ESTIMATOR } from "@koi/token-estimator";
+import { scanDirectory } from "./source-directory.js";
+import type { DirectorySourceConfig } from "./types.js";
+import { DEFAULT_MAX_INDEX_CHARS, DEFAULT_MAX_WARNINGS } from "./types.js";
+
+const defaultOptions = {
+  maxIndexCharsPerDoc: DEFAULT_MAX_INDEX_CHARS,
+  maxWarnings: DEFAULT_MAX_WARNINGS,
+  batchSize: 64,
+  estimator: HEURISTIC_ESTIMATOR,
+};
+
+// Track temp dirs for cleanup
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kv-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeFile(dir: string, path: string, content: string): Promise<void> {
+  const fullPath = join(dir, path);
+  await Bun.write(fullPath, content);
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("scanDirectory", () => {
+  test("scans markdown files in directory", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "doc1.md", "---\ntitle: Doc One\n---\nContent one.");
+    await writeFile(dir, "doc2.md", "---\ntitle: Doc Two\n---\nContent two.");
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.warnings).toHaveLength(0);
+
+    const titles = result.documents.map((d) => d.title).sort();
+    expect(titles).toEqual(["Doc One", "Doc Two"]);
+  });
+
+  test("respects glob pattern", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "readme.md", "Markdown file");
+    await writeFile(dir, "notes.txt", "Text file");
+
+    const config: DirectorySourceConfig = {
+      kind: "directory",
+      path: dir,
+      glob: "**/*.md",
+    };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]?.path).toBe("readme.md");
+  });
+
+  test("handles binary files gracefully (warning, not crash)", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "good.md", "Good content");
+    // Write a file with null bytes (binary)
+    const binaryPath = join(dir, "binary.md");
+    const buf = Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f]);
+    await Bun.write(binaryPath, buf);
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings[0]).toContain("Binary file skipped");
+  });
+
+  test("handles empty directory", async () => {
+    const dir = await createTempDir();
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("respects exclude list", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "keep.md", "Keep this");
+    await writeFile(dir, "templates/skip.md", "Skip this");
+
+    const config: DirectorySourceConfig = {
+      kind: "directory",
+      path: dir,
+      exclude: ["templates/**"],
+    };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]?.path).toBe("keep.md");
+  });
+
+  test("truncates content to maxIndexCharsPerDoc", async () => {
+    const dir = await createTempDir();
+    const longContent = "x".repeat(5000);
+    await writeFile(dir, "long.md", longContent);
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, {
+      ...defaultOptions,
+      maxIndexCharsPerDoc: 100,
+    });
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]?.body.length).toBeLessThanOrEqual(100);
+  });
+
+  test("extracts title from frontmatter or filename", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "with-title.md", "---\ntitle: Custom Title\n---\nBody.");
+    await writeFile(dir, "my-doc-name.md", "No frontmatter body.");
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    const byPath = new Map(result.documents.map((d) => [d.path, d]));
+    expect(byPath.get("with-title.md")?.title).toBe("Custom Title");
+    expect(byPath.get("my-doc-name.md")?.title).toBe("my doc name");
+  });
+
+  test("extracts tags from frontmatter", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "tagged.md", "---\ntitle: Tagged\ntags: [api, auth]\n---\nBody.");
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents[0]?.tags).toEqual(["api", "auth"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FileSystemBackend path
+// ---------------------------------------------------------------------------
+
+function createMockBackend(files: ReadonlyMap<string, string>): FileSystemBackend {
+  return {
+    name: "mock",
+    list: (_path, options) => {
+      const entries = [...files.keys()]
+        .filter((p) => {
+          if (options?.glob === undefined) return true;
+          const glob = new Bun.Glob(options.glob);
+          return glob.match(p);
+        })
+        .map((p) => ({ path: p, kind: "file" as const }));
+      return { ok: true, value: { entries, truncated: false } } satisfies Result<
+        {
+          readonly entries: readonly { readonly path: string; readonly kind: "file" }[];
+          readonly truncated: boolean;
+        },
+        KoiError
+      >;
+    },
+    read: (path) => {
+      const content = files.get(path);
+      if (content === undefined) {
+        return {
+          ok: false,
+          error: { code: "NOT_FOUND", message: `Not found: ${path}`, retryable: false },
+        } satisfies Result<never, KoiError>;
+      }
+      return {
+        ok: true,
+        value: { content, path, size: content.length },
+      };
+    },
+    write: () => {
+      throw new Error("Not implemented");
+    },
+    edit: () => {
+      throw new Error("Not implemented");
+    },
+    search: () => {
+      throw new Error("Not implemented");
+    },
+  };
+}
+
+describe("scanDirectory with FileSystemBackend", () => {
+  test("uses backend list() + read()", async () => {
+    const files = new Map([
+      ["docs/auth.md", "---\ntitle: Auth\n---\nAuthentication content."],
+      ["docs/api.md", "---\ntitle: API\n---\nAPI design content."],
+    ]);
+    const backend = createMockBackend(files);
+
+    const config: DirectorySourceConfig = {
+      kind: "directory",
+      path: "/vault",
+      backend,
+    };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.warnings).toHaveLength(0);
+    const titles = result.documents.map((d) => d.title).sort();
+    expect(titles).toEqual(["API", "Auth"]);
+  });
+
+  test("handles read failure as warning", async () => {
+    const backend: FileSystemBackend = {
+      name: "failing-mock",
+      list: () => ({
+        ok: true,
+        value: {
+          entries: [
+            { path: "good.md", kind: "file" as const },
+            { path: "bad.md", kind: "file" as const },
+          ],
+          truncated: false,
+        },
+      }),
+      read: (path) => {
+        if (path === "good.md") {
+          return { ok: true, value: { content: "Good content.", path, size: 13 } };
+        }
+        return {
+          ok: false,
+          error: { code: "INTERNAL", message: "Disk error", retryable: false },
+        } satisfies Result<never, KoiError>;
+      },
+      write: () => {
+        throw new Error("Not implemented");
+      },
+      edit: () => {
+        throw new Error("Not implemented");
+      },
+      search: () => {
+        throw new Error("Not implemented");
+      },
+    };
+
+    const config: DirectorySourceConfig = {
+      kind: "directory",
+      path: "/vault",
+      backend,
+    };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Disk error");
+  });
+
+  test("without backend uses Bun APIs (backward compat)", async () => {
+    const dir = await createTempDir();
+    await writeFile(dir, "compat.md", "---\ntitle: Compat\n---\nBackward compatible.");
+
+    const config: DirectorySourceConfig = { kind: "directory", path: dir };
+    const result = await scanDirectory(config, defaultOptions);
+
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]?.title).toBe("Compat");
+    // Bun path should produce real mtimeMs (not Date.now())
+    expect(result.documents[0]?.lastModified).toBeLessThanOrEqual(Date.now());
+    expect(result.documents[0]?.lastModified).toBeGreaterThan(0);
+  });
+});

--- a/packages/knowledge-vault/src/source-directory.ts
+++ b/packages/knowledge-vault/src/source-directory.ts
@@ -1,0 +1,269 @@
+/**
+ * Directory source — scans a directory tree for markdown files.
+ *
+ * Supports two discovery paths:
+ * - **Backend provided**: uses FileSystemBackend.list() + .read() for remote/abstract FS
+ * - **No backend (default)**: uses Bun.Glob + Bun.file() for local FS
+ *
+ * Parses frontmatter, extracts title/tags, and truncates content to the
+ * configured index char limit.
+ */
+
+import { join } from "node:path";
+import type { FileSystemBackend, TokenEstimator } from "@koi/core";
+
+import { parseFrontmatter } from "./frontmatter.js";
+import type { DirectorySourceConfig, ParsedDocument, ScanResult } from "./types.js";
+import { DEFAULT_GLOB } from "./types.js";
+
+/** Options controlling directory scan behavior. */
+export interface ScanOptions {
+  readonly maxIndexCharsPerDoc: number;
+  readonly maxWarnings: number;
+  readonly batchSize: number;
+  readonly estimator: TokenEstimator;
+}
+
+/**
+ * Scan a directory for markdown files and parse them into documents.
+ *
+ * When `config.backend` is provided, delegates discovery to the backend's
+ * `list()` and reading to `read()`. Otherwise falls back to Bun APIs.
+ */
+export async function scanDirectory(
+  config: DirectorySourceConfig,
+  options: ScanOptions,
+): Promise<ScanResult> {
+  if (config.backend !== undefined) {
+    return scanWithBackend(config, config.backend, options);
+  }
+  return scanWithBun(config, options);
+}
+
+// ---------------------------------------------------------------------------
+// Path A: FileSystemBackend
+// ---------------------------------------------------------------------------
+
+async function scanWithBackend(
+  config: DirectorySourceConfig,
+  backend: FileSystemBackend,
+  options: ScanOptions,
+): Promise<ScanResult> {
+  const globPattern = config.glob ?? DEFAULT_GLOB;
+  const maxChars = options.maxIndexCharsPerDoc;
+
+  const listResult = await backend.list(config.path, {
+    recursive: true,
+    glob: globPattern,
+  });
+
+  if (!listResult.ok) {
+    return {
+      documents: [],
+      warnings: [`Failed to list directory "${config.path}": ${listResult.error.message}`],
+    };
+  }
+
+  // Filter to files only, apply exclude patterns
+  const paths = listResult.value.entries
+    .filter((entry) => entry.kind === "file")
+    .map((entry) => entry.path)
+    .filter((path) => !shouldExclude(path, config.exclude));
+
+  const documents: ParsedDocument[] = [];
+  const warnings: string[] = [];
+
+  for (const batch of batches(paths, options.batchSize)) {
+    const results = await Promise.allSettled(
+      batch.map((filePath) =>
+        readAndParseFromBackend(backend, filePath, maxChars, options.estimator),
+      ),
+    );
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        documents.push(result.value);
+      } else {
+        if (warnings.length < options.maxWarnings) {
+          const reason =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          warnings.push(reason);
+        }
+      }
+    }
+  }
+
+  return { documents, warnings };
+}
+
+async function readAndParseFromBackend(
+  backend: FileSystemBackend,
+  filePath: string,
+  maxChars: number,
+  estimator: TokenEstimator,
+): Promise<ParsedDocument> {
+  const readResult = await backend.read(filePath);
+
+  if (!readResult.ok) {
+    throw new Error(`Failed to read "${filePath}": ${readResult.error.message}`);
+  }
+
+  const raw = readResult.value.content;
+
+  // Guard against binary files — check for null bytes
+  if (raw.includes("\0")) {
+    throw new Error(`Binary file skipped: ${filePath}`);
+  }
+
+  const { metadata, body } = parseFrontmatter(raw);
+  const title = extractTitle(metadata, filePath);
+  const tags = extractTags(metadata);
+  const truncatedBody = body.slice(0, maxChars);
+
+  const tokenResult = estimator.estimateText(truncatedBody);
+  const tokens = typeof tokenResult === "number" ? tokenResult : await tokenResult;
+
+  return {
+    path: filePath,
+    title,
+    body: truncatedBody,
+    frontmatter: metadata,
+    tags,
+    lastModified: Date.now(),
+    tokens,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Path B: Bun APIs (default, backward compat)
+// ---------------------------------------------------------------------------
+
+async function scanWithBun(
+  config: DirectorySourceConfig,
+  options: ScanOptions,
+): Promise<ScanResult> {
+  const globPattern = config.glob ?? DEFAULT_GLOB;
+  const maxChars = options.maxIndexCharsPerDoc;
+  const glob = new Bun.Glob(globPattern);
+
+  // Collect all matching paths
+  const paths: string[] = [];
+  for await (const path of glob.scan({ cwd: config.path, dot: false })) {
+    if (shouldExclude(path, config.exclude)) continue;
+    paths.push(path);
+  }
+
+  // Batch-read files
+  const documents: ParsedDocument[] = [];
+  const warnings: string[] = [];
+
+  for (const batch of batches(paths, options.batchSize)) {
+    const results = await Promise.allSettled(
+      batch.map((relativePath) =>
+        readAndParseBun(config.path, relativePath, maxChars, options.estimator),
+      ),
+    );
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        documents.push(result.value);
+      } else {
+        if (warnings.length < options.maxWarnings) {
+          const reason =
+            result.reason instanceof Error ? result.reason.message : String(result.reason);
+          warnings.push(reason);
+        }
+      }
+    }
+  }
+
+  return { documents, warnings };
+}
+
+async function readAndParseBun(
+  basePath: string,
+  relativePath: string,
+  maxChars: number,
+  estimator: TokenEstimator,
+): Promise<ParsedDocument> {
+  const fullPath = join(basePath, relativePath);
+  const file = Bun.file(fullPath);
+  const stat = await file.stat();
+  const raw = await file.text();
+
+  // Guard against binary files — check for null bytes
+  if (raw.includes("\0")) {
+    throw new Error(`Binary file skipped: ${relativePath}`);
+  }
+
+  const { metadata, body } = parseFrontmatter(raw);
+  const title = extractTitle(metadata, relativePath);
+  const tags = extractTags(metadata);
+  const truncatedBody = body.slice(0, maxChars);
+
+  const tokenResult = estimator.estimateText(truncatedBody);
+  const tokens = typeof tokenResult === "number" ? tokenResult : await tokenResult;
+
+  return {
+    path: relativePath,
+    title,
+    body: truncatedBody,
+    frontmatter: metadata,
+    tags,
+    lastModified: stat.mtimeMs,
+    tokens,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function extractTitle(metadata: Readonly<Record<string, unknown>>, fallbackPath: string): string {
+  const title = metadata["title"];
+  if (typeof title === "string" && title !== "") return title;
+
+  // Derive from filename
+  const segments = fallbackPath.split("/");
+  const filename = segments[segments.length - 1] ?? fallbackPath;
+  return filename.replace(/\.md$/i, "").replace(/[-_]/g, " ");
+}
+
+function extractTags(metadata: Readonly<Record<string, unknown>>): readonly string[] {
+  const raw = metadata["tags"];
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((t): t is string => typeof t === "string")
+      .map((t) => t.trim())
+      .filter((t) => t !== "");
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t !== "");
+  }
+  return [];
+}
+
+function shouldExclude(path: string, excludePatterns: readonly string[] | undefined): boolean {
+  if (excludePatterns === undefined || excludePatterns.length === 0) {
+    return false;
+  }
+  return excludePatterns.some((pattern) => {
+    const glob = new Bun.Glob(pattern);
+    return glob.match(path);
+  });
+}
+
+/** Yield batches of items from an array. */
+function* batches<T>(items: readonly T[], size: number): Generator<readonly T[]> {
+  for (
+    // let is required — loop counter
+    let i = 0;
+    i < items.length;
+    i += size
+  ) {
+    yield items.slice(i, i + size);
+  }
+}

--- a/packages/knowledge-vault/src/source-index.test.ts
+++ b/packages/knowledge-vault/src/source-index.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiError, Result } from "@koi/core";
+import type { SearchPage } from "@koi/search-provider";
+import { scanIndex } from "./source-index.js";
+import type { IndexSourceConfig } from "./types.js";
+
+function makeRetriever(
+  result: Result<SearchPage<unknown>, KoiError>,
+): IndexSourceConfig["backend"] {
+  return {
+    retrieve: async () => result,
+  };
+}
+
+describe("scanIndex", () => {
+  test("transforms retriever results into ParsedDocuments", async () => {
+    const backend = makeRetriever({
+      ok: true,
+      value: {
+        results: [
+          {
+            id: "doc-1",
+            score: 0.9,
+            content: "Authentication guide content",
+            metadata: {
+              title: "Auth Guide",
+              tags: ["auth", "security"],
+              lastModified: 1000,
+            },
+            source: "test",
+          },
+          {
+            id: "doc-2",
+            score: 0.7,
+            content: "API reference content",
+            metadata: { title: "API Ref" },
+            source: "test",
+          },
+        ],
+        hasMore: false,
+      },
+    });
+
+    const config: IndexSourceConfig = {
+      kind: "index",
+      name: "test-index",
+      backend,
+    };
+
+    const result = await scanIndex(config, 100);
+    expect(result.documents).toHaveLength(2);
+    expect(result.warnings).toHaveLength(0);
+
+    expect(result.documents[0]?.path).toBe("doc-1");
+    expect(result.documents[0]?.title).toBe("Auth Guide");
+    expect(result.documents[0]?.body).toBe("Authentication guide content");
+    expect(result.documents[0]?.tags).toEqual(["auth", "security"]);
+    expect(result.documents[0]?.lastModified).toBe(1000);
+
+    expect(result.documents[1]?.title).toBe("API Ref");
+    expect(result.documents[1]?.tags).toEqual([]);
+  });
+
+  test("returns warning on retriever error", async () => {
+    const backend = makeRetriever({
+      ok: false,
+      error: {
+        code: "EXTERNAL",
+        message: "Connection refused",
+        retryable: false,
+      },
+    });
+
+    const config: IndexSourceConfig = {
+      kind: "index",
+      name: "failing-index",
+      backend,
+    };
+
+    const result = await scanIndex(config, 100);
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Connection refused");
+  });
+
+  test("uses id as title fallback when no title in metadata", async () => {
+    const backend = makeRetriever({
+      ok: true,
+      value: {
+        results: [
+          {
+            id: "untitled-doc",
+            score: 0.5,
+            content: "Some content",
+            metadata: {},
+            source: "test",
+          },
+        ],
+        hasMore: false,
+      },
+    });
+
+    const config: IndexSourceConfig = {
+      kind: "index",
+      backend,
+    };
+
+    const result = await scanIndex(config, 100);
+    expect(result.documents[0]?.title).toBe("untitled-doc");
+  });
+
+  test("handles empty results", async () => {
+    const backend = makeRetriever({
+      ok: true,
+      value: { results: [], hasMore: false },
+    });
+
+    const config: IndexSourceConfig = {
+      kind: "index",
+      backend,
+    };
+
+    const result = await scanIndex(config, 100);
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/packages/knowledge-vault/src/source-index.ts
+++ b/packages/knowledge-vault/src/source-index.ts
@@ -1,0 +1,65 @@
+/**
+ * Index source — delegates search to a Retriever<T> backend.
+ *
+ * Thin adapter that transforms Retriever results into ParsedDocument[].
+ * The actual search implementation lives in the backend (e.g., SQLite FTS,
+ * vector store).
+ */
+
+import type { IndexSourceConfig, ParsedDocument, ScanResult } from "./types.js";
+
+/**
+ * Query an index backend and return results as ParsedDocuments.
+ *
+ * Uses the Retriever's `retrieve()` method to fetch documents,
+ * then maps them to the internal ParsedDocument format.
+ */
+export async function scanIndex(config: IndexSourceConfig, maxDocs: number): Promise<ScanResult> {
+  const result = await config.backend.retrieve({
+    text: "*",
+    limit: maxDocs,
+  });
+
+  if (!result.ok) {
+    return {
+      documents: [],
+      warnings: [`Index source "${config.name ?? "index"}": ${result.error.message}`],
+    };
+  }
+
+  const documents: ParsedDocument[] = result.value.results.map((r) => ({
+    path: r.id,
+    title: extractStringField(r.metadata, "title") ?? r.id,
+    body: r.content,
+    frontmatter: r.metadata,
+    tags: extractTagsField(r.metadata),
+    lastModified: extractNumberField(r.metadata, "lastModified") ?? Date.now(),
+    tokens: Math.ceil(r.content.length / 4),
+  }));
+
+  return { documents, warnings: [] };
+}
+
+function extractStringField(
+  metadata: Readonly<Record<string, unknown>>,
+  field: string,
+): string | undefined {
+  const value = metadata[field];
+  return typeof value === "string" ? value : undefined;
+}
+
+function extractNumberField(
+  metadata: Readonly<Record<string, unknown>>,
+  field: string,
+): number | undefined {
+  const value = metadata[field];
+  return typeof value === "number" ? value : undefined;
+}
+
+function extractTagsField(metadata: Readonly<Record<string, unknown>>): readonly string[] {
+  const raw = metadata["tags"];
+  if (Array.isArray(raw)) {
+    return raw.filter((t): t is string => typeof t === "string");
+  }
+  return [];
+}

--- a/packages/knowledge-vault/src/source-nexus.test.ts
+++ b/packages/knowledge-vault/src/source-nexus.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { scanNexus } from "./source-nexus.js";
+import type { NexusSourceConfig } from "./types.js";
+
+// Use a test server to mock Nexus HTTP responses
+let server: ReturnType<typeof Bun.serve>;
+let baseUrl: string;
+
+// Track responses per path for different test scenarios
+const responseMap = new Map<string, { status: number; body: unknown }>();
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      const handler = responseMap.get(url.pathname);
+      if (handler !== undefined) {
+        return new Response(JSON.stringify(handler.body), {
+          status: handler.status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+  baseUrl = `http://localhost:${String(server.port)}`;
+});
+
+afterEach(() => {
+  responseMap.clear();
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("scanNexus", () => {
+  test("fetches documents from nexus endpoint", async () => {
+    responseMap.set("/knowledge", {
+      status: 200,
+      body: {
+        documents: [
+          {
+            id: "doc-1",
+            title: "Auth Patterns",
+            content: "Authentication patterns and best practices.",
+            tags: ["auth", "patterns"],
+            lastModified: 1000,
+          },
+          {
+            id: "doc-2",
+            title: "API Design",
+            content: "REST API design guidelines.",
+            tags: ["api"],
+          },
+        ],
+      },
+    });
+
+    const config: NexusSourceConfig = {
+      kind: "nexus",
+      name: "test-nexus",
+      endpoint: `${baseUrl}/knowledge`,
+    };
+
+    const result = await scanNexus(config, 100);
+    expect(result.documents).toHaveLength(2);
+    expect(result.warnings).toHaveLength(0);
+
+    expect(result.documents[0]?.path).toBe("doc-1");
+    expect(result.documents[0]?.title).toBe("Auth Patterns");
+    expect(result.documents[0]?.tags).toEqual(["auth", "patterns"]);
+
+    expect(result.documents[1]?.title).toBe("API Design");
+  });
+
+  test("returns warning on HTTP error", async () => {
+    responseMap.set("/error", {
+      status: 500,
+      body: { error: "Internal server error" },
+    });
+
+    const config: NexusSourceConfig = {
+      kind: "nexus",
+      name: "failing-nexus",
+      endpoint: `${baseUrl}/error`,
+    };
+
+    const result = await scanNexus(config, 100);
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("HTTP 500");
+  });
+
+  test("returns warning on response error field", async () => {
+    responseMap.set("/api-error", {
+      status: 200,
+      body: { error: "Rate limit exceeded" },
+    });
+
+    const config: NexusSourceConfig = {
+      kind: "nexus",
+      name: "rate-limited",
+      endpoint: `${baseUrl}/api-error`,
+    };
+
+    const result = await scanNexus(config, 100);
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Rate limit exceeded");
+  });
+
+  test("handles empty documents array", async () => {
+    responseMap.set("/empty", {
+      status: 200,
+      body: { documents: [] },
+    });
+
+    const config: NexusSourceConfig = {
+      kind: "nexus",
+      endpoint: `${baseUrl}/empty`,
+    };
+
+    const result = await scanNexus(config, 100);
+    expect(result.documents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("handles missing optional fields with defaults", async () => {
+    responseMap.set("/minimal", {
+      status: 200,
+      body: {
+        documents: [{ id: "min-doc", content: "Minimal document." }],
+      },
+    });
+
+    const config: NexusSourceConfig = {
+      kind: "nexus",
+      endpoint: `${baseUrl}/minimal`,
+    };
+
+    const result = await scanNexus(config, 100);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]?.title).toBe("min-doc");
+    expect(result.documents[0]?.tags).toEqual([]);
+    expect(result.documents[0]?.lastModified).toBeGreaterThan(0);
+  });
+});

--- a/packages/knowledge-vault/src/source-nexus.ts
+++ b/packages/knowledge-vault/src/source-nexus.ts
@@ -1,0 +1,80 @@
+/**
+ * Nexus source — queries a remote Nexus endpoint for knowledge documents.
+ *
+ * Thin HTTP adapter that fetches documents from a Nexus knowledge API
+ * and maps them to the internal ParsedDocument format.
+ */
+
+import type { NexusSourceConfig, ParsedDocument, ScanResult } from "./types.js";
+
+interface NexusResponse {
+  readonly documents?: readonly NexusDocument[];
+  readonly error?: string;
+}
+
+interface NexusDocument {
+  readonly id: string;
+  readonly title?: string;
+  readonly content: string;
+  readonly tags?: readonly string[];
+  readonly lastModified?: number;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Fetch documents from a Nexus knowledge endpoint.
+ */
+export async function scanNexus(config: NexusSourceConfig, maxDocs: number): Promise<ScanResult> {
+  const url = new URL(config.endpoint);
+  url.searchParams.set("limit", String(maxDocs));
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    return {
+      documents: [],
+      warnings: [
+        `Nexus source "${config.name ?? "nexus"}": HTTP ${String(response.status)} ${response.statusText}`,
+      ],
+    };
+  }
+
+  const raw: unknown = await response.json();
+  if (!isNexusResponse(raw)) {
+    return {
+      documents: [],
+      warnings: [`Nexus source "${config.name ?? "nexus"}": unexpected response shape`],
+    };
+  }
+
+  if (raw.error !== undefined) {
+    return {
+      documents: [],
+      warnings: [`Nexus source "${config.name ?? "nexus"}": ${raw.error}`],
+    };
+  }
+
+  const documents: ParsedDocument[] = (raw.documents ?? []).map((doc) => ({
+    path: doc.id,
+    title: doc.title ?? doc.id,
+    body: doc.content,
+    frontmatter: doc.metadata ?? {},
+    tags: doc.tags ?? [],
+    lastModified: doc.lastModified ?? Date.now(),
+    tokens: Math.ceil(doc.content.length / 4),
+  }));
+
+  return { documents, warnings: [] };
+}
+
+/** Type guard for Nexus API response. Validates shape at system boundary. */
+function isNexusResponse(value: unknown): value is NexusResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj["error"] !== undefined && typeof obj["error"] !== "string") return false;
+  if (obj["documents"] !== undefined && !Array.isArray(obj["documents"])) return false;
+  return true;
+}

--- a/packages/knowledge-vault/src/types.ts
+++ b/packages/knowledge-vault/src/types.ts
@@ -1,0 +1,141 @@
+/**
+ * @koi/knowledge-vault — Types and constants.
+ *
+ * Defines the KNOWLEDGE ECS component, configuration types, and internal
+ * data structures for the knowledge vault pipeline.
+ */
+
+import type { FileSystemBackend, SubsystemToken } from "@koi/core";
+import { token } from "@koi/core";
+import type { FileSystemScope } from "@koi/scope";
+import type { Retriever } from "@koi/search-provider";
+
+// ---------------------------------------------------------------------------
+// KNOWLEDGE ECS component token
+// ---------------------------------------------------------------------------
+
+/** ECS component token for runtime knowledge vault access. */
+export const KNOWLEDGE: SubsystemToken<KnowledgeComponent> =
+  token<KnowledgeComponent>("koi.knowledge");
+
+// ---------------------------------------------------------------------------
+// Component interface (attached to agent at assembly time)
+// ---------------------------------------------------------------------------
+
+/** Component providing query access to indexed knowledge bases. */
+export interface KnowledgeComponent {
+  readonly sources: readonly KnowledgeSourceInfo[];
+  readonly query: (query: string, limit?: number) => Promise<readonly KnowledgeDocument[]>;
+  readonly refresh: () => Promise<RefreshResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Public value types
+// ---------------------------------------------------------------------------
+
+/** A single document returned from a knowledge query. */
+export interface KnowledgeDocument {
+  readonly path: string;
+  readonly title: string;
+  readonly content: string;
+  readonly tags: readonly string[];
+  readonly lastModified: number;
+  readonly relevanceScore: number;
+}
+
+/** Metadata about a configured knowledge source. */
+export interface KnowledgeSourceInfo {
+  readonly name: string;
+  readonly kind: KnowledgeSourceKind;
+  readonly description?: string | undefined;
+  readonly documentCount: number;
+}
+
+export type KnowledgeSourceKind = "directory" | "index" | "nexus";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Top-level config for createKnowledgeVaultProvider(). */
+export interface KnowledgeVaultConfig {
+  readonly sources: readonly KnowledgeSourceConfig[];
+  /** Token budget for query results. Default: 4000. */
+  readonly tokenBudget?: number | undefined;
+  /** Minimum relevance score (0–1). Default: 0.0 (include all). */
+  readonly relevanceThreshold?: number | undefined;
+  /** Max chars indexed per document for BM25. Default: 2000. */
+  readonly maxIndexCharsPerDoc?: number | undefined;
+  /** Maximum accumulated warnings before truncation. Default: 50. */
+  readonly maxWarnings?: number | undefined;
+  /** Filesystem scope for path boundary enforcement. Applied to directory sources with backends. */
+  readonly scope?: FileSystemScope | undefined;
+}
+
+/** Discriminated union of source configurations. */
+export type KnowledgeSourceConfig = DirectorySourceConfig | IndexSourceConfig | NexusSourceConfig;
+
+export interface DirectorySourceConfig {
+  readonly kind: "directory";
+  readonly name?: string | undefined;
+  readonly description?: string | undefined;
+  readonly path: string;
+  /** Glob pattern for file discovery. Default: "**\/*.md" */
+  readonly glob?: string | undefined;
+  /** Glob patterns to exclude. */
+  readonly exclude?: readonly string[] | undefined;
+  /** Optional filesystem backend. When absent, uses Bun APIs (local FS). */
+  readonly backend?: FileSystemBackend | undefined;
+}
+
+export interface IndexSourceConfig {
+  readonly kind: "index";
+  readonly name?: string | undefined;
+  readonly description?: string | undefined;
+  readonly backend: Retriever<unknown>;
+}
+
+export interface NexusSourceConfig {
+  readonly kind: "nexus";
+  readonly name?: string | undefined;
+  readonly description?: string | undefined;
+  readonly endpoint: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal value types (used across source modules + orchestration)
+// ---------------------------------------------------------------------------
+
+/** A document after parsing, before BM25 scoring. */
+export interface ParsedDocument {
+  readonly path: string;
+  readonly title: string;
+  readonly body: string;
+  readonly frontmatter: Readonly<Record<string, unknown>>;
+  readonly tags: readonly string[];
+  readonly lastModified: number;
+  readonly tokens: number;
+}
+
+/** Result of scanning a single source. */
+export interface ScanResult {
+  readonly documents: readonly ParsedDocument[];
+  readonly warnings: readonly string[];
+}
+
+/** Result of a refresh operation. */
+export interface RefreshResult {
+  readonly documentCount: number;
+  readonly warnings: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TOKEN_BUDGET = 4000;
+export const DEFAULT_RELEVANCE_THRESHOLD = 0.0;
+export const DEFAULT_MAX_INDEX_CHARS = 2000;
+export const DEFAULT_MAX_WARNINGS = 50;
+export const DEFAULT_BATCH_SIZE = 64;
+export const DEFAULT_GLOB = "**/*.md";

--- a/packages/knowledge-vault/src/vault-service.test.ts
+++ b/packages/knowledge-vault/src/vault-service.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { FileSystemBackend } from "@koi/core";
+import type { FileSystemScope } from "@koi/scope";
+import type { KnowledgeVaultConfig } from "./types.js";
+import { createVaultService } from "./vault-service.js";
+
+const tempDirs: string[] = [];
+
+async function createTestVault(
+  docs: readonly { readonly path: string; readonly content: string }[],
+): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kv-vs-"));
+  tempDirs.push(dir);
+  for (const doc of docs) {
+    await Bun.write(join(dir, doc.path), doc.content);
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe("createVaultService", () => {
+  test("creates service from directory source and answers queries", async () => {
+    const dir = await createTestVault([
+      {
+        path: "auth.md",
+        content:
+          "---\ntitle: Authentication\ntags: [auth, security]\n---\nJWT tokens, OAuth2 flows, session management.",
+      },
+      {
+        path: "api.md",
+        content:
+          "---\ntitle: API Design\ntags: [api, rest]\n---\nREST endpoints, pagination, error handling.",
+      },
+      {
+        path: "database.md",
+        content:
+          "---\ntitle: Database\ntags: [database, sql]\n---\nPostgreSQL schema, migrations, indexing.",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir, name: "docs" }],
+      tokenBudget: 4000,
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const service = result.value;
+    expect(service.sources).toHaveLength(1);
+    expect(service.sources[0]?.documentCount).toBe(3);
+
+    // Query for authentication-related docs
+    const docs = await service.query("authentication JWT");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+    expect(docs[0]?.title).toBe("Authentication");
+  });
+
+  test("returns empty results for empty query", async () => {
+    const dir = await createTestVault([{ path: "doc.md", content: "Some content." }]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("");
+    expect(docs).toHaveLength(0);
+  });
+
+  test("refresh rebuilds index with new documents", async () => {
+    const dir = await createTestVault([
+      { path: "initial.md", content: "Initial content about security." },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const service = result.value;
+    expect(service.sources[0]?.documentCount).toBe(1);
+
+    // Add a new file
+    await Bun.write(join(dir, "new.md"), "New content about deployment.");
+
+    const refreshResult = await service.refresh();
+    expect(refreshResult.documentCount).toBe(2);
+  });
+
+  test("handles empty directory source", async () => {
+    const dir = await createTestVault([]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("anything");
+    expect(docs).toHaveLength(0);
+  });
+
+  test("respects relevanceThreshold filter", async () => {
+    const dir = await createTestVault([
+      {
+        path: "exact.md",
+        content: "---\ntitle: Exact Match\n---\nauthentication authentication authentication",
+      },
+      {
+        path: "vague.md",
+        content: "---\ntitle: Vague\n---\ngeneral content about many topics",
+      },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+      relevanceThreshold: 0.5,
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("authentication");
+    // "vague.md" should be filtered out by threshold
+    for (const doc of docs) {
+      expect(doc.relevanceScore).toBeGreaterThanOrEqual(0.5);
+    }
+  });
+
+  test("query limit caps number of results", async () => {
+    const dir = await createTestVault([
+      { path: "a.md", content: "topic one details" },
+      { path: "b.md", content: "topic two details" },
+      { path: "c.md", content: "topic three details" },
+    ]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [{ kind: "directory", path: dir }],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const docs = await result.value.query("topic", 1);
+    expect(docs.length).toBeLessThanOrEqual(1);
+  });
+
+  test("description surfaces in source info", async () => {
+    const dir = await createTestVault([{ path: "doc.md", content: "Some content about auth." }]);
+
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        {
+          kind: "directory",
+          path: dir,
+          name: "docs",
+          description: "Internal engineering docs",
+        },
+      ],
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.sources).toHaveLength(1);
+    expect(result.value.sources[0]?.description).toBe("Internal engineering docs");
+  });
+
+  test("scope wraps backend when both provided", async () => {
+    const tmpRoot = await createTestVault([]);
+    const absRoot = resolve(tmpRoot);
+    const insidePath = join(absRoot, "inside.md");
+
+    // Track which paths are read
+    const readPaths: string[] = [];
+    const mockBackend: FileSystemBackend = {
+      name: "scoped-test",
+      list: () => ({
+        ok: true,
+        value: {
+          entries: [{ path: insidePath, kind: "file" as const }],
+          truncated: false,
+        },
+      }),
+      read: (path) => {
+        readPaths.push(path);
+        return {
+          ok: true,
+          value: { content: "Scoped content.", path, size: 15 },
+        };
+      },
+      write: () => {
+        throw new Error("Not implemented");
+      },
+      edit: () => {
+        throw new Error("Not implemented");
+      },
+      search: () => {
+        throw new Error("Not implemented");
+      },
+    };
+
+    const scope: FileSystemScope = { root: absRoot, mode: "ro" };
+
+    const config: KnowledgeVaultConfig = {
+      sources: [
+        {
+          kind: "directory",
+          path: absRoot,
+          backend: mockBackend,
+        },
+      ],
+      scope,
+    };
+
+    const result = await createVaultService(config);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The backend should have been wrapped — read() should receive resolved paths
+    expect(readPaths.length).toBeGreaterThanOrEqual(1);
+    expect(result.value.sources[0]?.documentCount).toBe(1);
+  });
+});

--- a/packages/knowledge-vault/src/vault-service.ts
+++ b/packages/knowledge-vault/src/vault-service.ts
@@ -1,0 +1,257 @@
+/**
+ * Vault service — core orchestration for knowledge vault.
+ *
+ * Scans sources → builds BM25 index → answers queries with budget selection.
+ * Central coordination point between source modules, BM25, and selector.
+ */
+
+import type { FileSystemBackend, KoiError, Result, TokenEstimator } from "@koi/core";
+import type { FileSystemScope } from "@koi/scope";
+import { createScopedFileSystem } from "@koi/scope";
+import { HEURISTIC_ESTIMATOR } from "@koi/token-estimator";
+
+import { type BM25Index, createBM25Index } from "./bm25.js";
+import { type ScoredDocument, selectWithinBudget } from "./selector.js";
+import { scanDirectory } from "./source-directory.js";
+import { scanIndex } from "./source-index.js";
+import { scanNexus } from "./source-nexus.js";
+import type {
+  DirectorySourceConfig,
+  KnowledgeDocument,
+  KnowledgeSourceConfig,
+  KnowledgeSourceInfo,
+  KnowledgeVaultConfig,
+  ParsedDocument,
+  RefreshResult,
+  ScanResult,
+} from "./types.js";
+import {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_MAX_INDEX_CHARS,
+  DEFAULT_MAX_WARNINGS,
+  DEFAULT_RELEVANCE_THRESHOLD,
+  DEFAULT_TOKEN_BUDGET,
+} from "./types.js";
+
+/** Public interface for querying a knowledge vault. */
+export interface VaultService {
+  readonly query: (query: string, limit?: number) => Promise<readonly KnowledgeDocument[]>;
+  readonly refresh: () => Promise<RefreshResult>;
+  readonly sources: readonly KnowledgeSourceInfo[];
+}
+
+/**
+ * Create a vault service from configuration.
+ *
+ * Performs initial scan of all sources and builds the BM25 index.
+ * Returns `Result` — may fail if all sources fail to load.
+ */
+export async function createVaultService(
+  config: KnowledgeVaultConfig,
+  estimator?: TokenEstimator,
+): Promise<Result<VaultService, KoiError>> {
+  const est = estimator ?? HEURISTIC_ESTIMATOR;
+  const tokenBudget = config.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+  const relevanceThreshold = config.relevanceThreshold ?? DEFAULT_RELEVANCE_THRESHOLD;
+  const maxIndexChars = config.maxIndexCharsPerDoc ?? DEFAULT_MAX_INDEX_CHARS;
+  const maxWarnings = config.maxWarnings ?? DEFAULT_MAX_WARNINGS;
+
+  const vaultScope = config.scope;
+
+  // Mutable state — rebuilt on refresh()
+  // let is required — state rebuilt on refresh
+  let state = await buildState(config.sources, maxIndexChars, maxWarnings, est, vaultScope);
+
+  function query(queryText: string, limit?: number): Promise<readonly KnowledgeDocument[]> {
+    if (queryText.trim() === "") {
+      return Promise.resolve([]);
+    }
+
+    const bm25Results = state.index.search(queryText, limit ?? 100);
+
+    // Map BM25 results to scored documents
+    const scored: ScoredDocument[] = [];
+    for (const r of bm25Results) {
+      if (r.score < relevanceThreshold) continue;
+
+      const doc = state.docMap.get(r.id);
+      if (doc === undefined) continue;
+
+      const sourceIdx = state.sourceIndexMap.get(r.id) ?? 0;
+      scored.push({
+        document: {
+          path: doc.path,
+          title: doc.title,
+          content: doc.body,
+          tags: doc.tags,
+          lastModified: doc.lastModified,
+          relevanceScore: r.score,
+        },
+        sourceIndex: sourceIdx,
+      });
+    }
+
+    const selection = selectWithinBudget(scored, state.sourceInfos, tokenBudget, est);
+
+    const results = limit !== undefined ? selection.selected.slice(0, limit) : selection.selected;
+
+    return Promise.resolve(results);
+  }
+
+  async function refresh(): Promise<RefreshResult> {
+    state = await buildState(config.sources, maxIndexChars, maxWarnings, est, vaultScope);
+    return {
+      documentCount: state.totalDocs,
+      warnings: state.warnings,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      query,
+      refresh,
+      get sources(): readonly KnowledgeSourceInfo[] {
+        return state.sourceInfos;
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal state management
+// ---------------------------------------------------------------------------
+
+interface VaultState {
+  readonly index: BM25Index;
+  readonly docMap: ReadonlyMap<string, ParsedDocument>;
+  readonly sourceIndexMap: ReadonlyMap<string, number>;
+  readonly sourceInfos: readonly KnowledgeSourceInfo[];
+  readonly warnings: readonly string[];
+  readonly totalDocs: number;
+}
+
+async function buildState(
+  sources: readonly KnowledgeSourceConfig[],
+  maxIndexChars: number,
+  maxWarnings: number,
+  estimator: TokenEstimator,
+  scope?: FileSystemScope | undefined,
+): Promise<VaultState> {
+  const allWarnings: string[] = [];
+  const sourceInfos: KnowledgeSourceInfo[] = [];
+  const sourceIndexMap = new Map<string, number>();
+  const docMap = new Map<string, ParsedDocument>();
+
+  // Internal keys are namespaced by source index to avoid collisions
+  // when multiple sources have documents with the same relative path
+  const internalKeys: string[] = [];
+
+  const scanResults = await Promise.allSettled(
+    sources.map((source) => scanSource(source, maxIndexChars, maxWarnings, estimator, scope)),
+  );
+
+  for (const [i, result] of scanResults.entries()) {
+    const sourceConfig = sources[i]!;
+    if (result.status === "fulfilled") {
+      const scan = result.value;
+      for (const doc of scan.documents) {
+        const key = `${String(i)}:${doc.path}`;
+        sourceIndexMap.set(key, i);
+        docMap.set(key, doc);
+        internalKeys.push(key);
+      }
+      for (const w of scan.warnings) {
+        if (allWarnings.length < maxWarnings) {
+          allWarnings.push(w);
+        }
+      }
+      sourceInfos.push({
+        name: sourceConfig.name ?? `${sourceConfig.kind}-${String(i)}`,
+        kind: sourceConfig.kind,
+        description: sourceConfig.description,
+        documentCount: scan.documents.length,
+      });
+    } else {
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      if (allWarnings.length < maxWarnings) {
+        allWarnings.push(`Source "${sourceConfig.name ?? sourceConfig.kind}" failed: ${reason}`);
+      }
+      sourceInfos.push({
+        name: sourceConfig.name ?? `${sourceConfig.kind}-${String(i)}`,
+        kind: sourceConfig.kind,
+        description: sourceConfig.description,
+        documentCount: 0,
+      });
+    }
+  }
+
+  // Build BM25 index using internal keys as document IDs
+  const bm25Docs: {
+    readonly id: string;
+    readonly text: string;
+    readonly titleText: string;
+    readonly tagText: string;
+  }[] = [];
+  for (const key of internalKeys) {
+    const doc = docMap.get(key);
+    if (doc === undefined) continue;
+    bm25Docs.push({
+      id: key,
+      text: doc.body,
+      titleText: doc.title,
+      tagText: doc.tags.join(" "),
+    });
+  }
+
+  const index = createBM25Index(bm25Docs);
+
+  return {
+    index,
+    docMap,
+    sourceIndexMap,
+    sourceInfos,
+    warnings: allWarnings,
+    totalDocs: internalKeys.length,
+  };
+}
+
+async function scanSource(
+  config: KnowledgeSourceConfig,
+  maxIndexChars: number,
+  maxWarnings: number,
+  estimator: TokenEstimator,
+  scope?: FileSystemScope | undefined,
+): Promise<ScanResult> {
+  switch (config.kind) {
+    case "directory": {
+      const effectiveConfig = wrapDirectoryBackendWithScope(config, scope);
+      return scanDirectory(effectiveConfig, {
+        maxIndexCharsPerDoc: maxIndexChars,
+        maxWarnings,
+        batchSize: DEFAULT_BATCH_SIZE,
+        estimator,
+      });
+    }
+    case "index":
+      return scanIndex(config, 1000);
+    case "nexus":
+      return scanNexus(config, 1000);
+  }
+}
+
+/**
+ * Wrap a directory source's backend with scope enforcement when both are present.
+ *
+ * Returns the config unchanged if either backend or scope is absent.
+ */
+function wrapDirectoryBackendWithScope(
+  config: DirectorySourceConfig,
+  scope: FileSystemScope | undefined,
+): DirectorySourceConfig {
+  if (config.backend === undefined || scope === undefined) {
+    return config;
+  }
+  const scopedBackend: FileSystemBackend = createScopedFileSystem(config.backend, scope);
+  return { ...config, backend: scopedBackend };
+}

--- a/packages/knowledge-vault/tsconfig.json
+++ b/packages/knowledge-vault/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../scope" },
+    { "path": "../search-provider" },
+    { "path": "../token-estimator" }
+  ]
+}

--- a/packages/knowledge-vault/tsup.config.ts
+++ b/packages/knowledge-vault/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Adds three capabilities to `@koi/knowledge-vault` (L2):

- **`description` field** on all source configs (`DirectorySourceConfig`, `IndexSourceConfig`, `NexusSourceConfig`) and `KnowledgeSourceInfo` — agents can understand what each knowledge source contains
- **`FileSystemBackend` support** in `DirectorySourceConfig` — directory scanning works with remote/virtual filesystems (Nexus, S3, in-memory mocks) alongside the existing Bun.file() local path
- **`scope` integration** via `FileSystemScope` on `KnowledgeVaultConfig` — path boundary enforcement using `createScopedFileSystem()` from `@koi/scope`

## What this enables

Agents can now query knowledge from **remote filesystems** with **path boundary enforcement**, not just local disk:

```typescript
createKnowledgeVaultProvider({
  sources: [{
    kind: "directory",
    path: "/project/docs",
    description: "Internal API reference",
    backend: nexusBackend,  // remote FS
  }],
  scope: { root: "/project/docs", mode: "ro" },  // sandboxed
});
```

## Changes

- `packages/knowledge-vault/src/types.ts` — added `description`, `backend`, `scope` fields
- `packages/knowledge-vault/src/source-directory.ts` — refactored into two paths: `scanWithBackend()` (FileSystemBackend) and `scanWithBun()` (local, backward compat)
- `packages/knowledge-vault/src/vault-service.ts` — surfaces `description`, wraps backend with scope via `wrapDirectoryBackendWithScope()`
- `packages/knowledge-vault/src/index.ts` — re-exports `FileSystemBackend` and `FileSystemScope` types
- `packages/knowledge-vault/package.json` — added `@koi/scope` (L0u) dependency
- `packages/knowledge-vault/tsconfig.json` — added project references
- `docs/L2/knowledge-vault.md` — full package documentation

## Verification

- [x] `bun run --cwd packages/knowledge-vault typecheck` — clean
- [x] `bun test --cwd packages/knowledge-vault` — 80 tests pass (7 new), 0 failures
- [x] `bun run check:layers` — all packages respect layer boundaries
- [x] `bun run --cwd packages/knowledge-vault build` — ESM + DTS output clean
- [x] `bun run --cwd packages/knowledge-vault lint` — only pre-existing warnings

## Test plan

- [x] `scanDirectory` with `FileSystemBackend` uses `list()` + `read()`
- [x] `scanDirectory` with backend handles read failure as warning
- [x] `scanDirectory` without backend uses Bun APIs (backward compat)
- [x] `description` surfaces in source info
- [x] `scope` wraps backend when both provided
- [x] Provider surfaces source descriptions
- [x] Full pipeline with mock FileSystemBackend (e2e)

Closes #327