### PR TITLE
feat: enforce token budget on identity persona instructions

### DIFF
--- a/docs/L2/soul.md
+++ b/docs/L2/soul.md
@@ -77,7 +77,7 @@ index.ts                 ← public re-exports
 ├── config.ts            ← CreateSoulOptions + ContentInput + ChannelPersonaConfig
 │                           validateSoulConfig(), DEFAULT_*_MAX_TOKENS
 │                           type guards: isRecord(), isContentInput(), isIdentityConfig()
-├── persona-map.ts       ← ResolvedPersona, CachedPersona
+├── persona-map.ts       ← ResolvedPersona, CachedPersona, PersonaMapResult
 │                           resolvePersonaContent(), generatePersonaText()
 │                           createPersonaMap(), createPersonaWatchedPaths()
 ├── state.ts             ← SoulState (atomic closure state)
@@ -228,11 +228,19 @@ Default token budget: `4000` tokens.
 Each persona maps a `channelId` (e.g. `"@koi/channel-telegram"`) to:
 - **name** — injected as `"You are {name}."` prefix
 - **avatar** — metadata only (not injected into text)
-- **instructions** — inline string or file path with persona-specific instructions
+- **instructions** — inline string or `{ path, maxTokens? }` with persona-specific instructions
 
 Personas with no name and no instructions produce no text and are excluded from the map.
 
-Default token budget: `2000` tokens.
+Default token budget: `2000` tokens (`DEFAULT_IDENTITY_MAX_TOKENS`).
+
+**Token budget enforcement:** Both inline and file-based persona instructions are bounded
+to `DEFAULT_IDENTITY_MAX_TOKENS` (2000 tokens ≈ 8000 chars). File reads use bounded I/O
+via `readBoundedFile(path, maxChars)` — only the first `maxChars` bytes are read from disk,
+preventing large persona files from consuming the context window. Inline strings are
+truncated via `truncateToTokenBudget()`. Each persona can override the default budget with
+`{ path: "...", maxTokens: 500 }`. When truncation occurs, a warning is emitted via
+`console.warn` and included in the `PersonaMapResult.warnings` array.
 
 ### User layer (per-user)
 
@@ -464,10 +472,13 @@ interface ChannelPersonaConfig {
   readonly name?: string;
   /** Avatar URL or path for this channel persona. */
   readonly avatar?: string;
-  /** Inline instructions string or file path reference. */
-  readonly instructions?: string | { readonly path: string };
+  /** Inline instructions string or file path reference with optional token budget. */
+  readonly instructions?: string | { readonly path: string; readonly maxTokens?: number };
 }
 ```
+
+When `instructions` is a `{ path, maxTokens? }` object, `maxTokens` overrides the default
+identity token budget (2000) for this persona only. Validated as a positive finite number.
 
 ### `SoulMiddleware`
 
@@ -635,7 +646,34 @@ const mw = await createSoulMiddleware({
 });
 ```
 
-### 4. Manifest-driven via `@koi/starter`
+### 4. Per-persona token budget override
+
+```typescript
+const mw = await createSoulMiddleware({
+  soul: "SOUL.md",
+  identity: {
+    personas: [
+      {
+        channelId: "@koi/channel-telegram",
+        name: "Koi Bot",
+        // Large persona file — bounded to default 2000 tokens (~8000 chars)
+        instructions: { path: "personas/telegram.md" },
+      },
+      {
+        channelId: "@koi/channel-slack",
+        name: "Koi Assistant",
+        // Tight budget — only 500 tokens (~2000 chars) for this persona
+        instructions: { path: "personas/slack.md", maxTokens: 500 },
+      },
+    ],
+  },
+  basePath: import.meta.dir,
+});
+// If telegram.md is 20KB, it's truncated to ~8000 chars with a warning:
+//   [soul middleware] identity persona "@koi/channel-telegram": content truncated ...
+```
+
+### 5. Manifest-driven via `@koi/starter`
 
 ```yaml
 # agent.yaml
@@ -665,7 +703,7 @@ import { createConfiguredKoi } from "@koi/starter";
 const koi = await createConfiguredKoi({ manifestPath: "agent.yaml" });
 ```
 
-### 5. Per-user refresh — dynamic user context
+### 6. Per-user refresh — dynamic user context
 
 ```typescript
 const mw = await createSoulMiddleware({
@@ -677,7 +715,7 @@ const mw = await createSoulMiddleware({
 // External process updates USER.md → next model call picks up new content
 ```
 
-### 6. Composing with other middleware
+### 7. Composing with other middleware
 
 ```typescript
 import { createKoi } from "@koi/engine";
@@ -701,7 +739,7 @@ const koi = createKoi({
 });
 ```
 
-### 7. Self-modification enabled (default)
+### 8. Self-modification enabled (default)
 
 ```typescript
 // selfModify defaults to true — the agent learns about its personality files
@@ -713,7 +751,7 @@ const mw = await createSoulMiddleware({
 // Agent sees: "[Soul System] Your personality is defined in these files: ..."
 ```
 
-### 8. Self-modification disabled
+### 9. Self-modification disabled
 
 ```typescript
 const mw = await createSoulMiddleware({

--- a/packages/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -38,6 +38,7 @@ interface ChannelPersonaConfig {
     /** Inline instructions string or file path reference for this persona. */
     readonly instructions?: string | {
         readonly path: string;
+        readonly maxTokens?: number;
     };
 }
 /** Options for creating the unified soul middleware. */
@@ -125,6 +126,12 @@ interface ResolvedPersona {
     readonly avatar?: string;
     readonly instructions: string;
     readonly sources: readonly string[];
+    readonly warnings: readonly string[];
+}
+/** Result of creating the persona map, including aggregated warnings. */
+interface PersonaMapResult {
+    readonly map: ReadonlyMap<string, CachedPersona>;
+    readonly warnings: readonly string[];
 }
 /** Cached per-channel persona entry. Stores text for O(1) lookup at call time. */
 interface CachedPersona {
@@ -135,10 +142,11 @@ interface CachedPersona {
 }
 /**
  * Resolves instruction content for a single persona config entry.
- * If instructions is a \`{ path }\` object, reads from disk asynchronously.
- * If instructions is an inline string, uses it directly.
+ * If instructions is a \`{ path }\` object, reads from disk with bounded I/O.
+ * If instructions is an inline string, truncates to the token budget.
+ * Applies DEFAULT_IDENTITY_MAX_TOKENS unless overridden per-persona.
  */
-declare function resolvePersonaContent(persona: ChannelPersonaConfig, basePath: string | undefined): Promise<ResolvedPersona>;
+declare function resolvePersonaContent(persona: ChannelPersonaConfig, basePath: string | undefined, maxTokens?: number): Promise<ResolvedPersona>;
 /**
  * Generates the persona text from a resolved persona.
  * Returns undefined when nothing meaningful to inject (no name, no instructions).
@@ -147,8 +155,9 @@ declare function generatePersonaText(resolved: ResolvedPersona): string | undefi
 /**
  * Resolves all personas and creates the channelId => CachedPersona map.
  * Personas with no injectable content (no name, no instructions) are excluded.
+ * Returns the map along with aggregated warnings from all persona resolutions.
  */
-declare function createPersonaMap(personas: readonly ChannelPersonaConfig[], basePath: string | undefined): Promise<Map<string, CachedPersona>>;
+declare function createPersonaMap(personas: readonly ChannelPersonaConfig[], basePath: string | undefined): Promise<PersonaMapResult>;
 /**
  * Collects all tracked file paths from a persona map into a Set.
  */
@@ -242,6 +251,6 @@ declare function generateMetaInstructionText(sources: MetaInstructionSources, se
  */
 declare function createSoulMessage(soulText: string, identityText: string | undefined, userText: string, metaInstructionText?: string): InboundMessage | undefined;
 
-export { type CachedPersona, type ChannelPersonaConfig, type ContentInput, type CreateSoulOptions, DEFAULT_IDENTITY_MAX_TOKENS, DEFAULT_SOUL_MAX_TOKENS, DEFAULT_TOTAL_MAX_TOKENS, DEFAULT_USER_MAX_TOKENS, type MetaInstructionSources, type ResolvedPersona, type SoulMiddleware, type SoulState, createAllWatchedPaths, createPersonaMap, createPersonaWatchedPaths, createSoulMessage, createSoulMiddleware, descriptor, enrichRequest, extractInput, extractMaxTokens, generateMetaInstructionText, generatePersonaText, personasFromManifest, resolvePersonaContent, validateSoulConfig };
+export { type CachedPersona, type ChannelPersonaConfig, type ContentInput, type CreateSoulOptions, DEFAULT_IDENTITY_MAX_TOKENS, DEFAULT_SOUL_MAX_TOKENS, DEFAULT_TOTAL_MAX_TOKENS, DEFAULT_USER_MAX_TOKENS, type MetaInstructionSources, type PersonaMapResult, type ResolvedPersona, type SoulMiddleware, type SoulState, createAllWatchedPaths, createPersonaMap, createPersonaWatchedPaths, createSoulMessage, createSoulMiddleware, descriptor, enrichRequest, extractInput, extractMaxTokens, generateMetaInstructionText, generatePersonaText, personasFromManifest, resolvePersonaContent, validateSoulConfig };
 "
 `;

--- a/packages/soul/src/config.test.ts
+++ b/packages/soul/src/config.test.ts
@@ -88,6 +88,21 @@ describe("validateSoulConfig — valid configs", () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  test("accepts persona with instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: 500 },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -283,5 +298,84 @@ describe("validateSoulConfig — invalid identity", () => {
       basePath: "/tmp",
     });
     expect(result.ok).toBe(false);
+  });
+
+  test("rejects persona with negative instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: -1 },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxTokens");
+  });
+
+  test("rejects persona with zero instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: 0 },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects persona with non-number instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: "big" },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxTokens");
+  });
+
+  test("rejects persona with NaN instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: NaN },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxTokens");
+  });
+
+  test("rejects persona with Infinity instructions.maxTokens", () => {
+    const result = validateSoulConfig({
+      identity: {
+        personas: [
+          {
+            channelId: "@koi/channel-telegram",
+            instructions: { path: "./persona.md", maxTokens: Infinity },
+          },
+        ],
+      },
+      basePath: "/tmp",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxTokens");
   });
 });

--- a/packages/soul/src/config.ts
+++ b/packages/soul/src/config.ts
@@ -27,7 +27,7 @@ export interface ChannelPersonaConfig {
   /** Avatar URL or path for this channel persona. */
   readonly avatar?: string;
   /** Inline instructions string or file path reference for this persona. */
-  readonly instructions?: string | { readonly path: string };
+  readonly instructions?: string | { readonly path: string; readonly maxTokens?: number };
 }
 
 /** Options for creating the unified soul middleware. */
@@ -170,6 +170,18 @@ function validatePersonaEntry(entry: unknown, index: number): KoiError | undefin
         return {
           code: "VALIDATION",
           message: `identity.personas[${index}].instructions.path must be a string`,
+          retryable: RETRYABLE_DEFAULTS.VALIDATION,
+        };
+      }
+      if (
+        entry.instructions.maxTokens !== undefined &&
+        (typeof entry.instructions.maxTokens !== "number" ||
+          !Number.isFinite(entry.instructions.maxTokens) ||
+          entry.instructions.maxTokens <= 0)
+      ) {
+        return {
+          code: "VALIDATION",
+          message: `identity.personas[${index}].instructions.maxTokens must be a positive number`,
           retryable: RETRYABLE_DEFAULTS.VALIDATION,
         };
       }

--- a/packages/soul/src/index.ts
+++ b/packages/soul/src/index.ts
@@ -25,7 +25,7 @@ export {
 } from "./config.js";
 export { descriptor } from "./descriptor.js";
 export { personasFromManifest } from "./manifest.js";
-export type { CachedPersona, ResolvedPersona } from "./persona-map.js";
+export type { CachedPersona, PersonaMapResult, ResolvedPersona } from "./persona-map.js";
 export {
   createPersonaMap,
   createPersonaWatchedPaths,

--- a/packages/soul/src/persona-map.test.ts
+++ b/packages/soul/src/persona-map.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { CHARS_PER_TOKEN } from "@koi/file-resolution";
+import { DEFAULT_IDENTITY_MAX_TOKENS } from "./config.js";
 import {
   createPersonaMap,
   createPersonaWatchedPaths,
@@ -32,12 +34,14 @@ describe("resolvePersonaContent", () => {
     expect(result.channelId).toBe("@koi/channel-telegram");
     expect(result.instructions).toBe("Be casual.");
     expect(result.sources).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
   });
 
   test("returns empty instructions when not provided", async () => {
     const result = await resolvePersonaContent({ channelId: "@koi/channel-cli" }, undefined);
     expect(result.instructions).toBe("");
     expect(result.sources).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
   });
 
   test("reads file instructions asynchronously", async () => {
@@ -51,6 +55,7 @@ describe("resolvePersonaContent", () => {
     expect(result.instructions).toBe("Be helpful and concise.");
     expect(result.sources).toHaveLength(1);
     expect(result.sources[0]).toContain("persona.md");
+    expect(result.warnings).toHaveLength(0);
   });
 
   test("returns empty instructions for missing file", async () => {
@@ -60,6 +65,7 @@ describe("resolvePersonaContent", () => {
     );
     expect(result.instructions).toBe("");
     expect(result.sources).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
   });
 
   test("includes name and avatar when provided", async () => {
@@ -89,6 +95,7 @@ describe("generatePersonaText", () => {
       name: "Alex",
       instructions: "Be casual.",
       sources: [],
+      warnings: [],
     });
     expect(text).toBe("You are Alex.\n\nBe casual.");
   });
@@ -99,6 +106,7 @@ describe("generatePersonaText", () => {
       name: "Alex",
       instructions: "",
       sources: [],
+      warnings: [],
     });
     expect(text).toBe("You are Alex.");
   });
@@ -108,6 +116,7 @@ describe("generatePersonaText", () => {
       channelId: "@koi/channel-telegram",
       instructions: "Be casual.",
       sources: [],
+      warnings: [],
     });
     expect(text).toBe("Be casual.");
   });
@@ -117,6 +126,7 @@ describe("generatePersonaText", () => {
       channelId: "@koi/channel-telegram",
       instructions: "",
       sources: [],
+      warnings: [],
     });
     expect(text).toBeUndefined();
   });
@@ -128,7 +138,7 @@ describe("generatePersonaText", () => {
 
 describe("createPersonaMap", () => {
   test("creates map entries for personas with injectable content", async () => {
-    const map = await createPersonaMap(
+    const { map, warnings } = await createPersonaMap(
       [
         { channelId: "@koi/channel-telegram", name: "Alex", instructions: "Be casual." },
         { channelId: "@koi/channel-slack", instructions: "Be formal." },
@@ -138,10 +148,11 @@ describe("createPersonaMap", () => {
     expect(map.size).toBe(2);
     expect(map.has("@koi/channel-telegram")).toBe(true);
     expect(map.has("@koi/channel-slack")).toBe(true);
+    expect(warnings).toHaveLength(0);
   });
 
   test("excludes personas with no name and no instructions", async () => {
-    const map = await createPersonaMap(
+    const { map } = await createPersonaMap(
       [{ channelId: "@koi/channel-cli" }, { channelId: "@koi/channel-telegram", name: "Alex" }],
       undefined,
     );
@@ -150,7 +161,7 @@ describe("createPersonaMap", () => {
   });
 
   test("stores text instead of pre-built message", async () => {
-    const map = await createPersonaMap(
+    const { map } = await createPersonaMap(
       [{ channelId: "@koi/channel-telegram", name: "Alex", instructions: "Be casual." }],
       undefined,
     );
@@ -161,7 +172,7 @@ describe("createPersonaMap", () => {
   });
 
   test("returns empty map for empty personas array", async () => {
-    const map = await createPersonaMap([], undefined);
+    const { map } = await createPersonaMap([], undefined);
     expect(map.size).toBe(0);
   });
 });
@@ -175,7 +186,7 @@ describe("createPersonaWatchedPaths", () => {
     const filePath = join(tmpDir, "persona.md");
     await writeFile(filePath, "Be helpful.");
 
-    const map = await createPersonaMap(
+    const { map } = await createPersonaMap(
       [{ channelId: "@koi/channel-telegram", instructions: { path: "persona.md" } }],
       tmpDir,
     );
@@ -184,7 +195,7 @@ describe("createPersonaWatchedPaths", () => {
   });
 
   test("returns empty set for inline-only personas", async () => {
-    const map = await createPersonaMap(
+    const { map } = await createPersonaMap(
       [{ channelId: "@koi/channel-telegram", name: "Alex" }],
       undefined,
     );
@@ -195,5 +206,92 @@ describe("createPersonaWatchedPaths", () => {
   test("returns empty set for empty map", () => {
     const paths = createPersonaWatchedPaths(new Map());
     expect(paths.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token budget enforcement
+// ---------------------------------------------------------------------------
+
+describe("token budget enforcement", () => {
+  const defaultMaxChars = DEFAULT_IDENTITY_MAX_TOKENS * CHARS_PER_TOKEN; // 2000 * 4 = 8000
+
+  test("file content truncated to default budget", async () => {
+    const filePath = join(tmpDir, "large-persona.md");
+    const oversized = "x".repeat(defaultMaxChars + 1000);
+    await writeFile(filePath, oversized);
+
+    const result = await resolvePersonaContent(
+      { channelId: "@koi/channel-telegram", instructions: { path: "large-persona.md" } },
+      tmpDir,
+    );
+    expect(result.instructions.length).toBeLessThanOrEqual(defaultMaxChars);
+  });
+
+  test("inline content truncated to default budget", async () => {
+    const oversized = "y".repeat(defaultMaxChars + 500);
+
+    const result = await resolvePersonaContent(
+      { channelId: "@koi/channel-telegram", instructions: oversized },
+      undefined,
+    );
+    expect(result.instructions.length).toBeLessThanOrEqual(defaultMaxChars);
+  });
+
+  test("warnings returned when truncation occurs", async () => {
+    const filePath = join(tmpDir, "big-persona.md");
+    await writeFile(filePath, "z".repeat(defaultMaxChars + 2000));
+
+    const result = await resolvePersonaContent(
+      { channelId: "@koi/channel-telegram", instructions: { path: "big-persona.md" } },
+      tmpDir,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("truncated");
+  });
+
+  test("per-persona maxTokens override honored", async () => {
+    const customMaxTokens = 500;
+    const customMaxChars = customMaxTokens * CHARS_PER_TOKEN; // 2000
+    const filePath = join(tmpDir, "custom-persona.md");
+    await writeFile(filePath, "a".repeat(customMaxChars + 500));
+
+    const result = await resolvePersonaContent(
+      {
+        channelId: "@koi/channel-telegram",
+        instructions: { path: "custom-persona.md", maxTokens: customMaxTokens },
+      },
+      tmpDir,
+    );
+    expect(result.instructions.length).toBeLessThanOrEqual(customMaxChars);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("content within budget passes through unchanged", async () => {
+    const filePath = join(tmpDir, "small-persona.md");
+    const content = "Short persona instructions.";
+    await writeFile(filePath, content);
+
+    const result = await resolvePersonaContent(
+      { channelId: "@koi/channel-telegram", instructions: { path: "small-persona.md" } },
+      tmpDir,
+    );
+    expect(result.instructions).toBe(content);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("createPersonaMap aggregates warnings from multiple personas", async () => {
+    const oversized = "w".repeat(defaultMaxChars + 1000);
+    const filePath = join(tmpDir, "p1.md");
+    await writeFile(filePath, oversized);
+
+    const { warnings } = await createPersonaMap(
+      [
+        { channelId: "@koi/channel-telegram", instructions: oversized },
+        { channelId: "@koi/channel-slack", instructions: { path: "p1.md" } },
+      ],
+      tmpDir,
+    );
+    expect(warnings.length).toBe(2);
   });
 });

--- a/packages/soul/src/persona-map.ts
+++ b/packages/soul/src/persona-map.ts
@@ -6,8 +6,9 @@
  */
 
 import { resolve } from "node:path";
-import { readBoundedFile } from "@koi/file-resolution";
+import { CHARS_PER_TOKEN, readBoundedFile, truncateToTokenBudget } from "@koi/file-resolution";
 import type { ChannelPersonaConfig } from "./config.js";
+import { DEFAULT_IDENTITY_MAX_TOKENS } from "./config.js";
 
 /** A resolved persona with loaded instruction text and tracked file paths. */
 export interface ResolvedPersona {
@@ -16,6 +17,13 @@ export interface ResolvedPersona {
   readonly avatar?: string;
   readonly instructions: string;
   readonly sources: readonly string[];
+  readonly warnings: readonly string[];
+}
+
+/** Result of creating the persona map, including aggregated warnings. */
+export interface PersonaMapResult {
+  readonly map: ReadonlyMap<string, CachedPersona>;
+  readonly warnings: readonly string[];
 }
 
 /** Cached per-channel persona entry. Stores text for O(1) lookup at call time. */
@@ -28,12 +36,14 @@ export interface CachedPersona {
 
 /**
  * Resolves instruction content for a single persona config entry.
- * If instructions is a `{ path }` object, reads from disk asynchronously.
- * If instructions is an inline string, uses it directly.
+ * If instructions is a `{ path }` object, reads from disk with bounded I/O.
+ * If instructions is an inline string, truncates to the token budget.
+ * Applies DEFAULT_IDENTITY_MAX_TOKENS unless overridden per-persona.
  */
 export async function resolvePersonaContent(
   persona: ChannelPersonaConfig,
   basePath: string | undefined,
+  maxTokens: number = DEFAULT_IDENTITY_MAX_TOKENS,
 ): Promise<ResolvedPersona> {
   const optionalFields = {
     ...(persona.name !== undefined ? { name: persona.name } : {}),
@@ -41,29 +51,68 @@ export async function resolvePersonaContent(
   };
 
   if (persona.instructions === undefined) {
-    return { channelId: persona.channelId, ...optionalFields, instructions: "", sources: [] };
-  }
-
-  if (typeof persona.instructions === "string") {
     return {
       channelId: persona.channelId,
       ...optionalFields,
-      instructions: persona.instructions,
+      instructions: "",
       sources: [],
+      warnings: [],
     };
   }
 
-  // { path: string } — load from file
+  // Determine effective token budget: per-persona override > caller default
+  const effectiveMaxTokens =
+    typeof persona.instructions !== "string" && persona.instructions.maxTokens !== undefined
+      ? persona.instructions.maxTokens
+      : maxTokens;
+
+  const label = `identity persona "${persona.channelId}"`;
+
+  if (typeof persona.instructions === "string") {
+    const { text, warning } = truncateToTokenBudget(
+      persona.instructions,
+      effectiveMaxTokens,
+      label,
+    );
+    return {
+      channelId: persona.channelId,
+      ...optionalFields,
+      instructions: text,
+      sources: [],
+      warnings: warning !== undefined ? [warning] : [],
+    };
+  }
+
+  // { path: string; maxTokens?: number } — load from file with bounded I/O
   const filePath =
     basePath !== undefined
       ? resolve(basePath, persona.instructions.path)
       : resolve(persona.instructions.path);
-  const content = await readBoundedFile(filePath);
+  const maxChars = effectiveMaxTokens * CHARS_PER_TOKEN;
+  const result = await readBoundedFile(filePath, maxChars);
+
+  if (result === undefined) {
+    return {
+      channelId: persona.channelId,
+      ...optionalFields,
+      instructions: "",
+      sources: [],
+      warnings: [],
+    };
+  }
+
+  const warnings: readonly string[] = result.truncated
+    ? [
+        `${label}: content truncated from ${String(result.originalSize)} chars to ${String(maxChars)} chars (~${String(effectiveMaxTokens)} tokens)`,
+      ]
+    : [];
+
   return {
     channelId: persona.channelId,
     ...optionalFields,
-    instructions: content ?? "",
-    sources: content !== undefined ? [filePath] : [],
+    instructions: result.content,
+    sources: [filePath],
+    warnings,
   };
 }
 
@@ -84,12 +133,15 @@ export function generatePersonaText(resolved: ResolvedPersona): string | undefin
 /**
  * Resolves all personas and creates the channelId => CachedPersona map.
  * Personas with no injectable content (no name, no instructions) are excluded.
+ * Returns the map along with aggregated warnings from all persona resolutions.
  */
 export async function createPersonaMap(
   personas: readonly ChannelPersonaConfig[],
   basePath: string | undefined,
-): Promise<Map<string, CachedPersona>> {
+): Promise<PersonaMapResult> {
   const resolved = await Promise.all(personas.map((p) => resolvePersonaContent(p, basePath)));
+
+  const allWarnings = resolved.flatMap((r) => [...r.warnings]);
 
   const map = new Map<string, CachedPersona>();
   for (const r of resolved) {
@@ -98,7 +150,7 @@ export async function createPersonaMap(
 
     map.set(r.channelId, { text, sources: r.sources });
   }
-  return map;
+  return { map, warnings: allWarnings };
 }
 
 /**

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -106,15 +106,17 @@ function emitWarnings(warnings: readonly string[]): void {
  * Creates the full SoulState from all three layers.
  */
 async function createState(options: CreateSoulOptions): Promise<SoulState> {
-  const [soulResult, personaMap, userResult] = await Promise.all([
+  const [soulResult, personaResult, userResult] = await Promise.all([
     resolveSoulLayer(options),
     createPersonaMap(options.identity?.personas ?? [], options.basePath),
     resolveUserLayer(options),
   ]);
 
   emitWarnings(soulResult.warnings);
+  emitWarnings(personaResult.warnings);
   emitWarnings(userResult.warnings);
 
+  const personaMap = personaResult.map;
   const watchedPaths = createAllWatchedPaths(soulResult.sources, personaMap, userResult.sources);
   const selfModify = options.selfModify ?? true;
 


### PR DESCRIPTION
## Summary

Fixes #409 — `@koi/identity` missing token budget enforcement.

- `resolvePersonaContent()` called `readBoundedFile(filePath)` without `maxChars`, allowing large persona markdown files to be injected in full into the system prompt, consuming excessive context window
- `DEFAULT_IDENTITY_MAX_TOKENS = 2000` existed in `config.ts` but was **never wired** into persona resolution
- The soul and user layers already enforced token budgets via `resolveContent()` from `@koi/file-resolution`; the identity/persona layer was the only one that bypassed this

### Changes

- **`config.ts`**: Extended `ChannelPersonaConfig.instructions` type to `string | { path; maxTokens? }`, added `maxTokens` validation (positive, finite number) in `validatePersonaEntry()`
- **`persona-map.ts`**: Applied `truncateToTokenBudget()` for inline content, `readBoundedFile(path, maxChars)` for file content, per-persona `maxTokens` override, new `PersonaMapResult { map, warnings }` return type
- **`soul.ts`**: Wired persona warnings through `emitWarnings()` in `createState()`
- **`index.ts`**: Exported new `PersonaMapResult` type
- **`docs/L2/soul.md`**: Documented token budget enforcement, per-persona override, new example

### What this enables

Large persona files (e.g. 50KB markdown) are now bounded to ~8000 chars (2000 tokens) by default. Per-persona override: `{ path: "persona.md", maxTokens: 500 }`. Truncation emits a warning. All three layers (soul, identity, user) now have consistent budget enforcement.

## Test plan

- [x] 8 new tests in `persona-map.test.ts` (file truncation, inline truncation, warnings, per-persona override, passthrough, warning aggregation)
- [x] 5 new tests in `config.test.ts` (valid maxTokens, negative, zero, non-number, NaN, Infinity)
- [x] All 127 existing + new tests pass (`bun test`)
- [x] Build succeeds (`bun run build`)
- [x] Lint clean (`bun run lint`)
- [x] API surface snapshot updated