### PR TITLE
feat: add @koi/middleware-call-dedup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1137,6 +1137,18 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware-call-dedup": {
+      "name": "@koi/middleware-call-dedup",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/hash": "workspace:*",
+        "@koi/resolve": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware-call-limits": {
       "name": "@koi/middleware-call-limits",
       "version": "0.0.0",
@@ -2872,6 +2884,8 @@
     "@koi/middleware-ace": ["@koi/middleware-ace@workspace:packages/middleware-ace"],
 
     "@koi/middleware-audit": ["@koi/middleware-audit@workspace:packages/middleware-audit"],
+
+    "@koi/middleware-call-dedup": ["@koi/middleware-call-dedup@workspace:packages/middleware-call-dedup"],
 
     "@koi/middleware-call-limits": ["@koi/middleware-call-limits@workspace:packages/middleware-call-limits"],
 

--- a/docs/L2/middleware-call-dedup.md
+++ b/docs/L2/middleware-call-dedup.md
@@ -1,0 +1,282 @@
+# @koi/middleware-call-dedup — Deterministic Tool Call Result Caching
+
+`@koi/middleware-call-dedup` is an L2 middleware package that caches results of identical deterministic tool calls within a session. When an agent calls the same tool with the same arguments multiple times, the 2nd+ call returns the cached result instantly — no network round-trip, no re-execution, no quota burn.
+
+---
+
+## Why It Exists
+
+Agents frequently call the same deterministic tool multiple times per session with identical arguments. Each call executes fully — file I/O, network requests, token counting, billing. The loop guard detects *patterns* but still executes each call. This middleware caches *results*.
+
+```
+Without call-dedup:
+  file_read("/config.json")  ─► execute (50ms)  ─► result A
+  file_read("/config.json")  ─► execute (50ms)  ─► result A  ← wasted
+  file_read("/config.json")  ─► execute (50ms)  ─► result A  ← wasted
+  file_read("/config.json")  ─► execute (50ms)  ─► result A  ← wasted
+  Total: 4 executions, 200ms
+
+With call-dedup:
+  file_read("/config.json")  ─► execute (50ms)  ─► result A  ← cached
+  file_read("/config.json")  ─► cache hit (0ms) ─► result A  (metadata.cached = true)
+  file_read("/config.json")  ─► cache hit (0ms) ─► result A  (metadata.cached = true)
+  file_read("/config.json")  ─► cache hit (0ms) ─► result A  (metadata.cached = true)
+  Total: 1 execution, 50ms
+```
+
+Three key mechanisms:
+
+1. **SHA-256 cache key** — `computeContentHash({ session, tool, input })` produces a deterministic key from sessionId + toolId + input, ensuring session isolation
+2. **LRU + TTL eviction** — entries expire after a configurable TTL (default 5 min) and the store caps at a max size (default 100) with LRU eviction
+3. **Smart exclusion** — mutating tools (`shell_exec`, `file_write`, etc.) are excluded by default and always execute
+
+---
+
+## Architecture
+
+### Layer Position
+
+```
+L0  @koi/core                        ─ KoiMiddleware, ToolRequest, ToolResponse,
+                                         TurnContext, CapabilityFragment (types only)
+L0u @koi/hash                        ─ computeContentHash (SHA-256)
+L0u @koi/resolve                     ─ BrickDescriptor (manifest auto-resolution)
+L2  @koi/middleware-call-dedup       ─ this package (no L1 dependency)
+```
+
+### Internal Module Map
+
+```
+index.ts                    ← public re-exports
+│
+├── types.ts                ← CallDedupStore, CacheEntry, CacheHitInfo
+├── config.ts               ← CallDedupConfig, DEFAULT_EXCLUDE, validateCallDedupConfig
+├── store.ts                ← createInMemoryDedupStore (Map-backed LRU)
+├── call-dedup.ts           ← createCallDedupMiddleware() factory
+└── descriptor.ts           ← BrickDescriptor for manifest auto-resolution
+```
+
+### Middleware Priority
+
+```
+170 ─ (available)
+175 ─ call-limits        ← enforce call count budgets
+185 ─ call-dedup         ← this package (cache after limit check)
+200 ─ pay                ← billing
+225 ─ compactor          ← context compaction
+```
+
+The dedup middleware runs at priority 185 — after call-limits (175) so a deduplicated call does not consume the call budget, but before pay (200) so cached results bypass billing.
+
+---
+
+## How It Works
+
+### Cache Key Generation
+
+Each cache key is derived from three components to ensure correctness and session isolation:
+
+```
+cacheKey = SHA-256({ session: sessionId, tool: toolId, input: { ... } })
+```
+
+The deterministic serialization in `computeContentHash` sorts object keys recursively, so `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` produce the same hash.
+
+### wrapToolCall Flow
+
+```
+Request arrives
+  │
+  ├─ Tool excluded? ──────────────────► next(request)  (always execute)
+  │
+  ├─ Include list exists & tool not in it? ─► next(request)  (skip cache)
+  │
+  ├─ Compute cache key (sessionId + toolId + input)
+  │
+  ├─ Cache hit & not expired? ────────► return cached response
+  │   │                                  (metadata.cached = true)
+  │   │                                  (fire onCacheHit callback)
+  │   │
+  │   └─ Expired? ────────────────────► delete stale entry, fall through
+  │
+  ├─ Execute next(request)
+  │   │
+  │   ├─ Tool threw? ─────────────────► re-throw (never cache exceptions)
+  │   │
+  │   ├─ Response blocked/error? ─────► return without caching
+  │   │
+  │   └─ Success ─────────────────────► store result, return response
+  │
+  └─ (unreachable)
+```
+
+### Default Exclusions
+
+These tools are excluded from caching by default because they are side-effecting:
+
+| Tool | Reason |
+|------|--------|
+| `shell_exec` | Executes shell commands with side effects |
+| `file_write` | Writes to filesystem |
+| `file_delete` | Deletes files |
+| `file_create` | Creates files |
+| `agent_send` | Sends messages to other agents |
+| `agent_spawn` | Spawns new agent processes |
+
+User-supplied `exclude` entries are merged with these defaults.
+
+---
+
+## API Reference
+
+### `createCallDedupMiddleware(config?)`
+
+Factory function that creates a `KoiMiddleware` with a `wrapToolCall` hook.
+
+```typescript
+import { createCallDedupMiddleware } from "@koi/middleware-call-dedup";
+
+const dedup = createCallDedupMiddleware({
+  ttlMs: 60_000,        // 1 minute TTL (default: 300_000 = 5 min)
+  maxEntries: 50,        // LRU capacity (default: 100)
+  exclude: ["my_tool"],  // merged with DEFAULT_EXCLUDE
+  onCacheHit: (info) => console.log(`Hit: ${info.toolId}`),
+});
+```
+
+Returns `KoiMiddleware` with:
+- `name`: `"koi:call-dedup"`
+- `priority`: `185`
+- `wrapToolCall`: cache-or-execute logic
+- `describeCapabilities`: returns `{ label: "call-dedup", description: "..." }`
+
+### `CallDedupConfig`
+
+```typescript
+interface CallDedupConfig {
+  readonly ttlMs?: number;           // Cache TTL in ms (default: 300_000)
+  readonly maxEntries?: number;      // Max cache entries (default: 100)
+  readonly include?: readonly string[];  // Whitelist (undefined = all non-excluded)
+  readonly exclude?: readonly string[];  // Blacklist (merged with DEFAULT_EXCLUDE)
+  readonly hashFn?: (sessionId: string, toolId: string, input: JsonObject) => string;
+  readonly now?: () => number;       // Clock injection for testing
+  readonly store?: CallDedupStore;   // Custom store (default: in-memory LRU)
+  readonly onCacheHit?: (info: CacheHitInfo) => void;
+}
+```
+
+### `createInMemoryDedupStore(maxEntries)`
+
+Creates a Map-backed LRU store with sync operations:
+
+```typescript
+import { createInMemoryDedupStore } from "@koi/middleware-call-dedup";
+
+const store = createInMemoryDedupStore(200);
+```
+
+### `CallDedupStore`
+
+Interface for custom store implementations (e.g., Redis-backed):
+
+```typescript
+interface CallDedupStore {
+  readonly get: (key: string) => CacheEntry | undefined | Promise<CacheEntry | undefined>;
+  readonly set: (key: string, entry: CacheEntry) => void | Promise<void>;
+  readonly delete: (key: string) => boolean | Promise<boolean>;
+  readonly size: () => number | Promise<number>;
+  readonly clear: () => void | Promise<void>;
+}
+```
+
+### `validateCallDedupConfig(config)`
+
+Validates raw input (e.g., from YAML) into a typed config:
+
+```typescript
+const result = validateCallDedupConfig({ ttlMs: 60000 });
+if (result.ok) {
+  const config = result.value; // CallDedupConfig
+}
+```
+
+---
+
+## Examples
+
+### Manifest-Driven (koi.yaml)
+
+```yaml
+middleware:
+  - name: call-dedup
+    options:
+      ttlMs: 60000
+      exclude: [my_custom_mutation_tool]
+```
+
+No code changes needed — the `BrickDescriptor` handles resolution automatically.
+
+### Programmatic Factory
+
+```typescript
+import { createCallDedupMiddleware } from "@koi/middleware-call-dedup";
+
+const dedup = createCallDedupMiddleware({
+  ttlMs: 120_000,
+  include: ["file_read", "web_search", "code_search"],
+  onCacheHit: ({ toolId, sessionId }) => {
+    metrics.increment("cache_hit", { tool: toolId, session: sessionId });
+  },
+});
+```
+
+### With Custom Store
+
+```typescript
+import type { CallDedupStore } from "@koi/middleware-call-dedup";
+import { createCallDedupMiddleware } from "@koi/middleware-call-dedup";
+
+const redisStore: CallDedupStore = {
+  async get(key) { /* Redis GET + JSON parse */ },
+  async set(key, entry) { /* Redis SET with TTL */ },
+  async delete(key) { /* Redis DEL */ },
+  async size() { /* Redis DBSIZE */ },
+  async clear() { /* Redis FLUSHDB */ },
+};
+
+const dedup = createCallDedupMiddleware({ store: redisStore });
+```
+
+---
+
+## What This Feature Enables
+
+### 1. Reduced Latency
+Cached tool calls return instantly (sub-millisecond) instead of waiting for I/O. An agent that reads the same file 5 times per session saves 4 round-trips.
+
+### 2. Lower Cost
+Deduplicated calls skip billing middleware (priority 185 < pay at 200). For agents using metered APIs (web search, code search), this directly reduces token and API costs.
+
+### 3. Quota Preservation
+Rate-limited tools (call-limits middleware at priority 175) count each execution. Cached responses don't reach the tool executor, so they don't consume the quota budget.
+
+### 4. Deterministic Behavior
+Same input always produces the same cached output within the TTL window, reducing non-determinism in multi-turn agent sessions.
+
+### 5. Session Isolation
+Cache keys include `sessionId`, so agent A's cached results never leak into agent B's session — even if they call the same tool with the same input.
+
+---
+
+## Layer Compliance
+
+```
+@koi/middleware-call-dedup imports:
+  ✅ @koi/core      (L0)  — KoiMiddleware, ToolRequest, ToolResponse, etc.
+  ✅ @koi/hash       (L0u) — computeContentHash
+  ✅ @koi/resolve    (L0u) — BrickDescriptor
+  ❌ @koi/engine     (L1)  — NOT imported
+  ❌ peer L2          —      NOT imported
+```
+
+All interface properties are `readonly`. No vendor types. No framework-isms.

--- a/packages/middleware-call-dedup/package.json
+++ b/packages/middleware-call-dedup/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@koi/middleware-call-dedup",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/hash": "workspace:*",
+    "@koi/resolve": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/middleware-call-dedup/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware-call-dedup/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,124 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-call-dedup API surface . has stable type surface 1`] = `
+"import { ToolResponse, KoiMiddleware } from '@koi/core/middleware';
+import { JsonObject } from '@koi/core/common';
+import { Result, KoiError } from '@koi/core/errors';
+import { KoiMiddleware as KoiMiddleware$1 } from '@koi/core';
+import { BrickDescriptor } from '@koi/resolve';
+
+/**
+ * Call dedup types — cache store interface and cache entry types.
+ */
+
+/** A cached tool response with an expiration timestamp. */
+interface CacheEntry {
+    readonly response: ToolResponse;
+    readonly expiresAt: number;
+}
+/**
+ * Key-value cache store for deduplicating tool call results.
+ * Implementations may be sync (in-memory) or async (network).
+ */
+interface CallDedupStore {
+    readonly get: (key: string) => CacheEntry | undefined | Promise<CacheEntry | undefined>;
+    readonly set: (key: string, entry: CacheEntry) => void | Promise<void>;
+    readonly delete: (key: string) => boolean | Promise<boolean>;
+    readonly size: () => number | Promise<number>;
+    readonly clear: () => void | Promise<void>;
+}
+/** Info passed to onCacheHit callbacks. */
+interface CacheHitInfo {
+    readonly sessionId: string;
+    readonly toolId: string;
+    readonly cacheKey: string;
+}
+
+/**
+ * Call dedup middleware configuration and validation.
+ */
+
+/** Tools excluded from caching by default (mutating / side-effecting). */
+declare const DEFAULT_EXCLUDE: readonly ["shell_exec", "file_write", "file_delete", "file_create", "agent_send", "agent_spawn"];
+interface CallDedupConfig {
+    /** Cache TTL in milliseconds. Default: 300_000 (5 min). */
+    readonly ttlMs?: number | undefined;
+    /** Maximum cache entries before LRU eviction. Default: 100. */
+    readonly maxEntries?: number | undefined;
+    /** Whitelist — only cache these tools. undefined = all non-excluded tools. */
+    readonly include?: readonly string[] | undefined;
+    /** Blacklist — merged with DEFAULT_EXCLUDE. */
+    readonly exclude?: readonly string[] | undefined;
+    /** Custom hash function for cache key generation. Must include sessionId for session isolation. */
+    readonly hashFn?: ((sessionId: string, toolId: string, input: JsonObject) => string) | undefined;
+    /** Clock injection for deterministic TTL tests. */
+    readonly now?: (() => number) | undefined;
+    /** Custom cache store. Default: in-memory LRU store. */
+    readonly store?: CallDedupStore | undefined;
+    /** Callback fired on cache hits. */
+    readonly onCacheHit?: ((info: CacheHitInfo) => void) | undefined;
+}
+/**
+ * Validates raw config input into a typed CallDedupConfig.
+ * Empty \`{}\` is valid (all defaults apply).
+ */
+declare function validateCallDedupConfig(config: unknown): Result<CallDedupConfig, KoiError>;
+
+/**
+ * Call dedup middleware — caches deterministic tool call results.
+ *
+ * Identical tool calls (same sessionId + toolId + input) within the TTL
+ * return the cached response instantly, avoiding redundant execution.
+ *
+ * Priority 185: runs after call-limits (175), before pay (200).
+ */
+
+/**
+ * Creates a call dedup middleware that caches deterministic tool call results.
+ *
+ * Tools in the exclude list (merged with DEFAULT_EXCLUDE) always execute.
+ * If an include list is provided, only listed tools are cached (minus excludes).
+ * Errors, blocked responses, and exceptions are never cached.
+ */
+declare function createCallDedupMiddleware(config?: CallDedupConfig): KoiMiddleware;
+
+/**
+ * BrickDescriptor for @koi/middleware-call-dedup.
+ *
+ * Enables manifest auto-resolution: validates call-dedup options
+ * from koi.yaml, then creates the dedup middleware.
+ *
+ * Usage in koi.yaml:
+ *   middleware:
+ *     - name: call-dedup
+ *       options:
+ *         ttlMs: 60000
+ *         exclude: [my_custom_mutation_tool]
+ */
+
+/**
+ * Descriptor for call-dedup middleware.
+ *
+ * Creates a dedup middleware from validated YAML options.
+ * Uses in-memory LRU store by default.
+ */
+declare const descriptor: BrickDescriptor<KoiMiddleware$1>;
+
+/**
+ * In-memory dedup store — Map-backed, LRU eviction, sync returns.
+ */
+
+/**
+ * Creates a Map-backed dedup store with LRU eviction.
+ *
+ * LRU is implemented via Map insertion order:
+ * - \`get()\` deletes and re-inserts the entry to promote it
+ * - \`set()\` evicts the oldest entry when at capacity
+ *
+ * All operations are synchronous (no async overhead for the common case).
+ */
+declare function createInMemoryDedupStore(maxEntries: number): CallDedupStore;
+
+export { type CacheEntry, type CacheHitInfo, type CallDedupConfig, type CallDedupStore, DEFAULT_EXCLUDE, createCallDedupMiddleware, createInMemoryDedupStore, descriptor, validateCallDedupConfig };
+"
+`;

--- a/packages/middleware-call-dedup/src/__tests__/api-surface.test.ts
+++ b/packages/middleware-call-dedup/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware-call-dedup/src/call-dedup.test.ts
+++ b/packages/middleware-call-dedup/src/call-dedup.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from "bun:test";
+import { sessionId } from "@koi/core/ecs";
+import type { ToolRequest, ToolResponse } from "@koi/core/middleware";
+import {
+  createMockSessionContext,
+  createMockTurnContext,
+  createSpyToolHandler,
+} from "@koi/test-utils";
+import { createCallDedupMiddleware } from "./call-dedup.js";
+import { DEFAULT_EXCLUDE } from "./config.js";
+import type { CacheHitInfo } from "./types.js";
+
+function toolRequest(toolId: string, input: Record<string, unknown> = {}): ToolRequest {
+  return { toolId, input };
+}
+
+describe("createCallDedupMiddleware", () => {
+  test("has correct name and priority", () => {
+    const mw = createCallDedupMiddleware();
+    expect(mw.name).toBe("koi:call-dedup");
+    expect(mw.priority).toBe(185);
+  });
+
+  test("cache hit: 2nd identical call skips execution", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "result1" });
+    const req = toolRequest("file_read", { path: "/a.txt" });
+
+    const r1 = await wrap(ctx, req, spy.handler);
+    const r2 = await wrap(ctx, req, spy.handler);
+
+    expect(spy.calls.length).toBe(1);
+    expect(r1.output).toBe("result1");
+    expect(r2.output).toBe("result1");
+    expect(r2.metadata?.cached).toBe(true);
+  });
+
+  test("cache miss: different toolId executes separately", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    await wrap(ctx, toolRequest("tool_a"), spy.handler);
+    await wrap(ctx, toolRequest("tool_b"), spy.handler);
+
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("cache miss: different input executes separately", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    await wrap(ctx, toolRequest("file_read", { path: "/a" }), spy.handler);
+    await wrap(ctx, toolRequest("file_read", { path: "/b" }), spy.handler);
+
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("TTL expiry: stale entry re-executes", async () => {
+    let clock = 1000;
+    const mw = createCallDedupMiddleware({ ttlMs: 100, now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "fresh" });
+    const req = toolRequest("file_read", { path: "/a" });
+
+    await wrap(ctx, req, spy.handler);
+    // Advance past TTL
+    clock = 1200;
+    await wrap(ctx, req, spy.handler);
+
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("excluded tool always executes", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({
+      now: () => clock,
+      exclude: ["my_mutation"],
+    });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+    const req = toolRequest("my_mutation", { data: "x" });
+
+    await wrap(ctx, req, spy.handler);
+    await wrap(ctx, req, spy.handler);
+
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("DEFAULT_EXCLUDE tools are excluded by default", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    for (const toolId of DEFAULT_EXCLUDE) {
+      await wrap(ctx, toolRequest(toolId), spy.handler);
+      await wrap(ctx, toolRequest(toolId), spy.handler);
+    }
+
+    // Each DEFAULT_EXCLUDE tool called twice = 2 * DEFAULT_EXCLUDE.length
+    expect(spy.calls.length).toBe(DEFAULT_EXCLUDE.length * 2);
+  });
+
+  test("user exclude merges with DEFAULT_EXCLUDE", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({
+      now: () => clock,
+      exclude: ["custom_write"],
+    });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    // shell_exec from DEFAULT_EXCLUDE
+    await wrap(ctx, toolRequest("shell_exec"), spy.handler);
+    await wrap(ctx, toolRequest("shell_exec"), spy.handler);
+    // custom_write from user exclude
+    await wrap(ctx, toolRequest("custom_write"), spy.handler);
+    await wrap(ctx, toolRequest("custom_write"), spy.handler);
+
+    expect(spy.calls.length).toBe(4);
+  });
+
+  test("include list restricts caching scope", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({
+      now: () => clock,
+      include: ["file_read"],
+    });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    // file_read is included → cached
+    await wrap(ctx, toolRequest("file_read"), spy.handler);
+    await wrap(ctx, toolRequest("file_read"), spy.handler);
+    expect(spy.calls.length).toBe(1);
+
+    // web_search is NOT included → always executes
+    await wrap(ctx, toolRequest("web_search"), spy.handler);
+    await wrap(ctx, toolRequest("web_search"), spy.handler);
+    expect(spy.calls.length).toBe(3);
+  });
+
+  test("include + exclude: tool in both is excluded", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({
+      now: () => clock,
+      include: ["shell_exec", "file_read"],
+      exclude: [],
+    });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+
+    // shell_exec is in DEFAULT_EXCLUDE → excluded even though in include list
+    await wrap(ctx, toolRequest("shell_exec"), spy.handler);
+    await wrap(ctx, toolRequest("shell_exec"), spy.handler);
+    expect(spy.calls.length).toBe(2);
+
+    // file_read is included and not excluded → cached
+    await wrap(ctx, toolRequest("file_read"), spy.handler);
+    await wrap(ctx, toolRequest("file_read"), spy.handler);
+    expect(spy.calls.length).toBe(3);
+  });
+
+  test("tool exception is not cached", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    let callCount = 0;
+    const failHandler = async (_req: ToolRequest): Promise<ToolResponse> => {
+      callCount++;
+      throw new Error("tool failed");
+    };
+    const req = toolRequest("search", { q: "test" });
+
+    await expect(wrap(ctx, req, failHandler)).rejects.toThrow("tool failed");
+    await expect(wrap(ctx, req, failHandler)).rejects.toThrow("tool failed");
+
+    expect(callCount).toBe(2);
+  });
+
+  test("blocked response is not cached", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({
+      output: "blocked",
+      metadata: { blocked: true, reason: "denied" },
+    });
+    const req = toolRequest("file_read", { path: "/secret" });
+
+    await wrap(ctx, req, spy.handler);
+    await wrap(ctx, req, spy.handler);
+
+    // Blocked responses are not cached → both calls execute
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("cached response has metadata.cached = true", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "data" });
+    const req = toolRequest("file_read", { path: "/a" });
+
+    const r1 = await wrap(ctx, req, spy.handler);
+    const r2 = await wrap(ctx, req, spy.handler);
+
+    expect(r1.metadata?.cached).toBeUndefined();
+    expect(r2.metadata?.cached).toBe(true);
+  });
+
+  test("onCacheHit callback fires with correct info", async () => {
+    const clock = 1000;
+    const hits: CacheHitInfo[] = [];
+    const mw = createCallDedupMiddleware({
+      now: () => clock,
+      onCacheHit: (info) => hits.push(info),
+    });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctx = createMockTurnContext();
+    const spy = createSpyToolHandler({ output: "ok" });
+    const req = toolRequest("file_read", { path: "/a" });
+
+    await wrap(ctx, req, spy.handler);
+    expect(hits.length).toBe(0);
+
+    await wrap(ctx, req, spy.handler);
+    expect(hits.length).toBe(1);
+    const hit = hits[0];
+    expect(hit).toBeDefined();
+    if (hit) {
+      expect(hit.toolId).toBe("file_read");
+      expect(hit.sessionId).toBe(ctx.session.sessionId);
+      expect(typeof hit.cacheKey).toBe("string");
+    }
+  });
+
+  test("session isolation: different sessionId = separate cache entries", async () => {
+    const clock = 1000;
+    const mw = createCallDedupMiddleware({ now: () => clock });
+    const wrap = mw.wrapToolCall;
+    if (!wrap) throw new Error("wrapToolCall is not defined");
+    const ctxA = createMockTurnContext({
+      session: createMockSessionContext({ sessionId: sessionId("sess-a") }),
+    });
+    const ctxB = createMockTurnContext({
+      session: createMockSessionContext({ sessionId: sessionId("sess-b") }),
+    });
+    const spy = createSpyToolHandler({ output: "ok" });
+    const req = toolRequest("file_read", { path: "/a" });
+
+    await wrap(ctxA, req, spy.handler);
+    await wrap(ctxB, req, spy.handler);
+
+    // Different sessions → both execute
+    expect(spy.calls.length).toBe(2);
+  });
+
+  test("describeCapabilities returns capability fragment", () => {
+    const mw = createCallDedupMiddleware();
+    const ctx = createMockTurnContext();
+    const cap = mw.describeCapabilities(ctx);
+    expect(cap).toBeDefined();
+    if (cap) {
+      expect(cap.label).toBe("call-dedup");
+      expect(typeof cap.description).toBe("string");
+    }
+  });
+});

--- a/packages/middleware-call-dedup/src/call-dedup.ts
+++ b/packages/middleware-call-dedup/src/call-dedup.ts
@@ -1,0 +1,129 @@
+/**
+ * Call dedup middleware — caches deterministic tool call results.
+ *
+ * Identical tool calls (same sessionId + toolId + input) within the TTL
+ * return the cached response instantly, avoiding redundant execution.
+ *
+ * Priority 185: runs after call-limits (175), before pay (200).
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { computeContentHash } from "@koi/hash";
+import {
+  type CallDedupConfig,
+  DEFAULT_EXCLUDE,
+  DEFAULT_MAX_ENTRIES,
+  DEFAULT_TTL_MS,
+} from "./config.js";
+import { createInMemoryDedupStore } from "./store.js";
+
+function defaultHashFn(sessionId: string, toolId: string, input: JsonObject): string {
+  return computeContentHash({ session: sessionId, tool: toolId, input });
+}
+
+/**
+ * Creates a call dedup middleware that caches deterministic tool call results.
+ *
+ * Tools in the exclude list (merged with DEFAULT_EXCLUDE) always execute.
+ * If an include list is provided, only listed tools are cached (minus excludes).
+ * Errors, blocked responses, and exceptions are never cached.
+ */
+export function createCallDedupMiddleware(config?: CallDedupConfig): KoiMiddleware {
+  const ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries = config?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const store = config?.store ?? createInMemoryDedupStore(maxEntries);
+  const now = config?.now ?? Date.now;
+  const onCacheHit = config?.onCacheHit;
+  const userHashFn = config?.hashFn;
+  // Merge user excludes with defaults
+  const excludeSet = new Set<string>([...DEFAULT_EXCLUDE, ...(config?.exclude ?? [])]);
+  const includeSet = config?.include !== undefined ? new Set<string>(config.include) : undefined;
+
+  function isCacheable(toolId: string): boolean {
+    if (excludeSet.has(toolId)) return false;
+    if (includeSet !== undefined) return includeSet.has(toolId);
+    return true;
+  }
+
+  function computeCacheKey(sessionId: string, toolId: string, input: JsonObject): string {
+    if (userHashFn !== undefined) {
+      return userHashFn(sessionId, toolId, input);
+    }
+    return defaultHashFn(sessionId, toolId, input);
+  }
+
+  const capabilityFragment: CapabilityFragment = {
+    label: "call-dedup",
+    description: "Caches identical deterministic tool call results within TTL",
+  };
+
+  return {
+    name: "koi:call-dedup",
+    priority: 185,
+    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => capabilityFragment,
+
+    async wrapToolCall(
+      ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      const toolId = request.toolId;
+
+      // Skip cache for excluded / non-included tools
+      if (!isCacheable(toolId)) {
+        return next(request);
+      }
+
+      const sessionId = ctx.session.sessionId;
+      const cacheKey = computeCacheKey(sessionId, toolId, request.input);
+      const currentTime = now();
+
+      // Check cache
+      const cached = await store.get(cacheKey);
+      if (cached !== undefined) {
+        if (cached.expiresAt > currentTime) {
+          // Cache hit — notify observer (errors must not break cache behavior)
+          if (onCacheHit !== undefined) {
+            try {
+              onCacheHit({ sessionId, toolId, cacheKey });
+            } catch (_e: unknown) {
+              // Observability callback failure is non-fatal
+            }
+          }
+          return {
+            ...cached.response,
+            metadata: { ...cached.response.metadata, cached: true },
+          };
+        }
+        // Expired — clean up stale entry
+        await store.delete(cacheKey);
+      }
+
+      // Cache miss — execute
+      const response = await next(request);
+
+      // Never cache blocked or error responses
+      const meta = response.metadata;
+      if (meta?.blocked === true || meta?.error === true) {
+        return response;
+      }
+
+      // Fresh timestamp after tool execution for accurate TTL
+      const storeTime = now();
+      await store.set(cacheKey, {
+        response,
+        expiresAt: storeTime + ttlMs,
+      });
+
+      return response;
+    },
+  };
+}

--- a/packages/middleware-call-dedup/src/config.test.ts
+++ b/packages/middleware-call-dedup/src/config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { validateCallDedupConfig } from "./config.js";
+
+describe("validateCallDedupConfig", () => {
+  test("valid: empty config (all defaults)", () => {
+    const result = validateCallDedupConfig({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("valid: full config with all fields", () => {
+    const result = validateCallDedupConfig({
+      ttlMs: 60_000,
+      maxEntries: 50,
+      include: ["file_read"],
+      exclude: ["my_tool"],
+      hashFn: () => "key",
+      now: () => Date.now(),
+      store: {
+        get: () => undefined,
+        set: () => {},
+        delete: () => false,
+        size: () => 0,
+        clear: () => {},
+      },
+      onCacheHit: () => {},
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("invalid: null", () => {
+    const result = validateCallDedupConfig(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("non-null object");
+  });
+
+  test("invalid: non-object (string)", () => {
+    const result = validateCallDedupConfig("bad");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("non-null object");
+  });
+
+  test("invalid: negative ttlMs", () => {
+    const result = validateCallDedupConfig({ ttlMs: -1 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("ttlMs");
+  });
+
+  test("invalid: zero ttlMs", () => {
+    const result = validateCallDedupConfig({ ttlMs: 0 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("ttlMs");
+  });
+
+  test("invalid: non-finite ttlMs (Infinity)", () => {
+    const result = validateCallDedupConfig({ ttlMs: Infinity });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("ttlMs");
+  });
+
+  test("invalid: non-integer maxEntries (1.5)", () => {
+    const result = validateCallDedupConfig({ maxEntries: 1.5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("maxEntries");
+  });
+
+  test("invalid: non-array include", () => {
+    const result = validateCallDedupConfig({ include: "file_read" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("include");
+  });
+
+  test("invalid: store missing methods", () => {
+    const result = validateCallDedupConfig({ store: { get: () => {} } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toContain("store");
+  });
+});

--- a/packages/middleware-call-dedup/src/config.ts
+++ b/packages/middleware-call-dedup/src/config.ts
@@ -1,0 +1,128 @@
+/**
+ * Call dedup middleware configuration and validation.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { KoiError, Result } from "@koi/core/errors";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CacheHitInfo, CallDedupStore } from "./types.js";
+
+/** Default TTL: 5 minutes. */
+export const DEFAULT_TTL_MS = 300_000;
+
+/** Default maximum cache entries. */
+export const DEFAULT_MAX_ENTRIES = 100;
+
+/** Tools excluded from caching by default (mutating / side-effecting). */
+export const DEFAULT_EXCLUDE = [
+  "shell_exec",
+  "file_write",
+  "file_delete",
+  "file_create",
+  "agent_send",
+  "agent_spawn",
+] as const;
+
+export interface CallDedupConfig {
+  /** Cache TTL in milliseconds. Default: 300_000 (5 min). */
+  readonly ttlMs?: number | undefined;
+  /** Maximum cache entries before LRU eviction. Default: 100. */
+  readonly maxEntries?: number | undefined;
+  /** Whitelist — only cache these tools. undefined = all non-excluded tools. */
+  readonly include?: readonly string[] | undefined;
+  /** Blacklist — merged with DEFAULT_EXCLUDE. */
+  readonly exclude?: readonly string[] | undefined;
+  /** Custom hash function for cache key generation. Must include sessionId for session isolation. */
+  readonly hashFn?: ((sessionId: string, toolId: string, input: JsonObject) => string) | undefined;
+  /** Clock injection for deterministic TTL tests. */
+  readonly now?: (() => number) | undefined;
+  /** Custom cache store. Default: in-memory LRU store. */
+  readonly store?: CallDedupStore | undefined;
+  /** Callback fired on cache hits. */
+  readonly onCacheHit?: ((info: CacheHitInfo) => void) | undefined;
+}
+
+function validationError(message: string): { readonly ok: false; readonly error: KoiError } {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function isPositiveFiniteInteger(value: unknown): boolean {
+  return (
+    typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value > 0
+  );
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isValidStore(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const s = value as Record<string, unknown>;
+  return (
+    typeof s.get === "function" &&
+    typeof s.set === "function" &&
+    typeof s.delete === "function" &&
+    typeof s.size === "function" &&
+    typeof s.clear === "function"
+  );
+}
+
+/**
+ * Validates raw config input into a typed CallDedupConfig.
+ * Empty `{}` is valid (all defaults apply).
+ */
+export function validateCallDedupConfig(config: unknown): Result<CallDedupConfig, KoiError> {
+  if (config === null || config === undefined || typeof config !== "object") {
+    return validationError("Config must be a non-null object");
+  }
+
+  if (Array.isArray(config)) {
+    return validationError("Config must be a non-null object");
+  }
+
+  const c = config as Record<string, unknown>;
+
+  if (c.ttlMs !== undefined && !isPositiveFiniteInteger(c.ttlMs)) {
+    return validationError("'ttlMs' must be a positive finite integer");
+  }
+
+  if (c.maxEntries !== undefined && !isPositiveFiniteInteger(c.maxEntries)) {
+    return validationError("'maxEntries' must be a positive finite integer");
+  }
+
+  if (c.include !== undefined && !isStringArray(c.include)) {
+    return validationError("'include' must be an array of strings");
+  }
+
+  if (c.exclude !== undefined && !isStringArray(c.exclude)) {
+    return validationError("'exclude' must be an array of strings");
+  }
+
+  if (c.hashFn !== undefined && typeof c.hashFn !== "function") {
+    return validationError("'hashFn' must be a function");
+  }
+
+  if (c.now !== undefined && typeof c.now !== "function") {
+    return validationError("'now' must be a function");
+  }
+
+  if (c.store !== undefined && !isValidStore(c.store)) {
+    return validationError(
+      "'store' must be an object with get, set, delete, size, and clear methods",
+    );
+  }
+
+  if (c.onCacheHit !== undefined && typeof c.onCacheHit !== "function") {
+    return validationError("'onCacheHit' must be a function");
+  }
+
+  return { ok: true, value: config as CallDedupConfig };
+}

--- a/packages/middleware-call-dedup/src/descriptor.ts
+++ b/packages/middleware-call-dedup/src/descriptor.ts
@@ -1,0 +1,65 @@
+/**
+ * BrickDescriptor for @koi/middleware-call-dedup.
+ *
+ * Enables manifest auto-resolution: validates call-dedup options
+ * from koi.yaml, then creates the dedup middleware.
+ *
+ * Usage in koi.yaml:
+ *   middleware:
+ *     - name: call-dedup
+ *       options:
+ *         ttlMs: 60000
+ *         exclude: [my_custom_mutation_tool]
+ */
+
+import type { KoiError, KoiMiddleware, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BrickDescriptor } from "@koi/resolve";
+import { createCallDedupMiddleware } from "./call-dedup.js";
+import { validateCallDedupConfig } from "./config.js";
+
+function descriptorValidationError(message: string): {
+  readonly ok: false;
+  readonly error: KoiError;
+} {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function validateCallDedupDescriptorOptions(input: unknown): Result<unknown, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return descriptorValidationError("call-dedup options must be an object");
+  }
+
+  // Delegate to the config validator for field-level checks
+  return validateCallDedupConfig(input);
+}
+
+/**
+ * Descriptor for call-dedup middleware.
+ *
+ * Creates a dedup middleware from validated YAML options.
+ * Uses in-memory LRU store by default.
+ */
+export const descriptor: BrickDescriptor<KoiMiddleware> = {
+  kind: "middleware",
+  name: "@koi/middleware-call-dedup",
+  aliases: ["call-dedup"],
+  description: "Caches identical deterministic tool call results to avoid redundant execution",
+  optionsValidator: validateCallDedupDescriptorOptions,
+  factory(options): KoiMiddleware {
+    const opts = options as Record<string, unknown>;
+    return createCallDedupMiddleware({
+      ttlMs: typeof opts.ttlMs === "number" ? opts.ttlMs : undefined,
+      maxEntries: typeof opts.maxEntries === "number" ? opts.maxEntries : undefined,
+      include: Array.isArray(opts.include) ? (opts.include as readonly string[]) : undefined,
+      exclude: Array.isArray(opts.exclude) ? (opts.exclude as readonly string[]) : undefined,
+    });
+  },
+};

--- a/packages/middleware-call-dedup/src/index.ts
+++ b/packages/middleware-call-dedup/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @koi/middleware-call-dedup — Deterministic tool call result caching.
+ *
+ * Caches identical tool call results so the 2nd+ call with the same
+ * sessionId + toolId + input returns instantly without re-execution.
+ */
+
+export { createCallDedupMiddleware } from "./call-dedup.js";
+export type { CallDedupConfig } from "./config.js";
+export { DEFAULT_EXCLUDE, validateCallDedupConfig } from "./config.js";
+export { descriptor } from "./descriptor.js";
+export { createInMemoryDedupStore } from "./store.js";
+export type { CacheEntry, CacheHitInfo, CallDedupStore } from "./types.js";

--- a/packages/middleware-call-dedup/src/store.test.ts
+++ b/packages/middleware-call-dedup/src/store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryDedupStore } from "./store.js";
+import type { CacheEntry } from "./types.js";
+
+function entry(output: string, expiresAt: number): CacheEntry {
+  return { response: { output }, expiresAt };
+}
+
+describe("createInMemoryDedupStore", () => {
+  test("get returns undefined for missing key", () => {
+    const store = createInMemoryDedupStore(10);
+    expect(store.get("missing")).toBeUndefined();
+  });
+
+  test("set + get returns cached entry", () => {
+    const store = createInMemoryDedupStore(10);
+    const e = entry("hello", 9999);
+    store.set("k1", e);
+    expect(store.get("k1")).toEqual(e);
+  });
+
+  test("delete removes existing key and returns true", () => {
+    const store = createInMemoryDedupStore(10);
+    store.set("k1", entry("a", 1));
+    expect(store.delete("k1")).toBe(true);
+    expect(store.get("k1")).toBeUndefined();
+  });
+
+  test("delete returns false for missing key", () => {
+    const store = createInMemoryDedupStore(10);
+    expect(store.delete("nope")).toBe(false);
+  });
+
+  test("evicts oldest entry when at capacity", () => {
+    const store = createInMemoryDedupStore(2);
+    store.set("a", entry("1", 100));
+    store.set("b", entry("2", 100));
+    // At capacity — inserting c should evict a (oldest)
+    store.set("c", entry("3", 100));
+    expect(store.get("a")).toBeUndefined();
+    expect(store.get("b")).toBeDefined();
+    expect(store.get("c")).toBeDefined();
+  });
+
+  test("LRU promotion: accessed entry survives eviction", () => {
+    const store = createInMemoryDedupStore(2);
+    store.set("a", entry("1", 100));
+    store.set("b", entry("2", 100));
+    // Access a to promote it — b is now oldest
+    store.get("a");
+    store.set("c", entry("3", 100));
+    expect(store.get("a")).toBeDefined();
+    expect(store.get("b")).toBeUndefined();
+    expect(store.get("c")).toBeDefined();
+  });
+
+  test("size returns correct count", () => {
+    const store = createInMemoryDedupStore(10);
+    expect(store.size()).toBe(0);
+    store.set("a", entry("1", 100));
+    store.set("b", entry("2", 100));
+    expect(store.size()).toBe(2);
+  });
+
+  test("clear empties all entries", () => {
+    const store = createInMemoryDedupStore(10);
+    store.set("a", entry("1", 100));
+    store.set("b", entry("2", 100));
+    store.clear();
+    expect(store.size()).toBe(0);
+    expect(store.get("a")).toBeUndefined();
+  });
+});

--- a/packages/middleware-call-dedup/src/store.ts
+++ b/packages/middleware-call-dedup/src/store.ts
@@ -1,0 +1,55 @@
+/**
+ * In-memory dedup store — Map-backed, LRU eviction, sync returns.
+ */
+
+import type { CacheEntry, CallDedupStore } from "./types.js";
+
+/**
+ * Creates a Map-backed dedup store with LRU eviction.
+ *
+ * LRU is implemented via Map insertion order:
+ * - `get()` deletes and re-inserts the entry to promote it
+ * - `set()` evicts the oldest entry when at capacity
+ *
+ * All operations are synchronous (no async overhead for the common case).
+ */
+export function createInMemoryDedupStore(maxEntries: number): CallDedupStore {
+  const cache = new Map<string, CacheEntry>();
+
+  return {
+    get(key: string): CacheEntry | undefined {
+      const entry = cache.get(key);
+      if (entry === undefined) return undefined;
+      // LRU promotion: delete and re-insert to move to end
+      cache.delete(key);
+      cache.set(key, entry);
+      return entry;
+    },
+
+    set(key: string, entry: CacheEntry): void {
+      // If key already exists, delete first to refresh insertion order
+      if (cache.has(key)) {
+        cache.delete(key);
+      } else if (cache.size >= maxEntries) {
+        // Evict oldest (first) entry
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) {
+          cache.delete(oldest);
+        }
+      }
+      cache.set(key, entry);
+    },
+
+    delete(key: string): boolean {
+      return cache.delete(key);
+    },
+
+    size(): number {
+      return cache.size;
+    },
+
+    clear(): void {
+      cache.clear();
+    },
+  };
+}

--- a/packages/middleware-call-dedup/src/types.ts
+++ b/packages/middleware-call-dedup/src/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Call dedup types — cache store interface and cache entry types.
+ */
+
+import type { ToolResponse } from "@koi/core/middleware";
+
+/** A cached tool response with an expiration timestamp. */
+export interface CacheEntry {
+  readonly response: ToolResponse;
+  readonly expiresAt: number;
+}
+
+/**
+ * Key-value cache store for deduplicating tool call results.
+ * Implementations may be sync (in-memory) or async (network).
+ */
+export interface CallDedupStore {
+  readonly get: (key: string) => CacheEntry | undefined | Promise<CacheEntry | undefined>;
+  readonly set: (key: string, entry: CacheEntry) => void | Promise<void>;
+  readonly delete: (key: string) => boolean | Promise<boolean>;
+  readonly size: () => number | Promise<number>;
+  readonly clear: () => void | Promise<void>;
+}
+
+/** Info passed to onCacheHit callbacks. */
+export interface CacheHitInfo {
+  readonly sessionId: string;
+  readonly toolId: string;
+  readonly cacheKey: string;
+}

--- a/packages/middleware-call-dedup/tsconfig.json
+++ b/packages/middleware-call-dedup/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../core" }, { "path": "../resolve" }]
+}

--- a/packages/middleware-call-dedup/tsup.config.ts
+++ b/packages/middleware-call-dedup/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Adds new L2 middleware package `@koi/middleware-call-dedup` that caches deterministic tool call results within a session
- Identical calls (same sessionId + toolId + input) return cached response instantly — no re-execution, no quota burn
- SHA-256 cache key via `computeContentHash` for session isolation, LRU + TTL eviction (defaults: 100 entries, 5 min TTL)
- `DEFAULT_EXCLUDE` for side-effecting tools (shell_exec, file_write, file_delete, file_create, agent_send, agent_spawn)
- BrickDescriptor for manifest auto-resolution (`name: call-dedup` in koi.yaml)
- 36 tests across store, config, middleware, and API surface

## What this enables

Agents often call the same deterministic tool (file_read, web_fetch, search) with identical args multiple times per session. Before: every call executes fully. After: 2nd+ calls return cached result instantly.

- **Reduced latency**: cached calls return sub-millisecond
- **Lower cost**: deduplicated calls skip billing (priority 185 < pay at 200)
- **Quota preservation**: cached responses don't consume call-limits budget (priority 185 > call-limits at 175)
- **Session isolation**: cache keys include sessionId, preventing cross-session leakage

## Package structure

```
packages/middleware-call-dedup/
├── src/types.ts          — CallDedupStore, CacheEntry, CacheHitInfo
├── src/config.ts         — CallDedupConfig, DEFAULT_EXCLUDE, validateCallDedupConfig
├── src/store.ts          — createInMemoryDedupStore (LRU + TTL)
├── src/call-dedup.ts     — createCallDedupMiddleware (priority 185)
├── src/descriptor.ts     — BrickDescriptor for manifest auto-resolution
├── src/index.ts          — public exports
└── tests (4 files, 36 tests)
docs/L2/middleware-call-dedup.md — full documentation
```

## Verification

- [x] `bun install` — workspace linked
- [x] `tsc --noEmit` — zero type errors
- [x] `biome check` — lint clean
- [x] `bun test` — 36 pass, 0 fail
- [x] `tsup` build — dist/index.js + dist/index.d.ts
- [x] `check:layers` — no layer violations
- [x] Code review: fixed 2 CRITICAL + 3 HIGH issues

Closes #495