### PR TITLE
refactor: extract duplicate descriptor validation utilities

### DIFF
--- a/docs/L2/descriptor-validation.md
+++ b/docs/L2/descriptor-validation.md
@@ -1,0 +1,146 @@
+# Descriptor Validation Helpers
+
+Shared validation utilities for `BrickDescriptor.optionsValidator` functions. Eliminates the typeof-object boilerplate duplicated across 47+ descriptor files.
+
+---
+
+## Why It Exists
+
+Every L2 package that registers a `BrickDescriptor` needs an `optionsValidator` function. Before these helpers, each package copy-pasted the same 10-15 lines:
+
+```typescript
+// This exact block was duplicated 47 times:
+function validateFooOptions(input: unknown): Result<unknown, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: "Foo options must be an object",
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+  const opts = input as Record<string, unknown>; // banned cast
+  // ...field-specific checks...
+}
+```
+
+Problems with copy-paste:
+- **28 banned `as` casts** — each file cast `input as Record<string, unknown>` after the type guard
+- **3 inconsistent `retryable` values** — some files used `false` instead of `RETRYABLE_DEFAULTS.VALIDATION`
+- **Maintenance burden** — changing the error format required editing 47 files
+
+---
+
+## What It Provides
+
+Two helpers in `@koi/resolve`, exported for use by all descriptor files:
+
+### `validateOptionalDescriptorOptions(input, label)`
+
+Lenient — accepts `null`/`undefined` as empty `{}`. Use for engines, channels, and other descriptors where options are truly optional.
+
+```typescript
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
+
+// Simple descriptor (no field validation needed):
+export const descriptor: BrickDescriptor<EngineAdapter> = {
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Loop engine"),
+  // ...
+};
+```
+
+### `validateRequiredDescriptorOptions(input, label)`
+
+Strict — rejects `null`/`undefined`. Use for middleware and services where an options object is expected.
+
+```typescript
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
+
+// Simple descriptor:
+export const descriptor: BrickDescriptor<KoiMiddleware> = {
+  optionsValidator: (input) => validateRequiredDescriptorOptions(input, "Sandbox"),
+  // ...
+};
+```
+
+### Complex descriptors (with field-level validation)
+
+For descriptors that validate specific fields after the object check, use the helper to replace only the boilerplate:
+
+```typescript
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
+
+function validateAuditDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Audit");
+  if (!base.ok) return base;
+  const opts = base.value; // narrowed to Record<string, unknown> — no cast needed
+
+  if (opts.maxEntrySize !== undefined && typeof opts.maxEntrySize !== "number") {
+    return { ok: false, error: { code: "VALIDATION", message: "...", retryable: RETRYABLE_DEFAULTS.VALIDATION } };
+  }
+
+  return { ok: true, value: opts };
+}
+```
+
+---
+
+## `findClosestMatch` — "Did you mean?" suggestions
+
+Also extracted as part of this work: `findClosestMatch` in `@koi/validation` provides Levenshtein-based typo suggestions. Previously duplicated between `@koi/manifest` and `@koi/resolve`.
+
+```typescript
+import { findClosestMatch } from "@koi/validation";
+
+const suggestion = findClosestMatch("audti", ["audit", "sandbox", "pay"]);
+// → "audit"
+```
+
+Used by the resolver to produce helpful error messages:
+
+```
+middleware "audti" not found in registry. Available: [audit, sandbox, pay]. Did you mean "audit"?
+```
+
+---
+
+## Architecture
+
+Both helpers live in **L0u** packages — the same layer as the descriptors that consume them:
+
+```
+L0   @koi/core          Types only (KoiError, Result, RETRYABLE_DEFAULTS)
+L0u  @koi/validation    findClosestMatch (+ levenshteinDistance)
+L0u  @koi/resolve       validateOptionalDescriptorOptions, validateRequiredDescriptorOptions
+L2   @koi/middleware-*   Import from @koi/resolve — no layer violation
+L2   @koi/engine-*       Import from @koi/resolve — no layer violation
+L2   @koi/channel-*      Import from @koi/resolve — no layer violation
+```
+
+No new packages were created. No new dependencies were added to any `package.json`.
+
+---
+
+## How Resolution Works (end-to-end)
+
+```
+koi.yaml (manifest)
+    │
+    ▼
+Resolver reads manifest sections (engine, middleware, channel, model)
+    │
+    │  For each entry:
+    │  1. Look up BrickDescriptor in registry by name
+    │     └─ Not found? → findClosestMatch → "Did you mean ...?"
+    │  2. Call descriptor.optionsValidator(options)
+    │     └─ Uses validateOptional/RequiredDescriptorOptions
+    │  3. Call descriptor.factory(validatedOptions, context)
+    │     └─ Returns live EngineAdapter / KoiMiddleware / ChannelAdapter
+    │
+    ▼
+Running agent with resolved components
+```

--- a/packages/acp/src/descriptor.ts
+++ b/packages/acp/src/descriptor.ts
@@ -5,9 +5,9 @@
  * No required options — the channel operates from the current process.
  */
 
-import type { ChannelAdapter, CompanionSkillDefinition, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter, CompanionSkillDefinition } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createAcpChannel } from "./acp-channel.js";
 import type { AcpServerConfig } from "./types.js";
 
@@ -43,21 +43,6 @@ channel:
 `,
 };
 
-function validateAcpServerOptions(input: unknown): Result<unknown, KoiError> {
-  // No required options — all are optional
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "ACP server options must be an object (or omitted entirely)",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
-
 /**
  * Descriptor for the ACP server channel.
  * Registered under the name "@koi/acp" with alias "acp-server".
@@ -69,7 +54,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   description: "ACP protocol server channel for IDE integration",
   tags: ["acp", "ide", "channel", "json-rpc"],
   companionSkills: [ACP_SERVER_COMPANION_SKILL],
-  optionsValidator: validateAcpServerOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "ACP"),
   factory(options: Record<string, unknown>, _context: ResolutionContext): ChannelAdapter {
     const config: AcpServerConfig = {
       ...(typeof options === "object" && options !== null ? (options as AcpServerConfig) : {}),

--- a/packages/channel-chat-sdk/src/descriptor.ts
+++ b/packages/channel-chat-sdk/src/descriptor.ts
@@ -5,25 +5,11 @@
  * channel adapter. Each platform in the config gets its own ChannelAdapter.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { validateChatSdkChannelConfig } from "./config.js";
 import { createChatSdkChannels } from "./create-chat-sdk-channels.js";
-
-function validateChatSdkChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Chat SDK channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for Chat SDK multi-platform channel adapter.
@@ -35,7 +21,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-chat-sdk",
   aliases: ["chat-sdk"],
-  optionsValidator: validateChatSdkChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Chat SDK channel"),
   factory(options: unknown, _context: ResolutionContext): ChannelAdapter {
     const raw = (options ?? {}) as Record<string, unknown>;
 

--- a/packages/channel-cli/src/descriptor.ts
+++ b/packages/channel-cli/src/descriptor.ts
@@ -4,23 +4,10 @@
  * Enables manifest auto-resolution for the CLI stdin/stdout channel.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createCliChannel } from "./cli-channel.js";
-
-function validateCliChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "CLI channel options must be an object",
-        retryable: false,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for CLI channel adapter.
@@ -30,7 +17,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-cli",
   aliases: ["cli"],
-  optionsValidator: validateCliChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "CLI channel"),
   factory(): ChannelAdapter {
     return createCliChannel();
   },

--- a/packages/channel-discord/src/descriptor.ts
+++ b/packages/channel-discord/src/descriptor.ts
@@ -6,25 +6,11 @@
  * Application ID is read from context.env.DISCORD_APPLICATION_ID.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import type { DiscordFeatures } from "./config.js";
 import { createDiscordChannel } from "./discord-channel.js";
-
-function validateDiscordChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Discord channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 function parseFeatures(options: Readonly<Record<string, unknown>>): DiscordFeatures | undefined {
   const features = options.features;
@@ -49,7 +35,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-discord",
   aliases: ["discord"],
-  optionsValidator: validateDiscordChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Discord channel"),
   factory(options, context: ResolutionContext): ChannelAdapter {
     const token = context.env.DISCORD_BOT_TOKEN;
     if (token === undefined || token === "") {

--- a/packages/channel-email/src/descriptor.ts
+++ b/packages/channel-email/src/descriptor.ts
@@ -5,24 +5,10 @@
  * IMAP and SMTP settings are read from environment variables.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createEmailChannel } from "./email-channel.js";
-
-function validateEmailChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Email channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for Email channel adapter.
@@ -32,7 +18,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-email",
   aliases: ["email"],
-  optionsValidator: validateEmailChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Email channel"),
   factory(options, context: ResolutionContext): ChannelAdapter {
     const opts = options as Readonly<Record<string, unknown>>;
 

--- a/packages/channel-matrix/src/descriptor.ts
+++ b/packages/channel-matrix/src/descriptor.ts
@@ -5,24 +5,10 @@
  * homeserverUrl and accessToken are read from environment.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createMatrixChannel } from "./matrix-channel.js";
-
-function validateMatrixChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Matrix channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for Matrix channel adapter.
@@ -32,7 +18,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-matrix",
   aliases: ["matrix"],
-  optionsValidator: validateMatrixChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Matrix channel"),
   factory(_options, context: ResolutionContext): ChannelAdapter {
     const homeserverUrl = context.env.MATRIX_HOMESERVER_URL;
     const accessToken = context.env.MATRIX_ACCESS_TOKEN;

--- a/packages/channel-mobile/src/descriptor.ts
+++ b/packages/channel-mobile/src/descriptor.ts
@@ -5,25 +5,11 @@
  * Port is read from options or defaults to 8080.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { DEFAULT_MOBILE_PORT } from "./config.js";
 import { createMobileChannel } from "./mobile-channel.js";
-
-function validateMobileChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Mobile channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for mobile channel adapter.
@@ -33,7 +19,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-mobile",
   aliases: ["mobile"],
-  optionsValidator: validateMobileChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Mobile channel"),
   factory(options, _context: ResolutionContext): ChannelAdapter {
     const opts = options as Readonly<Record<string, unknown>>;
     const port = typeof opts.port === "number" ? opts.port : DEFAULT_MOBILE_PORT;

--- a/packages/channel-signal/src/descriptor.ts
+++ b/packages/channel-signal/src/descriptor.ts
@@ -5,24 +5,10 @@
  * Account phone number is read from SIGNAL_ACCOUNT env var.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createSignalChannel } from "./signal-channel.js";
-
-function validateSignalChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Signal channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for Signal channel adapter.
@@ -32,7 +18,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-signal",
   aliases: ["signal"],
-  optionsValidator: validateSignalChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Signal channel"),
   factory(options, context: ResolutionContext): ChannelAdapter {
     const account = context.env.SIGNAL_ACCOUNT;
     if (account === undefined || account === "") {

--- a/packages/channel-slack/src/descriptor.ts
+++ b/packages/channel-slack/src/descriptor.ts
@@ -6,25 +6,11 @@
  * App token is read from context.env.SLACK_APP_TOKEN.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import type { SlackDeployment, SlackFeatures } from "./config.js";
 import { createSlackChannel } from "./slack-channel.js";
-
-function validateSlackChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Slack channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 function parseDeployment(
   options: Readonly<Record<string, unknown>>,
@@ -72,7 +58,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-slack",
   aliases: ["slack"],
-  optionsValidator: validateSlackChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Slack channel"),
   factory(options, context: ResolutionContext): ChannelAdapter {
     const botToken = context.env.SLACK_BOT_TOKEN;
     if (botToken === undefined || botToken === "") {

--- a/packages/channel-teams/src/descriptor.ts
+++ b/packages/channel-teams/src/descriptor.ts
@@ -5,24 +5,10 @@
  * Reads appId, appPassword, and tenantId from environment.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createTeamsChannel } from "./teams-channel.js";
-
-function validateTeamsChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Teams channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for Teams channel adapter.
@@ -32,7 +18,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-teams",
   aliases: ["teams"],
-  optionsValidator: validateTeamsChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Teams channel"),
   factory(_options, context: ResolutionContext): ChannelAdapter {
     const appId = context.env.TEAMS_APP_ID;
     const appPassword = context.env.TEAMS_APP_PASSWORD;

--- a/packages/channel-telegram/src/descriptor.ts
+++ b/packages/channel-telegram/src/descriptor.ts
@@ -5,25 +5,11 @@
  * Token is read from context.env.TELEGRAM_BOT_TOKEN.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import type { TelegramDeployment } from "./telegram-channel.js";
 import { createTelegramChannel } from "./telegram-channel.js";
-
-function validateTelegramChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Telegram channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 function parseDeployment(options: Readonly<Record<string, unknown>>): TelegramDeployment {
   if (typeof options.webhookUrl === "string") {
@@ -44,7 +30,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-telegram",
   aliases: ["telegram"],
-  optionsValidator: validateTelegramChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Telegram channel"),
   factory(options, context: ResolutionContext): ChannelAdapter {
     const token = context.env.TELEGRAM_BOT_TOKEN;
     if (token === undefined || token === "") {

--- a/packages/channel-voice/src/descriptor.ts
+++ b/packages/channel-voice/src/descriptor.ts
@@ -6,23 +6,9 @@
  * environment variables plus STT/TTS provider configuration.
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
-
-function validateVoiceChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Voice channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 /**
  * Descriptor for voice channel adapter.
@@ -37,7 +23,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-voice",
   aliases: ["voice"],
-  optionsValidator: validateVoiceChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Voice channel"),
   factory(): ChannelAdapter {
     throw new Error(
       "@koi/channel-voice requires LiveKit credentials and STT/TTS config. " +

--- a/packages/channel-whatsapp/src/descriptor.ts
+++ b/packages/channel-whatsapp/src/descriptor.ts
@@ -5,24 +5,10 @@
  * Auth state path is read from options or defaults to "./whatsapp_auth".
  */
 
-import type { ChannelAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { ChannelAdapter } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createWhatsAppChannel } from "./whatsapp-channel.js";
-
-function validateWhatsAppChannelOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "WhatsApp channel options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
 
 /**
  * Descriptor for WhatsApp channel adapter.
@@ -32,7 +18,7 @@ export const descriptor: BrickDescriptor<ChannelAdapter> = {
   kind: "channel",
   name: "@koi/channel-whatsapp",
   aliases: ["whatsapp"],
-  optionsValidator: validateWhatsAppChannelOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "WhatsApp channel"),
   factory(options): ChannelAdapter {
     const opts = options as Readonly<Record<string, unknown>>;
     const authStatePath =

--- a/packages/context/src/descriptor.ts
+++ b/packages/context/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import type { ContextSource } from "./types.js";
 
 function isSourceArray(value: unknown): value is readonly ContextSource[] {
@@ -22,19 +23,12 @@ function isSourceArray(value: unknown): value is readonly ContextSource[] {
   );
 }
 
-function validateContextDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Context options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateContextDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Context");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (opts.sources !== undefined && !isSourceArray(opts.sources)) {
     return {
@@ -47,7 +41,7 @@ function validateContextDescriptorOptions(input: unknown): Result<unknown, KoiEr
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/engine-acp/src/descriptor.test.ts
+++ b/packages/engine-acp/src/descriptor.test.ts
@@ -43,3 +43,23 @@ describe("engine-acp descriptor", () => {
     expect(skill.tags).toContain("engine");
   });
 });
+
+describe("optionsValidator", () => {
+  test("accepts valid object with command", () => {
+    const result = descriptor.optionsValidator({ command: "claude" });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object input", () => {
+    const result = descriptor.optionsValidator("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects null and undefined", () => {
+    expect(descriptor.optionsValidator(null).ok).toBe(false);
+    expect(descriptor.optionsValidator(undefined).ok).toBe(false);
+  });
+});

--- a/packages/engine-acp/src/descriptor.ts
+++ b/packages/engine-acp/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createAcpAdapter } from "./adapter.js";
 import type { AcpAdapterConfig } from "./types.js";
 
@@ -48,19 +49,10 @@ engine:
 `,
 };
 
-function validateAcpEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "ACP engine options must be an object with a 'command' field",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateAcpEngineOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "ACP engine");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (typeof opts.command !== "string" || opts.command === "") {
     return {
@@ -73,7 +65,7 @@ function validateAcpEngineOptions(input: unknown): Result<unknown, KoiError> {
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/engine-claude/src/descriptor.test.ts
+++ b/packages/engine-claude/src/descriptor.test.ts
@@ -43,3 +43,23 @@ describe("engine-claude descriptor", () => {
     expect(skill.tags).toContain("engine");
   });
 });
+
+describe("optionsValidator", () => {
+  test("accepts valid object", () => {
+    const result = descriptor.optionsValidator({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object input", () => {
+    const result = descriptor.optionsValidator("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("accepts null and undefined as optional", () => {
+    expect(descriptor.optionsValidator(null).ok).toBe(true);
+    expect(descriptor.optionsValidator(undefined).ok).toBe(true);
+  });
+});

--- a/packages/engine-claude/src/descriptor.ts
+++ b/packages/engine-claude/src/descriptor.ts
@@ -5,9 +5,9 @@
  * Requires ANTHROPIC_API_KEY environment variable.
  */
 
-import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { CompanionSkillDefinition, EngineAdapter } from "@koi/core";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 const CLAUDE_COMPANION_SKILL: CompanionSkillDefinition = {
   name: "engine-claude-guide",
@@ -43,20 +43,6 @@ engine:
 `,
 };
 
-function validateClaudeEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Claude engine options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
-
 /**
  * Descriptor for Claude engine adapter.
  *
@@ -72,7 +58,7 @@ export const descriptor: BrickDescriptor<EngineAdapter> = {
   description: "Claude Agent SDK engine for Anthropic-native orchestration",
   tags: ["claude", "agent-sdk", "anthropic"],
   companionSkills: [CLAUDE_COMPANION_SKILL],
-  optionsValidator: validateClaudeEngineOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Claude engine"),
   factory(_options, _context: ResolutionContext): EngineAdapter {
     throw new Error(
       "@koi/engine-claude requires SDK function bindings. " +

--- a/packages/engine-external/src/descriptor.test.ts
+++ b/packages/engine-external/src/descriptor.test.ts
@@ -43,3 +43,23 @@ describe("engine-external descriptor", () => {
     expect(skill.tags).toContain("engine");
   });
 });
+
+describe("optionsValidator", () => {
+  test("accepts valid object with command", () => {
+    const result = descriptor.optionsValidator({ command: "node" });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object input", () => {
+    const result = descriptor.optionsValidator("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects null and undefined", () => {
+    expect(descriptor.optionsValidator(null).ok).toBe(false);
+    expect(descriptor.optionsValidator(undefined).ok).toBe(false);
+  });
+});

--- a/packages/engine-external/src/descriptor.ts
+++ b/packages/engine-external/src/descriptor.ts
@@ -9,6 +9,7 @@
 import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createExternalAdapter } from "./adapter.js";
 import type { ExternalAdapterConfig } from "./types.js";
 
@@ -53,19 +54,10 @@ engine:
 `,
 };
 
-function validateExternalEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "External engine options must be an object with a 'command' field",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateExternalEngineOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "External engine");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (typeof opts.command !== "string" || opts.command === "") {
     return {
@@ -78,7 +70,7 @@ function validateExternalEngineOptions(input: unknown): Result<unknown, KoiError
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/engine-loop/src/descriptor.test.ts
+++ b/packages/engine-loop/src/descriptor.test.ts
@@ -43,3 +43,23 @@ describe("engine-loop descriptor", () => {
     expect(skill.tags).toContain("engine");
   });
 });
+
+describe("optionsValidator", () => {
+  test("accepts valid object", () => {
+    const result = descriptor.optionsValidator({});
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object input", () => {
+    const result = descriptor.optionsValidator("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("accepts null and undefined as optional", () => {
+    expect(descriptor.optionsValidator(null).ok).toBe(true);
+    expect(descriptor.optionsValidator(undefined).ok).toBe(true);
+  });
+});

--- a/packages/engine-loop/src/descriptor.ts
+++ b/packages/engine-loop/src/descriptor.ts
@@ -4,8 +4,9 @@
  * Enables manifest auto-resolution for the pure TypeScript ReAct loop engine.
  */
 
-import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
+import type { CompanionSkillDefinition, EngineAdapter } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 const LOOP_COMPANION_SKILL: CompanionSkillDefinition = {
   name: "engine-loop-guide",
@@ -38,20 +39,6 @@ engine:
 `,
 };
 
-function validateLoopEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Loop engine options must be an object",
-        retryable: false,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
-
 /**
  * Descriptor for loop engine adapter.
  *
@@ -67,7 +54,7 @@ export const descriptor: BrickDescriptor<EngineAdapter> = {
   description: "Default lightweight ReAct loop engine in pure TypeScript",
   tags: ["default", "react-loop", "typescript"],
   companionSkills: [LOOP_COMPANION_SKILL],
-  optionsValidator: validateLoopEngineOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Loop engine"),
   factory(): EngineAdapter {
     throw new Error(
       "@koi/engine-loop requires a modelCall handler. " +

--- a/packages/engine-pi/src/descriptor.test.ts
+++ b/packages/engine-pi/src/descriptor.test.ts
@@ -43,3 +43,26 @@ describe("engine-pi descriptor", () => {
     expect(skill.tags).toContain("engine");
   });
 });
+
+describe("optionsValidator", () => {
+  test("accepts valid object with model", () => {
+    const result = descriptor.optionsValidator({ model: "anthropic:claude-sonnet-4-5-20250929" });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects non-object input", () => {
+    const result = descriptor.optionsValidator("invalid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("accepts null/undefined but requires model field", () => {
+    const nullResult = descriptor.optionsValidator(null);
+    expect(nullResult.ok).toBe(false);
+
+    const undefResult = descriptor.optionsValidator(undefined);
+    expect(undefResult.ok).toBe(false);
+  });
+});

--- a/packages/engine-pi/src/descriptor.ts
+++ b/packages/engine-pi/src/descriptor.ts
@@ -7,6 +7,7 @@
 import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { createPiAdapter } from "./adapter.js";
 import type { PiAdapterConfig } from "./types.js";
 
@@ -43,19 +44,10 @@ engine:
 `,
 };
 
-function validatePiEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Pi engine options must be an object with a 'model' field",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = (input ?? {}) as Record<string, unknown>;
+function validatePiEngineOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateOptionalDescriptorOptions(input, "Pi engine");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (typeof opts.model !== "string" || opts.model === "") {
     return {
@@ -68,7 +60,7 @@ function validatePiEngineOptions(input: unknown): Result<unknown, KoiError> {
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/engine-rlm/src/descriptor.ts
+++ b/packages/engine-rlm/src/descriptor.ts
@@ -4,8 +4,9 @@
  * Enables manifest auto-resolution for the RLM engine adapter.
  */
 
-import type { CompanionSkillDefinition, EngineAdapter, KoiError, Result } from "@koi/core";
+import type { CompanionSkillDefinition, EngineAdapter } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 const RLM_COMPANION_SKILL: CompanionSkillDefinition = {
   name: "engine-rlm-guide",
@@ -40,20 +41,6 @@ engine:
 `,
 };
 
-function validateRlmEngineOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "RLM engine options must be an object",
-        retryable: false,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
-
 /**
  * Descriptor for RLM engine adapter.
  *
@@ -68,7 +55,7 @@ export const descriptor: BrickDescriptor<EngineAdapter> = {
   description: "Recursive Language Model engine — process unbounded inputs via virtualized REPL",
   tags: ["rlm", "recursive", "unbounded-input"],
   companionSkills: [RLM_COMPANION_SKILL],
-  optionsValidator: validateRlmEngineOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "RLM engine"),
   factory(): EngineAdapter {
     throw new Error(
       "@koi/engine-rlm requires a modelCall handler. " +

--- a/packages/filesystem/src/descriptor.ts
+++ b/packages/filesystem/src/descriptor.ts
@@ -11,27 +11,17 @@
 import type { ComponentProvider, KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import { OPERATIONS } from "./constants.js";
 
 const TRUST_TIERS = ["sandbox", "verified", "promoted"] as const;
 
-function validateFilesystemDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined) {
-    return { ok: true, value: {} };
-  }
-
-  if (typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Filesystem options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateFilesystemDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateOptionalDescriptorOptions(input, "Filesystem");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   // Validate operations
   if (opts.operations !== undefined) {
@@ -85,7 +75,7 @@ function validateFilesystemDescriptorOptions(input: unknown): Result<unknown, Ko
     }
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/forge/src/descriptor.ts
+++ b/packages/forge/src/descriptor.ts
@@ -5,23 +5,8 @@
  * Creates a forge runtime that auto-discovers forged artifacts.
  */
 
-import type { KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
-
-function validateForgeDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Forge options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 /**
  * Descriptor for forge component provider.
@@ -35,7 +20,7 @@ export const descriptor: BrickDescriptor<unknown> = {
   kind: "forge",
   name: "@koi/forge",
   aliases: ["forge"],
-  optionsValidator: validateForgeDescriptorOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Forge"),
   factory(): unknown {
     throw new Error(
       "@koi/forge requires a ForgeStore and TieredSandboxExecutor. " +

--- a/packages/manifest/src/warnings.ts
+++ b/packages/manifest/src/warnings.ts
@@ -2,26 +2,8 @@
  * Unknown field detection with Levenshtein-based "did you mean?" suggestions.
  */
 
-import { levenshteinDistance } from "@koi/validation";
+import { findClosestMatch } from "@koi/validation";
 import type { ManifestWarning } from "./types.js";
-
-/** Maximum Levenshtein distance to consider a field name a "close match". */
-const MAX_SUGGESTION_DISTANCE = 3;
-
-/**
- * Finds the closest known field name to the given unknown field.
- *
- * @returns The closest match if within `MAX_SUGGESTION_DISTANCE`, or `undefined`.
- */
-function findClosestField(unknown: string, knownFields: readonly string[]): string | undefined {
-  return knownFields.reduce<{ readonly distance: number; readonly match: string | undefined }>(
-    (best, known) => {
-      const distance = levenshteinDistance(unknown, known, MAX_SUGGESTION_DISTANCE);
-      return distance < best.distance ? { distance, match: known } : best;
-    },
-    { distance: MAX_SUGGESTION_DISTANCE + 1, match: undefined },
-  ).match;
-}
 
 /**
  * Detects unknown top-level fields in parsed YAML and produces warnings.
@@ -39,7 +21,7 @@ export function detectUnknownFields(
   return Object.keys(parsed)
     .filter((key) => !knownSet.has(key))
     .map((key): ManifestWarning => {
-      const suggestion = findClosestField(key, knownFields);
+      const suggestion = findClosestMatch(key, knownFields);
       return {
         path: key,
         message: `Unknown field "${key}" in manifest`,

--- a/packages/middleware-ace/src/descriptor.ts
+++ b/packages/middleware-ace/src/descriptor.ts
@@ -8,22 +8,14 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createAceMiddleware } from "./ace.js";
 import { createInMemoryPlaybookStore, createInMemoryTrajectoryStore } from "./stores.js";
 
-function validateAceDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "ACE options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateAceDescriptorOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "ACE");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxInjectionTokens !== undefined &&
@@ -41,7 +33,7 @@ function validateAceDescriptorOptions(input: unknown): Result<unknown, KoiError>
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-audit/src/descriptor.ts
+++ b/packages/middleware-audit/src/descriptor.ts
@@ -8,22 +8,14 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createAuditMiddleware } from "./audit.js";
 import { createConsoleAuditSink } from "./sink.js";
 
-function validateAuditDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Audit options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateAuditDescriptorOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Audit");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxEntrySize !== undefined &&
@@ -39,7 +31,7 @@ function validateAuditDescriptorOptions(input: unknown): Result<unknown, KoiErro
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-call-limits/src/descriptor.ts
+++ b/packages/middleware-call-limits/src/descriptor.ts
@@ -8,23 +8,17 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createModelCallLimitMiddleware } from "./model-call-limit.js";
 import { createInMemoryCallLimitStore } from "./store.js";
 import { createToolCallLimitMiddleware } from "./tool-call-limit.js";
 
-function validateCallLimitsDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Call limits options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateCallLimitsDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Call limits");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxModelCalls !== undefined &&
@@ -65,7 +59,7 @@ function validateCallLimitsDescriptorOptions(input: unknown): Result<unknown, Ko
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-compactor/src/descriptor.ts
+++ b/packages/middleware-compactor/src/descriptor.ts
@@ -9,22 +9,16 @@
 import type { KoiError, KoiMiddleware, ModelHandler, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createCompactorMiddleware } from "./compactor-middleware.js";
 import { createMemoryCompactionStore } from "./memory-compaction-store.js";
 
-function validateCompactorDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Compactor options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateCompactorDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Compactor");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.contextWindowSize !== undefined &&
@@ -54,7 +48,7 @@ function validateCompactorDescriptorOptions(input: unknown): Result<unknown, Koi
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-context-editing/src/descriptor.ts
+++ b/packages/middleware-context-editing/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createContextEditingMiddleware } from "./context-editing.js";
 import type { ContextEditingConfig } from "./types.js";
 
@@ -15,19 +16,12 @@ function isStringArray(value: unknown): value is readonly string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
-function validateContextEditingDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Context-editing options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateContextEditingDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Context editing");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.triggerTokenCount !== undefined &&
@@ -54,7 +48,7 @@ function validateContextEditingDescriptorOptions(input: unknown): Result<unknown
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-guided-retry/src/descriptor.ts
+++ b/packages/middleware-guided-retry/src/descriptor.ts
@@ -5,25 +5,10 @@
  * then creates the guided retry middleware.
  */
 
-import type { KoiError, KoiMiddleware, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { KoiMiddleware } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createGuidedRetryMiddleware } from "./guided-retry.js";
-
-function validateGuidedRetryDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Guided retry options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  return { ok: true, value: input };
-}
 
 /**
  * Descriptor for guided-retry middleware.
@@ -33,7 +18,7 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   kind: "middleware",
   name: "@koi/middleware-guided-retry",
   aliases: ["guided-retry"],
-  optionsValidator: validateGuidedRetryDescriptorOptions,
+  optionsValidator: (input) => validateRequiredDescriptorOptions(input, "Guided retry"),
   factory(): KoiMiddleware {
     const handle = createGuidedRetryMiddleware({});
     return handle.middleware;

--- a/packages/middleware-memory/src/descriptor.ts
+++ b/packages/middleware-memory/src/descriptor.ts
@@ -8,22 +8,16 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createMemoryMiddleware } from "./memory.js";
 import { createInMemoryStore } from "./store.js";
 
-function validateMemoryDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Memory options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateMemoryDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Memory");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxRecallTokens !== undefined &&
@@ -54,7 +48,7 @@ function validateMemoryDescriptorOptions(input: unknown): Result<unknown, KoiErr
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-output-verifier/src/descriptor.ts
+++ b/packages/middleware-output-verifier/src/descriptor.ts
@@ -9,23 +9,17 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { nonEmpty } from "./builtin-checks.js";
 import { createOutputVerifierMiddleware } from "./output-verifier.js";
 import type { JudgeConfig, VerifierConfig } from "./types.js";
 
-function validateVerifierDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Output verifier options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateVerifierDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Output verifier");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.vetoThreshold !== undefined &&
@@ -66,7 +60,7 @@ function validateVerifierDescriptorOptions(input: unknown): Result<unknown, KoiE
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-pay/src/descriptor.ts
+++ b/packages/middleware-pay/src/descriptor.ts
@@ -9,22 +9,14 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createPayMiddleware } from "./pay.js";
 import { createDefaultCostCalculator, createInMemoryBudgetTracker } from "./tracker.js";
 
-function validatePayDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Pay options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validatePayDescriptorOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Pay");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (typeof opts.budget !== "number" || opts.budget <= 0) {
     return {
@@ -37,7 +29,7 @@ function validatePayDescriptorOptions(input: unknown): Result<unknown, KoiError>
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-permissions/src/descriptor.ts
+++ b/packages/middleware-permissions/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import type { PermissionRules } from "./engine.js";
 import { createPatternPermissionBackend } from "./engine.js";
 import { createPermissionsMiddleware } from "./permissions.js";
@@ -18,19 +19,12 @@ import { createPermissionsMiddleware } from "./permissions.js";
  * Accepts { allow?: string[], deny?: string[], ask?: string[] } — the
  * simplified manifest format (not the full PermissionsMiddlewareConfig).
  */
-function validatePermissionsDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Permissions options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validatePermissionsDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Permissions");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   // Validate allow
   if (opts.allow !== undefined && !isStringArray(opts.allow)) {
@@ -68,7 +62,7 @@ function validatePermissionsDescriptorOptions(input: unknown): Result<unknown, K
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 function isStringArray(value: unknown): value is readonly string[] {

--- a/packages/middleware-pii/src/descriptor.ts
+++ b/packages/middleware-pii/src/descriptor.ts
@@ -8,25 +8,17 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createAllDetectors } from "./detectors.js";
 import { createPIIMiddleware } from "./pii-middleware.js";
 import type { PIIConfig, PIIStrategy } from "./types.js";
 
 const VALID_STRATEGIES: readonly string[] = ["block", "redact", "mask", "hash"];
 
-function validatePIIDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "PII options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validatePIIDescriptorOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "PII");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (opts.strategy !== undefined && !VALID_STRATEGIES.includes(opts.strategy as string)) {
     return {
@@ -50,7 +42,7 @@ function validatePIIDescriptorOptions(input: unknown): Result<unknown, KoiError>
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-planning/src/descriptor.ts
+++ b/packages/middleware-planning/src/descriptor.ts
@@ -5,25 +5,10 @@
  * then creates the plan middleware.
  */
 
-import type { KoiError, KoiMiddleware, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { KoiMiddleware } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createPlanMiddleware } from "./plan-middleware.js";
-
-function validatePlanningDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Planning options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  return { ok: true, value: input };
-}
 
 /**
  * Descriptor for planning middleware.
@@ -33,7 +18,7 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   kind: "middleware",
   name: "@koi/middleware-planning",
   aliases: ["planning"],
-  optionsValidator: validatePlanningDescriptorOptions,
+  optionsValidator: (input) => validateRequiredDescriptorOptions(input, "Planning"),
   factory(): KoiMiddleware {
     return createPlanMiddleware();
   },

--- a/packages/middleware-report/src/descriptor.ts
+++ b/packages/middleware-report/src/descriptor.ts
@@ -8,21 +8,15 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createReportMiddleware } from "./report.js";
 
-function validateReportDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Report options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateReportDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Report");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxActions !== undefined &&
@@ -52,7 +46,7 @@ function validateReportDescriptorOptions(input: unknown): Result<unknown, KoiErr
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-sandbox/src/descriptor.ts
+++ b/packages/middleware-sandbox/src/descriptor.ts
@@ -5,27 +5,12 @@
  * then creates the sandbox middleware with default trust tier profiles.
  */
 
-import type { KoiError, KoiMiddleware, Result } from "@koi/core";
+import type { KoiMiddleware } from "@koi/core";
 import type { TrustTier } from "@koi/core/ecs";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { SandboxProfile } from "@koi/core/sandbox-profile";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createSandboxMiddleware } from "./sandbox-middleware.js";
-
-function validateSandboxDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Sandbox options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  return { ok: true, value: input };
-}
 
 /**
  * Default sandbox profiles by trust tier.
@@ -61,7 +46,7 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   kind: "middleware",
   name: "@koi/middleware-sandbox",
   aliases: ["sandbox"],
-  optionsValidator: validateSandboxDescriptorOptions,
+  optionsValidator: (input) => validateRequiredDescriptorOptions(input, "Sandbox"),
   factory(): KoiMiddleware {
     return createSandboxMiddleware({
       profileFor: (tier: TrustTier): SandboxProfile => DEFAULT_PROFILES[tier],

--- a/packages/middleware-sanitize/src/descriptor.ts
+++ b/packages/middleware-sanitize/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import type { SanitizeMiddlewareConfig } from "./config.js";
 import { resolvePresets } from "./rules.js";
 import { createSanitizeMiddleware } from "./sanitize-middleware.js";
@@ -24,19 +25,12 @@ function isStringArray(value: unknown): value is readonly string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
-function validateSanitizeDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Sanitize options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateSanitizeDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Sanitize");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (opts.presets !== undefined) {
     if (!isStringArray(opts.presets)) {
@@ -64,7 +58,7 @@ function validateSanitizeDescriptorOptions(input: unknown): Result<unknown, KoiE
     }
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-semantic-retry/src/descriptor.ts
+++ b/packages/middleware-semantic-retry/src/descriptor.ts
@@ -8,21 +8,15 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createSemanticRetryMiddleware } from "./semantic-retry.js";
 
-function validateSemanticRetryDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Semantic retry options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateSemanticRetryDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Semantic retry");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxRetries !== undefined &&
@@ -38,7 +32,7 @@ function validateSemanticRetryDescriptorOptions(input: unknown): Result<unknown,
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-tool-audit/src/descriptor.ts
+++ b/packages/middleware-tool-audit/src/descriptor.ts
@@ -8,21 +8,15 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createToolAuditMiddleware } from "./tool-audit.js";
 
-function validateToolAuditDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Tool audit options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateToolAuditDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Tool audit");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.unusedThresholdSessions !== undefined &&
@@ -128,7 +122,7 @@ function validateToolAuditDescriptorOptions(input: unknown): Result<unknown, Koi
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-tool-selector/src/descriptor.ts
+++ b/packages/middleware-tool-selector/src/descriptor.ts
@@ -12,6 +12,7 @@
 import type { KoiError, KoiMiddleware, Result, ToolDescriptor } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor, ResolutionContext } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import type { ToolSelectorConfig } from "./config.js";
 import { extractLastUserText } from "./extract-query.js";
 import { detectModelTier } from "./model-tier.js";
@@ -22,19 +23,12 @@ function isStringArray(value: unknown): value is readonly string[] {
   return Array.isArray(value) && value.every((x) => typeof x === "string");
 }
 
-function validateToolSelectorDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Tool selector options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateToolSelectorDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Tool selector");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.maxTools !== undefined &&
@@ -121,7 +115,7 @@ function validateToolSelectorDescriptorOptions(input: unknown): Result<unknown, 
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/middleware-turn-ack/src/descriptor.ts
+++ b/packages/middleware-turn-ack/src/descriptor.ts
@@ -8,21 +8,15 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { createTurnAckMiddleware } from "./turn-ack.js";
 
-function validateTurnAckDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Turn-ack options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateTurnAckDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Turn ack");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (
     opts.debounceMs !== undefined &&
@@ -38,7 +32,7 @@ function validateTurnAckDescriptorOptions(input: unknown): Result<unknown, KoiEr
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/pay-nexus/src/descriptor.ts
+++ b/packages/pay-nexus/src/descriptor.ts
@@ -6,28 +6,20 @@
  */
 
 import type { KoiError, Result } from "@koi/core/errors";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { PayLedger } from "@koi/core/pay-ledger";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { validatePayLedgerConfig } from "./config.js";
 import { createNexusPayLedger } from "./ledger.js";
 
-function validatePayNexusOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Pay-nexus options must be an object with baseUrl and apiKey",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
+function validatePayNexusOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Pay Nexus");
+  if (!base.ok) return base;
 
   const result = validatePayLedgerConfig(input);
   if (!result.ok) return result;
 
-  return { ok: true, value: input };
+  return { ok: true, value: base.value };
 }
 
 export const payNexusDescriptor: BrickDescriptor<PayLedger> = {

--- a/packages/resolve/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/resolve/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,8 +1,25 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/resolve API surface . has stable type surface 1`] = `
-"import { BrickKind, CompanionSkillDefinition, Result, KoiError, JsonObject, AgentManifest, KoiMiddleware, ModelHandler, ChannelAdapter, EngineAdapter, MiddlewareConfig, ModelConfig, PermissionConfig } from '@koi/core';
+"import { Result, KoiError, BrickKind, CompanionSkillDefinition, JsonObject, AgentManifest, KoiMiddleware, ModelHandler, ChannelAdapter, EngineAdapter, MiddlewareConfig, ModelConfig, PermissionConfig } from '@koi/core';
 import { SearchProvider } from '@koi/search-provider';
+
+/**
+ * Shared validation helpers for BrickDescriptor optionsValidator functions.
+ *
+ * Centralises the typeof-object boilerplate that every descriptor.ts repeats.
+ */
+
+/**
+ * Validates descriptor options, allowing null/undefined as empty object.
+ * Use for descriptors where options are optional (engines, some channels).
+ */
+declare function validateOptionalDescriptorOptions(input: unknown, label: string): Result<Record<string, unknown>, KoiError>;
+/**
+ * Validates descriptor options, requiring a non-null object.
+ * Use for descriptors where options are required (most middleware).
+ */
+declare function validateRequiredDescriptorOptions(input: unknown, label: string): Result<Record<string, unknown>, KoiError>;
 
 /**
  * Core types for the manifest resolution layer.
@@ -338,6 +355,6 @@ interface SoulManifestSlice {
  */
 declare function resolveSoul(manifest: SoulManifestSlice, registry: ResolveRegistry, context: ResolutionContext): Promise<Result<KoiMiddleware | undefined, KoiError>>;
 
-export { type BrickDescriptor, type BrickFactory, type MiddlewareResolutionResult, type OptionsValidator, type ResolutionContext, type ResolutionFailure, type ResolveApprovalHandler, type ResolveKind, type ResolveRegistry, type ResolvedManifest, aggregateErrors, createRegistry, discoverDescriptors, formatResolutionError, parseModelName, resolveChannels, resolveEngine, resolveManifest, resolveMiddleware, resolveModel, resolveOne, resolvePermissions, resolveSearch, resolveSoul };
+export { type BrickDescriptor, type BrickFactory, type MiddlewareResolutionResult, type OptionsValidator, type ResolutionContext, type ResolutionFailure, type ResolveApprovalHandler, type ResolveKind, type ResolveRegistry, type ResolvedManifest, aggregateErrors, createRegistry, discoverDescriptors, formatResolutionError, parseModelName, resolveChannels, resolveEngine, resolveManifest, resolveMiddleware, resolveModel, resolveOne, resolvePermissions, resolveSearch, resolveSoul, validateOptionalDescriptorOptions, validateRequiredDescriptorOptions };
 "
 `;

--- a/packages/resolve/src/descriptor-validation.test.ts
+++ b/packages/resolve/src/descriptor-validation.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for descriptor validation helpers.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import {
+  validateOptionalDescriptorOptions,
+  validateRequiredDescriptorOptions,
+} from "./descriptor-validation.js";
+
+// ---------------------------------------------------------------------------
+// validateOptionalDescriptorOptions (lenient — null/undefined → {})
+// ---------------------------------------------------------------------------
+
+describe("validateOptionalDescriptorOptions", () => {
+  test("returns ok with empty object for undefined", () => {
+    const result = validateOptionalDescriptorOptions(undefined, "Test");
+    expect(result).toEqual({ ok: true, value: {} });
+  });
+
+  test("returns ok with empty object for null", () => {
+    const result = validateOptionalDescriptorOptions(null, "Test");
+    expect(result).toEqual({ ok: true, value: {} });
+  });
+
+  test("returns ok for empty object", () => {
+    const result = validateOptionalDescriptorOptions({}, "Test");
+    expect(result).toEqual({ ok: true, value: {} });
+  });
+
+  test("returns ok for object with properties", () => {
+    const result = validateOptionalDescriptorOptions({ foo: 1 }, "Test");
+    expect(result).toEqual({ ok: true, value: { foo: 1 } });
+  });
+
+  test("returns error for string", () => {
+    const result = validateOptionalDescriptorOptions("string", "Test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toBe("Test options must be an object");
+      expect(result.error.retryable).toBe(RETRYABLE_DEFAULTS.VALIDATION);
+    }
+  });
+
+  test("returns error for number", () => {
+    const result = validateOptionalDescriptorOptions(42, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for boolean", () => {
+    const result = validateOptionalDescriptorOptions(true, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for array", () => {
+    const result = validateOptionalDescriptorOptions([], "Test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("Test options must be an object");
+    }
+  });
+
+  test("returns error for zero", () => {
+    const result = validateOptionalDescriptorOptions(0, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for empty string", () => {
+    const result = validateOptionalDescriptorOptions("", "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("includes label in error message", () => {
+    const result = validateOptionalDescriptorOptions("bad", "MyEngine");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("MyEngine options must be an object");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRequiredDescriptorOptions (strict — null/undefined → error)
+// ---------------------------------------------------------------------------
+
+describe("validateRequiredDescriptorOptions", () => {
+  test("returns error for undefined", () => {
+    const result = validateRequiredDescriptorOptions(undefined, "Test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toBe("Test options must be an object");
+      expect(result.error.retryable).toBe(RETRYABLE_DEFAULTS.VALIDATION);
+    }
+  });
+
+  test("returns error for null", () => {
+    const result = validateRequiredDescriptorOptions(null, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns ok for empty object", () => {
+    const result = validateRequiredDescriptorOptions({}, "Test");
+    expect(result).toEqual({ ok: true, value: {} });
+  });
+
+  test("returns ok for object with properties", () => {
+    const result = validateRequiredDescriptorOptions({ foo: 1 }, "Test");
+    expect(result).toEqual({ ok: true, value: { foo: 1 } });
+  });
+
+  test("returns error for string", () => {
+    const result = validateRequiredDescriptorOptions("string", "Test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.message).toBe("Test options must be an object");
+    }
+  });
+
+  test("returns error for number", () => {
+    const result = validateRequiredDescriptorOptions(42, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for boolean", () => {
+    const result = validateRequiredDescriptorOptions(true, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for array", () => {
+    const result = validateRequiredDescriptorOptions([], "Test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("Test options must be an object");
+    }
+  });
+
+  test("returns error for zero", () => {
+    const result = validateRequiredDescriptorOptions(0, "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns error for empty string", () => {
+    const result = validateRequiredDescriptorOptions("", "Test");
+    expect(result.ok).toBe(false);
+  });
+
+  test("includes label in error message", () => {
+    const result = validateRequiredDescriptorOptions("bad", "Audit");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe("Audit options must be an object");
+    }
+  });
+});

--- a/packages/resolve/src/descriptor-validation.ts
+++ b/packages/resolve/src/descriptor-validation.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared validation helpers for BrickDescriptor optionsValidator functions.
+ *
+ * Centralises the typeof-object boilerplate that every descriptor.ts repeats.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+
+/**
+ * Validates descriptor options, allowing null/undefined as empty object.
+ * Use for descriptors where options are optional (engines, some channels).
+ */
+export function validateOptionalDescriptorOptions(
+  input: unknown,
+  label: string,
+): Result<Record<string, unknown>, KoiError> {
+  if (input === null || input === undefined) {
+    return { ok: true, value: {} };
+  }
+
+  if (typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `${label} options must be an object`,
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return { ok: true, value: input as Record<string, unknown> };
+}
+
+/**
+ * Validates descriptor options, requiring a non-null object.
+ * Use for descriptors where options are required (most middleware).
+ */
+export function validateRequiredDescriptorOptions(
+  input: unknown,
+  label: string,
+): Result<Record<string, unknown>, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `${label} options must be an object`,
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return { ok: true, value: input as Record<string, unknown> };
+}

--- a/packages/resolve/src/errors.test.ts
+++ b/packages/resolve/src/errors.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { levenshteinDistance } from "@koi/validation";
-import { aggregateErrors, findClosestName, formatResolutionError } from "./errors.js";
+import { findClosestMatch, levenshteinDistance } from "@koi/validation";
+import { aggregateErrors, formatResolutionError } from "./errors.js";
 import type { ResolutionFailure } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -34,23 +34,23 @@ describe("levenshteinDistance", () => {
 });
 
 // ---------------------------------------------------------------------------
-// findClosestName
+// findClosestMatch (moved from local findClosestName to @koi/validation)
 // ---------------------------------------------------------------------------
 
-describe("findClosestName", () => {
+describe("findClosestMatch", () => {
   test("finds closest match within threshold", () => {
     const candidates = ["anthropic", "openai", "openrouter"];
-    expect(findClosestName("anthrpic", candidates)).toBe("anthropic"); // distance 1
-    expect(findClosestName("opanai", candidates)).toBe("openai"); // distance 1
+    expect(findClosestMatch("anthrpic", candidates)).toBe("anthropic"); // distance 1
+    expect(findClosestMatch("opanai", candidates)).toBe("openai"); // distance 1
   });
 
   test("returns undefined when no match within threshold", () => {
     const candidates = ["anthropic", "openai"];
-    expect(findClosestName("completely-different", candidates)).toBeUndefined();
+    expect(findClosestMatch("completely-different", candidates)).toBeUndefined();
   });
 
   test("returns undefined for empty candidates", () => {
-    expect(findClosestName("anything", [])).toBeUndefined();
+    expect(findClosestMatch("anything", [])).toBeUndefined();
   });
 });
 

--- a/packages/resolve/src/errors.ts
+++ b/packages/resolve/src/errors.ts
@@ -4,25 +4,7 @@
 
 import type { KoiError } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
-import { levenshteinDistance } from "@koi/validation";
 import type { ResolutionFailure } from "./types.js";
-
-/** Maximum Levenshtein distance to consider a name a "close match". */
-const MAX_SUGGESTION_DISTANCE = 3;
-
-/**
- * Finds the closest name from a list of candidates.
- * Returns undefined if no match is within MAX_SUGGESTION_DISTANCE.
- */
-export function findClosestName(target: string, candidates: readonly string[]): string | undefined {
-  return candidates.reduce<{ readonly distance: number; readonly match: string | undefined }>(
-    (best, candidate) => {
-      const distance = levenshteinDistance(target, candidate, MAX_SUGGESTION_DISTANCE);
-      return distance < best.distance ? { distance, match: candidate } : best;
-    },
-    { distance: MAX_SUGGESTION_DISTANCE + 1, match: undefined },
-  ).match;
-}
 
 /**
  * Aggregates multiple resolution failures into a single KoiError.

--- a/packages/resolve/src/index.ts
+++ b/packages/resolve/src/index.ts
@@ -6,6 +6,11 @@
  * middleware, soul, permissions, and model resolution.
  */
 
+// descriptor validation
+export {
+  validateOptionalDescriptorOptions,
+  validateRequiredDescriptorOptions,
+} from "./descriptor-validation.js";
 // discovery
 export { discoverDescriptors } from "./discover.js";
 // errors

--- a/packages/resolve/src/resolve-model.ts
+++ b/packages/resolve/src/resolve-model.ts
@@ -7,7 +7,7 @@
 
 import type { KoiError, ModelConfig, ModelHandler, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
-import { findClosestName } from "./errors.js";
+import { findClosestMatch } from "@koi/validation";
 import type { ResolutionContext, ResolveRegistry } from "./types.js";
 
 /**
@@ -69,7 +69,7 @@ export async function resolveModel(
   const descriptor = registry.get("model", provider);
   if (descriptor === undefined) {
     const available = registry.list("model").map((d) => d.name);
-    const suggestion = findClosestName(provider, available);
+    const suggestion = findClosestMatch(provider, available);
     const hint = suggestion !== undefined ? ` Did you mean "${suggestion}"?` : "";
 
     return {

--- a/packages/resolve/src/resolve-one.ts
+++ b/packages/resolve/src/resolve-one.ts
@@ -7,7 +7,7 @@
 
 import type { JsonObject, KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
-import { findClosestName } from "./errors.js";
+import { findClosestMatch } from "@koi/validation";
 import type { BrickDescriptor, ResolutionContext, ResolveKind, ResolveRegistry } from "./types.js";
 
 /**
@@ -28,7 +28,7 @@ export async function resolveOne<T>(
 
   if (descriptor === undefined) {
     const available = registry.list(kind).map((d) => d.name);
-    const suggestion = findClosestName(config.name, available);
+    const suggestion = findClosestMatch(config.name, available);
     const hint = suggestion !== undefined ? ` Did you mean "${suggestion}"?` : "";
 
     return {

--- a/packages/scheduler-nexus/src/descriptor.ts
+++ b/packages/scheduler-nexus/src/descriptor.ts
@@ -6,27 +6,19 @@
  */
 
 import type { KoiError, Result, TaskQueueBackend } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import { validateNexusTaskQueueConfig } from "./config.js";
 import { createNexusTaskQueue } from "./nexus-queue.js";
 
-function validateSchedulerNexusOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Scheduler-nexus options must be an object with baseUrl and apiKey",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
+function validateSchedulerNexusOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Nexus scheduler");
+  if (!base.ok) return base;
 
   const result = validateNexusTaskQueueConfig(input);
   if (!result.ok) return result;
 
-  return { ok: true, value: input };
+  return { ok: true, value: base.value };
 }
 
 export const schedulerNexusDescriptor: BrickDescriptor<TaskQueueBackend> = {

--- a/packages/scheduler/src/descriptor.ts
+++ b/packages/scheduler/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 
 /** Schedule entry as it appears in the manifest. */
 interface ScheduleEntry {
@@ -30,19 +31,12 @@ function isScheduleArray(value: unknown): value is readonly ScheduleEntry[] {
   );
 }
 
-function validateSchedulerDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Scheduler options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateSchedulerDescriptorOptions(
+  input: unknown,
+): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Scheduler");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   if (opts.schedules !== undefined && !isScheduleArray(opts.schedules)) {
     return {
@@ -55,7 +49,7 @@ function validateSchedulerDescriptorOptions(input: unknown): Result<unknown, Koi
     };
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 /**

--- a/packages/search-brave/src/descriptor.ts
+++ b/packages/search-brave/src/descriptor.ts
@@ -6,29 +6,13 @@
  */
 
 import type { KoiError, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 import type { SearchProvider } from "@koi/search-provider";
 import { createBraveSearch } from "./brave-search.js";
 
-function validateBraveSearchOptions(input: unknown): Result<unknown, KoiError> {
-  // Options are optional — pass through whatever is provided
-  if (input === null || input === undefined) {
-    return { ok: true, value: {} };
-  }
-
-  if (typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Brave search options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  return { ok: true, value: input };
+function validateBraveSearchOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  return validateOptionalDescriptorOptions(input, "Brave search");
 }
 
 /**

--- a/packages/soul/src/descriptor.ts
+++ b/packages/soul/src/descriptor.ts
@@ -8,6 +8,7 @@
 import type { KoiError, KoiMiddleware, Result } from "@koi/core";
 import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
 import type { BrickDescriptor } from "@koi/resolve";
+import { validateRequiredDescriptorOptions } from "@koi/resolve";
 import type { ContentInput, CreateSoulOptions } from "./config.js";
 import { createSoulMiddleware } from "./soul.js";
 
@@ -17,19 +18,10 @@ import { createSoulMiddleware } from "./soul.js";
  * Accepts { soul?: ContentInput, user?: ContentInput } — basePath
  * is injected from context.manifestDir by the factory, not from YAML.
  */
-function validateSoulDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input === null || input === undefined || typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Soul options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-
-  const opts = input as Record<string, unknown>;
+function validateSoulDescriptorOptions(input: unknown): Result<Record<string, unknown>, KoiError> {
+  const base = validateRequiredDescriptorOptions(input, "Soul");
+  if (!base.ok) return base;
+  const opts = base.value;
 
   // Validate soul field if present
   if (opts.soul !== undefined) {
@@ -59,7 +51,7 @@ function validateSoulDescriptorOptions(input: unknown): Result<unknown, KoiError
     }
   }
 
-  return { ok: true, value: input };
+  return { ok: true, value: opts };
 }
 
 function isValidContentInput(value: unknown): value is ContentInput {

--- a/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/validation/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -192,6 +192,15 @@ declare function mergeSamplers(a: LatencySampler, b: LatencySampler): LatencySam
  * @returns The edit distance, or \`maxDistance + 1\` if the distance exceeds \`maxDistance\`.
  */
 declare function levenshteinDistance(a: string, b: string, maxDistance?: number): number;
+/**
+ * Finds the closest string match from candidates using Levenshtein distance.
+ *
+ * @param target - The string to find a match for
+ * @param candidates - The list of candidate strings to compare against
+ * @param maxDistance - Maximum distance to consider (default: 3)
+ * @returns The closest match within maxDistance, or undefined
+ */
+declare function findClosestMatch(target: string, candidates: readonly string[], maxDistance?: number): string | undefined;
 
 /**
  * Mutation pressure scoring — maps fitness scores to pressure zones.
@@ -327,6 +336,6 @@ declare function zodToKoiError(zodError: z.core.$ZodError, prefix?: string): Koi
  */
 declare function validateWith<T>(schema: z.ZodType<T>, raw: unknown, prefix?: string): Result<T, KoiError>;
 
-export { DEFAULT_DECAY_THRESHOLDS, DEFAULT_FITNESS_SCORING_CONFIG, type DecayThresholds, type FitnessScoringConfig, type PipelineValidation, SEVERITY_ORDER, type SchemaCompatibility, type Severity, type SortBricksOptions, applyBrickUpdate, checkSchemaCompatibility, computeBrickFitness, computeDrift, computeEffectiveTrailStrength, computeMutationPressure, computePercentile, computeTrailReinforcement, createLatencySampler, createMemoryStoreChangeNotifier, evaluateTrustDecay, isTrailEvaporated, levenshteinDistance, matchesBrickQuery, mergeSamplers, recordLatency, severityAtOrAbove, sortBricks, validateBrickArtifact, validatePipeline, validateWith, zodToKoiError };
+export { DEFAULT_DECAY_THRESHOLDS, DEFAULT_FITNESS_SCORING_CONFIG, type DecayThresholds, type FitnessScoringConfig, type PipelineValidation, SEVERITY_ORDER, type SchemaCompatibility, type Severity, type SortBricksOptions, applyBrickUpdate, checkSchemaCompatibility, computeBrickFitness, computeDrift, computeEffectiveTrailStrength, computeMutationPressure, computePercentile, computeTrailReinforcement, createLatencySampler, createMemoryStoreChangeNotifier, evaluateTrustDecay, findClosestMatch, isTrailEvaporated, levenshteinDistance, matchesBrickQuery, mergeSamplers, recordLatency, severityAtOrAbove, sortBricks, validateBrickArtifact, validatePipeline, validateWith, zodToKoiError };
 "
 `;

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -29,7 +29,7 @@ export {
   mergeSamplers,
   recordLatency,
 } from "./latency-sampler.js";
-export { levenshteinDistance } from "./levenshtein.js";
+export { findClosestMatch, levenshteinDistance } from "./levenshtein.js";
 export { computeMutationPressure } from "./mutation-pressure.js";
 export { matchesBrickQuery } from "./query-match.js";
 export { SEVERITY_ORDER, type Severity, severityAtOrAbove } from "./severity.js";

--- a/packages/validation/src/levenshtein.test.ts
+++ b/packages/validation/src/levenshtein.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { levenshteinDistance } from "./levenshtein.js";
+import { findClosestMatch, levenshteinDistance } from "./levenshtein.js";
 
 // ---------------------------------------------------------------------------
 // Basic correctness (backward-compatible — no maxDistance argument)
@@ -86,5 +86,44 @@ describe("levenshteinDistance with maxDistance", () => {
   test("maxDistance = Infinity behaves like no maxDistance", () => {
     expect(levenshteinDistance("kitten", "sitting", Infinity)).toBe(3);
     expect(levenshteinDistance("abc", "xyz", Infinity)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClosestMatch — higher-level helper
+// ---------------------------------------------------------------------------
+
+describe("findClosestMatch", () => {
+  test("returns undefined for empty candidates", () => {
+    expect(findClosestMatch("hello", [])).toBeUndefined();
+  });
+
+  test("returns exact match", () => {
+    expect(findClosestMatch("model", ["model", "engine", "channel"])).toBe("model");
+  });
+
+  test("returns close match within default threshold", () => {
+    expect(findClosestMatch("modle", ["model", "engine", "channel"])).toBe("model");
+  });
+
+  test("returns undefined when no match within threshold", () => {
+    expect(findClosestMatch("zzzzz", ["model", "engine", "channel"])).toBeUndefined();
+  });
+
+  test("picks closest among multiple candidates", () => {
+    expect(findClosestMatch("cat", ["bat", "car", "dog"])).toBe("bat");
+  });
+
+  test("respects custom maxDistance parameter", () => {
+    // "cat" -> "bat" = 1, within maxDistance=1
+    expect(findClosestMatch("cat", ["bat", "dog"], 1)).toBe("bat");
+    // "cat" -> "dog" = 3, exceeds maxDistance=1
+    expect(findClosestMatch("cat", ["dog"], 1)).toBeUndefined();
+  });
+
+  test("returns first match when distances are tied", () => {
+    // "bat" -> "cat" = 1, "bat" -> "hat" = 1, first wins (reduce keeps first)
+    const result = findClosestMatch("bat", ["cat", "hat"]);
+    expect(result).toBe("cat");
   });
 });

--- a/packages/validation/src/levenshtein.ts
+++ b/packages/validation/src/levenshtein.ts
@@ -70,3 +70,25 @@ export function levenshteinDistance(a: string, b: string, maxDistance: number = 
 
   return prev[aLen] ?? 0;
 }
+
+/**
+ * Finds the closest string match from candidates using Levenshtein distance.
+ *
+ * @param target - The string to find a match for
+ * @param candidates - The list of candidate strings to compare against
+ * @param maxDistance - Maximum distance to consider (default: 3)
+ * @returns The closest match within maxDistance, or undefined
+ */
+export function findClosestMatch(
+  target: string,
+  candidates: readonly string[],
+  maxDistance = 3,
+): string | undefined {
+  return candidates.reduce<{ readonly distance: number; readonly match: string | undefined }>(
+    (best, candidate) => {
+      const distance = levenshteinDistance(target, candidate, maxDistance);
+      return distance < best.distance ? { distance, match: candidate } : best;
+    },
+    { distance: maxDistance + 1, match: undefined },
+  ).match;
+}

--- a/packages/webhook-delivery/src/descriptor.ts
+++ b/packages/webhook-delivery/src/descriptor.ts
@@ -5,23 +5,9 @@
  * Validates webhook endpoint configuration from the manifest.
  */
 
-import type { KoiError, KoiMiddleware, Result } from "@koi/core";
-import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { KoiMiddleware } from "@koi/core";
 import type { BrickDescriptor } from "@koi/resolve";
-
-function validateWebhookDescriptorOptions(input: unknown): Result<unknown, KoiError> {
-  if (input !== null && input !== undefined && typeof input !== "object") {
-    return {
-      ok: false,
-      error: {
-        code: "VALIDATION",
-        message: "Webhook options must be an object",
-        retryable: RETRYABLE_DEFAULTS.VALIDATION,
-      },
-    };
-  }
-  return { ok: true, value: input ?? {} };
-}
+import { validateOptionalDescriptorOptions } from "@koi/resolve";
 
 /**
  * Descriptor for webhook delivery middleware.
@@ -35,7 +21,7 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   kind: "webhook",
   name: "@koi/webhook-delivery",
   aliases: ["webhook", "webhooks"],
-  optionsValidator: validateWebhookDescriptorOptions,
+  optionsValidator: (input) => validateOptionalDescriptorOptions(input, "Webhook delivery"),
   factory(): KoiMiddleware {
     throw new Error(
       "@koi/webhook-delivery requires an EventBackend. " +


### PR DESCRIPTION
## Summary

Closes #509

- Extract `findClosestMatch` to `@koi/validation` — was duplicated in `@koi/manifest` and `@koi/resolve`
- Add `validateOptionalDescriptorOptions` and `validateRequiredDescriptorOptions` helpers to `@koi/resolve`
- Update 47 descriptor files to use shared helpers:
  - Eliminates 28 banned `as Record<string, unknown>` casts
  - Normalizes 3 inconsistent `retryable` values to `RETRYABLE_DEFAULTS.VALIDATION`
- Add `optionsValidator` tests to 5 descriptor test files (engine-acp, engine-claude, engine-external, engine-loop, engine-pi)
- Add documentation at `docs/L2/descriptor-validation.md`

No new packages created. No new dependencies added. No layer violations.

**66 files changed, +817 / -784 lines (net +33)**

## Test plan

- [x] `bun test --filter validation` — findClosestMatch tests pass
- [x] `bun test --filter resolve` — descriptor-validation helper tests pass
- [x] `bun test --filter descriptor` — all descriptor test files pass
- [x] `turbo run typecheck` — no type errors (79/79 packages)
- [x] `turbo run build` — all packages build cleanly (79/79)
- [x] biome lint + format — clean
- [x] Anti-leak checklist: `@koi/core` has zero imports from other packages, L2 packages only import from L0/L0u