### PR TITLE
feat: add @koi/tool-exec — sandboxed code execution tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2166,6 +2166,16 @@
         "@koi/scope": "workspace:*",
       },
     },
+    "packages/tool-exec": {
+      "name": "@koi/tool-exec",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/tool-squash": {
       "name": "@koi/tool-squash",
       "version": "0.0.0",
@@ -3128,6 +3138,8 @@
     "@koi/tool-ask-user": ["@koi/tool-ask-user@workspace:packages/tool-ask-user"],
 
     "@koi/tool-browser": ["@koi/tool-browser@workspace:packages/tool-browser"],
+
+    "@koi/tool-exec": ["@koi/tool-exec@workspace:packages/tool-exec"],
 
     "@koi/tool-squash": ["@koi/tool-squash@workspace:packages/tool-squash"],
 

--- a/docs/L2/tool-exec.md
+++ b/docs/L2/tool-exec.md
@@ -1,0 +1,293 @@
+# @koi/tool-exec — Sandboxed Code Execution Tool
+
+`@koi/tool-exec` is an L2 package that provides the `exec` tool, enabling agents
+to run code in **any** `SandboxExecutor` backend (Docker, Cloudflare Workers, e2b,
+OS-level, etc.) with JSON input/output. It is a thin pass-through — no Wasm runtime,
+no tool bridging, no console capture.
+
+---
+
+## Why it exists
+
+Koi already has `execute_script` (@koi/code-executor) for tool orchestration in
+QuickJS Wasm. But some use cases don't need tool bridging — they need **compute**:
+
+```
+Without exec (LLM guesses the answer):
+
+  User:  "What's the average of these 500 salaries?"
+  Agent:  *tries mental math, makes rounding errors*
+  Agent:  "Approximately $87,400" ← wrong
+
+With exec (LLM delegates to a sandbox):
+
+  User:  "What's the average of these 500 salaries?"
+  Agent:  → exec({
+            code: "return input.salaries.reduce((a,b) => a+b, 0) / input.salaries.length",
+            input: { salaries: [...500 numbers...] }
+          })
+        ← { ok: true, output: 87450.50, durationMs: 3 }
+  Agent:  "The average salary is $87,450.50" ← correct
+```
+
+The key difference from `execute_script`:
+
+```
+              execute_script                    exec
+              ──────────────                    ────
+Sandbox       QuickJS Wasm (fixed)              Any SandboxExecutor (injected)
+Purpose       Orchestrate callTool() calls      Compute / transform / verify
+Tool access   callTool() RPC bridge             None
+Data input    None                              JSON via `input` parameter
+Console       Captured log/error/warn           None
+Language      JS/TS (transpiled)                Whatever the backend supports
+```
+
+`exec` is the **backend-agnostic** execution tool. The operator chooses which
+sandbox runs the code — Docker for heavy workloads, Cloudflare for edge, e2b
+for cloud dev environments — the agent doesn't care.
+
+---
+
+## What this enables
+
+1. **Accurate computation** — LLMs delegate math, aggregation, filtering to real code
+   instead of hallucinating results
+
+2. **Backend-agnostic execution** — same tool interface regardless of whether code
+   runs in Docker, Cloudflare Workers, e2b, or an OS sandbox
+
+3. **Data transformation** — reshape JSON, validate schemas, sort/filter/aggregate
+   with guaranteed correctness
+
+4. **Code verification** — run a snippet to confirm it produces expected output
+   before writing it to a file
+
+5. **Isolated by default** — no filesystem, no network (unless operator allows),
+   no tool access. Pure compute in a sandbox.
+
+---
+
+## Architecture
+
+### Layer position
+
+```
+L0  @koi/core              ─ SandboxExecutor, Tool, ToolDescriptor, SkillComponent
+                              (types + contracts only)
+L2  @koi/tool-exec         ─ this package (depends on L0 only)
+```
+
+Zero L0u dependencies. Zero external dependencies.
+
+### Internal module map
+
+```
+src/
+├── types.ts             ← ExecToolConfig, EXEC_TOOL_DESCRIPTOR, defaults
+├── exec-tool.ts         ← createExecTool() factory (validates, clamps, delegates)
+├── skill.ts             ← EXEC_SKILL companion skill (when to use exec vs execute_script)
+├── provider.ts          ← createExecProvider() attaches tool:exec + skill:exec-guide
+└── index.ts             ← public exports
+```
+
+### Execution flow
+
+```
+LLM calls exec({ code, input?, timeout_ms? })
+     │
+     ▼
+1. Validate input (code must be non-empty string)
+     │
+     ▼
+2. Clamp timeout
+     ├── Use timeout_ms if valid positive number
+     ├── Fall back to defaultTimeoutMs (5s)
+     └── Clamp to maxTimeoutMs (30s)
+     │
+     ▼
+3. Build ExecutionContext from config
+     ├── networkAllowed (default: false)
+     └── resourceLimits (optional maxMemoryMb, maxPids)
+     │
+     ▼
+4. Delegate to executor.execute(code, input, timeoutMs, context)
+     │
+     ▼
+5. Map result
+     ├── Success → { ok: true, output, durationMs }
+     ├── Expected error → { ok: false, error, code, durationMs }
+     └── Unexpected throw → { ok: false, error, code: "CRASH" }
+```
+
+---
+
+## Quick start
+
+### Attach to an agent
+
+```typescript
+import { createExecProvider } from "@koi/tool-exec";
+
+const provider = createExecProvider({
+  executor: myDockerSandbox,     // any SandboxExecutor implementation
+  defaultTimeoutMs: 5_000,       // optional (default: 5000)
+  maxTimeoutMs: 30_000,          // optional (default: 30000)
+  networkAllowed: false,         // optional (default: false)
+  resourceLimits: {              // optional
+    maxMemoryMb: 128,
+    maxPids: 10,
+  },
+});
+
+// provider.attach(agent) returns:
+//   tool:exec        → the callable tool
+//   skill:exec-guide → markdown injected into LLM context
+```
+
+### Use the tool factory directly
+
+```typescript
+import { createExecTool } from "@koi/tool-exec";
+
+const tool = createExecTool({ executor: mySandbox });
+
+const result = await tool.execute({
+  code: "return input.items.filter(i => i.active).length",
+  input: { items: [{ active: true }, { active: false }, { active: true }] },
+});
+// { ok: true, output: 2, durationMs: 5 }
+```
+
+---
+
+## Companion skill
+
+The provider attaches a `skill:exec-guide` alongside the tool. This markdown
+is injected into the LLM's system context to teach it:
+
+- **When to use `exec`** — compute, transform, verify with JSON input
+- **When to use `execute_script`** — orchestrate multiple `callTool()` calls
+- **When to skip both** — simple questions the LLM can answer directly
+- **Example calls** — concrete JSON showing code + input patterns
+
+Without the skill, the LLM only sees the bare tool descriptor and must guess
+when to reach for `exec`. The skill eliminates that guesswork.
+
+---
+
+## Error handling
+
+All errors are returned as structured objects, never thrown to the caller.
+
+```
+Error source                     Result
+────────────                     ──────
+Missing/empty code            →  { ok: false, error: "...", code: "VALIDATION" }
+Non-string code               →  { ok: false, error: "...", code: "VALIDATION" }
+Executor returns TIMEOUT      →  { ok: false, error: "...", code: "TIMEOUT", durationMs }
+Executor returns OOM          →  { ok: false, error: "...", code: "OOM", durationMs }
+Executor returns PERMISSION   →  { ok: false, error: "...", code: "PERMISSION", durationMs }
+Executor returns CRASH        →  { ok: false, error: "...", code: "CRASH", durationMs }
+Executor throws (infra error) →  { ok: false, error: "...", code: "CRASH" }
+```
+
+---
+
+## API reference
+
+### Factories
+
+| Export | Signature | Description |
+|--------|-----------|-------------|
+| `createExecTool` | `(config: ExecToolConfig) → Tool` | Creates the `exec` tool |
+| `createExecProvider` | `(config: ExecToolConfig) → ComponentProvider` | Attaches `tool:exec` + `skill:exec-guide` |
+
+### ExecToolConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `executor` | `SandboxExecutor` | *required* | The sandbox backend |
+| `defaultTimeoutMs` | `number` | `5000` | Timeout when model omits `timeout_ms` |
+| `maxTimeoutMs` | `number` | `30000` | Hard upper bound for timeout |
+| `networkAllowed` | `boolean` | `false` | Whether code may make network requests |
+| `resourceLimits` | `{ maxMemoryMb?, maxPids? }` | `undefined` | OS-level resource limits |
+
+### Tool input schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | `string` | Yes | Code to execute |
+| `input` | `any` | No | JSON data available as `input` variable |
+| `timeout_ms` | `number` | No | Execution timeout (clamped to server max) |
+
+### Exports
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `createExecTool` | factory | Creates the `exec` Tool directly |
+| `createExecProvider` | factory | ComponentProvider attaching tool + skill |
+| `EXEC_TOOL_DESCRIPTOR` | const | Tool descriptor (name, schema, description) |
+| `EXEC_SKILL` | const | SkillComponent for behavioral guidance |
+| `EXEC_SKILL_NAME` | const | `"exec-guide"` |
+| `EXEC_SKILL_CONTENT` | const | Skill markdown content |
+| `DEFAULT_TIMEOUT_MS` | const | `5000` |
+| `MAX_TIMEOUT_MS` | const | `30000` |
+| `ExecToolConfig` | type | Configuration interface |
+
+---
+
+## Testing
+
+```bash
+bun run --filter @koi/tool-exec test
+```
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `exec-tool.test.ts` | 24 | Success path, timeout clamping, context passthrough, validation, error forwarding, executor throws |
+| `provider.test.ts` | 5 | Provider name, tool attachment, skill attachment, descriptor, caching |
+
+29 tests, 46 assertions.
+
+---
+
+## Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Delegate to injected `SandboxExecutor` | Backend-agnostic — operator chooses Docker, cloud, OS |
+| No tool bridging (`callTool`) | That's `execute_script`'s job. Keep `exec` simple. |
+| No console capture | Same — `execute_script` handles that. Minimal surface. |
+| JSON `input` parameter | Structured data in, structured data out. Safer than string interpolation. |
+| Clamp timeout silently | Don't reject valid requests — just enforce the server limit. |
+| Companion skill vs longer description | Skills are injected into system context; descriptions are truncated in tool lists. |
+| `trustTier: "sandbox"` | Code runs in isolation — highest sandboxing requirement. |
+| Try/catch around executor call | Infrastructure failures (network, deserialization) must not propagate unhandled. |
+
+---
+
+## Layer compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────────┐
+    SandboxExecutor, ExecutionContext, Tool, ToolDescriptor,  │
+    SkillComponent, ComponentProvider, skillToken              │
+                                                              ▼
+L2  @koi/tool-exec ◀─────────────────────────────────────────┘
+    imports from L0 only
+    ✗ never imports @koi/engine (L1)
+    ✗ never imports peer L2 packages
+    ✗ never imports external dependencies
+    ✓ all interface properties readonly
+    ✓ no enum, class, any, as-assertion, non-null assertion
+    ✓ import type for type-only imports
+```
+
+---
+
+## Related
+
+- [@koi/code-executor](./code-executor.md) — QuickJS Wasm script execution with `callTool()` bridging
+- [@koi/sandbox-executor](./sandbox-executor.md) — trust-tiered executor for forge bricks
+- [@koi/core](../../packages/core/) — L0 contract definitions (SandboxExecutor, Tool)

--- a/packages/tool-exec/package.json
+++ b/packages/tool-exec/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@koi/tool-exec",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "devDependencies": {}
+}

--- a/packages/tool-exec/src/exec-tool.test.ts
+++ b/packages/tool-exec/src/exec-tool.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "bun:test";
+import type { SandboxError, SandboxExecutor, SandboxResult } from "@koi/core/sandbox-executor";
+import { createExecTool } from "./exec-tool.js";
+import type { ExecToolConfig } from "./types.js";
+
+/** Creates a mock executor that returns a fixed success result. */
+function successExecutor(result: SandboxResult): SandboxExecutor {
+  return {
+    execute: async () => ({ ok: true as const, value: result }),
+  };
+}
+
+/** Creates a mock executor that returns a fixed error result. */
+function errorExecutor(error: SandboxError): SandboxExecutor {
+  return {
+    execute: async () => ({ ok: false as const, error }),
+  };
+}
+
+/** Creates a mock executor that records its arguments and returns success. */
+function spyExecutor(): {
+  readonly executor: SandboxExecutor;
+  readonly calls: ReadonlyArray<{
+    readonly code: string;
+    readonly input: unknown;
+    readonly timeoutMs: number;
+    readonly context: unknown;
+  }>;
+} {
+  const calls: Array<{
+    readonly code: string;
+    readonly input: unknown;
+    readonly timeoutMs: number;
+    readonly context: unknown;
+  }> = [];
+  return {
+    calls,
+    executor: {
+      execute: async (code: string, input: unknown, timeoutMs: number, context?: unknown) => {
+        calls.push({ code, input, timeoutMs, context });
+        return { ok: true as const, value: { output: "ok", durationMs: 1 } };
+      },
+    },
+  };
+}
+
+/** Helper to create tool with defaults. */
+function createTool(overrides?: Partial<ExecToolConfig>): ReturnType<typeof createExecTool> {
+  return createExecTool({
+    executor: successExecutor({ output: "hello", durationMs: 42 }),
+    ...overrides,
+  });
+}
+
+/** Helper to get the first spy call (asserts it exists). */
+function firstCall(spy: ReturnType<typeof spyExecutor>): (typeof spy.calls)[number] {
+  const call = spy.calls[0];
+  expect(call).toBeDefined();
+  // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+  return call!;
+}
+
+describe("createExecTool", () => {
+  describe("descriptor and metadata", () => {
+    it("has descriptor with name exec", () => {
+      const tool = createTool();
+      expect(tool.descriptor.name).toBe("exec");
+    });
+
+    it("has trustTier sandbox", () => {
+      const tool = createTool();
+      expect(tool.trustTier).toBe("sandbox");
+    });
+
+    it("has code as required in inputSchema", () => {
+      const tool = createTool();
+      const schema = tool.descriptor.inputSchema;
+      expect(schema.required).toEqual(["code"]);
+    });
+  });
+
+  describe("success path", () => {
+    it("returns ok result with output and durationMs", async () => {
+      const tool = createTool();
+      const result = await tool.execute({ code: "return 1 + 1" });
+      expect(result).toEqual({ ok: true, output: "hello", durationMs: 42 });
+    });
+
+    it("passes code and input to executor", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return input.x", input: { x: 42 } });
+      expect(spy.calls).toHaveLength(1);
+      const call = firstCall(spy);
+      expect(call.code).toBe("return input.x");
+      expect(call.input).toEqual({ x: 42 });
+    });
+
+    it("defaults input to null when omitted", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).input).toBeNull();
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("uses default timeout when timeout_ms is omitted", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).timeoutMs).toBe(5_000);
+    });
+
+    it("uses custom defaultTimeoutMs from config", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor, defaultTimeoutMs: 10_000 });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).timeoutMs).toBe(10_000);
+    });
+
+    it("respects model-requested timeout_ms", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1", timeout_ms: 2_000 });
+      expect(firstCall(spy).timeoutMs).toBe(2_000);
+    });
+
+    it("clamps timeout_ms to maxTimeoutMs", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor, maxTimeoutMs: 10_000 });
+      await tool.execute({ code: "return 1", timeout_ms: 60_000 });
+      expect(firstCall(spy).timeoutMs).toBe(10_000);
+    });
+
+    it("ignores non-positive timeout_ms and uses default", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1", timeout_ms: -100 });
+      expect(firstCall(spy).timeoutMs).toBe(5_000);
+    });
+
+    it("ignores non-number timeout_ms and uses default", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1", timeout_ms: "fast" });
+      expect(firstCall(spy).timeoutMs).toBe(5_000);
+    });
+  });
+
+  describe("context passthrough", () => {
+    it("forwards networkAllowed from config", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor, networkAllowed: true });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).context).toEqual({ networkAllowed: true });
+    });
+
+    it("forwards resourceLimits from config", async () => {
+      const spy = spyExecutor();
+      const limits = { maxMemoryMb: 128, maxPids: 10 };
+      const tool = createExecTool({ executor: spy.executor, resourceLimits: limits });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).context).toEqual({ resourceLimits: limits });
+    });
+
+    it("omits networkAllowed when not configured", async () => {
+      const spy = spyExecutor();
+      const tool = createExecTool({ executor: spy.executor });
+      await tool.execute({ code: "return 1" });
+      expect(firstCall(spy).context).toEqual({});
+    });
+  });
+
+  describe("validation errors", () => {
+    it("returns VALIDATION error for missing code", async () => {
+      const tool = createTool();
+      const result = (await tool.execute({})) as { ok: boolean; code: string };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("VALIDATION");
+    });
+
+    it("returns VALIDATION error for empty code", async () => {
+      const tool = createTool();
+      const result = (await tool.execute({ code: "" })) as { ok: boolean; code: string };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("VALIDATION");
+    });
+
+    it("returns VALIDATION error for non-string code", async () => {
+      const tool = createTool();
+      const result = (await tool.execute({ code: 42 })) as { ok: boolean; code: string };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("VALIDATION");
+    });
+  });
+
+  describe("executor error forwarding", () => {
+    it("returns TIMEOUT error from executor", async () => {
+      const tool = createExecTool({
+        executor: errorExecutor({
+          code: "TIMEOUT",
+          message: "Execution timed out",
+          durationMs: 5000,
+        }),
+      });
+      const result = (await tool.execute({ code: "while(true){}" })) as {
+        ok: boolean;
+        code: string;
+        error: string;
+        durationMs: number;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("TIMEOUT");
+      expect(result.error).toBe("Execution timed out");
+      expect(result.durationMs).toBe(5000);
+    });
+
+    it("returns OOM error from executor", async () => {
+      const tool = createExecTool({
+        executor: errorExecutor({ code: "OOM", message: "Out of memory", durationMs: 100 }),
+      });
+      const result = (await tool.execute({ code: "new Array(1e10)" })) as {
+        ok: boolean;
+        code: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("OOM");
+    });
+
+    it("returns PERMISSION error from executor", async () => {
+      const tool = createExecTool({
+        executor: errorExecutor({
+          code: "PERMISSION",
+          message: "Network access denied",
+          durationMs: 0,
+        }),
+      });
+      const result = (await tool.execute({ code: "fetch('http://evil')" })) as {
+        ok: boolean;
+        code: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("PERMISSION");
+    });
+
+    it("returns CRASH error from executor", async () => {
+      const tool = createExecTool({
+        executor: errorExecutor({
+          code: "CRASH",
+          message: "Sandbox process exited",
+          durationMs: 50,
+        }),
+      });
+      const result = (await tool.execute({ code: "process.exit(1)" })) as {
+        ok: boolean;
+        code: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("CRASH");
+    });
+
+    it("returns CRASH error when executor throws an exception", async () => {
+      const tool = createExecTool({
+        executor: {
+          execute: async () => {
+            throw new Error("connection refused");
+          },
+        },
+      });
+      const result = (await tool.execute({ code: "return 1" })) as {
+        ok: boolean;
+        code: string;
+        error: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("CRASH");
+      expect(result.error).toBe("connection refused");
+    });
+
+    it("returns generic message when executor throws non-Error", async () => {
+      const tool = createExecTool({
+        executor: {
+          execute: async () => {
+            throw "string error";
+          },
+        },
+      });
+      const result = (await tool.execute({ code: "return 1" })) as {
+        ok: boolean;
+        code: string;
+        error: string;
+      };
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("CRASH");
+      expect(result.error).toBe("Sandbox executor threw an unexpected error");
+    });
+  });
+});

--- a/packages/tool-exec/src/exec-tool.ts
+++ b/packages/tool-exec/src/exec-tool.ts
@@ -1,0 +1,73 @@
+/**
+ * Exec tool factory — creates a Tool that runs code in a sandboxed executor.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { Tool, ToolExecuteOptions } from "@koi/core/ecs";
+import type { ExecutionContext } from "@koi/core/sandbox-executor";
+import {
+  DEFAULT_TIMEOUT_MS,
+  EXEC_TOOL_DESCRIPTOR,
+  type ExecToolConfig,
+  MAX_TIMEOUT_MS,
+} from "./types.js";
+
+/**
+ * Creates the `exec` tool — a thin pass-through to `SandboxExecutor.execute()`.
+ *
+ * The tool validates input, clamps the timeout, builds an `ExecutionContext`
+ * from the config, and delegates to the executor.
+ */
+export function createExecTool(config: ExecToolConfig): Tool {
+  const defaultTimeout = config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxTimeout = config.maxTimeoutMs ?? MAX_TIMEOUT_MS;
+
+  const context: ExecutionContext = {
+    ...(config.networkAllowed !== undefined ? { networkAllowed: config.networkAllowed } : {}),
+    ...(config.resourceLimits !== undefined ? { resourceLimits: config.resourceLimits } : {}),
+  };
+
+  return {
+    descriptor: EXEC_TOOL_DESCRIPTOR,
+    trustTier: "sandbox",
+
+    async execute(args: JsonObject, _options?: ToolExecuteOptions): Promise<unknown> {
+      const code = args.code;
+      if (typeof code !== "string" || code.length === 0) {
+        return { ok: false, error: "Missing or empty `code` parameter", code: "VALIDATION" };
+      }
+
+      const rawTimeout = args.timeout_ms;
+      const requestedTimeout =
+        typeof rawTimeout === "number" && rawTimeout > 0 ? rawTimeout : defaultTimeout;
+      const timeoutMs = Math.min(requestedTimeout, maxTimeout);
+
+      const input: unknown = args.input ?? null;
+
+      // let justified: assigned in try, used after catch for result mapping
+      let result: Awaited<ReturnType<typeof config.executor.execute>>;
+      try {
+        result = await config.executor.execute(code, input, timeoutMs, context);
+      } catch (e: unknown) {
+        const message =
+          e instanceof Error ? e.message : "Sandbox executor threw an unexpected error";
+        return { ok: false, error: message, code: "CRASH" };
+      }
+
+      if (result.ok) {
+        return {
+          ok: true,
+          output: result.value.output,
+          durationMs: result.value.durationMs,
+        };
+      }
+
+      return {
+        ok: false,
+        error: result.error.message,
+        code: result.error.code,
+        durationMs: result.error.durationMs,
+      };
+    },
+  };
+}

--- a/packages/tool-exec/src/index.ts
+++ b/packages/tool-exec/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @koi/tool-exec — Ephemeral sandboxed code execution tool (Layer 2)
+ *
+ * Thin wrapper around SandboxExecutor.execute() — validates input,
+ * clamps timeout, and returns the result. No Wasm, no tool bridge.
+ */
+
+export { createExecTool } from "./exec-tool.js";
+export { createExecProvider } from "./provider.js";
+export { EXEC_SKILL, EXEC_SKILL_CONTENT, EXEC_SKILL_NAME } from "./skill.js";
+export type { ExecToolConfig } from "./types.js";
+export { DEFAULT_TIMEOUT_MS, EXEC_TOOL_DESCRIPTOR, MAX_TIMEOUT_MS } from "./types.js";

--- a/packages/tool-exec/src/provider.test.ts
+++ b/packages/tool-exec/src/provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { skillToken } from "@koi/core";
+import type { Agent } from "@koi/core/ecs";
+import type { SandboxExecutor } from "@koi/core/sandbox-executor";
+import { createExecProvider } from "./provider.js";
+import { EXEC_SKILL_NAME } from "./skill.js";
+
+/** Minimal mock executor for provider tests. */
+const mockExecutor: SandboxExecutor = {
+  execute: async () => ({ ok: true as const, value: { output: null, durationMs: 0 } }),
+};
+
+/** Helper to get component map from attach result. */
+async function attachAndGetMap(
+  provider: ReturnType<typeof createExecProvider>,
+): Promise<ReadonlyMap<string, unknown>> {
+  const result = await provider.attach({} as Agent);
+  return result instanceof Map
+    ? result
+    : (result as { components: ReadonlyMap<string, unknown> }).components;
+}
+
+describe("createExecProvider", () => {
+  it("has name tool-exec", () => {
+    const provider = createExecProvider({ executor: mockExecutor });
+    expect(provider.name).toBe("tool-exec");
+  });
+
+  it("attaches a tool:exec component", async () => {
+    const provider = createExecProvider({ executor: mockExecutor });
+    const map = await attachAndGetMap(provider);
+    expect(map.has("tool:exec")).toBe(true);
+  });
+
+  it("returns a tool with descriptor name exec", async () => {
+    const provider = createExecProvider({ executor: mockExecutor });
+    const map = await attachAndGetMap(provider);
+    const tool = map.get("tool:exec") as { descriptor: { name: string } };
+    expect(tool.descriptor.name).toBe("exec");
+  });
+
+  it("attaches the exec-guide skill component", async () => {
+    const provider = createExecProvider({ executor: mockExecutor });
+    const map = await attachAndGetMap(provider);
+    const key = skillToken(EXEC_SKILL_NAME) as string;
+    expect(map.has(key)).toBe(true);
+    const skill = map.get(key) as { name: string; content: string };
+    expect(skill.name).toBe("exec-guide");
+    expect(skill.content).toContain("exec vs execute_script");
+  });
+
+  it("caches components across multiple attach calls", async () => {
+    const provider = createExecProvider({ executor: mockExecutor });
+    const agent = {} as Agent;
+    const first = await provider.attach(agent);
+    const second = await provider.attach(agent);
+    expect(first).toBe(second);
+  });
+});

--- a/packages/tool-exec/src/provider.ts
+++ b/packages/tool-exec/src/provider.ts
@@ -1,0 +1,35 @@
+/**
+ * ComponentProvider that attaches the exec tool + companion skill to an agent.
+ */
+
+import { skillToken } from "@koi/core";
+import type { Agent, ComponentProvider } from "@koi/core/ecs";
+import { createExecTool } from "./exec-tool.js";
+import { EXEC_SKILL, EXEC_SKILL_NAME } from "./skill.js";
+import type { ExecToolConfig } from "./types.js";
+
+/**
+ * Creates a ComponentProvider that attaches `tool:exec` and `skill:exec-guide`.
+ *
+ * Both are created once and cached — subsequent attach() calls return
+ * the same instances.
+ */
+export function createExecProvider(config: ExecToolConfig): ComponentProvider {
+  // let justified: mutable cache (set once on first attach, reused thereafter)
+  let cached: ReadonlyMap<string, unknown> | undefined;
+
+  return {
+    name: "tool-exec",
+
+    async attach(_agent: Agent): Promise<ReadonlyMap<string, unknown>> {
+      if (cached !== undefined) return cached;
+
+      const tool = createExecTool(config);
+      cached = new Map<string, unknown>([
+        ["tool:exec", tool],
+        [skillToken(EXEC_SKILL_NAME), EXEC_SKILL],
+      ]);
+      return cached;
+    },
+  };
+}

--- a/packages/tool-exec/src/skill.ts
+++ b/packages/tool-exec/src/skill.ts
@@ -1,0 +1,79 @@
+/**
+ * Skill component for the exec tool — teaches agents when and how to run code in a sandbox.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+import type { SkillComponent } from "@koi/core";
+
+/** Skill component name. */
+export const EXEC_SKILL_NAME = "exec-guide" as const;
+
+/**
+ * Markdown content teaching agents when to use exec vs execute_script.
+ * Injected into the agent's context alongside the tool descriptor.
+ */
+export const EXEC_SKILL_CONTENT: string = `
+# exec — sandboxed code execution
+
+## When to call exec
+
+Use \`exec\` when you need to **compute, transform, or verify** data in isolation:
+
+- **Math / data transforms**: aggregations, sorting, filtering, formatting that would be error-prone to do by hand
+- **Input validation**: check user-provided data against schemas or constraints
+- **Code verification**: run a snippet to confirm it produces the expected output
+- **JSON reshaping**: transform API responses or config objects into a different structure
+
+Pass structured data via the \`input\` parameter — the code receives it as the \`input\` variable
+and returns a result.
+
+## When NOT to call exec
+
+- **Orchestrating tool calls**: use \`execute_script\` instead — it has \`callTool()\` bridging
+- **Simple questions**: if you can answer directly without running code, just answer
+- **File I/O or network**: exec runs in an isolated sandbox with no filesystem or network access (unless explicitly configured)
+
+## exec vs execute_script
+
+| | exec | execute_script |
+|---|---|---|
+| Purpose | Compute / transform / verify | Orchestrate multiple tool calls |
+| Sandbox | Any backend (Docker, cloud, OS) | QuickJS Wasm (fixed) |
+| Tool bridging | No | Yes (\`callTool()\`) |
+| Data input | JSON via \`input\` param | None |
+| Console capture | No | Yes |
+
+## Example calls
+
+\`\`\`json
+{
+  "code": "return input.prices.reduce((sum, p) => sum + p, 0)",
+  "input": { "prices": [10, 20, 30] }
+}
+\`\`\`
+
+\`\`\`json
+{
+  "code": "const sorted = [...input.items].sort((a, b) => b.score - a.score); return sorted.slice(0, 3);",
+  "input": { "items": [{ "name": "a", "score": 5 }, { "name": "b", "score": 9 }, { "name": "c", "score": 2 }] }
+}
+\`\`\`
+
+## Timeout
+
+Default: 5 seconds. Max: 30 seconds. Pass \`timeout_ms\` for long-running computations.
+Values above the server max are clamped silently.
+`.trim();
+
+/**
+ * Pre-built SkillComponent for exec behavioral guidance.
+ * Attached automatically by createExecProvider alongside the tool.
+ */
+export const EXEC_SKILL: SkillComponent = {
+  name: EXEC_SKILL_NAME,
+  description:
+    "When to use exec for sandboxed computation vs execute_script for tool orchestration",
+  content: EXEC_SKILL_CONTENT,
+  tags: ["sandbox", "code-execution", "compute"],
+} as const satisfies SkillComponent;

--- a/packages/tool-exec/src/types.ts
+++ b/packages/tool-exec/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Configuration types for the exec tool.
+ */
+
+import type { ToolDescriptor } from "@koi/core/ecs";
+import type { ExecutionContext, SandboxExecutor } from "@koi/core/sandbox-executor";
+
+/** Configuration for creating an exec tool instance. */
+export interface ExecToolConfig {
+  /** The sandbox executor backend to delegate code execution to. */
+  readonly executor: SandboxExecutor;
+  /** Default timeout in milliseconds when the model omits `timeout_ms`. Default: 5000. */
+  readonly defaultTimeoutMs?: number | undefined;
+  /** Hard upper bound for `timeout_ms` — model-requested values are clamped. Default: 30000. */
+  readonly maxTimeoutMs?: number | undefined;
+  /** Whether executed code may make network requests. Default: false. */
+  readonly networkAllowed?: boolean | undefined;
+  /** OS-level resource limits forwarded to the sandbox. */
+  readonly resourceLimits?: ExecutionContext["resourceLimits"] | undefined;
+}
+
+export const DEFAULT_TIMEOUT_MS = 5_000;
+export const MAX_TIMEOUT_MS = 30_000;
+
+export const EXEC_TOOL_DESCRIPTOR: ToolDescriptor = {
+  name: "exec",
+  description:
+    "Execute code in an isolated sandbox and return the result. The code receives an optional JSON input via the `input` variable and must produce output by returning a value.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      code: {
+        type: "string",
+        description: "The code to execute in the sandbox.",
+      },
+      input: {
+        description: "Optional JSON input passed to the code as the `input` variable.",
+      },
+      timeout_ms: {
+        type: "number",
+        description: "Optional execution timeout in milliseconds (clamped to server max).",
+      },
+    },
+    required: ["code"],
+  },
+};

--- a/packages/tool-exec/tsconfig.json
+++ b/packages/tool-exec/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tool-exec/tsup.config.ts
+++ b/packages/tool-exec/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- New L2 package `@koi/tool-exec` providing the `exec` tool backed by any `SandboxExecutor` implementation (Docker, Cloudflare Workers, e2b, OS-level, etc.)
- Unlike `execute_script` (QuickJS Wasm + `callTool()` bridge), `exec` is a thin backend-agnostic pass-through for compute/transform/verify use cases with JSON input/output
- Companion skill (`skill:exec-guide`) auto-wired at assembly time teaches the LLM when to use `exec` vs `execute_script`

### What it enables

| Use case | Before | After |
|----------|--------|-------|
| Math/aggregation | LLM guesses (error-prone) | Delegated to sandbox, guaranteed correct |
| Data transformation | LLM tries to reshape JSON by hand | Code runs in any sandbox backend |
| Code verification | LLM simulates execution mentally | Actual execution with real output |

### Files

```
packages/tool-exec/
  src/types.ts              — ExecToolConfig, EXEC_TOOL_DESCRIPTOR, defaults
  src/exec-tool.ts          — createExecTool() factory
  src/skill.ts              — EXEC_SKILL companion skill
  src/provider.ts           — createExecProvider() → tool:exec + skill:exec-guide
  src/index.ts              — re-exports
  src/exec-tool.test.ts     — 24 tests
  src/provider.test.ts      — 5 tests
docs/L2/tool-exec.md        — full package documentation
```

### Layer compliance

- Imports from `@koi/core` (L0) only — zero L0u, zero external deps
- All interface properties `readonly`
- No `enum`, `class`, `any`, `as Type`, `!` assertions in production code
- Biome lint clean

## Test plan

- [x] `bun run --filter @koi/tool-exec typecheck` — clean
- [x] `bun run --filter @koi/tool-exec build` — clean (4.98 KB ESM)
- [x] `bun run --filter @koi/tool-exec test` — 29/29 pass, 57 assertions
- [x] `bunx biome check packages/tool-exec/src/` — no issues
- [x] Pre-push hooks (turborepo typecheck + build) — passed
- [x] Layer leakage review — passed
- [x] Code review — passed

Closes #549