### PR TITLE
feat: guide agent pattern with includes + ask_guide tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2199,6 +2199,20 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/tool-ask-guide": {
+      "name": "@koi/tool-ask-guide",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/search-provider": "workspace:*",
+        "@koi/token-estimator": "workspace:*",
+        "@koi/validation": "workspace:*",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/tool-ask-user": {
       "name": "@koi/tool-ask-user",
       "version": "0.0.0",
@@ -3202,6 +3216,8 @@
     "@koi/test-utils": ["@koi/test-utils@workspace:packages/test-utils"],
 
     "@koi/token-estimator": ["@koi/token-estimator@workspace:packages/token-estimator"],
+
+    "@koi/tool-ask-guide": ["@koi/tool-ask-guide@workspace:packages/tool-ask-guide"],
 
     "@koi/tool-ask-user": ["@koi/tool-ask-user@workspace:packages/tool-ask-user"],
 

--- a/docs/patterns/guide-agent.md
+++ b/docs/patterns/guide-agent.md
@@ -1,0 +1,152 @@
+# Guide Agent Pattern
+
+## Problem
+
+When agents search docs or skills directly, raw results flood the parent's
+context window with noise. A 500-token query returns 5,000 tokens of
+unfiltered content, most of which is irrelevant. The agent's context fills
+up, reasoning quality degrades, and costs increase.
+
+## Solution
+
+The **guide agent** pattern wraps knowledge retrieval in a thin tool that
+enforces a token budget. The agent asks a focused question, the tool
+searches and truncates, and the agent receives only concise, relevant context.
+
+```
+User: "How do I deploy to production?"
+       │
+       ▼
+   Agent (has ask_guide tool)
+       │
+   ask_guide({ question: "deploy to production" })
+       │
+       ▼
+   @koi/tool-ask-guide
+       │
+   createRetrieverSearch(retriever)  ←── @koi/search or @koi/search-nexus
+       │
+   accumulate results ≤ 500 tokens
+       │
+       ▼
+   Agent gets 2-3 relevant chunks (not 50 raw docs)
+```
+
+## What This Enables
+
+1. **Token-budgeted retrieval** — agents get concise answers instead of raw
+   search dumps. The `maxTokens` config (default 500) caps how much content
+   flows back into the agent's context window.
+
+2. **Nested skill includes** — SKILL.md files can reference shared docs via
+   the `includes` frontmatter directive. Related documentation is bundled at
+   load time, so skills stay DRY while search indexes get complete content.
+
+3. **Pluggable search backends** — the `createRetrieverSearch()` adapter
+   bridges any `Retriever` (from `@koi/search-provider`) to the tool.
+   Works with `@koi/search` (local hybrid BM25+vector) or
+   `@koi/search-nexus` (remote Nexus service) out of the box.
+
+## Packages
+
+| Package | Layer | Purpose |
+|---------|-------|---------|
+| `@koi/tool-ask-guide` | L2 | Tool + provider + Retriever adapter |
+| `@koi/skills` (extended) | L2 | `includes` directive + `resolveIncludes()` |
+| `@koi/search-provider` | L0u | `Retriever` interface (existing) |
+| `@koi/search` | L2 | Local hybrid search backend (existing) |
+| `@koi/search-nexus` | L2 | Remote Nexus search backend (existing) |
+
+## How It Works
+
+### The Tool
+
+1. **Agent calls `ask_guide`** with a natural-language question
+2. **Tool validates** the input (non-empty string)
+3. **Tool delegates** to the `search()` callback (wired via `createRetrieverSearch`)
+4. **Token accumulation** — results are added until the budget is hit
+5. **Structured response** — `{ results, totalFound, truncated }`
+
+### Nested Includes
+
+Skills can reference shared documentation via the `includes` directive
+in SKILL.md frontmatter:
+
+```yaml
+---
+name: domain-expert
+description: Answers questions about our domain
+includes:
+  - ./glossary.md
+  - ../shared/api-reference.md
+---
+# Domain Expert
+You are an expert on our domain...
+```
+
+When loaded with `loadSkillBody(dirPath, undefined, skillsRoot)`, the
+included files' content is appended to the skill body. This means search
+indexes over skill content automatically include the referenced docs.
+
+Resolution rules:
+- Relative paths only (`./` or `../`) — absolute paths and URLs rejected at schema level
+- Recursive resolution up to depth 3 (configurable via `maxDepth`)
+- Diamond dedup — if A and B both include C, C appears once
+- Cycle protection — visited set prevents infinite loops
+- Security boundary — resolved paths must stay within `skillsRoot` (enforced via `realpath`)
+
+## Wiring Example
+
+### With `@koi/search` (local)
+
+```typescript
+import { createAskGuideProvider, createRetrieverSearch } from "@koi/tool-ask-guide";
+import { createSearch } from "@koi/search";
+
+const search = createSearch({ dbPath: "./index.db", embedder: myEmbedder });
+
+const guide = createAskGuideProvider({
+  search: createRetrieverSearch(search.retriever),
+  maxTokens: 500,
+});
+```
+
+### With `@koi/search-nexus` (remote)
+
+```typescript
+import { createAskGuideProvider, createRetrieverSearch } from "@koi/tool-ask-guide";
+import { createNexusSearch } from "@koi/search-nexus";
+
+const nexus = createNexusSearch({ baseUrl: "https://nexus.example.com", apiKey: "..." });
+
+const guide = createAskGuideProvider({
+  search: createRetrieverSearch(nexus.retriever),
+  maxTokens: 500,
+});
+```
+
+### Manifest
+
+```yaml
+name: "knowledge-guide"
+version: "1.0.0"
+model: "anthropic:claude-haiku-4-5-20251001"
+skills:
+  - name: "domain-knowledge"
+    path: "./skills/domain"
+```
+
+## When to Use
+
+- Agents that answer knowledge questions from a corpus
+- Agents with access to large skill/doc libraries
+- Any agent where raw search results would pollute the context window
+
+## Anti-Patterns
+
+- **Don't dump all skills into the system prompt** — use the guide tool
+  for on-demand retrieval instead
+- **Don't skip the token budget** — unbounded results defeat the purpose
+- **Don't use for real-time user interaction** — use `ask_user` for that
+- **Don't create a custom search adapter** — use `createRetrieverSearch()`
+  to bridge any `Retriever` implementation

--- a/packages/manifest/src/__tests__/fixtures/guide-agent.yaml
+++ b/packages/manifest/src/__tests__/fixtures/guide-agent.yaml
@@ -1,0 +1,7 @@
+name: "knowledge-guide"
+version: "1.0.0"
+model: "anthropic:claude-haiku-4-5-20251001"
+description: "A guide agent that answers knowledge questions within a token budget"
+skills:
+  - name: "domain-knowledge"
+    path: "./skills/domain"

--- a/packages/manifest/src/__tests__/loader.test.ts
+++ b/packages/manifest/src/__tests__/loader.test.ts
@@ -236,6 +236,19 @@ describe("loadManifest (file-based)", () => {
     }
   });
 
+  test("loads guide-agent.yaml fixture", async () => {
+    const result = await loadManifest(resolve(FIXTURES, "guide-agent.yaml"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.manifest.name).toBe("knowledge-guide");
+      expect(result.value.manifest.model).toEqual({
+        name: "anthropic:claude-haiku-4-5-20251001",
+      });
+      expect(result.value.manifest.skills).toHaveLength(1);
+      expect(result.value.manifest.skills?.[0]?.name).toBe("domain-knowledge");
+    }
+  });
+
   test("returns error for non-existent file", async () => {
     const result = await loadManifest("/does/not/exist.yaml");
     expect(result.ok).toBe(false);

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -22,12 +22,16 @@ export { parseSkillMd } from "./parse.js";
 // Provider
 export type { SkillProviderConfig } from "./provider.js";
 export { createSkillComponentProvider } from "./provider.js";
+// Include resolution
+export { resolveIncludes } from "./resolve-includes.js";
 // Skill activator middleware
 export type { SkillActivatorConfig } from "./skill-activator-middleware.js";
 export { createSkillActivatorMiddleware } from "./skill-activator-middleware.js";
 // Types
 export type {
+  IncludeResolutionOptions,
   ProgressiveSkillProvider,
+  ResolvedInclude,
   SkillBodyEntry,
   SkillBundledEntry,
   SkillEntry,

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -13,7 +13,9 @@ import type { KoiError, Result } from "@koi/core";
 import type { ScanFinding } from "@koi/skill-scanner";
 import { createScanner } from "@koi/skill-scanner";
 import { parseSkillMd } from "./parse.js";
+import { resolveIncludes } from "./resolve-includes.js";
 import type {
+  IncludeResolutionOptions,
   SkillBodyEntry,
   SkillBundledEntry,
   SkillEntry,
@@ -196,10 +198,14 @@ export async function loadSkillMetadata(
 /**
  * Load skill at body level — frontmatter + markdown body + security scan.
  * Uses cached parse results when available (populated by loadSkillMetadata).
+ *
+ * When `skillsRoot` is provided and the frontmatter contains `includes`,
+ * the included file contents are appended to the body.
  */
 export async function loadSkillBody(
   dirPath: string,
   onSecurityFinding?: (findings: readonly ScanFinding[]) => void,
+  skillsRoot?: string,
 ): Promise<Result<SkillBodyEntry, KoiError>> {
   // Check cache first — reuse frontmatter and rawContent from prior metadata load
   const cached = skillCache.get(dirPath);
@@ -237,13 +243,24 @@ export async function loadSkillBody(
     onSecurityFinding(report.findings);
   }
 
+  // Resolve includes — append included content to body
+  let resolvedBody = body; // let: conditionally extended with included content
+  if (fm.includes !== undefined && fm.includes.length > 0 && skillsRoot !== undefined) {
+    const includeOptions: IncludeResolutionOptions = { skillsRoot };
+    const includesResult = await resolveIncludes(fm.includes, dirPath, includeOptions);
+    if (!includesResult.ok) return includesResult;
+
+    const includedContent = includesResult.value.map((inc) => inc.content).join("\n\n");
+    resolvedBody = `${body}\n\n${includedContent}`;
+  }
+
   return {
     ok: true,
     value: {
       level: "body",
       name: fm.name,
       description: fm.description,
-      body,
+      body: resolvedBody,
       dirPath,
       ...(fm.license !== undefined ? { license: fm.license } : {}),
       ...(fm.compatibility !== undefined ? { compatibility: fm.compatibility } : {}),
@@ -259,8 +276,9 @@ export async function loadSkillBody(
 export async function loadSkillBundled(
   dirPath: string,
   onSecurityFinding?: (findings: readonly ScanFinding[]) => void,
+  skillsRoot?: string,
 ): Promise<Result<SkillBundledEntry, KoiError>> {
-  const bodyResult = await loadSkillBody(dirPath, onSecurityFinding);
+  const bodyResult = await loadSkillBody(dirPath, onSecurityFinding, skillsRoot);
   if (!bodyResult.ok) return bodyResult;
 
   const scriptsDir = join(dirPath, "scripts");
@@ -299,14 +317,15 @@ export async function loadSkill(
   dirPath: string,
   level: SkillLoadLevel = "body",
   onSecurityFinding?: (findings: readonly ScanFinding[]) => void,
+  skillsRoot?: string,
 ): Promise<Result<SkillEntry, KoiError>> {
   switch (level) {
     case "metadata":
       return loadSkillMetadata(dirPath);
     case "body":
-      return loadSkillBody(dirPath, onSecurityFinding);
+      return loadSkillBody(dirPath, onSecurityFinding, skillsRoot);
     case "bundled":
-      return loadSkillBundled(dirPath, onSecurityFinding);
+      return loadSkillBundled(dirPath, onSecurityFinding, skillsRoot);
   }
 }
 

--- a/packages/skills/src/resolve-includes.test.ts
+++ b/packages/skills/src/resolve-includes.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveIncludes } from "./resolve-includes.js";
+
+/** Creates a file inside the temp directory using Bun.write (auto-creates parents). */
+async function writeFile(dir: string, relativePath: string, content: string): Promise<void> {
+  await Bun.write(join(dir, relativePath), content);
+}
+
+/** Creates a minimal SKILL.md frontmatter with optional includes. */
+function skillMd(includes?: readonly string[]): string {
+  const includesLine =
+    includes !== undefined && includes.length > 0
+      ? `includes:\n${includes.map((i) => `  - "${i}"`).join("\n")}\n`
+      : "";
+  return `---\nname: test-skill\ndescription: A test skill\n${includesLine}---\n# Test\n`;
+}
+
+describe("resolveIncludes", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "koi-includes-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("resolves single include at depth 1", async () => {
+    const skillDir = join(tempDir, "skill-a");
+    await writeFile(skillDir, "SKILL.md", skillMd(["./doc.md"]));
+    await writeFile(skillDir, "doc.md", "# Documentation\nSome helpful content.");
+
+    const result = await resolveIncludes(["./doc.md"], skillDir, { skillsRoot: tempDir });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.content).toBe("# Documentation\nSome helpful content.");
+    }
+  });
+
+  test("handles direct cycle (A includes B, B includes A)", async () => {
+    const skillDir = join(tempDir, "skill-a");
+    await writeFile(skillDir, "SKILL.md", skillMd(["./b.md"]));
+    await writeFile(
+      skillDir,
+      "b.md",
+      `---\nname: b\ndescription: B\nincludes:\n  - "./SKILL.md"\n---\n# B content`,
+    );
+
+    const result = await resolveIncludes(["./b.md"], skillDir, { skillsRoot: tempDir });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // B is included, A (SKILL.md) is skipped because it's in the visited set
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.content).toContain("# B content");
+    }
+  });
+
+  test("handles transitive cycle (A→B→C→A)", async () => {
+    const dirA = join(tempDir, "a");
+    const dirB = join(tempDir, "b");
+    const dirC = join(tempDir, "c");
+
+    await writeFile(dirA, "SKILL.md", skillMd(["../b/doc.md"]));
+    await writeFile(
+      dirB,
+      "doc.md",
+      `---\nname: b\ndescription: B\nincludes:\n  - "../c/doc.md"\n---\n# B`,
+    );
+    await writeFile(
+      dirC,
+      "doc.md",
+      `---\nname: c\ndescription: C\nincludes:\n  - "../a/SKILL.md"\n---\n# C`,
+    );
+
+    const result = await resolveIncludes(["../b/doc.md"], dirA, { skillsRoot: tempDir });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // B and C resolved, A skipped (in visited set from initialization)
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0]!.content).toContain("# B");
+      expect(result.value[1]!.content).toContain("# C");
+    }
+  });
+
+  test("deduplicates diamond dependency (A→B, A→C, B→D, C→D)", async () => {
+    const dir = join(tempDir, "skills");
+    await writeFile(dir, "SKILL.md", skillMd(["./b.md", "./c.md"]));
+    await writeFile(dir, "b.md", `---\nname: b\ndescription: B\nincludes:\n  - "./d.md"\n---\n# B`);
+    await writeFile(dir, "c.md", `---\nname: c\ndescription: C\nincludes:\n  - "./d.md"\n---\n# C`);
+    await writeFile(dir, "d.md", "# Shared D content");
+
+    const result = await resolveIncludes(["./b.md", "./c.md"], dir, { skillsRoot: tempDir });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // B, D (from B's includes), C — D not duplicated from C's includes
+      expect(result.value).toHaveLength(3);
+      const paths = result.value.map((r) => r.path);
+      const dOccurrences = paths.filter((p) => p.endsWith("d.md")).length;
+      expect(dOccurrences).toBe(1);
+    }
+  });
+
+  test("succeeds at max depth (depth 3)", async () => {
+    const dir = join(tempDir, "deep");
+    // A → B → C → D (3 levels of nesting, at the limit)
+    await writeFile(dir, "SKILL.md", skillMd(["./b.md"]));
+    await writeFile(dir, "b.md", `---\nname: b\ndescription: B\nincludes:\n  - "./c.md"\n---\n# B`);
+    await writeFile(dir, "c.md", `---\nname: c\ndescription: C\nincludes:\n  - "./d.md"\n---\n# C`);
+    await writeFile(dir, "d.md", "# D — leaf node");
+
+    const result = await resolveIncludes(["./b.md"], dir, {
+      skillsRoot: tempDir,
+      maxDepth: 3,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(3);
+    }
+  });
+
+  test("returns error when depth exceeded", async () => {
+    const dir = join(tempDir, "too-deep");
+    // A → B → C → D → E (4 levels, exceeds maxDepth=3)
+    await writeFile(dir, "SKILL.md", skillMd(["./b.md"]));
+    await writeFile(dir, "b.md", `---\nname: b\ndescription: B\nincludes:\n  - "./c.md"\n---\n# B`);
+    await writeFile(dir, "c.md", `---\nname: c\ndescription: C\nincludes:\n  - "./d.md"\n---\n# C`);
+    await writeFile(dir, "d.md", `---\nname: d\ndescription: D\nincludes:\n  - "./e.md"\n---\n# D`);
+    await writeFile(dir, "e.md", "# E — too deep");
+
+    const result = await resolveIncludes(["./b.md"], dir, {
+      skillsRoot: tempDir,
+      maxDepth: 3,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("depth exceeded");
+      expect(result.error.context).toHaveProperty("errorKind", "INCLUDE_DEPTH_EXCEEDED");
+    }
+  });
+
+  test("returns error for nonexistent include", async () => {
+    const dir = join(tempDir, "missing");
+    await writeFile(dir, "SKILL.md", skillMd(["./nonexistent.md"]));
+
+    const result = await resolveIncludes(["./nonexistent.md"], dir, { skillsRoot: tempDir });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("NOT_FOUND");
+      expect(result.error.context).toHaveProperty("errorKind", "INCLUDE_NOT_FOUND");
+    }
+  });
+
+  test("returns error for path traversal outside skillsRoot", async () => {
+    // Create a file outside skillsRoot but inside tempDir
+    const skillsRoot = join(tempDir, "skills");
+    const skillDir = join(skillsRoot, "my-skill");
+    await writeFile(skillDir, "SKILL.md", skillMd(["../../secret.env"]));
+    await writeFile(tempDir, "secret.env", "SECRET=leaked");
+
+    const result = await resolveIncludes(["../../secret.env"], skillDir, { skillsRoot });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+      expect(result.error.context).toHaveProperty("errorKind", "INCLUDE_PATH_VIOLATION");
+    }
+  });
+});

--- a/packages/skills/src/resolve-includes.ts
+++ b/packages/skills/src/resolve-includes.ts
@@ -1,0 +1,232 @@
+/**
+ * Nested include resolution for Agent Skills Standard.
+ *
+ * Resolves `includes` directives from SKILL.md frontmatter, supporting:
+ * - Relative paths (./file.md, ../sibling/file.md)
+ * - Recursive includes (up to configurable depth)
+ * - Diamond deduplication (visited set)
+ * - Security boundary enforcement (paths must stay within skillsRoot)
+ */
+
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { KoiError, Result } from "@koi/core";
+import type { IncludeResolutionOptions, ResolvedInclude } from "./types.js";
+
+const DEFAULT_MAX_DEPTH = 3;
+
+/**
+ * Resolves include directives from a skill's frontmatter.
+ *
+ * Algorithm:
+ * 1. Resolve skillsRoot once via realpath for security boundary checks
+ * 2. For each include path, resolve relative to skillDir
+ * 3. Follow symlinks via realpath, validate within skillsRoot boundary
+ * 4. Skip already-visited paths (diamond dedup, cycle protection)
+ * 5. Read file content, check for nested includes, recurse if found
+ * 6. Return ordered list of resolved includes
+ */
+export async function resolveIncludes(
+  includes: readonly string[],
+  skillDir: string,
+  options: IncludeResolutionOptions,
+): Promise<Result<readonly ResolvedInclude[], KoiError>> {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const visited = new Set<string>();
+
+  // Add the calling skill's SKILL.md to visited to prevent self-inclusion.
+  // This prevents cycles where an included file references back to the caller.
+  try {
+    const selfReal = await realpath(resolve(skillDir, "SKILL.md"));
+    visited.add(selfReal);
+  } catch {
+    // If current file can't be resolved, proceed without self-exclusion
+  }
+
+  // Resolve skillsRoot once — avoids redundant realpath calls per include path
+  let realRoot: string; // let: assigned in try, used across all recursive calls
+  try {
+    realRoot = await realpath(resolve(options.skillsRoot));
+  } catch (cause: unknown) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Skills root directory not found: ${options.skillsRoot}`,
+        retryable: false,
+        cause,
+        context: { skillsRoot: options.skillsRoot },
+      },
+    };
+  }
+
+  return resolveRecursive(includes, skillDir, realRoot, visited, maxDepth);
+}
+
+// ---------------------------------------------------------------------------
+// Single-path resolution
+// ---------------------------------------------------------------------------
+
+/** Resolves one include path: realpath → boundary check → dedup → read. */
+async function resolveOnePath(
+  includePath: string,
+  skillDir: string,
+  realRoot: string,
+  visited: Set<string>,
+): Promise<Result<ResolvedInclude | undefined, KoiError>> {
+  const absolutePath = resolve(skillDir, includePath);
+
+  // Follow symlinks and get canonical path
+  let realPath: string; // let: assigned in try, used after catch
+  try {
+    realPath = await realpath(absolutePath);
+  } catch (cause: unknown) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Included file not found: ${includePath} (resolved to ${absolutePath}). Check the path in your includes directive.`,
+        retryable: false,
+        cause,
+        context: { errorKind: "INCLUDE_NOT_FOUND", includePath, absolutePath },
+      },
+    };
+  }
+
+  // Security boundary: resolved path must stay within skillsRoot
+  if (!realPath.startsWith(`${realRoot}/`) && realPath !== realRoot) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `Include path escapes skills root: ${includePath} resolves to ${realPath}, which is outside ${realRoot}. Only relative paths within the skills directory are allowed.`,
+        retryable: false,
+        context: { errorKind: "INCLUDE_PATH_VIOLATION", includePath, realPath, realRoot },
+      },
+    };
+  }
+
+  // Diamond dedup / cycle protection: skip already-visited paths
+  if (visited.has(realPath)) {
+    return { ok: true, value: undefined };
+  }
+  visited.add(realPath);
+
+  // Read file content
+  let content: string; // let: assigned in try, used after catch
+  try {
+    content = await Bun.file(realPath).text();
+  } catch (cause: unknown) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Failed to read included file: ${realPath}`,
+        retryable: false,
+        cause,
+        context: { errorKind: "INCLUDE_NOT_FOUND", realPath },
+      },
+    };
+  }
+
+  return { ok: true, value: { path: realPath, content } };
+}
+
+// ---------------------------------------------------------------------------
+// Recursive resolution
+// ---------------------------------------------------------------------------
+
+/** Resolves all includes sequentially, recursing into nested includes. */
+async function resolveRecursive(
+  includes: readonly string[],
+  skillDir: string,
+  realRoot: string,
+  visited: Set<string>,
+  remainingDepth: number,
+): Promise<Result<readonly ResolvedInclude[], KoiError>> {
+  if (remainingDepth <= 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `Include depth exceeded maximum. Check for deep nesting in includes directives.`,
+        retryable: false,
+        context: { errorKind: "INCLUDE_DEPTH_EXCEEDED" },
+      },
+    };
+  }
+
+  const results: ResolvedInclude[] = [];
+
+  for (const includePath of includes) {
+    const oneResult = await resolveOnePath(includePath, skillDir, realRoot, visited);
+    if (!oneResult.ok) return oneResult;
+    if (oneResult.value === undefined) continue; // deduped — already visited
+
+    results.push(oneResult.value);
+
+    // Recurse into nested includes from the resolved file's frontmatter
+    const nestedIncludes = extractIncludes(oneResult.value.content);
+    if (nestedIncludes.length > 0) {
+      const nestedDir = resolve(oneResult.value.path, "..");
+      const nestedResult = await resolveRecursive(
+        nestedIncludes,
+        nestedDir,
+        realRoot,
+        visited,
+        remainingDepth - 1,
+      );
+      if (!nestedResult.ok) return nestedResult;
+      for (const nested of nestedResult.value) {
+        results.push(nested);
+      }
+    }
+  }
+
+  return { ok: true, value: results };
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter extraction (lightweight, no full validation)
+// ---------------------------------------------------------------------------
+
+/** Type guard: narrows unknown[] to readonly string[]. */
+function isStringArray(value: readonly unknown[]): value is readonly string[] {
+  return value.every((item) => typeof item === "string");
+}
+
+/**
+ * Extracts `includes` from YAML frontmatter without full validation.
+ * Lightweight extraction — only parses frontmatter to find includes list.
+ */
+function extractIncludes(content: string): readonly string[] {
+  const text = content.replace(/\r\n/g, "\n");
+
+  const openIdx = text.indexOf("---");
+  if (openIdx !== 0 && text.substring(0, openIdx).trim() !== "") {
+    return [];
+  }
+
+  const afterOpen = openIdx + 3;
+  const closeIdx = text.indexOf("\n---", afterOpen);
+  if (closeIdx === -1) {
+    return [];
+  }
+
+  const yamlStr = text.substring(afterOpen, closeIdx).trim();
+  try {
+    const parsed: unknown = Bun.YAML.parse(yamlStr);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return [];
+    }
+    // Narrowed to object by the guard above; satisfies isn't applicable to unknown
+    const record = parsed as Readonly<Record<string, unknown>>;
+    const includes = record["includes"];
+    if (Array.isArray(includes) && isStringArray(includes)) {
+      return includes;
+    }
+  } catch {
+    // Not valid YAML frontmatter — no includes to extract
+  }
+  return [];
+}

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -71,6 +71,28 @@ export function isAtOrAbove(current: SkillLoadLevel, target: SkillLoadLevel): bo
   return LEVEL_ORDER[current] >= LEVEL_ORDER[target];
 }
 
+// ---------------------------------------------------------------------------
+// Include resolution
+// ---------------------------------------------------------------------------
+
+/** A resolved include file with its path and content. */
+export interface ResolvedInclude {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** Options for resolving `includes` directives in SKILL.md frontmatter. */
+export interface IncludeResolutionOptions {
+  /** Root directory for security boundary — resolved paths must stay within this. */
+  readonly skillsRoot: string;
+  /** Maximum recursion depth for nested includes. Default: 3. */
+  readonly maxDepth?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Progressive provider
+// ---------------------------------------------------------------------------
+
 /** Extended ComponentProvider with dynamic level promotion. */
 export interface ProgressiveSkillProvider extends ComponentProvider {
   /** Promote a skill to a higher load level. No-op if already at target level. */

--- a/packages/skills/src/validate.test.ts
+++ b/packages/skills/src/validate.test.ts
@@ -127,4 +127,76 @@ describe("validateSkillFrontmatter", () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // includes directive
+  // ---------------------------------------------------------------------------
+
+  test("accepts valid includes with relative path", () => {
+    const result = validateSkillFrontmatter({
+      name: "with-includes",
+      description: "test",
+      includes: ["./doc.md"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.includes).toEqual(["./doc.md"]);
+    }
+  });
+
+  test("accepts includes with parent-relative and local paths", () => {
+    const result = validateSkillFrontmatter({
+      name: "multi-includes",
+      description: "test",
+      includes: ["../sibling/SKILL.md", "./local.md"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.includes).toEqual(["../sibling/SKILL.md", "./local.md"]);
+    }
+  });
+
+  test("accepts empty includes array", () => {
+    const result = validateSkillFrontmatter({
+      name: "empty-includes",
+      description: "test",
+      includes: [],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.includes).toEqual([]);
+    }
+  });
+
+  test("omits includes when not present (backwards compat)", () => {
+    const result = validateSkillFrontmatter({ name: "no-includes", description: "test" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect("includes" in result.value).toBe(false);
+    }
+  });
+
+  test("rejects absolute path in includes", () => {
+    const result = validateSkillFrontmatter({
+      name: "bad-includes",
+      description: "test",
+      includes: ["/etc/passwd"],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("rejects URL in includes", () => {
+    const result = validateSkillFrontmatter({
+      name: "url-includes",
+      description: "test",
+      includes: ["https://evil.com/payload.md"],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
 });

--- a/packages/skills/src/validate.ts
+++ b/packages/skills/src/validate.ts
@@ -20,6 +20,7 @@ export interface ValidatedSkillFrontmatter {
   readonly compatibility?: string;
   readonly metadata?: Readonly<Record<string, string>>;
   readonly allowedTools?: readonly string[];
+  readonly includes?: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -40,6 +41,12 @@ const skillNameSchema = z
   )
   .refine((s) => !s.includes("--"), "Skill name must not contain consecutive hyphens");
 
+/**
+ * Allowed include path pattern: relative paths only (./file.md, ../sibling/file.md).
+ * Rejects absolute paths (/etc/passwd) and URL schemes (https://...).
+ */
+const INCLUDE_PATH_RE = /^\.{1,2}\/[a-zA-Z0-9._/-]+$/;
+
 const skillFrontmatterSchema = z.object({
   name: skillNameSchema,
   description: z
@@ -50,6 +57,11 @@ const skillFrontmatterSchema = z.object({
   compatibility: z.string().max(500, "Compatibility must be at most 500 characters").optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   "allowed-tools": z.string().optional(),
+  includes: z
+    .array(
+      z.string().regex(INCLUDE_PATH_RE, "Include path must be a relative path (./... or ../..)"),
+    )
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -70,7 +82,7 @@ export function validateSkillFrontmatter(
     return { ok: false, error: zodToKoiError(result.error, "Skill frontmatter validation failed") };
   }
 
-  const { name, description, license, compatibility, metadata } = result.data;
+  const { name, description, license, compatibility, metadata, includes } = result.data;
   const allowedToolsRaw = result.data["allowed-tools"];
 
   // Parse allowed-tools: space-delimited string → array
@@ -86,6 +98,7 @@ export function validateSkillFrontmatter(
     ...(compatibility !== undefined ? { compatibility } : {}),
     ...(metadata !== undefined ? { metadata } : {}),
     ...(allowedTools !== undefined ? { allowedTools } : {}),
+    ...(includes !== undefined ? { includes } : {}),
   };
 
   return { ok: true, value: validated };

--- a/packages/tool-ask-guide/package.json
+++ b/packages/tool-ask-guide/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/tool-ask-guide",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/search-provider": "workspace:*",
+    "@koi/token-estimator": "workspace:*",
+    "@koi/validation": "workspace:*",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  }
+}

--- a/packages/tool-ask-guide/src/__tests__/api-surface.test.ts
+++ b/packages/tool-ask-guide/src/__tests__/api-surface.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ASK_GUIDE_TOOL_DESCRIPTOR,
+  createAskGuideProvider,
+  createAskGuideTool,
+  createRetrieverSearch,
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_MAX_TOKENS,
+} from "../index.js";
+
+describe("@koi/tool-ask-guide API surface", () => {
+  test("exports createAskGuideTool factory", () => {
+    expect(typeof createAskGuideTool).toBe("function");
+  });
+
+  test("exports createAskGuideProvider factory", () => {
+    expect(typeof createAskGuideProvider).toBe("function");
+  });
+
+  test("exports ASK_GUIDE_TOOL_DESCRIPTOR", () => {
+    expect(ASK_GUIDE_TOOL_DESCRIPTOR).toBeDefined();
+    expect(ASK_GUIDE_TOOL_DESCRIPTOR.name).toBe("ask_guide");
+  });
+
+  test("exports DEFAULT_MAX_TOKENS constant", () => {
+    expect(typeof DEFAULT_MAX_TOKENS).toBe("number");
+    expect(DEFAULT_MAX_TOKENS).toBe(500);
+  });
+
+  test("exports DEFAULT_MAX_RESULTS constant", () => {
+    expect(typeof DEFAULT_MAX_RESULTS).toBe("number");
+    expect(DEFAULT_MAX_RESULTS).toBe(10);
+  });
+
+  test("exports createRetrieverSearch adapter", () => {
+    expect(typeof createRetrieverSearch).toBe("function");
+  });
+});

--- a/packages/tool-ask-guide/src/ask-guide-tool.test.ts
+++ b/packages/tool-ask-guide/src/ask-guide-tool.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { createAskGuideTool } from "./ask-guide-tool.js";
+import { createAskGuideProvider } from "./provider.js";
+import type { GuideSearchResult } from "./types.js";
+
+/** Creates a search function that returns fixed results. */
+function fixedSearch(
+  results: readonly GuideSearchResult[],
+): (query: string, maxResults?: number) => Promise<readonly GuideSearchResult[]> {
+  return async (_query: string, _maxResults?: number) => results;
+}
+
+/** Creates a search function that throws. */
+function failingSearch(
+  error: Error,
+): (query: string, maxResults?: number) => Promise<readonly GuideSearchResult[]> {
+  return async () => {
+    throw error;
+  };
+}
+
+describe("createAskGuideTool", () => {
+  // -------------------------------------------------------------------------
+  // Descriptor
+  // -------------------------------------------------------------------------
+
+  test("descriptor has correct name and schema", () => {
+    const tool = createAskGuideTool({ search: fixedSearch([]) });
+    expect(tool.descriptor.name).toBe("ask_guide");
+    expect(tool.descriptor.inputSchema).toBeDefined();
+    expect(tool.descriptor.inputSchema.required).toContain("question");
+  });
+
+  test("trustTier is verified", () => {
+    const tool = createAskGuideTool({ search: fixedSearch([]) });
+    expect(tool.trustTier).toBe("verified");
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  test("returns results for valid question", async () => {
+    const results: readonly GuideSearchResult[] = [
+      { title: "Getting Started", content: "Install with bun add koi", source: "docs/start.md" },
+      { title: "Configuration", content: "Edit koi.yaml", source: "docs/config.md" },
+    ];
+    const tool = createAskGuideTool({ search: fixedSearch(results), maxTokens: 1000 });
+    const output = (await tool.execute({ question: "How do I install?" })) as {
+      results: readonly GuideSearchResult[];
+      totalFound: number;
+      truncated: boolean;
+    };
+
+    expect(output.results).toHaveLength(2);
+    expect(output.totalFound).toBe(2);
+    expect(output.truncated).toBe(false);
+    expect(output.results[0]!.title).toBe("Getting Started");
+  });
+
+  test("returns empty results when search finds nothing", async () => {
+    const tool = createAskGuideTool({ search: fixedSearch([]) });
+    const output = (await tool.execute({ question: "obscure query" })) as {
+      results: readonly GuideSearchResult[];
+      totalFound: number;
+      truncated: boolean;
+    };
+
+    expect(output.results).toHaveLength(0);
+    expect(output.totalFound).toBe(0);
+    expect(output.truncated).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Token budget
+  // -------------------------------------------------------------------------
+
+  test("truncates results when exceeding maxTokens budget", async () => {
+    // Each result ~50 chars = ~13 tokens. With maxTokens=15, only first fits.
+    const results: readonly GuideSearchResult[] = [
+      { title: "Short", content: "Brief content here for testing." },
+      { title: "Also short", content: "Another brief bit of content." },
+      { title: "Third", content: "Third result content for testing." },
+    ];
+    const tool = createAskGuideTool({ search: fixedSearch(results), maxTokens: 15 });
+    const output = (await tool.execute({ question: "test" })) as {
+      results: readonly GuideSearchResult[];
+      totalFound: number;
+      truncated: boolean;
+    };
+
+    expect(output.results.length).toBeLessThan(results.length);
+    expect(output.totalFound).toBe(3);
+    expect(output.truncated).toBe(true);
+  });
+
+  test("includes at least one result even if it exceeds budget", async () => {
+    // Single large result exceeds budget but should still be included
+    const results: readonly GuideSearchResult[] = [
+      { title: "Big Result", content: "x".repeat(500) },
+    ];
+    const tool = createAskGuideTool({ search: fixedSearch(results), maxTokens: 10 });
+    const output = (await tool.execute({ question: "test" })) as {
+      results: readonly GuideSearchResult[];
+      totalFound: number;
+      truncated: boolean;
+    };
+
+    expect(output.results).toHaveLength(1);
+    expect(output.truncated).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  test("returns validation error for empty question", async () => {
+    const tool = createAskGuideTool({ search: fixedSearch([]) });
+    const output = (await tool.execute({ question: "" })) as { error: string; code: string };
+
+    expect(output.code).toBe("VALIDATION");
+    expect(output.error).toBeDefined();
+  });
+
+  test("returns validation error for missing question", async () => {
+    const tool = createAskGuideTool({ search: fixedSearch([]) });
+    const output = (await tool.execute({})) as { error: string; code: string };
+
+    expect(output.code).toBe("VALIDATION");
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  test("returns error when search throws", async () => {
+    const tool = createAskGuideTool({
+      search: failingSearch(new Error("Search service unavailable")),
+    });
+    const output = (await tool.execute({ question: "test" })) as { error: string; code: string };
+
+    expect(output.code).toBe("EXTERNAL");
+    expect(output.error).toBe("Search service unavailable");
+  });
+
+  test("returns timeout error on abort", async () => {
+    const tool = createAskGuideTool({
+      search: async () => {
+        throw new DOMException("Aborted", "AbortError");
+      },
+    });
+    const output = (await tool.execute({ question: "test" })) as { error: string; code: string };
+
+    expect(output.code).toBe("TIMEOUT");
+  });
+
+  // -------------------------------------------------------------------------
+  // Provider wiring
+  // -------------------------------------------------------------------------
+
+  test("createAskGuideProvider returns a ComponentProvider", () => {
+    const provider = createAskGuideProvider({ search: fixedSearch([]) });
+    expect(provider.name).toBe("ask-guide");
+    expect(typeof provider.attach).toBe("function");
+  });
+});

--- a/packages/tool-ask-guide/src/ask-guide-tool.ts
+++ b/packages/tool-ask-guide/src/ask-guide-tool.ts
@@ -1,0 +1,89 @@
+/**
+ * Ask-guide tool factory — creates a Tool that queries knowledge within a token budget.
+ *
+ * Follows the same factory pattern as @koi/tool-ask-user but optimized for
+ * context retrieval rather than user elicitation.
+ */
+
+import type { JsonObject } from "@koi/core/common";
+import type { Tool, ToolExecuteOptions } from "@koi/core/ecs";
+import { estimateTokens } from "@koi/token-estimator";
+import { validateWith } from "@koi/validation";
+import { z } from "zod";
+import {
+  ASK_GUIDE_TOOL_DESCRIPTOR,
+  type AskGuideConfig,
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_MAX_TOKENS,
+  type GuideSearchResult,
+} from "./types.js";
+
+const questionSchema = z.object({
+  question: z.string().min(1, "Question must not be empty"),
+});
+
+/**
+ * Creates the `ask_guide` tool for knowledge retrieval within a token budget.
+ *
+ * Flow:
+ * 1. Validate input: non-empty question string
+ * 2. Call config.search() to get relevant results
+ * 3. Accumulate results within maxTokens budget
+ * 4. Return structured response with truncation indicator
+ */
+export function createAskGuideTool(config: AskGuideConfig): Tool {
+  const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const maxResults = config.maxResults ?? DEFAULT_MAX_RESULTS;
+
+  return {
+    descriptor: ASK_GUIDE_TOOL_DESCRIPTOR,
+    trustTier: "verified",
+
+    async execute(args: JsonObject, _options?: ToolExecuteOptions): Promise<unknown> {
+      // 1. Validate input
+      const inputResult = validateWith(questionSchema, args, "ask_guide input validation failed");
+      if (!inputResult.ok) {
+        return { error: inputResult.error.message, code: "VALIDATION" };
+      }
+
+      const { question } = inputResult.value;
+
+      // 2. Call search
+      let searchResults: readonly GuideSearchResult[]; // let: assigned in try, used after catch
+      try {
+        searchResults = await config.search(question, maxResults);
+      } catch (e: unknown) {
+        if (e instanceof DOMException && (e.name === "AbortError" || e.name === "TimeoutError")) {
+          return { error: "Search timed out", code: "TIMEOUT" };
+        }
+        const message = e instanceof Error ? e.message : "Unknown search error";
+        return { error: message, code: "EXTERNAL" };
+      }
+
+      if (searchResults.length === 0) {
+        return { results: [], totalFound: 0, truncated: false };
+      }
+
+      // 3. Accumulate results within token budget
+      const accumulated: GuideSearchResult[] = [];
+      let usedTokens = 0; // let: accumulator for token budget
+      let truncated = false; // let: flag set when budget exceeded
+
+      for (const result of searchResults) {
+        const resultTokens = estimateTokens(`${result.title}\n${result.content}`);
+        if (usedTokens + resultTokens > maxTokens && accumulated.length > 0) {
+          truncated = true;
+          break;
+        }
+        accumulated.push(result);
+        usedTokens += resultTokens;
+      }
+
+      return {
+        results: accumulated,
+        totalFound: searchResults.length,
+        truncated,
+      };
+    },
+  };
+}

--- a/packages/tool-ask-guide/src/index.ts
+++ b/packages/tool-ask-guide/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @koi/tool-ask-guide — Guide agent knowledge retrieval tool (Layer 2).
+ *
+ * Provides a thin tool that queries knowledge sources within a token budget,
+ * preventing context window pollution from raw search results.
+ */
+
+export { createAskGuideTool } from "./ask-guide-tool.js";
+export { createAskGuideProvider } from "./provider.js";
+export { createRetrieverSearch } from "./search-adapter.js";
+export type { AskGuideConfig, GuideSearchResult } from "./types.js";
+export {
+  ASK_GUIDE_TOOL_DESCRIPTOR,
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_MAX_TOKENS,
+} from "./types.js";

--- a/packages/tool-ask-guide/src/provider.ts
+++ b/packages/tool-ask-guide/src/provider.ts
@@ -1,0 +1,22 @@
+/**
+ * ComponentProvider that attaches the ask_guide tool to an agent.
+ */
+
+import { createSingleToolProvider } from "@koi/core";
+import type { ComponentProvider } from "@koi/core/ecs";
+import { createAskGuideTool } from "./ask-guide-tool.js";
+import type { AskGuideConfig } from "./types.js";
+
+/**
+ * Creates a ComponentProvider that attaches a single `tool:ask_guide` component.
+ *
+ * The tool is created once and cached — subsequent attach() calls return
+ * the same tool instance.
+ */
+export function createAskGuideProvider(config: AskGuideConfig): ComponentProvider {
+  return createSingleToolProvider({
+    name: "ask-guide",
+    toolName: "ask_guide",
+    createTool: () => createAskGuideTool(config),
+  });
+}

--- a/packages/tool-ask-guide/src/search-adapter.test.ts
+++ b/packages/tool-ask-guide/src/search-adapter.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiError, Result } from "@koi/core";
+import type { Retriever, SearchPage, SearchResult } from "@koi/search-provider";
+import { createRetrieverSearch } from "./search-adapter.js";
+
+/** Creates a mock Retriever that returns fixed results. */
+function mockRetriever(results: readonly SearchResult[]): Retriever {
+  return {
+    retrieve: async (): Promise<Result<SearchPage, KoiError>> => ({
+      ok: true,
+      value: { results, hasMore: false },
+    }),
+  };
+}
+
+/** Creates a mock Retriever that returns an error. */
+function failingRetriever(): Retriever {
+  return {
+    retrieve: async (): Promise<Result<SearchPage, KoiError>> => ({
+      ok: false,
+      error: {
+        code: "INTERNAL",
+        message: "Search index unavailable",
+        retryable: true,
+      },
+    }),
+  };
+}
+
+describe("createRetrieverSearch", () => {
+  test("maps SearchResult to GuideSearchResult", async () => {
+    const retriever = mockRetriever([
+      {
+        id: "doc-1",
+        score: 0.95,
+        content: "Deploy with `koi deploy --prod`",
+        metadata: { title: "Deployment Guide" },
+        source: "docs/deploy.md",
+      },
+      {
+        id: "doc-2",
+        score: 0.8,
+        content: "Rollback with `koi rollback`",
+        metadata: { title: "Rollback Procedures" },
+        source: "docs/rollback.md",
+      },
+    ]);
+
+    const search = createRetrieverSearch(retriever);
+    const results = await search("deploy", 10);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      title: "Deployment Guide",
+      content: "Deploy with `koi deploy --prod`",
+      source: "docs/deploy.md",
+    });
+    expect(results[1]).toEqual({
+      title: "Rollback Procedures",
+      content: "Rollback with `koi rollback`",
+      source: "docs/rollback.md",
+    });
+  });
+
+  test("falls back to id when metadata.title is missing", async () => {
+    const retriever = mockRetriever([
+      {
+        id: "chunk-42",
+        score: 0.7,
+        content: "Some content",
+        metadata: {},
+        source: "docs/misc.md",
+      },
+    ]);
+
+    const search = createRetrieverSearch(retriever);
+    const results = await search("query");
+
+    expect(results[0]!.title).toBe("chunk-42");
+  });
+
+  test("returns empty array on retriever error", async () => {
+    const search = createRetrieverSearch(failingRetriever());
+    const results = await search("query");
+
+    expect(results).toEqual([]);
+  });
+
+  test("passes maxResults as limit to retriever", async () => {
+    let capturedLimit: number | undefined;
+    const retriever: Retriever = {
+      retrieve: async (query) => {
+        capturedLimit = query.limit;
+        return { ok: true, value: { results: [], hasMore: false } };
+      },
+    };
+
+    const search = createRetrieverSearch(retriever);
+    await search("query", 5);
+
+    expect(capturedLimit).toBe(5);
+  });
+
+  test("defaults maxResults to 10", async () => {
+    let capturedLimit: number | undefined;
+    const retriever: Retriever = {
+      retrieve: async (query) => {
+        capturedLimit = query.limit;
+        return { ok: true, value: { results: [], hasMore: false } };
+      },
+    };
+
+    const search = createRetrieverSearch(retriever);
+    await search("query");
+
+    expect(capturedLimit).toBe(10);
+  });
+});

--- a/packages/tool-ask-guide/src/search-adapter.ts
+++ b/packages/tool-ask-guide/src/search-adapter.ts
@@ -1,0 +1,34 @@
+/**
+ * Adapter from @koi/search-provider's Retriever to ask_guide's search callback.
+ *
+ * Bridges the Retriever<T> contract (SearchQuery → SearchPage) to
+ * the simpler (query, maxResults) → GuideSearchResult[] signature.
+ */
+
+import type { Retriever } from "@koi/search-provider";
+import type { AskGuideConfig, GuideSearchResult } from "./types.js";
+
+/**
+ * Wraps a Retriever into the search callback expected by AskGuideConfig.
+ *
+ * Maps SearchResult fields to GuideSearchResult:
+ * - title: from metadata.title (falls back to result id)
+ * - content: SearchResult.content (the matched text)
+ * - source: SearchResult.source (file path or identifier)
+ */
+export function createRetrieverSearch(retriever: Retriever): AskGuideConfig["search"] {
+  return async (query: string, maxResults: number = 10): Promise<readonly GuideSearchResult[]> => {
+    const result = await retriever.retrieve({ text: query, limit: maxResults });
+    if (!result.ok) {
+      return [];
+    }
+
+    return result.value.results.map(
+      (r): GuideSearchResult => ({
+        title: typeof r.metadata["title"] === "string" ? r.metadata["title"] : r.id,
+        content: r.content,
+        source: r.source,
+      }),
+    );
+  };
+}

--- a/packages/tool-ask-guide/src/types.ts
+++ b/packages/tool-ask-guide/src/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Types for the ask-guide tool.
+ *
+ * L2 — imports from @koi/core only.
+ */
+
+import type { ToolDescriptor } from "@koi/core/ecs";
+
+/** A single search result returned by the guide's search function. */
+export interface GuideSearchResult {
+  /** Title or heading of the matched content. */
+  readonly title: string;
+  /** The matched content text. */
+  readonly content: string;
+  /** Optional source path or identifier. */
+  readonly source?: string;
+}
+
+/** Default token budget for guide responses. */
+export const DEFAULT_MAX_TOKENS = 500;
+
+/** Default maximum number of search results to request. */
+export const DEFAULT_MAX_RESULTS = 10;
+
+/**
+ * Configuration for the ask-guide tool.
+ *
+ * The `search` callback is the sole extension point — consumers wire up
+ * their own SearchProvider, Retriever, or custom search implementation.
+ */
+export interface AskGuideConfig {
+  /**
+   * Callback that searches for relevant content given a query.
+   * Returns an ordered list of results (best match first).
+   */
+  readonly search: (query: string, maxResults?: number) => Promise<readonly GuideSearchResult[]>;
+  /** Maximum token budget for the response. Default: 500. */
+  readonly maxTokens?: number | undefined;
+  /** Maximum search results to request. Default: 10. */
+  readonly maxResults?: number | undefined;
+}
+
+/** Tool descriptor exposed to the model for the ask_guide tool. */
+export const ASK_GUIDE_TOOL_DESCRIPTOR: ToolDescriptor = {
+  name: "ask_guide",
+  description:
+    "Ask a question about skills, docs, or knowledge. Returns concise, relevant context within a token budget. Use when you need information from the knowledge base without flooding your context.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        description: "The question to ask. Should be specific and focused for best results.",
+      },
+    },
+    required: ["question"],
+  },
+};

--- a/packages/tool-ask-guide/tsconfig.json
+++ b/packages/tool-ask-guide/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tool-ask-guide/tsup.config.ts
+++ b/packages/tool-ask-guide/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

Implements the guide agent pattern from #502 — nested skill resolution via `includes` directive + a thin `ask_guide` tool for token-budgeted knowledge retrieval.

- **`@koi/skills`**: Extended `ValidatedSkillFrontmatter` with optional `includes` field (Zod-validated relative paths). Added `resolveIncludes()` with cycle detection, diamond dedup, depth limits, and path traversal protection. Integrated into `loadSkillBody()`/`loadSkillBundled()`.
- **`@koi/tool-ask-guide`**: New L2 package. `ask_guide` tool searches knowledge via a configurable `search` callback, accumulates results within a token budget (default 500), and returns structured results. Includes `createRetrieverSearch()` adapter to wire `@koi/search-provider`'s `Retriever` interface.
- **Pattern doc**: `docs/patterns/guide-agent.md` with problem statement, flow diagram, wiring examples for `@koi/search` and `@koi/search-nexus`, anti-patterns.
- **Manifest fixture**: `guide-agent.yaml` parse test added to `@koi/manifest`.

### Layer compliance
- `@koi/tool-ask-guide` imports only from L0 (`@koi/core`) and L0u (`@koi/search-provider`, `@koi/token-estimator`, `@koi/validation`)
- No L2→L2 imports, no L2→L1 imports
- `bun scripts/check-layers.ts` passes

Closes #502

## Test plan

- [x] 6 new validation tests for `includes` frontmatter field
- [x] 8 resolution tests (cycle, diamond, depth, traversal, missing file)
- [x] 11 ask-guide tool tests (descriptor, happy path, token truncation, validation errors, provider wiring)
- [x] 5 search adapter tests (field mapping, fallbacks, error handling, limit passthrough)
- [x] 1 manifest fixture parse test
- [x] API surface snapshot test
- [ ] CI: typecheck + test pass for `@koi/skills`, `@koi/tool-ask-guide`, `@koi/manifest`