### PR TITLE
feat: auto-categorize memory-fs facts via keyword inference

### DIFF
--- a/docs/L2/memory-fs.md
+++ b/docs/L2/memory-fs.md
@@ -51,6 +51,7 @@ packages/memory-fs/
 ├── src/
 │   ├── index.ts              ─ Public exports (backend + provider + types)
 │   ├── types.ts              ─ MemoryFact (internal), FsMemory, config, DI contracts
+│   ├── category-inferrer.ts   ─ createKeywordCategoryInferrer() — keyword-based auto-categorization
 │   ├── fs-memory.ts          ─ createFsMemory() factory (~400 LOC)
 │   ├── fact-store.ts         ─ File I/O: read/write/append, write queue, cache
 │   ├── graph-walk.ts         ─ BFS causal graph expansion with score decay
@@ -142,32 +143,38 @@ Only 2 out of 5 exchanges stored — agent used judgment.
 When the agent calls `memory_store`:
 
 ```
-memory_store({ content, category, entities, causalParents? })
+memory_store({ content, category?, entities, causalParents? })
   │
   ▼
 1. Resolve entity: slugify(entities[0] ?? namespace ?? "_default")
   │
   ▼
-2. Read active facts for entity (from cache)
+2. Resolve category:
+   explicit category provided? → use it
+   categoryInferrer configured? → infer from content (keyword regex)
+   neither? → fall back to "context"
   │
   ▼
-3. Category pre-filter: only compare against same-category facts
+3. Read active facts for entity (from cache)
   │
   ▼
-4. Jaccard dedup: similarity ≥ 0.7 → REJECT (duplicate)
+4. Category pre-filter: only compare against same-category facts
   │
   ▼
-5. Contradiction check: same category + same entities → SUPERSEDE old fact
+5. Jaccard dedup: similarity ≥ 0.7 → REJECT (duplicate)
   │
   ▼
-6. Append fact via write queue (temp-file + rename for atomicity)
+6. Contradiction check: same category + same entities → SUPERSEDE old fact
   │
   ▼
-7. Bidirectional causal edges: if causalParents provided,
+7. Append fact via write queue (temp-file + rename for atomicity)
+  │
+  ▼
+8. Bidirectional causal edges: if causalParents provided,
    update each parent's causalChildren to include new fact ID
   │
   ▼
-8. Mark entity as dirty (for summary rebuild)
+9. Mark entity as dirty (for summary rebuild)
 ```
 
 ### Recall Flow
@@ -478,6 +485,109 @@ Merge behavior:
 - Handler returns `undefined` or `""` → falls through to supersede check
 - Handler throws → error logged, falls through (original fact not lost)
 
+### Auto-Category Inference
+
+When agents store facts via `memory_store` without an explicit `category`, the fact defaults to `"context"`. As memory stores grow (100+ facts), this "context" bucket becomes a junk drawer — degrading dedup, merge, and contradiction detection (all category-scoped).
+
+A `CategoryInferrer` DI slot on `FsMemoryConfig` solves this by auto-assigning categories at write time:
+
+```typescript
+type CategoryInferrer = (content: string) => string | Promise<string>;
+```
+
+The built-in `createKeywordCategoryInferrer()` maps 6 categories via regex — zero LLM cost:
+
+| Category | Trigger keywords |
+|----------|-----------------|
+| `decision` | chose, decided, picked, went with, settled on |
+| `error-pattern` | error, failed, bug, crash, exception, broken |
+| `preference` | prefers, likes, always uses, favourite, dislikes |
+| `correction` | corrected, fixed, wrong, mistake, shouldn't have |
+| `milestone` | completed, shipped, launched, deployed, released |
+| `relationship` | works with/for/at, reports to, manages, team |
+| *(no match)* | falls back to `"context"` |
+
+Rules are evaluated top-to-bottom; first match wins. All patterns are case-insensitive.
+
+```typescript
+import { createFsMemory, createKeywordCategoryInferrer } from "@koi/memory-fs";
+
+const mem = await createFsMemory({
+  baseDir: "/path/to/memory",
+  categoryInferrer: createKeywordCategoryInferrer(),
+});
+
+await mem.component.store("We decided to use Bun");
+// → category: "decision" (matched "decided")
+
+await mem.component.store("Build failed after upgrading tsup");
+// → category: "error-pattern" (matched "failed")
+
+await mem.component.store("The sky is blue");
+// → category: "context" (no match — fallback)
+
+// Explicit category always wins — inferrer is not called
+await mem.component.store("We decided on React", { category: "milestone" });
+// → category: "milestone"
+```
+
+**Customization**: Add domain-specific rules (prepended, higher priority) or override the fallback:
+
+```typescript
+const inferrer = createKeywordCategoryInferrer({
+  additionalRules: [
+    { category: "security", pattern: /\b(?:vulnerability|CVE|exploit)\b/i },
+  ],
+  fallback: "general", // instead of "context"
+});
+```
+
+**Async inferrers**: The DI slot accepts `Promise<string>`, so LLM-backed classifiers work too:
+
+```typescript
+const mem = await createFsMemory({
+  baseDir: "/path/to/memory",
+  categoryInferrer: async (content) => {
+    const response = await myModel.classify(content);
+    return response.category;
+  },
+});
+```
+
+**Error handling**: If the inferrer throws (LLM timeout, etc.), the error is logged and category falls back to `"context"` — the fact is never lost.
+
+**Context-Arena integration**: `createContextArena` auto-wires `createKeywordCategoryInferrer()` when `memoryFs` is configured. No extra config needed:
+
+```typescript
+const bundle = await createContextArena({
+  summarizer: myModel,
+  sessionId,
+  getMessages: () => messages,
+  memoryFs: {
+    config: { baseDir: "/data/memory" },
+    // categoryInferrer auto-wired ← keyword-based, zero LLM cost
+    // mergeHandler auto-wired ← uses summarizer
+  },
+});
+```
+
+#### Why This Matters
+
+Without auto-categorization, all uncategorized facts land in `"context"`:
+
+```
+"context" bucket (before):
+  - "We decided to use Bun"        ← should be "decision"
+  - "Build failed on CI"            ← should be "error-pattern"
+  - "User prefers dark mode"        ← should be "preference"
+  - "Deployed v2.0 to prod"         ← should be "milestone"
+
+  Dedup compares ALL of these against each other — false positives.
+  Contradiction detection treats them as same-category — false supersessions.
+```
+
+With auto-categorization, facts are bucketed correctly. Dedup only compares decisions against decisions, errors against errors, etc. Merge and contradiction detection become more precise.
+
 ---
 
 ## Per-User Memory Isolation
@@ -705,6 +815,7 @@ const mem = await createFsMemory({
   perEntityCap: 10,               // max cross-entity results per source entity (default: 10)
   retriever: customRetriever,     // optional: semantic search (DI)
   indexer: customIndexer,         // optional: search indexing (DI)
+  categoryInferrer: inferrer,     // optional: auto-categorize when category omitted (DI)
 });
 ```
 
@@ -813,7 +924,7 @@ The DI contracts (`FsSearchRetriever`, `FsSearchIndexer`) are local function typ
 
 ## Testing
 
-200+ tests total across 17 test files:
+230+ tests total across 19 test files:
 
 | Test File | Count | What It Covers |
 |-----------|-------|----------------|
@@ -827,7 +938,9 @@ The DI contracts (`FsSearchRetriever`, `FsSearchIndexer`) are local function typ
 | `graph-walk.test.ts` | 9 | BFS expansion, cycle detection, score decay, dedup |
 | `entity-index.test.ts` | 11 | Reverse index: build, add, lookup, dedup, self-ref guard |
 | `cross-entity.test.ts` | 17 | Cross-entity: decay, cap, cycles, hops, integration |
+| `category-inferrer.test.ts` | 28 | Keyword rules (6 categories), fallback, case insensitivity, ordering, custom rules, custom fallback |
 | `fs-memory.test.ts` | 38 | Full integration: store → recall → dedup → decay → causal → graph expansion → salience |
+| `fs-memory-category.test.ts` | 6 | Category inference integration: infer, override, backward compat, async, error fallback, dedup |
 | `provider/tools/store.test.ts` | 10 | Store tool: validation, causal_parents, dedup, errors |
 | `provider/tools/recall.test.ts` | 12 | Recall tool: limits, tiers, graph_expand, max_hops, errors |
 | `provider/tools/search.test.ts` | 7 | Search tool: entity list, entity lookup, errors |

--- a/packages/context-arena/src/arena-factory.ts
+++ b/packages/context-arena/src/arena-factory.ts
@@ -12,6 +12,7 @@ import type { ModelHandler } from "@koi/core/middleware";
 import type { MergeHandler } from "@koi/memory-fs";
 import {
   createFsMemory,
+  createKeywordCategoryInferrer,
   createMemoryProvider,
   createUserScopedMemoryProvider,
 } from "@koi/memory-fs";
@@ -77,9 +78,19 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
       ? (memoryFsConfig.mergeHandler ?? createDefaultMergeHandler(config.summarizer))
       : undefined;
 
+  // Auto-wire keyword category inferrer when not explicitly provided (zero LLM cost)
+  const categoryInferrer =
+    memoryFsConfig !== undefined
+      ? (memoryFsConfig.categoryInferrer ?? createKeywordCategoryInferrer())
+      : undefined;
+
   const effectiveFsConfig =
     memoryFsConfig !== undefined
-      ? { ...memoryFsConfig, ...(mergeHandler !== undefined ? { mergeHandler } : {}) }
+      ? {
+          ...memoryFsConfig,
+          ...(mergeHandler !== undefined ? { mergeHandler } : {}),
+          ...(categoryInferrer !== undefined ? { categoryInferrer } : {}),
+        }
       : undefined;
 
   // Create early so squash + compactor can share the component

--- a/packages/memory-fs/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/memory-fs/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -27,6 +27,13 @@ interface FsIndexDoc {
  * Return the merged text string, or \`undefined\` to fall through to supersede logic.
  */
 type MergeHandler = (existing: string, incoming: string) => Promise<string | undefined>;
+/**
+ * Infers a category from fact content when no explicit category is provided.
+ *
+ * May be sync (keyword matching) or async (LLM-backed).
+ * Return a category string; the default fallback is \`"context"\`.
+ */
+type CategoryInferrer = (content: string) => string | Promise<string>;
 interface FsMemoryConfig {
     readonly baseDir: string;
     readonly retriever?: FsSearchRetriever | undefined;
@@ -44,6 +51,8 @@ interface FsMemoryConfig {
     readonly mergeThreshold?: number | undefined;
     /** Enable composite salience scoring for recall ranking. Default true. */
     readonly salienceEnabled?: boolean | undefined;
+    /** Infers a category when the caller omits \`options.category\`. Default: none (falls back to \`"context"\`). */
+    readonly categoryInferrer?: CategoryInferrer | undefined;
 }
 interface FsMemory {
     readonly component: MemoryComponent;
@@ -58,6 +67,25 @@ interface TierDistribution {
     readonly cold: number;
     readonly total: number;
 }
+
+/**
+ * Keyword-based category inferrer — pure heuristic, no LLM cost.
+ *
+ * Scans fact content for category-indicating keywords and returns the
+ * first matching category. Falls back to \`"context"\` when no rule matches.
+ */
+
+interface CategoryRule {
+    readonly category: string;
+    readonly pattern: RegExp;
+}
+interface KeywordCategoryInferrerOptions {
+    /** Additional rules prepended to defaults (higher priority). */
+    readonly additionalRules?: readonly CategoryRule[] | undefined;
+    /** Override the default fallback category (\`"context"\`). */
+    readonly fallback?: string | undefined;
+}
+declare function createKeywordCategoryInferrer(options?: KeywordCategoryInferrerOptions): CategoryInferrer;
 
 declare function createFsMemory(config: FsMemoryConfig): Promise<FsMemory>;
 
@@ -171,6 +199,6 @@ interface UserScopedMemory {
 }
 declare function createUserScopedMemory(config: UserScopedMemoryConfig): UserScopedMemory;
 
-export { type FsIndexDoc, type FsMemory, type FsMemoryConfig, type FsSearchHit, type FsSearchIndexer, type FsSearchRetriever, MEMORY_OPERATIONS, MEMORY_SKILL_CONTENT, type MemoryOperation, type MemoryProviderConfig, type MergeHandler, type TierDistribution, type UserScopedMemory, type UserScopedMemoryConfig, type UserScopedMemoryProviderConfig, createFsMemory, createMemoryProvider, createMemoryRecallTool, createMemorySearchTool, createMemoryStoreTool, createUserScopedMemory, createUserScopedMemoryProvider, generateMemorySkillContent };
+export { type CategoryInferrer, type CategoryRule, type FsIndexDoc, type FsMemory, type FsMemoryConfig, type FsSearchHit, type FsSearchIndexer, type FsSearchRetriever, type KeywordCategoryInferrerOptions, MEMORY_OPERATIONS, MEMORY_SKILL_CONTENT, type MemoryOperation, type MemoryProviderConfig, type MergeHandler, type TierDistribution, type UserScopedMemory, type UserScopedMemoryConfig, type UserScopedMemoryProviderConfig, createFsMemory, createKeywordCategoryInferrer, createMemoryProvider, createMemoryRecallTool, createMemorySearchTool, createMemoryStoreTool, createUserScopedMemory, createUserScopedMemoryProvider, generateMemorySkillContent };
 "
 `;

--- a/packages/memory-fs/src/category-inferrer.test.ts
+++ b/packages/memory-fs/src/category-inferrer.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { CategoryRule } from "./category-inferrer.js";
+import { createKeywordCategoryInferrer } from "./category-inferrer.js";
+
+const infer = createKeywordCategoryInferrer();
+
+// ---------------------------------------------------------------------------
+// Table-driven: default rules
+// ---------------------------------------------------------------------------
+
+describe("createKeywordCategoryInferrer", () => {
+  const cases: readonly (readonly [string, string, string])[] = [
+    // decision
+    ["decision", "We chose TypeScript for the backend", "chose"],
+    ["decision", "Team decided to use Bun over Node", "decided"],
+    ["decision", "We settled on a monorepo layout", "settled on"],
+
+    // error-pattern
+    ["error-pattern", "Got an error when deploying to staging", "error"],
+    ["error-pattern", "Build failed after upgrading tsup", "failed"],
+    ["error-pattern", "The crash happens on Apple Silicon only", "crash"],
+
+    // preference
+    ["preference", "User prefers dark mode", "prefers"],
+    ["preference", "She always uses Vim keybindings", "always uses"],
+    ["preference", "His favourite editor is Zed", "favourite"],
+    ["preference", "He dislikes auto-formatting", "dislikes"],
+
+    // correction
+    ["correction", "I corrected the import paths", "corrected"],
+    ["correction", "That approach was wrong", "wrong"],
+    ["correction", "That was a mistake in the config", "mistake"],
+
+    // milestone
+    ["milestone", "v2.0 shipped to production today", "shipped"],
+    ["milestone", "We deployed the new auth flow", "deployed"],
+    ["milestone", "Feature complete — all tests green", "complete"],
+
+    // relationship
+    ["relationship", "Alice works with the infra team", "works with"],
+    ["relationship", "Bob reports to Carol", "reports to"],
+    ["relationship", "Dana manages the frontend guild", "manages"],
+    ["relationship", "The team owns the CI pipeline", "team"],
+  ];
+
+  test.each(cases)("returns %s for content with '%s' keyword (%s)", (expected, content) => {
+    expect(infer(content)).toBe(expected);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fallback
+  // ---------------------------------------------------------------------------
+
+  describe("fallback", () => {
+    test("returns 'context' for unmatched text", () => {
+      expect(infer("The sky is blue")).toBe("context");
+    });
+
+    test("returns 'context' for empty string", () => {
+      expect(infer("")).toBe("context");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case insensitivity
+  // ---------------------------------------------------------------------------
+
+  describe("case insensitivity", () => {
+    test("matches uppercase keywords", () => {
+      expect(infer("We CHOSE to go with Bun")).toBe("decision");
+    });
+
+    test("matches mixed-case keywords", () => {
+      expect(infer("Build Failed on CI")).toBe("error-pattern");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // First-match-wins ordering
+  // ---------------------------------------------------------------------------
+
+  describe("ordering", () => {
+    test("first matching rule wins when content has multiple category keywords", () => {
+      // "chose" → decision, "error" → error-pattern — decision appears first in rules
+      expect(infer("We chose to ignore that error")).toBe("decision");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config: additionalRules
+  // ---------------------------------------------------------------------------
+
+  describe("additionalRules", () => {
+    test("custom rules take priority over defaults", () => {
+      const customRule: CategoryRule = {
+        category: "security",
+        pattern: /\b(?:vulnerability|CVE|exploit)\b/i,
+      };
+      const customInfer = createKeywordCategoryInferrer({
+        additionalRules: [customRule],
+      });
+      expect(customInfer("Found a vulnerability in auth")).toBe("security");
+    });
+
+    test("falls through to default rules when custom rules don't match", () => {
+      const customRule: CategoryRule = {
+        category: "security",
+        pattern: /\bCVE\b/i,
+      };
+      const customInfer = createKeywordCategoryInferrer({
+        additionalRules: [customRule],
+      });
+      expect(customInfer("We chose Bun")).toBe("decision");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Config: custom fallback
+  // ---------------------------------------------------------------------------
+
+  describe("custom fallback", () => {
+    test("uses provided fallback instead of 'context'", () => {
+      const customInfer = createKeywordCategoryInferrer({ fallback: "general" });
+      expect(customInfer("The sky is blue")).toBe("general");
+    });
+  });
+});

--- a/packages/memory-fs/src/category-inferrer.ts
+++ b/packages/memory-fs/src/category-inferrer.ts
@@ -1,0 +1,80 @@
+/**
+ * Keyword-based category inferrer — pure heuristic, no LLM cost.
+ *
+ * Scans fact content for category-indicating keywords and returns the
+ * first matching category. Falls back to `"context"` when no rule matches.
+ */
+
+import type { CategoryInferrer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CategoryRule {
+  readonly category: string;
+  readonly pattern: RegExp;
+}
+
+export interface KeywordCategoryInferrerOptions {
+  /** Additional rules prepended to defaults (higher priority). */
+  readonly additionalRules?: readonly CategoryRule[] | undefined;
+  /** Override the default fallback category (`"context"`). */
+  readonly fallback?: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Default rules — ordered by specificity (most specific first)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RULES: readonly CategoryRule[] = [
+  {
+    category: "decision",
+    pattern: /\b(?:chose|chosen|decided|picked|went\s+with|settled\s+on)\b/i,
+  },
+  {
+    category: "error-pattern",
+    pattern: /\b(?:error|failed|failure|bug|crash|exception|broke|broken)\b/i,
+  },
+  {
+    category: "preference",
+    pattern: /\b(?:prefers?|likes?|always\s+uses?|favou?rite|dislikes?)\b/i,
+  },
+  {
+    category: "correction",
+    pattern: /\b(?:corrected?|corrections?|fixed|wrong|mistake|shouldn'?t\s+have)\b/i,
+  },
+  {
+    category: "milestone",
+    pattern: /\b(?:completed?|finished|shipped|launched|deployed|released|milestone|achieved)\b/i,
+  },
+  {
+    category: "relationship",
+    pattern: /\b(?:works?\s+(?:with|for|at|on)|reports?\s+to|manages?|owns?|maintains?|team)\b/i,
+  },
+];
+
+const DEFAULT_FALLBACK = "context";
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createKeywordCategoryInferrer(
+  options?: KeywordCategoryInferrerOptions,
+): CategoryInferrer {
+  const additional = options?.additionalRules ?? [];
+  const rules: readonly CategoryRule[] =
+    additional.length > 0 ? [...additional, ...DEFAULT_RULES] : DEFAULT_RULES;
+  const fallback = options?.fallback ?? DEFAULT_FALLBACK;
+
+  return (content: string): string => {
+    for (const rule of rules) {
+      rule.pattern.lastIndex = 0; // guard against /g flag on user-supplied patterns
+      if (rule.pattern.test(content)) {
+        return rule.category;
+      }
+    }
+    return fallback;
+  };
+}

--- a/packages/memory-fs/src/fs-memory-category.test.ts
+++ b/packages/memory-fs/src/fs-memory-category.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createKeywordCategoryInferrer } from "./category-inferrer.js";
+import { createFsMemory } from "./fs-memory.js";
+import type { FsMemory } from "./types.js";
+
+// let — needed for mutable test directory and memory refs
+let testDir: string;
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `koi-fs-memory-cat-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("category inference integration", () => {
+  // let — reassigned per test
+  let mem: FsMemory;
+
+  beforeEach(() => {
+    testDir = makeTmpDir();
+  });
+
+  afterEach(async () => {
+    await mem.close();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("infers category when options.category is omitted", async () => {
+    mem = await createFsMemory({
+      baseDir: testDir,
+      categoryInferrer: createKeywordCategoryInferrer(),
+    });
+
+    await mem.component.store("We decided to use Bun for the runtime", {
+      relatedEntities: ["project"],
+    });
+
+    const results = await mem.component.recall("Bun");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.metadata?.category).toBe("decision");
+  });
+
+  test("explicit category overrides inferrer", async () => {
+    mem = await createFsMemory({
+      baseDir: testDir,
+      categoryInferrer: createKeywordCategoryInferrer(),
+    });
+
+    await mem.component.store("We decided to use Bun for the runtime", {
+      relatedEntities: ["project"],
+      category: "milestone",
+    });
+
+    const results = await mem.component.recall("Bun");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.metadata?.category).toBe("milestone");
+  });
+
+  test("falls back to 'context' when no inferrer configured", async () => {
+    mem = await createFsMemory({ baseDir: testDir });
+
+    await mem.component.store("Some random fact", {
+      relatedEntities: ["project"],
+    });
+
+    const results = await mem.component.recall("random");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.metadata?.category).toBe("context");
+  });
+
+  test("async inferrer works", async () => {
+    const asyncInferrer = async (content: string): Promise<string> => {
+      // Simulate async (e.g., LLM-backed)
+      await Promise.resolve();
+      return content.includes("error") ? "error-pattern" : "context";
+    };
+
+    mem = await createFsMemory({
+      baseDir: testDir,
+      categoryInferrer: asyncInferrer,
+    });
+
+    await mem.component.store("Got an error in production", {
+      relatedEntities: ["infra"],
+    });
+
+    const results = await mem.component.recall("error");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.metadata?.category).toBe("error-pattern");
+  });
+
+  test("failing inferrer falls back to 'context'", async () => {
+    const brokenInferrer = (): string => {
+      throw new Error("LLM unavailable");
+    };
+
+    mem = await createFsMemory({
+      baseDir: testDir,
+      categoryInferrer: brokenInferrer,
+    });
+
+    await mem.component.store("Some content about the project", {
+      relatedEntities: ["project"],
+    });
+
+    const results = await mem.component.recall("content");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.metadata?.category).toBe("context");
+  });
+
+  test("dedup uses inferred category for same-category matching", async () => {
+    mem = await createFsMemory({
+      baseDir: testDir,
+      categoryInferrer: createKeywordCategoryInferrer(),
+    });
+
+    // Both will be inferred as "preference" — dedup should reject duplicate
+    await mem.component.store("User prefers dark mode in the editor", {
+      relatedEntities: ["user"],
+    });
+    await mem.component.store("User prefers dark mode in the editor", {
+      relatedEntities: ["user"],
+    });
+
+    const results = await mem.component.recall("dark mode");
+    expect(results).toHaveLength(1);
+    expect(results[0]?.metadata?.category).toBe("preference");
+  });
+});

--- a/packages/memory-fs/src/fs-memory.ts
+++ b/packages/memory-fs/src/fs-memory.ts
@@ -45,6 +45,7 @@ export async function createFsMemory(config: FsMemoryConfig): Promise<FsMemory> 
     mergeHandler,
     mergeThreshold = DEFAULT_MERGE_THRESHOLD,
     salienceEnabled = true,
+    categoryInferrer,
   } = config;
 
   if (baseDir.length === 0) {
@@ -134,7 +135,22 @@ export async function createFsMemory(config: FsMemoryConfig): Promise<FsMemory> 
   const store = async (content: string, options?: MemoryStoreOptions): Promise<void> => {
     const entity = resolveEntity(options);
     const now = new Date();
-    const category = options?.category ?? "context";
+    // let — reassigned in inferrer fallback path
+    let category = options?.category;
+    if (category === undefined && categoryInferrer !== undefined) {
+      try {
+        const inferred = await categoryInferrer(content);
+        category = inferred.length > 0 ? inferred : "context";
+      } catch (inferErr: unknown) {
+        console.warn(`[memory-fs] Category inferrer failed, falling back to "context"`, {
+          cause: inferErr,
+        });
+        category = "context";
+      }
+    }
+    if (category === undefined) {
+      category = "context";
+    }
 
     const causalParents =
       options?.causalParents !== undefined && options.causalParents.length > 0

--- a/packages/memory-fs/src/index.ts
+++ b/packages/memory-fs/src/index.ts
@@ -1,3 +1,5 @@
+export type { CategoryRule, KeywordCategoryInferrerOptions } from "./category-inferrer.js";
+export { createKeywordCategoryInferrer } from "./category-inferrer.js";
 export { createFsMemory } from "./fs-memory.js";
 export type { MemoryOperation } from "./provider/constants.js";
 export { MEMORY_OPERATIONS } from "./provider/constants.js";
@@ -11,6 +13,7 @@ export { createMemoryStoreTool } from "./provider/tools/store.js";
 export type { UserScopedMemoryProviderConfig } from "./provider/user-scoped-provider.js";
 export { createUserScopedMemoryProvider } from "./provider/user-scoped-provider.js";
 export type {
+  CategoryInferrer,
   FsIndexDoc,
   FsMemory,
   FsMemoryConfig,

--- a/packages/memory-fs/src/types.ts
+++ b/packages/memory-fs/src/types.ts
@@ -55,6 +55,14 @@ export interface FsIndexDoc {
  */
 export type MergeHandler = (existing: string, incoming: string) => Promise<string | undefined>;
 
+/**
+ * Infers a category from fact content when no explicit category is provided.
+ *
+ * May be sync (keyword matching) or async (LLM-backed).
+ * Return a category string; the default fallback is `"context"`.
+ */
+export type CategoryInferrer = (content: string) => string | Promise<string>;
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -76,6 +84,8 @@ export interface FsMemoryConfig {
   readonly mergeThreshold?: number | undefined;
   /** Enable composite salience scoring for recall ranking. Default true. */
   readonly salienceEnabled?: boolean | undefined;
+  /** Infers a category when the caller omits `options.category`. Default: none (falls back to `"context"`). */
+  readonly categoryInferrer?: CategoryInferrer | undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `CategoryInferrer` DI slot to `FsMemoryConfig` — infers category from fact content when `options.category` is omitted
- Ships `createKeywordCategoryInferrer()` with regex rules for 6 categories (decision, error-pattern, preference, correction, milestone, relationship)
- Auto-wired in `@koi/context-arena` when `memoryFs` is configured — zero extra config needed
- Zero LLM cost, zero new dependencies

## What this enables

Without auto-categorization, all uncategorized facts land in `"context"` — a junk drawer that degrades dedup, merge, and contradiction detection (all category-scoped). With this change:

- `"We decided to use Bun"` → auto-categorized as `decision`
- `"Build failed on CI"` → auto-categorized as `error-pattern`
- `"User prefers dark mode"` → auto-categorized as `preference`

Dedup only compares decisions against decisions, errors against errors, etc. Merge and contradiction detection become more precise as memory stores grow past 100+ facts.

## Files changed

| File | Change |
|------|--------|
| `packages/memory-fs/src/types.ts` | `CategoryInferrer` type + DI slot on `FsMemoryConfig` |
| `packages/memory-fs/src/category-inferrer.ts` | New: `createKeywordCategoryInferrer()` factory (~80 LOC) |
| `packages/memory-fs/src/fs-memory.ts` | Wire inferrer into `store()` with try/catch fallback |
| `packages/memory-fs/src/index.ts` | New exports |
| `packages/context-arena/src/arena-factory.ts` | Auto-wire keyword inferrer when memoryFs enabled |
| `docs/L2/memory-fs.md` | Document auto-category inference |
| `packages/memory-fs/src/category-inferrer.test.ts` | 28 unit tests (table-driven) |
| `packages/memory-fs/src/fs-memory-category.test.ts` | 6 integration tests |
| API surface snapshot | Regenerated |

## Anti-leak checklist

- [x] `@koi/core` untouched — zero L0 changes
- [x] `category-inferrer.ts` (L2) imports only from local `./types.js`
- [x] `arena-factory.ts` (L3) imports from L2 — allowed
- [x] All interface properties `readonly`
- [x] No vendor types, no `any`, no `enum`
- [x] All imports use `.js` extensions

## Test plan

- [x] 28 unit tests: all 6 categories, fallback, case insensitivity, ordering, custom rules, custom fallback
- [x] 6 integration tests: infer, explicit override, backward compat, async inferrer, failing inferrer fallback, dedup with inferred category
- [x] 0 regressions in existing 219 tests
- [x] Pre-push hook: full monorepo build + typecheck (44/44 tasks pass)
- [x] Lint clean (Biome)

Closes #563