### PR TITLE
feat: wire sortMiddlewareByPhase and mapTaskStatusToProcessState

### DIFF
--- a/packages/kernel/engine/src/compose.test.ts
+++ b/packages/kernel/engine/src/compose.test.ts
@@ -30,6 +30,7 @@ import {
   injectCapabilities,
   runSessionHooks,
   runTurnHooks,
+  sortMiddlewareByPhase,
 } from "./compose.js";
 
 // ---------------------------------------------------------------------------
@@ -502,6 +503,92 @@ async function createStartedAgent(): Promise<AgentEntity> {
 }
 
 // ---------------------------------------------------------------------------
+// sortMiddlewareByPhase
+// ---------------------------------------------------------------------------
+
+describe("sortMiddlewareByPhase", () => {
+  test("sorts by phase tier: intercept < resolve < observe", () => {
+    const observe: KoiMiddleware = {
+      name: "observe",
+      phase: "observe",
+      describeCapabilities: () => undefined,
+    };
+    const intercept: KoiMiddleware = {
+      name: "intercept",
+      phase: "intercept",
+      describeCapabilities: () => undefined,
+    };
+    const resolve: KoiMiddleware = {
+      name: "resolve",
+      phase: "resolve",
+      describeCapabilities: () => undefined,
+    };
+
+    const sorted = sortMiddlewareByPhase([observe, resolve, intercept]);
+
+    expect(sorted.map((m) => m.name)).toEqual(["intercept", "resolve", "observe"]);
+  });
+
+  test("defaults to resolve phase when phase is omitted", () => {
+    const noPhase: KoiMiddleware = { name: "no-phase", describeCapabilities: () => undefined };
+    const intercept: KoiMiddleware = {
+      name: "intercept",
+      phase: "intercept",
+      describeCapabilities: () => undefined,
+    };
+    const observe: KoiMiddleware = {
+      name: "observe",
+      phase: "observe",
+      describeCapabilities: () => undefined,
+    };
+
+    const sorted = sortMiddlewareByPhase([observe, noPhase, intercept]);
+
+    expect(sorted.map((m) => m.name)).toEqual(["intercept", "no-phase", "observe"]);
+  });
+
+  test("sorts by priority within the same phase tier", () => {
+    const low: KoiMiddleware = {
+      name: "low",
+      phase: "resolve",
+      priority: 100,
+      describeCapabilities: () => undefined,
+    };
+    const high: KoiMiddleware = {
+      name: "high",
+      phase: "resolve",
+      priority: 900,
+      describeCapabilities: () => undefined,
+    };
+    const mid: KoiMiddleware = {
+      name: "mid",
+      phase: "resolve",
+      priority: 500,
+      describeCapabilities: () => undefined,
+    };
+
+    const sorted = sortMiddlewareByPhase([high, low, mid]);
+
+    expect(sorted.map((m) => m.name)).toEqual(["low", "mid", "high"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const a: KoiMiddleware = { name: "a", phase: "observe", describeCapabilities: () => undefined };
+    const b: KoiMiddleware = {
+      name: "b",
+      phase: "intercept",
+      describeCapabilities: () => undefined,
+    };
+    const input = [a, b];
+
+    const sorted = sortMiddlewareByPhase(input);
+
+    expect(input.map((m) => m.name)).toEqual(["a", "b"]);
+    expect(sorted.map((m) => m.name)).toEqual(["b", "a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createTerminalHandlers
 // ---------------------------------------------------------------------------
 
@@ -749,6 +836,58 @@ describe("createComposedCallHandlers", () => {
 
     expect(receivedRequest).toBeDefined();
     expect(receivedRequest?.tools).toEqual(customTools);
+  });
+
+  test("sorts middleware by phase before composing chains", async () => {
+    const agent = await createStartedAgent();
+    const order: string[] = [];
+
+    const observe: KoiMiddleware = {
+      name: "observe",
+      phase: "observe",
+      describeCapabilities: () => undefined,
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("observe");
+        return next(req);
+      },
+    };
+
+    const intercept: KoiMiddleware = {
+      name: "intercept",
+      phase: "intercept",
+      describeCapabilities: () => undefined,
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("intercept");
+        return next(req);
+      },
+    };
+
+    const resolve: KoiMiddleware = {
+      name: "resolve",
+      phase: "resolve",
+      describeCapabilities: () => undefined,
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("resolve");
+        return next(req);
+      },
+    };
+
+    const rawModel = mock(() => Promise.resolve(mockModelResponse()));
+    const rawTool = mock(() => Promise.resolve(mockToolResponse()));
+
+    // Pass middleware in reverse order — compose should sort by phase tier
+    const handlers = createComposedCallHandlers(
+      [observe, resolve, intercept],
+      () => mockTurnContext(),
+      agent,
+      rawModel,
+      rawTool,
+    );
+
+    await handlers.modelCall(mockModelRequest());
+
+    // Onion order: intercept (outer) → resolve (middle) → observe (inner) → terminal
+    expect(order).toEqual(["intercept", "resolve", "observe"]);
   });
 });
 

--- a/packages/kernel/engine/src/compose.ts
+++ b/packages/kernel/engine/src/compose.ts
@@ -424,6 +424,8 @@ export function createComposedCallHandlers(
   rawModelStreamTerminal?: ModelStreamHandler,
   capabilityConfig?: CapabilityInjectionConfig,
 ): ComposedCallHandlers {
+  const sorted = sortMiddlewareByPhase(middleware);
+
   const { modelHandler, modelStreamHandler, toolHandler } = createTerminalHandlers(
     agent,
     rawModelTerminal,
@@ -431,8 +433,8 @@ export function createComposedCallHandlers(
     rawModelStreamTerminal,
   );
 
-  const modelChain = composeModelChain(middleware, modelHandler);
-  const toolChain = composeToolChain(middleware, toolHandler);
+  const modelChain = composeModelChain(sorted, modelHandler);
+  const toolChain = composeToolChain(sorted, toolHandler);
 
   // Extract tool descriptors from the agent's ECS components
   const toolComponents = agent.query<Tool>("tool:");
@@ -447,7 +449,7 @@ export function createComposedCallHandlers(
 
   const prepareRequest = (request: ModelRequest): ModelRequest => {
     const withTools = injectTools(request);
-    return injectCapabilities(middleware, getTurnContext(), withTools, capabilityConfig);
+    return injectCapabilities(sorted, getTurnContext(), withTools, capabilityConfig);
   };
 
   if (modelStreamHandler === undefined) {
@@ -458,7 +460,7 @@ export function createComposedCallHandlers(
     };
   }
 
-  const streamChain = composeModelStreamChain(middleware, modelStreamHandler);
+  const streamChain = composeModelStreamChain(sorted, modelStreamHandler);
 
   return {
     modelCall: (request) => modelChain(getTurnContext(), prepareRequest(request)),

--- a/packages/sched/scheduler/src/__tests__/stats-mapping.test.ts
+++ b/packages/sched/scheduler/src/__tests__/stats-mapping.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for mapSchedulerStatsByProcessState — verifies the TaskStatus → ProcessState
+ * mapping is correctly applied to scheduler stats counts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SchedulerStats } from "@koi/core";
+import { mapSchedulerStatsByProcessState } from "../stats-mapping.js";
+
+function makeStats(overrides?: Partial<SchedulerStats>): SchedulerStats {
+  return {
+    pending: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    deadLettered: 0,
+    activeSchedules: 0,
+    pausedSchedules: 0,
+    ...overrides,
+  };
+}
+
+describe("mapSchedulerStatsByProcessState", () => {
+  test("maps pending tasks to created", () => {
+    const result = mapSchedulerStatsByProcessState(makeStats({ pending: 5 }));
+    expect(result.created).toBe(5);
+    expect(result.running).toBe(0);
+    expect(result.terminated).toBe(0);
+  });
+
+  test("maps running tasks to running", () => {
+    const result = mapSchedulerStatsByProcessState(makeStats({ running: 3 }));
+    expect(result.created).toBe(0);
+    expect(result.running).toBe(3);
+    expect(result.terminated).toBe(0);
+  });
+
+  test("maps completed, failed, and dead_letter to terminated", () => {
+    const result = mapSchedulerStatsByProcessState(
+      makeStats({ completed: 10, failed: 2, deadLettered: 1 }),
+    );
+    expect(result.created).toBe(0);
+    expect(result.running).toBe(0);
+    expect(result.terminated).toBe(13);
+  });
+
+  test("aggregates all statuses correctly", () => {
+    const result = mapSchedulerStatsByProcessState(
+      makeStats({ pending: 3, running: 2, completed: 10, failed: 4, deadLettered: 1 }),
+    );
+    expect(result.created).toBe(3);
+    expect(result.running).toBe(2);
+    expect(result.terminated).toBe(15);
+  });
+
+  test("returns all zeros for empty stats", () => {
+    const result = mapSchedulerStatsByProcessState(makeStats());
+    expect(result.created).toBe(0);
+    expect(result.running).toBe(0);
+    expect(result.terminated).toBe(0);
+  });
+});

--- a/packages/sched/scheduler/src/index.ts
+++ b/packages/sched/scheduler/src/index.ts
@@ -17,3 +17,5 @@ export type { Semaphore } from "./semaphore.js";
 export { createSemaphore } from "./semaphore.js";
 export type { SqliteTaskStore } from "./sqlite-store.js";
 export { createSqliteTaskStore } from "./sqlite-store.js";
+export type { ProcessStateCounts } from "./stats-mapping.js";
+export { mapSchedulerStatsByProcessState } from "./stats-mapping.js";

--- a/packages/sched/scheduler/src/stats-mapping.ts
+++ b/packages/sched/scheduler/src/stats-mapping.ts
@@ -1,0 +1,64 @@
+/**
+ * Maps scheduler stats to ProcessState-grouped counts for unified monitoring.
+ *
+ * Dashboards and monitoring consumers need a single view across both the
+ * agent lifecycle (ProcessState) and the scheduler task lifecycle (TaskStatus).
+ * This module bridges the two using the L0 mapping function.
+ */
+
+import type { ProcessState, SchedulerStats, TaskStatus } from "@koi/core";
+import { mapTaskStatusToProcessState } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProcessStateCounts {
+  readonly created: number;
+  readonly running: number;
+  readonly terminated: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map SchedulerStats (TaskStatus-keyed counts) to ProcessState-keyed counts.
+ *
+ * | TaskStatus  | ProcessState |
+ * |-------------|--------------|
+ * | pending     | created      |
+ * | running     | running      |
+ * | completed   | terminated   |
+ * | failed      | terminated   |
+ * | dead_letter | terminated   |
+ */
+export function mapSchedulerStatsByProcessState(stats: SchedulerStats): ProcessStateCounts {
+  const counts: Record<ProcessState, number> = {
+    created: 0,
+    running: 0,
+    waiting: 0,
+    suspended: 0,
+    terminated: 0,
+  };
+
+  const statusCounts: readonly (readonly [TaskStatus, number])[] = [
+    ["pending", stats.pending],
+    ["running", stats.running],
+    ["completed", stats.completed],
+    ["failed", stats.failed],
+    ["dead_letter", stats.deadLettered],
+  ];
+
+  for (const [status, count] of statusCounts) {
+    const processState = mapTaskStatusToProcessState(status);
+    counts[processState] += count;
+  }
+
+  return {
+    created: counts.created,
+    running: counts.running,
+    terminated: counts.terminated,
+  };
+}


### PR DESCRIPTION
## Summary

Wires two contracts from PR #772 that were defined but had no callers:

- **`sortMiddlewareByPhase()`** — now called in `createComposedCallHandlers` to sort middleware by phase tier (`intercept→resolve→observe`) before composing onion chains. Previously middleware was composed in insertion order regardless of phase.
- **`mapTaskStatusToProcessState()`** — now consumed by new `mapSchedulerStatsByProcessState()` in `@koi/scheduler`, which maps `SchedulerStats` (TaskStatus-keyed counts) to `ProcessState`-keyed counts for unified monitoring dashboards.

## Changes

| File | Change |
|------|--------|
| `packages/kernel/engine/src/compose.ts` | Call `sortMiddlewareByPhase()` in `createComposedCallHandlers` |
| `packages/kernel/engine/src/compose.test.ts` | Add 4 unit tests for `sortMiddlewareByPhase` + 1 integration test for phase ordering through composed handlers |
| `packages/sched/scheduler/src/stats-mapping.ts` | New module: `mapSchedulerStatsByProcessState()` consuming `mapTaskStatusToProcessState` |
| `packages/sched/scheduler/src/index.ts` | Export new `ProcessStateCounts` type and `mapSchedulerStatsByProcessState` function |
| `packages/sched/scheduler/src/__tests__/stats-mapping.test.ts` | 5 tests covering all TaskStatus→ProcessState mappings |

## Test plan

- [x] `bun test packages/kernel/engine/src/compose.test.ts` — 76 tests pass (72 existing + 4 sort + 1 integration)
- [x] `bun test packages/sched/scheduler/src/__tests__/stats-mapping.test.ts` — 5 tests pass
- [x] `turbo run typecheck --filter=@koi/engine --filter=@koi/scheduler` — all green
- [x] Pre-push hook passes (full typecheck + build for affected packages)