### PR TITLE
feat: idle ProcessState and reuse flag for persistent copilots

### DIFF
--- a/docs/engine/idle-reuse.md
+++ b/docs/engine/idle-reuse.md
@@ -1,0 +1,157 @@
+# Idle State & Copilot Reuse
+
+Persistent copilots that survive between tasks via the `"idle"` ProcessState.
+
+**Layer**: L0 (`@koi/core`) types + L1 (`@koi/engine`) runtime
+**Files**: `core/src/ecs.ts`, `core/src/lifecycle.ts`, `core/src/assembly.ts`, `engine/src/koi.ts`
+**Issue**: [#687](https://github.com/windoliver/koi/issues/687)
+
+---
+
+## Overview
+
+Agents are normally ephemeral: task completes, agent terminates, runtime disposes.
+The idle-reuse feature lets a copilot **stay alive between tasks**, automatically
+sleeping when idle and waking when new messages arrive in its inbox.
+
+```
+created → running → idle → running → idle → ... → terminated
+              ↑        ↓       ↑
+              task 1   sleep   task 2 (no cold start)
+```
+
+One manifest flag enables it:
+
+```yaml
+name: my-copilot
+lifecycle: copilot    # survives parent death
+reuse: true           # go idle instead of terminating
+model:
+  name: claude-sonnet
+```
+
+## What This Enables
+
+- **Persistent copilots** — a copilot forged at runtime (`forge_agent`) keeps its
+  full context, middleware state, and forged tools across tasks without
+  serialization or cold-start latency.
+- **HITL workflows** — the copilot stays alive while waiting for human approval,
+  review, or follow-up instead of dying and respawning.
+- **Inbox-driven wake** — external systems push messages to the copilot's inbox;
+  the engine automatically wakes and processes them.
+- **Compose with long-running harness** — the idle state integrates with
+  `@koi/long-running` and `@koi/harness-scheduler` for multi-session lifecycle,
+  suspension, and checkpoint support.
+
+## ProcessState: "idle"
+
+Added to the `ProcessState` union in `@koi/core`:
+
+```
+ProcessState = "created" | "running" | "waiting" | "suspended" | "idle" | "terminated"
+```
+
+### Valid Transitions
+
+```
+running  → idle         (task_completed_idle)
+idle     → running      (inbox_wake)
+idle     → terminated   (any termination reason)
+```
+
+Invalid transitions from idle: `idle → waiting`, `idle → suspended`, `idle → created`.
+
+### TransitionReasons
+
+| Reason | Transition | Description |
+|--------|-----------|-------------|
+| `task_completed_idle` | running → idle | Task finished, agent staying alive |
+| `inbox_wake` | idle → running | New inbox message triggered wake |
+
+Both return exit code 0 (not errors).
+
+## Engine Behavior (`koi.ts`)
+
+When `manifest.reuse === true` and a task completes normally (`stopReason === "completed"`):
+
+1. **Don't terminate** — skip the `{ kind: "complete" }` transition
+2. **Transition to idle** — `agent.transition({ kind: "idle" })`
+3. **Poll inbox** — check `inbox.depth() > 0` every 1 second
+4. **Wake on message** — when inbox has items, transition back to running
+5. **Restart adapter** — create a new adapter stream, drain inbox at turn boundary
+6. **Repeat** — the reuse loop continues until abort or error
+
+Errors, timeouts, and `max_turns` always terminate — only normal completion triggers idle.
+
+```
+streamEvents() generator:
+  try {
+    session init
+    reuseLoop: while (true) {        ← NEW: outer loop
+      adapter = stream(input)
+      turnLoop: while (true) {       ← existing turn loop
+        suspension check
+        inbox drain
+        event processing
+        if (done && reuse) → break turnLoop → enter idle wait
+        if (done && !reuse) → transition(complete) → return
+      }
+      // Idle wait
+      transition(idle)
+      poll inbox every 1s (unref'd timer)
+      also watch registry for external wake
+      transition(resume)
+      continue reuseLoop               ← restart with new adapter
+    }
+  } finally {
+    cleanup (handles both running and idle states)
+  }
+```
+
+### Performance
+
+- **Idle polling**: `setInterval` at 1s with `.unref()` — does not keep the
+  process alive. The `depth()` check is O(1).
+- **Registry watch**: event-driven (zero polling). Fires on any registry
+  transition targeting this agent.
+- **No busy-wait**: the idle Promise parks the generator. CPU cost is near-zero.
+- **Cleanup**: timer and registry subscription are cleaned up on wake or abort.
+
+### ChildLifecycleEvents
+
+Parent agents observe copilot idle/wake via `ChildHandle`:
+
+```typescript
+childHandle.onEvent((event) => {
+  event.kind === "idled"  // copilot went idle
+  event.kind === "woke"   // copilot resumed
+});
+```
+
+## Manifest Configuration
+
+```typescript
+interface AgentManifest {
+  // ... existing fields ...
+  readonly lifecycle?: "copilot" | "worker" | undefined;
+  readonly reuse?: boolean | undefined;
+}
+```
+
+| Field | Value | Effect |
+|-------|-------|--------|
+| `lifecycle` | `"copilot"` | Survives parent death (existing) |
+| `reuse` | `true` | Goes idle after task instead of terminating (new) |
+
+Both flags together create a persistent copilot. `reuse` without `lifecycle: "copilot"`
+creates a reusable worker (still terminated by parent cascade).
+
+## Comparison with OpenClaw
+
+| Aspect | Koi (idle-reuse) | OpenClaw (Heartbeat) |
+|--------|-----------------|---------------------|
+| Between tasks | Process alive, state in memory | Process dead, state on filesystem |
+| Wake trigger | Inbox push (< 1s latency) | Cron job (default 30min) |
+| Context | Hot — runtime, tools, middleware preserved | Cold — reload from disk each time |
+| Cost while idle | Near-zero (unref'd timer) | Zero (no process) |
+| Trade-off | Memory usage | Cold-start latency |

--- a/packages/fs/registry-nexus/src/state-mapping.ts
+++ b/packages/fs/registry-nexus/src/state-mapping.ts
@@ -23,6 +23,7 @@ const KOI_TO_NEXUS: Readonly<Record<ProcessState, string>> = Object.freeze({
   running: "CONNECTED",
   waiting: "IDLE",
   suspended: "SUSPENDED",
+  idle: "IDLE",
   terminated: "SUSPENDED",
 });
 

--- a/packages/ipc/ipc-nexus/src/tools/discover.ts
+++ b/packages/ipc/ipc-nexus/src/tools/discover.ts
@@ -36,7 +36,7 @@ export function createDiscoverTool(
           phase: {
             type: "string",
             description:
-              "Filter by process state: created, running, waiting, suspended, or terminated. Defaults to running.",
+              "Filter by process state: created, running, waiting, suspended, idle, or terminated. Defaults to running.",
           },
         },
         required: [],
@@ -59,7 +59,7 @@ export function createDiscoverTool(
 
       if (rawPhase !== undefined && (typeof rawPhase !== "string" || !isProcessState(rawPhase))) {
         return {
-          error: `Invalid phase: ${String(rawPhase)}. Must be one of: created, running, waiting, suspended, terminated`,
+          error: `Invalid phase: ${String(rawPhase)}. Must be one of: created, running, waiting, suspended, idle, terminated`,
           code: "VALIDATION",
         };
       }

--- a/packages/kernel/core/src/__tests__/backward-compat.test.ts
+++ b/packages/kernel/core/src/__tests__/backward-compat.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_SCHEDULER_CONFIG,
   DELEGATION,
   EVENTS,
+  exitCodeForTransitionReason,
   external,
   FILESYSTEM,
   GOVERNANCE,
@@ -80,8 +81,8 @@ describe("RETRYABLE_DEFAULTS backward compatibility", () => {
 // ---------------------------------------------------------------------------
 
 describe("VALID_TRANSITIONS backward compatibility", () => {
-  test("all 5 process states exist", () => {
-    const states = ["created", "running", "waiting", "suspended", "terminated"] as const;
+  test("all 6 process states exist", () => {
+    const states = ["created", "running", "waiting", "suspended", "idle", "terminated"] as const;
     for (const state of states) {
       expect(VALID_TRANSITIONS).toHaveProperty(state);
     }
@@ -92,9 +93,10 @@ describe("VALID_TRANSITIONS backward compatibility", () => {
     expect(VALID_TRANSITIONS.created).toContain("terminated");
   });
 
-  test("running can transition to waiting, suspended, and terminated", () => {
+  test("running can transition to waiting, suspended, idle, and terminated", () => {
     expect(VALID_TRANSITIONS.running).toContain("waiting");
     expect(VALID_TRANSITIONS.running).toContain("suspended");
+    expect(VALID_TRANSITIONS.running).toContain("idle");
     expect(VALID_TRANSITIONS.running).toContain("terminated");
   });
 
@@ -107,6 +109,11 @@ describe("VALID_TRANSITIONS backward compatibility", () => {
   test("suspended can transition to running and terminated", () => {
     expect(VALID_TRANSITIONS.suspended).toContain("running");
     expect(VALID_TRANSITIONS.suspended).toContain("terminated");
+  });
+
+  test("idle can transition to running and terminated", () => {
+    expect(VALID_TRANSITIONS.idle).toContain("running");
+    expect(VALID_TRANSITIONS.idle).toContain("terminated");
   });
 
   test("terminated has no transitions", () => {
@@ -300,5 +307,19 @@ describe("ID factory backward compatibility", () => {
   test("scheduleId returns branded string", () => {
     const id = scheduleId("sch-1");
     expect(id as string).toBe("sch-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TransitionReason idle variants
+// ---------------------------------------------------------------------------
+
+describe("TransitionReason idle variants backward compatibility", () => {
+  test("task_completed_idle maps to exit code 0", () => {
+    expect(exitCodeForTransitionReason({ kind: "task_completed_idle" })).toBe(0);
+  });
+
+  test("inbox_wake maps to exit code 0", () => {
+    expect(exitCodeForTransitionReason({ kind: "inbox_wake" })).toBe(0);
   });
 });

--- a/packages/kernel/core/src/assembly.ts
+++ b/packages/kernel/core/src/assembly.ts
@@ -154,4 +154,10 @@ export interface AgentManifest {
    * Capabilities are identified by `capability:<name>` tags on brick artifacts.
    */
   readonly degeneracy?: Readonly<Record<string, DegeneracyConfig>> | undefined;
+  /**
+   * When true, the agent transitions to "idle" after task completion instead
+   * of terminating, enabling reuse via the agent pool. Scheduler-triggered
+   * tasks always pool regardless of this flag.
+   */
+  readonly reuse?: boolean | undefined;
 }

--- a/packages/kernel/core/src/ecs.ts
+++ b/packages/kernel/core/src/ecs.ts
@@ -165,7 +165,7 @@ export function toolCallId(id: string): ToolCallId {
 // Process identity
 // ---------------------------------------------------------------------------
 
-export type ProcessState = "created" | "running" | "waiting" | "suspended" | "terminated";
+export type ProcessState = "created" | "running" | "waiting" | "suspended" | "idle" | "terminated";
 
 export interface ProcessId {
   readonly id: AgentId;
@@ -504,6 +504,8 @@ export type ChildLifecycleEvent =
   | { readonly kind: "completed"; readonly childId: AgentId; readonly exitCode: number }
   | { readonly kind: "error"; readonly childId: AgentId; readonly cause?: unknown }
   | { readonly kind: "signaled"; readonly childId: AgentId; readonly signal: string }
+  | { readonly kind: "idled"; readonly childId: AgentId }
+  | { readonly kind: "woke"; readonly childId: AgentId }
   | { readonly kind: "terminated"; readonly childId: AgentId; readonly exitCode: number };
 
 /** Handle for monitoring and controlling a child agent's lifecycle. */

--- a/packages/kernel/core/src/lifecycle.ts
+++ b/packages/kernel/core/src/lifecycle.ts
@@ -58,7 +58,11 @@ export type TransitionReason =
   /** Agent received a STOP signal → transitioning to "suspended". */
   | { readonly kind: "signal_stop" }
   /** Agent received a CONT signal → transitioning from "suspended" to "running". */
-  | { readonly kind: "signal_cont" };
+  | { readonly kind: "signal_cont" }
+  /** Task completed, agent staying alive in idle pool (running → idle). */
+  | { readonly kind: "task_completed_idle" }
+  /** New message received in idle agent's inbox (idle → running). */
+  | { readonly kind: "inbox_wake" };
 
 // ---------------------------------------------------------------------------
 // Valid state transitions (architecture-doc invariants)
@@ -71,17 +75,19 @@ export type TransitionReason =
  *
  * Transitions:
  *   created → running, terminated
- *   running → waiting, suspended, terminated
+ *   running → waiting, suspended, idle, terminated
  *   waiting → running, suspended, terminated
  *   suspended → running, terminated
+ *   idle → running, terminated
  *   terminated → (none)
  */
 export const VALID_TRANSITIONS: Readonly<Record<ProcessState, readonly ProcessState[]>> =
   Object.freeze({
     created: ["running", "terminated"] as const,
-    running: ["waiting", "suspended", "terminated"] as const,
+    running: ["waiting", "suspended", "idle", "terminated"] as const,
     waiting: ["running", "suspended", "terminated"] as const,
     suspended: ["running", "terminated"] as const,
+    idle: ["running", "terminated"] as const,
     terminated: [] as const,
   });
 
@@ -251,6 +257,8 @@ export function exitCodeForTransitionReason(reason: TransitionReason): number {
     case "completed":
     case "signal_stop":
     case "signal_cont":
+    case "task_completed_idle":
+    case "inbox_wake":
       return 0;
     case "error":
       return 1;

--- a/packages/kernel/core/src/validation-utils.test.ts
+++ b/packages/kernel/core/src/validation-utils.test.ts
@@ -3,7 +3,7 @@ import { isProcessState, validateNonEmpty } from "./validation-utils.js";
 
 describe("isProcessState", () => {
   test("returns true for all valid process states", () => {
-    for (const state of ["created", "running", "waiting", "suspended", "terminated"]) {
+    for (const state of ["created", "running", "waiting", "suspended", "idle", "terminated"]) {
       expect(isProcessState(state)).toBe(true);
     }
   });

--- a/packages/kernel/core/src/validation-utils.ts
+++ b/packages/kernel/core/src/validation-utils.ts
@@ -18,6 +18,7 @@ const VALID_PROCESS_STATES: ReadonlySet<string> = new Set<ProcessState>([
   "running",
   "waiting",
   "suspended",
+  "idle",
   "terminated",
 ]);
 

--- a/packages/kernel/engine/src/__tests__/transitions.test.ts
+++ b/packages/kernel/engine/src/__tests__/transitions.test.ts
@@ -106,6 +106,43 @@ describe("validateTransition", () => {
     expect(result.ok).toBe(true);
   });
 
+  // --- Idle transitions ---
+
+  test("running → idle is valid", () => {
+    const result = validateTransition("running", "idle");
+    expect(result.ok).toBe(true);
+  });
+
+  test("idle → running is valid", () => {
+    const result = validateTransition("idle", "running");
+    expect(result.ok).toBe(true);
+  });
+
+  test("idle → terminated is valid", () => {
+    const result = validateTransition("idle", "terminated");
+    expect(result.ok).toBe(true);
+  });
+
+  test("idle → waiting is invalid", () => {
+    const result = validateTransition("idle", "waiting");
+    expect(result.ok).toBe(false);
+  });
+
+  test("idle → suspended is invalid", () => {
+    const result = validateTransition("idle", "suspended");
+    expect(result.ok).toBe(false);
+  });
+
+  test("idle → created is invalid", () => {
+    const result = validateTransition("idle", "created");
+    expect(result.ok).toBe(false);
+  });
+
+  test("created → idle is invalid", () => {
+    const result = validateTransition("created", "idle");
+    expect(result.ok).toBe(false);
+  });
+
   // --- Edge: verify all transitions in VALID_TRANSITIONS are accepted ---
 
   test("all valid transitions from architecture doc are accepted", () => {
@@ -221,6 +258,34 @@ describe("applyTransition", () => {
     applyTransition(original, input("created", "running", 0, { kind: "assembly_complete" }));
 
     expect(original).toEqual(originalCopy);
+  });
+
+  // --- Idle transition increments generation ---
+
+  test("running → idle increments generation", () => {
+    const result = applyTransition(
+      { phase: "running", generation: 2, conditions: [], lastTransitionAt: 0 },
+      input("running", "idle", 2, { kind: "task_completed_idle" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.phase).toBe("idle");
+      expect(result.value.generation).toBe(3);
+      expect(result.value.reason).toEqual({ kind: "task_completed_idle" });
+    }
+  });
+
+  test("idle → running increments generation", () => {
+    const result = applyTransition(
+      { phase: "idle", generation: 3, conditions: [], lastTransitionAt: 0 },
+      input("idle", "running", 3, { kind: "inbox_wake" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.phase).toBe("running");
+      expect(result.value.generation).toBe(4);
+      expect(result.value.reason).toEqual({ kind: "inbox_wake" });
+    }
   });
 
   // --- Multiple sequential transitions ---

--- a/packages/kernel/engine/src/child-handle.test.ts
+++ b/packages/kernel/engine/src/child-handle.test.ts
@@ -158,6 +158,38 @@ describe("createChildHandle", () => {
     expect(events).toHaveLength(2); // still 2, not 3
   });
 
+  test("fires idled event on running → idle", () => {
+    registry.register(entry("child-1", "running", 0));
+
+    const handle = createChildHandle(agentId("child-1"), "worker-1", registry);
+    const events: ChildLifecycleEvent[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    registry.transition(agentId("child-1"), "idle", 0, { kind: "task_completed_idle" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("idled");
+    expect(events[0]?.childId).toBe(agentId("child-1"));
+  });
+
+  test("fires woke event on idle → running", () => {
+    registry.register(entry("child-1", "running", 0));
+
+    const handle = createChildHandle(agentId("child-1"), "worker-1", registry);
+    const events: ChildLifecycleEvent[] = [];
+    handle.onEvent((e) => events.push(e));
+
+    // running → idle
+    registry.transition(agentId("child-1"), "idle", 0, { kind: "task_completed_idle" });
+    // idle → running
+    registry.transition(agentId("child-1"), "running", 1, { kind: "inbox_wake" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe("idled");
+    expect(events[1]?.kind).toBe("woke");
+    expect(events[1]?.childId).toBe(agentId("child-1"));
+  });
+
   test("multiple listeners receive events", () => {
     registry.register(entry("child-1", "created", 0));
 

--- a/packages/kernel/engine/src/child-handle.ts
+++ b/packages/kernel/engine/src/child-handle.ts
@@ -60,6 +60,16 @@ export function createChildHandle(
         notify({ kind: "started", childId });
       }
 
+      // running → idle = idled
+      if (event.from === "running" && event.to === "idle") {
+        notify({ kind: "idled", childId });
+      }
+
+      // idle → running = woke
+      if (event.from === "idle" && event.to === "running") {
+        notify({ kind: "woke", childId });
+      }
+
       // Any transition to terminated — map reason to completed/error/terminated
       if (event.to === "terminated") {
         const exitCode = exitCodeForTransitionReason(event.reason);

--- a/packages/kernel/engine/src/extension-composer.ts
+++ b/packages/kernel/engine/src/extension-composer.ts
@@ -33,11 +33,14 @@ const SIGNIFICANT_TRANSITIONS: ReadonlySet<string> = new Set([
   "created→running",
   "created→terminated",
   "running→suspended",
+  "running→idle",
   "running→terminated",
   "waiting→suspended",
   "waiting→terminated",
   "suspended→running",
   "suspended→terminated",
+  "idle→running",
+  "idle→terminated",
 ]);
 
 /** Check if a transition is significant (should invoke validators). O(1) set lookup. */

--- a/packages/kernel/engine/src/koi.ts
+++ b/packages/kernel/engine/src/koi.ts
@@ -77,6 +77,13 @@ function generatePid(
   };
 }
 
+/** Call .unref() on a timer if available (Bun Timer). Prevents idle timer from keeping process alive. */
+function unrefTimer(timer: ReturnType<typeof setInterval>): void {
+  if (timer !== null && typeof timer === "object" && "unref" in timer) {
+    (timer as { readonly unref: () => void }).unref();
+  }
+}
+
 /** Sort middleware by priority (ascending). Guards get low numbers, L2 middleware gets higher. */
 function sortByPriority(middleware: readonly KoiMiddleware[]): readonly KoiMiddleware[] {
   return [...middleware].sort((a, b) => (a.priority ?? 500) - (b.priority ?? 500));
@@ -451,139 +458,264 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
         effectiveInput = { ...input, callHandlers, signal: runSignal };
       }
 
-      adapterIterator = adapter.stream(effectiveInput)[Symbol.asyncIterator]();
+      // --- Reuse loop: wraps the main event loop for idle-wake cycling ---
+      // When manifest.reuse is true, the agent transitions to idle after task
+      // completion and waits for inbox messages before restarting.
+      // let justified: mutable flag for idle-wake flow control
+      let enterIdle = false;
 
-      // --- Main event loop ---
       while (true) {
-        // Turn-boundary suspension: if the agent is suspended, park here
-        // until the registry signals a resume (reactive Promise, zero polling).
-        if (options.registry !== undefined) {
-          const registryEntry = await options.registry.lookup(pid.id);
-          if (registryEntry?.status.phase === "suspended") {
-            await new Promise<void>((resolve) => {
-              // let justified: mutable ref to unsubscribe the suspension watcher
-              let unsub: (() => void) | undefined;
-              unsub = options.registry?.watch((watchEvent) => {
-                if (
-                  watchEvent.kind === "transitioned" &&
-                  watchEvent.agentId === pid.id &&
-                  watchEvent.to === "running"
-                ) {
-                  unsub?.();
-                  unsub = undefined;
-                  resolve();
-                }
-              });
-            });
-          }
-        }
+        adapterIterator = adapter.stream(effectiveInput)[Symbol.asyncIterator]();
+        enterIdle = false;
 
-        // Inbox drain: process queued messages at turn boundary.
-        // Steer items → adapter.inject() if available; fallback to followup.
-        // Collect/followup items accumulate for next turn context.
-        const inboxComponent: InboxComponent | undefined = agent.component(INBOX);
-        if (inboxComponent !== undefined && inboxComponent.depth() > 0) {
-          const inboxItems: readonly InboxItem[] = inboxComponent.drain();
-          for (const item of inboxItems) {
-            if (item.mode === "steer" && adapter.inject !== undefined) {
-              await adapter.inject({
-                senderId: item.from,
-                content: [{ kind: "text", text: item.content }],
-                timestamp: item.createdAt,
+        // --- Main event loop ---
+        turnLoop: while (true) {
+          // Turn-boundary suspension: if the agent is suspended, park here
+          // until the registry signals a resume (reactive Promise, zero polling).
+          if (options.registry !== undefined) {
+            const registryEntry = await options.registry.lookup(pid.id);
+            if (registryEntry?.status.phase === "suspended") {
+              await new Promise<void>((resolve) => {
+                // let justified: mutable ref to unsubscribe the suspension watcher
+                let unsub: (() => void) | undefined;
+                unsub = options.registry?.watch((watchEvent) => {
+                  if (
+                    watchEvent.kind === "transitioned" &&
+                    watchEvent.agentId === pid.id &&
+                    watchEvent.to === "running"
+                  ) {
+                    unsub?.();
+                    unsub = undefined;
+                    resolve();
+                  }
+                });
               });
             }
-            // collect/followup items: no immediate action needed here —
-            // middleware (e.g., inbox-middleware in L2) will route them
-            // into the next turn's context during onBeforeTurn hooks.
           }
-        }
 
-        // Deferred forge refresh: runs AFTER consumer processed turn_end,
-        // so tools/middleware injected between turns take effect next turn
-        if (pendingForgeRefresh) {
-          pendingForgeRefresh = false;
-          // Skip refresh if watch is active and nothing changed since last notification
-          const shouldRefresh = forge?.watch === undefined || forgeStateDirty;
-          if (shouldRefresh && forge !== undefined && cachedTerminals !== undefined) {
-            forgeStateDirty = false;
-            await refreshForgeState(cachedTerminals);
-          }
-        }
-
-        // Dynamic middleware refresh (e.g., debug-attach hot-wiring)
-        if (options.dynamicMiddleware !== undefined && cachedTerminals !== undefined) {
-          const dynamicMw = options.dynamicMiddleware();
-          if (dynamicMw !== previousDynamicMw) {
-            previousDynamicMw = dynamicMw;
-            const allMw = sortByPriority([
-              ...allMiddleware,
-              ...(previousForgedMw ?? []),
-              ...(dynamicMw ?? []),
-            ]);
-            activeToolChain = composeToolChain(allMw, cachedTerminals.toolHandler);
-            activeModelChain = composeModelChain(allMw, cachedTerminals.modelHandler);
-            if (cachedTerminals.modelStreamHandler !== undefined) {
-              activeStreamChain = composeModelStreamChain(
-                allMw,
-                cachedTerminals.modelStreamHandler,
-              );
+          // Inbox drain: process queued messages at turn boundary.
+          // Steer items → adapter.inject() if available; fallback to followup.
+          // Collect/followup items accumulate for next turn context.
+          const inboxComponent: InboxComponent | undefined = agent.component(INBOX);
+          if (inboxComponent !== undefined && inboxComponent.depth() > 0) {
+            const inboxItems: readonly InboxItem[] = inboxComponent.drain();
+            for (const item of inboxItems) {
+              if (item.mode === "steer" && adapter.inject !== undefined) {
+                await adapter.inject({
+                  senderId: item.from,
+                  content: [{ kind: "text", text: item.content }],
+                  timestamp: item.createdAt,
+                });
+              }
+              // collect/followup items: no immediate action needed here —
+              // middleware (e.g., inbox-middleware in L2) will route them
+              // into the next turn's context during onBeforeTurn hooks.
             }
           }
-        }
 
-        // Emit turn_start event with onBeforeTurn hooks
-        const turnCtx = createTurnContext({
-          session: sessionCtx,
-          turnIndex: currentTurnIndex,
-          messages: input.kind === "messages" ? input.messages : [],
-          signal: runSignal,
-          approvalHandler: options.approvalHandler,
-          sendStatus: options.sendStatus,
-        });
-        await runTurnHooks(allMiddleware, "onBeforeTurn", turnCtx);
-        yield { kind: "turn_start", turnIndex: currentTurnIndex } as EngineEvent;
-
-        // Process adapter events for this turn
-        while (true) {
-          const result = await adapterIterator.next();
-
-          if (result.done) {
-            // Adapter stream exhausted
-            agent.transition({ kind: "complete", stopReason: "completed" });
-            return;
-          }
-
-          const event = result.value;
-
-          if (event.kind === "turn_end") {
-            currentTurnIndex = event.turnIndex + 1;
-            pendingForgeRefresh = true;
-            const turnEndCtx = createTurnContext({
-              session: sessionCtx,
-              turnIndex: event.turnIndex,
-              messages: [],
-              signal: runSignal,
-              approvalHandler: options.approvalHandler,
-              sendStatus: options.sendStatus,
-            });
-            await runTurnHooks(allMiddleware, "onAfterTurn", turnEndCtx);
-            yield event;
-            break; // → next turn in outer loop
-          }
-
-          if (event.kind === "done") {
+          // Deferred forge refresh: runs AFTER consumer processed turn_end,
+          // so tools/middleware injected between turns take effect next turn
+          if (pendingForgeRefresh) {
             pendingForgeRefresh = false;
-            agent.transition({
-              kind: "complete",
-              stopReason: event.output.stopReason,
-              metrics: event.output.metrics,
-            });
+            // Skip refresh if watch is active and nothing changed since last notification
+            const shouldRefresh = forge?.watch === undefined || forgeStateDirty;
+            if (shouldRefresh && forge !== undefined && cachedTerminals !== undefined) {
+              forgeStateDirty = false;
+              await refreshForgeState(cachedTerminals);
+            }
+          }
+
+          // Dynamic middleware refresh (e.g., debug-attach hot-wiring)
+          if (options.dynamicMiddleware !== undefined && cachedTerminals !== undefined) {
+            const dynamicMw = options.dynamicMiddleware();
+            if (dynamicMw !== previousDynamicMw) {
+              previousDynamicMw = dynamicMw;
+              const allMw = sortByPriority([
+                ...allMiddleware,
+                ...(previousForgedMw ?? []),
+                ...(dynamicMw ?? []),
+              ]);
+              activeToolChain = composeToolChain(allMw, cachedTerminals.toolHandler);
+              activeModelChain = composeModelChain(allMw, cachedTerminals.modelHandler);
+              if (cachedTerminals.modelStreamHandler !== undefined) {
+                activeStreamChain = composeModelStreamChain(
+                  allMw,
+                  cachedTerminals.modelStreamHandler,
+                );
+              }
+            }
+          }
+
+          // Emit turn_start event with onBeforeTurn hooks
+          const turnCtx = createTurnContext({
+            session: sessionCtx,
+            turnIndex: currentTurnIndex,
+            messages: input.kind === "messages" ? input.messages : [],
+            signal: runSignal,
+            approvalHandler: options.approvalHandler,
+            sendStatus: options.sendStatus,
+          });
+          await runTurnHooks(allMiddleware, "onBeforeTurn", turnCtx);
+          yield { kind: "turn_start", turnIndex: currentTurnIndex } as EngineEvent;
+
+          // Process adapter events for this turn
+          while (true) {
+            const result = await adapterIterator.next();
+
+            if (result.done) {
+              // Adapter stream exhausted — idle if reusable, else terminate
+              if (agent.manifest.reuse === true) {
+                enterIdle = true;
+                break turnLoop;
+              }
+              agent.transition({ kind: "complete", stopReason: "completed" });
+              return;
+            }
+
+            const event = result.value;
+
+            if (event.kind === "turn_end") {
+              currentTurnIndex = event.turnIndex + 1;
+              pendingForgeRefresh = true;
+              const turnEndCtx = createTurnContext({
+                session: sessionCtx,
+                turnIndex: event.turnIndex,
+                messages: [],
+                signal: runSignal,
+                approvalHandler: options.approvalHandler,
+                sendStatus: options.sendStatus,
+              });
+              await runTurnHooks(allMiddleware, "onAfterTurn", turnEndCtx);
+              yield event;
+              break; // → next turn in outer loop
+            }
+
+            if (event.kind === "done") {
+              // Idle on normal completion if reusable; errors/timeouts always terminate
+              if (agent.manifest.reuse === true && event.output.stopReason === "completed") {
+                enterIdle = true;
+                yield event;
+                break turnLoop;
+              }
+              pendingForgeRefresh = false;
+              agent.transition({
+                kind: "complete",
+                stopReason: event.output.stopReason,
+                metrics: event.output.metrics,
+              });
+              yield event;
+              return;
+            }
+
             yield event;
+          }
+        }
+
+        // --- Idle-wake: park until inbox has items, then restart ---
+        if (!enterIdle) break;
+
+        // Clean up exhausted adapter iterator before idling
+        if (adapterIterator?.return !== undefined) {
+          try {
+            await adapterIterator.return();
+          } catch (_cleanupError: unknown) {
+            // Adapter cleanup failure during idle transition is non-fatal
+          }
+          adapterIterator = undefined;
+        }
+
+        agent.transition({ kind: "idle" });
+
+        // Update registry so external observers see the idle state
+        if (options.registry !== undefined) {
+          const entry = await options.registry.lookup(pid.id);
+          if (entry !== undefined && entry.status.phase !== "idle") {
+            await options.registry.transition(pid.id, "idle", entry.status.generation, {
+              kind: "task_completed_idle",
+            });
+          }
+        }
+
+        // Wait for inbox messages, abort signal, or external registry wake
+        const idleInbox: InboxComponent | undefined = agent.component(INBOX);
+        await new Promise<void>((resolve) => {
+          // Fast path: inbox already has items (pushed during final turn)
+          if (idleInbox !== undefined && idleInbox.depth() > 0) {
+            resolve();
+            return;
+          }
+          // Fast path: already aborted
+          if (runSignal.aborted) {
+            resolve();
             return;
           }
 
-          yield event;
+          // let justified: mutable timer ref for idle polling
+          let timer: ReturnType<typeof setInterval> | undefined;
+          // let justified: mutable unsubscribe ref for registry watcher
+          let unsub: (() => void) | undefined;
+
+          const cleanup = (): void => {
+            if (timer !== undefined) {
+              clearInterval(timer);
+              timer = undefined;
+            }
+            if (unsub !== undefined) {
+              unsub();
+              unsub = undefined;
+            }
+            runSignal.removeEventListener("abort", onIdleAbort);
+          };
+
+          const onIdleAbort = (): void => {
+            cleanup();
+            resolve();
+          };
+
+          // Abort signal — resolve immediately so finally block can terminate
+          runSignal.addEventListener("abort", onIdleAbort, { once: true });
+
+          // Poll inbox every 1s — unref'd so it doesn't keep the process alive
+          timer = setInterval(() => {
+            if (idleInbox !== undefined && idleInbox.depth() > 0) {
+              cleanup();
+              resolve();
+            }
+          }, 1_000);
+          // Bun's setInterval returns a Timer with .unref() — prevent keeping process alive
+          unrefTimer(timer);
+
+          // Also watch for external wake via registry (e.g., inbox push + registry transition)
+          if (options.registry !== undefined) {
+            unsub = options.registry.watch((watchEvent) => {
+              if (
+                watchEvent.kind === "transitioned" &&
+                watchEvent.agentId === pid.id &&
+                watchEvent.to === "running"
+              ) {
+                cleanup();
+                resolve();
+              }
+            });
+          }
+        });
+
+        // If aborted while idle, exit the reuse loop — finally block handles cleanup
+        if (runSignal.aborted) break;
+
+        // Resume from idle
+        agent.transition({ kind: "resume" });
+
+        // Update registry back to running
+        if (options.registry !== undefined) {
+          const entry = await options.registry.lookup(pid.id);
+          if (entry !== undefined && entry.status.phase === "idle") {
+            await options.registry.transition(pid.id, "running", entry.status.generation, {
+              kind: "inbox_wake",
+            });
+          }
         }
+        // Continue reuseLoop → creates new adapter stream, drains inbox at turn boundary
       }
     } catch (error: unknown) {
       // Guard error → convert to a done event
@@ -625,8 +757,8 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
         }
       }
 
-      // Transition agent if not already terminated (e.g., consumer break / return)
-      if (agent.state === "running") {
+      // Transition agent if not already terminated (e.g., consumer break / return / abort)
+      if (agent.state === "running" || agent.state === "idle") {
         agent.transition({ kind: "complete", stopReason: "interrupted" });
       }
 

--- a/packages/kernel/engine/src/lifecycle.ts
+++ b/packages/kernel/engine/src/lifecycle.ts
@@ -1,7 +1,7 @@
 /**
  * Agent lifecycle state machine — pure transition function.
  *
- * States: created → running → waiting → suspended → terminated
+ * States: created → running → waiting → suspended → idle → terminated
  * All transitions are pure: transition(current, event) → new state.
  * The terminated state is absorbing — no transitions out.
  */
@@ -21,6 +21,7 @@ export type AgentLifecycle =
       readonly suspendedAt: number;
       readonly reason: string;
     }
+  | { readonly state: "idle"; readonly idledAt: number }
   | {
       readonly state: "terminated";
       readonly stopReason: EngineStopReason;
@@ -39,6 +40,7 @@ export type LifecycleEvent =
   | { readonly kind: "wait"; readonly reason: WaitReason }
   | { readonly kind: "resume" }
   | { readonly kind: "suspend"; readonly reason: string }
+  | { readonly kind: "idle" }
   | {
       readonly kind: "complete";
       readonly stopReason: EngineStopReason;
@@ -94,6 +96,8 @@ export function transition(
           return { state: "waiting", reason: event.reason, since: now };
         case "suspend":
           return { state: "suspended", suspendedAt: now, reason: event.reason };
+        case "idle":
+          return { state: "idle", idledAt: now };
         case "complete":
           return terminated(event.stopReason, now, event.metrics);
         case "error":
@@ -119,6 +123,19 @@ export function transition(
     }
 
     case "suspended": {
+      switch (event.kind) {
+        case "resume":
+          return { state: "running", startedAt: now, turnIndex: 0 };
+        case "complete":
+          return terminated(event.stopReason, now, event.metrics);
+        case "error":
+          return terminated("error", now);
+        default:
+          return current;
+      }
+    }
+
+    case "idle": {
       switch (event.kind) {
         case "resume":
           return { state: "running", startedAt: now, turnIndex: 0 };

--- a/packages/lib/test-utils/src/agent-registry-contract.ts
+++ b/packages/lib/test-utils/src/agent-registry-contract.ts
@@ -205,6 +205,70 @@ export function runAgentRegistryContractTests(
           expect(result.error.code).toBe("VALIDATION");
         }
       });
+
+      test("running → idle transition succeeds", async () => {
+        await registry.register(entry("a1", "created", 0));
+        await registry.transition(agentId("a1"), "running", 0, { kind: "assembly_complete" });
+        const result = await registry.transition(agentId("a1"), "idle", 1, {
+          kind: "task_completed_idle",
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.status.phase).toBe("idle");
+          expect(result.value.status.generation).toBe(2);
+        }
+      });
+
+      test("idle → running transition succeeds", async () => {
+        await registry.register(entry("a1", "created", 0));
+        await registry.transition(agentId("a1"), "running", 0, { kind: "assembly_complete" });
+        await registry.transition(agentId("a1"), "idle", 1, { kind: "task_completed_idle" });
+        const result = await registry.transition(agentId("a1"), "running", 2, {
+          kind: "inbox_wake",
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.status.phase).toBe("running");
+          expect(result.value.status.generation).toBe(3);
+        }
+      });
+
+      test("idle → terminated transition succeeds", async () => {
+        await registry.register(entry("a1", "created", 0));
+        await registry.transition(agentId("a1"), "running", 0, { kind: "assembly_complete" });
+        await registry.transition(agentId("a1"), "idle", 1, { kind: "task_completed_idle" });
+        const result = await registry.transition(agentId("a1"), "terminated", 2, {
+          kind: "evicted",
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value.status.phase).toBe("terminated");
+        }
+      });
+
+      test("idle → waiting is invalid", async () => {
+        await registry.register(entry("a1", "created", 0));
+        await registry.transition(agentId("a1"), "running", 0, { kind: "assembly_complete" });
+        await registry.transition(agentId("a1"), "idle", 1, { kind: "task_completed_idle" });
+        const result = await registry.transition(agentId("a1"), "waiting", 2, {
+          kind: "awaiting_response",
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("VALIDATION");
+        }
+      });
+
+      test("list filters by idle phase", async () => {
+        await registry.register(entry("a1", "created", 0));
+        await registry.register(entry("a2", "created", 0));
+        await registry.transition(agentId("a1"), "running", 0, { kind: "assembly_complete" });
+        await registry.transition(agentId("a1"), "idle", 1, { kind: "task_completed_idle" });
+
+        const idle = await registry.list({ phase: "idle" });
+        expect(idle).toHaveLength(1);
+        expect(idle[0]?.agentId).toBe(agentId("a1"));
+      });
     });
 
     // -----------------------------------------------------------------------

--- a/packages/sched/long-running/src/harness.ts
+++ b/packages/sched/long-running/src/harness.ts
@@ -120,6 +120,8 @@ export function mapProcessStateToHarnessPhase(
       return "active";
     case "suspended":
       return "suspended";
+    case "idle":
+      return "idle";
     case "terminated":
       return reason?.kind === "completed" ? "completed" : "failed";
   }

--- a/packages/sched/scheduler/src/stats-mapping.ts
+++ b/packages/sched/scheduler/src/stats-mapping.ts
@@ -40,6 +40,7 @@ export function mapSchedulerStatsByProcessState(stats: SchedulerStats): ProcessS
     running: 0,
     waiting: 0,
     suspended: 0,
+    idle: 0,
     terminated: 0,
   };
 


### PR DESCRIPTION
## Summary

- Add `"idle"` to ProcessState so copilots can survive between tasks
- Add `reuse: true` manifest flag — engine auto-transitions to idle after task completion and wakes on inbox messages
- Full idle-wake cycle: no cold starts, no respawning, context stays hot

## What this enables

A copilot with `reuse: true` + `lifecycle: "copilot"` never dies. It automatically sleeps when idle and wakes when a message arrives in its inbox. The engine handles the loop internally — poll inbox every 1s (unref'd), watch registry for external wake, respond to abort signal.

```
created → running → idle → running → idle → ... → terminated
              ↑        ↓       ↑
              task 1   sleep   task 2 (instant, no spawn)
```

## Changes

**L0 (`@koi/core`):**
- `"idle"` added to ProcessState union
- `task_completed_idle` / `inbox_wake` TransitionReason variants
- `reuse?: boolean` on AgentManifest
- `idled` / `woke` ChildLifecycleEvent variants

**L1 (`@koi/engine`):**
- Idle state handling in engine lifecycle state machine
- Reuse loop in `koi.ts` — abort-safe inbox polling + registry transitions
- `idled`/`woke` event emission in child-handle

**L2 (exhaustive sites):**
- state-mapping, stats-mapping, harness, discover, extension-composer

**Tests:** idle transitions, child-handle events, registry contract (100+ lines)
**Docs:** `docs/engine/idle-reuse.md`

## Test plan

- [x] 548 core tests pass
- [x] 62 engine tests pass (33 transition + 29 child-handle)
- [x] Biome lint clean
- [x] Typecheck passes (pre-push hook)
- [x] Build succeeds
- [ ] Manual: verify copilot with `reuse: true` idles and wakes on inbox push
- [ ] Manual: verify abort signal terminates idle copilot cleanly

Closes #687