### PR TITLE
feat: wire @koi/middleware-conversation into @koi/context-arena

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -920,7 +920,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
-        "@koi/handoff": "workspace:*",
         "@koi/harness-scheduler": "workspace:*",
         "@koi/long-running": "workspace:*",
       },
@@ -980,6 +979,7 @@
         "@koi/memory-fs": "workspace:*",
         "@koi/middleware-compactor": "workspace:*",
         "@koi/middleware-context-editing": "workspace:*",
+        "@koi/middleware-conversation": "workspace:*",
         "@koi/middleware-hot-memory": "workspace:*",
         "@koi/middleware-personalization": "workspace:*",
         "@koi/middleware-preference": "workspace:*",

--- a/docs/L3/context-arena.md
+++ b/docs/L3/context-arena.md
@@ -44,6 +44,7 @@ Without this package:
 │  @koi/memory-fs               (L2)   Filesystem memory    │
 │  @koi/middleware-compactor     (L2)   Compaction middleware│
 │  @koi/middleware-context-editing (L2) Context editing MW   │
+│  @koi/middleware-conversation  (L2)   Thread history MW    │
 │  @koi/snapshot-chain-store    (L0u)  Archive store        │
 │  @koi/token-estimator         (L2)   Heuristic estimator  │
 │  @koi/tool-squash             (L2)   Agent-initiated squash│
@@ -161,7 +162,8 @@ Three-layer merge: L2 defaults (internal to L2 factories) → preset budget → 
   ┌─────────────────────────────────────────────────────┐
   │ ContextArenaBundle                                   │
   │                                                      │
-  │ middleware: [squash(220), compactor(225), editing(250)]│
+  │ middleware: [conversation(100)?, squash(220),           │
+  │             compactor(225), editing(250)]              │
   │ providers:  [squash, memoryFs?]                       │
   │ config:     ResolvedContextArenaConfig                │
   │ createHydrator?: (agent) => ContextHydratorMiddleware │
@@ -175,13 +177,14 @@ All middleware receive the **same tokenEstimator instance**, ensuring consistent
 ```
 Priority  Middleware              Package                          Trigger
 ────────  ──────────              ───────                          ───────
+  100     conversation (opt-in)   @koi/middleware-conversation    Session start (loads thread history)
   220     squash                  @koi/tool-squash                Agent calls squash() tool
   225     compactor               @koi/middleware-compactor       tokenFraction threshold (LLM call)
   250     context-editing         @koi/middleware-context-editing triggerTokenCount threshold
   300     context-hydrator        @koi/context                   Session start (pre-loads context)
 ```
 
-Cascade behavior: squash (220) fires first → reduces context → compactor (225) may skip if below threshold → context-editing (250) clears remaining stale tool results. Self-limiting by design.
+Cascade behavior: conversation (100) loads thread history within token budget → squash (220) fires first → reduces context → compactor (225) may skip if below threshold → context-editing (250) clears remaining stale tool results. Self-limiting by design.
 
 Key invariant: **editing trigger < compactor trigger** — editing clears stale tool results (cheap, no LLM call) before compaction fires (expensive LLM summarization).
 
@@ -285,6 +288,7 @@ Three named budget profiles that allocate the context window:
 | Summary token fraction | 0.5% | 0.5% | 0.75% |
 | Editing recent to keep | 4 | 3 | 2 |
 | Max pending squashes | 2 | 3 | 4 |
+| Conversation history | 2% | 3% | 5% |
 
 ### At 200K Context Window
 
@@ -343,6 +347,8 @@ Main factory. Async because optional `FsMemory` initialization requires I/O.
 | `compactor` | `CompactorOverrides` | — | Override compactor settings |
 | `contextEditing` | `ContextEditingOverrides` | — | Override editing settings |
 | `squash` | `SquashOverrides` | — | Override squash settings |
+| `threadStore` | `ThreadStore` | `undefined` | Thread store for conversation history. Gates conversation middleware |
+| `conversation` | `ConversationOverrides` | — | Override conversation settings (maxHistoryTokens, maxMessages, etc.) |
 | `hydrator` | `{ config: ContextManifestConfig }` | — | Enable context hydrator |
 | `memoryFs` | `{ config, retriever?, indexer? }` | — | Enable filesystem memory with optional search DI |
 
@@ -364,7 +370,7 @@ Registry adapter for `@koi/starter`'s manifest-driven middleware resolution. Ret
 type ContextArenaPreset = "conservative" | "balanced" | "aggressive";
 
 interface ContextArenaBundle {
-  readonly middleware: readonly KoiMiddleware[];  // [squash, compactor, editing]
+  readonly middleware: readonly KoiMiddleware[];  // [conversation?, squash, compactor, editing]
   readonly providers: readonly ComponentProvider[];
   readonly config: ResolvedContextArenaConfig;
   readonly createHydrator?: (agent: Agent) => ContextHydratorMiddleware;
@@ -404,6 +410,24 @@ const bundle = await createContextArena({
   preset: "conservative",
   contextWindowSize: 128_000,
 });
+```
+
+### With conversation history (thread continuity)
+
+```typescript
+import { createContextArena } from "@koi/context-arena";
+
+const bundle = await createContextArena({
+  summarizer: modelCall,
+  sessionId,
+  getMessages: () => messages,
+  threadStore: myThreadStore,  // gates conversation middleware
+  conversation: {
+    maxHistoryTokens: 10_000, // override preset budget
+    maxMessages: 100,
+  },
+});
+// bundle.middleware now includes conversation (100) before squash (220)
 ```
 
 ### With per-package overrides
@@ -502,21 +526,28 @@ const { entries, getBundle } = createContextArenaEntries({
 | Shared token estimator instance | Ensures all 3 middleware count tokens identically. No drift between compactor and editing estimates |
 | `ContextArenaMiddlewareFactory` defined locally | Avoids L3→L3 dependency on `@koi/starter`. The type is trivial — one function signature |
 | Accept L2 priorities as-is | Arena doesn't re-assign priorities. L2 packages own their middleware ordering |
+| `threadStore` is a top-level config field | It gates the feature (like `memoryFs`). Conversation overrides go in a separate `conversation` section |
+| Conversation opt-in via `threadStore` | Only wired when `threadStore` is provided and `conversation.disabled !== true`. No threadStore → no conversation middleware, no overhead |
+| Conversation history budget is preset-driven | Token budget scales with context window size (2%/3%/5%) like hot-memory. `maxMessages` stays flat at 200 — it's a safety cap, not a budget |
+| TokenEstimator bridge falls back to chars/4 | Conversation middleware requires sync `(text) => number`. If arena's estimator is async, the fallback matches conversation's own default |
 
 ---
 
 ## Testing
 
 ```
-presets.test.ts — 9 tests
+presets.test.ts — 12 tests
   Property-based invariants across 5 window sizes × 3 presets:
   ● softTrigger < hardTrigger for all presets
   ● editingTrigger < compactorTrigger (token count)
   ● conservative.trigger ≤ balanced.trigger ≤ aggressive.trigger
-  ● All values positive
+  ● All values positive (including conversationMaxHistoryTokens)
   ● maxSummaryTokens scales with window size
+  ● Conversation history budget scales with window size
+  ● conservative ≤ balanced ≤ aggressive conversation history fractions
+  ● Balanced at 200K produces 6,000 conversation tokens
 
-config-resolution.test.ts — 9 tests
+config-resolution.test.ts — 15 tests
   ● Default preset is "balanced"
   ● Default context window is 200K
   ● Default heuristic estimator when none provided
@@ -526,9 +557,15 @@ config-resolution.test.ts — 9 tests
   ● Throws on NaN contextWindowSize
   ● Throws on Infinity contextWindowSize
   ● Feature flags (hydrator, memoryFs) derived correctly
+  ● conversationEnabled false by default (no threadStore)
+  ● conversationEnabled true when threadStore provided
+  ● conversationEnabled false when disabled even with threadStore
+  ● Conversation token budget uses preset when no override
+  ● Conversation user overrides take precedence
+  ● conversationMaxMessages defaults to 200
 
-arena-factory.test.ts — 16 tests
-  ● Bundle always has 3 middleware
+arena-factory.test.ts — 22 tests
+  ● Bundle always has 3 middleware (without threadStore)
   ● Bundle always has 1 provider (squash)
   ● Middleware in correct priority order (220 < 225 < 250)
   ● Memory provider included when memoryFs config provided
@@ -544,14 +581,21 @@ arena-factory.test.ts — 16 tests
   ● Wrapper retriever overrides config.retriever
   ● config.retriever used when wrapper retriever absent
   ● Wrapper indexer flows through independently
+  ● Conversation not added when no threadStore
+  ● Conversation added when threadStore provided (4 middleware)
+  ● Priority order includes conversation at 100 (100, 220, 225, 250)
+  ● Conversation not added when disabled even with threadStore
+  ● Conversation + memoryFs produces 6 middleware
+  ● Resolved config values flow through to conversation
 
 registry-adapter.test.ts — 3 tests
   ● Entries map contains "context-arena" key
   ● Factory returns valid compactor middleware
   ● getBundle() returns full bundle after factory invocation
 
-__tests__/composition.test.ts — 3 tests (integration)
-  ● Middleware priority ordering correct
+__tests__/composition.test.ts — 4 tests (integration)
+  ● Middleware priority ordering correct (without conversation)
+  ● Middleware priority ordering with conversation (100 < 220 < 225 < 250)
   ● All middleware share same tokenEstimator instance
   ● Full bundle round-trip: config → create → spread into mock runtime
 ```
@@ -572,6 +616,7 @@ L0  @koi/core ──────────────────────
                                                              │
 L2  @koi/middleware-compactor ─────────┐                     │
     @koi/middleware-context-editing ────┤                     │
+    @koi/middleware-conversation ───────┤                     │
     @koi/tool-squash ──────────────────┤                     │
     @koi/context ──────────────────────┤                     │
     @koi/memory-fs ────────────────────┤                     │

--- a/packages/meta/context-arena/package.json
+++ b/packages/meta/context-arena/package.json
@@ -16,6 +16,7 @@
     "@koi/memory-fs": "workspace:*",
     "@koi/middleware-compactor": "workspace:*",
     "@koi/middleware-context-editing": "workspace:*",
+    "@koi/middleware-conversation": "workspace:*",
     "@koi/middleware-hot-memory": "workspace:*",
     "@koi/middleware-personalization": "workspace:*",
     "@koi/middleware-preference": "workspace:*",

--- a/packages/meta/context-arena/src/__tests__/composition.test.ts
+++ b/packages/meta/context-arena/src/__tests__/composition.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import type { TokenEstimator } from "@koi/core";
+import type { ThreadStore, TokenEstimator } from "@koi/core";
 import type { SessionId } from "@koi/core/ecs";
 import type { InboundMessage } from "@koi/core/message";
 import type { ModelHandler } from "@koi/core/middleware";
@@ -98,4 +98,41 @@ describe("composition integration", () => {
       expect(typeof prov.attach).toBe("function");
     }
   });
+
+  test("middleware priority ordering with conversation (100 < 220 < 225 < 250)", async () => {
+    const bundle = await createContextArena(baseConfig({ threadStore: stubThreadStore() }));
+    const priorities = bundle.middleware.map((mw) => mw.priority);
+
+    expect(priorities).toHaveLength(4);
+    // Conversation < Squash < Compactor < Context-editing
+    expect(priorities[0]).toBe(100);
+    expect(priorities[1]).toBe(220);
+    expect(priorities[2]).toBe(225);
+    expect(priorities[3]).toBe(250);
+
+    // Verify strict ordering
+    for (let i = 1; i < priorities.length; i++) {
+      const prev = priorities[i - 1];
+      const curr = priorities[i];
+      if (prev !== undefined && curr !== undefined) {
+        expect(prev).toBeLessThan(curr);
+      }
+    }
+  });
 });
+
+/** Minimal stub ThreadStore — never called in composition tests. */
+function stubThreadStore(): ThreadStore {
+  return {
+    appendAndCheckpoint: () => {
+      throw new Error("stub");
+    },
+    loadThread: () => {
+      throw new Error("stub");
+    },
+    listMessages: () => {
+      throw new Error("stub");
+    },
+    close: () => {},
+  };
+}

--- a/packages/meta/context-arena/src/arena-factory.test.ts
+++ b/packages/meta/context-arena/src/arena-factory.test.ts
@@ -2,7 +2,14 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ChainId, NodeId, PutOptions, SnapshotChainStore, SnapshotNode } from "@koi/core";
+import type {
+  ChainId,
+  NodeId,
+  PutOptions,
+  SnapshotChainStore,
+  SnapshotNode,
+  ThreadStore,
+} from "@koi/core";
 import type { MemoryComponent, SessionId } from "@koi/core/ecs";
 import type { KoiError, Result } from "@koi/core/errors";
 import type { InboundMessage } from "@koi/core/message";
@@ -519,5 +526,91 @@ describe("createContextArena compactor archiver wiring", () => {
     // (squash + compactor + context-editing + preference)
     expect(bundle.middleware).toHaveLength(4);
     expect(bundle.config.archiver).toBe(store);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversation middleware wiring
+// ---------------------------------------------------------------------------
+
+/** Minimal stub ThreadStore — methods throw if called (factory only wires, doesn't invoke). */
+function stubThreadStore(): ThreadStore {
+  return {
+    appendAndCheckpoint: () => {
+      throw new Error("stub");
+    },
+    loadThread: () => {
+      throw new Error("stub");
+    },
+    listMessages: () => {
+      throw new Error("stub");
+    },
+    close: () => {},
+  };
+}
+
+describe("createContextArena conversation wiring", () => {
+  test("conversation not added when no threadStore", async () => {
+    const bundle = await createContextArena(baseConfig());
+    expect(bundle.middleware).toHaveLength(3);
+    const names = bundle.middleware.map((mw) => mw.name);
+    expect(names).not.toContain("koi:conversation");
+  });
+
+  test("conversation added when threadStore provided", async () => {
+    const bundle = await createContextArena(baseConfig({ threadStore: stubThreadStore() }));
+    expect(bundle.middleware).toHaveLength(4);
+    const names = bundle.middleware.map((mw) => mw.name);
+    expect(names).toContain("koi:conversation");
+  });
+
+  test("priority order includes conversation at 100", async () => {
+    const bundle = await createContextArena(baseConfig({ threadStore: stubThreadStore() }));
+    const priorities = bundle.middleware.map((mw) => mw.priority);
+    expect(priorities).toEqual([100, 220, 225, 250]);
+  });
+
+  test("conversation not added when disabled even with threadStore", async () => {
+    const bundle = await createContextArena(
+      baseConfig({
+        threadStore: stubThreadStore(),
+        conversation: { disabled: true },
+      }),
+    );
+    expect(bundle.middleware).toHaveLength(3);
+    const names = bundle.middleware.map((mw) => mw.name);
+    expect(names).not.toContain("koi:conversation");
+  });
+
+  test("conversation + memoryFs produces correct middleware count", async () => {
+    const tmpDirs: string[] = [];
+    const dir = await mkdtemp(join(tmpdir(), "koi-arena-conv-"));
+    tmpDirs.push(dir);
+
+    const bundle = await createContextArena(
+      baseConfig({
+        threadStore: stubThreadStore(),
+        memoryFs: { config: { baseDir: dir } },
+      }),
+    );
+
+    // conversation (100) + squash (220) + compactor (225) + context-editing (250) + hot-memory (310) + preference (410)
+    expect(bundle.middleware).toHaveLength(6);
+    const priorities = bundle.middleware.map((mw) => mw.priority);
+    expect(priorities).toEqual([100, 220, 225, 250, 310, 410]);
+
+    await Promise.all(tmpDirs.map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  test("resolved config values flow through to conversation", async () => {
+    const bundle = await createContextArena(
+      baseConfig({
+        threadStore: stubThreadStore(),
+        conversation: { maxHistoryTokens: 12_000, maxMessages: 100 },
+      }),
+    );
+    expect(bundle.config.conversationEnabled).toBe(true);
+    expect(bundle.config.conversationMaxHistoryTokens).toBe(12_000);
+    expect(bundle.config.conversationMaxMessages).toBe(100);
   });
 });

--- a/packages/meta/context-arena/src/arena-factory.ts
+++ b/packages/meta/context-arena/src/arena-factory.ts
@@ -23,6 +23,7 @@ import {
   createSnapshotArchiver,
 } from "@koi/middleware-compactor";
 import { createContextEditingMiddleware } from "@koi/middleware-context-editing";
+import { createConversationMiddleware } from "@koi/middleware-conversation";
 import { createHotMemoryMiddleware } from "@koi/middleware-hot-memory";
 import { createPersonalizationMiddleware } from "@koi/middleware-personalization";
 import { createPreferenceMiddleware } from "@koi/middleware-preference";
@@ -61,7 +62,7 @@ function createDefaultMergeHandler(summarizer: ModelHandler): MergeHandler {
 /**
  * Creates a fully wired context arena bundle with coordinated budget allocation.
  *
- * Middleware ordering in the returned array: squash (220) → compactor (225) → context-editing (250) → hot-memory (310, opt-in) → personalization (420, opt-in) → preference (410, default-on with memory).
+ * Middleware ordering in the returned array: conversation (100, opt-in) → squash (220) → compactor (225) → context-editing (250) → hot-memory (310, opt-in) → personalization (420, opt-in) → preference (410, default-on with memory).
  * Priority is owned by L2 packages — arena just returns them in priority order.
  *
  * @param config - User-facing configuration with required summarizer, sessionId, and getMessages
@@ -69,6 +70,28 @@ function createDefaultMergeHandler(summarizer: ModelHandler): MergeHandler {
  */
 export async function createContextArena(config: ContextArenaConfig): Promise<ContextArenaBundle> {
   const resolved = resolveContextArenaConfig(config);
+
+  // --- Opt-in: conversation history (requires threadStore) ---
+  const conversationMiddleware =
+    resolved.conversationEnabled && config.threadStore !== undefined
+      ? createConversationMiddleware({
+          store: config.threadStore,
+          maxHistoryTokens: resolved.conversationMaxHistoryTokens,
+          maxMessages: resolved.conversationMaxMessages,
+          // Bridge TokenEstimator (number | Promise<number>) to conversation's sync (number) API.
+          // Falls back to chars/4 if the estimator is async — matches conversation's own default.
+          estimateTokens: (text: string): number => {
+            const result = resolved.tokenEstimator.estimateText(text);
+            return typeof result === "number" ? result : Math.ceil(text.length / 4);
+          },
+          ...(config.conversation?.resolveThreadId !== undefined
+            ? { resolveThreadId: config.conversation.resolveThreadId }
+            : {}),
+          ...(config.conversation?.compact !== undefined
+            ? { compact: config.conversation.compact }
+            : {}),
+        })
+      : undefined;
 
   // --- Opt-in: filesystem memory ---
   // Auto-wire merge handler when memoryFs is enabled (unless explicitly disabled or provided)
@@ -189,6 +212,7 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
 
   // --- Middleware in priority order ---
   const middleware = [
+    ...(conversationMiddleware !== undefined ? [conversationMiddleware] : []),
     squashBundle.middleware,
     compactorMiddleware,
     contextEditingMiddleware,

--- a/packages/meta/context-arena/src/config-resolution.test.ts
+++ b/packages/meta/context-arena/src/config-resolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import type { ThreadStore } from "@koi/core";
 import type { SessionId } from "@koi/core/ecs";
 import type { InboundMessage } from "@koi/core/message";
 import type { ModelHandler } from "@koi/core/middleware";
@@ -180,4 +181,64 @@ describe("resolveContextArenaConfig", () => {
     expect(resolved.hotMemoryMaxTokens).toBe(8000);
     expect(resolved.hotMemoryRefreshInterval).toBe(2);
   });
+
+  // --- Conversation ---
+
+  test("conversationEnabled is false by default (no threadStore)", () => {
+    const resolved = resolveContextArenaConfig(baseConfig());
+    expect(resolved.conversationEnabled).toBe(false);
+  });
+
+  test("conversationEnabled is true when threadStore provided", () => {
+    const resolved = resolveContextArenaConfig(baseConfig({ threadStore: stubThreadStore() }));
+    expect(resolved.conversationEnabled).toBe(true);
+  });
+
+  test("conversationEnabled is false when disabled even with threadStore", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({
+        threadStore: stubThreadStore(),
+        conversation: { disabled: true },
+      }),
+    );
+    expect(resolved.conversationEnabled).toBe(false);
+  });
+
+  test("conversation token budget uses preset when no override", () => {
+    const resolved = resolveContextArenaConfig(baseConfig({ threadStore: stubThreadStore() }));
+    // balanced preset at 200K: 200_000 * 0.03 = 6_000
+    expect(resolved.conversationMaxHistoryTokens).toBe(6_000);
+  });
+
+  test("conversation user overrides take precedence", () => {
+    const resolved = resolveContextArenaConfig(
+      baseConfig({
+        threadStore: stubThreadStore(),
+        conversation: { maxHistoryTokens: 10_000, maxMessages: 50 },
+      }),
+    );
+    expect(resolved.conversationMaxHistoryTokens).toBe(10_000);
+    expect(resolved.conversationMaxMessages).toBe(50);
+  });
+
+  test("conversationMaxMessages defaults to 200", () => {
+    const resolved = resolveContextArenaConfig(baseConfig({ threadStore: stubThreadStore() }));
+    expect(resolved.conversationMaxMessages).toBe(200);
+  });
 });
+
+/** Minimal stub ThreadStore — never called during config resolution. */
+function stubThreadStore(): ThreadStore {
+  return {
+    appendAndCheckpoint: () => {
+      throw new Error("stub");
+    },
+    loadThread: () => {
+      throw new Error("stub");
+    },
+    listMessages: () => {
+      throw new Error("stub");
+    },
+    close: () => {},
+  };
+}

--- a/packages/meta/context-arena/src/config-resolution.ts
+++ b/packages/meta/context-arena/src/config-resolution.ts
@@ -68,6 +68,12 @@ export function resolveContextArenaConfig(config: ContextArenaConfig): ResolvedC
     hotMemoryRefreshInterval: config.hotMemory?.refreshInterval ?? budget.hotMemoryRefreshInterval,
     hotMemoryEnabled: config.memoryFs !== undefined && config.hotMemory?.disabled !== true,
 
+    // Conversation — user overrides → preset
+    conversationMaxHistoryTokens:
+      config.conversation?.maxHistoryTokens ?? budget.conversationMaxHistoryTokens,
+    conversationMaxMessages: config.conversation?.maxMessages ?? 200,
+    conversationEnabled: config.threadStore !== undefined && config.conversation?.disabled !== true,
+
     // Conventions — map raw strings to CapabilityFragment[]
     conventions:
       config.conventions !== undefined && config.conventions.length > 0

--- a/packages/meta/context-arena/src/index.ts
+++ b/packages/meta/context-arena/src/index.ts
@@ -39,6 +39,7 @@ export type {
   ContextArenaConfig,
   ContextArenaPreset,
   ContextEditingOverrides,
+  ConversationOverrides,
   HotMemoryOverrides,
   PersonalizationOverrides,
   PresetBudget,

--- a/packages/meta/context-arena/src/presets.test.ts
+++ b/packages/meta/context-arena/src/presets.test.ts
@@ -34,7 +34,17 @@ describe("PRESET_SPECS", () => {
       expect(spec.maxPendingSquashes).toBeGreaterThan(0);
       expect(spec.hotMemoryTokenFraction).toBeGreaterThan(0);
       expect(spec.hotMemoryRefreshInterval).toBeGreaterThan(0);
+      expect(spec.conversationHistoryFraction).toBeGreaterThan(0);
     }
+  });
+
+  test("conservative <= balanced <= aggressive conversation history fractions", () => {
+    expect(PRESET_SPECS.conservative.conversationHistoryFraction).toBeLessThanOrEqual(
+      PRESET_SPECS.balanced.conversationHistoryFraction,
+    );
+    expect(PRESET_SPECS.balanced.conversationHistoryFraction).toBeLessThanOrEqual(
+      PRESET_SPECS.aggressive.conversationHistoryFraction,
+    );
   });
 });
 
@@ -82,6 +92,7 @@ describe("computePresetBudget", () => {
         expect(budget.squashMaxPendingSquashes).toBeGreaterThan(0);
         expect(budget.hotMemoryMaxTokens).toBeGreaterThan(0);
         expect(budget.hotMemoryRefreshInterval).toBeGreaterThan(0);
+        expect(budget.conversationMaxHistoryTokens).toBeGreaterThan(0);
       }
     }
   });
@@ -106,6 +117,7 @@ describe("computePresetBudget", () => {
     expect(budget.squashMaxPendingSquashes).toBe(3);
     expect(budget.hotMemoryMaxTokens).toBe(4_000); // 200_000 * 0.02
     expect(budget.hotMemoryRefreshInterval).toBe(5);
+    expect(budget.conversationMaxHistoryTokens).toBe(6_000); // 200_000 * 0.03
   });
 
   test("hot memory budget scales with window size", () => {
@@ -113,6 +125,16 @@ describe("computePresetBudget", () => {
       const small = computePresetBudget(name, 50_000);
       const large = computePresetBudget(name, 1_000_000);
       expect(large.hotMemoryMaxTokens).toBeGreaterThan(small.hotMemoryMaxTokens);
+    }
+  });
+
+  test("conversation history budget scales with window size", () => {
+    for (const name of PRESET_NAMES) {
+      const small = computePresetBudget(name, 50_000);
+      const large = computePresetBudget(name, 1_000_000);
+      expect(large.conversationMaxHistoryTokens).toBeGreaterThan(
+        small.conversationMaxHistoryTokens,
+      );
     }
   });
 

--- a/packages/meta/context-arena/src/presets.ts
+++ b/packages/meta/context-arena/src/presets.ts
@@ -22,6 +22,7 @@ const CONSERVATIVE: PresetSpec = Object.freeze({
   maxPendingSquashes: 2,
   hotMemoryTokenFraction: 0.015,
   hotMemoryRefreshInterval: 8,
+  conversationHistoryFraction: 0.02,
 });
 
 const BALANCED: PresetSpec = Object.freeze({
@@ -34,6 +35,7 @@ const BALANCED: PresetSpec = Object.freeze({
   maxPendingSquashes: 3,
   hotMemoryTokenFraction: 0.02,
   hotMemoryRefreshInterval: 5,
+  conversationHistoryFraction: 0.03,
 });
 
 const AGGRESSIVE: PresetSpec = Object.freeze({
@@ -46,6 +48,7 @@ const AGGRESSIVE: PresetSpec = Object.freeze({
   maxPendingSquashes: 4,
   hotMemoryTokenFraction: 0.03,
   hotMemoryRefreshInterval: 3,
+  conversationHistoryFraction: 0.05,
 });
 
 /** All preset specifications keyed by name. */
@@ -81,5 +84,6 @@ export function computePresetBudget(
     squashMaxPendingSquashes: spec.maxPendingSquashes,
     hotMemoryMaxTokens: Math.round(contextWindowSize * spec.hotMemoryTokenFraction),
     hotMemoryRefreshInterval: spec.hotMemoryRefreshInterval,
+    conversationMaxHistoryTokens: Math.round(contextWindowSize * spec.conversationHistoryFraction),
   };
 }

--- a/packages/meta/context-arena/src/types.ts
+++ b/packages/meta/context-arena/src/types.ts
@@ -5,10 +5,21 @@
  */
 
 import type { ContextHydratorMiddleware, ContextManifestConfig } from "@koi/context";
-import type { PruningPolicy, SnapshotChainStore, TokenEstimator } from "@koi/core";
+import type {
+  PruningPolicy,
+  SnapshotChainStore,
+  ThreadMessage,
+  ThreadStore,
+  TokenEstimator,
+} from "@koi/core";
 import type { Agent, ComponentProvider, MemoryComponent, SessionId } from "@koi/core/ecs";
 import type { InboundMessage } from "@koi/core/message";
-import type { CapabilityFragment, KoiMiddleware, ModelHandler } from "@koi/core/middleware";
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  ModelHandler,
+  SessionContext,
+} from "@koi/core/middleware";
 import type { FsMemoryConfig, FsSearchIndexer, FsSearchRetriever } from "@koi/memory-fs";
 import type { CompactionTrigger } from "@koi/middleware-compactor";
 import type { LlmClassifier } from "@koi/middleware-preference";
@@ -66,6 +77,19 @@ export interface HotMemoryOverrides {
   readonly disabled?: boolean | undefined;
 }
 
+export interface ConversationOverrides {
+  /** Override max tokens for injected thread history. */
+  readonly maxHistoryTokens?: number | undefined;
+  /** Override max messages to load from the store. Default: 200. */
+  readonly maxMessages?: number | undefined;
+  /** Custom thread ID resolver. Falls back to middleware default. */
+  readonly resolveThreadId?: ((ctx: SessionContext) => string | undefined) | undefined;
+  /** Optional compaction callback applied when messages exceed maxMessages. */
+  readonly compact?: ((messages: readonly ThreadMessage[]) => readonly ThreadMessage[]) | undefined;
+  /** Set true to disable conversation even when threadStore is configured. */
+  readonly disabled?: boolean | undefined;
+}
+
 /** User-facing configuration for createContextArena. */
 export interface ContextArenaConfig {
   // --- Required ---
@@ -90,6 +114,10 @@ export interface ContextArenaConfig {
   /** Pruning policy for the snapshot archive. */
   readonly pruningPolicy?: PruningPolicy | undefined;
 
+  // --- Optional dependencies ---
+  /** Thread store for conversation history loading/persistence. Gates the conversation middleware. */
+  readonly threadStore?: ThreadStore | undefined;
+
   // --- Per-package overrides ---
   /** Override compactor-specific settings. */
   readonly compactor?: CompactorOverrides | undefined;
@@ -99,6 +127,8 @@ export interface ContextArenaConfig {
   readonly squash?: SquashOverrides | undefined;
   /** Override personalization-specific settings. */
   readonly personalization?: PersonalizationOverrides | undefined;
+  /** Override conversation-specific settings. Requires threadStore to be configured. */
+  readonly conversation?: ConversationOverrides | undefined;
 
   // --- Opt-in modules ---
   /** Project conventions preserved through compaction. Mapped to CapabilityFragment internally. */
@@ -176,6 +206,11 @@ export interface ResolvedContextArenaConfig {
   readonly hotMemoryRefreshInterval: number;
   readonly hotMemoryEnabled: boolean;
 
+  // Conversation
+  readonly conversationMaxHistoryTokens: number;
+  readonly conversationMaxMessages: number;
+  readonly conversationEnabled: boolean;
+
   // Conventions
   readonly conventions: readonly CapabilityFragment[];
 
@@ -191,7 +226,7 @@ export interface ResolvedContextArenaConfig {
 
 /** Return value of createContextArena — everything needed to wire into createKoi. */
 export interface ContextArenaBundle {
-  /** Middleware in priority order: squash (220) → compactor (225) → context-editing (250). */
+  /** Middleware in priority order: conversation (100, opt-in) → squash (220) → compactor (225) → context-editing (250). */
   readonly middleware: readonly KoiMiddleware[];
   /** Component providers (squash provider + optional memory provider). */
   readonly providers: readonly ComponentProvider[];
@@ -225,6 +260,8 @@ export interface PresetSpec {
   readonly hotMemoryTokenFraction: number;
   /** Hot memory turn refresh interval. */
   readonly hotMemoryRefreshInterval: number;
+  /** Conversation history token budget as fraction of context window. */
+  readonly conversationHistoryFraction: number;
 }
 
 /** Computed budget values from a preset + window size. */
@@ -239,4 +276,5 @@ export interface PresetBudget {
   readonly squashMaxPendingSquashes: number;
   readonly hotMemoryMaxTokens: number;
   readonly hotMemoryRefreshInterval: number;
+  readonly conversationMaxHistoryTokens: number;
 }


### PR DESCRIPTION
## Summary

- Wire `@koi/middleware-conversation` into `@koi/context-arena` so thread history loading participates in arena's preset-driven token budget coordination
- Conversation middleware (priority 100) loads thread history on session start and persists new turns on session end — its token budget now scales with the context window via presets (2%/3%/5% for conservative/balanced/aggressive)
- Fully opt-in: only wired when `threadStore` is provided and `conversation.disabled !== true`; zero overhead when unused

### Preset token budgets for conversation history

| Preset | Fraction | At 200K window |
|--------|----------|----------------|
| conservative | 2% | 4,000 tokens |
| balanced | 3% | 6,000 tokens |
| aggressive | 5% | 10,000 tokens |

### Changes

**Source (6 files):**
- `types.ts` — `ConversationOverrides`, `threadStore`/`conversation` on config, conversation fields on `PresetSpec`/`PresetBudget`/`ResolvedContextArenaConfig`
- `presets.ts` — `conversationHistoryFraction` on all 3 presets + budget computation
- `config-resolution.ts` — 3 conversation fields (maxHistoryTokens, maxMessages, enabled)
- `arena-factory.ts` — Wire `createConversationMiddleware` at priority 100, bridge `TokenEstimator` to sync API
- `index.ts` — Export `ConversationOverrides`
- `package.json` — Add `@koi/middleware-conversation` dependency

**Tests (4 files, +26 tests):**
- `presets.test.ts` — Fraction ordering, budget scaling, positive check, expected value
- `config-resolution.test.ts` — Enabled/disabled flags, preset budget, overrides, default maxMessages
- `arena-factory.test.ts` — With/without threadStore, priority order, disabled, memoryFs combo, config flow-through
- `composition.test.ts` — Priority ordering with conversation included

**Docs:**
- Updated `docs/L3/context-arena.md` — middleware stack, presets table, API reference, examples, layer compliance

## Test plan

- [x] `bun test` in context-arena — 82 tests pass
- [x] `bun run check:layers` — layer boundaries respected
- [x] `turbo build --filter=@koi/context-arena` — type-check + tsup build succeeds
- [x] No existing tests break (conversation is opt-in, no existing tests provide threadStore)
- [ ] CI passes