### PR TITLE
fix: phase-aware middleware sorting, registry listener safety, and composition consolidation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -385,6 +385,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "@koi/event-delivery": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",
@@ -398,6 +399,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "@koi/event-delivery": "workspace:*",
       },
       "devDependencies": {
         "@koi/engine": "workspace:*",
@@ -749,6 +751,7 @@
       "dependencies": {
         "@koi/core": "workspace:*",
         "@koi/errors": "workspace:*",
+        "@koi/event-delivery": "workspace:*",
         "@koi/execution-context": "workspace:*",
         "@koi/hash": "workspace:*",
         "@koi/session-repair": "workspace:*",

--- a/packages/fs/registry-memory/package.json
+++ b/packages/fs/registry-memory/package.json
@@ -11,7 +11,8 @@
     }
   },
   "dependencies": {
-    "@koi/core": "workspace:*"
+    "@koi/core": "workspace:*",
+    "@koi/event-delivery": "workspace:*"
   },
   "devDependencies": {
     "@koi/engine": "workspace:*",

--- a/packages/fs/registry-memory/src/memory-registry.ts
+++ b/packages/fs/registry-memory/src/memory-registry.ts
@@ -36,6 +36,7 @@ import {
   VALID_TRANSITIONS,
   validation,
 } from "@koi/core";
+import { createListenerSet } from "@koi/event-delivery";
 import { agentStreamId, REGISTRY_INDEX_STREAM } from "./stream-ids.js";
 
 // ---------------------------------------------------------------------------
@@ -73,18 +74,11 @@ export async function createMemoryRegistry(backend: EventBackend): Promise<Memor
   const sequenceMap = new Map<string, number>(); // agentId → last known stream sequence
   const knownAgentIds = new Set<AgentId>(); // tracks all ever-registered agent IDs
 
-  // let: replaced on watch/unsubscribe (same pattern as InMemoryRegistry)
-  let listeners: ReadonlySet<(event: RegistryEvent) => void> = new Set();
-
-  // -------------------------------------------------------------------------
-  // Internal helpers
-  // -------------------------------------------------------------------------
-
-  function notify(event: RegistryEvent): void {
-    for (const listener of listeners) {
-      listener(event);
-    }
-  }
+  const listeners = createListenerSet<RegistryEvent>({
+    onError: (err) =>
+      console.warn("[registry-memory] listener threw:", err instanceof Error ? err.message : err),
+  });
+  const notify = listeners.notify;
 
   /**
    * Inline transition validation using VALID_TRANSITIONS from L0.
@@ -455,17 +449,13 @@ export async function createMemoryRegistry(backend: EventBackend): Promise<Memor
   }
 
   function watch(listener: (event: RegistryEvent) => void): () => void {
-    listeners = new Set([...listeners, listener]);
-    return () => {
-      listeners = new Set([...listeners].filter((l) => l !== listener));
-    };
+    return listeners.subscribe(listener);
   }
 
   async function dispose(): Promise<void> {
     projection.clear();
     sequenceMap.clear();
     knownAgentIds.clear();
-    listeners = new Set();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/fs/registry-nexus/package.json
+++ b/packages/fs/registry-nexus/package.json
@@ -11,7 +11,8 @@
     }
   },
   "dependencies": {
-    "@koi/core": "workspace:*"
+    "@koi/core": "workspace:*",
+    "@koi/event-delivery": "workspace:*"
   },
   "devDependencies": {
     "@koi/engine": "workspace:*",

--- a/packages/fs/registry-nexus/src/nexus-registry.ts
+++ b/packages/fs/registry-nexus/src/nexus-registry.ts
@@ -27,6 +27,7 @@ import type {
   VisibilityContext,
 } from "@koi/core";
 import { agentGroupId, agentId, matchesFilter, VALID_TRANSITIONS } from "@koi/core";
+import { createListenerSet } from "@koi/event-delivery";
 import type { NexusRegistryConfig } from "./config.js";
 import { DEFAULT_NEXUS_REGISTRY_CONFIG } from "./config.js";
 import type { NexusAgent } from "./nexus-client.js";
@@ -58,8 +59,10 @@ export async function createNexusRegistry(config: NexusRegistryConfig): Promise<
   const projection = new Map<string, RegistryEntry>();
   /** Nexus-side generation per agent — separate from Koi generation. */
   const nexusGens = new Map<string, number>();
-  // let: replaced on watch/unsubscribe (immutable-set pattern)
-  let listeners: ReadonlySet<(event: RegistryEvent) => void> = new Set();
+  const listeners = createListenerSet<RegistryEvent>({
+    onError: (err) =>
+      console.warn("[registry-nexus] listener threw:", err instanceof Error ? err.message : err),
+  });
   // let: poll timer handle, cleared on dispose
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   // let: disposed flag to prevent operations after cleanup
@@ -69,11 +72,7 @@ export async function createNexusRegistry(config: NexusRegistryConfig): Promise<
   // Internal helpers
   // -------------------------------------------------------------------------
 
-  function notify(event: RegistryEvent): void {
-    for (const listener of listeners) {
-      listener(event);
-    }
-  }
+  const notify = listeners.notify;
 
   /** Map a NexusAgent to a RegistryEntry using metadata for full status. */
   function mapNexusAgentToEntry(agent: NexusAgent): RegistryEntry {
@@ -463,10 +462,7 @@ export async function createNexusRegistry(config: NexusRegistryConfig): Promise<
   }
 
   function watch(listener: (event: RegistryEvent) => void): () => void {
-    listeners = new Set([...listeners, listener]);
-    return () => {
-      listeners = new Set([...listeners].filter((l) => l !== listener));
-    };
+    return listeners.subscribe(listener);
   }
 
   async function dispose(): Promise<void> {
@@ -477,7 +473,6 @@ export async function createNexusRegistry(config: NexusRegistryConfig): Promise<
     }
     projection.clear();
     nexusGens.clear();
-    listeners = new Set();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/kernel/engine/package.json
+++ b/packages/kernel/engine/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@koi/core": "workspace:*",
     "@koi/errors": "workspace:*",
+    "@koi/event-delivery": "workspace:*",
     "@koi/execution-context": "workspace:*",
     "@koi/hash": "workspace:*",
     "@koi/session-repair": "workspace:*"

--- a/packages/kernel/engine/src/child-handle.test.ts
+++ b/packages/kernel/engine/src/child-handle.test.ts
@@ -190,6 +190,22 @@ describe("createChildHandle", () => {
     expect(events[1]?.childId).toBe(agentId("child-1"));
   });
 
+  test("throwing listener does not prevent other listeners from firing", () => {
+    registry.register(entry("child-1", "created", 0));
+
+    const handle = createChildHandle(agentId("child-1"), "worker-1", registry);
+    const events: ChildLifecycleEvent[] = [];
+    handle.onEvent(() => {
+      throw new Error("boom");
+    });
+    handle.onEvent((e) => events.push(e));
+
+    registry.transition(agentId("child-1"), "running", 0, { kind: "assembly_complete" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("started");
+  });
+
   test("multiple listeners receive events", () => {
     registry.register(entry("child-1", "created", 0));
 

--- a/packages/kernel/engine/src/child-handle.ts
+++ b/packages/kernel/engine/src/child-handle.ts
@@ -23,6 +23,7 @@ import type {
   TransitionReason,
 } from "@koi/core";
 import { AGENT_SIGNALS, exitCodeForTransitionReason } from "@koi/core";
+import { createListenerSet } from "@koi/event-delivery";
 
 /** Default grace period for TERM signal before force-termination (ms). */
 const DEFAULT_GRACE_PERIOD_MS = 5000;
@@ -38,17 +39,14 @@ export function createChildHandle(
   abortController?: AbortController,
   gracePeriodMs: number = DEFAULT_GRACE_PERIOD_MS,
 ): ChildHandle {
-  const listeners = new Set<(event: ChildLifecycleEvent) => void>();
+  const listeners = createListenerSet<ChildLifecycleEvent>({
+    onError: (err) =>
+      console.warn("[child-handle] listener threw:", err instanceof Error ? err.message : err),
+  });
   // let justified: set once, cleared on cleanup
   let unsubscribe: (() => void) | undefined;
   // let justified: last-seen TransitionReason for exit-code computation
   let lastReason: TransitionReason | undefined;
-
-  function notify(event: ChildLifecycleEvent): void {
-    for (const listener of listeners) {
-      listener(event);
-    }
-  }
 
   unsubscribe = registry.watch((event) => {
     if (event.kind === "transitioned" && event.agentId === childId) {
@@ -57,28 +55,28 @@ export function createChildHandle(
 
       // created → running = started
       if (event.from === "created" && event.to === "running") {
-        notify({ kind: "started", childId });
+        listeners.notify({ kind: "started", childId });
       }
 
       // running → idle = idled
       if (event.from === "running" && event.to === "idle") {
-        notify({ kind: "idled", childId });
+        listeners.notify({ kind: "idled", childId });
       }
 
       // idle → running = woke
       if (event.from === "idle" && event.to === "running") {
-        notify({ kind: "woke", childId });
+        listeners.notify({ kind: "woke", childId });
       }
 
       // Any transition to terminated — map reason to completed/error/terminated
       if (event.to === "terminated") {
         const exitCode = exitCodeForTransitionReason(event.reason);
         if (event.reason.kind === "completed") {
-          notify({ kind: "completed", childId, exitCode });
+          listeners.notify({ kind: "completed", childId, exitCode });
         } else if (event.reason.kind === "error") {
-          notify({ kind: "error", childId, cause: event.reason.cause });
+          listeners.notify({ kind: "error", childId, cause: event.reason.cause });
         }
-        notify({ kind: "terminated", childId, exitCode });
+        listeners.notify({ kind: "terminated", childId, exitCode });
         cleanup();
       }
     }
@@ -86,7 +84,7 @@ export function createChildHandle(
     // Deregistered = terminated (child removed from registry)
     if (event.kind === "deregistered" && event.agentId === childId) {
       // No reason available for deregister — use default exit code 1
-      notify({ kind: "terminated", childId, exitCode: 1 });
+      listeners.notify({ kind: "terminated", childId, exitCode: 1 });
       cleanup();
     }
   });
@@ -99,7 +97,7 @@ export function createChildHandle(
   }
 
   async function signal(kind: string): Promise<void> {
-    notify({ kind: "signaled", childId, signal: kind });
+    listeners.notify({ kind: "signaled", childId, signal: kind });
 
     switch (kind) {
       case AGENT_SIGNALS.STOP: {
@@ -195,10 +193,7 @@ export function createChildHandle(
   }
 
   function onEvent(listener: (event: ChildLifecycleEvent) => void): () => void {
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
+    return listeners.subscribe(listener);
   }
 
   return {

--- a/packages/kernel/engine/src/compose.test.ts
+++ b/packages/kernel/engine/src/compose.test.ts
@@ -28,6 +28,8 @@ import {
   createTerminalHandlers,
   formatCapabilityMessage,
   injectCapabilities,
+  recomposeChains,
+  resolveActiveMiddleware,
   runSessionHooks,
   runTurnHooks,
   sortMiddlewareByPhase,
@@ -1724,5 +1726,161 @@ describe("createComposedCallHandlers capability injection", () => {
     // Only injected tools message, no capabilities message
     const capMsg = receivedRequest?.messages.find((m) => m.senderId === "system:capabilities");
     expect(capMsg).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveActiveMiddleware
+// ---------------------------------------------------------------------------
+
+describe("resolveActiveMiddleware", () => {
+  function mw(
+    name: string,
+    phase?: "intercept" | "resolve" | "observe",
+    priority?: number,
+  ): KoiMiddleware {
+    return {
+      name,
+      ...(phase !== undefined ? { phase } : {}),
+      ...(priority !== undefined ? { priority } : {}),
+      describeCapabilities: () => undefined,
+    };
+  }
+
+  test("returns phase-sorted array for static-only input", () => {
+    const result = resolveActiveMiddleware([
+      mw("obs", "observe", 100),
+      mw("int", "intercept", 900),
+    ]);
+
+    expect(result[0]?.name).toBe("int");
+    expect(result[1]?.name).toBe("obs");
+  });
+
+  test("merges static + forged, phase-sorted", () => {
+    const result = resolveActiveMiddleware([mw("static", "observe")], [mw("forged", "intercept")]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.name).toBe("forged");
+    expect(result[1]?.name).toBe("static");
+  });
+
+  test("merges static + forged + dynamic, phase-sorted", () => {
+    const result = resolveActiveMiddleware(
+      [mw("static", "resolve")],
+      [mw("forged", "observe")],
+      [mw("dynamic", "intercept")],
+    );
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.name).toBe("dynamic");
+    expect(result[1]?.name).toBe("static");
+    expect(result[2]?.name).toBe("forged");
+  });
+
+  test("empty forged/dynamic treated as absent", () => {
+    const static_ = [mw("a"), mw("b")];
+    const resultWithUndef = resolveActiveMiddleware(static_);
+    const resultWithEmpty = resolveActiveMiddleware(static_, [], []);
+
+    expect(resultWithUndef).toHaveLength(2);
+    expect(resultWithEmpty).toHaveLength(2);
+  });
+
+  test("does not mutate input arrays", () => {
+    const input = [mw("obs", "observe"), mw("int", "intercept")];
+    const snapshot = [...input];
+
+    resolveActiveMiddleware(input);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  test("intercept middleware always before observe regardless of priority", () => {
+    const result = resolveActiveMiddleware([
+      mw("obs-low", "observe", 1),
+      mw("int-high", "intercept", 999),
+    ]);
+
+    expect(result[0]?.name).toBe("int-high");
+    expect(result[1]?.name).toBe("obs-low");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recomposeChains
+// ---------------------------------------------------------------------------
+
+describe("recomposeChains", () => {
+  test("returns all three chains when stream terminal provided", () => {
+    const sorted: readonly KoiMiddleware[] = [];
+    const terminals = {
+      modelHandler: async () => mockModelResponse(),
+      toolHandler: async () => ({ output: "ok" }),
+      modelStreamHandler: () => (async function* () {})(),
+    };
+
+    const chains = recomposeChains(sorted, terminals);
+
+    expect(typeof chains.toolChain).toBe("function");
+    expect(typeof chains.modelChain).toBe("function");
+    expect(chains.streamChain).toBeDefined();
+    expect(typeof chains.streamChain).toBe("function");
+  });
+
+  test("returns toolChain + modelChain only when no stream terminal", () => {
+    const sorted: readonly KoiMiddleware[] = [];
+    const terminals = {
+      modelHandler: async () => mockModelResponse(),
+      toolHandler: async () => ({ output: "ok" }),
+    };
+
+    const chains = recomposeChains(sorted, terminals);
+
+    expect(typeof chains.toolChain).toBe("function");
+    expect(typeof chains.modelChain).toBe("function");
+    expect(chains.streamChain).toBeUndefined();
+  });
+
+  test("chains dispatch through middleware in correct order", async () => {
+    const order: string[] = [];
+    const mw: KoiMiddleware = {
+      name: "recorder",
+      phase: "resolve",
+      describeCapabilities: () => undefined,
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("model-before");
+        const res = await next(req);
+        order.push("model-after");
+        return res;
+      },
+      wrapToolCall: async (_ctx, req, next) => {
+        order.push("tool-before");
+        const res = await next(req);
+        order.push("tool-after");
+        return res;
+      },
+    };
+
+    const terminals = {
+      modelHandler: async () => {
+        order.push("model-terminal");
+        return mockModelResponse();
+      },
+      toolHandler: async () => {
+        order.push("tool-terminal");
+        return { output: "ok" } as ToolResponse;
+      },
+    };
+
+    const chains = recomposeChains([mw], terminals);
+    const ctx = mockTurnContext();
+
+    await chains.modelChain(ctx, mockModelRequest());
+    expect(order).toEqual(["model-before", "model-terminal", "model-after"]);
+
+    order.length = 0;
+    await chains.toolChain(ctx, mockToolRequest());
+    expect(order).toEqual(["tool-before", "tool-terminal", "tool-after"]);
   });
 });

--- a/packages/kernel/engine/src/compose.ts
+++ b/packages/kernel/engine/src/compose.ts
@@ -55,6 +55,55 @@ export function sortMiddlewareByPhase(
 }
 
 // ---------------------------------------------------------------------------
+// Middleware merging + chain recomposition
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge static, forged, and dynamic middleware into a single phase-sorted array.
+ * Callers are responsible for identity-check gating (only call when sources change).
+ */
+export function resolveActiveMiddleware(
+  staticMiddleware: readonly KoiMiddleware[],
+  forgedMiddleware?: readonly KoiMiddleware[],
+  dynamicMiddleware?: readonly KoiMiddleware[],
+): readonly KoiMiddleware[] {
+  if (forgedMiddleware === undefined && dynamicMiddleware === undefined) {
+    return sortMiddlewareByPhase(staticMiddleware);
+  }
+  return sortMiddlewareByPhase([
+    ...staticMiddleware,
+    ...(forgedMiddleware ?? []),
+    ...(dynamicMiddleware ?? []),
+  ]);
+}
+
+/** Terminal handler references returned by recomposeChains. */
+export interface RecomposedChains {
+  readonly toolChain: (ctx: TurnContext, request: ToolRequest) => Promise<ToolResponse>;
+  readonly modelChain: (ctx: TurnContext, request: ModelRequest) => Promise<ModelResponse>;
+  readonly streamChain:
+    | ((ctx: TurnContext, request: ModelRequest) => AsyncIterable<ModelChunk>)
+    | undefined;
+}
+
+/**
+ * Compose tool, model, and optional stream chains from sorted middleware + terminals.
+ * Does NOT sort — caller must pass pre-sorted middleware (from resolveActiveMiddleware).
+ */
+export function recomposeChains(
+  sortedMiddleware: readonly KoiMiddleware[],
+  terminals: TerminalHandlers,
+): RecomposedChains {
+  const toolChain = composeToolChain(sortedMiddleware, terminals.toolHandler);
+  const modelChain = composeModelChain(sortedMiddleware, terminals.modelHandler);
+  const streamChain =
+    terminals.modelStreamHandler !== undefined
+      ? composeModelStreamChain(sortedMiddleware, terminals.modelStreamHandler)
+      : undefined;
+  return { toolChain, modelChain, streamChain };
+}
+
+// ---------------------------------------------------------------------------
 // Generic onion composition
 // ---------------------------------------------------------------------------
 

--- a/packages/kernel/engine/src/koi.test.ts
+++ b/packages/kernel/engine/src/koi.test.ts
@@ -3365,3 +3365,137 @@ describe("discovery:miss emission", () => {
     expect(errorCaught).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase ordering integration
+// ---------------------------------------------------------------------------
+
+describe("createKoi middleware phase ordering", () => {
+  test("intercept middleware runs before observe regardless of priority", async () => {
+    const order: string[] = [];
+
+    // Middleware A: observe phase, low priority (would run first in priority-only sort)
+    const observeMw: KoiMiddleware = {
+      name: "observe-mw",
+      phase: "observe",
+      priority: 100,
+      describeCapabilities: () => ({ label: "obs", description: "obs" }),
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("observe");
+        return next(req);
+      },
+    };
+
+    // Middleware B: intercept phase, high priority number
+    const interceptMw: KoiMiddleware = {
+      name: "intercept-mw",
+      phase: "intercept",
+      priority: 900,
+      describeCapabilities: () => ({ label: "int", description: "int" }),
+      wrapModelCall: async (_ctx, req, next) => {
+        order.push("intercept");
+        return next(req);
+      },
+    };
+
+    const modelTerminal = mock(() => Promise.resolve({ content: "ok", model: "test" }));
+
+    // Adapter that calls modelCall via callHandlers
+    const adapter: EngineAdapter = {
+      engineId: "phase-test",
+      capabilities: { text: true, images: false, files: false, audio: false },
+      terminals: { modelCall: modelTerminal },
+      stream: (input: EngineInput) => ({
+        async *[Symbol.asyncIterator]() {
+          // Call model via callHandlers to trigger middleware chain
+          if (input.callHandlers?.modelCall !== undefined) {
+            await input.callHandlers.modelCall({ messages: [] });
+          }
+          yield { kind: "done" as const, output: doneOutput() };
+        },
+      }),
+    };
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      // Pass observe first, intercept second — sort should fix ordering
+      middleware: [observeMw, interceptMw],
+      loopDetection: false,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    // Intercept should execute before observe (outer onion = runs first)
+    expect(order).toEqual(["intercept", "observe"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forged middleware scope integration
+// ---------------------------------------------------------------------------
+
+describe("createKoi forged middleware scope", () => {
+  test("forged middleware wrapModelCall participates but lifecycle hooks do not", async () => {
+    const forgedWrapped: string[] = [];
+    const forgedLifecycle: string[] = [];
+
+    const forgedMw: KoiMiddleware = {
+      name: "forged-test",
+      describeCapabilities: () => ({ label: "forged-cap", description: "should not appear" }),
+      wrapModelCall: async (_ctx, req, next) => {
+        forgedWrapped.push("wrapModelCall");
+        return next(req);
+      },
+      onBeforeTurn: async () => {
+        forgedLifecycle.push("onBeforeTurn");
+      },
+      onAfterTurn: async () => {
+        forgedLifecycle.push("onAfterTurn");
+      },
+    };
+
+    const modelTerminal = mock(() => Promise.resolve({ content: "ok", model: "test" }));
+
+    // let: mutable captured messages for assertion
+    const _capturedMessages: readonly unknown[] = [];
+
+    const adapter: EngineAdapter = {
+      engineId: "forge-scope-test",
+      capabilities: { text: true, images: false, files: false, audio: false },
+      terminals: { modelCall: modelTerminal },
+      stream: (input: EngineInput) => ({
+        async *[Symbol.asyncIterator]() {
+          if (input.callHandlers?.modelCall !== undefined) {
+            const req = { messages: [] };
+            // The request gets prepared with capabilities inside callHandlers
+            await input.callHandlers.modelCall(req);
+          }
+          yield { kind: "done" as const, output: doneOutput() };
+        },
+      }),
+    };
+
+    const forge: ForgeRuntime = {
+      resolveTool: async () => undefined,
+      toolDescriptors: async () => [],
+      middleware: async () => [forgedMw],
+    };
+
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter,
+      forge,
+      loopDetection: false,
+    });
+
+    await collectEvents(runtime.run({ kind: "text", text: "test" }));
+
+    // forged middleware's wrapModelCall WAS called
+    expect(forgedWrapped).toEqual(["wrapModelCall"]);
+
+    // forged middleware's lifecycle hooks were NOT called
+    // (lifecycle hooks only run on static allMiddleware, not forged)
+    expect(forgedLifecycle).toEqual([]);
+  });
+});

--- a/packages/kernel/engine/src/koi.ts
+++ b/packages/kernel/engine/src/koi.ts
@@ -42,11 +42,10 @@ import { runWithExecutionContext } from "@koi/execution-context";
 import { AgentEntity } from "./agent-entity.js";
 import { createBrickRequiresExtension } from "./brick-requires-extension.js";
 import {
-  composeModelChain,
-  composeModelStreamChain,
-  composeToolChain,
   createTerminalHandlers,
   injectCapabilities,
+  recomposeChains,
+  resolveActiveMiddleware,
   runSessionHooks,
   runTurnHooks,
 } from "./compose.js";
@@ -82,11 +81,6 @@ function unrefTimer(timer: ReturnType<typeof setInterval>): void {
   if (timer !== null && typeof timer === "object" && "unref" in timer) {
     (timer as { readonly unref: () => void }).unref();
   }
-}
-
-/** Sort middleware by priority (ascending). Guards get low numbers, L2 middleware gets higher. */
-function sortByPriority(middleware: readonly KoiMiddleware[]): readonly KoiMiddleware[] {
-  return [...middleware].sort((a, b) => (a.priority ?? 500) - (b.priority ?? 500));
 }
 
 /** Factory for constructing TurnContext with hierarchical turnId. */
@@ -171,8 +165,8 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
   // --- 2c. Wire transition validator into agent entity ---
   agent.setTransitionValidator(composed.validateTransition);
 
-  // --- 3. Compose middleware chain: guard middleware + user middleware, sorted by priority ---
-  const allMiddleware: readonly KoiMiddleware[] = sortByPriority([
+  // --- 3. Compose middleware chain: guard middleware + user middleware, phase-sorted ---
+  const allMiddleware: readonly KoiMiddleware[] = resolveActiveMiddleware([
     ...composed.guardMiddleware,
     ...middleware,
   ]);
@@ -309,12 +303,11 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
         const forgedMw = await forge.middleware();
         if (forgedMw !== previousForgedMw) {
           previousForgedMw = forgedMw;
-          const allMw: readonly KoiMiddleware[] = [...allMiddleware, ...forgedMw];
-          activeToolChain = composeToolChain(allMw, terminals.toolHandler);
-          activeModelChain = composeModelChain(allMw, terminals.modelHandler);
-          if (terminals.modelStreamHandler !== undefined) {
-            activeStreamChain = composeModelStreamChain(allMw, terminals.modelStreamHandler);
-          }
+          const sorted = resolveActiveMiddleware(allMiddleware, forgedMw);
+          const chains = recomposeChains(sorted, terminals);
+          activeToolChain = chains.toolChain;
+          activeModelChain = chains.modelChain;
+          activeStreamChain = chains.streamChain;
         }
       }
     }
@@ -381,15 +374,11 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
           rawModelStreamTerminal,
         );
 
-        // Initial chain composition
-        activeToolChain = composeToolChain(allMiddleware, cachedTerminals.toolHandler);
-        activeModelChain = composeModelChain(allMiddleware, cachedTerminals.modelHandler);
-        if (cachedTerminals.modelStreamHandler !== undefined) {
-          activeStreamChain = composeModelStreamChain(
-            allMiddleware,
-            cachedTerminals.modelStreamHandler,
-          );
-        }
+        // Initial chain composition (allMiddleware is already phase-sorted)
+        const initialChains = recomposeChains(allMiddleware, cachedTerminals);
+        activeToolChain = initialChains.toolChain;
+        activeModelChain = initialChains.modelChain;
+        activeStreamChain = initialChains.streamChain;
 
         // Entity tool descriptors (static, from assembly)
         const entityTools = agent.query<Tool>("tool:");
@@ -430,7 +419,14 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
         // Capture toolsAccessor in a const for the getter closure
         const accessor = toolsAccessor;
 
-        // Inject tool descriptors + capability descriptions into ModelRequest
+        /**
+         * Prepares a model request by injecting tool descriptors and capability descriptions.
+         *
+         * Note: Uses static `allMiddleware` (guards + user middleware) for capability injection.
+         * Forged and dynamic middleware participate in the call onion (wrapModelCall/wrapToolCall)
+         * but do NOT contribute to the [Active Capabilities] message. This is by design —
+         * injected middleware is "wrappers-only" and joins mid-session.
+         */
         const prepareRequest = (request: ModelRequest): ModelRequest => {
           // Inject tool descriptors if not already present
           const withTools: ModelRequest =
@@ -545,19 +541,15 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
             const dynamicMw = options.dynamicMiddleware();
             if (dynamicMw !== previousDynamicMw) {
               previousDynamicMw = dynamicMw;
-              const allMw = sortByPriority([
-                ...allMiddleware,
-                ...(previousForgedMw ?? []),
-                ...(dynamicMw ?? []),
-              ]);
-              activeToolChain = composeToolChain(allMw, cachedTerminals.toolHandler);
-              activeModelChain = composeModelChain(allMw, cachedTerminals.modelHandler);
-              if (cachedTerminals.modelStreamHandler !== undefined) {
-                activeStreamChain = composeModelStreamChain(
-                  allMw,
-                  cachedTerminals.modelStreamHandler,
-                );
-              }
+              const sorted = resolveActiveMiddleware(
+                allMiddleware,
+                previousForgedMw ?? undefined,
+                dynamicMw ?? undefined,
+              );
+              const chains = recomposeChains(sorted, cachedTerminals);
+              activeToolChain = chains.toolChain;
+              activeModelChain = chains.modelChain;
+              activeStreamChain = chains.streamChain;
             }
           }
 

--- a/packages/kernel/engine/src/registry.ts
+++ b/packages/kernel/engine/src/registry.ts
@@ -20,6 +20,7 @@ import type {
   VisibilityContext,
 } from "@koi/core";
 import { mapRegistryEntryToDescriptor, matchesFilter } from "@koi/core";
+import { createListenerSet } from "@koi/event-delivery";
 import { applyTransition } from "./transitions.js";
 
 // ---------------------------------------------------------------------------
@@ -64,24 +65,21 @@ export type InMemoryRegistry = Omit<
 
 export function createInMemoryRegistry(): InMemoryRegistry {
   const store = new Map<string, RegistryEntry>();
-  let listeners: ReadonlySet<(event: RegistryEvent) => void> = new Set(); // let: replaced on watch/unsubscribe
-
-  function notify(event: RegistryEvent): void {
-    for (const listener of listeners) {
-      listener(event);
-    }
-  }
+  const listeners = createListenerSet<RegistryEvent>({
+    onError: (err) =>
+      console.warn("[registry] listener threw:", err instanceof Error ? err.message : err),
+  });
 
   function register(entry: RegistryEntry): RegistryEntry {
     store.set(entry.agentId, entry);
-    notify({ kind: "registered", entry });
+    listeners.notify({ kind: "registered", entry });
     return entry;
   }
 
   function deregister(id: AgentId): boolean {
     const existed = store.delete(id);
     if (existed) {
-      notify({ kind: "deregistered", agentId: id });
+      listeners.notify({ kind: "deregistered", agentId: id });
     }
     return existed;
   }
@@ -132,7 +130,7 @@ export function createInMemoryRegistry(): InMemoryRegistry {
     };
     store.set(id, updated);
 
-    notify({
+    listeners.notify({
       kind: "transitioned",
       agentId: id,
       from: current.status.phase,
@@ -166,21 +164,17 @@ export function createInMemoryRegistry(): InMemoryRegistry {
     };
     store.set(id, updated);
 
-    notify({ kind: "patched", agentId: id, fields, entry: updated });
+    listeners.notify({ kind: "patched", agentId: id, fields, entry: updated });
 
     return { ok: true, value: updated };
   }
 
   function watch(listener: (event: RegistryEvent) => void): () => void {
-    listeners = new Set([...listeners, listener]);
-    return () => {
-      listeners = new Set([...listeners].filter((l) => l !== listener));
-    };
+    return listeners.subscribe(listener);
   }
 
   async function dispose(): Promise<void> {
     store.clear();
-    listeners = new Set();
   }
 
   function descriptor(id: AgentId): ProcessDescriptor | undefined {

--- a/packages/kernel/engine/src/types.ts
+++ b/packages/kernel/engine/src/types.ts
@@ -287,7 +287,12 @@ export interface ForgeRuntime {
   readonly resolveTool: (toolId: string) => Promise<Tool | undefined>;
   /** Get descriptors for all currently available forged tools. */
   readonly toolDescriptors: () => Promise<readonly ToolDescriptor[]>;
-  /** Get currently active forged middleware. Re-queried at turn boundaries. */
+  /**
+   * Get currently active forged middleware. Re-queried at turn boundaries.
+   * Forged middleware participates in wrapper hooks only (wrapModelCall, wrapModelStream,
+   * wrapToolCall). It does NOT participate in lifecycle hooks (onSessionStart/End,
+   * onBeforeTurn/AfterTurn) or describeCapabilities.
+   */
   readonly middleware?: () => Promise<readonly KoiMiddleware[]>;
   /** Push notification when forged capabilities change. Returns unsubscribe. */
   readonly watch?: (listener: (event: StoreChangeEvent) => void) => () => void;

--- a/packages/lib/event-delivery/src/index.ts
+++ b/packages/lib/event-delivery/src/index.ts
@@ -6,5 +6,5 @@
  */
 export type { DeliveryCallbacks, DeliveryConfig, DeliveryManager } from "./delivery-manager.js";
 export { createDeliveryManager } from "./delivery-manager.js";
-export type { ListenerSet } from "./listener-set.js";
+export type { ListenerSet, ListenerSetOptions } from "./listener-set.js";
 export { createListenerSet } from "./listener-set.js";

--- a/packages/lib/event-delivery/src/listener-set.test.ts
+++ b/packages/lib/event-delivery/src/listener-set.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { createListenerSet } from "./listener-set.js";
 
 describe("createListenerSet", () => {
@@ -59,5 +59,74 @@ describe("createListenerSet", () => {
     unsub();
     unsub(); // should not throw
     expect(set.size()).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Snapshot iteration
+  // ---------------------------------------------------------------------------
+
+  test("snapshot guarantees all listeners fire even if one unsubscribes another", () => {
+    const set = createListenerSet<string>();
+    const received: string[] = [];
+
+    // Listener A unsubscribes listener B during notification.
+    // With snapshot iteration, B should still fire for this notification.
+    // let: unsub ref captured by closure before assignment
+    let unsubB: (() => void) | undefined;
+    set.subscribe((e) => {
+      received.push(`A:${e}`);
+      unsubB?.();
+    });
+    unsubB = set.subscribe((e) => {
+      received.push(`B:${e}`);
+    });
+
+    set.notify("evt");
+
+    expect(received).toEqual(["A:evt", "B:evt"]);
+
+    // After the notification, B should be unsubscribed — second notify should not reach B
+    received.length = 0;
+    set.notify("evt2");
+    expect(received).toEqual(["A:evt2"]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // onError callback
+  // ---------------------------------------------------------------------------
+
+  test("onError callback receives error and event", () => {
+    const onError = mock<(err: unknown, event: string) => void>(() => {});
+    const set = createListenerSet<string>({ onError });
+
+    const thrown = new Error("kaboom");
+    set.subscribe(() => {
+      throw thrown;
+    });
+
+    set.notify("test-event");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(thrown, "test-event");
+  });
+
+  test("multiple listeners can throw independently with onError", () => {
+    const errors: unknown[] = [];
+    const set = createListenerSet<number>({
+      onError: (err) => errors.push(err),
+    });
+
+    const err1 = new Error("one");
+    const err2 = new Error("two");
+    set.subscribe(() => {
+      throw err1;
+    });
+    set.subscribe(() => {
+      throw err2;
+    });
+
+    set.notify(42);
+
+    expect(errors).toEqual([err1, err2]);
   });
 });

--- a/packages/lib/event-delivery/src/listener-set.ts
+++ b/packages/lib/event-delivery/src/listener-set.ts
@@ -6,9 +6,15 @@
  * implementations should use this instead of raw Set<fn> + manual try/catch.
  */
 
+/** Options for configuring a ListenerSet. */
+export interface ListenerSetOptions<T> {
+  /** Called when a listener throws. If omitted, errors are silently swallowed. */
+  readonly onError?: (err: unknown, event: T) => void;
+}
+
 /** A set of listeners with safe notification and cleanup. */
 export interface ListenerSet<T> {
-  /** Notify all listeners. Listener errors are swallowed. */
+  /** Notify all listeners. Listener errors are swallowed (or forwarded to onError). */
   readonly notify: (event: T) => void;
   /** Subscribe a listener. Returns an unsubscribe function. */
   readonly subscribe: (fn: (event: T) => void) => () => void;
@@ -17,14 +23,20 @@ export interface ListenerSet<T> {
 }
 
 /** Create a defensive listener set that swallows listener errors. */
-export function createListenerSet<T>(): ListenerSet<T> {
+export function createListenerSet<T>(options?: ListenerSetOptions<T>): ListenerSet<T> {
   const listeners = new Set<(event: T) => void>();
+  const onError = options?.onError;
 
   const notify = (event: T): void => {
-    for (const listener of listeners) {
+    // Snapshot: guarantees all listeners fire even if one unsubscribes another mid-iteration.
+    const snapshot = [...listeners];
+    for (const listener of snapshot) {
       try {
         listener(event);
-      } catch (_err: unknown) {
+      } catch (err: unknown) {
+        if (onError !== undefined) {
+          onError(err, event);
+        }
         // Listener errors must not break the mutation return path.
       }
     }

--- a/packages/lib/test-utils/src/agent-registry-contract.ts
+++ b/packages/lib/test-utils/src/agent-registry-contract.ts
@@ -327,6 +327,23 @@ export function runAgentRegistryContractTests(
         await registry.register(entry("a2"));
         expect(events).toHaveLength(1); // no new event
       });
+
+      test("throwing listener does not break transition or other listeners", async () => {
+        await registry.register(entry("a1", "created", 0));
+
+        const events: RegistryEvent[] = [];
+        registry.watch(() => {
+          throw new Error("boom");
+        });
+        registry.watch((e) => events.push(e));
+
+        const result = await registry.transition(agentId("a1"), "running", 0, {
+          kind: "assembly_complete",
+        });
+        expect(result.ok).toBe(true);
+        expect(events).toHaveLength(1);
+        expect(events[0]?.kind).toBe("transitioned");
+      });
     });
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Phase-blind sorting bug fixed**: Replaced `sortByPriority` (priority-only) in `koi.ts` with `resolveActiveMiddleware()` which sorts by `MiddlewarePhase` tier first (intercept → resolve → observe), then by priority within each tier
- **Registry listener safety**: All 3 `AgentRegistry` implementations + `child-handle` now use `ListenerSet` from `@koi/event-delivery` with snapshot iteration and `onError` callback — a throwing listener no longer breaks state transitions or other listeners
- **Composition consolidation**: Extracted `resolveActiveMiddleware()` (pure merge+sort) and `recomposeChains()` (triple chain builder) into `compose.ts`, eliminating 3× inline chain-building duplication in `koi.ts`
- **Middleware scope documented**: `ForgeRuntime.middleware` and `prepareRequest` now have JSDoc documenting that forged/dynamic middleware is "wrappers-only" (participates in `wrapModelCall`/`wrapToolCall` but NOT lifecycle hooks or `describeCapabilities`)

## Changed files (18)

| Area | Files |
|------|-------|
| ListenerSet | `listener-set.ts`, `listener-set.test.ts`, `index.ts` |
| Registries | `registry.ts`, `nexus-registry.ts`, `memory-registry.ts` + 3 `package.json` |
| Composition | `compose.ts`, `compose.test.ts` |
| Engine | `koi.ts`, `koi.test.ts`, `types.ts` |
| Child handle | `child-handle.ts`, `child-handle.test.ts` |
| Test utils | `agent-registry-contract.ts` |

## Test plan

- [x] ListenerSet snapshot + onError tests pass (8/8)
- [x] Registry contract "throwing listener" test added and passes across all 3 implementations
- [x] Child-handle "throwing listener" test added and passes
- [x] `resolveActiveMiddleware` + `recomposeChains` unit tests pass (9 new)
- [x] Phase ordering integration test (intercept before observe)
- [x] Forged middleware scope integration test (wrappers fire, lifecycle doesn't)
- [x] Full engine test suite: 1116 tests, 0 failures
- [x] Full build passes (87 turbo tasks)
- [x] Layer check passes
- [x] Biome lint clean