### PR TITLE
fix: reset guard state per session to prevent bleed across run() calls

### DIFF
--- a/packages/kernel/engine/src/guards.test.ts
+++ b/packages/kernel/engine/src/guards.test.ts
@@ -8,6 +8,7 @@ import type {
   ModelChunk,
   ModelRequest,
   ModelResponse,
+  SessionContext,
   SubsystemToken,
   ToolRequest,
   ToolResponse,
@@ -57,6 +58,10 @@ function mockToolResponse(output: unknown = 42): ToolResponse {
 
 type ModelNext = (req: ModelRequest) => Promise<ModelResponse>;
 type ToolNext = (req: ToolRequest) => Promise<ToolResponse>;
+
+function mockSessionContext(): SessionContext {
+  return { agentId: "a1", sessionId: sessionId("s1"), runId: runId("r1"), metadata: {} };
+}
 
 /** Extract wrapModelCall from a guard, asserting it exists. */
 function getModelWrap(
@@ -2159,5 +2164,148 @@ describe("composed guards interaction", () => {
         expect(e.message).toContain("Loop detected");
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onSessionStart — guard state reset across sessions
+// ---------------------------------------------------------------------------
+
+describe("onSessionStart resets guard state", () => {
+  test("iteration guard resets turns and tokens across sessions", async () => {
+    const guard = createIterationGuard({ maxTurns: 2, maxTokens: 200 });
+    const wrap = getModelWrap(guard);
+    const next: ModelNext = mock(() =>
+      Promise.resolve(mockModelResponse({ inputTokens: 30, outputTokens: 20 })),
+    );
+    const ctx = mockTurnContext();
+
+    // Session 1: consume 2 turns (turns counter = 2 after trackUsage)
+    await wrap(ctx, mockModelRequest(), next);
+    await wrap(ctx, mockModelRequest(), next);
+
+    // Without reset, next call would throw (turns=2 >= maxTurns=2)
+    // Reset via onSessionStart
+    await guard.onSessionStart?.(mockSessionContext());
+
+    // Session 2: should start fresh — 2 more turns succeed
+    await wrap(ctx, mockModelRequest(), next);
+    await wrap(ctx, mockModelRequest(), next);
+    expect(next).toHaveBeenCalledTimes(4);
+
+    // 3rd call in session 2 hits the limit (turns=2 >= maxTurns=2)
+    try {
+      await wrap(ctx, mockModelRequest(), next);
+      expect.unreachable("should have thrown");
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(KoiRuntimeError);
+      if (e instanceof KoiRuntimeError) {
+        expect(e.code).toBe("TIMEOUT");
+        expect(e.message).toContain("Max turns exceeded");
+      }
+    }
+  });
+
+  test("iteration guard resets duration timer across sessions", async () => {
+    const guard = createIterationGuard({ maxDurationMs: 50 });
+    const wrap = getModelWrap(guard);
+    const next: ModelNext = mock(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      return mockModelResponse();
+    });
+    const ctx = mockTurnContext();
+
+    // Session 1: one slow call (30ms elapsed)
+    await wrap(ctx, mockModelRequest(), next);
+
+    // Wait to exceed the 50ms budget from original startedAt
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Reset via onSessionStart — refreshes startedAt
+    await guard.onSessionStart?.(mockSessionContext());
+
+    // Session 2: should succeed (fresh timer)
+    await wrap(ctx, mockModelRequest(), next);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  test("loop detector resets state across sessions", async () => {
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 3,
+      noProgressEnabled: false,
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    // Session 1: 2 identical calls (below threshold of 3)
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+
+    // Reset via onSessionStart
+    await detector.onSessionStart?.(mockSessionContext());
+
+    // Session 2: 2 more identical calls — without reset, this would be 4 (over threshold)
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(next).toHaveBeenCalledTimes(4);
+
+    // 3rd call in session 2 hits the threshold
+    await expect(wrap(ctx, mockToolRequest("calc", { a: 1 }), next)).rejects.toBeInstanceOf(
+      KoiRuntimeError,
+    );
+  });
+
+  test("loop detector resets warnings across sessions", async () => {
+    const warnings: unknown[] = [];
+    const detector = createLoopDetector({
+      windowSize: 8,
+      threshold: 4,
+      warningThreshold: 2,
+      noProgressEnabled: false,
+      onWarning: (info) => warnings.push(info),
+    });
+    const wrap = getToolWrap(detector);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    // Session 1: trigger warning
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(warnings).toHaveLength(1);
+
+    // Reset
+    await detector.onSessionStart?.(mockSessionContext());
+
+    // Session 2: same hash should fire warning again (firedWarnings was cleared)
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    await wrap(ctx, mockToolRequest("calc", { a: 1 }), next);
+    expect(warnings).toHaveLength(2);
+  });
+
+  test("spawn guard resets fan-out warning across sessions", async () => {
+    const warnings: unknown[] = [];
+    const guard = createSpawnGuard({
+      policy: {
+        maxFanOut: 5,
+        fanOutWarningAt: 1,
+        onWarning: (info) => warnings.push(info),
+      },
+    });
+    const wrap = getToolWrap(guard);
+    const next: ToolNext = mock(() => Promise.resolve(mockToolResponse()));
+    const ctx = mockTurnContext();
+
+    // Session 1: trigger fan-out warning (use default spawn tool id "forge_agent")
+    await wrap(ctx, mockToolRequest("forge_agent"), next);
+    expect(warnings).toHaveLength(1);
+
+    // Reset
+    await guard.onSessionStart?.(mockSessionContext());
+
+    // Session 2: warning should fire again
+    await wrap(ctx, mockToolRequest("forge_agent"), next);
+    expect(warnings).toHaveLength(2);
   });
 });

--- a/packages/kernel/engine/src/guards.ts
+++ b/packages/kernel/engine/src/guards.ts
@@ -3,7 +3,8 @@
  * loop detection, and spawn governance.
  *
  * Each guard is created by a factory function that closes over mutable state.
- * State is scoped to the middleware instance lifetime (one per session).
+ * State is reset per session via onSessionStart hooks, so guards are safe
+ * to reuse across multiple run() calls on the same KoiRuntime.
  */
 
 import type {
@@ -66,10 +67,11 @@ export function createIterationGuard(config?: Partial<IterationLimits>): KoiMidd
     ...config,
   };
 
-  // let justified: mutable counters scoped to this middleware instance lifetime
+  // let justified: mutable counters reset per session via onSessionStart
   let turns = 0;
   let totalTokens = 0;
-  const startedAt = Date.now();
+  // let justified: mutable timestamp reset per session via onSessionStart
+  let startedAt = Date.now();
 
   function checkLimits(): void {
     if (turns >= limits.maxTurns) {
@@ -112,6 +114,12 @@ export function createIterationGuard(config?: Partial<IterationLimits>): KoiMidd
     name: "koi:iteration-guard",
     describeCapabilities: () => undefined,
     priority: 0,
+
+    onSessionStart: async () => {
+      turns = 0;
+      totalTokens = 0;
+      startedAt = Date.now();
+    },
 
     wrapModelCall: async (_ctx, request, next) => {
       checkLimits();
@@ -380,7 +388,7 @@ export function createLoopDetector(config?: Partial<LoopDetectionConfig>): KoiMi
 
   // Circular buffer for O(1) insert + evict
   const ringBuffer = new Array<number>(detection.windowSize).fill(0);
-  // let justified: mutable write cursor and fill count for circular buffer
+  // let justified: mutable write cursor and fill count for circular buffer, reset per session
   let cursor = 0;
   let filled = 0;
 
@@ -400,6 +408,17 @@ export function createLoopDetector(config?: Partial<LoopDetectionConfig>): KoiMi
   /** Queued warnings to inject into the next model call. */
   // let justified: mutable binding swapped on each injection cycle
   let pendingWarnings: readonly LoopWarningInfo[] = [];
+
+  /** Reset all mutable state for a new session. */
+  function resetState(): void {
+    ringBuffer.fill(0);
+    cursor = 0;
+    filled = 0;
+    hashCounts.clear();
+    firedWarnings.clear();
+    noProgressState.clear();
+    pendingWarnings = [];
+  }
 
   // Both conditions required: injectWarning must not be explicitly disabled,
   // AND warningThreshold must be set (otherwise no warnings are ever generated).
@@ -441,6 +460,10 @@ export function createLoopDetector(config?: Partial<LoopDetectionConfig>): KoiMi
     name: "koi:loop-detector",
     describeCapabilities: () => undefined,
     priority: 1,
+
+    onSessionStart: async () => {
+      resetState();
+    },
 
     // Only attach model hooks when injection is enabled — avoids per-call
     // overhead on the hot path when no warnings can ever be queued.
@@ -624,6 +647,11 @@ export function createSpawnGuard(options?: CreateSpawnGuardOptions): KoiMiddlewa
     name: "koi:spawn-guard",
     describeCapabilities: () => undefined,
     priority: 2,
+
+    onSessionStart: async () => {
+      directChildren = 0;
+      firedFanOutWarning = false;
+    },
 
     wrapToolCall: async (_ctx, request, next) => {
       // 0. Check depth-based tool restrictions (applies to ALL tools)


### PR DESCRIPTION
## Summary

- **Iteration guard** (`createIterationGuard`): turns, token count, and duration timer now reset via `onSessionStart` hook — previously accumulated across `run()` calls on the same `KoiRuntime`
- **Loop detector** (`createLoopDetector`): ring buffer, frequency map, warning set, no-progress state, and pending warnings now reset per session
- **Spawn guard** (`createSpawnGuard`): `directChildren` counter and `firedFanOutWarning` flag now reset per session

Without this fix, reusable agents (those that call `run()` multiple times on the same runtime instance) could hit false timeouts, premature loop detection, and suppressed warnings due to state bleeding across sessions.

## Test plan

- [x] 5 regression tests added covering all three guards' `onSessionStart` reset behavior
- [x] All 103 guard tests pass (98 existing + 5 new)
- [x] Function coverage increased from 90.63% to 91.67%
- [x] Biome lint/format passes
- [x] TypeScript typecheck passes
- [ ] CI green