### PR TITLE
feat: wire audit-sink-local & audit-sink-nexus into @koi/governance

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1084,6 +1084,8 @@
       "name": "@koi/governance",
       "version": "0.0.0",
       "dependencies": {
+        "@koi/audit-sink-local": "workspace:*",
+        "@koi/audit-sink-nexus": "workspace:*",
         "@koi/capability-verifier": "workspace:*",
         "@koi/core": "workspace:*",
         "@koi/delegation": "workspace:*",

--- a/docs/L3/governance.md
+++ b/docs/L3/governance.md
@@ -38,7 +38,7 @@ const stack = createGovernanceStack({
 // Strict — PII redaction, guardrails, read-only filesystem, HTTPS-only browser
 const strict = createGovernanceStack({
   preset: "strict",
-  audit: { sink: myAuditSink },
+  auditBackend: { kind: "sqlite", dbPath: "./audit.db" },
   backends: { filesystem: myFsBackend },
 });
 
@@ -143,6 +143,72 @@ if (delegationEscalationHandle?.isPending()) {
 
 **Not included in presets** — requires deployment-specific config (channel, agent IDs).
 
+## Declarative Audit Backend
+
+Instead of manually importing and instantiating audit sink packages, use the
+`auditBackend` field to declaratively select which backend to use. The factory
+auto-creates the `AuditSink` and wires it into both the audit middleware and
+scope backends (`backends.auditSink`) in a single config field.
+
+### Supported Backends
+
+| Kind | Package | Storage | Cleanup |
+|------|---------|---------|---------|
+| `sqlite` | `@koi/audit-sink-local` | Local SQLite database | `close()` tracked as disposable |
+| `ndjson` | `@koi/audit-sink-local` | Newline-delimited JSON file | `close()` tracked as disposable |
+| `nexus` | `@koi/audit-sink-nexus` | Batched writes to Nexus server | Timer `.unref()`'d (no disposable) |
+| `custom` | (user-provided) | Any `AuditSink` implementation | User manages lifecycle |
+
+### Examples
+
+```typescript
+// SQLite — local development / single-node deployments
+const stack = createGovernanceStack({
+  preset: "standard",
+  auditBackend: { kind: "sqlite", dbPath: "./audit.db" },
+  backends: { filesystem: myFsBackend },
+});
+
+// NDJSON — lightweight file-based logging
+const stack = createGovernanceStack({
+  auditBackend: { kind: "ndjson", filePath: "/var/log/koi/audit.ndjson" },
+});
+
+// Nexus — production, multi-node, durable + queryable
+const stack = createGovernanceStack({
+  preset: "strict",
+  auditBackend: {
+    kind: "nexus",
+    baseUrl: "http://nexus.internal:2026",
+    apiKey: process.env.NEXUS_API_KEY!,
+  },
+});
+
+// Custom — bring your own AuditSink
+const stack = createGovernanceStack({
+  auditBackend: { kind: "custom", sink: myCustomSink },
+});
+
+// Combine with other audit middleware options
+const stack = createGovernanceStack({
+  auditBackend: { kind: "sqlite", dbPath: ":memory:" },
+  audit: { redactRequestBodies: true, maxEntrySize: 20_000 },
+  // NOTE: audit.sink must NOT be set when auditBackend is used (mutually exclusive)
+});
+```
+
+### Mutual Exclusion
+
+`auditBackend` and `audit.sink` are **mutually exclusive**. Providing both
+throws an error with an actionable message. Use `auditBackend` for declarative
+selection, or provide `audit: { sink }` for manual wiring.
+
+### Disposable Lifecycle
+
+SQLite and NDJSON sinks expose a `close()` method that is automatically tracked
+in the bundle's `disposables` array. Call `disposable[Symbol.dispose]()` (or use
+a `using` block) to release file handles on shutdown.
+
 ## Deployment Presets
 
 ### `open` (default)
@@ -238,4 +304,4 @@ interface ResolvedGovernanceMeta {
 Dependencies:
 - L0: `@koi/core` (types)
 - L0u: `@koi/scope` (enforcer, scoping)
-- L2: `@koi/filesystem`, `@koi/tool-browser`, 11 middleware packages
+- L2: `@koi/audit-sink-local`, `@koi/audit-sink-nexus`, `@koi/filesystem`, `@koi/tool-browser`, 11 middleware packages

--- a/packages/meta/governance/package.json
+++ b/packages/meta/governance/package.json
@@ -11,6 +11,8 @@
     }
   },
   "dependencies": {
+    "@koi/audit-sink-local": "workspace:*",
+    "@koi/audit-sink-nexus": "workspace:*",
     "@koi/capability-verifier": "workspace:*",
     "@koi/core": "workspace:*",
     "@koi/delegation": "workspace:*",

--- a/packages/meta/governance/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/meta/governance/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,11 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/governance API surface . has stable type surface 1`] = `
-"import { SessionRevocationStore } from '@koi/capability-verifier';
+"import { SqliteAuditSinkConfig, NdjsonAuditSinkConfig } from '@koi/audit-sink-local';
+export { NdjsonAuditSinkConfig, SqliteAuditSinkConfig, createNdjsonAuditSink, createSqliteAuditSink } from '@koi/audit-sink-local';
+import { NexusAuditSinkConfig } from '@koi/audit-sink-nexus';
+export { NexusAuditSinkConfig, createNexusAuditSink, validateNexusAuditSinkConfig } from '@koi/audit-sink-nexus';
+import { SessionRevocationStore } from '@koi/capability-verifier';
 export { SessionRevocationStore } from '@koi/capability-verifier';
 import { DelegationMiddlewareConfig, DelegationManager } from '@koi/delegation';
 export { DelegationMiddlewareConfig, DelegationProviderConfig } from '@koi/delegation';
@@ -25,7 +29,7 @@ import { PIIConfig } from '@koi/middleware-pii';
 export { PIIConfig } from '@koi/middleware-pii';
 import { SanitizeMiddlewareConfig } from '@koi/middleware-sanitize';
 export { SanitizeMiddlewareConfig } from '@koi/middleware-sanitize';
-import { FileSystemBackend, CredentialComponent, MemoryComponent, AuditSink, ScopeEnforcer, PermissionBackend, KoiMiddleware, ComponentProvider } from '@koi/core';
+import { AuditSink, FileSystemBackend, CredentialComponent, MemoryComponent, ScopeEnforcer, PermissionBackend, KoiMiddleware, ComponentProvider } from '@koi/core';
 import { NexusPermissionBackend, OnGrantHook, OnRevokeHook } from '@koi/permissions-nexus';
 import { BrowserDriver } from '@koi/tool-browser';
 
@@ -36,6 +40,17 @@ import { BrowserDriver } from '@koi/tool-browser';
  * deployment presets, scope configuration, and the GovernanceBundle return shape.
  */
 
+/** Declarative audit backend selection — auto-creates the AuditSink and wires it into audit middleware + scope backends. */
+type AuditBackendConfig = ({
+    readonly kind: "sqlite";
+} & SqliteAuditSinkConfig) | ({
+    readonly kind: "ndjson";
+} & NdjsonAuditSinkConfig) | ({
+    readonly kind: "nexus";
+} & NexusAuditSinkConfig) | {
+    readonly kind: "custom";
+    readonly sink: AuditSink;
+};
 /** Deployment preset levels for governance stacks. */
 type GovernancePreset = "open" | "standard" | "strict";
 /** Scope configuration for governed capabilities. */
@@ -85,6 +100,11 @@ interface GovernanceStackConfig {
      * Creates a pattern permission backend automatically.
      */
     readonly permissionRules?: PermissionRules | undefined;
+    /**
+     * Declarative audit backend. Auto-creates the AuditSink and wires it
+     * into audit middleware + scope backends. Mutually exclusive with \`audit.sink\`.
+     */
+    readonly auditBackend?: AuditBackendConfig | undefined;
     /** Coarse-grained tool allow/deny/ask rules. Priority 100. */
     readonly permissions?: PermissionsMiddlewareConfig | undefined;
     /** Progressive command allowlisting. Priority 110 (overridden from default). */
@@ -226,6 +246,6 @@ declare function createGovernanceStack(config: GovernanceStackConfig): Governanc
 /** Frozen registry of governance preset specs, keyed by preset name. */
 declare const GOVERNANCE_PRESET_SPECS: Readonly<Record<GovernancePreset, GovernancePresetSpec>>;
 
-export { GOVERNANCE_PRESET_SPECS, type GovernanceBundle, type GovernancePreset, type GovernancePresetSpec, type GovernanceScopeBackends, type GovernanceScopeConfig, type GovernanceStackConfig, type NexusDelegationHooks, type ResolvedGovernanceMeta, createGovernanceStack, resolveGovernanceConfig };
+export { type AuditBackendConfig, GOVERNANCE_PRESET_SPECS, type GovernanceBundle, type GovernancePreset, type GovernancePresetSpec, type GovernanceScopeBackends, type GovernanceScopeConfig, type GovernanceStackConfig, type NexusDelegationHooks, type ResolvedGovernanceMeta, createGovernanceStack, resolveGovernanceConfig };
 "
 `;

--- a/packages/meta/governance/src/__tests__/governance-stack.test.ts
+++ b/packages/meta/governance/src/__tests__/governance-stack.test.ts
@@ -457,6 +457,96 @@ describe("createGovernanceStack", () => {
       expect(names).not.toContain("koi:delegation-escalation");
     }
   });
+
+  // ── Audit backend (declarative) ──────────────────────────────────
+
+  test("auditBackend: sqlite → creates audit middleware with auto-created sink", () => {
+    const { middlewares } = createGovernanceStack({
+      auditBackend: { kind: "sqlite", dbPath: ":memory:" },
+    });
+    const audit = middlewares.find((mw) => mw.name === "audit");
+    expect(audit).toBeDefined();
+  });
+
+  test("auditBackend: ndjson → creates audit middleware with NDJSON sink", () => {
+    const tmpPath = `/tmp/koi-test-audit-${Date.now()}.ndjson`;
+    const { middlewares, disposables } = createGovernanceStack({
+      auditBackend: { kind: "ndjson", filePath: tmpPath },
+    });
+    const audit = middlewares.find((mw) => mw.name === "audit");
+    expect(audit).toBeDefined();
+    // Clean up
+    for (const d of disposables) {
+      d[Symbol.dispose]();
+    }
+  });
+
+  test("auditBackend: nexus → creates audit middleware with no close disposable", () => {
+    const mockFetch = Object.assign(async () => new Response("{}"), {
+      preconnect: (_url: string | URL) => {},
+    }) as typeof fetch;
+    const { middlewares, disposables } = createGovernanceStack({
+      auditBackend: {
+        kind: "nexus",
+        baseUrl: "http://localhost:2026",
+        apiKey: "test-key",
+        fetch: mockFetch,
+      },
+    });
+    const audit = middlewares.find((mw) => mw.name === "audit");
+    expect(audit).toBeDefined();
+    expect(disposables).toHaveLength(0);
+  });
+
+  test("auditBackend: custom → uses provided sink", () => {
+    const sink = createInMemoryAuditSink();
+    const { middlewares } = createGovernanceStack({
+      auditBackend: { kind: "custom", sink },
+    });
+    const audit = middlewares.find((mw) => mw.name === "audit");
+    expect(audit).toBeDefined();
+  });
+
+  test("auditBackend + audit.sink → throws mutual exclusion error", () => {
+    const sink = createInMemoryAuditSink();
+    expect(() =>
+      createGovernanceStack({
+        auditBackend: { kind: "sqlite", dbPath: ":memory:" },
+        audit: { sink },
+      }),
+    ).toThrow("mutually exclusive");
+  });
+
+  test("auditBackend auto-wires backends.auditSink for scope-wiring", () => {
+    // When auditBackend is provided with scope + backends, the sink should
+    // be wired into backends.auditSink automatically
+    const { middlewares, disposables } = createGovernanceStack({
+      auditBackend: { kind: "sqlite", dbPath: ":memory:" },
+    });
+    // Audit middleware should exist (proves sink was wired into audit config)
+    expect(middlewares.find((mw) => mw.name === "audit")).toBeDefined();
+    // SQLite sink produces a close disposable
+    expect(disposables.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("auditBackend: sqlite produces close disposable", () => {
+    const { disposables } = createGovernanceStack({
+      auditBackend: { kind: "sqlite", dbPath: ":memory:" },
+    });
+    expect(disposables.length).toBeGreaterThanOrEqual(1);
+    // Should not throw
+    for (const d of disposables) {
+      d[Symbol.dispose]();
+    }
+  });
+
+  test("auditBackend: custom produces no close disposable", () => {
+    const sink = createInMemoryAuditSink();
+    const { disposables } = createGovernanceStack({
+      auditBackend: { kind: "custom", sink },
+    });
+    expect(disposables).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/meta/governance/src/governance-stack.ts
+++ b/packages/meta/governance/src/governance-stack.ts
@@ -19,10 +19,13 @@
  *   375  koi:guardrails
  */
 
+import { createNdjsonAuditSink, createSqliteAuditSink } from "@koi/audit-sink-local";
+import { createNexusAuditSink } from "@koi/audit-sink-nexus";
 import type { SessionRevocationStore } from "@koi/capability-verifier";
 import { createCapabilityVerifier, createSessionRevocationStore } from "@koi/capability-verifier";
 import type {
   Agent,
+  AuditSink,
   ComponentProvider,
   DelegationId,
   MailboxComponent,
@@ -60,7 +63,7 @@ import { createNexusOnGrant, createNexusOnRevoke } from "@koi/permissions-nexus"
 
 import { resolveGovernanceConfig } from "./config-resolution.js";
 import { wireGovernanceScope } from "./scope-wiring.js";
-import type { GovernanceBundle, GovernanceStackConfig } from "./types.js";
+import type { AuditBackendConfig, GovernanceBundle, GovernanceStackConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Approval routing provider (auto-discovery)
@@ -221,6 +224,42 @@ function autoWireVerifier(delegation: DelegationMiddlewareConfig | undefined): A
 }
 
 // ---------------------------------------------------------------------------
+// Audit backend auto-wiring
+// ---------------------------------------------------------------------------
+
+interface AuditSinkResult {
+  readonly sink: AuditSink;
+  /** Optional close disposable (for SQLite/NDJSON cleanup). */
+  readonly close?: (() => void) | undefined;
+}
+
+/** Create an AuditSink from a declarative AuditBackendConfig. */
+function createAuditSinkFromConfig(config: AuditBackendConfig): AuditSinkResult {
+  switch (config.kind) {
+    case "sqlite": {
+      const { kind: _, ...sinkConfig } = config;
+      const sink = createSqliteAuditSink(sinkConfig);
+      return { sink, close: sink.close };
+    }
+    case "ndjson": {
+      const { kind: _, ...sinkConfig } = config;
+      const sink = createNdjsonAuditSink(sinkConfig);
+      return { sink, close: sink.close };
+    }
+    case "nexus": {
+      const { kind: _, ...sinkConfig } = config;
+      return { sink: createNexusAuditSink(sinkConfig) };
+    }
+    case "custom":
+      return { sink: config.sink };
+    default: {
+      const _exhaustive: never = config;
+      throw new Error(`Unknown audit backend kind: ${(_exhaustive as AuditBackendConfig).kind}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main factory
 // ---------------------------------------------------------------------------
 
@@ -241,7 +280,29 @@ function autoWireVerifier(delegation: DelegationMiddlewareConfig | undefined): A
  * and mailbox from the agent entity — zero explicit config needed.
  */
 export function createGovernanceStack(config: GovernanceStackConfig): GovernanceBundle {
-  const resolved = resolveGovernanceConfig(config);
+  // Validate: auditBackend and audit.sink are mutually exclusive
+  if (config.auditBackend !== undefined && config.audit?.sink !== undefined) {
+    throw new Error(
+      "GovernanceStack: 'auditBackend' and 'audit.sink' are mutually exclusive. " +
+        "Use 'auditBackend' for declarative backend selection, or provide 'audit.sink' directly.",
+    );
+  }
+
+  // Auto-create audit sink from declarative config
+  const auditSinkResult =
+    config.auditBackend !== undefined ? createAuditSinkFromConfig(config.auditBackend) : undefined;
+
+  // If auditBackend is provided, merge the sink into the config before resolution
+  const effectiveConfig =
+    auditSinkResult !== undefined
+      ? {
+          ...config,
+          audit: { ...config.audit, sink: auditSinkResult.sink },
+          backends: { ...config.backends, auditSink: auditSinkResult.sink },
+        }
+      : config;
+
+  const resolved = resolveGovernanceConfig(effectiveConfig);
 
   // Validate: capabilityRequest requires delegationBridge
   if (config.capabilityRequest !== undefined && config.delegationBridge === undefined) {
@@ -283,6 +344,13 @@ export function createGovernanceStack(config: GovernanceStackConfig): Governance
   // agentId (pid.id), parentId (pid.parent), and mailbox (MAILBOX component) during
   // agent assembly. Zero explicit config needed — routing is wired dynamically.
   const disposables: Disposable[] = [];
+
+  // Track audit sink close for cleanup (SQLite/NDJSON file handles)
+  if (auditSinkResult?.close !== undefined) {
+    const closeFn = auditSinkResult.close;
+    disposables.push({ [Symbol.dispose]: closeFn });
+  }
+
   const approvalRouting =
     resolved.execApprovals !== undefined
       ? createApprovalRoutingProvider(resolved.execApprovals, disposables)

--- a/packages/meta/governance/src/index.ts
+++ b/packages/meta/governance/src/index.ts
@@ -22,6 +22,12 @@
  * ```
  */
 
+// ── Types: audit backends ────────────────────────────────────────────────
+export type { NdjsonAuditSinkConfig, SqliteAuditSinkConfig } from "@koi/audit-sink-local";
+// ── Factories: audit backends ────────────────────────────────────────────
+export { createNdjsonAuditSink, createSqliteAuditSink } from "@koi/audit-sink-local";
+export type { NexusAuditSinkConfig } from "@koi/audit-sink-nexus";
+export { createNexusAuditSink, validateNexusAuditSinkConfig } from "@koi/audit-sink-nexus";
 // ── Types: capability verifier ──────────────────────────────────────────
 export type { SessionRevocationStore } from "@koi/capability-verifier";
 // ── Types: middleware sub-configs ────────────────────────────────────────
@@ -50,6 +56,7 @@ export { createGovernanceStack } from "./governance-stack.js";
 export { GOVERNANCE_PRESET_SPECS } from "./presets.js";
 // ── Types: governance bundle ────────────────────────────────────────────
 export type {
+  AuditBackendConfig,
   GovernanceBundle,
   GovernancePreset,
   GovernancePresetSpec,

--- a/packages/meta/governance/src/types.ts
+++ b/packages/meta/governance/src/types.ts
@@ -5,6 +5,8 @@
  * deployment presets, scope configuration, and the GovernanceBundle return shape.
  */
 
+import type { NdjsonAuditSinkConfig, SqliteAuditSinkConfig } from "@koi/audit-sink-local";
+import type { NexusAuditSinkConfig } from "@koi/audit-sink-nexus";
 import type { SessionRevocationStore } from "@koi/capability-verifier";
 import type {
   AuditSink,
@@ -32,6 +34,17 @@ import type { PIIConfig } from "@koi/middleware-pii";
 import type { SanitizeMiddlewareConfig } from "@koi/middleware-sanitize";
 import type { NexusPermissionBackend, OnGrantHook, OnRevokeHook } from "@koi/permissions-nexus";
 import type { BrowserDriver } from "@koi/tool-browser";
+
+// ---------------------------------------------------------------------------
+// Audit backend config
+// ---------------------------------------------------------------------------
+
+/** Declarative audit backend selection — auto-creates the AuditSink and wires it into audit middleware + scope backends. */
+export type AuditBackendConfig =
+  | ({ readonly kind: "sqlite" } & SqliteAuditSinkConfig)
+  | ({ readonly kind: "ndjson" } & NdjsonAuditSinkConfig)
+  | ({ readonly kind: "nexus" } & NexusAuditSinkConfig)
+  | { readonly kind: "custom"; readonly sink: AuditSink };
 
 // ---------------------------------------------------------------------------
 // Deployment presets
@@ -97,6 +110,13 @@ export interface GovernanceStackConfig {
    * Creates a pattern permission backend automatically.
    */
   readonly permissionRules?: PermissionRules | undefined;
+
+  // ── Audit backend (declarative) ─────────────────────────────────────
+  /**
+   * Declarative audit backend. Auto-creates the AuditSink and wires it
+   * into audit middleware + scope backends. Mutually exclusive with `audit.sink`.
+   */
+  readonly auditBackend?: AuditBackendConfig | undefined;
 
   // ── Middleware configs (all optional) ─────────────────────────────────
   /** Coarse-grained tool allow/deny/ask rules. Priority 100. */


### PR DESCRIPTION
## Summary

- Add declarative `auditBackend` field to `GovernanceStackConfig` with a discriminated union (`sqlite | ndjson | nexus | custom`)
- Factory auto-creates the `AuditSink` and wires it into both the audit middleware config and scope backends (`backends.auditSink`)
- Disposable tracking for file-based sinks (SQLite/NDJSON `close()` registered in `disposables`)
- Mutual exclusion validation: `auditBackend` and `audit.sink` cannot both be provided
- Re-export sink types/factories from `@koi/governance` for convenience
- 8 new tests covering all backend kinds, mutual exclusion error, and disposable lifecycle
- Updated docs/L3/governance.md with usage examples and backend comparison table

## What this enables

Users of `@koi/governance` can now declaratively select an audit backend without manually importing sink packages:

```typescript
// Before: manual import + instantiation
import { createSqliteAuditSink } from "@koi/audit-sink-local";
const sink = createSqliteAuditSink({ dbPath: "./audit.db" });
const stack = createGovernanceStack({ audit: { sink } });

// After: one-liner
const stack = createGovernanceStack({
  auditBackend: { kind: "sqlite", dbPath: "./audit.db" },
});
```

Supports SQLite, NDJSON, Nexus, and custom sinks. File-based sinks auto-register their `close()` in the bundle's `disposables` for proper cleanup.

## Test plan

- [x] `auditBackend: { kind: "sqlite" }` creates audit middleware with SQLite sink
- [x] `auditBackend: { kind: "ndjson" }` creates audit middleware with NDJSON sink
- [x] `auditBackend: { kind: "nexus" }` creates audit middleware with Nexus sink (no close disposable)
- [x] `auditBackend: { kind: "custom", sink }` uses provided sink
- [x] Both `audit.sink` and `auditBackend` throws mutual exclusion error
- [x] SQLite/NDJSON sinks produce close disposables; custom does not
- [x] Typecheck passes
- [x] API surface snapshot updated
- [x] 85/85 tests pass