### PR TITLE
feat: add @koi/middleware-event-rules package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1320,6 +1320,19 @@
         "@koi/test-utils": "workspace:*",
       },
     },
+    "packages/middleware/middleware-event-rules": {
+      "name": "@koi/middleware-event-rules",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/resolve": "workspace:*",
+        "@koi/validation": "workspace:*",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@koi/test-utils": "workspace:*",
+      },
+    },
     "packages/middleware/middleware-feedback-loop": {
       "name": "@koi/middleware-feedback-loop",
       "version": "0.0.0",
@@ -3355,6 +3368,8 @@
     "@koi/middleware-degenerate": ["@koi/middleware-degenerate@workspace:packages/middleware/middleware-degenerate"],
 
     "@koi/middleware-delegation-escalation": ["@koi/middleware-delegation-escalation@workspace:packages/security/middleware-delegation-escalation"],
+
+    "@koi/middleware-event-rules": ["@koi/middleware-event-rules@workspace:packages/middleware/middleware-event-rules"],
 
     "@koi/middleware-event-trace": ["@koi/middleware-event-trace@workspace:packages/observability/middleware-event-trace"],
 

--- a/docs/L2/middleware-event-rules.md
+++ b/docs/L2/middleware-event-rules.md
@@ -1,0 +1,354 @@
+# @koi/middleware-event-rules — Declarative Event-to-Action Rule Engine
+
+`@koi/middleware-event-rules` is an L2 middleware package that maps engine events (tool failures, budget warnings, session lifecycle) to actions (escalate, notify, log, skip_tool) via declarative YAML rules. No custom middleware code needed.
+
+---
+
+## Why It Exists
+
+Reacting to engine events currently requires writing custom middleware. For common patterns like "escalate after 3 tool failures" or "notify on high turn count", this is boilerplate. This package replaces that boilerplate with a YAML rule engine.
+
+```
+Without event-rules:
+  Write middleware ─► implement onAfterTurn ─► track counter ─► check threshold
+  ─► interpolate message ─► call escalation API ─► handle errors ─► test everything
+  Total: ~200 lines of middleware code per pattern
+
+With event-rules:
+  rules:
+    - name: tool-failure-escalate
+      on: tool_call
+      match: { ok: false, toolId: { regex: "^shell_" } }
+      condition: { count: 3, window: "1m" }
+      actions:
+        - type: escalate
+          message: "Tool {{toolId}} failed {{count}} times"
+  Total: 8 lines of YAML
+```
+
+---
+
+## Architecture
+
+### Layer Position
+
+```
+L0  @koi/core                          ─ KoiMiddleware, ToolRequest, ToolResponse,
+                                           SessionContext, TurnContext (types only)
+L0u @koi/resolve                       ─ BrickDescriptor (manifest auto-resolution)
+L0u @koi/validation                    ─ validateWith, zodToKoiError
+L2  @koi/middleware-event-rules        ─ this package (no L1 dependency)
+```
+
+### Internal Module Map
+
+```
+index.ts                    ← public re-exports
+│
+├── types.ts                ← RuleEventType, MatchValue, CompiledRule, ActionContext, etc.
+├── duration.ts             ← parseDuration("30s" → 30000)
+├── interpolate.ts          ← interpolate("{{var}}", context)
+├── rule-schema.ts          ← Zod validation + compilation (regex, duration, indexing)
+├── rule-engine.ts          ← createRuleEngine() — evaluate rules, windowed counters
+├── actions.ts              ← executeActions() — per-action dispatch with degradation
+├── load-rules.ts           ← loadRulesFromFile/String (YAML → compiled ruleset)
+├── rule-middleware.ts       ← createEventRulesMiddleware() factory
+└── descriptor.ts           ← BrickDescriptor for manifest auto-resolution
+```
+
+### Middleware Priority
+
+```
+500 ─ (default)
+750 ─ event-rules          ← this package (observe phase)
+```
+
+The middleware runs at priority 750 in the `observe` phase — read-only telemetry/audit tier. It observes events after business logic middleware has run.
+
+---
+
+## How It Works
+
+### Event Vocabulary
+
+Rules use a local event vocabulary decoupled from `EngineEvent`:
+
+| Event | Middleware Hook | Available Match Fields |
+|-------|----------------|----------------------|
+| `tool_call` | `wrapToolCall` (after `next()`) | `toolId`, `ok`, flat `input` fields |
+| `turn_complete` | `onAfterTurn` | `turnIndex`, `agentId`, `sessionId` |
+| `session_start` | `onSessionStart` | `agentId`, `sessionId`, `userId`, `channelId` |
+| `session_end` | `onSessionEnd` | `agentId`, `sessionId`, `userId`, `channelId` |
+
+### Match Predicates
+
+Flat object with value-driven dispatch:
+
+| Syntax | Type | Example |
+|--------|------|---------|
+| `field: value` | Exact match | `ok: false` |
+| `field: { regex: "pattern" }` | Regex | `toolId: { regex: "^shell_" }` |
+| `field: { gte: n }` | Numeric comparison | `turnIndex: { gte: 15 }` |
+| `field: [a, b, c]` | oneOf | `toolId: ["shell_exec", "file_write"]` |
+
+All predicates in a rule's `match` block use AND logic.
+
+### Windowed Counters
+
+Rules can require a minimum event count within a time window:
+
+```yaml
+condition:
+  count: 3       # must match 3 times...
+  window: "1m"   # ...within 1 minute
+```
+
+Counter state is session-scoped, in-memory, bounded to 1000 entries per rule, and pruned on read (no background timers). Binary search over sorted timestamps makes lookups efficient.
+
+### Built-in Actions
+
+| Action | Required Fields | Dependency | Degradation |
+|--------|----------------|------------|-------------|
+| `emit` | `event` | `emitEvent` | Log fallback |
+| `escalate` | `message` | `requestEscalation` | Log fallback |
+| `log` | `level`, `message` | `logger` | Console fallback |
+| `notify` | `channel`, `message` | `sendNotification` | Log fallback |
+| `skip_tool` | `toolId` | None | Blocks in `wrapToolCall` |
+
+Actions support `{{variable}}` template interpolation from event fields. Missing variables produce `"<undefined:varName>"` sentinels.
+
+Each action is wrapped in try/catch — errors are logged but never propagate.
+
+### Evaluation Order
+
+Rules are evaluated in declaration order. By default all matching rules fire (evaluate-all). Set `stopOnMatch: true` on a rule to stop after the first match.
+
+Rules are pre-indexed by event type at load time (`Map<EventType, Rule[]>`), so only relevant rules are evaluated per event.
+
+---
+
+## API Reference
+
+### `createEventRulesMiddleware(config)`
+
+Factory function that creates a `KoiMiddleware` with session lifecycle, turn, and tool call hooks.
+
+```typescript
+import { createEventRulesMiddleware, validateEventRulesConfig } from "@koi/middleware-event-rules";
+
+const result = validateEventRulesConfig(yamlParsed);
+if (!result.ok) throw new Error(result.error.message);
+
+const mw = createEventRulesMiddleware({
+  ruleset: result.value,
+  actionContext: {
+    requestEscalation: (msg) => escalationService.send(msg),
+    sendNotification: (channel, msg) => notifier.send(channel, msg),
+    logger: customLogger,
+  },
+});
+```
+
+Returns `KoiMiddleware` with:
+- `name`: `"koi:event-rules"`
+- `priority`: `750`
+- `phase`: `"observe"`
+- `onSessionStart`, `onSessionEnd`, `onAfterTurn`, `wrapToolCall`
+- `describeCapabilities`: returns `{ label: "event-rules", description: "..." }`
+
+### `validateEventRulesConfig(input)`
+
+Validates and compiles raw input (from YAML or object) into an immutable `CompiledRuleset`:
+
+```typescript
+const result = validateEventRulesConfig({
+  rules: [{ name: "r1", on: "tool_call", actions: [{ type: "log", level: "warn", message: "x" }] }],
+});
+if (result.ok) {
+  const ruleset = result.value; // CompiledRuleset
+}
+```
+
+Performs exhaustive validation via Zod: unique rule names, valid event types, required action fields, regex compilation, duration parsing. Invalid input returns `Result<never, KoiError>`.
+
+### `loadRulesFromFile(path)` / `loadRulesFromString(yaml)`
+
+Convenience loaders that parse YAML and validate in one step:
+
+```typescript
+const result = await loadRulesFromFile("./rules.yaml");
+if (result.ok) {
+  const mw = createEventRulesMiddleware({ ruleset: result.value });
+}
+```
+
+### `createRuleEngine(ruleset, now?)`
+
+Low-level engine for evaluating rules outside of middleware context:
+
+```typescript
+const engine = createRuleEngine(ruleset, () => Date.now());
+const result = engine.evaluate({ type: "tool_call", fields: { toolId: "shell_exec", ok: false }, sessionId });
+// result.actions — matched actions to execute
+// result.skipToolIds — tools to circuit-break
+```
+
+### `EventRulesConfig`
+
+```typescript
+interface EventRulesConfig {
+  readonly ruleset: CompiledRuleset;   // Pre-validated + compiled rules
+  readonly actionContext?: ActionContext; // Injected dependencies
+  readonly now?: () => number;          // Clock injection for testing
+}
+```
+
+### `ActionContext`
+
+```typescript
+interface ActionContext {
+  readonly logger?: RuleLogger;
+  readonly emitEvent?: (event: string, data: unknown) => void | Promise<void>;
+  readonly requestEscalation?: (message: string) => void | Promise<void>;
+  readonly sendNotification?: (channel: string, message: string) => void | Promise<void>;
+}
+```
+
+---
+
+## Examples
+
+### Manifest-Driven (koi.yaml)
+
+```yaml
+middleware:
+  - name: event-rules
+    options:
+      rules:
+        - name: tool-failure-escalate
+          on: tool_call
+          match:
+            ok: false
+            toolId: { regex: "^shell_" }
+          condition:
+            count: 3
+            window: "1m"
+          actions:
+            - type: escalate
+              message: "Tool {{toolId}} failed {{count}} times in {{window}}"
+          stopOnMatch: true
+
+        - name: budget-warning
+          on: turn_complete
+          match:
+            turnIndex: { gte: 15 }
+          actions:
+            - type: notify
+              channel: status
+              message: "Turn count {{turnIndex}} — session {{sessionId}}"
+
+        - name: long-turn-alert
+          on: turn_complete
+          match:
+            turnIndex: { gte: 20 }
+          actions:
+            - type: log
+              level: warn
+              message: "Session {{sessionId}} exceeded 20 turns"
+```
+
+### Programmatic Factory
+
+```typescript
+import {
+  createEventRulesMiddleware,
+  validateEventRulesConfig,
+} from "@koi/middleware-event-rules";
+
+const result = validateEventRulesConfig({
+  rules: [
+    {
+      name: "block-dangerous-tools",
+      on: "tool_call",
+      match: { ok: false, toolId: { regex: "^(shell_|file_delete)" } },
+      condition: { count: 2, window: "5m" },
+      actions: [
+        { type: "skip_tool", toolId: "shell_exec" },
+        { type: "escalate", message: "Blocked {{toolId}} after repeated failures" },
+      ],
+    },
+  ],
+});
+
+if (result.ok) {
+  const mw = createEventRulesMiddleware({
+    ruleset: result.value,
+    actionContext: {
+      requestEscalation: async (msg) => {
+        await slackWebhook.send({ text: msg });
+      },
+    },
+  });
+}
+```
+
+---
+
+## What This Feature Enables
+
+### 1. Zero-Code Event Reactions
+
+Define complex event-reaction patterns in YAML without writing middleware. Common patterns (escalation, alerting, circuit-breaking) become configuration rather than code.
+
+### 2. Tool Circuit-Breaking
+
+The `skip_tool` action blocks subsequent calls to a specific tool after failure thresholds are met. This prevents cascading failures — if `shell_exec` fails 3 times, it is automatically blocked for the rest of the session.
+
+### 3. Budget and Turn Monitoring
+
+Monitor session health with turn-count thresholds. Get notifications when sessions are running long (>15 turns) or send alerts when they exceed safety limits (>20 turns).
+
+### 4. Windowed Failure Detection
+
+Counters with time windows detect burst failures without triggering on spread-out errors. "3 failures in 1 minute" catches hot failures while ignoring occasional errors.
+
+### 5. Graceful Degradation
+
+All action dependencies are optional. If the escalation service is unavailable, escalate degrades to error logging. If the notification channel is missing, notify degrades to warning logging. Rules never crash the middleware pipeline.
+
+### 6. Session-Scoped State
+
+Each session gets its own rule engine with independent counter state. One session's failure count does not affect another's. State is cleaned up when the session ends.
+
+### 7. Declarative Agent Governance
+
+Combined with the manifest system, this enables platform operators to define governance policies (failure thresholds, alerting rules, safety limits) in the agent manifest without touching agent code.
+
+---
+
+## Performance
+
+| Aspect | Design | Complexity |
+|--------|--------|------------|
+| Rule lookup | Pre-indexed `Map<EventType, Rule[]>` | O(1) type lookup |
+| Predicate matching | Compiled closures (regex pre-compiled) | O(predicates) per rule |
+| Counter access | Sorted array + binary search prune | O(log n) prune |
+| Counter memory | Bounded 1000 entries per rule | Fixed upper bound |
+| Compilation | One-time at load | O(rules) |
+| Background work | None — prune-on-read only | Zero timers |
+
+---
+
+## Layer Compliance
+
+```
+@koi/middleware-event-rules imports:
+  ✅ @koi/core        (L0)  — KoiMiddleware, SessionContext, TurnContext, etc.
+  ✅ @koi/resolve      (L0u) — BrickDescriptor
+  ✅ @koi/validation   (L0u) — validateWith
+  ✅ zod               (ext) — schema validation
+  ❌ @koi/engine       (L1)  — NOT imported
+  ❌ peer L2            —      NOT imported
+```
+
+All interface properties are `readonly`. No vendor types. No framework-isms.

--- a/packages/middleware/middleware-event-rules/package.json
+++ b/packages/middleware/middleware-event-rules/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@koi/middleware-event-rules",
+  "description": "Declarative YAML rule engine mapping engine events to actions — no middleware code needed",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/resolve": "workspace:*",
+    "@koi/validation": "workspace:*",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@koi/test-utils": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/middleware/middleware-event-rules/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/middleware/middleware-event-rules/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,0 +1,274 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`@koi/middleware-event-rules API surface . has stable type surface 1`] = `
+"import { SessionId } from '@koi/core/ecs';
+import { KoiMiddleware, Result, KoiError } from '@koi/core';
+import { BrickDescriptor } from '@koi/resolve';
+import { KoiMiddleware as KoiMiddleware$1 } from '@koi/core/middleware';
+
+/**
+ * Type definitions for @koi/middleware-event-rules.
+ *
+ * Covers the YAML rule schema, compiled runtime types,
+ * action context, and evaluation results.
+ */
+
+/** Rule-local event vocabulary, decoupled from EngineEvent. */
+type RuleEventType = "tool_call" | "turn_complete" | "session_start" | "session_end";
+/** Regex match operator. */
+interface RegexOperator {
+    readonly regex: string;
+}
+/** Numeric comparison operators. */
+interface NumericOperator {
+    readonly gte?: number | undefined;
+    readonly lte?: number | undefined;
+    readonly gt?: number | undefined;
+    readonly lt?: number | undefined;
+}
+/** A match value: primitive exact match, operator object, or array (oneOf). */
+type MatchValue = string | number | boolean | RegexOperator | NumericOperator | readonly (string | number | boolean)[];
+/** Match predicate object — flat key-value pairs. */
+type MatchPredicates = Readonly<Record<string, MatchValue>>;
+/** Built-in action types. */
+type ActionType = "emit" | "escalate" | "log" | "notify" | "skip_tool";
+/** Log level for \`log\` action. */
+type LogLevel = "info" | "warn" | "error" | "debug";
+/** Raw action as parsed from YAML. */
+interface RawAction {
+    readonly type: ActionType;
+    readonly event?: string;
+    readonly message?: string;
+    readonly channel?: string;
+    readonly level?: LogLevel;
+    readonly toolId?: string;
+}
+/** Windowed counter condition. */
+interface RawCondition {
+    readonly count: number;
+    readonly window: string;
+}
+/** A single rule as parsed from YAML. */
+interface RawRule {
+    readonly name: string;
+    readonly on: RuleEventType;
+    readonly match?: MatchPredicates;
+    readonly condition?: RawCondition;
+    readonly actions: readonly RawAction[];
+    readonly stopOnMatch?: boolean;
+}
+/** Top-level YAML config. */
+interface RawEventRulesConfig {
+    readonly rules: readonly RawRule[];
+}
+/** A compiled predicate: field name + test closure. */
+interface CompiledPredicate {
+    readonly field: string;
+    readonly test: (value: unknown) => boolean;
+}
+/** A compiled rule with parsed window, compiled predicates, and indexed position. */
+interface CompiledRule {
+    readonly name: string;
+    readonly on: RuleEventType;
+    readonly predicates: readonly CompiledPredicate[];
+    readonly condition: {
+        readonly count: number;
+        readonly windowMs: number;
+    } | undefined;
+    readonly actions: readonly RawAction[];
+    readonly stopOnMatch: boolean;
+}
+/** Immutable compiled ruleset with pre-indexed lookup by event type. */
+interface CompiledRuleset {
+    readonly rules: readonly CompiledRule[];
+    readonly byEventType: ReadonlyMap<RuleEventType, readonly CompiledRule[]>;
+}
+/** An event emitted to the rule engine for evaluation. */
+interface RuleEvent {
+    readonly type: RuleEventType;
+    readonly fields: Readonly<Record<string, unknown>>;
+    readonly sessionId: SessionId;
+}
+/** Result of evaluating rules against an event. */
+interface RuleEvalResult {
+    /** Actions to execute. */
+    readonly actions: readonly ResolvedAction[];
+    /** Tool IDs to skip (from skip_tool actions). */
+    readonly skipToolIds: readonly string[];
+}
+/** An action resolved with its originating rule name and event context. */
+interface ResolvedAction {
+    readonly ruleName: string;
+    readonly action: RawAction;
+}
+/** Logger interface for rule actions. */
+interface RuleLogger {
+    readonly info: (message: string) => void;
+    readonly warn: (message: string) => void;
+    readonly error: (message: string) => void;
+    readonly debug: (message: string) => void;
+}
+/** Dependencies injected into action execution. */
+interface ActionContext {
+    readonly logger?: RuleLogger;
+    readonly emitEvent?: (event: string, data: unknown) => void | Promise<void>;
+    readonly requestEscalation?: (message: string) => void | Promise<void>;
+    readonly sendNotification?: (channel: string, message: string) => void | Promise<void>;
+}
+/** A rule engine instance scoped to a single session. */
+interface RuleEngine {
+    /** Evaluate an event against the ruleset and return matched actions. */
+    readonly evaluate: (event: RuleEvent) => RuleEvalResult;
+    /** Clear all counter state. */
+    readonly reset: () => void;
+}
+/** Configuration for createEventRulesMiddleware. */
+interface EventRulesConfig {
+    /** Compiled ruleset (already validated). */
+    readonly ruleset: CompiledRuleset;
+    /** Action context dependencies. */
+    readonly actionContext?: ActionContext;
+    /** Injectable clock for testing. Default: Date.now. */
+    readonly now?: () => number;
+}
+
+/**
+ * Action execution — runs resolved actions with graceful degradation.
+ *
+ * Each action is wrapped in try/catch. Errors are logged but never propagated.
+ * Missing dependencies degrade to logging.
+ */
+
+/**
+ * Executes resolved actions with template interpolation and graceful degradation.
+ *
+ * @param resolvedActions - Actions matched by the rule engine.
+ * @param eventContext - Context for template interpolation (event fields + extras).
+ * @param actionContext - Injected dependencies for action execution.
+ */
+declare function executeActions(resolvedActions: readonly ResolvedAction[], eventContext: Readonly<Record<string, unknown>>, actionContext: ActionContext): Promise<void>;
+
+/**
+ * BrickDescriptor for @koi/middleware-event-rules.
+ *
+ * Enables manifest auto-resolution: validates event rules options
+ * from koi.yaml, then creates the event-rules middleware.
+ *
+ * Usage in koi.yaml:
+ *   middleware:
+ *     - name: event-rules
+ *       options:
+ *         rules:
+ *           - name: tool-failure-escalate
+ *             on: tool_call
+ *             match:
+ *               ok: false
+ *             condition:
+ *               count: 3
+ *               window: "1m"
+ *             actions:
+ *               - type: escalate
+ *                 message: "Tool {{toolId}} failed {{count}} times"
+ */
+
+/**
+ * Descriptor for event-rules middleware.
+ *
+ * Creates a declarative event→action middleware from validated YAML options.
+ */
+declare const descriptor: BrickDescriptor<KoiMiddleware>;
+
+/**
+ * Duration string parser — converts "30s", "5m", "1h" to milliseconds.
+ */
+/**
+ * Parses a duration string into milliseconds.
+ *
+ * @returns milliseconds, or \`undefined\` for invalid/zero input.
+ */
+declare function parseDuration(input: string): number | undefined;
+
+/**
+ * Shallow template interpolation for rule action messages.
+ *
+ * Replaces \`{{varName}}\` placeholders with values from a context object.
+ * Undefined variables produce \`"<undefined:varName>"\` sentinel strings.
+ */
+/**
+ * Interpolates \`{{varName}}\` placeholders in a template string.
+ *
+ * @param template - String with \`{{varName}}\` placeholders.
+ * @param context - Key-value context for substitution.
+ * @returns Interpolated string.
+ */
+declare function interpolate(template: string, context: Readonly<Record<string, unknown>>): string;
+
+/**
+ * Rule loading utilities — parse YAML strings or files into compiled rulesets.
+ */
+
+/**
+ * Parses a YAML string into a compiled ruleset.
+ *
+ * @param yaml - YAML string containing event rules config.
+ * @returns Compiled ruleset or validation error.
+ */
+declare function loadRulesFromString(yaml: string): Result<CompiledRuleset, KoiError>;
+/**
+ * Loads and compiles event rules from a YAML file.
+ *
+ * @param filePath - Path to the YAML file.
+ * @returns Compiled ruleset or error.
+ */
+declare function loadRulesFromFile(filePath: string): Promise<Result<CompiledRuleset, KoiError>>;
+
+/**
+ * Rule engine — evaluates compiled rules against events.
+ *
+ * Session-scoped, in-memory counter state with sorted-array storage
+ * and binary-search prune-on-read. No background timers.
+ */
+
+/**
+ * Creates a rule engine for a compiled ruleset.
+ *
+ * @param ruleset - Pre-compiled and indexed ruleset.
+ * @param now - Injectable clock (default: Date.now).
+ */
+declare function createRuleEngine(ruleset: CompiledRuleset, now?: () => number): RuleEngine;
+
+/**
+ * Event rules middleware — declarative event→action mapping.
+ *
+ * Hooks into session lifecycle, turn completion, and tool calls to evaluate
+ * rules and execute actions. Session-scoped engine instances with in-memory
+ * counter state.
+ *
+ * Priority 750: observe phase, runs after most business-logic middleware.
+ */
+
+/**
+ * Creates an event-rules middleware from a compiled ruleset.
+ *
+ * @param config - Compiled ruleset + optional action context + clock.
+ */
+declare function createEventRulesMiddleware(config: EventRulesConfig): KoiMiddleware$1;
+
+/**
+ * Zod schema + compilation for event rule configs.
+ *
+ * Validates YAML input exhaustively at load time, compiles regex patterns
+ * into closures, parses duration strings, and pre-indexes rules by event type.
+ */
+
+/**
+ * Validates and compiles an event rules config from unknown input.
+ *
+ * Performs exhaustive validation (Zod), compiles regex into closures,
+ * parses durations, and pre-indexes rules by event type.
+ */
+declare function validateEventRulesConfig(input: unknown): Result<CompiledRuleset, KoiError>;
+
+export { type ActionContext, type ActionType, type CompiledPredicate, type CompiledRule, type CompiledRuleset, type EventRulesConfig, type LogLevel, type MatchPredicates, type MatchValue, type NumericOperator, type RawAction, type RawCondition, type RawEventRulesConfig, type RawRule, type RegexOperator, type ResolvedAction, type RuleEngine, type RuleEvalResult, type RuleEvent, type RuleEventType, type RuleLogger, createEventRulesMiddleware, createRuleEngine, descriptor, executeActions, interpolate, loadRulesFromFile, loadRulesFromString, parseDuration, validateEventRulesConfig };
+"
+`;

--- a/packages/middleware/middleware-event-rules/src/__tests__/api-surface.test.ts
+++ b/packages/middleware/middleware-event-rules/src/__tests__/api-surface.test.ts
@@ -1,0 +1,40 @@
+/**
+ * API surface stability tests.
+ *
+ * Snapshots .d.ts files for all exports. Requires a prior build.
+ * Package name is read dynamically from package.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ExportConfig {
+  readonly types: string;
+  readonly import: string;
+}
+
+const pkgPath = resolve(__dirname, "../../package.json");
+const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+  readonly name: string;
+  readonly exports: Readonly<Record<string, ExportConfig>>;
+};
+
+const exportEntries = Object.entries(pkgJson.exports) as ReadonlyArray<
+  readonly [string, ExportConfig]
+>;
+
+describe(`${pkgJson.name} API surface`, () => {
+  test("package.json has at least one export entry", () => {
+    expect(exportEntries.length).toBeGreaterThan(0);
+  });
+
+  for (const [subpath, config] of exportEntries) {
+    const dtsPath = resolve(__dirname, "../..", config.types);
+
+    test(`${subpath} has stable type surface`, () => {
+      const dts = readFileSync(dtsPath, "utf-8");
+      expect(dts).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/middleware/middleware-event-rules/src/__tests__/integration.test.ts
+++ b/packages/middleware/middleware-event-rules/src/__tests__/integration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Integration tests — end-to-end scenarios exercising the full middleware pipeline.
+ *
+ * Tests use createEventRulesMiddleware directly with mock contexts,
+ * validating event→rule→action flow for three real-world scenarios.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { RunId, SessionId, TurnId } from "@koi/core/ecs";
+import type { SessionContext, ToolRequest, ToolResponse, TurnContext } from "@koi/core/middleware";
+import { createEventRulesMiddleware } from "../rule-middleware.js";
+import { validateEventRulesConfig } from "../rule-schema.js";
+import type { ActionContext } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function compile(rules: readonly Record<string, unknown>[]) {
+  const result = validateEventRulesConfig({ rules });
+  if (!result.ok) throw new Error(`Compilation failed: ${result.error.message}`);
+  return result.value;
+}
+
+function makeSessionCtx(overrides?: Partial<SessionContext>): SessionContext {
+  return {
+    agentId: "test-agent",
+    sessionId: "sess-1" as SessionId,
+    runId: "run-1" as RunId,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTurnCtx(turnIndex: number, session?: SessionContext): TurnContext {
+  return {
+    session: session ?? makeSessionCtx(),
+    turnIndex,
+    turnId: `turn-${turnIndex}` as TurnId,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function makeToolRequest(toolId: string, input: Record<string, unknown> = {}): ToolRequest {
+  return { toolId, input };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Tool failure escalation
+// ---------------------------------------------------------------------------
+
+describe("Integration: tool failure escalation", () => {
+  test("escalates after 3 tool failures within window", async () => {
+    const ruleset = compile([
+      {
+        name: "tool-failure-escalate",
+        on: "tool_call",
+        match: { ok: false, toolId: { regex: "^shell_" } },
+        condition: { count: 3, window: "1m" },
+        actions: [
+          { type: "escalate", message: "Tool {{toolId}} failed {{count}} times in {{window}}" },
+        ],
+        stopOnMatch: true,
+      },
+    ]);
+
+    const requestEscalation = mock((_message: string) => {});
+    const actionContext: ActionContext = { requestEscalation };
+
+    // let justified: mutable clock for test
+    let clock = 10_000;
+    const mw = createEventRulesMiddleware({
+      ruleset,
+      actionContext,
+      now: () => clock,
+    });
+
+    const turnCtx = makeTurnCtx(0);
+    const req = makeToolRequest("shell_exec");
+    const failHandler = mock(
+      async () =>
+        ({
+          output: "error",
+          metadata: { error: true },
+        }) satisfies ToolResponse,
+    );
+
+    // 3 failed tool calls
+    await mw.wrapToolCall?.(turnCtx, req, failHandler);
+    clock += 1_000;
+    await mw.wrapToolCall?.(turnCtx, req, failHandler);
+    clock += 1_000;
+    await mw.wrapToolCall?.(turnCtx, req, failHandler);
+
+    expect(requestEscalation).toHaveBeenCalledTimes(1);
+    // Message includes interpolated toolId
+    // biome-ignore lint/style/noNonNullAssertion: safe — asserted exactly 1 call above
+    const call = requestEscalation.mock.calls[0]!;
+    expect(call[0]).toContain("shell_exec");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Budget warning on high turn count
+// ---------------------------------------------------------------------------
+
+describe("Integration: budget warning", () => {
+  test("notifies when turnIndex >= 15", async () => {
+    const ruleset = compile([
+      {
+        name: "budget-warning",
+        on: "turn_complete",
+        match: { turnIndex: { gte: 15 } },
+        actions: [
+          {
+            type: "notify",
+            channel: "status",
+            message: "Turn count {{turnIndex}} — session {{sessionId}}",
+          },
+        ],
+      },
+    ]);
+
+    const sendNotification = mock((_channel: string, _message: string) => {});
+    const actionContext: ActionContext = { sendNotification };
+
+    const mw = createEventRulesMiddleware({ ruleset, actionContext });
+    const session = makeSessionCtx({ sessionId: "sess-budget" as SessionId });
+
+    // Simulate session start
+    await mw.onSessionStart?.(session);
+
+    // Turn 14 — should not trigger
+    await mw.onAfterTurn?.(makeTurnCtx(14, session));
+    expect(sendNotification).toHaveBeenCalledTimes(0);
+
+    // Turn 15 — should trigger
+    await mw.onAfterTurn?.(makeTurnCtx(15, session));
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotification.mock.calls[0]?.[0]).toBe("status");
+    expect(sendNotification.mock.calls[0]?.[1]).toContain("15");
+    expect(sendNotification.mock.calls[0]?.[1]).toContain("sess-budget");
+
+    // Turn 20 — should also trigger
+    await mw.onAfterTurn?.(makeTurnCtx(20, session));
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: skip_tool circuit-breaker
+// ---------------------------------------------------------------------------
+
+describe("Integration: skip_tool circuit-breaker", () => {
+  test("blocks tool calls after skip_tool action fires", async () => {
+    const ruleset = compile([
+      {
+        name: "block-shell",
+        on: "tool_call",
+        match: { ok: false, toolId: "shell_exec" },
+        condition: { count: 2, window: "1m" },
+        actions: [{ type: "skip_tool", toolId: "shell_exec" }],
+      },
+    ]);
+
+    // let justified: mutable clock
+    let clock = 10_000;
+    const mw = createEventRulesMiddleware({
+      ruleset,
+      now: () => clock,
+    });
+
+    const session = makeSessionCtx();
+    await mw.onSessionStart?.(session);
+
+    const turnCtx = makeTurnCtx(0, session);
+    const req = makeToolRequest("shell_exec");
+    const failHandler = mock(
+      async () =>
+        ({
+          output: "error",
+          metadata: { error: true },
+        }) satisfies ToolResponse,
+    );
+
+    const wrap = mw.wrapToolCall;
+    expect(wrap).toBeDefined();
+    if (wrap === undefined) return;
+
+    // 1st failure — not yet blocked
+    const r1 = await wrap(turnCtx, req, failHandler);
+    expect(r1.metadata?.blocked).toBeUndefined();
+    clock += 1_000;
+
+    // 2nd failure — triggers skip_tool
+    const r2 = await wrap(turnCtx, req, failHandler);
+    expect(r2.metadata?.blocked).toBeUndefined(); // The call itself still goes through
+
+    // 3rd attempt — should be blocked without calling handler
+    const successHandler = mock(
+      async () =>
+        ({
+          output: "success",
+        }) satisfies ToolResponse,
+    );
+    const r3 = await wrap(turnCtx, req, successHandler);
+    expect(r3.metadata?.blocked).toBe(true);
+    expect(successHandler).not.toHaveBeenCalled();
+
+    // Other tools not affected
+    const otherReq = makeToolRequest("web_fetch");
+    const r4 = await wrap(turnCtx, otherReq, successHandler);
+    expect(r4.output).toBe("success");
+  });
+
+  test("cleans up session state on session end", async () => {
+    const ruleset = compile([
+      { name: "r1", on: "tool_call", actions: [{ type: "log", level: "info", message: "x" }] },
+    ]);
+
+    const mw = createEventRulesMiddleware({ ruleset });
+    const session = makeSessionCtx();
+
+    await mw.onSessionStart?.(session);
+    await mw.onSessionEnd?.(session);
+
+    // Should not throw on a fresh session after cleanup
+    await mw.onSessionStart?.(session);
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/actions.test.ts
+++ b/packages/middleware/middleware-event-rules/src/actions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, mock, test } from "bun:test";
+import { executeActions } from "./actions.js";
+import type { ActionContext, ResolvedAction, RuleLogger } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockLogger(): RuleLogger & {
+  readonly calls: readonly { readonly level: string; readonly message: string }[];
+} {
+  const calls: { level: string; message: string }[] = [];
+  return {
+    calls,
+    info: (msg) => {
+      calls.push({ level: "info", message: msg });
+    },
+    warn: (msg) => {
+      calls.push({ level: "warn", message: msg });
+    },
+    error: (msg) => {
+      calls.push({ level: "error", message: msg });
+    },
+    debug: (msg) => {
+      calls.push({ level: "debug", message: msg });
+    },
+  };
+}
+
+function action(type: string, extra: Record<string, unknown> = {}): ResolvedAction {
+  return { ruleName: "test-rule", action: { type, ...extra } as ResolvedAction["action"] };
+}
+
+// ---------------------------------------------------------------------------
+// Action execution
+// ---------------------------------------------------------------------------
+
+describe("executeActions", () => {
+  test("executes log action with interpolated message", async () => {
+    const logger = createMockLogger();
+    const ctx: ActionContext = { logger };
+
+    await executeActions(
+      [action("log", { level: "warn", message: "Tool {{toolId}} failed" })],
+      { toolId: "shell_exec" },
+      ctx,
+    );
+
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]).toEqual({ level: "warn", message: "Tool shell_exec failed" });
+  });
+
+  test("executes escalate action with dependency", async () => {
+    const logger = createMockLogger();
+    const requestEscalation = mock(() => {});
+    const ctx: ActionContext = { logger, requestEscalation };
+
+    await executeActions([action("escalate", { message: "Help needed" })], {}, ctx);
+
+    expect(requestEscalation).toHaveBeenCalledWith("Help needed");
+  });
+
+  test("degrades escalate to log.error when dependency missing", async () => {
+    const logger = createMockLogger();
+    const ctx: ActionContext = { logger };
+
+    await executeActions([action("escalate", { message: "Help needed" })], {}, ctx);
+
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]?.level).toBe("error");
+    expect(logger.calls[0]?.message).toContain("Help needed");
+  });
+
+  test("executes notify action with dependency", async () => {
+    const logger = createMockLogger();
+    const sendNotification = mock(() => {});
+    const ctx: ActionContext = { logger, sendNotification };
+
+    await executeActions(
+      [action("notify", { channel: "ops", message: "Alert: {{msg}}" })],
+      { msg: "high turns" },
+      ctx,
+    );
+
+    expect(sendNotification).toHaveBeenCalledWith("ops", "Alert: high turns");
+  });
+
+  test("degrades notify to log.warn when dependency missing", async () => {
+    const logger = createMockLogger();
+    const ctx: ActionContext = { logger };
+
+    await executeActions([action("notify", { channel: "ops", message: "Alert" })], {}, ctx);
+
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]?.level).toBe("warn");
+    expect(logger.calls[0]?.message).toContain("ops");
+  });
+
+  test("executes emit action with dependency", async () => {
+    const logger = createMockLogger();
+    const emitEvent = mock(() => {});
+    const ctx: ActionContext = { logger, emitEvent };
+
+    await executeActions([action("emit", { event: "custom.alert", message: "hi" })], {}, ctx);
+
+    expect(emitEvent).toHaveBeenCalledWith("custom.alert", { message: "hi" });
+  });
+
+  test("degrades emit to log.info when dependency missing", async () => {
+    const logger = createMockLogger();
+    const ctx: ActionContext = { logger };
+
+    await executeActions([action("emit", { event: "custom.alert", message: "hi" })], {}, ctx);
+
+    expect(logger.calls).toHaveLength(1);
+    expect(logger.calls[0]?.level).toBe("info");
+  });
+
+  test("catches and logs action errors without propagating", async () => {
+    const logger = createMockLogger();
+    const requestEscalation = mock(() => {
+      throw new Error("escalation service down");
+    });
+    const ctx: ActionContext = { logger, requestEscalation };
+
+    // Should not throw
+    await executeActions(
+      [
+        action("escalate", { message: "first" }),
+        action("log", { level: "info", message: "second" }),
+      ],
+      {},
+      ctx,
+    );
+
+    // First action error logged, second action still executes
+    const errorCalls = logger.calls.filter((c) => c.level === "error");
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0]?.message).toContain("escalation service down");
+
+    const infoCalls = logger.calls.filter((c) => c.level === "info");
+    expect(infoCalls).toHaveLength(1);
+    expect(infoCalls[0]?.message).toBe("second");
+  });
+
+  test("skip_tool action is a no-op (handled by caller)", async () => {
+    const logger = createMockLogger();
+    const ctx: ActionContext = { logger };
+
+    await executeActions([action("skip_tool", { toolId: "shell_exec" })], {}, ctx);
+
+    expect(logger.calls).toHaveLength(0);
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/actions.ts
+++ b/packages/middleware/middleware-event-rules/src/actions.ts
@@ -1,0 +1,115 @@
+/**
+ * Action execution — runs resolved actions with graceful degradation.
+ *
+ * Each action is wrapped in try/catch. Errors are logged but never propagated.
+ * Missing dependencies degrade to logging.
+ */
+
+import { interpolate } from "./interpolate.js";
+import type { ActionContext, RawAction, ResolvedAction, RuleLogger } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Console fallback logger
+// ---------------------------------------------------------------------------
+
+const CONSOLE_LOGGER: RuleLogger = {
+  info: (msg) => console.info(`[event-rules] ${msg}`),
+  warn: (msg) => console.warn(`[event-rules] ${msg}`),
+  error: (msg) => console.error(`[event-rules] ${msg}`),
+  debug: (msg) => console.debug(`[event-rules] ${msg}`),
+};
+
+// ---------------------------------------------------------------------------
+// Per-action executors
+// ---------------------------------------------------------------------------
+
+async function executeEmit(
+  action: RawAction,
+  message: string,
+  ctx: ActionContext,
+  logger: RuleLogger,
+): Promise<void> {
+  const event = action.event ?? "";
+  if (ctx.emitEvent !== undefined) {
+    await ctx.emitEvent(event, { message });
+  } else {
+    logger.info(`[emit degraded] event=${event} message=${message}`);
+  }
+}
+
+async function executeEscalate(
+  message: string,
+  ctx: ActionContext,
+  logger: RuleLogger,
+): Promise<void> {
+  if (ctx.requestEscalation !== undefined) {
+    await ctx.requestEscalation(message);
+  } else {
+    logger.error(`[escalate degraded] ${message}`);
+  }
+}
+
+function executeLog(action: RawAction, message: string, logger: RuleLogger): void {
+  const level = action.level ?? "info";
+  logger[level](message);
+}
+
+async function executeNotify(
+  action: RawAction,
+  message: string,
+  ctx: ActionContext,
+  logger: RuleLogger,
+): Promise<void> {
+  const channel = action.channel ?? "";
+  if (ctx.sendNotification !== undefined) {
+    await ctx.sendNotification(channel, message);
+  } else {
+    logger.warn(`[notify degraded] channel=${channel} message=${message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes resolved actions with template interpolation and graceful degradation.
+ *
+ * @param resolvedActions - Actions matched by the rule engine.
+ * @param eventContext - Context for template interpolation (event fields + extras).
+ * @param actionContext - Injected dependencies for action execution.
+ */
+export async function executeActions(
+  resolvedActions: readonly ResolvedAction[],
+  eventContext: Readonly<Record<string, unknown>>,
+  actionContext: ActionContext,
+): Promise<void> {
+  const logger = actionContext.logger ?? CONSOLE_LOGGER;
+
+  for (const { ruleName, action } of resolvedActions) {
+    try {
+      const message = action.message !== undefined ? interpolate(action.message, eventContext) : "";
+
+      switch (action.type) {
+        case "emit":
+          await executeEmit(action, message, actionContext, logger);
+          break;
+        case "escalate":
+          await executeEscalate(message, actionContext, logger);
+          break;
+        case "log":
+          executeLog(action, message, logger);
+          break;
+        case "notify":
+          await executeNotify(action, message, actionContext, logger);
+          break;
+        case "skip_tool":
+          // skip_tool is handled by the caller via skipToolIds — no action to execute
+          break;
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logger.error(`Action '${action.type}' from rule '${ruleName}' failed: ${msg}`);
+    }
+  }
+}

--- a/packages/middleware/middleware-event-rules/src/descriptor.ts
+++ b/packages/middleware/middleware-event-rules/src/descriptor.ts
@@ -1,0 +1,69 @@
+/**
+ * BrickDescriptor for @koi/middleware-event-rules.
+ *
+ * Enables manifest auto-resolution: validates event rules options
+ * from koi.yaml, then creates the event-rules middleware.
+ *
+ * Usage in koi.yaml:
+ *   middleware:
+ *     - name: event-rules
+ *       options:
+ *         rules:
+ *           - name: tool-failure-escalate
+ *             on: tool_call
+ *             match:
+ *               ok: false
+ *             condition:
+ *               count: 3
+ *               window: "1m"
+ *             actions:
+ *               - type: escalate
+ *                 message: "Tool {{toolId}} failed {{count}} times"
+ */
+
+import type { KoiError, KoiMiddleware, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import type { BrickDescriptor } from "@koi/resolve";
+import { createEventRulesMiddleware } from "./rule-middleware.js";
+import { validateEventRulesConfig } from "./rule-schema.js";
+
+function descriptorValidationError(message: string): {
+  readonly ok: false;
+  readonly error: KoiError;
+} {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}
+
+function validateDescriptorOptions(input: unknown): Result<unknown, KoiError> {
+  if (input === null || input === undefined || typeof input !== "object") {
+    return descriptorValidationError("event-rules options must be an object");
+  }
+  return validateEventRulesConfig(input);
+}
+
+/**
+ * Descriptor for event-rules middleware.
+ *
+ * Creates a declarative event→action middleware from validated YAML options.
+ */
+export const descriptor: BrickDescriptor<KoiMiddleware> = {
+  kind: "middleware",
+  name: "@koi/middleware-event-rules",
+  aliases: ["event-rules"],
+  description: "Declarative YAML rule engine mapping engine events to actions",
+  optionsValidator: validateDescriptorOptions,
+  factory(options): KoiMiddleware {
+    const result = validateEventRulesConfig(options);
+    if (!result.ok) {
+      throw new Error(`Event rules config validation failed: ${result.error.message}`);
+    }
+    return createEventRulesMiddleware({ ruleset: result.value });
+  },
+};

--- a/packages/middleware/middleware-event-rules/src/duration.test.ts
+++ b/packages/middleware/middleware-event-rules/src/duration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parseDuration } from "./duration.js";
+
+describe("parseDuration", () => {
+  test("parses seconds to milliseconds", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+  });
+
+  test("parses minutes to milliseconds", () => {
+    expect(parseDuration("5m")).toBe(300_000);
+  });
+
+  test("parses hours to milliseconds", () => {
+    expect(parseDuration("1h")).toBe(3_600_000);
+  });
+
+  test("returns undefined for zero value", () => {
+    expect(parseDuration("0s")).toBeUndefined();
+  });
+
+  test("returns undefined for invalid input", () => {
+    expect(parseDuration("abc")).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(parseDuration("")).toBeUndefined();
+  });
+
+  test("returns undefined for unsupported unit", () => {
+    expect(parseDuration("5d")).toBeUndefined();
+  });
+
+  test("returns undefined for negative value", () => {
+    expect(parseDuration("-1s")).toBeUndefined();
+  });
+
+  test("parses large values", () => {
+    expect(parseDuration("120m")).toBe(7_200_000);
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/duration.ts
+++ b/packages/middleware/middleware-event-rules/src/duration.ts
@@ -1,0 +1,27 @@
+/**
+ * Duration string parser — converts "30s", "5m", "1h" to milliseconds.
+ */
+
+const DURATION_RE = /^(\d+)(s|m|h)$/;
+
+const UNIT_MS: Readonly<Record<string, number>> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+};
+
+/**
+ * Parses a duration string into milliseconds.
+ *
+ * @returns milliseconds, or `undefined` for invalid/zero input.
+ */
+export function parseDuration(input: string): number | undefined {
+  const match = DURATION_RE.exec(input);
+  if (match === null) return undefined;
+  const value = Number(match[1]);
+  const unit = match[2];
+  if (value === 0 || unit === undefined) return undefined;
+  const multiplier = UNIT_MS[unit];
+  if (multiplier === undefined) return undefined;
+  return value * multiplier;
+}

--- a/packages/middleware/middleware-event-rules/src/index.ts
+++ b/packages/middleware/middleware-event-rules/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * @koi/middleware-event-rules — Declarative event→action rule engine.
+ *
+ * Maps engine events (tool failures, budget warnings, state transitions)
+ * to actions (escalate, notify, log, skip_tool) via YAML rules.
+ */
+
+export { executeActions } from "./actions.js";
+export { descriptor } from "./descriptor.js";
+export { parseDuration } from "./duration.js";
+export { interpolate } from "./interpolate.js";
+export { loadRulesFromFile, loadRulesFromString } from "./load-rules.js";
+export { createRuleEngine } from "./rule-engine.js";
+export { createEventRulesMiddleware } from "./rule-middleware.js";
+export { validateEventRulesConfig } from "./rule-schema.js";
+export type {
+  ActionContext,
+  ActionType,
+  CompiledPredicate,
+  CompiledRule,
+  CompiledRuleset,
+  EventRulesConfig,
+  LogLevel,
+  MatchPredicates,
+  MatchValue,
+  NumericOperator,
+  RawAction,
+  RawCondition,
+  RawEventRulesConfig,
+  RawRule,
+  RegexOperator,
+  ResolvedAction,
+  RuleEngine,
+  RuleEvalResult,
+  RuleEvent,
+  RuleEventType,
+  RuleLogger,
+} from "./types.js";

--- a/packages/middleware/middleware-event-rules/src/interpolate.test.ts
+++ b/packages/middleware/middleware-event-rules/src/interpolate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { interpolate } from "./interpolate.js";
+
+describe("interpolate", () => {
+  test("replaces known variables", () => {
+    expect(interpolate("Hello {{name}}", { name: "world" })).toBe("Hello world");
+  });
+
+  test("replaces multiple variables", () => {
+    const result = interpolate("{{a}} and {{b}}", { a: "foo", b: "bar" });
+    expect(result).toBe("foo and bar");
+  });
+
+  test("produces placeholder for undefined variables", () => {
+    expect(interpolate("{{missing}}", {})).toBe("<undefined:missing>");
+  });
+
+  test("returns template unchanged when no placeholders", () => {
+    expect(interpolate("no vars here", { key: "val" })).toBe("no vars here");
+  });
+
+  test("stringifies numeric values", () => {
+    expect(interpolate("count: {{n}}", { n: 42 })).toBe("count: 42");
+  });
+
+  test("stringifies boolean values", () => {
+    expect(interpolate("ok: {{flag}}", { flag: true })).toBe("ok: true");
+  });
+
+  test("handles repeated variable", () => {
+    expect(interpolate("{{x}} {{x}}", { x: "a" })).toBe("a a");
+  });
+
+  test("handles empty template", () => {
+    expect(interpolate("", { a: 1 })).toBe("");
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/interpolate.ts
+++ b/packages/middleware/middleware-event-rules/src/interpolate.ts
@@ -1,0 +1,23 @@
+/**
+ * Shallow template interpolation for rule action messages.
+ *
+ * Replaces `{{varName}}` placeholders with values from a context object.
+ * Undefined variables produce `"<undefined:varName>"` sentinel strings.
+ */
+
+const TEMPLATE_RE = /\{\{(\w+)\}\}/g;
+
+/**
+ * Interpolates `{{varName}}` placeholders in a template string.
+ *
+ * @param template - String with `{{varName}}` placeholders.
+ * @param context - Key-value context for substitution.
+ * @returns Interpolated string.
+ */
+export function interpolate(template: string, context: Readonly<Record<string, unknown>>): string {
+  return template.replace(TEMPLATE_RE, (_match, key: string) => {
+    const value = context[key];
+    if (value === undefined) return `<undefined:${key}>`;
+    return String(value);
+  });
+}

--- a/packages/middleware/middleware-event-rules/src/load-rules.ts
+++ b/packages/middleware/middleware-event-rules/src/load-rules.ts
@@ -1,0 +1,63 @@
+/**
+ * Rule loading utilities — parse YAML strings or files into compiled rulesets.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core/errors";
+import { validateEventRulesConfig } from "./rule-schema.js";
+import type { CompiledRuleset } from "./types.js";
+
+/**
+ * Parses a YAML string into a compiled ruleset.
+ *
+ * @param yaml - YAML string containing event rules config.
+ * @returns Compiled ruleset or validation error.
+ */
+export function loadRulesFromString(yaml: string): Result<CompiledRuleset, KoiError> {
+  // let justified: Bun.YAML.parse may throw, need catch
+  let parsed: unknown;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    parsed = Bun.YAML.parse(yaml);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION",
+        message: `Failed to parse YAML: ${msg}`,
+        retryable: RETRYABLE_DEFAULTS.VALIDATION,
+      },
+    };
+  }
+
+  return validateEventRulesConfig(parsed);
+}
+
+/**
+ * Loads and compiles event rules from a YAML file.
+ *
+ * @param filePath - Path to the YAML file.
+ * @returns Compiled ruleset or error.
+ */
+export async function loadRulesFromFile(
+  filePath: string,
+): Promise<Result<CompiledRuleset, KoiError>> {
+  // let justified: Bun.file().text() may throw
+  let content: string;
+  try {
+    content = await Bun.file(filePath).text();
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Failed to read rules file '${filePath}': ${msg}`,
+        retryable: RETRYABLE_DEFAULTS.NOT_FOUND,
+      },
+    };
+  }
+
+  return loadRulesFromString(content);
+}

--- a/packages/middleware/middleware-event-rules/src/rule-engine.test.ts
+++ b/packages/middleware/middleware-event-rules/src/rule-engine.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionId } from "@koi/core/ecs";
+import { createRuleEngine } from "./rule-engine.js";
+import { validateEventRulesConfig } from "./rule-schema.js";
+import type { RuleEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function compile(rules: readonly Record<string, unknown>[]) {
+  const result = validateEventRulesConfig({ rules });
+  if (!result.ok) throw new Error(`Compilation failed: ${result.error.message}`);
+  return result.value;
+}
+
+function makeEvent(type: string, fields: Record<string, unknown> = {}): RuleEvent {
+  return { type: type as RuleEvent["type"], fields, sessionId: "sess-1" as SessionId };
+}
+
+// ---------------------------------------------------------------------------
+// Predicate matching
+// ---------------------------------------------------------------------------
+
+describe("createRuleEngine — predicate matching", () => {
+  test("exact boolean match", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { ok: false },
+        actions: [{ type: "log", level: "warn", message: "fail" }],
+      },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    const hit = engine.evaluate(makeEvent("tool_call", { ok: false }));
+    expect(hit.actions).toHaveLength(1);
+
+    const miss = engine.evaluate(makeEvent("tool_call", { ok: true }));
+    expect(miss.actions).toHaveLength(0);
+  });
+
+  test("regex match", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { toolId: { regex: "^shell_" } },
+        actions: [{ type: "log", level: "warn", message: "x" }],
+      },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    expect(engine.evaluate(makeEvent("tool_call", { toolId: "shell_exec" })).actions).toHaveLength(
+      1,
+    );
+    expect(engine.evaluate(makeEvent("tool_call", { toolId: "web_fetch" })).actions).toHaveLength(
+      0,
+    );
+  });
+
+  test("numeric gte match", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "turn_complete",
+        match: { turnIndex: { gte: 15 } },
+        actions: [{ type: "log", level: "info", message: "x" }],
+      },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    expect(engine.evaluate(makeEvent("turn_complete", { turnIndex: 14 })).actions).toHaveLength(0);
+    expect(engine.evaluate(makeEvent("turn_complete", { turnIndex: 15 })).actions).toHaveLength(1);
+    expect(engine.evaluate(makeEvent("turn_complete", { turnIndex: 20 })).actions).toHaveLength(1);
+  });
+
+  test("AND logic — all predicates must match", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { ok: false, toolId: { regex: "^shell_" } },
+        actions: [{ type: "log", level: "warn", message: "x" }],
+      },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    expect(
+      engine.evaluate(makeEvent("tool_call", { ok: false, toolId: "shell_exec" })).actions,
+    ).toHaveLength(1);
+    expect(
+      engine.evaluate(makeEvent("tool_call", { ok: true, toolId: "shell_exec" })).actions,
+    ).toHaveLength(0);
+    expect(
+      engine.evaluate(makeEvent("tool_call", { ok: false, toolId: "web_fetch" })).actions,
+    ).toHaveLength(0);
+  });
+
+  test("rule without match matches all events of that type", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "turn_complete",
+        actions: [{ type: "log", level: "info", message: "always" }],
+      },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    expect(engine.evaluate(makeEvent("turn_complete", {})).actions).toHaveLength(1);
+    expect(engine.evaluate(makeEvent("turn_complete", { anything: 123 })).actions).toHaveLength(1);
+  });
+
+  test("no rules for event type returns empty result", () => {
+    const ruleset = compile([
+      { name: "r1", on: "tool_call", actions: [{ type: "log", level: "info", message: "x" }] },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    const result = engine.evaluate(makeEvent("session_start", {}));
+    expect(result.actions).toHaveLength(0);
+    expect(result.skipToolIds).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stopOnMatch
+// ---------------------------------------------------------------------------
+
+describe("createRuleEngine — stopOnMatch", () => {
+  test("stops evaluating after first matching rule with stopOnMatch", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        actions: [{ type: "log", level: "info", message: "first" }],
+        stopOnMatch: true,
+      },
+      { name: "r2", on: "tool_call", actions: [{ type: "log", level: "info", message: "second" }] },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    const result = engine.evaluate(makeEvent("tool_call", {}));
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0]?.ruleName).toBe("r1");
+  });
+
+  test("evaluates all rules when stopOnMatch is false", () => {
+    const ruleset = compile([
+      { name: "r1", on: "tool_call", actions: [{ type: "log", level: "info", message: "first" }] },
+      { name: "r2", on: "tool_call", actions: [{ type: "log", level: "info", message: "second" }] },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    const result = engine.evaluate(makeEvent("tool_call", {}));
+    expect(result.actions).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Counter / windowed conditions
+// ---------------------------------------------------------------------------
+
+describe("createRuleEngine — windowed conditions", () => {
+  test("does not trigger until count threshold is reached", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { ok: false },
+        condition: { count: 3, window: "1m" },
+        actions: [{ type: "escalate", message: "fail" }],
+      },
+    ]);
+
+    // let justified: mutable clock for test injection
+    let clock = 1000;
+    const engine = createRuleEngine(ruleset, () => clock);
+    const event = makeEvent("tool_call", { ok: false });
+
+    expect(engine.evaluate(event).actions).toHaveLength(0); // 1st
+    clock += 1000;
+    expect(engine.evaluate(event).actions).toHaveLength(0); // 2nd
+    clock += 1000;
+    expect(engine.evaluate(event).actions).toHaveLength(1); // 3rd — triggers
+  });
+
+  test("expired entries are pruned from counter window", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { ok: false },
+        condition: { count: 3, window: "10s" },
+        actions: [{ type: "escalate", message: "fail" }],
+      },
+    ]);
+
+    // let justified: mutable clock for test injection
+    let clock = 1000;
+    const engine = createRuleEngine(ruleset, () => clock);
+    const event = makeEvent("tool_call", { ok: false });
+
+    engine.evaluate(event); // 1st at t=1000
+    clock += 1000;
+    engine.evaluate(event); // 2nd at t=2000
+
+    // Jump past window — both entries expire
+    clock = 20_000;
+    expect(engine.evaluate(event).actions).toHaveLength(0); // Only 1 in window
+  });
+
+  test("reset clears all counter state", () => {
+    const ruleset = compile([
+      {
+        name: "r1",
+        on: "tool_call",
+        match: { ok: false },
+        condition: { count: 2, window: "1m" },
+        actions: [{ type: "escalate", message: "fail" }],
+      },
+    ]);
+
+    const engine = createRuleEngine(ruleset, () => 1000);
+    const event = makeEvent("tool_call", { ok: false });
+
+    engine.evaluate(event); // 1st
+    engine.reset();
+    expect(engine.evaluate(event).actions).toHaveLength(0); // 1st again after reset
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skip_tool action
+// ---------------------------------------------------------------------------
+
+describe("createRuleEngine — skip_tool", () => {
+  test("collects skipToolIds from skip_tool actions", () => {
+    const ruleset = compile([
+      { name: "r1", on: "tool_call", actions: [{ type: "skip_tool", toolId: "shell_exec" }] },
+    ]);
+    const engine = createRuleEngine(ruleset);
+
+    const result = engine.evaluate(makeEvent("tool_call", {}));
+    expect(result.skipToolIds).toEqual(["shell_exec"]);
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/rule-engine.ts
+++ b/packages/middleware/middleware-event-rules/src/rule-engine.ts
@@ -1,0 +1,146 @@
+/**
+ * Rule engine — evaluates compiled rules against events.
+ *
+ * Session-scoped, in-memory counter state with sorted-array storage
+ * and binary-search prune-on-read. No background timers.
+ */
+
+import type {
+  CompiledRule,
+  CompiledRuleset,
+  ResolvedAction,
+  RuleEngine,
+  RuleEvalResult,
+  RuleEvent,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum counter entries per rule to bound memory. */
+const MAX_COUNTER_ENTRIES = 1000;
+
+// ---------------------------------------------------------------------------
+// Counter helpers (sorted array + binary search)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds the first index in a sorted array where `arr[i] >= threshold`.
+ * Returns `arr.length` if all elements are below threshold.
+ */
+function lowerBound(arr: readonly number[], threshold: number): number {
+  // let is justified: binary search loop variable
+  let lo = 0;
+  // let is justified: binary search loop variable
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    // biome-ignore lint/style/noNonNullAssertion: mid is bounded by arr.length
+    if (arr[mid]! < threshold) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+// ---------------------------------------------------------------------------
+// RuleEngine
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a rule engine for a compiled ruleset.
+ *
+ * @param ruleset - Pre-compiled and indexed ruleset.
+ * @param now - Injectable clock (default: Date.now).
+ */
+export function createRuleEngine(
+  ruleset: CompiledRuleset,
+  now: () => number = Date.now,
+): RuleEngine {
+  /** Counter state: rule name → sorted array of timestamps. */
+  const counters = new Map<string, number[]>();
+
+  function getCount(ruleName: string, windowMs: number): number {
+    const timestamps = counters.get(ruleName);
+    if (timestamps === undefined) return 0;
+
+    const threshold = now() - windowMs;
+    const startIdx = lowerBound(timestamps, threshold);
+
+    // Prune expired entries
+    if (startIdx > 0) {
+      timestamps.splice(0, startIdx);
+    }
+
+    return timestamps.length;
+  }
+
+  function incrementCounter(ruleName: string): void {
+    const timestamps = counters.get(ruleName);
+    const currentTime = now();
+
+    if (timestamps === undefined) {
+      counters.set(ruleName, [currentTime]);
+      return;
+    }
+
+    // Enforce max entries by dropping oldest
+    if (timestamps.length >= MAX_COUNTER_ENTRIES) {
+      timestamps.splice(0, 1);
+    }
+
+    timestamps.push(currentTime);
+  }
+
+  function matchesPredicate(
+    rule: CompiledRule,
+    fields: Readonly<Record<string, unknown>>,
+  ): boolean {
+    for (const pred of rule.predicates) {
+      if (!pred.test(fields[pred.field])) return false;
+    }
+    return true;
+  }
+
+  function evaluate(event: RuleEvent): RuleEvalResult {
+    const rules = ruleset.byEventType.get(event.type);
+    if (rules === undefined) {
+      return { actions: [], skipToolIds: [] };
+    }
+
+    const actions: ResolvedAction[] = [];
+    const skipToolIds: string[] = [];
+
+    for (const rule of rules) {
+      if (!matchesPredicate(rule, event.fields)) continue;
+
+      // Check windowed condition
+      if (rule.condition !== undefined) {
+        incrementCounter(rule.name);
+        const count = getCount(rule.name, rule.condition.windowMs);
+        if (count < rule.condition.count) continue;
+      }
+
+      // Collect actions
+      for (const action of rule.actions) {
+        actions.push({ ruleName: rule.name, action });
+        if (action.type === "skip_tool" && action.toolId !== undefined) {
+          skipToolIds.push(action.toolId);
+        }
+      }
+
+      if (rule.stopOnMatch) break;
+    }
+
+    return { actions, skipToolIds };
+  }
+
+  function reset(): void {
+    counters.clear();
+  }
+
+  return { evaluate, reset };
+}

--- a/packages/middleware/middleware-event-rules/src/rule-middleware.ts
+++ b/packages/middleware/middleware-event-rules/src/rule-middleware.ts
@@ -1,0 +1,202 @@
+/**
+ * Event rules middleware — declarative event→action mapping.
+ *
+ * Hooks into session lifecycle, turn completion, and tool calls to evaluate
+ * rules and execute actions. Session-scoped engine instances with in-memory
+ * counter state.
+ *
+ * Priority 750: observe phase, runs after most business-logic middleware.
+ */
+
+import type { SessionId } from "@koi/core/ecs";
+import type {
+  CapabilityFragment,
+  KoiMiddleware,
+  SessionContext,
+  ToolHandler,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core/middleware";
+import { executeActions } from "./actions.js";
+import { createRuleEngine } from "./rule-engine.js";
+import type { ActionContext, EventRulesConfig, RuleEngine, RuleEvent } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an event-rules middleware from a compiled ruleset.
+ *
+ * @param config - Compiled ruleset + optional action context + clock.
+ */
+export function createEventRulesMiddleware(config: EventRulesConfig): KoiMiddleware {
+  const { ruleset, actionContext = {}, now = Date.now } = config;
+
+  /** Session-scoped engine instances. */
+  const engines = new Map<SessionId, RuleEngine>();
+
+  /** Per-session set of tool IDs to skip (circuit-break). */
+  const skipSets = new Map<SessionId, Set<string>>();
+
+  function getOrCreateEngine(sessionId: SessionId): RuleEngine {
+    const existing = engines.get(sessionId);
+    if (existing !== undefined) return existing;
+    const engine = createRuleEngine(ruleset, now);
+    engines.set(sessionId, engine);
+    return engine;
+  }
+
+  function getSkipSet(sessionId: SessionId): Set<string> {
+    const existing = skipSets.get(sessionId);
+    if (existing !== undefined) return existing;
+    const skipSet = new Set<string>();
+    skipSets.set(sessionId, skipSet);
+    return skipSet;
+  }
+
+  async function evaluateAndExecute(
+    event: RuleEvent,
+    ctx: ActionContext,
+  ): Promise<readonly string[]> {
+    const engine = getOrCreateEngine(event.sessionId);
+    const result = engine.evaluate(event);
+
+    if (result.actions.length > 0) {
+      await executeActions(result.actions, event.fields, ctx);
+    }
+
+    return result.skipToolIds;
+  }
+
+  const capabilityFragment: CapabilityFragment = {
+    label: "event-rules",
+    description: `Declarative event rules: ${ruleset.rules.length} rule(s) loaded`,
+  };
+
+  return {
+    name: "koi:event-rules",
+    priority: 750,
+    phase: "observe",
+
+    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => capabilityFragment,
+
+    async onSessionStart(ctx: SessionContext): Promise<void> {
+      const sessionId = ctx.sessionId;
+      getOrCreateEngine(sessionId);
+
+      const event: RuleEvent = {
+        type: "session_start",
+        sessionId,
+        fields: {
+          agentId: ctx.agentId,
+          sessionId,
+          userId: ctx.userId,
+          channelId: ctx.channelId,
+        },
+      };
+
+      await evaluateAndExecute(event, actionContext);
+    },
+
+    async onSessionEnd(ctx: SessionContext): Promise<void> {
+      const sessionId = ctx.sessionId;
+
+      const event: RuleEvent = {
+        type: "session_end",
+        sessionId,
+        fields: {
+          agentId: ctx.agentId,
+          sessionId,
+          userId: ctx.userId,
+          channelId: ctx.channelId,
+        },
+      };
+
+      await evaluateAndExecute(event, actionContext);
+
+      // Clean up session state
+      const engine = engines.get(sessionId);
+      if (engine !== undefined) {
+        engine.reset();
+        engines.delete(sessionId);
+      }
+      skipSets.delete(sessionId);
+    },
+
+    async onAfterTurn(ctx: TurnContext): Promise<void> {
+      const sessionId = ctx.session.sessionId;
+
+      const event: RuleEvent = {
+        type: "turn_complete",
+        sessionId,
+        fields: {
+          turnIndex: ctx.turnIndex,
+          agentId: ctx.session.agentId,
+          sessionId,
+        },
+      };
+
+      await evaluateAndExecute(event, actionContext);
+    },
+
+    async wrapToolCall(
+      ctx: TurnContext,
+      request: ToolRequest,
+      next: ToolHandler,
+    ): Promise<ToolResponse> {
+      const sessionId = ctx.session.sessionId;
+      const skipSet = getSkipSet(sessionId);
+
+      // Check if tool is circuit-broken
+      if (skipSet.has(request.toolId)) {
+        return {
+          output: `Tool '${request.toolId}' is blocked by event rules`,
+          metadata: { blocked: true, error: true },
+        };
+      }
+
+      // Execute tool
+      const response = await next(request);
+
+      // Build event with ok derived from metadata
+      const ok = !(response.metadata?.error === true);
+      const event: RuleEvent = {
+        type: "tool_call",
+        sessionId,
+        fields: {
+          toolId: request.toolId,
+          ok,
+          ...flattenInput(request.input),
+        },
+      };
+
+      // Evaluate rules and update skip set
+      const newSkipIds = await evaluateAndExecute(event, actionContext);
+      for (const toolId of newSkipIds) {
+        skipSet.add(toolId);
+      }
+
+      return response;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flattens input object for match field access.
+ * Only includes primitive values (string, number, boolean) from top level.
+ */
+function flattenInput(input: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> {
+  const flat: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      flat[key] = value;
+    }
+  }
+  return flat;
+}

--- a/packages/middleware/middleware-event-rules/src/rule-schema.test.ts
+++ b/packages/middleware/middleware-event-rules/src/rule-schema.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, test } from "bun:test";
+import { validateEventRulesConfig } from "./rule-schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validConfig(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    rules: [
+      {
+        name: "test-rule",
+        on: "tool_call",
+        match: { ok: false },
+        actions: [{ type: "log", level: "warn", message: "test" }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Valid configs
+// ---------------------------------------------------------------------------
+
+describe("validateEventRulesConfig — valid configs", () => {
+  test("accepts minimal valid config", () => {
+    const result = validateEventRulesConfig(validConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rules).toHaveLength(1);
+      expect(result.value.rules[0]?.name).toBe("test-rule");
+    }
+  });
+
+  test("accepts config with all event types", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        { name: "r1", on: "tool_call", actions: [{ type: "log", level: "info", message: "a" }] },
+        {
+          name: "r2",
+          on: "turn_complete",
+          actions: [{ type: "log", level: "info", message: "b" }],
+        },
+        {
+          name: "r3",
+          on: "session_start",
+          actions: [{ type: "log", level: "info", message: "c" }],
+        },
+        { name: "r4", on: "session_end", actions: [{ type: "log", level: "info", message: "d" }] },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rules).toHaveLength(4);
+    }
+  });
+
+  test("accepts config with condition (count + window)", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "windowed",
+          on: "tool_call",
+          match: { ok: false },
+          condition: { count: 3, window: "1m" },
+          actions: [{ type: "escalate", message: "fail" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — array validated non-empty
+      const rule = result.value.rules[0]!;
+      expect(rule.condition).toEqual({ count: 3, windowMs: 60_000 });
+    }
+  });
+
+  test("accepts config with regex match", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "regex-rule",
+          on: "tool_call",
+          match: { toolId: { regex: "^shell_" } },
+          actions: [{ type: "log", level: "warn", message: "shell" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — validated single rule with single predicate
+      const pred = result.value.rules[0]!.predicates[0]!;
+      expect(pred.field).toBe("toolId");
+      expect(pred.test("shell_exec")).toBe(true);
+      expect(pred.test("web_fetch")).toBe(false);
+    }
+  });
+
+  test("accepts config with numeric gte match", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "numeric-rule",
+          on: "turn_complete",
+          match: { turnIndex: { gte: 15 } },
+          actions: [{ type: "log", level: "warn", message: "high turns" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — validated single rule with single predicate
+      const pred = result.value.rules[0]!.predicates[0]!;
+      expect(pred.test(15)).toBe(true);
+      expect(pred.test(14)).toBe(false);
+      expect(pred.test(20)).toBe(true);
+    }
+  });
+
+  test("accepts config with oneOf array match", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "oneof-rule",
+          on: "tool_call",
+          match: { toolId: ["shell_exec", "file_write"] },
+          actions: [{ type: "log", level: "warn", message: "risky" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — validated single rule with single predicate
+      const pred = result.value.rules[0]!.predicates[0]!;
+      expect(pred.test("shell_exec")).toBe(true);
+      expect(pred.test("file_write")).toBe(true);
+      expect(pred.test("web_fetch")).toBe(false);
+    }
+  });
+
+  test("accepts config with exact boolean match", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "bool-rule",
+          on: "tool_call",
+          match: { ok: false },
+          actions: [{ type: "log", level: "warn", message: "failed" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — validated single rule with single predicate
+      const pred = result.value.rules[0]!.predicates[0]!;
+      expect(pred.test(false)).toBe(true);
+      expect(pred.test(true)).toBe(false);
+    }
+  });
+
+  test("accepts all action types with required fields", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        { name: "r1", on: "tool_call", actions: [{ type: "emit", event: "custom.alert" }] },
+        { name: "r2", on: "tool_call", actions: [{ type: "escalate", message: "help" }] },
+        { name: "r3", on: "tool_call", actions: [{ type: "log", level: "info", message: "log" }] },
+        {
+          name: "r4",
+          on: "tool_call",
+          actions: [{ type: "notify", channel: "ops", message: "hey" }],
+        },
+        { name: "r5", on: "tool_call", actions: [{ type: "skip_tool", toolId: "shell_exec" }] },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts stopOnMatch flag", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "stop-rule",
+          on: "tool_call",
+          actions: [{ type: "log", level: "info", message: "x" }],
+          stopOnMatch: true,
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rules[0]?.stopOnMatch).toBe(true);
+    }
+  });
+
+  test("pre-indexes rules by event type", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        { name: "r1", on: "tool_call", actions: [{ type: "log", level: "info", message: "a" }] },
+        { name: "r2", on: "tool_call", actions: [{ type: "log", level: "info", message: "b" }] },
+        {
+          name: "r3",
+          on: "turn_complete",
+          actions: [{ type: "log", level: "info", message: "c" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.byEventType.get("tool_call")).toHaveLength(2);
+      expect(result.value.byEventType.get("turn_complete")).toHaveLength(1);
+      expect(result.value.byEventType.get("session_start")).toBeUndefined();
+    }
+  });
+
+  test("accepts rule without match (matches all events of type)", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "all-turns",
+          on: "turn_complete",
+          actions: [{ type: "log", level: "info", message: "turn done" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.rules[0]?.predicates).toHaveLength(0);
+    }
+  });
+
+  test("compiles combined numeric operators (gte + lte)", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "range-rule",
+          on: "turn_complete",
+          match: { turnIndex: { gte: 5, lte: 10 } },
+          actions: [{ type: "log", level: "info", message: "in range" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // biome-ignore lint/style/noNonNullAssertion: safe — validated single rule with single predicate
+      const pred = result.value.rules[0]!.predicates[0]!;
+      expect(pred.test(4)).toBe(false);
+      expect(pred.test(5)).toBe(true);
+      expect(pred.test(7)).toBe(true);
+      expect(pred.test(10)).toBe(true);
+      expect(pred.test(11)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid configs
+// ---------------------------------------------------------------------------
+
+describe("validateEventRulesConfig — rejections", () => {
+  test("rejects null input", () => {
+    const result = validateEventRulesConfig(null);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects empty rules array", () => {
+    const result = validateEventRulesConfig({ rules: [] });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects empty rule name", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        { name: "", on: "tool_call", actions: [{ type: "log", level: "info", message: "x" }] },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects unknown event type", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "bad",
+          on: "unknown_event",
+          actions: [{ type: "log", level: "info", message: "x" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects duplicate rule names", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        { name: "dup", on: "tool_call", actions: [{ type: "log", level: "info", message: "a" }] },
+        {
+          name: "dup",
+          on: "turn_complete",
+          actions: [{ type: "log", level: "info", message: "b" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects empty actions array", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "no-actions", on: "tool_call", actions: [] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects emit action without event field", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "bad-emit", on: "tool_call", actions: [{ type: "emit" }] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects escalate action without message field", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "bad-esc", on: "tool_call", actions: [{ type: "escalate" }] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects log action without level", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "bad-log", on: "tool_call", actions: [{ type: "log", message: "x" }] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects notify action without channel", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "bad-notif", on: "tool_call", actions: [{ type: "notify", message: "x" }] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects skip_tool action without toolId", () => {
+    const result = validateEventRulesConfig({
+      rules: [{ name: "bad-skip", on: "tool_call", actions: [{ type: "skip_tool" }] }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects invalid regex pattern", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "bad-regex",
+          on: "tool_call",
+          match: { toolId: { regex: "[invalid" } },
+          actions: [{ type: "log", level: "info", message: "x" }],
+        },
+      ],
+    });
+    // Regex compilation happens during compilation, but invalid regex should cause an error
+    // The regex is compiled in compilePredicate — new RegExp("[invalid") throws
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects condition with invalid window format", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "bad-window",
+          on: "tool_call",
+          condition: { count: 3, window: "abc" },
+          actions: [{ type: "log", level: "info", message: "x" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects condition with zero count", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "zero-count",
+          on: "tool_call",
+          condition: { count: 0, window: "1m" },
+          actions: [{ type: "log", level: "info", message: "x" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects numeric operator with no comparisons", () => {
+    const result = validateEventRulesConfig({
+      rules: [
+        {
+          name: "empty-num",
+          on: "turn_complete",
+          match: { turnIndex: {} },
+          actions: [{ type: "log", level: "info", message: "x" }],
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/middleware/middleware-event-rules/src/rule-schema.ts
+++ b/packages/middleware/middleware-event-rules/src/rule-schema.ts
@@ -1,0 +1,256 @@
+/**
+ * Zod schema + compilation for event rule configs.
+ *
+ * Validates YAML input exhaustively at load time, compiles regex patterns
+ * into closures, parses duration strings, and pre-indexes rules by event type.
+ */
+
+import type { KoiError, Result } from "@koi/core";
+import { validateWith } from "@koi/validation";
+import { z } from "zod";
+import { parseDuration } from "./duration.js";
+import type {
+  CompiledPredicate,
+  CompiledRule,
+  CompiledRuleset,
+  MatchValue,
+  NumericOperator,
+  RawEventRulesConfig,
+  RawRule,
+  RegexOperator,
+  RuleEventType,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EVENT_TYPES: readonly RuleEventType[] = [
+  "tool_call",
+  "turn_complete",
+  "session_start",
+  "session_end",
+] as const;
+
+const ACTION_TYPES = ["emit", "escalate", "log", "notify", "skip_tool"] as const;
+const LOG_LEVELS = ["info", "warn", "error", "debug"] as const;
+
+// ---------------------------------------------------------------------------
+// Match value schemas
+// ---------------------------------------------------------------------------
+
+const regexOperatorSchema = z.object({
+  regex: z
+    .string()
+    .min(1)
+    .refine(
+      (pattern) => {
+        try {
+          new RegExp(pattern);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: "Invalid regular expression" },
+    ),
+});
+const numericOperatorSchema = z
+  .object({
+    gte: z.number().optional(),
+    lte: z.number().optional(),
+    gt: z.number().optional(),
+    lt: z.number().optional(),
+  })
+  .refine(
+    (o) => o.gte !== undefined || o.lte !== undefined || o.gt !== undefined || o.lt !== undefined,
+    {
+      message: "Numeric operator must have at least one of gte, lte, gt, lt",
+    },
+  );
+
+const primitiveSchema = z.union([z.string(), z.number(), z.boolean()]);
+const oneOfSchema = z.array(primitiveSchema).min(1);
+
+const matchValueSchema = z.union([
+  primitiveSchema,
+  regexOperatorSchema,
+  numericOperatorSchema,
+  oneOfSchema,
+]);
+
+// ---------------------------------------------------------------------------
+// Action schema
+// ---------------------------------------------------------------------------
+
+const actionSchema = z
+  .object({
+    type: z.enum(ACTION_TYPES),
+    event: z.string().optional(),
+    message: z.string().optional(),
+    channel: z.string().optional(),
+    level: z.enum(LOG_LEVELS).optional(),
+    toolId: z.string().optional(),
+  })
+  .refine(
+    (a) => {
+      switch (a.type) {
+        case "emit":
+          return a.event !== undefined;
+        case "escalate":
+          return a.message !== undefined;
+        case "log":
+          return a.level !== undefined && a.message !== undefined;
+        case "notify":
+          return a.channel !== undefined && a.message !== undefined;
+        case "skip_tool":
+          return a.toolId !== undefined;
+        default:
+          return true;
+      }
+    },
+    {
+      message: "Action is missing required fields for its type",
+    },
+  );
+
+// ---------------------------------------------------------------------------
+// Condition schema
+// ---------------------------------------------------------------------------
+
+const conditionSchema = z.object({
+  count: z.number().int().min(1),
+  window: z.string().refine((w) => parseDuration(w) !== undefined, {
+    message: "Invalid duration format — use s/m/h (e.g., '30s', '5m', '1h')",
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Rule schema
+// ---------------------------------------------------------------------------
+
+const ruleSchema = z.object({
+  name: z.string().min(1),
+  on: z.enum(EVENT_TYPES as unknown as [string, ...string[]]),
+  match: z.record(z.string(), matchValueSchema).optional(),
+  condition: conditionSchema.optional(),
+  actions: z.array(actionSchema).min(1),
+  stopOnMatch: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Top-level config schema
+// ---------------------------------------------------------------------------
+
+const eventRulesConfigSchema = z
+  .object({
+    rules: z.array(ruleSchema).min(1),
+  })
+  .refine(
+    (cfg) => {
+      const names = cfg.rules.map((r) => r.name);
+      return new Set(names).size === names.length;
+    },
+    { message: "Rule names must be unique" },
+  );
+
+// ---------------------------------------------------------------------------
+// Compilation
+// ---------------------------------------------------------------------------
+
+function isRegexOperator(v: unknown): v is RegexOperator {
+  return typeof v === "object" && v !== null && "regex" in v;
+}
+
+function isNumericOperator(v: unknown): v is NumericOperator {
+  if (typeof v !== "object" || v === null) return false;
+  return "gte" in v || "lte" in v || "gt" in v || "lt" in v;
+}
+
+function compilePredicate(field: string, value: MatchValue): CompiledPredicate {
+  // Array → oneOf
+  if (Array.isArray(value)) {
+    const allowed = new Set(value.map(String));
+    return { field, test: (v: unknown) => allowed.has(String(v)) };
+  }
+
+  // Regex operator
+  if (isRegexOperator(value)) {
+    const re = new RegExp(value.regex);
+    return { field, test: (v: unknown) => typeof v === "string" && re.test(v) };
+  }
+
+  // Numeric operator
+  if (isNumericOperator(value)) {
+    return {
+      field,
+      test: (v: unknown) => {
+        if (typeof v !== "number") return false;
+        if (value.gte !== undefined && v < value.gte) return false;
+        if (value.lte !== undefined && v > value.lte) return false;
+        if (value.gt !== undefined && v <= value.gt) return false;
+        if (value.lt !== undefined && v >= value.lt) return false;
+        return true;
+      },
+    };
+  }
+
+  // Primitive exact match
+  return { field, test: (v: unknown) => v === value };
+}
+
+function compileRule(raw: RawRule): CompiledRule {
+  const predicates: readonly CompiledPredicate[] = raw.match
+    ? Object.entries(raw.match).map(([field, value]) => compilePredicate(field, value))
+    : [];
+
+  // Window is validated by Zod refine — parseDuration is guaranteed non-undefined here
+  const condition = raw.condition
+    ? { count: raw.condition.count, windowMs: parseDuration(raw.condition.window) ?? 0 }
+    : undefined;
+
+  return {
+    name: raw.name,
+    on: raw.on,
+    predicates,
+    condition,
+    actions: raw.actions,
+    stopOnMatch: raw.stopOnMatch ?? false,
+  };
+}
+
+function compileRuleset(raw: RawEventRulesConfig): CompiledRuleset {
+  const rules = raw.rules.map(compileRule);
+  const byEventType = new Map<RuleEventType, CompiledRule[]>();
+
+  for (const rule of rules) {
+    const existing = byEventType.get(rule.on);
+    if (existing !== undefined) {
+      byEventType.set(rule.on, [...existing, rule]);
+    } else {
+      byEventType.set(rule.on, [rule]);
+    }
+  }
+
+  return { rules, byEventType };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates and compiles an event rules config from unknown input.
+ *
+ * Performs exhaustive validation (Zod), compiles regex into closures,
+ * parses durations, and pre-indexes rules by event type.
+ */
+export function validateEventRulesConfig(input: unknown): Result<CompiledRuleset, KoiError> {
+  const result = validateWith(
+    eventRulesConfigSchema,
+    input,
+    "Event rules config validation failed",
+  );
+  if (!result.ok) return result;
+  return { ok: true, value: compileRuleset(result.value as RawEventRulesConfig) };
+}

--- a/packages/middleware/middleware-event-rules/src/types.ts
+++ b/packages/middleware/middleware-event-rules/src/types.ts
@@ -1,0 +1,186 @@
+/**
+ * Type definitions for @koi/middleware-event-rules.
+ *
+ * Covers the YAML rule schema, compiled runtime types,
+ * action context, and evaluation results.
+ */
+
+import type { SessionId } from "@koi/core/ecs";
+
+// ---------------------------------------------------------------------------
+// Event vocabulary
+// ---------------------------------------------------------------------------
+
+/** Rule-local event vocabulary, decoupled from EngineEvent. */
+export type RuleEventType = "tool_call" | "turn_complete" | "session_start" | "session_end";
+
+// ---------------------------------------------------------------------------
+// Match predicates (YAML input)
+// ---------------------------------------------------------------------------
+
+/** Regex match operator. */
+export interface RegexOperator {
+  readonly regex: string;
+}
+
+/** Numeric comparison operators. */
+export interface NumericOperator {
+  readonly gte?: number | undefined;
+  readonly lte?: number | undefined;
+  readonly gt?: number | undefined;
+  readonly lt?: number | undefined;
+}
+
+/** A match value: primitive exact match, operator object, or array (oneOf). */
+export type MatchValue =
+  | string
+  | number
+  | boolean
+  | RegexOperator
+  | NumericOperator
+  | readonly (string | number | boolean)[];
+
+/** Match predicate object — flat key-value pairs. */
+export type MatchPredicates = Readonly<Record<string, MatchValue>>;
+
+// ---------------------------------------------------------------------------
+// Actions (YAML input)
+// ---------------------------------------------------------------------------
+
+/** Built-in action types. */
+export type ActionType = "emit" | "escalate" | "log" | "notify" | "skip_tool";
+
+/** Log level for `log` action. */
+export type LogLevel = "info" | "warn" | "error" | "debug";
+
+/** Raw action as parsed from YAML. */
+export interface RawAction {
+  readonly type: ActionType;
+  readonly event?: string;
+  readonly message?: string;
+  readonly channel?: string;
+  readonly level?: LogLevel;
+  readonly toolId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Rule (YAML input)
+// ---------------------------------------------------------------------------
+
+/** Windowed counter condition. */
+export interface RawCondition {
+  readonly count: number;
+  readonly window: string;
+}
+
+/** A single rule as parsed from YAML. */
+export interface RawRule {
+  readonly name: string;
+  readonly on: RuleEventType;
+  readonly match?: MatchPredicates;
+  readonly condition?: RawCondition;
+  readonly actions: readonly RawAction[];
+  readonly stopOnMatch?: boolean;
+}
+
+/** Top-level YAML config. */
+export interface RawEventRulesConfig {
+  readonly rules: readonly RawRule[];
+}
+
+// ---------------------------------------------------------------------------
+// Compiled runtime types
+// ---------------------------------------------------------------------------
+
+/** A compiled predicate: field name + test closure. */
+export interface CompiledPredicate {
+  readonly field: string;
+  readonly test: (value: unknown) => boolean;
+}
+
+/** A compiled rule with parsed window, compiled predicates, and indexed position. */
+export interface CompiledRule {
+  readonly name: string;
+  readonly on: RuleEventType;
+  readonly predicates: readonly CompiledPredicate[];
+  readonly condition: { readonly count: number; readonly windowMs: number } | undefined;
+  readonly actions: readonly RawAction[];
+  readonly stopOnMatch: boolean;
+}
+
+/** Immutable compiled ruleset with pre-indexed lookup by event type. */
+export interface CompiledRuleset {
+  readonly rules: readonly CompiledRule[];
+  readonly byEventType: ReadonlyMap<RuleEventType, readonly CompiledRule[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime event + evaluation result
+// ---------------------------------------------------------------------------
+
+/** An event emitted to the rule engine for evaluation. */
+export interface RuleEvent {
+  readonly type: RuleEventType;
+  readonly fields: Readonly<Record<string, unknown>>;
+  readonly sessionId: SessionId;
+}
+
+/** Result of evaluating rules against an event. */
+export interface RuleEvalResult {
+  /** Actions to execute. */
+  readonly actions: readonly ResolvedAction[];
+  /** Tool IDs to skip (from skip_tool actions). */
+  readonly skipToolIds: readonly string[];
+}
+
+/** An action resolved with its originating rule name and event context. */
+export interface ResolvedAction {
+  readonly ruleName: string;
+  readonly action: RawAction;
+}
+
+// ---------------------------------------------------------------------------
+// Action context — injected dependencies for action execution
+// ---------------------------------------------------------------------------
+
+/** Logger interface for rule actions. */
+export interface RuleLogger {
+  readonly info: (message: string) => void;
+  readonly warn: (message: string) => void;
+  readonly error: (message: string) => void;
+  readonly debug: (message: string) => void;
+}
+
+/** Dependencies injected into action execution. */
+export interface ActionContext {
+  readonly logger?: RuleLogger;
+  readonly emitEvent?: (event: string, data: unknown) => void | Promise<void>;
+  readonly requestEscalation?: (message: string) => void | Promise<void>;
+  readonly sendNotification?: (channel: string, message: string) => void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Rule engine
+// ---------------------------------------------------------------------------
+
+/** A rule engine instance scoped to a single session. */
+export interface RuleEngine {
+  /** Evaluate an event against the ruleset and return matched actions. */
+  readonly evaluate: (event: RuleEvent) => RuleEvalResult;
+  /** Clear all counter state. */
+  readonly reset: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Config for factory
+// ---------------------------------------------------------------------------
+
+/** Configuration for createEventRulesMiddleware. */
+export interface EventRulesConfig {
+  /** Compiled ruleset (already validated). */
+  readonly ruleset: CompiledRuleset;
+  /** Action context dependencies. */
+  readonly actionContext?: ActionContext;
+  /** Injectable clock for testing. Default: Date.now. */
+  readonly now?: () => number;
+}

--- a/packages/middleware/middleware-event-rules/tsconfig.json
+++ b/packages/middleware/middleware-event-rules/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../../kernel/core" },
+    { "path": "../../fs/resolve" },
+    { "path": "../../lib/validation" }
+  ]
+}

--- a/packages/middleware/middleware-event-rules/tsup.config.ts
+++ b/packages/middleware/middleware-event-rules/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- New L2 package `@koi/middleware-event-rules` — declarative YAML rule engine mapping engine events to actions
- Replaces custom middleware boilerplate for common patterns like tool failure escalation, budget warnings, and circuit-breaking
- 4 event types (`tool_call`, `turn_complete`, `session_start`, `session_end`) with 5 action types (`emit`, `escalate`, `log`, `notify`, `skip_tool`)
- Includes full documentation under `docs/L2/middleware-event-rules.md`

### Key design decisions
- Rule-local event vocabulary decoupled from EngineEvent
- Evaluate-all by default, `stopOnMatch: true` opt-in
- Windowed counters: session-scoped, bounded (1000 max), binary-search prune-on-read, no background timers
- Regex compiled at Zod validation time, rules pre-indexed by event type
- Action errors caught and logged, never propagated
- Graceful degradation when action dependencies are missing

### Stats
- 10 source files (~920 lines), 7 test files (~830 lines), 3 config files
- 71 tests passing (unit + integration + API surface snapshot)
- Build, typecheck, lint, layer check all clean

Closes #831

## Test plan

- [x] `bun run build` — tsup ESM + .d.ts compiles cleanly
- [x] `bun run typecheck` — zero type errors
- [x] `bun run lint` — Biome passes
- [x] `bun test` — 71 tests pass
- [x] `scripts/check-layers.ts` — no layer violations
- [x] Integration test: tool failure escalation (3 failures → requestEscalation)
- [x] Integration test: budget warning (turnIndex >= 15 → sendNotification)
- [x] Integration test: skip_tool circuit-breaker (blocks subsequent calls)
- [x] API surface snapshot for stability tracking