### PR TITLE
fix: close 7 security gaps across middleware packages

### DIFF
--- a/packages/security/exec-approvals/src/middleware.ts
+++ b/packages/security/exec-approvals/src/middleware.ts
@@ -248,6 +248,7 @@ async function runAnalyzer(
   context: JsonObject,
   timeoutMs: number,
 ): Promise<RiskAnalysis> {
+  const ac = new AbortController();
   try {
     return await Promise.race([
       Promise.resolve(analyzer.analyze(toolId, input, context)),
@@ -256,10 +257,13 @@ async function runAnalyzer(
         if (typeof timer === "object" && "unref" in timer) {
           (timer as { unref(): void }).unref();
         }
+        ac.signal.addEventListener("abort", () => clearTimeout(timer), { once: true });
       }),
     ]);
   } catch {
     return RISK_ANALYSIS_UNKNOWN;
+  } finally {
+    ac.abort(); // Clear the timeout timer if analyze resolved first
   }
 }
 

--- a/packages/security/middleware-audit/src/audit.ts
+++ b/packages/security/middleware-audit/src/audit.ts
@@ -94,7 +94,17 @@ export function createAuditMiddleware(config: AuditMiddlewareConfig): KoiMiddlew
         durationMs: 0,
         metadata: ctx.metadata,
       };
-      fireAndForget(entry);
+      // Await the session_end entry before flushing to prevent the race
+      // where flush completes before the entry is durably queued.
+      try {
+        await sink.log(entry);
+      } catch (error: unknown) {
+        if (onError) {
+          onError(error, entry);
+        } else {
+          swallowError(error, { package: "middleware-audit", operation: "sink.log" });
+        }
+      }
 
       if (sink.flush) {
         await sink.flush();

--- a/packages/security/middleware-delegation-escalation/src/escalation-gate.ts
+++ b/packages/security/middleware-delegation-escalation/src/escalation-gate.ts
@@ -49,11 +49,30 @@ export function parseHumanResponse(message: InboundMessage): EscalationDecision 
 // Factory
 // ---------------------------------------------------------------------------
 
+export interface EscalationGateOptions {
+  /** AbortSignal to cancel the escalation. */
+  readonly signal?: AbortSignal;
+  /** Maximum time in ms before the escalation times out. */
+  readonly timeoutMs?: number;
+  /**
+   * Correlation token to filter inbound messages.
+   * Only messages whose metadata.correlationToken or threadId matches
+   * this value will be considered. Without this, in shared channels
+   * unrelated traffic can accidentally resolve the gate.
+   */
+  readonly correlationToken?: string;
+}
+
 export function createEscalationGate(
   channel: ChannelAdapter,
-  signal?: AbortSignal,
+  signalOrOptions?: AbortSignal | EscalationGateOptions,
   timeoutMs?: number,
 ): EscalationGate {
+  // Support both old positional args and new options object
+  const isOpts = signalOrOptions !== undefined && !(signalOrOptions instanceof AbortSignal);
+  const signal = isOpts ? signalOrOptions.signal : signalOrOptions;
+  const resolvedTimeoutMs = isOpts ? signalOrOptions.timeoutMs : timeoutMs;
+  const correlationToken = isOpts ? signalOrOptions.correlationToken : undefined;
   // let: mutable — gate state is inherently stateful (pending → resolved)
   let pending = true;
   // let: mutable — cleanup references cleared on resolution
@@ -86,21 +105,30 @@ export function createEscalationGate(
       resolve({ kind: "abort", reason: "Escalation cancelled" });
     };
 
-    // Listen for human response
+    // Listen for human response — filter by correlationToken when set
     unsubscribe = channel.onMessage(async (message: InboundMessage) => {
       if (!pending) return;
+      if (correlationToken !== undefined) {
+        const meta = message.metadata as Record<string, unknown> | undefined;
+        const matchesThread = message.threadId === correlationToken;
+        const matchesMeta = meta?.correlationToken === correlationToken;
+        if (!matchesThread && !matchesMeta) return; // Not our escalation — ignore
+      }
       const decision = parseHumanResponse(message);
       cleanup();
       resolve(decision);
     });
 
     // Timeout race
-    if (timeoutMs !== undefined && timeoutMs > 0) {
+    if (resolvedTimeoutMs !== undefined && resolvedTimeoutMs > 0) {
       timer = setTimeout(() => {
         if (!pending) return;
         cleanup();
-        resolve({ kind: "abort", reason: `Escalation timed out after ${String(timeoutMs)}ms` });
-      }, timeoutMs);
+        resolve({
+          kind: "abort",
+          reason: `Escalation timed out after ${String(resolvedTimeoutMs)}ms`,
+        });
+      }, resolvedTimeoutMs);
     }
 
     // AbortSignal race

--- a/packages/security/middleware-guardrails/src/guardrails.ts
+++ b/packages/security/middleware-guardrails/src/guardrails.ts
@@ -48,6 +48,8 @@ export function createGuardrailsMiddleware(config: GuardrailsConfig): KoiMiddlew
 
   const hasModelOutputRules = modelOutputRules.length > 0;
   const hasToolOutputRules = toolOutputRules.length > 0;
+  // If any model output rules use "block" action, stream must buffer to prevent leakage
+  const hasBlockRules = modelOutputRules.some((r) => (r.action ?? "block") === "block");
 
   // Pre-built map for O(1) rule lookup by name
   const rulesByName = new Map(config.rules.map((r) => [r.name, r]));
@@ -200,6 +202,10 @@ export function createGuardrailsMiddleware(config: GuardrailsConfig): KoiMiddlew
             let buffer = "";
             // let justified: track buffer overflow state
             let overflowed = false;
+            // When block rules exist, hold chunks until validation passes on done
+            // to prevent yielding content that will later be blocked.
+            const pendingChunks: ModelChunk[] = hasBlockRules ? [] : [];
+            const shouldBuffer = hasBlockRules;
 
             for await (const chunk of next(request)) {
               switch (chunk.kind) {
@@ -223,21 +229,37 @@ export function createGuardrailsMiddleware(config: GuardrailsConfig): KoiMiddlew
                       buffer += chunk.delta;
                     }
                   }
-                  yield chunk;
+                  if (shouldBuffer) {
+                    pendingChunks.push(chunk);
+                  } else {
+                    yield chunk;
+                  }
                   break;
                 }
                 case "done": {
                   if (!overflowed && buffer.length > 0) {
                     const result = validateAllModelRules(buffer);
                     buffer = ""; // Release memory before potential throw
-                    if (!result.valid) handleStreamFailure(result);
+                    if (!result.valid) {
+                      pendingChunks.length = 0; // Release buffered chunks
+                      handleStreamFailure(result);
+                    }
                   }
                   buffer = ""; // Release memory
+                  // Flush buffered chunks now that validation passed
+                  for (const pending of pendingChunks) {
+                    yield pending;
+                  }
+                  pendingChunks.length = 0;
                   yield chunk;
                   break;
                 }
                 default: {
-                  yield chunk;
+                  if (shouldBuffer) {
+                    pendingChunks.push(chunk);
+                  } else {
+                    yield chunk;
+                  }
                 }
               }
             }

--- a/packages/security/middleware-intent-capsule/src/config.ts
+++ b/packages/security/middleware-intent-capsule/src/config.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CapsuleVerifier } from "@koi/core/intent-capsule";
+import { verifyEd25519 } from "@koi/crypto-utils";
 
 /** Configuration for the intent capsule middleware. */
 export interface IntentCapsuleConfig {
@@ -54,14 +55,17 @@ export function resolveConfig(config: IntentCapsuleConfig): Required<IntentCapsu
 }
 
 /**
- * Default CapsuleVerifier: checks that the stored mandateHash matches
- * the re-computed hash of the current mandate fields.
- * A mismatch means the capsule was created from a different mandate.
+ * Default CapsuleVerifier: checks mandate hash equality AND verifies
+ * the Ed25519 signature against the capsule's public key.
+ * Hash check first (cheap), then signature verification (crypto).
  */
 const defaultVerifier: CapsuleVerifier = {
   verify(capsule, currentMandateHash) {
     if (capsule.mandateHash !== currentMandateHash) {
       return { ok: false, reason: "mandate_hash_mismatch" };
+    }
+    if (!verifyEd25519(capsule.mandateHash, capsule.publicKey, capsule.signature)) {
+      return { ok: false, reason: "invalid_signature" };
     }
     return { ok: true, capsule };
   },

--- a/packages/security/middleware-pay/src/pay.ts
+++ b/packages/security/middleware-pay/src/pay.ts
@@ -61,6 +61,17 @@ export function createPayMiddleware(config: PayMiddlewareConfig): KoiMiddleware 
   }
 
   async function checkBudget(sessionId: string): Promise<void> {
+    // Fast path: if a previous call already recorded overspend, fail immediately
+    // without an async tracker query. This closes the single-call overspend gap
+    // by ensuring subsequent calls within the same turn are blocked instantly.
+    if (hardKill) {
+      const cached = lastKnownRemaining.get(sessionId);
+      if (cached !== undefined && cached <= 0) {
+        throw KoiRuntimeError.from("RATE_LIMIT", `Budget exhausted. Limit: $${budget.toFixed(4)}`, {
+          context: { budget, remaining: 0 },
+        });
+      }
+    }
     const remainingBudget = await tracker.remaining(sessionId, budget);
     if (hardKill && remainingBudget <= 0) {
       throw KoiRuntimeError.from("RATE_LIMIT", `Budget exhausted. Limit: $${budget.toFixed(4)}`, {

--- a/packages/security/middleware-permissions/src/permissions.ts
+++ b/packages/security/middleware-permissions/src/permissions.ts
@@ -261,6 +261,17 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
       }
     }
 
+    // Fail closed: any slot not filled by cache or backend defaults to deny
+    const MISSING_DENY: PermissionDecision = {
+      effect: "deny",
+      reason: "No decision returned by permission backend — failing closed",
+    };
+    for (let i = 0; i < results.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = MISSING_DENY;
+      }
+    }
+
     return results as readonly PermissionDecision[];
   }
 
@@ -287,11 +298,13 @@ export function createPermissionsMiddleware(config: PermissionsMiddlewareConfig)
       const decisions = await resolveBatch(queries);
       const durationMs = clock() - startMs;
 
-      // Audit each decision and filter out denied tools — keep allow + ask
+      // Audit each decision and filter out denied tools — keep allow + ask.
+      // Fail closed: missing decisions are treated as deny.
       const filtered = request.tools.filter((t, i) => {
         const d = decisions[i];
-        if (d !== undefined) auditDecision(ctx, t.name, d, durationMs);
-        return d?.effect !== "deny";
+        if (d === undefined) return false;
+        auditDecision(ctx, t.name, d, durationMs);
+        return d.effect !== "deny";
       });
 
       return next({ ...request, tools: filtered });


### PR DESCRIPTION
## Summary

- **P1 — Batch permissions fail-open**: `resolveBatch` now fills undefined slots with deny decisions; `wrapModelCall` filter explicitly rejects undefined (fail-closed)
- **P1 — Escalation gate unfiltered messages**: `createEscalationGate` accepts `correlationToken` option to filter `onMessage` by `threadId` or `metadata.correlationToken`; backward-compatible overload
- **P1 — Guardrail stream leakage**: `wrapModelStream` buffers all chunks when block rules exist and only yields after validation passes on `done`
- **P2 — Intent capsule signature skipped**: Default `CapsuleVerifier` now calls `verifyEd25519(mandateHash, publicKey, signature)` after the hash equality check
- **P2 — Budget single-call overspend**: `checkBudget` adds fast-path cache read from `lastKnownRemaining` to block subsequent calls instantly after overspend without async tracker roundtrip
- **P2 — Audit session-end race**: `onSessionEnd` awaits `sink.log(entry)` before `sink.flush()`, eliminating the fire-and-forget race
- **P3 — Analyzer timer leak**: `runAnalyzer` uses `AbortController` to `clearTimeout` when `analyze` resolves first

## Test plan

- [x] `middleware-delegation-escalation`: 11 pass, 0 fail
- [x] `middleware-guardrails`: 28 pass, 0 fail
- [x] `middleware-intent-capsule`: 13 pass, 0 fail
- [x] `middleware-pay`: 33 pass, 0 fail
- [x] `middleware-audit`: 26 pass, 0 fail
- [x] `exec-approvals`: 30 pass, 0 fail
- [x] Full turbo build + typecheck: 47/47 tasks pass
- [ ] `middleware-permissions`: blocked by pre-existing `@koi/hash` module resolution issue in worktree (ESM build succeeds)