### PR TITLE
fix: goal & planning middleware bugs

### DIFF
--- a/packages/middleware/middleware-goal/src/anchor/goal-anchor.test.ts
+++ b/packages/middleware/middleware-goal/src/anchor/goal-anchor.test.ts
@@ -39,6 +39,14 @@ describe("createGoalAnchorMiddleware", () => {
     expect(mw.priority).toBe(340);
   });
 
+  test("throws KoiRuntimeError with VALIDATION code on invalid config", () => {
+    expect(() =>
+      createGoalAnchorMiddleware({ objectives: 42 } as unknown as Parameters<
+        typeof createGoalAnchorMiddleware
+      >[0]),
+    ).toThrow(expect.objectContaining({ code: "VALIDATION" }));
+  });
+
   describe("1. onSessionStart initializes todo with all objectives as pending", () => {
     test("all items start as pending", async () => {
       const completed: string[] = [];

--- a/packages/middleware/middleware-goal/src/anchor/goal-anchor.ts
+++ b/packages/middleware/middleware-goal/src/anchor/goal-anchor.ts
@@ -17,11 +17,18 @@ import type {
   SessionContext,
   TurnContext,
 } from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
 import type { GoalAnchorConfig } from "./config.js";
+import { validateGoalAnchorConfig } from "./config.js";
 import { createTodoState, detectCompletions, renderTodoBlock } from "./todo.js";
 import type { TodoItem, TodoState } from "./types.js";
 
 export function createGoalAnchorMiddleware(config: GoalAnchorConfig): KoiMiddleware {
+  const validResult = validateGoalAnchorConfig(config);
+  if (!validResult.ok) {
+    throw KoiRuntimeError.from(validResult.error.code, validResult.error.message);
+  }
+
   const header = config.header ?? "## Current Objectives";
   const sessions = new Map<string, TodoState>();
   const hasObjectives = config.objectives.length > 0;

--- a/packages/middleware/middleware-goal/src/planning/plan-middleware.test.ts
+++ b/packages/middleware/middleware-goal/src/planning/plan-middleware.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { JsonObject } from "@koi/core/common";
 import type { ToolDescriptor } from "@koi/core/ecs";
+import { sessionId } from "@koi/core/ecs";
 import type { InboundMessage } from "@koi/core/message";
 import type {
   CapabilityFragment,
@@ -8,7 +9,11 @@ import type {
   ModelRequest,
   ModelResponse,
 } from "@koi/core/middleware";
-import { createMockTurnContext, testMiddlewareContract } from "@koi/test-utils";
+import {
+  createMockSessionContext,
+  createMockTurnContext,
+  testMiddlewareContract,
+} from "@koi/test-utils";
 import { createPlanMiddleware } from "./plan-middleware.js";
 import { WRITE_PLAN_TOOL_NAME } from "./plan-tool.js";
 import type { PlanItem } from "./types.js";
@@ -132,7 +137,10 @@ describe("wrapToolCall — write_plan interception", () => {
       capturedPlan = plan;
     };
     const mw = createPlanMiddleware({ onPlanUpdate });
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
+    await mw.onBeforeTurn?.(ctx);
 
     const response = await mw.wrapToolCall?.(
       ctx,
@@ -156,7 +164,9 @@ describe("wrapToolCall — write_plan interception", () => {
 
   test("passes through non-plan tool calls", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
     const expected = { output: "tool result" };
 
     const response = await mw.wrapToolCall?.(
@@ -169,7 +179,9 @@ describe("wrapToolCall — write_plan interception", () => {
 
   test("rejects second write_plan call in same turn", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
 
     // Reset per-turn counter
     await mw.onBeforeTurn?.(ctx);
@@ -190,7 +202,9 @@ describe("wrapToolCall — write_plan interception", () => {
 
   test("allows write_plan again after onBeforeTurn resets counter", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
 
     const input = {
       plan: [{ content: "Step 1", status: "pending" }],
@@ -209,7 +223,9 @@ describe("wrapToolCall — write_plan interception", () => {
 
   test("returns error for invalid plan input", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
     await mw.onBeforeTurn?.(ctx);
 
     const response = await mw.wrapToolCall?.(
@@ -225,7 +241,9 @@ describe("wrapToolCall — write_plan interception", () => {
 
   test("returns error for plan items with invalid status", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
     await mw.onBeforeTurn?.(ctx);
 
     const response = await mw.wrapToolCall?.(
@@ -251,7 +269,9 @@ describe("wrapToolCall — write_plan interception", () => {
       lastCapturedPlan = plan;
     };
     const mw = createPlanMiddleware({ onPlanUpdate });
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
 
     await mw.onBeforeTurn?.(ctx);
     await mw.wrapToolCall?.(
@@ -291,7 +311,9 @@ describe("wrapToolCall — write_plan interception", () => {
 describe("plan persistence across turns", () => {
   test("plan state persists after wrapModelCall", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
 
     // Turn 1: create plan
     await mw.onBeforeTurn?.(ctx);
@@ -326,7 +348,9 @@ describe("describeCapabilities", () => {
 
   test("returns label 'planning' and description changes based on plan state", async () => {
     const mw = createPlanMiddleware();
-    const ctx = createMockTurnContext();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
 
     // Before any plan is written — no active plan
     const before = mw.describeCapabilities?.(ctx) as CapabilityFragment;
@@ -350,5 +374,117 @@ describe("describeCapabilities", () => {
     const after = mw.describeCapabilities?.(ctx) as CapabilityFragment;
     expect(after.label).toBe("planning");
     expect(after.description).toContain("Plan active");
+  });
+});
+
+describe("session isolation", () => {
+  test("plan from session A is not visible in session B", async () => {
+    const mw = createPlanMiddleware();
+    const sessionA = createMockSessionContext({ sessionId: sessionId("session-a") });
+    const sessionB = createMockSessionContext({ sessionId: sessionId("session-b") });
+    await mw.onSessionStart?.(sessionA);
+    await mw.onSessionStart?.(sessionB);
+
+    const ctxA = createMockTurnContext({ session: sessionA, turnIndex: 0 });
+    await mw.onBeforeTurn?.(ctxA);
+
+    // Write plan in session A
+    await mw.wrapToolCall?.(
+      ctxA,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "Session A task", status: "in_progress" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+
+    // Session B should have no plan
+    const ctxB = createMockTurnContext({ session: sessionB, turnIndex: 0 });
+    const response = await mw.wrapModelCall?.(ctxB, createRequest("hello"), async () =>
+      createResponse("ok"),
+    );
+    const plan = response?.metadata?.currentPlan as unknown as readonly PlanItem[];
+    expect(plan).toHaveLength(0);
+  });
+
+  test("state is cleaned up after onSessionEnd", async () => {
+    const mw = createPlanMiddleware();
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+
+    const ctx = createMockTurnContext({ session: sessionCtx, turnIndex: 0 });
+    await mw.onBeforeTurn?.(ctx);
+
+    // Write plan
+    await mw.wrapToolCall?.(
+      ctx,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "Task", status: "pending" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+
+    // End session
+    await mw.onSessionEnd?.(sessionCtx);
+
+    // After session end, wrapToolCall should return error (no session state)
+    const ctx2 = createMockTurnContext({ session: sessionCtx, turnIndex: 1 });
+    const response = await mw.wrapToolCall?.(
+      ctx2,
+      {
+        toolId: WRITE_PLAN_TOOL_NAME,
+        input: {
+          plan: [{ content: "New task", status: "pending" }],
+        } satisfies JsonObject,
+      },
+      async () => ({ output: "x" }),
+    );
+    expect((response?.output as Record<string, unknown>).error).toBeDefined();
+  });
+
+  test("writePlanCallsThisTurn counter is per-session", async () => {
+    const mw = createPlanMiddleware();
+    const sessionA = createMockSessionContext({ sessionId: sessionId("session-a") });
+    const sessionB = createMockSessionContext({ sessionId: sessionId("session-b") });
+    await mw.onSessionStart?.(sessionA);
+    await mw.onSessionStart?.(sessionB);
+
+    const ctxA = createMockTurnContext({ session: sessionA, turnIndex: 0 });
+    const ctxB = createMockTurnContext({ session: sessionB, turnIndex: 0 });
+    await mw.onBeforeTurn?.(ctxA);
+    await mw.onBeforeTurn?.(ctxB);
+
+    const input = {
+      plan: [{ content: "Step 1", status: "pending" }],
+    } satisfies JsonObject;
+
+    // Use session A's once-per-turn quota
+    const firstA = await mw.wrapToolCall?.(
+      ctxA,
+      { toolId: WRITE_PLAN_TOOL_NAME, input },
+      async () => ({ output: "x" }),
+    );
+    expect(firstA?.output).toContain("Plan updated");
+
+    // Session B should still be able to call write_plan
+    const firstB = await mw.wrapToolCall?.(
+      ctxB,
+      { toolId: WRITE_PLAN_TOOL_NAME, input },
+      async () => ({ output: "x" }),
+    );
+    expect(firstB?.output).toContain("Plan updated");
+
+    // Session A's second call should fail
+    const secondA = await mw.wrapToolCall?.(
+      ctxA,
+      { toolId: WRITE_PLAN_TOOL_NAME, input },
+      async () => ({ output: "x" }),
+    );
+    expect((secondA?.output as Record<string, unknown>).error).toContain("once per response");
   });
 });

--- a/packages/middleware/middleware-goal/src/planning/plan-middleware.ts
+++ b/packages/middleware/middleware-goal/src/planning/plan-middleware.ts
@@ -14,6 +14,7 @@ import type {
   ModelRequest,
   ModelResponse,
   ModelStreamHandler,
+  SessionContext,
   ToolHandler,
   ToolRequest,
   ToolResponse,
@@ -48,11 +49,12 @@ export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
   const priority = validated.priority ?? DEFAULT_PRIORITY;
   const onPlanUpdate = validated.onPlanUpdate;
 
-  // Closure state — persists across turns
-  // let justified: plan state that changes on each write_plan call
-  let currentPlan: readonly PlanItem[] = [];
-  // let justified: per-turn counter reset in onBeforeTurn
-  let writePlanCallsThisTurn = 0;
+  interface PlanSessionState {
+    readonly currentPlan: readonly PlanItem[];
+    readonly writePlanCallsThisTurn: number;
+  }
+
+  const sessions = new Map<string, PlanSessionState>();
 
   /** Enrich a model request with the plan system message and tool descriptor. */
   function enrichRequest(request: ModelRequest): ModelRequest {
@@ -101,35 +103,59 @@ export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
   return {
     name: "plan",
     priority,
-    describeCapabilities: (_ctx: TurnContext): CapabilityFragment => {
-      if (currentPlan.length === 0) {
+
+    async onSessionStart(ctx: SessionContext): Promise<void> {
+      sessions.set(ctx.sessionId as string, {
+        currentPlan: [],
+        writePlanCallsThisTurn: 0,
+      });
+    },
+
+    async onSessionEnd(ctx: SessionContext): Promise<void> {
+      sessions.delete(ctx.sessionId as string);
+    },
+
+    describeCapabilities: (ctx: TurnContext): CapabilityFragment | undefined => {
+      const state = sessions.get(ctx.session.sessionId as string);
+      if (!state) {
         return {
           label: "planning",
           description: "Planning: write_plan tool injected, no active plan",
         };
       }
-      const pending = currentPlan.filter((i) => i.status === "pending").length;
-      const inProgress = currentPlan.filter((i) => i.status === "in_progress").length;
-      const completed = currentPlan.filter((i) => i.status === "completed").length;
+      if (state.currentPlan.length === 0) {
+        return {
+          label: "planning",
+          description: "Planning: write_plan tool injected, no active plan",
+        };
+      }
+      const pending = state.currentPlan.filter((i) => i.status === "pending").length;
+      const inProgress = state.currentPlan.filter((i) => i.status === "in_progress").length;
+      const completed = state.currentPlan.filter((i) => i.status === "completed").length;
       return {
         label: "planning",
-        description: `Plan active: ${String(currentPlan.length)} items (${String(pending)} pending, ${String(inProgress)} in progress, ${String(completed)} completed)`,
+        description: `Plan active: ${String(state.currentPlan.length)} items (${String(pending)} pending, ${String(inProgress)} in progress, ${String(completed)} completed)`,
       };
     },
 
-    async onBeforeTurn(_ctx: TurnContext): Promise<void> {
-      writePlanCallsThisTurn = 0;
+    async onBeforeTurn(ctx: TurnContext): Promise<void> {
+      const sessionId = ctx.session.sessionId as string;
+      const state = sessions.get(sessionId);
+      if (!state) return;
+      sessions.set(sessionId, { ...state, writePlanCallsThisTurn: 0 });
     },
 
     async wrapModelCall(
-      _ctx: TurnContext,
+      ctx: TurnContext,
       request: ModelRequest,
       next: ModelHandler,
     ): Promise<ModelResponse> {
+      const state = sessions.get(ctx.session.sessionId as string);
       const enriched = enrichRequest(request);
       const response = await next(enriched);
 
       // Attach current plan to response metadata for observability
+      const currentPlan = state?.currentPlan ?? [];
       const metadata: JsonObject = {
         ...response.metadata,
         currentPlan: currentPlan as unknown as JsonObject,
@@ -147,7 +173,7 @@ export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
     },
 
     async wrapToolCall(
-      _ctx: TurnContext,
+      ctx: TurnContext,
       request: ToolRequest,
       next: ToolHandler,
     ): Promise<ToolResponse> {
@@ -156,9 +182,19 @@ export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
         return next(request);
       }
 
+      const sessionId = ctx.session.sessionId as string;
+      const state = sessions.get(sessionId);
+      if (!state) {
+        return {
+          output: { error: "No active session for plan middleware" },
+          metadata: { planError: true },
+        };
+      }
+
       // Enforce at-most-once per turn
-      writePlanCallsThisTurn += 1;
-      if (writePlanCallsThisTurn > 1) {
+      const callCount = state.writePlanCallsThisTurn + 1;
+      sessions.set(sessionId, { ...state, writePlanCallsThisTurn: callCount });
+      if (callCount > 1) {
         return {
           output: { error: "write_plan can only be called once per response" },
           metadata: { planError: true },
@@ -175,12 +211,12 @@ export function createPlanMiddleware(config?: PlanConfig): KoiMiddleware {
       }
 
       // Atomically replace the plan
-      currentPlan = parsed;
-      onPlanUpdate?.(currentPlan);
+      sessions.set(sessionId, { currentPlan: parsed, writePlanCallsThisTurn: callCount });
+      onPlanUpdate?.(parsed);
 
       return {
-        output: formatPlanSummary(currentPlan),
-        metadata: { currentPlan: currentPlan as unknown as JsonObject },
+        output: formatPlanSummary(parsed),
+        metadata: { currentPlan: parsed as unknown as JsonObject },
       };
     },
   };

--- a/packages/middleware/middleware-goal/src/reminder/goal-reminder.test.ts
+++ b/packages/middleware/middleware-goal/src/reminder/goal-reminder.test.ts
@@ -82,6 +82,16 @@ describe("createGoalReminderMiddleware", () => {
     expect(mw.priority).toBe(330);
   });
 
+  test("throws KoiRuntimeError with VALIDATION code on invalid config", () => {
+    expect(() =>
+      createGoalReminderMiddleware({
+        sources: [],
+        baseInterval: 2,
+        maxInterval: 8,
+      } as unknown as GoalReminderConfig),
+    ).toThrow(expect.objectContaining({ code: "VALIDATION" }));
+  });
+
   test("injects on trigger turns and skips others (baseInterval=2)", async () => {
     const mw = createGoalReminderMiddleware(makeConfig({ baseInterval: 2, maxInterval: 8 }));
     const sessionCtx = createMockSessionContext();
@@ -312,6 +322,76 @@ describe("createGoalReminderMiddleware", () => {
 
     expect(capturedReq).toBeDefined();
     expect(capturedReq?.messages[0]?.senderId).toBe("system:goal-reminder");
+  });
+
+  test("static-only sources contribute to drift detection keywords", async () => {
+    // With static source "use TypeScript strict mode", keywords include "typescript", "strict", "mode"
+    // When messages DON'T contain these keywords → drifting → interval stays at base
+    const mw = createGoalReminderMiddleware(
+      makeConfig({
+        sources: [{ kind: "static", text: "use TypeScript strict mode" }],
+        baseInterval: 2,
+        maxInterval: 16,
+      }),
+    );
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+
+    const handler = async (_req: ModelRequest) => makeModelResponse("ok");
+    // Messages say "turn N" which won't match "typescript"/"strict"/"mode"
+    // → defaultIsDrifting returns true → interval stays at 2 (never doubles)
+    const requests = await simulateTurns(mw, sessionCtx, 6, handler);
+
+    // Triggers at turns 1, 3, 5 (0-indexed) because interval stays 2
+    expect(requests[1]?.messages[0]?.senderId).toBe("system:goal-reminder");
+    expect(requests[3]?.messages[0]?.senderId).toBe("system:goal-reminder");
+    expect(requests[5]?.messages[0]?.senderId).toBe("system:goal-reminder");
+  });
+
+  test("mixed manifest+static sources both contribute keywords", async () => {
+    const mw = createGoalReminderMiddleware(
+      makeConfig({
+        sources: [
+          { kind: "manifest", objectives: ["complete the task"] },
+          { kind: "static", text: "follow coding standards" },
+        ],
+        baseInterval: 2,
+        maxInterval: 16,
+      }),
+    );
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+
+    const handler = async (_req: ModelRequest) => makeModelResponse("ok");
+    // Messages say "turn N" — won't match "complete", "task", "follow", "coding", "standards"
+    const requests = await simulateTurns(mw, sessionCtx, 4, handler);
+
+    // Drifting → interval stays at 2 → trigger at turn 1, 3
+    expect(requests[1]?.messages[0]?.senderId).toBe("system:goal-reminder");
+    expect(requests[3]?.messages[0]?.senderId).toBe("system:goal-reminder");
+  });
+
+  test("dynamic-only sources yield empty goalStrings (no static keywords)", async () => {
+    const mw = createGoalReminderMiddleware(
+      makeConfig({
+        sources: [{ kind: "dynamic", fetch: () => "dynamic content" }],
+        baseInterval: 2,
+        maxInterval: 16,
+      }),
+    );
+    const sessionCtx = createMockSessionContext();
+    await mw.onSessionStart?.(sessionCtx);
+
+    const handler = async (_req: ModelRequest) => makeModelResponse("ok");
+    const requests = await simulateTurns(mw, sessionCtx, 7, handler);
+
+    // goalStrings is empty → defaultIsDrifting returns false → not drifting
+    // → interval doubles: base=2 → trigger at 1, then interval=4 → trigger at 5
+    expect(requests[1]?.messages[0]?.senderId).toBe("system:goal-reminder");
+    // Turn 3 should NOT trigger (interval doubled to 4)
+    expect(requests[3]?.messages[0]?.senderId).not.toBe("system:goal-reminder");
+    // Turn 5 should trigger (1+4=5)
+    expect(requests[5]?.messages[0]?.senderId).toBe("system:goal-reminder");
   });
 
   test("reminder content includes XML tags from sources", async () => {

--- a/packages/middleware/middleware-goal/src/reminder/goal-reminder.ts
+++ b/packages/middleware/middleware-goal/src/reminder/goal-reminder.ts
@@ -17,7 +17,9 @@ import type {
   SessionContext,
   TurnContext,
 } from "@koi/core/middleware";
+import { KoiRuntimeError } from "@koi/errors";
 import type { GoalReminderConfig } from "./config.js";
+import { validateGoalReminderConfig } from "./config.js";
 import { computeNextInterval, defaultIsDrifting } from "./interval.js";
 import { resolveAllSources } from "./sources.js";
 import type { ReminderSessionState } from "./types.js";
@@ -30,15 +32,23 @@ const INITIAL_STATE_FACTORY = (baseInterval: number): ReminderSessionState => ({
 });
 
 export function createGoalReminderMiddleware(config: GoalReminderConfig): KoiMiddleware {
+  const validResult = validateGoalReminderConfig(config);
+  if (!validResult.ok) {
+    throw KoiRuntimeError.from(validResult.error.code, validResult.error.message);
+  }
+
   const header = config.header ?? "Reminder";
   const baseInterval = config.baseInterval;
   const maxInterval = config.maxInterval;
   const sessions = new Map<string, ReminderSessionState>();
 
   // Extract goal strings for default drift detection
-  const goalStrings: readonly string[] = config.sources.flatMap((s) =>
-    s.kind === "manifest" ? s.objectives : [],
-  );
+  const goalStrings: readonly string[] = config.sources.flatMap((s): readonly string[] => {
+    if (s.kind === "manifest") return s.objectives;
+    if (s.kind === "static") return [s.text];
+    // "dynamic" and "tasks" are resolved at runtime, can't extract statically
+    return [];
+  });
 
   const customIsDrifting = config.isDrifting;
 


### PR DESCRIPTION
## Summary

- **Config validation**: `createGoalAnchorMiddleware` and `createGoalReminderMiddleware` now call their `validate*Config()` at construction and throw `KoiRuntimeError` with `VALIDATION` code on invalid input (previously failed late with TypeError)
- **Drift detection**: `goal-reminder` now includes `static` source text in keyword extraction for `defaultIsDrifting` (was only extracting from `manifest` sources, making drift detection blind to static-only configurations)
- **Session isolation**: Planning middleware replaces closure-scoped `let currentPlan` / `let writePlanCallsThisTurn` with `Map<sessionId, PlanSessionState>` and adds `onSessionStart`/`onSessionEnd` lifecycle hooks (previously plans leaked between concurrent sessions)

## Test plan

- [x] goal-anchor: invalid config throws with VALIDATION code
- [x] goal-reminder: invalid config throws with VALIDATION code
- [x] goal-reminder: static-only sources contribute to drift detection keywords
- [x] goal-reminder: mixed manifest+static sources both contribute keywords
- [x] goal-reminder: dynamic-only sources yield empty goalStrings (expected)
- [x] planning: plan from session A not visible in session B
- [x] planning: state cleaned up after onSessionEnd
- [x] planning: writePlanCallsThisTurn counter is per-session
- [x] All 67 tests pass across 3 test files