### PR TITLE
fix: resolve forge subsystem bugs — dead code, dropped config, session isolation

### DIFF
--- a/packages/forge/crystallize/src/auto-forge-middleware.ts
+++ b/packages/forge/crystallize/src/auto-forge-middleware.ts
@@ -17,6 +17,7 @@ import type {
   ForgeScope,
   ForgeStore,
   KoiMiddleware,
+  SessionContext,
   ToolArtifact,
   ToolPolicy,
   TurnContext,
@@ -203,7 +204,7 @@ export function createAutoForgeMiddleware(config: AutoForgeConfig): KoiMiddlewar
 
   const forgeHandler = createCrystallizeForgeHandler(forgeHandlerConfig);
 
-  // justified: mutable counters encapsulated within factory closure
+  // justified: mutable counters reset per session via onSessionStart
   let lastForgedCount = 0;
   let demandForgedCount = 0;
   const demandBudget = config.demandBudget ?? DEFAULT_FORGE_BUDGET;
@@ -344,6 +345,13 @@ export function createAutoForgeMiddleware(config: AutoForgeConfig): KoiMiddlewar
   return {
     name: "auto-forge",
     priority: 960, // After crystallize middleware (950)
+
+    async onSessionStart(_ctx: SessionContext): Promise<void> {
+      // Reset per-session counters so each session gets its own budget
+      forgeHandler.resetForSession();
+      lastForgedCount = 0;
+      demandForgedCount = 0;
+    },
 
     async onAfterTurn(_ctx: TurnContext): Promise<void> {
       // --- Existing: process crystallization candidates ---

--- a/packages/forge/crystallize/src/forge-handler.ts
+++ b/packages/forge/crystallize/src/forge-handler.ts
@@ -55,6 +55,8 @@ export interface CrystallizeForgeHandler {
     now: number,
   ) => readonly CrystallizedToolDescriptor[];
   readonly getForgedCount: () => number;
+  /** Reset per-session counters. Call on session start. */
+  readonly resetForSession: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,6 +126,10 @@ export function createCrystallizeForgeHandler(
   return {
     handleCandidates,
     getForgedCount: () => forgedCount,
+    resetForSession: () => {
+      forgedCount = 0;
+      forgedNames.clear();
+    },
   };
 }
 

--- a/packages/forge/forge-demand/src/__tests__/demand-pipeline.test.ts
+++ b/packages/forge/forge-demand/src/__tests__/demand-pipeline.test.ts
@@ -72,7 +72,8 @@ describe("demand pipeline integration", () => {
 
     const ctx = createMockTurnContext();
     const response = {
-      content: [{ kind: "text", text: "I don't have a tool for image compression." }],
+      content: "I don't have a tool for image compression.",
+      model: "test-model",
       usage: { inputTokens: 10, outputTokens: 20 },
     };
     const next = async () => response;

--- a/packages/forge/forge-demand/src/demand-detector.test.ts
+++ b/packages/forge/forge-demand/src/demand-detector.test.ts
@@ -19,9 +19,10 @@ function createToolRequest(toolId: string): {
 
 function createModelResponse(text: string): ModelResponse {
   return {
-    content: [{ kind: "text", text }],
+    content: text,
+    model: "test-model",
     usage: { inputTokens: 0, outputTokens: 0 },
-  } as unknown as ModelResponse;
+  };
 }
 
 function createSuccessToolResponse(): ToolResponse {

--- a/packages/forge/forge-demand/src/demand-detector.ts
+++ b/packages/forge/forge-demand/src/demand-detector.ts
@@ -74,14 +74,7 @@ function triggerKey(trigger: ForgeTrigger): string {
 // ---------------------------------------------------------------------------
 
 function extractResponseText(response: ModelResponse): string {
-  if (!Array.isArray(response.content)) return "";
-  const parts: string[] = [];
-  for (const block of response.content as readonly Record<string, unknown>[]) {
-    if (typeof block.text === "string") {
-      parts.push(block.text);
-    }
-  }
-  return parts.join(" ");
+  return typeof response.content === "string" ? response.content : "";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/forge-exaptation/src/exaptation-detector.ts
+++ b/packages/forge/forge-exaptation/src/exaptation-detector.ts
@@ -69,8 +69,8 @@ export function createExaptationDetector(config: ExaptationConfig): ExaptationHa
   // let: monotonically increasing signal counter for unique IDs
   let signalCounter = 0;
 
-  // let: most recent model response text, captured by wrapModelCall
-  let lastModelResponseText = "";
+  // Session-keyed model response text, captured by wrapModelCall
+  const lastModelResponseBySession = new Map<string, string>();
 
   // -------------------------------------------------------------------------
   // Internal helpers
@@ -205,17 +205,19 @@ export function createExaptationDetector(config: ExaptationConfig): ExaptationHa
     priority: 465,
 
     async wrapModelCall(
-      _ctx: TurnContext,
+      ctx: TurnContext,
       request: ModelRequest,
       next: ModelHandler,
     ): Promise<ModelResponse> {
       const response = await next(request);
 
-      // Capture model response text for the next wrapToolCall
-      lastModelResponseText =
-        typeof response.content === "string" && response.content.length > 0
-          ? truncateToWords(response.content, maxWords)
-          : "";
+      // Capture model response text keyed by session for the next wrapToolCall
+      const sid = ctx.session.sessionId;
+      if (typeof response.content === "string" && response.content.length > 0) {
+        lastModelResponseBySession.set(sid, truncateToWords(response.content, maxWords));
+      } else {
+        lastModelResponseBySession.set(sid, "");
+      }
 
       // Cache tool descriptions from the request if available
       if (request.tools !== undefined) {
@@ -238,13 +240,14 @@ export function createExaptationDetector(config: ExaptationConfig): ExaptationHa
       const agentId = ctx.session.agentId;
 
       // Observe intent before executing the tool call
+      const modelResponseText = lastModelResponseBySession.get(ctx.session.sessionId) ?? "";
       const descriptionTokens = toolDescriptionCache.get(toolId);
-      if (descriptionTokens !== undefined && lastModelResponseText.length > 0) {
-        const contextTokens = tokenize(lastModelResponseText);
+      if (descriptionTokens !== undefined && modelResponseText.length > 0) {
+        const contextTokens = tokenize(modelResponseText);
         const divergence = computeJaccardDistance(descriptionTokens, contextTokens);
 
         const observation: UsagePurposeObservation = {
-          contextText: lastModelResponseText,
+          contextText: modelResponseText,
           agentId,
           divergenceScore: divergence,
           observedAt: clock(),

--- a/packages/forge/forge-optimizer/src/optimizer-middleware.test.ts
+++ b/packages/forge/forge-optimizer/src/optimizer-middleware.test.ts
@@ -31,7 +31,7 @@ function createMockSessionContext(): unknown {
 }
 
 function createMockTurnContext(): unknown {
-  return { turnIndex: 0 };
+  return { turnIndex: 0, session: { sessionId: "test-session" } };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/forge/forge-optimizer/src/optimizer-middleware.ts
+++ b/packages/forge/forge-optimizer/src/optimizer-middleware.ts
@@ -53,19 +53,20 @@ export function createOptimizerMiddleware(config: OptimizerMiddlewareConfig): Ko
     clock: config.clock,
   });
 
-  let lastResults: readonly OptimizationResult[] = [];
+  const resultsBySession = new Map<string, readonly OptimizationResult[]>();
 
   return {
     name: "forge-optimizer",
     priority: 990, // Late — runs after all other middleware
 
-    async onSessionEnd(_ctx: SessionContext): Promise<void> {
+    async onSessionEnd(ctx: SessionContext): Promise<void> {
       const results = await optimizer.sweep();
-      lastResults = results;
+      resultsBySession.set(ctx.sessionId, results);
       config.onSweepComplete?.(results);
     },
 
-    describeCapabilities(_ctx: TurnContext): CapabilityFragment | undefined {
+    describeCapabilities(ctx: TurnContext): CapabilityFragment | undefined {
+      const lastResults = resultsBySession.get(ctx.session.sessionId) ?? [];
       if (lastResults.length === 0) return undefined;
 
       const deprecated = lastResults.filter((r) => r.action === "deprecate").length;

--- a/packages/meta/forge/src/create-full-forge-system.ts
+++ b/packages/meta/forge/src/create-full-forge-system.ts
@@ -77,6 +77,7 @@ export function createFullForgeSystem(config: CreateFullForgeSystemConfig): Full
   const runtime = createForgeRuntime({
     store: config.store,
     executor: config.executor,
+    dependencyConfig: config.forgeConfig.dependencies,
     ...(config.signer !== undefined ? { signer: config.signer } : {}),
   });
 


### PR DESCRIPTION
## Summary

Fixes 5 bugs across the forge subsystem identified in code review:

1. **forge-demand: dead capability-gap detection** — `extractResponseText()` checked `Array.isArray()` on `ModelResponse.content` which is always a `string`, so gap detection never ran. Tests hid this with `as unknown as ModelResponse` casts.
2. **create-full-forge-system: dropped dependency policy** — `forgeConfig.dependencies` was never passed to `createForgeRuntime()`, so the runtime silently fell back to default allow/blocklists, ignoring caller-configured dependency policy.
3. **forge-exaptation: cross-session model intent leak** — a single closure-level `lastModelResponseText` was shared across all sessions. Session B's `wrapToolCall` could consume Session A's model response text.
4. **crystallize/auto-forge: shared session counters** — `maxForgedPerSession` was documented as per-session but used lifetime closure counters with no reset. One session could spend another's forge budget.
5. **forge-optimizer: cross-session result leak** — `lastResults` was global closure state, so `describeCapabilities()` could surface one session's optimization results in unrelated sessions.

## Changes

| File | Change |
|------|--------|
| `forge-demand/demand-detector.ts` | `extractResponseText()` → handle `string` content |
| `forge-demand/demand-detector.test.ts` | Fix test helper to use proper `ModelResponse` (string content, no cast) |
| `forge-demand/__tests__/demand-pipeline.test.ts` | Same test fix for integration test |
| `meta/forge/create-full-forge-system.ts` | Pass `dependencyConfig` to `createForgeRuntime()` |
| `forge-exaptation/exaptation-detector.ts` | Replace closure `let` with `Map<SessionId, string>` |
| `crystallize/forge-handler.ts` | Add `resetForSession()` to `CrystallizeForgeHandler` |
| `crystallize/auto-forge-middleware.ts` | Add `onSessionStart` hook to reset counters per session |
| `forge-optimizer/optimizer-middleware.ts` | Replace closure `let` with `Map<SessionId, results>` |
| `forge-optimizer/optimizer-middleware.test.ts` | Fix mock context to include `session.sessionId` |

## Test plan

- [x] `@koi/forge-demand` — 105 tests pass (including previously-broken capability gap tests)
- [x] `@koi/forge-exaptation` — all tests pass
- [x] `@koi/crystallize` — all tests pass
- [x] `@koi/forge-optimizer` — 4 tests pass
- [x] `@koi/forge` (meta) — 175 tests pass
- [x] All 5 packages build cleanly via turbo