### PR TITLE
feat: @koi/session-state + ci-L1.yml + setup composite action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,14 @@
 # Changes here affect ALL packages. Require at least 2 reviews.
 #
 # GitHub branch protection must be configured to:
-#   - Require 2 approving reviews for PRs touching packages/core/
+#   - Require 2 approving reviews for PRs touching packages/kernel/core/
 #   - Require review from code owners (Settings > Branches > Require review from Code Owners)
 #
 # See docs/architecture/Koi.md for layer definitions.
 # Canonical L0u list: scripts/layers.ts → L0U_PACKAGES
 
 # Layer 0 kernel — 2 reviewers enforced via branch protection
-packages/core/ @taofeng
+packages/kernel/core/ @taofeng
 
 # Layer governance — canonical source of truth for layer membership and CI enforcement.
 # Changes here have the same blast radius as L0 changes.

--- a/packages/middleware/middleware-semantic-retry/src/descriptor.ts
+++ b/packages/middleware/middleware-semantic-retry/src/descriptor.ts
@@ -44,7 +44,7 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   name: "@koi/middleware-semantic-retry",
   aliases: ["semantic-retry"],
   optionsValidator: validateSemanticRetryDescriptorOptions,
-  factory(options): KoiMiddleware {
+  factory(options: Record<string, unknown>): KoiMiddleware {
     const maxRetries = typeof options.maxRetries === "number" ? options.maxRetries : undefined;
 
     const config: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Three issues addressed in this PR:

### 1. `@koi/session-state` L0u package (#869)
Per-session state management with FIFO eviction for middleware authors. Replaces error-prone module-scoped `let` variables (which caused 5 production bugs in PRs #853, #862-864) with a type-safe `createSessionState<T>(factory, config?)` factory.

- `SessionStateManager<T>`: get, getOrCreate, update, delete, clear, size
- Bounded by maxSessions (default 1000) with FIFO eviction + onEvict callback
- 14 tests, all O(1) operations
- Docs: `docs/patterns/session-state.md`

### 2. CI governance completion (#870)
- **`.github/actions/setup/action.yml`** — composite action deduplicating Bun + Turborepo + cache setup across all CI workflows
- **`.github/workflows/ci-L1.yml`** — dedicated workflow for `packages/kernel/engine/**` changes, scoped to `@koi/engine...` dependents
- **ci-L0.yml / ci-L2.yml** — updated to use the composite action (removes ~30 lines of duplication)

### Design note
The issue suggested a reusable workflow (`workflow_call`), but reusable workflows run as entire jobs — you can't add steps from the caller. A **composite action** is the correct GitHub Actions pattern for reusable setup steps within a job.

Closes #869, closes #870

## Test plan

### @koi/session-state
- [x] 14 tests pass (`bun test --cwd packages/lib/session-state`)
- [x] Typecheck + build pass
- [x] Layer compliance (`bun scripts/check-layers.ts`)
- [x] Doc sync (`bun scripts/check-doc-sync.ts`)

### CI workflows
- [x] YAML syntax valid (no `${{ }}` interpolation in `run:` blocks)
- [x] ci-L1.yml paths filter matches `packages/kernel/engine/**`
- [x] ci-L0.yml and ci-L2.yml use composite action correctly
- [ ] Verify: PR touching `packages/kernel/engine/` triggers ci-L1.yml
- [ ] Verify: PR touching only L2 package does NOT trigger ci-L1.yml