### PR TITLE
fix: harden component providers and tool safety checks

### DIFF
--- a/packages/fs/lsp/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/fs/lsp/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -232,6 +232,11 @@ declare function createLspClientPool(config: LspClientPoolConfig): LspClientPool
  *
  * Async factory that connects to all LSP servers in parallel, negotiates
  * capabilities, and wraps supported operations as Koi Tool components.
+ *
+ * Single-agent design: LSP clients are shared across all attached agents.
+ * Detach closes all LSP clients, so only the last agent should trigger
+ * detach. Create a separate provider instance per agent if multi-agent
+ * use is needed.
  */
 
 interface LspServerFailure {

--- a/packages/fs/lsp/src/component-provider.ts
+++ b/packages/fs/lsp/src/component-provider.ts
@@ -3,6 +3,11 @@
  *
  * Async factory that connects to all LSP servers in parallel, negotiates
  * capabilities, and wraps supported operations as Koi Tool components.
+ *
+ * Single-agent design: LSP clients are shared across all attached agents.
+ * Detach closes all LSP clients, so only the last agent should trigger
+ * detach. Create a separate provider instance per agent if multi-agent
+ * use is needed.
  */
 
 import type { Agent, ComponentProvider, KoiError } from "@koi/core";
@@ -174,13 +179,20 @@ export async function createLspComponentProvider(
     }
   }
 
+  // let: ref-count for safe client disposal — only close when last agent detaches
+  let refCount = 0;
+
   const provider: ComponentProvider = {
     name: "lsp",
     attach: async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
+      refCount++;
       return allTools;
     },
     detach: async (_agent: Agent): Promise<void> => {
-      await Promise.all(clients.map((c) => c.close()));
+      refCount--;
+      if (refCount <= 0) {
+        await Promise.all(clients.map((c) => c.close()));
+      }
     },
   };
 

--- a/packages/fs/skills/src/provider.ts
+++ b/packages/fs/skills/src/provider.ts
@@ -7,6 +7,10 @@
  *
  * Uses parallel loading via Promise.allSettled for initial attach, and fires
  * ComponentEvent notifications on promote() for downstream consumers.
+ *
+ * Single-agent design: the provider caches results from the first attach() and
+ * binds ComponentEvents to that agent's ID. Create a separate provider instance
+ * per agent if multi-agent use is needed.
  */
 
 import { resolve } from "node:path";
@@ -181,7 +185,16 @@ export function createSkillComponentProvider(
   // -------------------------------------------------------------------
 
   const attach = async (agent: Agent): Promise<AttachResult> => {
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      // Warn if a different agent re-uses this single-agent provider
+      const incomingId = agent.pid?.id ?? agentId("unknown");
+      if (attachedAgentId !== incomingId && (attachedAgentId as string) !== "unknown") {
+        throw new Error(
+          `SkillProvider is single-agent: already attached to ${attachedAgentId as string}, cannot attach to ${incomingId as string}. Create a separate provider per agent.`,
+        );
+      }
+      return cached;
+    }
 
     // Defensive: extract AgentId from pid.id if available, fallback for minimal stubs
     attachedAgentId = agent.pid?.id ?? agentId("unknown");

--- a/packages/fs/tool-ask-guide/src/ask-guide-tool.test.ts
+++ b/packages/fs/tool-ask-guide/src/ask-guide-tool.test.ts
@@ -94,8 +94,9 @@ describe("createAskGuideTool", () => {
     expect(output.truncated).toBe(true);
   });
 
-  test("includes at least one result even if it exceeds budget", async () => {
-    // Single large result exceeds budget but should still be included
+  test("includes at least one result even if it exceeds budget but flags truncated", async () => {
+    // Single large result exceeds budget — included to avoid empty response,
+    // but truncated flag is set so callers know the budget was exceeded.
     const results: readonly GuideSearchResult[] = [
       { title: "Big Result", content: "x".repeat(500) },
     ];
@@ -107,7 +108,7 @@ describe("createAskGuideTool", () => {
     };
 
     expect(output.results).toHaveLength(1);
-    expect(output.truncated).toBe(false);
+    expect(output.truncated).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/fs/tool-ask-guide/src/ask-guide-tool.ts
+++ b/packages/fs/tool-ask-guide/src/ask-guide-tool.ts
@@ -81,6 +81,11 @@ export function createAskGuideTool(config: AskGuideConfig): Tool {
         usedTokens += resultTokens;
       }
 
+      // Flag budget exceeded even when the first result alone overflows
+      if (usedTokens > maxTokens) {
+        truncated = true;
+      }
+
       return {
         results: accumulated,
         totalFound: searchResults.length,

--- a/packages/fs/tool-browser/src/browser-component-provider.ts
+++ b/packages/fs/tool-browser/src/browser-component-provider.ts
@@ -4,9 +4,14 @@
  * Both engine-claude and engine-pi discover tools via `agent.query<Tool>("tool:")`.
  * This provider creates Tool components from a BrowserDriver, making them
  * available to any engine with zero engine changes.
+ *
+ * Single-agent design: this provider shares a single BrowserDriver backend.
+ * Attaching multiple agents would share browser state (tabs, cookies) and
+ * detaching any agent would dispose the backend for all. Create a separate
+ * provider instance per agent if multi-agent use is needed.
  */
 
-import type { BrowserDriver, ComponentProvider, Tool, ToolPolicy } from "@koi/core";
+import type { Agent, AgentId, BrowserDriver, ComponentProvider, Tool, ToolPolicy } from "@koi/core";
 import {
   BROWSER,
   createServiceProvider,
@@ -198,6 +203,26 @@ export function createBrowserProvider(config: BrowserProviderConfig): ComponentP
   const compiledSecurity: CompiledNavigationSecurity | undefined =
     scope === undefined && security !== undefined ? compileNavigationSecurity(security) : undefined;
 
+  // let: ref-count for safe backend disposal — only dispose when last agent detaches
+  let refCount = 0;
+  // let: track attached agent for single-agent safety check
+  let attachedAgent: AgentId | undefined;
+
+  function guardAttach(agent: Agent): void {
+    refCount++;
+    if (attachedAgent === undefined) {
+      attachedAgent = agent.pid.id;
+    }
+  }
+
+  async function guardDetach(): Promise<void> {
+    refCount--;
+    if (refCount <= 0) {
+      attachedAgent = undefined;
+      if (backend.dispose) await backend.dispose();
+    }
+  }
+
   // Split operations into standard (handled by createServiceProvider factories)
   // and custom (handled by customTools hook).
   const standardOps = operations.filter((op): op is StandardOperation => STANDARD_OPS.has(op));
@@ -220,14 +245,18 @@ export function createBrowserProvider(config: BrowserProviderConfig): ComponentP
     ]);
     return {
       name: `browser:${backend.name}`,
-      attach: async () => components,
-      detach: async () => {
-        if (backend.dispose) await backend.dispose();
+      attach: async (agent: Agent) => {
+        guardAttach(agent);
+        return components;
+      },
+      detach: async (_agent: Agent) => {
+        await guardDetach();
       },
     };
   }
 
-  return createServiceProvider({
+  // Wrap createServiceProvider to add ref-counting for backend disposal
+  const inner = createServiceProvider({
     name: `browser:${backend.name}`,
     singletonToken: BROWSER,
     backend,
@@ -239,8 +268,17 @@ export function createBrowserProvider(config: BrowserProviderConfig): ComponentP
       ...createCustomToolEntries(operations, b, prefix, policy, compiledSecurity),
       [skillToken(BROWSER_SKILL_NAME) as string, BROWSER_SKILL],
     ],
-    detach: async (b) => {
-      if (b.dispose) await b.dispose();
-    },
   });
+
+  return {
+    name: inner.name,
+    ...(inner.priority !== undefined ? { priority: inner.priority } : {}),
+    attach: async (agent: Agent) => {
+      guardAttach(agent);
+      return inner.attach(agent);
+    },
+    detach: async (_agent: Agent) => {
+      await guardDetach();
+    },
+  };
 }

--- a/packages/fs/tools-web/src/url-policy.ts
+++ b/packages/fs/tools-web/src/url-policy.ts
@@ -1,5 +1,11 @@
 /**
  * URL policy — blocks SSRF targets (private IPs, metadata endpoints, localhost).
+ *
+ * Limitation: checks are string-based pattern matching on the URL. This does NOT
+ * protect against DNS rebinding attacks where a domain initially resolves to a
+ * public IP (passing the check) then rebinds to a private IP during the actual
+ * fetch. A full mitigation would require pre-flight DNS resolution and IP
+ * validation, which is not implemented here.
  */
 
 // ---------------------------------------------------------------------------

--- a/packages/fs/tools-web/src/web-executor.ts
+++ b/packages/fs/tools-web/src/web-executor.ts
@@ -165,7 +165,16 @@ export function createWebExecutor(config: WebExecutorConfig = {}): WebExecutor {
       options?: WebFetchOptions,
     ): Promise<Result<WebFetchResult, KoiError>> => {
       const method = options?.method ?? "GET";
-      const cacheKey = `${method}:${url}`;
+      // Normalize URL to canonical form to prevent cache key collisions
+      // from semantically identical URLs with different encodings
+      const normalizedUrl = (() => {
+        try {
+          return new URL(url).href;
+        } catch {
+          return url;
+        }
+      })();
+      const cacheKey = `${method}:${normalizedUrl}`;
 
       // Check cache (GET/HEAD only)
       if (fetchCache !== undefined && (method === "GET" || method === "HEAD")) {

--- a/packages/sched/scheduler-provider/src/scheduler-component-provider.ts
+++ b/packages/sched/scheduler-provider/src/scheduler-component-provider.ts
@@ -3,7 +3,15 @@
  *
  * Wraps a TaskScheduler into a SchedulerComponent with pinned agentId,
  * then exposes 9 tools for agent interaction. The agentId is captured at
- * attach() time — agents can only schedule/cancel their own tasks.
+ * attach() time.
+ *
+ * Ownership enforcement:
+ * - submit/schedule: agentId is pinned — agents can only create work for themselves.
+ * - query/history: agentId filter is injected — agents only see their own tasks.
+ * - cancel: ownership verified via query before cancellation.
+ * - unschedule/pause/resume: NOT ownership-verified. The TaskScheduler L0 contract
+ *   does not expose schedule lookup by ID. ScheduleIds are opaque ULIDs returned
+ *   by schedule(), making cross-agent collisions improbable.
  */
 
 import type {
@@ -60,6 +68,8 @@ export interface SchedulerProviderConfig {
 /**
  * Creates a SchedulerComponent that wraps TaskScheduler with a pinned agentId.
  * The agentId is captured from the agent at attach() time.
+ *
+ * cancel() verifies task ownership via query before allowing cancellation.
  */
 function createSchedulerComponentForAgent(
   scheduler: TaskScheduler,
@@ -72,7 +82,12 @@ function createSchedulerComponentForAgent(
       options?: TaskOptions,
     ): TaskId | Promise<TaskId> => scheduler.submit(pinnedAgentId, input, mode, options),
 
-    cancel: (id: TaskId): boolean | Promise<boolean> => scheduler.cancel(id),
+    cancel: async (id: TaskId): Promise<boolean> => {
+      // Verify the task belongs to this agent before cancelling
+      const tasks = await scheduler.query({ agentId: pinnedAgentId });
+      if (!tasks.some((t) => t.id === id)) return false;
+      return scheduler.cancel(id);
+    },
 
     schedule: (
       expression: string,


### PR DESCRIPTION
## Summary

Fixes 6 valid findings from codex review batch 3:

1. **scheduler-provider**: `cancel()` now verifies task ownership via `scheduler.query({ agentId })` before allowing cancellation. Documents limitation for `unschedule/pause/resume` (no schedule lookup in L0 contract).

2. **tool-browser**: Adds ref-counting for backend disposal — `detach()` only calls `backend.dispose()` when the last agent detaches, preventing premature disposal in multi-agent scenarios.

3. **lsp**: Adds ref-counting so `detach()` only closes LSP clients when the last attached agent leaves. Documents single-agent design.

4. **skills**: Guards against multi-agent misuse — throws if a second agent with a different ID tries to `attach()` to a provider already bound to another agent. Documents single-agent design.

5. **tools-web**: Normalizes fetch cache keys via `new URL(url).href` to prevent encoding-based dedup bypass. Documents DNS rebinding limitation in `url-policy.ts`.

6. **tool-ask-guide**: Sets `truncated: true` when the first (and only) result exceeds the token budget, so callers know the budget was exceeded even though the result is still included.

Findings verified as **INVALID** (not fixed):
- Scheduler semaphore leak: `finally { semaphore.release() }` guarantees release
- Catalog `get()` error collapsing: `fanOut()` preserves errors via `sourceErrors`

## Test plan
- [x] All 6 modified packages build successfully
- [x] scheduler-provider: 330 tests pass
- [x] tool-browser: 6 integration tests pass (incl. dispose-on-detach)
- [x] lsp: 9 component-provider tests pass, API surface snapshot updated
- [x] skills: 30 provider tests pass
- [x] tools-web: 23 web-executor tests pass
- [x] tool-ask-guide: 11 tests pass (updated oversized-result test expectation)
- [x] Biome lint clean
- [x] Pre-push typecheck passes