### PR TITLE
fix: address codex findings in debug, procfs, dashboard, eval

### DIFF
--- a/packages/observability/agent-discovery/src/component-provider.ts
+++ b/packages/observability/agent-discovery/src/component-provider.ts
@@ -40,7 +40,10 @@ export function createDiscoveryProvider(config?: DiscoveryProviderConfig): Compo
     name: "agent-discovery",
 
     attach: async (_agent: Agent): Promise<ReadonlyMap<string, unknown>> => {
+      // Snapshot is bounded-stale (cache TTL). The discover_agents tool
+      // always calls discovery.discover() for fresh results.
       const agents = await discovery.discover();
+
       return new Map<string, unknown>([
         [toolToken(tool.descriptor.name) as string, tool],
         [EXTERNAL_AGENTS as string, agents],

--- a/packages/observability/agent-procfs/src/agent-mounter.ts
+++ b/packages/observability/agent-procfs/src/agent-mounter.ts
@@ -62,7 +62,19 @@ export function createAgentMounter(config: AgentMounterConfig): AgentMounter {
     }
   }
 
-  // Watch for registry changes
+  // Hydrate with agents that already exist in the registry
+  void (async () => {
+    try {
+      const existing = await registry.list();
+      for (const entry of existing) {
+        mountAgent(entry.agentId);
+      }
+    } catch {
+      // Best-effort — if list() fails, we still get future events via watch()
+    }
+  })();
+
+  // Watch for future registry changes
   const unsubscribe = registry.watch((event) => {
     switch (event.kind) {
       case "registered":

--- a/packages/observability/dashboard-ui/src/app.tsx
+++ b/packages/observability/dashboard-ui/src/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { PageShell } from "./components/layout/page-shell.js";
 import { AgentsPage } from "./pages/agents-page.js";
 import { useSse } from "./hooks/use-sse.js";
+import { getDashboardConfig } from "./lib/dashboard-config.js";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,9 +20,10 @@ function SseProvider({ children }: { readonly children: React.ReactNode }): Reac
 }
 
 export function App(): React.ReactElement {
+  const { basePath } = getDashboardConfig();
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename="/dashboard">
+      <BrowserRouter basename={basePath}>
         <SseProvider>
           <Routes>
             <Route element={<PageShell />}>

--- a/packages/observability/dashboard-ui/src/hooks/use-sse.ts
+++ b/packages/observability/dashboard-ui/src/hooks/use-sse.ts
@@ -12,6 +12,7 @@ import type { DashboardEvent, DashboardEventBatch } from "@koi/dashboard-types";
 import { isAgentEvent } from "@koi/dashboard-types";
 import type { QueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { getDashboardConfig } from "../lib/dashboard-config.js";
 import { createSseClient } from "../lib/sse-client.js";
 import { useAgentsStore } from "../stores/agents-store.js";
 import { useConnectionStore } from "../stores/connection-store.js";
@@ -48,8 +49,9 @@ export function useSse(queryClient: QueryClient): void {
   const setConnectionStatus = useConnectionStore((s) => s.setStatus);
 
   useEffect(() => {
+    const { apiPath } = getDashboardConfig();
     const client = createSseClient({
-      url: "/dashboard/api/events",
+      url: `${apiPath}/events`,
       onBatch: (batch: DashboardEventBatch) => {
         for (const event of batch.events) {
           handleEvent(event, queryClient);

--- a/packages/observability/dashboard-ui/src/lib/api-client.ts
+++ b/packages/observability/dashboard-ui/src/lib/api-client.ts
@@ -11,7 +11,9 @@ import type {
   DashboardSystemMetrics,
 } from "@koi/dashboard-types";
 
-const API_BASE = "/dashboard/api";
+import { getDashboardConfig } from "./dashboard-config.js";
+
+const API_BASE = getDashboardConfig().apiPath;
 
 async function fetchApi<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`, init);

--- a/packages/observability/dashboard-ui/src/lib/dashboard-config.ts
+++ b/packages/observability/dashboard-ui/src/lib/dashboard-config.ts
@@ -1,0 +1,30 @@
+/**
+ * Dashboard runtime configuration — reads from window globals or falls back to defaults.
+ *
+ * The server can inject config at runtime via a <script> tag setting
+ * window.__DASHBOARD_CONFIG__ before the app bundle loads.
+ */
+
+interface DashboardRuntimeConfig {
+  readonly basePath: string;
+  readonly apiPath: string;
+}
+
+declare global {
+  interface Window {
+    readonly __DASHBOARD_CONFIG__?: Partial<DashboardRuntimeConfig>;
+  }
+}
+
+const DEFAULT_BASE_PATH = "/dashboard";
+const DEFAULT_API_PATH = "/dashboard/api";
+
+/** Resolve dashboard config from window globals or defaults. */
+export function getDashboardConfig(): DashboardRuntimeConfig {
+  const injected = typeof window !== "undefined" ? window.__DASHBOARD_CONFIG__ : undefined;
+
+  return {
+    basePath: injected?.basePath ?? DEFAULT_BASE_PATH,
+    apiPath: injected?.apiPath ?? DEFAULT_API_PATH,
+  };
+}

--- a/packages/observability/debug/src/debug-middleware.ts
+++ b/packages/observability/debug/src/debug-middleware.ts
@@ -11,17 +11,19 @@ import type {
   BreakpointOptions,
   BreakpointPredicate,
   DebugEvent,
+  DebugSessionId,
   EngineEvent,
   KoiMiddleware,
   ModelHandler,
   ModelRequest,
   ModelResponse,
+  ToolCallId,
   ToolHandler,
   ToolRequest,
   ToolResponse,
   TurnContext,
 } from "@koi/core";
-import { breakpointId } from "@koi/core";
+import { breakpointId, toolCallId } from "@koi/core";
 import { matchesBreakpoint } from "./breakpoint-matcher.js";
 import { DEBUG_MIDDLEWARE_NAME, DEBUG_MIDDLEWARE_PRIORITY } from "./constants.js";
 import type { EventRingBuffer } from "./event-ring-buffer.js";
@@ -62,6 +64,8 @@ export interface DebugController {
   readonly pausedEvent: () => EngineEvent | undefined;
   /** Get the breakpoint that caused the pause (if any). */
   readonly pausedBreakpointId: () => BreakpointId | undefined;
+  /** Set the debug session ID (called by DebugSession after construction). */
+  readonly setSessionId: (id: DebugSessionId) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,7 +78,12 @@ export interface DebugMiddlewareResult {
 }
 
 /** Create a debug middleware with controller interface. */
-export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddlewareResult {
+export function createDebugMiddleware(
+  eventBuffer: EventRingBuffer,
+  sessionId?: DebugSessionId,
+): DebugMiddlewareResult {
+  // let justified: session ID may be set after construction via setSessionId
+  let debugSessId: DebugSessionId = sessionId ?? ("" as DebugSessionId);
   // let justified: mutable active flag
   let active = false;
 
@@ -125,7 +134,7 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
 
           emitDebugEvent({
             kind: "breakpoint_hit",
-            debugSessionId: "" as ReturnType<typeof import("@koi/core").debugSessionId>,
+            debugSessionId: debugSessId,
             breakpointId: bpId,
             turnIndex: currentTurnIndex,
             event,
@@ -139,7 +148,7 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
 
           emitDebugEvent({
             kind: "paused",
-            debugSessionId: "" as ReturnType<typeof import("@koi/core").debugSessionId>,
+            debugSessionId: debugSessId,
             breakpointId: bpId,
             turnIndex: currentTurnIndex,
           });
@@ -153,7 +162,7 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
 
           emitDebugEvent({
             kind: "resumed",
-            debugSessionId: "" as ReturnType<typeof import("@koi/core").debugSessionId>,
+            debugSessionId: debugSessId,
           });
 
           // Only hit one breakpoint per event
@@ -178,14 +187,14 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
       };
     },
 
-    onBeforeTurn: async (_ctx: TurnContext): Promise<void> => {
+    onBeforeTurn: async (ctx: TurnContext): Promise<void> => {
       if (!active) return;
-      await processEvent({ kind: "turn_start", turnIndex: currentTurnIndex });
+      await processEvent({ kind: "turn_start", turnIndex: ctx.turnIndex });
     },
 
-    onAfterTurn: async (_ctx: TurnContext): Promise<void> => {
+    onAfterTurn: async (ctx: TurnContext): Promise<void> => {
       if (!active) return;
-      await processEvent({ kind: "turn_end", turnIndex: currentTurnIndex });
+      await processEvent({ kind: "turn_end", turnIndex: ctx.turnIndex });
     },
 
     wrapToolCall: async (
@@ -195,17 +204,19 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
     ): Promise<ToolResponse> => {
       if (!active) return next(request);
 
+      const callId: ToolCallId = toolCallId(crypto.randomUUID());
+
       await processEvent({
         kind: "tool_call_start",
         toolName: request.toolId,
-        callId: "" as ReturnType<typeof import("@koi/core").toolCallId>,
+        callId,
       });
 
       const response = await next(request);
 
       await processEvent({
         kind: "tool_call_end",
-        callId: "" as ReturnType<typeof import("@koi/core").toolCallId>,
+        callId,
         result: response.output,
       });
 
@@ -281,6 +292,9 @@ export function createDebugMiddleware(eventBuffer: EventRingBuffer): DebugMiddle
     eventBuffer: () => eventBuffer,
     pausedEvent: () => pausedEvt,
     pausedBreakpointId: () => pausedBpId,
+    setSessionId: (sid: DebugSessionId) => {
+      debugSessId = sid;
+    },
   };
 
   return { middleware, controller };

--- a/packages/observability/debug/src/debug-session.ts
+++ b/packages/observability/debug/src/debug-session.ts
@@ -50,8 +50,9 @@ export function createDebugSession(config: CreateDebugSessionConfig): DebugSessi
   let detached = false;
   const attachedSince = new Date().toISOString();
 
-  // Activate the middleware
+  // Activate the middleware and bind session ID for event correlation
   controller.activate();
+  controller.setSessionId(id);
 
   // Emit attached event
   const listeners = new Set<(event: DebugEvent) => void>();
@@ -153,12 +154,34 @@ export function createDebugSession(config: CreateDebugSessionConfig): DebugSessi
       });
     },
 
-    step: (_options?: StepOptions) => {
+    step: (options?: StepOptions) => {
       const check = assertPaused();
       if (!check.ok) return check;
 
-      // Release the gate to allow one step
+      const count = options?.count ?? 1;
+      const until = options?.until;
+
+      if (until !== undefined) {
+        // Install a one-shot breakpoint for the "until" predicate, then resume
+        controller.addBreakpoint(until, { once: true, label: "step-until" });
+      } else if (count > 1) {
+        // Install a one-shot breakpoint at the target turn index
+        const targetTurn = controller.turnIndex() + count;
+        controller.addBreakpoint(
+          { kind: "turn", turnIndex: targetTurn },
+          { once: true, label: "step-target" },
+        );
+      }
+
+      // Release the gate to allow execution
       controller.releaseGate();
+
+      emitToSession({
+        kind: "step_completed",
+        debugSessionId: id,
+        turnIndex: controller.turnIndex(),
+      });
+
       return { ok: true, value: undefined };
     },
 

--- a/packages/observability/eval/src/scorer.ts
+++ b/packages/observability/eval/src/scorer.ts
@@ -29,7 +29,7 @@ export function computeSummary(
     meanScore: mean(allScores),
     latencyP50Ms: computePercentile(allLatencies, 50),
     latencyP95Ms: computePercentile(allLatencies, 95),
-    totalCostUsd: 0,
+    totalCostUsd: trials.reduce((sum, t) => sum + (t.metrics.costUsd ?? 0), 0),
     byTask,
   };
 }

--- a/packages/observability/eval/src/store/fs-store.ts
+++ b/packages/observability/eval/src/store/fs-store.ts
@@ -89,12 +89,27 @@ async function listRunMetas(baseDir: string, evalName: string): Promise<readonly
 
     for (const file of summaryFiles) {
       try {
+        const runId = file.replace(".summary.json", "");
         const content = await Bun.file(join(dir, file)).text();
         const summary = JSON.parse(content) as EvalSummary;
+
+        // Attempt to read timestamp from the full run file
+        let timestamp = "";
+        try {
+          const runFile = Bun.file(join(dir, `${runId}.json`));
+          if (await runFile.exists()) {
+            const runContent = await runFile.text();
+            const run = JSON.parse(runContent) as { readonly timestamp?: string };
+            timestamp = run.timestamp ?? "";
+          }
+        } catch {
+          // Fall back to empty timestamp if run file is missing/corrupted
+        }
+
         metas.push({
-          id: file.replace(".summary.json", ""),
+          id: runId,
           name: evalName,
-          timestamp: "",
+          timestamp,
           passRate: summary.passRate,
           taskCount: summary.taskCount,
         });


### PR DESCRIPTION
## Summary

Fixes 7 valid findings from Codex review across observability packages:

- **debug-middleware**: Use `ctx.turnIndex` from `TurnContext` instead of stale `currentTurnIndex` in `onBeforeTurn`/`onAfterTurn`; generate real `ToolCallId` and `DebugSessionId` instead of empty-string placeholders; add `setSessionId()` to controller interface
- **debug-session**: Implement `step()` with `StepOptions` support (`count` and `until` predicates); bind debug session ID on controller after activation
- **agent-procfs**: Hydrate existing agents via `registry.list()` on startup so agents registered before mounter creation get mounted
- **dashboard-ui**: Extract `getDashboardConfig()` to centralize `basePath`/`apiPath` instead of hardcoding `"/dashboard"` and `"/dashboard/api"`
- **eval/scorer**: Sum trial costs in `totalCostUsd` instead of hardcoding `0`
- **eval/fs-store**: Read timestamp from full run JSON in `listRunMetas` instead of always returning empty string

## Test plan

- [x] All 5 modified packages build successfully (`turbo build`)
- [x] All tests pass across `@koi/debug`, `@koi/agent-procfs`, `@koi/eval`, `@koi/agent-discovery` (51 tasks, 0 failures)
- [x] `@koi/core` tests pass (no API surface changes)
- [x] Biome formatting passes
- [x] Pre-push typecheck passes