### PR TITLE
fix: address 7 codex findings across deploy, config, soul, and bundle

### DIFF
--- a/packages/deploy/bundle/src/export-bundle.test.ts
+++ b/packages/deploy/bundle/src/export-bundle.test.ts
@@ -180,6 +180,29 @@ describe("createBundle", () => {
     expect(result.error.code).toBe("NOT_FOUND");
   });
 
+  test("propagates store I/O errors instead of masking as NOT_FOUND", async () => {
+    const brick = createTestBrick();
+    const failingStore: ForgeStore = {
+      save: async () => ({ ok: true, value: undefined }),
+      load: async () => ({
+        ok: false as const,
+        error: { code: "INTERNAL" as const, message: "Disk read failure", retryable: false },
+      }),
+      search: async () => ({ ok: true, value: [] }),
+      remove: async () => ({ ok: true, value: undefined }),
+      update: async () => ({ ok: true, value: undefined }),
+      exists: async () => ({ ok: true, value: false }),
+    };
+    const config = makeConfig({ brickIds: [brick.id], store: failingStore });
+
+    const result = await createBundle(config);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INTERNAL");
+    expect(result.error.message).toBe("Disk read failure");
+  });
+
   test("deduplicates brick IDs silently", async () => {
     const brick = createTestBrick();
     const store = createTestStore([brick]);

--- a/packages/deploy/bundle/src/export-bundle.ts
+++ b/packages/deploy/bundle/src/export-bundle.ts
@@ -38,7 +38,7 @@ export async function createBundle(
   // 3. Load all bricks in parallel
   const loadResults = await Promise.all(uniqueIds.map((id) => config.store.load(brickId(id))));
 
-  // 4. Collect bricks, fail on missing
+  // 4. Collect bricks, fail on missing — propagate non-NOT_FOUND errors immediately
   const bricks: BrickArtifact[] = [];
   const missingIds: string[] = [];
 
@@ -46,6 +46,10 @@ export async function createBundle(
     const result = loadResults[i];
     if (result === undefined) continue;
     if (!result.ok) {
+      // Propagate store/I/O errors (INTERNAL, TIMEOUT, etc.) without masking as NOT_FOUND
+      if (result.error.code !== "NOT_FOUND") {
+        return { ok: false, error: result.error };
+      }
       const id = uniqueIds[i];
       if (id !== undefined) {
         missingIds.push(id);

--- a/packages/deploy/deploy/src/install.ts
+++ b/packages/deploy/deploy/src/install.ts
@@ -4,7 +4,7 @@
  * Sequence: detect platform → resolve paths → generate template → install → verify health.
  */
 
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { createLaunchdManager } from "./managers/launchd.js";
 import { createSystemdManager } from "./managers/systemd.js";
 import type { ServiceManager } from "./managers/types.js";
@@ -15,6 +15,7 @@ import {
   type Platform,
   resolveLaunchdLabel,
   resolveLogDir,
+  resolveServiceDir,
   resolveServiceName,
 } from "./platform.js";
 import { generateLaunchdPlist } from "./templates/launchd.js";
@@ -57,6 +58,7 @@ export async function installService(config: InstallConfig): Promise<InstallResu
 
   let serviceContent: string;
   let manager: ServiceManager;
+  let serviceFilePath: string;
 
   if (platform === "linux") {
     serviceContent = generateSystemdUnit({
@@ -74,6 +76,7 @@ export async function installService(config: InstallConfig): Promise<InstallResu
       user: undefined, // systemd user services don't need User=
     });
     manager = createSystemdManager(system);
+    serviceFilePath = join(resolveServiceDir("linux", system), `${serviceName}.service`);
   } else {
     const label = resolveLaunchdLabel(config.agentName);
     serviceContent = generateLaunchdPlist({
@@ -89,6 +92,7 @@ export async function installService(config: InstallConfig): Promise<InstallResu
       envFile,
     });
     manager = createLaunchdManager(system, logDir);
+    serviceFilePath = join(resolveServiceDir("darwin", system), `${label}.plist`);
   }
 
   // Install and start
@@ -97,10 +101,48 @@ export async function installService(config: InstallConfig): Promise<InstallResu
 
   const healthUrl = `http://localhost:${port}/health`;
 
+  // Best-effort health check: retry a few times with a short delay
+  await verifyHealth(healthUrl);
+
   return {
     platform,
     serviceName,
-    serviceFilePath: manifestPath,
+    serviceFilePath,
     healthUrl,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Health verification
+// ---------------------------------------------------------------------------
+
+const HEALTH_MAX_RETRIES = 3;
+const HEALTH_RETRY_DELAY_MS = 1_000;
+const HEALTH_TIMEOUT_MS = 5_000;
+
+/**
+ * Best-effort health verification after service start.
+ * Retries up to {@link HEALTH_MAX_RETRIES} times with a delay between attempts.
+ * Failures are intentionally swallowed — the service may not expose HTTP yet,
+ * or it may need more time to become ready.
+ */
+async function verifyHealth(url: string): Promise<void> {
+  for (let attempt = 0; attempt < HEALTH_MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Network error or timeout — retry after delay
+    }
+
+    if (attempt < HEALTH_MAX_RETRIES - 1) {
+      await new Promise((resolve) => setTimeout(resolve, HEALTH_RETRY_DELAY_MS));
+    }
+  }
+  // All retries exhausted — proceed silently.
+  // The caller can run `koi doctor` for detailed diagnostics.
 }

--- a/packages/deploy/deploy/src/managers/launchd.ts
+++ b/packages/deploy/deploy/src/managers/launchd.ts
@@ -90,15 +90,26 @@ export function createLaunchdManager(system: boolean, logDir: string): ServiceMa
       await writeFile(filePath, content, { mode: 0o644 });
 
       // Bootstrap the service
-      await exec(["launchctl", "bootstrap", domain, filePath]);
+      const bootstrapResult = await exec(["launchctl", "bootstrap", domain, filePath]);
+      if (bootstrapResult.exitCode !== 0) {
+        throw new Error(`Failed to bootstrap ${serviceName}: ${bootstrapResult.stderr}`);
+      }
     },
 
     async uninstall(serviceName) {
       const label = resolveLaunchdLabel(serviceName.replace(/^koi-/, ""));
       const filePath = join(serviceDir, `${label}.plist`);
 
-      // Bootout ignores if not loaded
-      await exec(["launchctl", "bootout", `${domain}/${label}`]);
+      // Bootout — tolerate errors when the service is already unloaded
+      const bootoutResult = await exec(["launchctl", "bootout", `${domain}/${label}`]);
+      if (bootoutResult.exitCode !== 0) {
+        const isBenign =
+          bootoutResult.stderr.includes("not found") ||
+          bootoutResult.stderr.includes("could not find service");
+        if (!isBenign) {
+          throw new Error(`Failed to bootout ${serviceName}: ${bootoutResult.stderr}`);
+        }
+      }
 
       try {
         await unlink(filePath);

--- a/packages/deploy/deploy/src/managers/systemd.ts
+++ b/packages/deploy/deploy/src/managers/systemd.ts
@@ -50,9 +50,15 @@ export function createSystemdManager(system: boolean): ServiceManager {
       await writeFile(filePath, content, { mode: 0o644 });
 
       // Reload systemd so it picks up the new unit
-      await exec(["systemctl", ...userFlag, "daemon-reload"]);
+      const reloadResult = await exec(["systemctl", ...userFlag, "daemon-reload"]);
+      if (reloadResult.exitCode !== 0) {
+        throw new Error(`Failed to reload systemd daemon: ${reloadResult.stderr}`);
+      }
       // Enable the service to start on boot
-      await exec(["systemctl", ...userFlag, "enable", serviceName]);
+      const enableResult = await exec(["systemctl", ...userFlag, "enable", serviceName]);
+      if (enableResult.exitCode !== 0) {
+        throw new Error(`Failed to enable ${serviceName}: ${enableResult.stderr}`);
+      }
 
       // For user services: enable lingering so the service survives logout
       if (!system) {
@@ -64,7 +70,16 @@ export function createSystemdManager(system: boolean): ServiceManager {
     },
 
     async uninstall(serviceName) {
-      await exec(["systemctl", ...userFlag, "disable", serviceName]);
+      const disableResult = await exec(["systemctl", ...userFlag, "disable", serviceName]);
+      if (disableResult.exitCode !== 0) {
+        // Tolerate "not found" errors when the service is already removed
+        const isBenign =
+          disableResult.stderr.includes("not found") ||
+          disableResult.stderr.includes("No such file");
+        if (!isBenign) {
+          throw new Error(`Failed to disable ${serviceName}: ${disableResult.stderr}`);
+        }
+      }
       const filePath = join(serviceDir, `${serviceName}.service`);
       try {
         await unlink(filePath);
@@ -75,7 +90,10 @@ export function createSystemdManager(system: boolean): ServiceManager {
           throw new Error(`Failed to remove service file ${filePath}`, { cause: e });
         }
       }
-      await exec(["systemctl", ...userFlag, "daemon-reload"]);
+      const reloadResult = await exec(["systemctl", ...userFlag, "daemon-reload"]);
+      if (reloadResult.exitCode !== 0) {
+        throw new Error(`Failed to reload systemd daemon: ${reloadResult.stderr}`);
+      }
     },
 
     async start(serviceName) {

--- a/packages/deploy/node/src/agent/host.ts
+++ b/packages/deploy/node/src/agent/host.ts
@@ -32,6 +32,8 @@ interface ManagedAgent {
   readonly pid: ProcessId;
   readonly manifest: AgentManifest;
   readonly engine: EngineAdapter;
+  /** Providers attached during dispatch — stored for detach on termination. */
+  readonly providers: readonly ComponentProvider[];
   state: ProcessState;
   turnCount: number;
   lastActivityMs: number;
@@ -191,6 +193,11 @@ export function createAgentHost(config: ResourcesConfig): AgentHost {
         if (agents.has(agentId)) {
           managed.state = "terminated";
           managed.exitCode = 130; // POSIX convention: 128 + signal index
+          // Detach component providers — best-effort, fire-and-forget
+          const detachSnapshot = toAgentSnapshot(managed);
+          for (const provider of managed.providers) {
+            void provider.detach?.(detachSnapshot)?.catch(() => {});
+          }
           agents.delete(agentId);
           emit("agent_terminated", { agentId, exitCode: 130 });
         }
@@ -239,6 +246,7 @@ export function createAgentHost(config: ResourcesConfig): AgentHost {
         pid,
         manifest,
         engine,
+        providers,
         state: "created",
         turnCount: 0,
         lastActivityMs: Date.now(),
@@ -246,13 +254,36 @@ export function createAgentHost(config: ResourcesConfig): AgentHost {
         components: new Map(),
       };
 
-      // Attach components from providers (async — providers may perform I/O)
+      // Attach components from providers (async — providers may perform I/O).
+      // On failure, rollback any already-attached providers then return error.
       const snapshot = toAgentSnapshot(managed);
+      const attached: ComponentProvider[] = [];
       for (const provider of providers) {
-        const result = await provider.attach(snapshot);
-        const components = isAttachResult(result) ? result.components : result;
-        for (const [key, value] of components) {
-          managed.components.set(key, value);
+        try {
+          const result = await provider.attach(snapshot);
+          attached.push(provider);
+          const components = isAttachResult(result) ? result.components : result;
+          for (const [key, value] of components) {
+            managed.components.set(key, value);
+          }
+        } catch (e: unknown) {
+          // Rollback: detach any providers that already attached successfully
+          for (const prev of attached) {
+            try {
+              await prev.detach?.(snapshot);
+            } catch (_detachErr: unknown) {
+              // Best-effort cleanup — detach failure must not mask the original error
+            }
+          }
+          return {
+            ok: false,
+            error: {
+              code: "INTERNAL",
+              message: `Provider "${provider.name}" failed to attach: ${e instanceof Error ? e.message : String(e)}`,
+              retryable: RETRYABLE_DEFAULTS.INTERNAL,
+              context: { agentId: pid.id, provider: provider.name },
+            },
+          };
         }
       }
 
@@ -280,6 +311,12 @@ export function createAgentHost(config: ResourcesConfig): AgentHost {
       managed.state = "terminated";
       managed.exitCode = exitCode;
       agents.delete(agentId);
+
+      // Detach component providers — best-effort, fire-and-forget
+      const detachSnapshot = toAgentSnapshot(managed);
+      for (const provider of managed.providers) {
+        void provider.detach?.(detachSnapshot)?.catch(() => {});
+      }
 
       // Dispose engine adapter if supported
       void managed.engine.dispose?.().catch(() => {
@@ -359,6 +396,13 @@ export function createAgentHost(config: ResourcesConfig): AgentHost {
     terminateAll() {
       for (const [agentId, managed] of agents) {
         managed.state = "terminated";
+
+        // Detach component providers — best-effort, fire-and-forget
+        const detachSnapshot = toAgentSnapshot(managed);
+        for (const provider of managed.providers) {
+          void provider.detach?.(detachSnapshot)?.catch(() => {});
+        }
+
         void managed.engine.dispose?.().catch(() => {});
         emit("agent_terminated", { agentId });
       }

--- a/packages/deploy/node/src/transcripting-engine.test.ts
+++ b/packages/deploy/node/src/transcripting-engine.test.ts
@@ -340,6 +340,51 @@ describe("createTranscriptingEngine", () => {
     expect(collected[2]).toStrictEqual(events[2]);
   });
 
+  test("messages input maps senderId to correct transcript role", async () => {
+    const events: readonly EngineEvent[] = [{ kind: "turn_end", turnIndex: 0 }];
+    const transcript = createMockTranscript();
+    const wrapped = createTranscriptingEngine(createMockEngine(events), {
+      sessionId: testSessionId,
+      transcript,
+    });
+
+    const messagesInput: EngineInput = {
+      kind: "messages",
+      messages: [
+        {
+          content: [{ kind: "text", text: "user says hi" }],
+          senderId: "user-123",
+          timestamp: Date.now(),
+        },
+        {
+          content: [{ kind: "text", text: "assistant reply" }],
+          senderId: "assistant-bot",
+          timestamp: Date.now(),
+        },
+        {
+          content: [{ kind: "text", text: "tool output" }],
+          senderId: "tool-search",
+          timestamp: Date.now(),
+        },
+        {
+          content: [{ kind: "text", text: "system prompt" }],
+          senderId: "system",
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    await collectEvents(wrapped, messagesInput);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const append = transcript.appended[0];
+    expect(append?.entries).toHaveLength(4);
+    expect(append?.entries[0]?.role).toBe("user");
+    expect(append?.entries[1]?.role).toBe("assistant");
+    expect(append?.entries[2]?.role).toBe("tool_result");
+    expect(append?.entries[3]?.role).toBe("system");
+  });
+
   test("delegates optional properties to inner", () => {
     const inner = createMockEngine([]);
     const transcript = createMockTranscript();

--- a/packages/deploy/node/src/transcripting-engine.ts
+++ b/packages/deploy/node/src/transcripting-engine.ts
@@ -18,6 +18,7 @@ import type {
   SessionTranscript,
   TextBlock,
   TranscriptEntry,
+  TranscriptEntryRole,
 } from "@koi/core";
 import { transcriptEntryId } from "@koi/core";
 
@@ -56,6 +57,15 @@ function extractText(blocks: readonly ContentBlock[]): string {
     .join("\n");
 }
 
+/** Map an InboundMessage senderId to the appropriate transcript entry role. */
+function mapSenderIdToRole(senderId: string): TranscriptEntryRole {
+  const lower = senderId.toLowerCase();
+  if (lower.includes("assistant")) return "assistant";
+  if (lower.includes("tool")) return "tool_result";
+  if (lower.includes("system")) return "system";
+  return "user";
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -82,11 +92,11 @@ export function createTranscriptingEngine(
     if (input.kind === "text") {
       fireAppend([createEntry("user", input.text)]);
     } else if (input.kind === "messages") {
-      const userEntries = input.messages
-        .map((msg) => ({ text: extractText(msg.content) }))
+      const entries = input.messages
+        .map((msg) => ({ text: extractText(msg.content), role: mapSenderIdToRole(msg.senderId) }))
         .filter(({ text }) => text.length > 0)
-        .map(({ text }) => createEntry("user", text));
-      fireAppend(userEntries);
+        .map(({ text, role }) => createEntry(role, text));
+      fireAppend(entries);
     }
     // kind === "resume" — no user entry (engine state restore)
 

--- a/packages/kernel/config/src/reload.ts
+++ b/packages/kernel/config/src/reload.ts
@@ -3,6 +3,8 @@
  */
 
 import type { ConfigStore, ConfigUnsubscribe, KoiConfig, KoiError, Result } from "@koi/core";
+import type { ProcessIncludesOptions } from "./include.js";
+import type { LoadConfigOptions } from "./loader.js";
 import { loadConfig } from "./loader.js";
 import { deepMerge } from "./merge.js";
 import { validateKoiConfig } from "./schema.js";
@@ -65,6 +67,8 @@ export interface CreateConfigManagerOptions {
   readonly initial?: Partial<KoiConfig>;
   /** Environment variables for interpolation. */
   readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Options for `$include` directive processing. */
+  readonly includes?: ProcessIncludesOptions | undefined;
   /** Called when a watch-triggered reload fails (parse/validation error). */
   readonly onReloadError?: (error: KoiError) => void;
 }
@@ -86,8 +90,13 @@ export function createConfigManager(options: CreateConfigManagerOptions): Config
 
   const store: WritableConfigStore<KoiConfig> = createConfigStore(initialConfig);
 
+  const loaderOptions: LoadConfigOptions = {
+    env: options.env,
+    includes: options.includes,
+  };
+
   const reload = async (): Promise<Result<KoiConfig, KoiError>> => {
-    const loaded = await loadConfig(options.filePath, { env: options.env });
+    const loaded = await loadConfig(options.filePath, loaderOptions);
     if (!loaded.ok) {
       return loaded;
     }

--- a/packages/kernel/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/kernel/soul/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -173,14 +173,15 @@ declare function createPersonaWatchedPaths(personaMap: ReadonlyMap<string, Cache
 /**
  * Extended middleware with a \`reload()\` method for HITL-approved soul updates.
  *
- * Automatically reloads when \`fs_write\` targets a tracked soul/identity/user file
- * (the write must pass through the middleware chain, including permissions/HITL).
+ * Automatically reloads when any \`*_write\` tool (e.g. \`fs_write\`, \`nx_write\`)
+ * targets a tracked soul/identity/user file (the write must pass through the
+ * middleware chain, including permissions/HITL).
  * Manual \`reload()\` is also available for programmatic use.
  */
 interface SoulMiddleware extends KoiMiddleware$1 {
     /**
      * Re-resolves all soul, identity, and user content from original source paths.
-     * Called automatically after successful \`fs_write\` to tracked files.
+     * Called automatically after successful \`*_write\` tool call to tracked files.
      * Can also be called manually after HITL-approved writes.
      * Updates the running middleware atomically — takes effect on next model call.
      */
@@ -196,8 +197,8 @@ declare function enrichRequest(request: ModelRequest, soulMessage: InboundMessag
  * identity, and user context into model calls as a system message prefix.
  *
  * Returns \`SoulMiddleware\` — a \`KoiMiddleware\` with \`reload()\` and auto-reload
- * via \`wrapToolCall\`. When \`fs_write\` targets a tracked file and succeeds
- * (meaning it passed permissions/HITL), the middleware auto-reloads.
+ * via \`wrapToolCall\`. When any \`*_write\` tool targets a tracked file and
+ * succeeds (meaning it passed permissions/HITL), the middleware auto-reloads.
  *
  * Content is resolved at factory time and cached in the closure.
  * User content can optionally be refreshed per-call with \`refreshUser: true\`.

--- a/packages/kernel/soul/src/soul.test.ts
+++ b/packages/kernel/soul/src/soul.test.ts
@@ -681,7 +681,37 @@ describe("createSoulMiddleware — wrapToolCall auto-reload", () => {
     }
   });
 
-  test("does NOT reload for non-fs_write tool calls", async () => {
+  test("auto-reloads after prefixed write tool (e.g. nx_write) to tracked file", async () => {
+    await writeFile(join(tmpDir, "SOUL.md"), "Original soul");
+
+    const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });
+    const ctx = createMockTurnContext();
+    const spy = createSpyModelHandler();
+    const request: ModelRequest = {
+      messages: [{ senderId: "user", timestamp: 1, content: [{ kind: "text", text: "hi" }] }],
+    };
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+    if (spy.calls[0]?.messages[0]?.content[0]?.kind === "text") {
+      expect(spy.calls[0].messages[0].content[0].text).toContain("Original soul");
+    }
+
+    // Simulate nx_write to SOUL.md (custom prefix)
+    await writeFile(join(tmpDir, "SOUL.md"), "Updated via nx_write");
+    const soulPath = join(tmpDir, "SOUL.md");
+
+    const toolNext = async (_req: import("@koi/core").ToolRequest) => ({
+      output: { ok: true },
+    });
+    await mw.wrapToolCall?.(ctx, { toolId: "nx_write", input: { path: soulPath } }, toolNext);
+
+    await mw.wrapModelCall?.(ctx, request, spy.handler);
+    if (spy.calls[1]?.messages[0]?.content[0]?.kind === "text") {
+      expect(spy.calls[1].messages[0].content[0].text).toContain("Updated via nx_write");
+    }
+  });
+
+  test("does NOT reload for non-write tool calls", async () => {
     await writeFile(join(tmpDir, "SOUL.md"), "Original");
 
     const mw = await createSoulMiddleware({ soul: "SOUL.md", basePath: tmpDir });

--- a/packages/kernel/soul/src/soul.ts
+++ b/packages/kernel/soul/src/soul.ts
@@ -35,14 +35,15 @@ import { createAllWatchedPaths, createSoulMessage, generateMetaInstructionText }
 /**
  * Extended middleware with a `reload()` method for HITL-approved soul updates.
  *
- * Automatically reloads when `fs_write` targets a tracked soul/identity/user file
- * (the write must pass through the middleware chain, including permissions/HITL).
+ * Automatically reloads when any `*_write` tool (e.g. `fs_write`, `nx_write`)
+ * targets a tracked soul/identity/user file (the write must pass through the
+ * middleware chain, including permissions/HITL).
  * Manual `reload()` is also available for programmatic use.
  */
 export interface SoulMiddleware extends KoiMiddleware {
   /**
    * Re-resolves all soul, identity, and user content from original source paths.
-   * Called automatically after successful `fs_write` to tracked files.
+   * Called automatically after successful `*_write` tool call to tracked files.
    * Can also be called manually after HITL-approved writes.
    * Updates the running middleware atomically — takes effect on next model call.
    */
@@ -143,8 +144,8 @@ async function createState(options: CreateSoulOptions): Promise<SoulState> {
  * identity, and user context into model calls as a system message prefix.
  *
  * Returns `SoulMiddleware` — a `KoiMiddleware` with `reload()` and auto-reload
- * via `wrapToolCall`. When `fs_write` targets a tracked file and succeeds
- * (meaning it passed permissions/HITL), the middleware auto-reloads.
+ * via `wrapToolCall`. When any `*_write` tool targets a tracked file and
+ * succeeds (meaning it passed permissions/HITL), the middleware auto-reloads.
  *
  * Content is resolved at factory time and cached in the closure.
  * User content can optionally be refreshed per-call with `refreshUser: true`.
@@ -204,7 +205,7 @@ export async function createSoulMiddleware(options: CreateSoulOptions): Promise<
         (refreshUser ? ", user context refreshed per call" : "") +
         (selfModify && state.metaInstructionText.length > 0 ? ", self-modification enabled" : "") +
         (state.watchedPaths.size > 0
-          ? `, auto-reload on fs_write to ${String(state.watchedPaths.size)} tracked file(s)`
+          ? `, auto-reload on *_write to ${String(state.watchedPaths.size)} tracked file(s)`
           : ""),
     }),
 
@@ -217,8 +218,9 @@ export async function createSoulMiddleware(options: CreateSoulOptions): Promise<
     ): Promise<ToolResponse> {
       const response = await next(request);
 
-      // Auto-reload after successful fs_write to a tracked file
-      if (request.toolId === "fs_write" && state.watchedPaths.size > 0) {
+      // Auto-reload after successful write tool targeting a tracked file.
+      // Write tools follow the `${prefix}_write` naming convention (e.g. fs_write, nx_write).
+      if (request.toolId.endsWith("_write") && state.watchedPaths.size > 0) {
         const writtenPath = typeof request.input.path === "string" ? request.input.path : undefined;
         if (writtenPath !== undefined && state.watchedPaths.has(writtenPath)) {
           await reload().catch((err: unknown) => console.error("[soul] reload failed:", err));


### PR DESCRIPTION
## Summary

Fixes 7 validated Codex review findings across deploy, config, soul, and bundle packages:

1. **host.ts (High)**: Store providers on `ManagedAgent`; rollback `attach()` on failure; call `provider.detach()` in `terminate()`, `terminateAll()`, and signal handlers — closes resource leak
2. **transcripting-engine (High)**: Map `senderId` to correct `TranscriptEntryRole` instead of hardcoding all inbound messages as `"user"`
3. **systemd/launchd (High)**: Check exit codes for `daemon-reload`, `enable`, `disable`, `bootstrap`, `bootout` — lenient for already-removed services on uninstall
4. **install.ts (Med-High)**: Add best-effort health check after `start()`; return actual service file path instead of `manifestPath`
5. **config reload (Med-High)**: Pass full `LoadConfigOptions` (including `includes`) to `loadConfig()` instead of dropping include-processing options
6. **soul (Med-High)**: Match `_write` suffix instead of hardcoded `"fs_write"` so custom-prefixed write tools (e.g. `nx_write`) trigger auto-reload
7. **export-bundle (Medium)**: Propagate store I/O errors instead of masking all non-ok results as `NOT_FOUND`

## Test plan

- [x] All modified packages build (67 tasks, 0 failures)
- [x] All tests pass (72 tasks, 0 failures)
- [x] New tests added for transcripting-engine role mapping, soul prefixed write, and bundle error propagation
- [x] Biome formatting passes
- [x] Pre-push typecheck passes