### PR TITLE
fix: address 7 deploy review findings

### DIFF
--- a/packages/deploy/bundle/src/brick-content.ts
+++ b/packages/deploy/bundle/src/brick-content.ts
@@ -7,8 +7,14 @@
 
 import type { BrickArtifact } from "@koi/core";
 
-/** Extract the primary content string from a brick artifact for ID recomputation. */
-export function extractBrickContent(brick: BrickArtifact): string {
+/**
+ * Extract the primary content string from a brick artifact for ID recomputation.
+ * For non-composite kinds only — composite bricks need special handling via
+ * computePipelineBrickId (which includes outputKind in the hash).
+ */
+export function extractBrickContent(
+  brick: Exclude<BrickArtifact, { readonly kind: "composite" }>,
+): string {
   switch (brick.kind) {
     case "tool":
     case "middleware":
@@ -18,7 +24,5 @@ export function extractBrickContent(brick: BrickArtifact): string {
       return brick.content;
     case "agent":
       return brick.manifestYaml;
-    case "composite":
-      return brick.steps.map((s) => s.brickId).join(",");
   }
 }

--- a/packages/deploy/bundle/src/export-bundle.ts
+++ b/packages/deploy/bundle/src/export-bundle.ts
@@ -12,7 +12,7 @@
 
 import type { AgentBundle, BrickArtifact, KoiError, Result } from "@koi/core";
 import { BUNDLE_FORMAT_VERSION, brickId, bundleId, notFound, validation } from "@koi/core";
-import { computeBrickId, computeContentHash } from "@koi/hash";
+import { computeBrickId, computeContentHash, computePipelineBrickId } from "@koi/hash";
 
 import { extractBrickContent } from "./brick-content.js";
 import type { ExportBundleConfig } from "./types.js";
@@ -68,8 +68,14 @@ export async function createBundle(
 
   // 5. Verify integrity of each brick
   for (const brick of bricks) {
-    const content = extractBrickContent(brick);
-    const expectedId = computeBrickId(brick.kind, content, brick.files);
+    const expectedId =
+      brick.kind === "composite"
+        ? computePipelineBrickId(
+            brick.steps.map((s) => brickId(s.brickId)),
+            brick.outputKind,
+            brick.files,
+          )
+        : computeBrickId(brick.kind, extractBrickContent(brick), brick.files);
     if (expectedId !== brick.id) {
       return {
         ok: false,

--- a/packages/deploy/bundle/src/import-bundle.ts
+++ b/packages/deploy/bundle/src/import-bundle.ts
@@ -11,8 +11,13 @@
  */
 
 import type { BrickArtifact, KoiError, Result } from "@koi/core";
-import { BUNDLE_FORMAT_VERSION, DEFAULT_SANDBOXED_POLICY, validation } from "@koi/core";
-import { computeBrickId, computeContentHash } from "@koi/hash";
+import {
+  BUNDLE_FORMAT_VERSION,
+  DEFAULT_SANDBOXED_POLICY,
+  brickId as toBrickId,
+  validation,
+} from "@koi/core";
+import { computeBrickId, computeContentHash, computePipelineBrickId } from "@koi/hash";
 import { validateBrickArtifact } from "@koi/validation";
 
 import { extractBrickContent } from "./brick-content.js";
@@ -92,8 +97,14 @@ export async function importBundle(
       const brick = validationResult.value;
 
       // Verify integrity: recompute BrickId from content
-      const content = extractBrickContent(brick);
-      const expectedId = computeBrickId(brick.kind, content, brick.files);
+      const expectedId =
+        brick.kind === "composite"
+          ? computePipelineBrickId(
+              brick.steps.map((s) => toBrickId(s.brickId)),
+              brick.outputKind,
+              brick.files,
+            )
+          : computeBrickId(brick.kind, extractBrickContent(brick), brick.files);
       if (expectedId !== brick.id) {
         return {
           kind: "error",

--- a/packages/deploy/deploy/src/platform.ts
+++ b/packages/deploy/deploy/src/platform.ts
@@ -92,9 +92,11 @@ export function resolveServiceName(agentName: string): string {
 
 /** Converts an agent name to a launchd label: "my-agent" → "com.koi.my-agent". */
 export function resolveLaunchdLabel(agentName: string): string {
+  // Use the same sanitization as resolveServiceName (dots → dashes) so that
+  // install and start/stop/status derive the same label for dotted agent names.
   const sanitized = agentName
     .toLowerCase()
-    .replace(/[^a-z0-9.]/g, "-")
+    .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
   return `com.koi.${sanitized}`;

--- a/packages/deploy/deploy/src/templates/launchd.ts
+++ b/packages/deploy/deploy/src/templates/launchd.ts
@@ -2,6 +2,8 @@
  * launchd plist template generator for macOS.
  */
 
+import { readFileSync } from "node:fs";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -32,6 +34,33 @@ function escapeXml(s: string): string {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * Parse a dotenv-style file into key-value pairs.
+ * Supports KEY=VALUE, ignores comments (#) and blank lines.
+ * Does not expand variables — mirrors systemd EnvironmentFile semantics.
+ */
+function parseEnvFile(filePath: string): ReadonlyMap<string, string> {
+  const entries = new Map<string, string>();
+  const content = readFileSync(filePath, "utf-8");
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eqIdx = line.indexOf("=");
+    if (eqIdx < 1) continue;
+    const key = line.slice(0, eqIdx).trim();
+    // Strip optional surrounding quotes from value
+    let value = line.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    entries.set(key, value);
+  }
+  return entries;
+}
+
 // ---------------------------------------------------------------------------
 // Template
 // ---------------------------------------------------------------------------
@@ -53,13 +82,23 @@ export function generateLaunchdPlist(config: LaunchdTemplateConfig): string {
 
   const argsXml = args.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
 
-  const envVars = [
-    "  <key>EnvironmentVariables</key>",
-    "  <dict>",
-    "    <key>PATH</key>",
-    "    <string>/usr/local/bin:/usr/bin:/bin</string>",
-    "  </dict>",
-  ].join("\n");
+  // Build environment variables: always include PATH, merge envFile if provided
+  const envEntries = new Map<string, string>();
+  envEntries.set("PATH", "/usr/local/bin:/usr/bin:/bin");
+
+  if (config.envFile !== undefined) {
+    for (const [key, value] of parseEnvFile(config.envFile)) {
+      envEntries.set(key, value);
+    }
+  }
+
+  const envLines = ["  <key>EnvironmentVariables</key>", "  <dict>"];
+  for (const [key, value] of envEntries) {
+    envLines.push(`    <key>${escapeXml(key)}</key>`);
+    envLines.push(`    <string>${escapeXml(value)}</string>`);
+  }
+  envLines.push("  </dict>");
+  const envVars = envLines.join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/packages/deploy/nexus-embed/src/pid-manager.ts
+++ b/packages/deploy/nexus-embed/src/pid-manager.ts
@@ -4,6 +4,7 @@
  * Handles read/write/check of PID files with stale detection.
  */
 
+import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { PID_FILE } from "./constants.js";
@@ -45,6 +46,25 @@ export function isProcessAlive(pid: number): boolean {
     process.kill(pid, 0);
     return true;
   } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify that a PID belongs to a Nexus process by checking its command line.
+ * Prevents killing an unrelated process after PID reuse.
+ */
+export function isNexusProcess(pid: number): boolean {
+  try {
+    // Use ps to get the full command line for the PID
+    const output = execSync(`ps -o args= -p ${String(pid)}`, {
+      encoding: "utf-8",
+      timeout: 2_000,
+    }).trim();
+    // Nexus runs as "python ... nexus serve" or similar — check for "nexus"
+    return output.includes("nexus");
+  } catch {
+    // ps failed — process doesn't exist or we can't inspect it
     return false;
   }
 }

--- a/packages/deploy/nexus-embed/src/stop.ts
+++ b/packages/deploy/nexus-embed/src/stop.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import type { KoiError, Result } from "@koi/core";
 import { removeConnectionState } from "./connection-store.js";
 import { DEFAULT_DATA_DIR_NAME } from "./constants.js";
-import { isProcessAlive, readPid, removePid } from "./pid-manager.js";
+import { isNexusProcess, isProcessAlive, readPid, removePid } from "./pid-manager.js";
 
 /** Maximum time to wait for daemon to exit after SIGTERM (ms). */
 const STOP_TIMEOUT_MS = 5_000;
@@ -37,6 +37,22 @@ export async function stopEmbedNexus(config?: {
   }
 
   const wasRunning = isProcessAlive(pid);
+
+  if (wasRunning && !isNexusProcess(pid)) {
+    // PID is alive but it's not a Nexus process — stale PID file after PID reuse.
+    // Clean up state files but do NOT kill the unrelated process.
+    removePid(dataDir);
+    removeConnectionState(dataDir);
+    return {
+      ok: false,
+      error: {
+        code: "EXTERNAL" as const,
+        message: `PID ${String(pid)} is alive but is not a Nexus process (possible PID reuse). Cleaned up stale state files.`,
+        retryable: false,
+        context: { dataDir, pid },
+      },
+    };
+  }
 
   if (wasRunning) {
     try {

--- a/packages/deploy/node/src/node.ts
+++ b/packages/deploy/node/src/node.ts
@@ -301,7 +301,6 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
               capacity: { current: 0, max: 0, available: 0 },
             },
           });
-          advertiseCapabilities();
         });
 
         const discoveryPromise = discovery.publish({
@@ -323,6 +322,9 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
           currentState = "stopped";
           throw new Error("Failed to connect to Gateway", { cause: connectResult.reason });
         }
+
+        // Advertise capabilities AFTER discovery completes so the tool list is populated
+        advertiseCapabilities();
 
         currentState = "connected";
 
@@ -676,7 +678,6 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
             kind: "node:handshake",
             payload: { nodeId, version: "0.0.0", capacity: host.capacity() },
           });
-          advertiseCapabilities();
         });
 
         const discoveryPromise = discovery.publish({
@@ -702,6 +703,9 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
           currentState = "stopped";
           throw new Error("Failed to connect to Gateway", { cause: connectResult.reason });
         }
+
+        // Advertise capabilities AFTER discovery completes so the tool list is populated
+        advertiseCapabilities();
 
         if (deps?.sessionStore !== undefined && deps?.onRecover !== undefined) {
           await recoverAgents(deps.onRecover, deps.sessionStore);

--- a/packages/deploy/node/src/tools/local-resolver.ts
+++ b/packages/deploy/node/src/tools/local-resolver.ts
@@ -5,7 +5,14 @@
  * Priority: local config > built-in defaults (first-wins).
  */
 
-import type { KoiError, Result, SourceBundle, Tool, ToolDescriptor } from "@koi/core";
+import type {
+  KoiError,
+  Result,
+  SourceBundle,
+  Tool,
+  ToolDescriptor,
+  ToolExecuteOptions,
+} from "@koi/core";
 import { DEFAULT_SANDBOXED_POLICY, RETRYABLE_DEFAULTS } from "@koi/core";
 import { createFilesystemTool } from "./filesystem.js";
 import { createShellTool } from "./shell.js";
@@ -99,7 +106,13 @@ export function createLocalResolver(config: ResolverConfig): LocalResolver {
             descriptor,
             origin: "primordial",
             policy: DEFAULT_SANDBOXED_POLICY,
-            async execute(args) {
+            async execute(args, options?: ToolExecuteOptions) {
+              const signal = options?.signal;
+
+              if (signal?.aborted) {
+                return { error: "Tool call cancelled", cancelled: true };
+              }
+
               if (command === undefined) {
                 return { error: "Tool has no executable command" };
               }
@@ -115,16 +128,46 @@ export function createLocalResolver(config: ResolverConfig): LocalResolver {
                 stdout: "pipe",
                 stderr: "pipe",
               });
-              // Pass tool args via stdin instead of env to avoid shell expansion attacks
-              proc.stdin.write(JSON.stringify(args));
-              proc.stdin.end();
-              const stdout = await new Response(proc.stdout).text();
-              const exitCode = await proc.exited;
-              if (exitCode !== 0) {
-                const stderr = await new Response(proc.stderr).text();
-                return { error: stderr, exitCode };
+
+              // Kill child process on abort
+              if (signal === undefined) {
+                // No signal — run without cancellation support
+                proc.stdin.write(JSON.stringify(args));
+                proc.stdin.end();
+                const stdout = await new Response(proc.stdout).text();
+                const exitCode = await proc.exited;
+                if (exitCode !== 0) {
+                  const stderr = await new Response(proc.stderr).text();
+                  return { error: stderr, exitCode };
+                }
+                return { output: stdout, exitCode: 0 };
               }
-              return { output: stdout, exitCode: 0 };
+
+              const onAbort = (): void => {
+                proc.kill();
+              };
+              signal.addEventListener("abort", onAbort, { once: true });
+
+              try {
+                // Pass tool args via stdin instead of env to avoid shell expansion attacks
+                proc.stdin.write(JSON.stringify(args));
+                proc.stdin.end();
+                const stdout = await new Response(proc.stdout).text();
+                const exitCode = await proc.exited;
+
+                if (signal.aborted) {
+                  proc.kill();
+                  return { error: "Tool call cancelled", cancelled: true };
+                }
+
+                if (exitCode !== 0) {
+                  const stderr = await new Response(proc.stderr).text();
+                  return { error: stderr, exitCode };
+                }
+                return { output: stdout, exitCode: 0 };
+              } finally {
+                signal.removeEventListener("abort", onAbort);
+              }
             },
           };
 

--- a/packages/lib/validation/src/brick-validation.ts
+++ b/packages/lib/validation/src/brick-validation.ts
@@ -63,8 +63,15 @@ function validateUniversalOptionals(
   data: Record<string, unknown>,
   source: string,
 ): Result<void, KoiError> {
-  if (data.files !== undefined && !isRecord(data.files)) {
-    return fail("'files' must be an object if present", source);
+  if (data.files !== undefined) {
+    if (!isRecord(data.files)) {
+      return fail("'files' must be an object if present", source);
+    }
+    for (const [key, value] of Object.entries(data.files)) {
+      if (typeof value !== "string") {
+        return fail(`'files["${key}"]' must be a string, got ${typeof value}`, source);
+      }
+    }
   }
   if (data.requires !== undefined && !isRecord(data.requires)) {
     return fail("'requires' must be an object if present", source);


### PR DESCRIPTION
## Summary

Fixes 7 high/medium findings from the Codex deploy code review:

- **Directory tools ignore AbortSignal** — `local-resolver.ts` `execute()` now accepts the signal, registers an abort listener that kills the spawned shell, and returns early if already cancelled
- **Launchd label dot/dash inconsistency** — `resolveLaunchdLabel()` regex changed from `[^a-z0-9.]` to `[^a-z0-9-]` to match `resolveServiceName()`, so `foo.bar` produces consistent labels in install vs start/stop/status
- **envFile silently ignored on macOS** — `generateLaunchdPlist()` now reads the envFile and merges its variables into the plist `EnvironmentVariables` dict alongside PATH
- **Composite brick integrity mismatch** — export/import now use `computePipelineBrickId(stepIds, outputKind, files)` for composite bricks, matching how forge creates them
- **PID reuse → kill wrong process** — added `isNexusProcess(pid)` that checks `ps -o args=` for "nexus"; `stopEmbedNexus()` returns an error and cleans up stale state if the PID belongs to a different process
- **Capabilities advertised before discovery** — moved `advertiseCapabilities()` after `Promise.allSettled` resolves in both Thin and Full mode start paths
- **Bundle file values not validated** — `validateBrickArtifact()` now checks each `files` entry is a string, preventing crashes in `CryptoHasher.update()`

## Test plan

- [x] All 90 existing tests pass across affected packages (local-resolver, tool-call-handler, platform, launchd, pid-manager, stop, export-bundle, import-bundle)
- [x] Biome lint/format clean on all 10 changed files
- [x] Turborepo typecheck + build pass (64/64 tasks)
- [ ] Verify dotted agent names install/start correctly on macOS
- [ ] Verify envFile variables appear in running launchd service environment
- [ ] Test composite brick export→import round-trip