### PR TITLE
fix: address 11 deploy review findings from Codex audit

### DIFF
--- a/packages/deploy/bundle/src/import-bundle.ts
+++ b/packages/deploy/bundle/src/import-bundle.ts
@@ -77,8 +77,17 @@ export async function importBundle(
     return { ok: true, value: { imported: 0, skipped: 0, errors: [] } };
   }
 
+  // 3b. Deduplicate bricks by ID — a bundle may contain the same brick twice
+  const seenIds = new Set<string>();
+  const uniqueBricks: readonly BrickArtifact[] = bundle.bricks.filter((b) => {
+    const id = String(b.id);
+    if (seenIds.has(id)) return false;
+    seenIds.add(id);
+    return true;
+  });
+
   // 4. Validate and verify each brick, then import in parallel
-  const importTasks = bundle.bricks.map(
+  const importTasks = uniqueBricks.map(
     async (
       rawBrick,
     ): Promise<{

--- a/packages/deploy/deploy/src/managers/launchd.ts
+++ b/packages/deploy/deploy/src/managers/launchd.ts
@@ -89,6 +89,19 @@ export function createLaunchdManager(system: boolean, logDir: string): ServiceMa
       await mkdir(logDir, { recursive: true });
       await writeFile(filePath, content, { mode: 0o644 });
 
+      // Bootout first if already loaded — makes redeploy idempotent
+      const bootoutResult = await exec(["launchctl", "bootout", `${domain}/${label}`]);
+      if (bootoutResult.exitCode !== 0) {
+        const isBenign =
+          bootoutResult.stderr.includes("not found") ||
+          bootoutResult.stderr.includes("could not find service");
+        if (!isBenign) {
+          throw new Error(
+            `Failed to bootout ${serviceName} before reinstall: ${bootoutResult.stderr}`,
+          );
+        }
+      }
+
       // Bootstrap the service
       const bootstrapResult = await exec(["launchctl", "bootstrap", domain, filePath]);
       if (bootstrapResult.exitCode !== 0) {

--- a/packages/deploy/deploy/src/managers/systemd.ts
+++ b/packages/deploy/deploy/src/managers/systemd.ts
@@ -97,7 +97,9 @@ export function createSystemdManager(system: boolean): ServiceManager {
     },
 
     async start(serviceName) {
-      const result = await exec(["systemctl", ...userFlag, "start", serviceName]);
+      // Use restart to pick up config changes when the service is already running.
+      // restart is a no-op → start when the service is not yet active.
+      const result = await exec(["systemctl", ...userFlag, "restart", serviceName]);
       if (result.exitCode !== 0) {
         throw new Error(`Failed to start ${serviceName}: ${result.stderr}`);
       }

--- a/packages/deploy/deploy/src/templates/systemd.test.ts
+++ b/packages/deploy/deploy/src/templates/systemd.test.ts
@@ -26,10 +26,10 @@ describe("generateSystemdUnit", () => {
     expect(output).toContain("Description=Koi Agent - my-agent");
   });
 
-  it("uses correct ExecStart command", () => {
+  it("uses correct ExecStart command with quoted paths", () => {
     const output = generateSystemdUnit(BASE_CONFIG);
     expect(output).toContain(
-      "ExecStart=/usr/local/bin/bun /app/node_modules/.bin/koi serve --manifest /app/koi.yaml --port 9100",
+      'ExecStart="/usr/local/bin/bun" "/app/node_modules/.bin/koi" serve --manifest "/app/koi.yaml" --port 9100',
     );
   });
 

--- a/packages/deploy/deploy/src/templates/systemd.ts
+++ b/packages/deploy/deploy/src/templates/systemd.ts
@@ -68,7 +68,7 @@ export function generateSystemdUnit(config: SystemdTemplateConfig): string {
     "Type=simple",
     ...(config.user !== undefined ? [`User=${config.user}`] : []),
     `WorkingDirectory=${config.workDir}`,
-    `ExecStart=${config.bunPath} ${config.koiPath} serve --manifest ${config.manifestPath} --port ${config.port}`,
+    `ExecStart="${config.bunPath}" "${config.koiPath}" serve --manifest "${config.manifestPath}" --port ${config.port}`,
     `ExecStartPost=/bin/sh -c 'for i in 1 2 3 4 5; do curl -sf http://localhost:${config.port}/health && exit 0; sleep 1; done; exit 1'`,
     `Restart=${config.restart}`,
     `RestartSec=${config.restartDelaySec}s`,

--- a/packages/deploy/nexus-embed/src/ensure-running.ts
+++ b/packages/deploy/nexus-embed/src/ensure-running.ts
@@ -21,7 +21,7 @@ import {
 } from "./connection-store.js";
 import { DEFAULT_DATA_DIR_NAME, DEFAULT_HOST, DEFAULT_PORT, DEFAULT_PROFILE } from "./constants.js";
 import { pollHealth, probeHealth } from "./health-check.js";
-import { cleanStalePid, readPid, removePid, writePid } from "./pid-manager.js";
+import { cleanStalePid, isProcessAlive, readPid, removePid, writePid } from "./pid-manager.js";
 import type { ConnectionState, EmbedConfig, EmbedResult } from "./types.js";
 
 /** Ensure a Nexus server is running locally, spawning one if needed. */
@@ -53,8 +53,19 @@ export async function ensureNexusRunning(
         };
       }
     }
+
+    // Config mismatch with a still-alive process — stop it before spawning new one
+    if (!configMatches && savedState.pid !== undefined && isProcessAlive(savedState.pid)) {
+      try {
+        process.kill(savedState.pid, "SIGTERM");
+      } catch {
+        /* best effort */
+      }
+    }
+
     // Dead or config mismatch — clean up stale state
     cleanStalePid(dataDir);
+    removePid(dataDir);
     removeConnectionState(dataDir);
   }
 

--- a/packages/deploy/nexus-embed/src/pid-manager.ts
+++ b/packages/deploy/nexus-embed/src/pid-manager.ts
@@ -53,6 +53,9 @@ export function isProcessAlive(pid: number): boolean {
 /**
  * Verify that a PID belongs to a Nexus process by checking its command line.
  * Prevents killing an unrelated process after PID reuse.
+ *
+ * Matches "nexus" by default, and also matches the resolved NEXUS_COMMAND
+ * executable name so wrapper-style setups are correctly identified.
  */
 export function isNexusProcess(pid: number): boolean {
   try {
@@ -61,8 +64,19 @@ export function isNexusProcess(pid: number): boolean {
       encoding: "utf-8",
       timeout: 2_000,
     }).trim();
-    // Nexus runs as "python ... nexus serve" or similar — check for "nexus"
-    return output.includes("nexus");
+
+    // Always check for the literal "nexus" (covers default uv run nexus, python -m nexus, etc.)
+    if (output.includes("nexus")) return true;
+
+    // Also match the NEXUS_COMMAND executable name for wrapper-style setups
+    const nexusCmd = process.env.NEXUS_COMMAND;
+    if (nexusCmd !== undefined && nexusCmd.trim().length > 0) {
+      const cmdParts = nexusCmd.trim().split(/\s+/);
+      const executable = cmdParts[0];
+      if (executable !== undefined && output.includes(executable)) return true;
+    }
+
+    return false;
   } catch {
     // ps failed — process doesn't exist or we can't inspect it
     return false;

--- a/packages/deploy/node/src/connection/protocol.ts
+++ b/packages/deploy/node/src/connection/protocol.ts
@@ -16,6 +16,8 @@ import type { NodeFrame, NodeFrameKind } from "../types.js";
 const VALID_FRAME_KINDS: ReadonlySet<string> = new Set<NodeFrameKind>([
   "agent:dispatch",
   "agent:message",
+  "agent:signal",
+  "agent:signal_group",
   "agent:status",
   "agent:terminate",
   "node:auth",

--- a/packages/deploy/node/src/node.ts
+++ b/packages/deploy/node/src/node.ts
@@ -186,10 +186,8 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
   const frameCounters = createFrameCounters();
   const dedup = createFrameDeduplicator();
 
-  // Forward transport events to node-level listeners
-  const unsubTransport = transport.onEvent((event) => {
-    emit(event.type, event.data);
-  });
+  // let: registered in start(), cleaned up in stop(), re-registered on restart
+  let unsubTransport: () => void = () => {};
 
   // -- Shared: outbound frame sender ----------------------------------------
 
@@ -288,6 +286,10 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
       async start() {
         if (currentState === "connected" || currentState === "starting") return;
         currentState = "starting";
+
+        // (Re-)register event forwarding — survives stop → start cycles
+        unsubTransport();
+        unsubTransport = transport.onEvent((event) => emit(event.type, event.data));
 
         const connectPromise = transport.connect().then(() => {
           transport.send({
@@ -459,50 +461,63 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
     // let: set during start(), used during stop()
     let shutdown: ShutdownHandler | undefined;
 
-    // Forward host events to node-level listeners
-    const unsubHost = host.onEvent((event) => emit(event.type, event.data));
+    // let: registered in start(), cleaned up in stop(), re-registered on restart
+    let unsubHost: () => void = () => {};
+    let unsubReconnect: () => void = () => {};
+    let unsubTerminal: () => void = () => {};
 
-    // Reconnect replay for full mode
-    const unsubReconnect = transport.onEvent((event) => {
-      if (event.type === "reconnected" && deliveryMgr !== undefined) {
-        void (async () => {
-          try {
-            for (const agent of host.list()) {
-              const sid = sessionByAgent.get(agent.pid.id);
-              if (sid !== undefined) {
-                await deliveryMgr.replayPendingFrames(sid);
+    /** Register full-mode event forwarding listeners. Safe to call multiple times. */
+    function registerFullModeListeners(): void {
+      // Tear down previous registrations (no-op on first call)
+      unsubHost();
+      unsubReconnect();
+      unsubTerminal();
+
+      // Forward host events to node-level listeners
+      unsubHost = host.onEvent((event) => emit(event.type, event.data));
+
+      // Reconnect replay for full mode
+      unsubReconnect = transport.onEvent((event) => {
+        if (event.type === "reconnected" && deliveryMgr !== undefined) {
+          void (async () => {
+            try {
+              for (const agent of host.list()) {
+                const sid = sessionByAgent.get(agent.pid.id);
+                if (sid !== undefined) {
+                  await deliveryMgr.replayPendingFrames(sid);
+                }
               }
+            } catch (e: unknown) {
+              emit("agent_crashed", { reason: "Reconnect replay failed", error: e });
             }
-          } catch (e: unknown) {
-            emit("agent_crashed", { reason: "Reconnect replay failed", error: e });
-          }
-        })();
-      }
-    });
-
-    // Send a one-shot terminal status frame immediately when an agent terminates,
-    // so the gateway can resolve waitForAgent() without waiting for the next cycle.
-    const unsubTerminal = host.onEvent((event) => {
-      if (event.type === "agent_terminated") {
-        const data = event.data as { agentId: string; exitCode: number } | undefined;
-        if (data?.agentId !== undefined) {
-          const payload: AgentStatusPayload = {
-            agentId: data.agentId,
-            state: "terminated",
-            turnCount: 0,
-            lastActivityMs: Date.now(),
-            exitCode: data.exitCode,
-          };
-          sendFrame({
-            nodeId,
-            agentId: data.agentId,
-            correlationId: generateCorrelationId(nodeId),
-            kind: "agent:status",
-            payload: { agents: [payload] },
-          });
+          })();
         }
-      }
-    });
+      });
+
+      // Send a one-shot terminal status frame immediately when an agent terminates,
+      // so the gateway can resolve waitForAgent() without waiting for the next cycle.
+      unsubTerminal = host.onEvent((event) => {
+        if (event.type === "agent_terminated") {
+          const data = event.data as { agentId: string; exitCode: number } | undefined;
+          if (data?.agentId !== undefined) {
+            const payload: AgentStatusPayload = {
+              agentId: data.agentId,
+              state: "terminated",
+              turnCount: 0,
+              lastActivityMs: Date.now(),
+              exitCode: data.exitCode,
+            };
+            sendFrame({
+              nodeId,
+              agentId: data.agentId,
+              correlationId: generateCorrelationId(nodeId),
+              kind: "agent:status",
+              payload: { agents: [payload] },
+            });
+          }
+        }
+      });
+    }
 
     // Wire inbound frame handler — full mode handles agent frames + tool_call
     transport.onFrame((frame) => {
@@ -619,15 +634,24 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
             await result.engine.loadState(session.lastEngineState);
           }
 
+          // Wrap with transcript decorator if transcript store is available
+          const effectiveEngine =
+            deps?.transcript !== undefined
+              ? createTranscriptingEngine(result.engine, {
+                  sessionId: toSessionId(session.sessionId),
+                  transcript: deps.transcript,
+                })
+              : result.engine;
+
           const dispatchResult = await host.dispatch(
             result.pid,
             session.manifestSnapshot,
-            result.engine,
+            effectiveEngine,
             result.providers ?? [],
           );
 
           if (dispatchResult.ok) {
-            engines.set(result.pid.id, result.engine);
+            engines.set(result.pid.id, effectiveEngine);
             sessionByAgent.set(result.pid.id, session.sessionId);
             if (deliveryMgr !== undefined && pendingFrames.has(session.sessionId)) {
               await deliveryMgr.replayPendingFrames(session.sessionId);
@@ -669,6 +693,11 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
       async start() {
         if (currentState === "connected" || currentState === "starting") return;
         currentState = "starting";
+
+        // (Re-)register event forwarding — survives stop → start cycles
+        unsubTransport();
+        unsubTransport = transport.onEvent((event) => emit(event.type, event.data));
+        registerFullModeListeners();
 
         const connectPromise = transport.connect().then(() => {
           transport.send({
@@ -797,17 +826,52 @@ export function createNode(rawConfig: unknown, deps?: NodeDeps): Result<KoiNode,
         if (result.ok) {
           engines.set(pid.id, effectiveEngine);
           sessionByAgent.set(pid.id, sid);
+
+          // Persist session for crash recovery
+          if (deps?.sessionStore !== undefined) {
+            const counters = frameCounters.get(pid.id);
+            const record: SessionRecord = {
+              sessionId: toSessionId(sid),
+              agentId: pid.id,
+              manifestSnapshot: manifest,
+              seq: counters.seq,
+              remoteSeq: counters.remoteSeq,
+              connectedAt: Date.now(),
+              lastPersistedAt: Date.now(),
+              metadata: {},
+            };
+            const saveResult = await deps.sessionStore.saveSession(record);
+            if (!saveResult.ok) {
+              emit("agent_crashed", {
+                agentId: pid.id,
+                reason: "Failed to persist session",
+                error: saveResult.error,
+              });
+            }
+          }
         }
         return result;
       },
 
       terminate(agentId) {
+        const sid = sessionByAgent.get(agentId);
         const result = host.terminate(agentId);
         if (result.ok) {
           engines.delete(agentId);
           sessionByAgent.delete(agentId);
           frameCounters.remove(agentId);
           inbox.clear(agentId);
+
+          // Remove persisted session (fire-and-forget — terminate is sync)
+          if (deps?.sessionStore !== undefined && sid !== undefined) {
+            void Promise.resolve(deps.sessionStore.removeSession(sid)).catch((e: unknown) => {
+              emit("agent_crashed", {
+                agentId,
+                reason: "Failed to remove persisted session",
+                error: e,
+              });
+            });
+          }
         }
         return result;
       },

--- a/packages/deploy/node/src/transcripting-engine.ts
+++ b/packages/deploy/node/src/transcripting-engine.ts
@@ -82,9 +82,13 @@ export function createTranscriptingEngine(
 
   function fireAppend(entries: readonly TranscriptEntry[]): void {
     if (entries.length === 0) return;
-    void Promise.resolve(transcript.append(sessionId, entries)).catch(() => {
-      // Intentionally swallowed — transcript failure must not block the stream.
-    });
+    try {
+      void Promise.resolve(transcript.append(sessionId, entries)).catch(() => {
+        // Intentionally swallowed — transcript failure must not block the stream.
+      });
+    } catch {
+      // Swallow sync throws from transcript.append() — must not block the stream.
+    }
   }
 
   async function* wrappedStream(input: EngineInput): AsyncGenerator<EngineEvent> {

--- a/packages/lib/validation/src/brick-validation.ts
+++ b/packages/lib/validation/src/brick-validation.ts
@@ -103,6 +103,12 @@ function validateKindFields(data: Record<string, unknown>, source: string): Resu
       break;
     case "composite":
       if (!Array.isArray(data.steps)) return fail("composite missing 'steps' array", source);
+      for (let i = 0; i < data.steps.length; i++) {
+        const step = data.steps[i];
+        if (!isRecord(step)) return fail(`composite steps[${String(i)}] is not an object`, source);
+        if (!isNonEmptyString((step as Record<string, unknown>).brickId))
+          return fail(`composite steps[${String(i)}] missing 'brickId'`, source);
+      }
       if (!isRecord(data.exposedInput))
         return fail("composite missing 'exposedInput' object", source);
       if (!isRecord(data.exposedOutput))


### PR DESCRIPTION
## Summary

Addresses all 11 high/medium findings from the Codex deploy review audit:

- **protocol.ts**: Add `agent:signal` and `agent:signal_group` to `VALID_FRAME_KINDS` — these were defined in `NodeFrameKind` and handled in the node switch but rejected at decode time
- **node.ts (session persistence)**: Call `saveSession()` after dispatch and `removeSession()` after terminate so crash recovery actually has data to recover from
- **systemd.ts / launchd.ts (idempotent redeploy)**: Use `systemctl restart` instead of `start`; `launchctl bootout` before `bootstrap` on reinstall
- **systemd.ts (ExecStart quoting)**: Quote all path segments in ExecStart so paths with spaces don't get split by systemd
- **ensure-running.ts (orphan daemon)**: SIGTERM the old Nexus process on config mismatch before spawning a new one, preventing orphaned daemons
- **brick-validation.ts (composite steps)**: Validate each composite step is an object with a `brickId` string, preventing runtime throws during import
- **node.ts (listener lifecycle)**: Move event listener registration into `start()` via `registerFullModeListeners()` so stop→start cycles re-register transport/host forwarding
- **node.ts (recovery transcript)**: Wrap recovered engines with `createTranscriptingEngine` so transcript entries continue after crash recovery
- **transcripting-engine.ts (sync throw)**: Wrap `transcript.append()` in try/catch to catch synchronous throws, not just rejected promises
- **pid-manager.ts (process matching)**: Also match `NEXUS_COMMAND` executable name in `isNexusProcess` for wrapper-style setups
- **import-bundle.ts (dedup)**: Deduplicate bricks by ID before parallel import to prevent race conditions with duplicate entries

## Test plan

- [x] All 174 tests pass across 8 affected test files (0 failures)
- [x] Updated systemd template test to expect quoted ExecStart paths
- [x] Biome lint/format passes
- [x] ESM builds succeed for all affected packages
- [ ] Manual: verify redeploy on Linux (systemctl restart) and macOS (bootout + bootstrap)
- [ ] Manual: verify Nexus embed config change stops old daemon