### PR TITLE
fix: address 6 Codex review findings across 5 packages

### DIFF
--- a/packages/fs/events-sqlite/src/sqlite-backend.ts
+++ b/packages/fs/events-sqlite/src/sqlite-backend.ts
@@ -374,37 +374,84 @@ export function createSqliteEventBackend(config: SqliteEventBackendConfig = {}):
       const direction = options?.direction ?? "forward";
       const limit = options?.limit ?? Number.MAX_SAFE_INTEGER;
       const typeFilter = options?.types !== undefined ? new Set(options.types) : undefined;
+      const needsPostFilter = eventTtlMs !== undefined || typeFilter !== undefined;
 
       try {
-        // Fetch one extra to detect hasMore
-        const fetchLimit = limit < Number.MAX_SAFE_INTEGER ? limit + 1 : limit;
         const stmt = direction === "backward" ? readEventsBackwardStmt : readEventsForwardStmt;
-        const rows = stmt.all(streamId, from, to, fetchLimit);
 
-        // let is required: progressively filtered
-        let envelopes = rows.map(mapRowToEnvelope);
+        if (!needsPostFilter) {
+          // Fast path: no post-fetch filtering, limit+1 sentinel is reliable
+          const fetchLimit = limit < Number.MAX_SAFE_INTEGER ? limit + 1 : limit;
+          const rows = stmt.all(streamId, from, to, fetchLimit);
+          const envelopes = rows.map(mapRowToEnvelope);
 
-        // TTL filtering
-        if (eventTtlMs !== undefined) {
-          const cutoff = ttlCutoff();
-          envelopes = envelopes.filter((e) => e.timestamp > cutoff);
+          if (limit < Number.MAX_SAFE_INTEGER && envelopes.length > limit) {
+            return {
+              ok: true,
+              value: { events: envelopes.slice(0, limit), hasMore: true },
+            };
+          }
+          return { ok: true, value: { events: envelopes, hasMore: false } };
         }
 
-        // Type filtering
-        if (typeFilter !== undefined) {
-          envelopes = envelopes.filter((e) => typeFilter.has(e.type));
+        // Slow path: TTL and/or type filters applied after fetch.
+        // Over-fetch in batches to collect enough matching events and
+        // reliably detect whether more exist beyond the requested limit.
+        const cutoff = eventTtlMs !== undefined ? ttlCutoff() : 0;
+        const batchSize =
+          limit < Number.MAX_SAFE_INTEGER ? (limit + 1) * 2 : Number.MAX_SAFE_INTEGER;
+        const collected: EventEnvelope[] = [];
+        // let is required: range bounds narrow across batches
+        // SQL: WHERE sequence >= rangeFrom AND sequence < rangeTo
+        let rangeFrom = from;
+        let rangeTo = to;
+        // let is required: flag set when DB rows are exhausted
+        let dbExhausted = false;
+
+        while (collected.length <= limit) {
+          const rows = stmt.all(streamId, rangeFrom, rangeTo, batchSize);
+          if (rows.length === 0) {
+            dbExhausted = true;
+            break;
+          }
+
+          for (const row of rows) {
+            const env = mapRowToEnvelope(row);
+            if (eventTtlMs !== undefined && env.timestamp <= cutoff) continue;
+            if (typeFilter !== undefined && !typeFilter.has(env.type)) continue;
+            collected.push(env);
+            if (collected.length > limit) break;
+          }
+
+          // Narrow the range past the rows we already fetched.
+          // Forward: last row has highest sequence → advance lower bound
+          // Backward: last row (ORDER BY DESC) has lowest sequence → lower upper bound
+          const lastRow = rows[rows.length - 1];
+          if (lastRow === undefined) {
+            dbExhausted = true;
+            break;
+          }
+          if (direction === "backward") {
+            rangeTo = lastRow.sequence;
+          } else {
+            rangeFrom = lastRow.sequence + 1;
+          }
+
+          if (rows.length < batchSize) {
+            dbExhausted = true;
+            break;
+          }
         }
 
-        if (limit < Number.MAX_SAFE_INTEGER && envelopes.length > limit) {
+        if (limit < Number.MAX_SAFE_INTEGER && collected.length > limit) {
           return {
             ok: true,
-            value: { events: envelopes.slice(0, limit), hasMore: true },
+            value: { events: collected.slice(0, limit), hasMore: true },
           };
         }
-
         return {
           ok: true,
-          value: { events: envelopes, hasMore: false },
+          value: { events: collected, hasMore: !dbExhausted },
         };
       } catch (e: unknown) {
         return { ok: false, error: mapSqliteError(e, "read") };

--- a/packages/fs/filesystem-nexus/src/nexus-filesystem-backend.ts
+++ b/packages/fs/filesystem-nexus/src/nexus-filesystem-backend.ts
@@ -135,9 +135,15 @@ function mapNotFoundError<T>(result: {
 
 /** Strip basePath prefix from a full path, returning the user-relative path. */
 function stripBasePath(base: string, fullPath: string): string {
-  if (fullPath.startsWith(base)) {
-    const relative = fullPath.slice(base.length);
-    return relative.startsWith("/") ? relative : `/${relative}`;
+  // Exact match: path IS the base directory
+  if (fullPath === base) {
+    return "/";
+  }
+  // Path-boundary check: ensure base is followed by "/" to prevent
+  // sibling-prefix collisions (e.g. base="/fs" must not match "/fspath/a.txt")
+  const baseWithSlash = base.endsWith("/") ? base : `${base}/`;
+  if (fullPath.startsWith(baseWithSlash)) {
+    return `/${fullPath.slice(baseWithSlash.length)}`;
   }
   return fullPath;
 }

--- a/packages/fs/filesystem/src/tools/edit.ts
+++ b/packages/fs/filesystem/src/tools/edit.ts
@@ -55,13 +55,24 @@ export function createFsEditTool(
       const dryRunResult = parseOptionalBoolean(args, "dryRun");
       if (!dryRunResult.ok) return dryRunResult.err;
 
-      const edits: readonly FileEdit[] = editsResult.value.map((e) => {
-        const entry = e as Record<string, unknown>;
-        return {
-          oldText: typeof entry.oldText === "string" ? entry.oldText : "",
-          newText: typeof entry.newText === "string" ? entry.newText : "",
-        };
-      });
+      const edits: readonly FileEdit[] = [];
+      for (let i = 0; i < editsResult.value.length; i++) {
+        const entry = editsResult.value[i] as Record<string, unknown>;
+        if (typeof entry.oldText !== "string") {
+          return {
+            error: `edits[${String(i)}].oldText must be a string, got ${typeof entry.oldText}`,
+          };
+        }
+        if (typeof entry.newText !== "string") {
+          return {
+            error: `edits[${String(i)}].newText must be a string, got ${typeof entry.newText}`,
+          };
+        }
+        (edits as FileEdit[]).push({
+          oldText: entry.oldText,
+          newText: entry.newText,
+        });
+      }
 
       const options: FileEditOptions = {
         ...(dryRunResult.value !== undefined && { dryRun: dryRunResult.value }),

--- a/packages/fs/resolve/src/resolve-one.ts
+++ b/packages/fs/resolve/src/resolve-one.ts
@@ -56,12 +56,12 @@ export async function resolveOne<T>(
     };
   }
 
-  // 3. Call factory
-  const EMPTY_OPTIONS: JsonObject = {};
+  // 3. Call factory — pass validated (potentially normalized) options, not raw input
   try {
     // Generic cast: registry returns BrickDescriptor<unknown>, caller narrows via T
     const typedDescriptor = descriptor as BrickDescriptor<T>;
-    const instance = await typedDescriptor.factory(config.options ?? EMPTY_OPTIONS, context);
+    const validatedOptions = (validationResult.value ?? config.options ?? {}) as JsonObject;
+    const instance = await typedDescriptor.factory(validatedOptions, context);
     return { ok: true, value: instance };
   } catch (e: unknown) {
     return {

--- a/packages/fs/resolve/src/resolve-search.ts
+++ b/packages/fs/resolve/src/resolve-search.ts
@@ -46,6 +46,21 @@ export async function resolveSearch(
   // config is narrowed to `object & { name: string }` — access via Record for options
   const obj = config as Record<string, unknown>;
   const name = config.name;
+
+  // Fail fast on non-object options instead of silently dropping
+  if (obj.options !== undefined && obj.options !== null) {
+    if (typeof obj.options !== "object") {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `search.options must be an object, got ${typeof obj.options}`,
+          retryable: false,
+        },
+      };
+    }
+  }
+
   const options =
     typeof obj.options === "object" && obj.options !== null
       ? (obj.options as Record<string, unknown>)

--- a/packages/fs/tools-web/src/url-policy.test.ts
+++ b/packages/fs/tools-web/src/url-policy.test.ts
@@ -52,6 +52,40 @@ describe("isBlockedUrl", () => {
     expect(isBlockedUrl("http://db.local:5432/")).toBe(true);
   });
 
+  test("blocks IPv6 link-local (fe80::/10)", () => {
+    expect(isBlockedUrl("http://[fe80::1]/")).toBe(true);
+    expect(isBlockedUrl("http://[fe80::1%25eth0]:8080/")).toBe(true);
+    expect(isBlockedUrl("http://[feb0::1]/")).toBe(true);
+  });
+
+  test("blocks IPv6 unique local addresses (fc00::/7)", () => {
+    expect(isBlockedUrl("http://[fc00::1]/")).toBe(true);
+    expect(isBlockedUrl("http://[fd12:3456::1]/")).toBe(true);
+  });
+
+  test("blocks IPv6 unspecified address (::)", () => {
+    expect(isBlockedUrl("http://[::]/")).toBe(true);
+    expect(isBlockedUrl("http://::/")).toBe(true);
+  });
+
+  test("blocks numeric IPv4 (decimal integer form)", () => {
+    // 2130706433 = 127.0.0.1
+    expect(isBlockedUrl("http://2130706433/")).toBe(true);
+    // 167772161 = 10.0.0.1
+    expect(isBlockedUrl("http://167772161/secret")).toBe(true);
+  });
+
+  test("blocks octal IPv4", () => {
+    // 0177.0.0.1 = 127.0.0.1
+    expect(isBlockedUrl("http://0177.0.0.1/")).toBe(true);
+  });
+
+  test("blocks hex IPv4", () => {
+    // 0x7f.0.0.1 = 127.0.0.1
+    expect(isBlockedUrl("http://0x7f.0.0.1/")).toBe(true);
+    expect(isBlockedUrl("http://0x7f000001/")).toBe(true);
+  });
+
   test("allows public URLs", () => {
     expect(isBlockedUrl("https://example.com")).toBe(false);
     expect(isBlockedUrl("https://api.github.com/repos")).toBe(false);

--- a/packages/fs/tools-web/src/url-policy.ts
+++ b/packages/fs/tools-web/src/url-policy.ts
@@ -24,8 +24,20 @@ const BLOCKED_PATTERNS: readonly RegExp[] = [
   /^https?:\/\/169\.254\.\d{1,3}\.\d{1,3}(?:[:/]|$)/,
   // IPv6 loopback
   /^https?:\/\/\[?::1\]?(?:[:/]|$)/i,
+  // IPv6 link-local (fe80::/10)
+  /^https?:\/\/\[fe[89ab][0-9a-f]:/i,
+  // IPv6 unique local addresses (fc00::/7 — fc00::/8 + fd00::/8)
+  /^https?:\/\/\[f[cd][0-9a-f]{2}:/i,
+  // IPv6 unspecified address
+  /^https?:\/\/\[?::\]?(?:[:/]|$)/i,
   // Unspecified address
   /^https?:\/\/0\.0\.0\.0(?:[:/]|$)/,
+  // Numeric IPv4 (decimal integer form, e.g. http://2130706433/ = 127.0.0.1)
+  /^https?:\/\/\d{8,10}(?:[:/]|$)/,
+  // Octal IPv4 (e.g. http://0177.0.0.1/ = 127.0.0.1)
+  /^https?:\/\/0\d+\./,
+  // Hex IPv4 (e.g. http://0x7f.0.0.1/ = 127.0.0.1)
+  /^https?:\/\/0x[0-9a-f]+/i,
   // Kubernetes internal services
   /^https?:\/\/[^/]*\.internal(?:[:/]|$)/i,
   /^https?:\/\/[^/]*\.local(?:[:/]|$)/i,


### PR DESCRIPTION
## Summary

Fixes 6 validated findings from Codex code review (3 High, 3 Medium):

- **resolve-one.ts** (High): Pass `validationResult.value` (normalized options) to factory instead of raw `config.options` — validators that apply defaults/coerce types now have their output respected
- **url-policy.ts** (High): Add 6 SSRF blocklist patterns for IPv6 link-local (`fe80::/10`), ULA (`fc00::/7`), unspecified (`::`) , decimal/octal/hex numeric IPv4 encodings
- **edit.ts** (High): Reject non-string `oldText`/`newText` with descriptive error instead of silently coercing to `""` (which could cause mass replacement)
- **resolve-search.ts** (Medium): Fail fast with `VALIDATION` error on non-object `search.options` instead of silently dropping to `undefined`
- **nexus-filesystem-backend.ts** (Medium): Fix `stripBasePath` path-boundary check — `startsWith(base)` → `startsWith(base + "/")` to prevent sibling-prefix collisions (e.g. `/fs` matching `/fspath/a.txt`)
- **sqlite-backend.ts** (Medium): Fix `hasMore` pagination — was derived from `limit+1` sentinel before TTL/type filters, now uses batched fetch with correct forward/backward cursor logic

## Test plan

- [x] url-policy: 16 tests pass (6 new for IPv6/numeric IPv4 patterns), 100% coverage
- [x] Biome formatting passes
- [x] Pre-push typecheck + build passes (58/58 tasks successful)
- [ ] Verify resolve-one change with an optionsValidator that normalizes defaults
- [ ] Verify edit.ts rejects `{ oldText: 123, newText: "x" }` with error
- [ ] Verify sqlite-backend filtered pagination returns correct `hasMore`