### PR TITLE
fix: address 9 Codex audit findings across 7 packages

### DIFF
--- a/packages/lib/errors/src/__tests__/circuit-breaker.test.ts
+++ b/packages/lib/errors/src/__tests__/circuit-breaker.test.ts
@@ -176,6 +176,46 @@ describe("HALF_OPEN state", () => {
     const snap = cb.recordFailure(500);
     expect(snap.state).toBe("OPEN");
   });
+
+  test("blocks concurrent callers in HALF_OPEN — only one probe at a time", () => {
+    const config = makeConfig({ failureThreshold: 1, cooldownMs: 100 });
+    let now = 0;
+    const cb = createCircuitBreaker(config, () => now);
+
+    cb.recordFailure(500);
+    now = 100;
+
+    // First caller gets through (probe)
+    expect(cb.isAllowed()).toBe(true);
+    // Second caller should be blocked while probe is in flight
+    expect(cb.isAllowed()).toBe(false);
+    expect(cb.isAllowed()).toBe(false);
+
+    // Probe completes with success → back to CLOSED
+    cb.recordSuccess();
+    // Now requests flow freely
+    expect(cb.isAllowed()).toBe(true);
+    expect(cb.isAllowed()).toBe(true);
+  });
+
+  test("probe failure unblocks next probe attempt after cooldown", () => {
+    const config = makeConfig({ failureThreshold: 1, cooldownMs: 100 });
+    let now = 0;
+    const cb = createCircuitBreaker(config, () => now);
+
+    cb.recordFailure(500);
+    now = 100;
+    cb.isAllowed(); // probe allowed
+    cb.recordFailure(500); // probe failed → OPEN
+
+    // Still in OPEN before next cooldown
+    expect(cb.isAllowed()).toBe(false);
+
+    // After another cooldown, a new probe should be allowed
+    now = 200;
+    expect(cb.isAllowed()).toBe(true); // new probe
+    expect(cb.isAllowed()).toBe(false); // blocked again
+  });
 });
 
 describe("ring buffer behavior", () => {

--- a/packages/lib/errors/src/circuit-breaker.ts
+++ b/packages/lib/errors/src/circuit-breaker.ts
@@ -54,6 +54,7 @@ export function createCircuitBreaker(
   // Mutable internal state (encapsulated, never exposed directly)
   let state: CircuitState = "CLOSED";
   let lastTransitionAt = clock();
+  let probeInFlight = false;
 
   // Ring buffer for failure timestamps
   const ringBuffer: number[] = new Array(config.failureThreshold).fill(0);
@@ -114,12 +115,15 @@ export function createCircuitBreaker(
           // Check if cooldown has passed → transition to HALF_OPEN
           if (now - lastTransitionAt >= config.cooldownMs) {
             transitionTo("HALF_OPEN");
+            probeInFlight = true;
             return true;
           }
           return false;
         }
         case "HALF_OPEN":
-          // Allow one probe request
+          // Allow exactly one probe request at a time
+          if (probeInFlight) return false;
+          probeInFlight = true;
           return true;
         default: {
           const _exhaustive: never = state;
@@ -132,6 +136,7 @@ export function createCircuitBreaker(
       switch (state) {
         case "HALF_OPEN":
           // Probe succeeded → close circuit
+          probeInFlight = false;
           transitionTo("CLOSED");
           resetRingBuffer();
           break;
@@ -169,6 +174,7 @@ export function createCircuitBreaker(
         }
         case "HALF_OPEN":
           // Probe failed → back to OPEN
+          probeInFlight = false;
           transitionTo("OPEN");
           break;
         case "OPEN":
@@ -187,6 +193,7 @@ export function createCircuitBreaker(
     },
 
     reset(): void {
+      probeInFlight = false;
       transitionTo("CLOSED");
       resetRingBuffer();
     },

--- a/packages/lib/event-delivery/src/delivery-manager.test.ts
+++ b/packages/lib/event-delivery/src/delivery-manager.test.ts
@@ -313,6 +313,63 @@ describe("createDeliveryManager", () => {
       expect(dlq.ok).toBe(true);
       if (dlq.ok) expect(dlq.value).toHaveLength(0);
     });
+
+    test("purgeDeadLetters calls removeDeadLetter on persistent backend", async () => {
+      const removedIds: string[] = [];
+      const cbWithTracking: DeliveryCallbacks = {
+        ...cb,
+        removeDeadLetter: (id) => {
+          removedIds.push(id);
+          return true;
+        },
+      };
+      const dm2 = createDeliveryManager(cbWithTracking);
+
+      dm2.subscribe({
+        streamId: "s",
+        subscriptionName: "sub-purge-persist",
+        fromPosition: 0,
+        maxRetries: 1,
+        handler: () => {
+          throw new Error("purge persist test");
+        },
+      });
+
+      dm2.notifySubscribers("s", createEnvelope({ streamId: "s", sequence: 1 }));
+      dm2.notifySubscribers("s", createEnvelope({ streamId: "s", sequence: 2 }));
+      await Bun.sleep(100);
+
+      dm2.purgeDeadLetters({ subscriptionName: "sub-purge-persist" });
+      expect(removedIds).toHaveLength(2);
+    });
+
+    test("handler is not re-executed when persistPosition fails", async () => {
+      // let justified: mutable counter for tracking handler invocations
+      let handlerCalls = 0;
+      const cbFailPersist: DeliveryCallbacks = {
+        ...cb,
+        persistPosition: () => {
+          throw new Error("persist boom");
+        },
+      };
+      const dm2 = createDeliveryManager(cbFailPersist);
+
+      dm2.subscribe({
+        streamId: "s",
+        subscriptionName: "sub-persist-fail",
+        fromPosition: 0,
+        maxRetries: 3,
+        handler: () => {
+          handlerCalls++;
+        },
+      });
+
+      dm2.notifySubscribers("s", createEnvelope({ streamId: "s", sequence: 1 }));
+      await Bun.sleep(100);
+
+      // Handler should execute exactly once — persistPosition failure must not retry it
+      expect(handlerCalls).toBe(1);
+    });
   });
 
   describe("closeAll", () => {

--- a/packages/lib/event-delivery/src/delivery-manager.ts
+++ b/packages/lib/event-delivery/src/delivery-manager.ts
@@ -130,10 +130,6 @@ export function createDeliveryManager(
       attempts++;
       try {
         await sub.handler(event);
-        // Success — advance position
-        sub.position = event.sequence;
-        await callbacks.persistPosition(sub.subscriptionName, event.sequence);
-        return;
       } catch (err: unknown) {
         if (attempts >= sub.maxRetries) {
           // Dead-letter the event
@@ -158,7 +154,22 @@ export function createDeliveryManager(
           return;
         }
         // Immediate retry (no backoff)
+        continue;
       }
+      // Handler succeeded — advance position outside handler retry scope.
+      // persistPosition failure must not re-execute the handler (at-least-once).
+      sub.position = event.sequence;
+      try {
+        await callbacks.persistPosition(sub.subscriptionName, event.sequence);
+      } catch (persistErr: unknown) {
+        // In-memory position is already advanced. On restart, replay will
+        // re-deliver from the last persisted position (at-least-once semantics).
+        console.warn(
+          "[event-delivery] failed to persist position:",
+          persistErr instanceof Error ? persistErr.message : persistErr,
+        );
+      }
+      return;
     }
   }
 
@@ -315,6 +326,9 @@ export function createDeliveryManager(
 
   const purgeDeadLetters = (filter?: DeadLetterFilter): Result<void, KoiError> => {
     if (filter === undefined) {
+      for (const entry of deadLetters) {
+        void callbacks.removeDeadLetter(entry.id);
+      }
       deadLetters.length = 0;
       return { ok: true, value: undefined };
     }
@@ -328,6 +342,7 @@ export function createDeliveryManager(
         filter.subscriptionName === undefined || entry.subscriptionName === filter.subscriptionName;
       if (matchStream && matchSub) {
         deadLetters.splice(i, 1);
+        void callbacks.removeDeadLetter(entry.id);
       }
     }
 

--- a/packages/lib/hash/src/brick-id.test.ts
+++ b/packages/lib/hash/src/brick-id.test.ts
@@ -78,6 +78,20 @@ describe("computeBrickId", () => {
     // so the hash should be identical to no-files.
     expect(withUndefined).toBe(withEmpty);
   });
+
+  test("files with ambiguous key/value boundaries produce different IDs", () => {
+    // { a: "bc" } vs { ab: "c" } must not collide
+    const a = computeBrickId("tool", "body", { a: "bc" });
+    const b = computeBrickId("tool", "body", { ab: "c" });
+    expect(a).not.toBe(b);
+  });
+
+  test("single-entry vs multi-entry files with same concatenation differ", () => {
+    // { "ab": "cd" } vs { "a": "b", "c": "d" } must not collide
+    const single = computeBrickId("tool", "body", { ab: "cd" });
+    const multi = computeBrickId("tool", "body", { a: "b", c: "d" });
+    expect(single).not.toBe(multi);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/lib/hash/src/brick-id.ts
+++ b/packages/lib/hash/src/brick-id.ts
@@ -90,9 +90,11 @@ function feedFiles(
   const sortedKeys = Object.keys(files).sort();
   for (const key of sortedKeys) {
     hasher.update(key);
+    hasher.update("\0");
     const value = files[key];
     if (value !== undefined) {
       hasher.update(value);
     }
+    hasher.update("\0");
   }
 }

--- a/packages/lib/nexus-client/src/batch-read.test.ts
+++ b/packages/lib/nexus-client/src/batch-read.test.ts
@@ -133,4 +133,32 @@ describe("batchRead", () => {
       expect(result.value.size).toBe(0);
     }
   });
+
+  test("clamps concurrency of 0 to 1 — no infinite loop", async () => {
+    const responses = new Map<string, Result<string, KoiError>>([
+      ["a.json", { ok: true, value: "content" }],
+    ]);
+    const client = createMockClient(responses);
+
+    const result = await batchRead(client, ["a.json"], { concurrency: 0 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.size).toBe(1);
+    }
+  });
+
+  test("clamps negative concurrency to 1", async () => {
+    const responses = new Map<string, Result<string, KoiError>>([
+      ["a.json", { ok: true, value: "content" }],
+    ]);
+    const client = createMockClient(responses);
+
+    const result = await batchRead(client, ["a.json"], { concurrency: -5 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.size).toBe(1);
+    }
+  });
 });

--- a/packages/lib/nexus-client/src/batch-read.ts
+++ b/packages/lib/nexus-client/src/batch-read.ts
@@ -22,7 +22,7 @@ export async function batchRead(
   paths: readonly string[],
   options?: { readonly concurrency?: number },
 ): Promise<Result<ReadonlyMap<string, string>, KoiError>> {
-  const concurrency = options?.concurrency ?? DEFAULT_BATCH_CONCURRENCY;
+  const concurrency = Math.max(1, options?.concurrency ?? DEFAULT_BATCH_CONCURRENCY);
   const results = new Map<string, string>();
 
   for (let i = 0; i < paths.length; i += concurrency) {

--- a/packages/lib/nexus-client/src/nexus-client.test.ts
+++ b/packages/lib/nexus-client/src/nexus-client.test.ts
@@ -163,6 +163,28 @@ describe("createNexusClient", () => {
     }
   });
 
+  test("returns error for malformed JSON-RPC response without result or error", async () => {
+    const client = createNexusClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: createMockFetch(
+        async () =>
+          new Response(JSON.stringify({ jsonrpc: "2.0", id: 1 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    });
+
+    const result = await client.rpc("test", {});
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+      expect(result.error.message).toContain("missing result");
+    }
+  });
+
   test("uses globalThis.fetch when no fetch provided", () => {
     // Just verifying it doesn't throw during construction
     const client = createNexusClient({

--- a/packages/lib/nexus-client/src/nexus-client.ts
+++ b/packages/lib/nexus-client/src/nexus-client.ts
@@ -37,7 +37,7 @@ export function createNexusClient(config: NexusClientConfig): NexusClient {
     try {
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (config.apiKey) {
-        headers["Authorization"] = `Bearer ${config.apiKey}`;
+        headers.Authorization = `Bearer ${config.apiKey}`;
       }
 
       response = await fetchFn(config.baseUrl, {
@@ -73,6 +73,17 @@ export function createNexusClient(config: NexusClientConfig): NexusClient {
 
     if ("error" in json) {
       return { ok: false, error: mapRpcError(json.error) };
+    }
+
+    if (!("result" in json)) {
+      return {
+        ok: false,
+        error: {
+          code: "INTERNAL",
+          message: "Malformed JSON-RPC response: missing result",
+          retryable: false,
+        },
+      };
     }
 
     return { ok: true, value: json.result };

--- a/packages/lib/preset-resolver/src/lookup-preset.test.ts
+++ b/packages/lib/preset-resolver/src/lookup-preset.test.ts
@@ -29,6 +29,13 @@ describe("lookupPreset", () => {
     expect(result.spec).toEqual({ maxRetries: 1 });
   });
 
+  test("throws for unknown preset name", () => {
+    // Force an unknown preset at runtime via type cast
+    expect(() => lookupPreset(SPECS, "nonexistent" as Preset, "standard")).toThrow(
+      /Unknown preset: "nonexistent"/,
+    );
+  });
+
   test("returns frozen spec without modification", () => {
     const frozenSpecs = Object.freeze({
       a: Object.freeze({ value: 10 }),

--- a/packages/lib/preset-resolver/src/lookup-preset.ts
+++ b/packages/lib/preset-resolver/src/lookup-preset.ts
@@ -13,6 +13,9 @@ export function lookupPreset<P extends string, S>(
   defaultPreset: NoInfer<P>,
 ): { readonly preset: P; readonly spec: Readonly<S> } {
   const resolved = preset ?? defaultPreset;
+  if (!(resolved in specs)) {
+    throw new Error(`Unknown preset: "${resolved}". Available: ${Object.keys(specs).join(", ")}`);
+  }
   const spec = specs[resolved];
   return { preset: resolved, spec };
 }

--- a/packages/lib/shutdown/src/shutdown.test.ts
+++ b/packages/lib/shutdown/src/shutdown.test.ts
@@ -167,6 +167,37 @@ describe("ShutdownHandler", () => {
     expect(events.filter((e) => e === "shutdown_error")).toHaveLength(1);
   });
 
+  it("runs cleanup and emits shutdown_complete when onStopAccepting throws", async () => {
+    const order: string[] = [];
+    const events: string[] = [];
+
+    const handler = createShutdownHandler(
+      {
+        onStopAccepting: () => {
+          order.push("stop");
+          throw new Error("stop exploded");
+        },
+        onDrainAgents: async () => {
+          order.push("drain");
+        },
+        onCleanup: async () => {
+          order.push("cleanup");
+        },
+      },
+      (type: string) => {
+        events.push(type);
+      },
+    );
+
+    await handler.shutdown();
+
+    // Drain and cleanup must still run despite stop failing
+    expect(order).toEqual(["stop", "drain", "cleanup"]);
+    expect(events).toContain("shutdown_started");
+    expect(events).toContain("shutdown_error");
+    expect(events).toContain("shutdown_complete");
+  });
+
   it("install is idempotent — repeated calls do not leak listeners", () => {
     const handler = createShutdownHandler(
       {

--- a/packages/lib/shutdown/src/shutdown.ts
+++ b/packages/lib/shutdown/src/shutdown.ts
@@ -50,8 +50,15 @@ export function createShutdownHandler(
 
     emit("shutdown_started", { signal });
 
-    // 1. Stop accepting new work
-    callbacks.onStopAccepting();
+    // 1. Stop accepting new work — guarded so drain/cleanup always run
+    try {
+      callbacks.onStopAccepting();
+    } catch (stopError: unknown) {
+      emit("shutdown_error", {
+        phase: "stopAccepting",
+        error: stopError instanceof Error ? stopError.message : String(stopError),
+      });
+    }
 
     // 2. Drain active work with timeout — wrapped in try/finally so
     //    cleanup and shutdown_complete are always reached, even if

--- a/packages/lib/variant-selection/src/execute-with-failover.test.ts
+++ b/packages/lib/variant-selection/src/execute-with-failover.test.ts
@@ -207,6 +207,47 @@ describe("executeWithFailover", () => {
     }
   });
 
+  test("graceful degradation — tries open-breaker alternatives when all healthy ones fail", async () => {
+    const pool = makePool([makeEntry("a", 0.9), makeEntry("b", 0.5), makeEntry("c", 0.3)]);
+    // Both 'b' and 'c' have open breakers
+    const bBreaker = createCircuitBreaker(
+      { failureThreshold: 1, cooldownMs: 60_000, failureWindowMs: 60_000, failureStatusCodes: [] },
+      clock,
+    );
+    bBreaker.recordFailure();
+    const cBreaker = createCircuitBreaker(
+      { failureThreshold: 1, cooldownMs: 60_000, failureWindowMs: 60_000, failureStatusCodes: [] },
+      clock,
+    );
+    cBreaker.recordFailure();
+    const breakers: BreakerMap = new Map([
+      ["a", createCircuitBreaker(undefined, clock)],
+      ["b", bBreaker],
+      ["c", cBreaker],
+    ]);
+    now = 1000;
+
+    const result = await executeWithFailover({
+      pool,
+      breakers,
+      selectOptions: { strategy: "fitness", ctx: { clock, random: () => 0.01 } },
+      execute: async (v) => {
+        now += 5;
+        // Primary 'a' fails, 'b' open (skipped initially), 'c' open (skipped initially)
+        // Graceful degradation: try 'b' which succeeds
+        if (v.id === "a") throw new Error("primary failed");
+        return `result-${v.id}`;
+      },
+      clock,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Should have tried 'a' (failed), then skipped b/c, then retried b (succeeded)
+      expect(result.value.result).toBe("result-b");
+    }
+  });
+
   test("records duration correctly on success and failure", async () => {
     const pool = makePool([makeEntry("a", 0.9), makeEntry("b", 0.5)]);
     const breakers: BreakerMap = new Map();

--- a/packages/lib/variant-selection/src/execute-with-failover.ts
+++ b/packages/lib/variant-selection/src/execute-with-failover.ts
@@ -77,13 +77,14 @@ export async function executeWithFailover<T, R>(
     return { ok: false, attempts, lastError: primaryResult.error };
   }
 
-  // Try alternatives sequentially
+  // Try alternatives sequentially, skipping open breakers first
   let lastError: unknown = primaryResult.error;
+  const attempted = new Set<string>([selection.selected.id]);
   for (const alt of selection.alternatives) {
-    // Skip open circuit breakers (but still try if all are open — handled by select)
     const breaker = breakers.get(alt.id);
     if (breaker !== undefined && !breaker.isAllowed()) continue;
 
+    attempted.add(alt.id);
     const altResult = await tryVariant(alt, execute, breakers, clock);
     attempts.push(altResult.attempt);
     if (altResult.ok) {
@@ -93,6 +94,26 @@ export async function executeWithFailover<T, R>(
           result: altResult.result,
           attempts,
           selectedVariantId: alt.id,
+        },
+      };
+    }
+    lastError = altResult.error;
+  }
+
+  // Graceful degradation: try any pool variants not yet attempted (including
+  // those filtered at selection time due to open breakers)
+  for (const variant of pool.variants) {
+    if (attempted.has(variant.id)) continue;
+    attempted.add(variant.id);
+    const altResult = await tryVariant(variant, execute, breakers, clock);
+    attempts.push(altResult.attempt);
+    if (altResult.ok) {
+      return {
+        ok: true,
+        value: {
+          result: altResult.result,
+          attempts,
+          selectedVariantId: variant.id,
         },
       };
     }


### PR DESCRIPTION
## Summary

- **brick-id**: add `\0` separators in `feedFiles` to prevent hash collisions from ambiguous key/value concatenation (`{a:"bc"}` vs `{ab:"c"}`)
- **delivery-manager**: separate handler retry from `persistPosition` — handler failure retries, but persist failure after successful handler only logs (prevents duplicate side effects)
- **delivery-manager**: `purgeDeadLetters` now calls `callbacks.removeDeadLetter()` for each purged entry, matching the pattern in `retryDeadLetter`
- **batch-read**: `Math.max(1, concurrency)` guards against 0 (infinite loop) and negative values (backward iteration)
- **shutdown**: wrap `onStopAccepting()` in try/catch matching drain/cleanup pattern — cleanup and `shutdown_complete` always fire
- **circuit-breaker**: add `probeInFlight` flag to limit HALF_OPEN state to exactly one concurrent probe request
- **execute-with-failover**: after exhausting healthy alternatives, try unattempted pool variants (including open-breaker ones) for graceful degradation
- **nexus-client**: reject malformed JSON-RPC responses missing both `result` and `error` fields
- **lookup-preset**: throw on unknown preset names instead of silently returning `undefined`

## Test plan

- [x] `@koi/hash` — 2 new collision regression tests
- [x] `@koi/event-delivery` — 2 new tests (purge persistence + handler-not-re-executed on persist failure)
- [x] `@koi/nexus-client` (batch-read) — 2 new tests (concurrency 0 and negative)
- [x] `@koi/shutdown` — 1 new test (cleanup runs when onStopAccepting throws)
- [x] `@koi/errors` (circuit-breaker) — 2 new tests (concurrent probe blocking + probe reset after failure)
- [x] `@koi/variant-selection` — 1 new test (open-breaker graceful degradation)
- [x] `@koi/nexus-client` — 1 new test (malformed JSON-RPC detection)
- [x] `@koi/preset-resolver` — 1 new test (throws for unknown preset)
- [x] All 7 packages pass turbo build + typecheck + test (52/52 tasks)