### PR TITLE
fix: address 10 Codex audit findings across 8 packages

### DIFF
--- a/packages/meta/agent-spawner/src/delegation-protocol.test.ts
+++ b/packages/meta/agent-spawner/src/delegation-protocol.test.ts
@@ -139,13 +139,23 @@ describe("buildAcpStdin", () => {
     }
   });
 
-  test("third line contains the prompt", () => {
+  test("third line contains the prompt with matching sessionId", () => {
     const stdin = buildAcpStdin("implement feature X");
     const lines = stdin.trim().split("\n");
     const lastLine = lines[2] ?? "";
     const parsed = JSON.parse(lastLine);
     expect(parsed.method).toBe("session/prompt");
     expect(parsed.params.messages[0].content).toBe("implement feature X");
+
+    // Verify sessionId in session/prompt matches the one in session/new
+    const sessionLine = lines[1] ?? "";
+    const sessionParsed = JSON.parse(sessionLine);
+    expect(sessionParsed.method).toBe("session/new");
+    expect(parsed.params.sessionId).toBe(sessionParsed.params.sessionId);
+    // Must not be the hardcoded "default"
+    expect(parsed.params.sessionId).not.toBe("default");
+    expect(typeof parsed.params.sessionId).toBe("string");
+    expect(parsed.params.sessionId.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/meta/agent-spawner/src/delegation-protocol.ts
+++ b/packages/meta/agent-spawner/src/delegation-protocol.ts
@@ -113,16 +113,32 @@ export function buildAcpArgs(command: string, model?: string): readonly string[]
   return args;
 }
 
-/** Build newline-delimited JSON-RPC stdin for an ACP session. */
+/**
+ * Build newline-delimited JSON-RPC stdin for an ACP session.
+ *
+ * Uses a pre-allocated session ID so the session/new response and session/prompt
+ * request agree on the same ID. This is necessary because stdin is pre-built as a
+ * single string (batch mode) — we cannot read the session/new response before
+ * sending session/prompt.
+ *
+ * TODO: Implement interactive ACP session handling where the spawner reads the
+ * session/new response before sending session/prompt, supporting ACP servers that
+ * allocate server-side session IDs.
+ */
 export function buildAcpStdin(prompt: string): string {
+  // Pre-allocate a client-side session ID so both session/new and session/prompt
+  // reference the same value. ACP servers that honour client-suggested IDs will
+  // accept this; servers that allocate their own IDs require interactive handling.
+  const clientSessionId = `koi-spawn-${Date.now()}`;
+
   const init = buildRequest("initialize", {
     protocolVersion: "0.1",
     clientInfo: { name: "koi-agent-spawner", version: "0.0.0" },
     capabilities: {},
   });
-  const session = buildRequest("session/new", {});
+  const session = buildRequest("session/new", { sessionId: clientSessionId });
   const promptReq = buildRequest("session/prompt", {
-    sessionId: "default",
+    sessionId: clientSessionId,
     messages: [{ role: "user", content: prompt }],
   });
 

--- a/packages/meta/autonomous/src/autonomous.ts
+++ b/packages/meta/autonomous/src/autonomous.ts
@@ -92,11 +92,19 @@ export function createAutonomousAgent(parts: AutonomousAgentParts): AutonomousAg
             metrics,
             createdAt: Date.now(),
           };
-          await threadStore.appendAndCheckpoint(
+          const checkpointResult = await threadStore.appendAndCheckpoint(
             threadId(status.harnessId),
             [], // no individual thread messages to append for harness-type checkpoints
             snapshot,
           );
+          if (!checkpointResult.ok) {
+            // Surface checkpoint failures — silent loss of autonomous state is
+            // worse than a noisy error. Callers can catch and decide policy.
+            throw new Error(
+              `Autonomous checkpoint failed for harness ${status.harnessId}: ${checkpointResult.error.message}`,
+              { cause: checkpointResult.error },
+            );
+          }
           void ctx.trigger; // trigger is informational; checkpoint is unconditional here
         },
       }),

--- a/packages/meta/channels/src/__tests__/config-resolution.test.ts
+++ b/packages/meta/channels/src/__tests__/config-resolution.test.ts
@@ -60,13 +60,22 @@ describe("resolveChannelStackConfig", () => {
     expect(result.registry).toBe(customRegistry);
   });
 
-  test("empty channels array falls through to preset", () => {
+  test("empty channels array means zero channels (not preset fallback)", () => {
     const result = resolveChannelStackConfig({
       channels: [],
       preset: "standard",
     });
 
-    // Empty array → falls through to preset
+    // Explicit empty array means "no channels" — distinct from undefined
+    expect(result.channels).toHaveLength(0);
+  });
+
+  test("omitted channels falls through to preset", () => {
+    const result = resolveChannelStackConfig({
+      preset: "standard",
+    });
+
+    // No channels property → falls through to preset
     expect(result.channels).toHaveLength(4);
   });
 });

--- a/packages/meta/channels/src/adapters/chat-sdk.ts
+++ b/packages/meta/channels/src/adapters/chat-sdk.ts
@@ -20,6 +20,14 @@ export async function createChatSdkShim(
     if (adapters.length === 0) {
       throw new Error("[channel-chat-sdk] No platforms configured in chat-sdk config");
     }
+    if (adapters.length > 1) {
+      const names = adapters.map((a) => (a as { readonly name?: string }).name ?? "unknown");
+      process.stderr.write(
+        `[channel-chat-sdk] Warning: ${String(adapters.length)} platforms configured ` +
+          `(${names.join(", ")}), but only the first is used. ` +
+          `Configure each platform as a separate channel in the manifest for multi-platform support.\n`,
+      );
+    }
     return adapters[0] as ChannelAdapter;
   } catch (error: unknown) {
     if (error instanceof Error && error.message.includes("No platforms configured")) {

--- a/packages/meta/channels/src/config-resolution.ts
+++ b/packages/meta/channels/src/config-resolution.ts
@@ -37,8 +37,10 @@ export function resolveChannelStackConfig(config: ChannelStackConfig): ResolvedC
     healthTimeoutMs: config.healthTimeoutMs ?? DEFAULT_HEALTH_TIMEOUT_MS,
   };
 
-  // Explicit channels take priority over preset
-  if (config.channels !== undefined && config.channels.length > 0) {
+  // Explicit channels take priority over preset.
+  // An empty array (channels: []) is a valid explicit config meaning "no channels"
+  // — distinct from undefined which means "use preset".
+  if (config.channels !== undefined) {
     return { channels: config.channels, registry: config.registry, runtimeOpts };
   }
 

--- a/packages/meta/cli/src/commands/serve.ts
+++ b/packages/meta/cli/src/commands/serve.ts
@@ -12,7 +12,13 @@
 
 import { createContextExtension } from "@koi/context";
 import { createContextArena } from "@koi/context-arena";
-import type { ContentBlock, EngineInput, InboundMessage, KoiMiddleware } from "@koi/core";
+import type {
+  ComponentProvider,
+  ContentBlock,
+  EngineInput,
+  InboundMessage,
+  KoiMiddleware,
+} from "@koi/core";
 import { sessionId } from "@koi/core";
 import { createHealthServer } from "@koi/deploy";
 import { createKoi } from "@koi/engine";
@@ -90,8 +96,9 @@ export async function runServe(flags: ServeFlags): Promise<void> {
   // 6b. Wire conversation persistence via context-arena (graceful fallback)
   // let justified: message buffer for squash partitioning, cleared per-session
   let currentMessages: readonly InboundMessage[] = [];
-  // let justified: set inside try/catch, read when building runtime middleware
+  // let justified: set inside try/catch, read when building runtime middleware/providers
   let arenaMiddleware: readonly KoiMiddleware[] = [];
+  let arenaProviders: readonly ComponentProvider[] = [];
 
   // let justified: mutable binding updated per-message so resolveThreadId can read the
   // current session key. Updated inside the serial queue before each runtime.run() call.
@@ -102,6 +109,9 @@ export async function runServe(flags: ServeFlags): Promise<void> {
       store: createInMemorySnapshotChainStore(),
     });
 
+    // TODO(#2): Single synthetic sessionId means all threads share the same
+    // squash/compaction archive namespace. Per-thread archive isolation requires
+    // squash/compactor APIs to accept a sessionId resolver function.
     const arenaBundle = await createContextArena({
       summarizer: resolved.value.model,
       sessionId: sessionId(`serve:${manifest.name}:${Date.now()}`),
@@ -113,6 +123,7 @@ export async function runServe(flags: ServeFlags): Promise<void> {
     });
 
     arenaMiddleware = arenaBundle.middleware;
+    arenaProviders = arenaBundle.providers;
 
     if (flags.verbose) {
       process.stderr.write(
@@ -128,7 +139,7 @@ export async function runServe(flags: ServeFlags): Promise<void> {
     manifest,
     adapter,
     middleware: [...resolved.value.middleware, ...arenaMiddleware, ...nexus.middlewares],
-    providers: [...nexus.providers],
+    providers: [...nexus.providers, ...arenaProviders],
     extensions,
   });
 

--- a/packages/meta/cli/src/resolve-agent.ts
+++ b/packages/meta/cli/src/resolve-agent.ts
@@ -142,10 +142,11 @@ const ALL_DESCRIPTORS: readonly BrickDescriptor<unknown>[] = [
 
 /**
  * Detects the monorepo `packages/` directory relative to this module.
- * Both `src/` and `dist/` live two levels under `packages/cli/`.
+ * This module lives at `packages/meta/cli/src/`, so three levels up
+ * reaches the `packages/` root where discoverable packages reside.
  */
 function detectPackagesDir(): string {
-  return pathResolve(import.meta.dir, "..", "..");
+  return pathResolve(import.meta.dir, "..", "..", "..");
 }
 
 /**

--- a/packages/meta/context-arena/src/arena-factory.ts
+++ b/packages/meta/context-arena/src/arena-factory.ts
@@ -314,12 +314,22 @@ export async function createContextArena(config: ContextArenaConfig): Promise<Co
   ];
 
   // --- Opt-in: memory provider (user-scoped or single-instance) ---
+  // When user-scoped AND session-binding is active, share the same scopedMemory
+  // instance so the provider routes to the same per-user memory as the middleware proxy.
+  // This prevents the mismatch where middleware uses SessionContext.userId but
+  // the provider routes by agent.pid.ownerId (a static value set at attach time).
   const memoryProvider =
-    config.memoryFs?.userScoped === true && effectiveFsConfig !== undefined
+    config.memoryFs?.userScoped === true &&
+    effectiveFsConfig !== undefined &&
+    scopedMemory !== undefined
       ? createUserScopedMemoryProvider({
           baseDir: effectiveFsConfig.baseDir,
           maxCachedUsers: config.memoryFs.maxCachedUsers,
           memoryConfig: effectiveFsConfig,
+          // TODO(#6): Provider tools still resolve userId from agent.pid.ownerId at attach time,
+          // while the arena's session-binding middleware resolves from SessionContext.userId per-session.
+          // In multi-user serve mode these can diverge. Full fix requires provider tools to accept
+          // a dynamic userId resolver, similar to createScopedMemoryProxy above.
         })
       : fsMemory !== undefined
         ? createMemoryProvider({ memory: fsMemory })

--- a/packages/meta/governance/src/governance-stack.ts
+++ b/packages/meta/governance/src/governance-stack.ts
@@ -117,6 +117,14 @@ function createApprovalRoutingProvider(
   // Late-binding onAsk — resolves the correct handler per agent at call time.
   // Falls back to user's original onAsk, then to deny_once.
   const dynamicOnAsk = async (req: ExecApprovalRequest): Promise<ProgressiveDecision> => {
+    // Route by agentId when the request carries agent identity
+    if (req.agentId !== undefined) {
+      const targetHandler = agentHandlers.get(req.agentId);
+      if (targetHandler !== undefined) {
+        return targetHandler(req);
+      }
+      // agentId provided but no handler found — fall through to fallback
+    }
     if (agentHandlers.size > 1) {
       console.warn(
         `[koi:governance] dynamicOnAsk: ${agentHandlers.size} agent handlers registered but ` +

--- a/packages/security/exec-approvals/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/security/exec-approvals/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -68,6 +68,14 @@ interface ExecApprovalRequest {
      * Absent when no securityAnalyzer is configured in ExecApprovalsConfig.
      */
     readonly riskAnalysis?: RiskAnalysis;
+    /**
+     * Agent identity for multi-agent approval routing.
+     * When a governance stack is shared across multiple agents, this field
+     * enables deterministic routing to the correct agent's approval handler.
+     * Optional for backward compatibility — when absent, the governance stack
+     * falls back to first-handler-wins (with a console warning).
+     */
+    readonly agentId?: string | undefined;
 }
 
 /**

--- a/packages/security/exec-approvals/src/types.ts
+++ b/packages/security/exec-approvals/src/types.ts
@@ -55,4 +55,12 @@ export interface ExecApprovalRequest {
    * Absent when no securityAnalyzer is configured in ExecApprovalsConfig.
    */
   readonly riskAnalysis?: RiskAnalysis;
+  /**
+   * Agent identity for multi-agent approval routing.
+   * When a governance stack is shared across multiple agents, this field
+   * enables deterministic routing to the correct agent's approval handler.
+   * Optional for backward compatibility — when absent, the governance stack
+   * falls back to first-handler-wins (with a console warning).
+   */
+  readonly agentId?: string | undefined;
 }

--- a/packages/security/middleware-permissions/src/descriptor.ts
+++ b/packages/security/middleware-permissions/src/descriptor.ts
@@ -79,10 +79,26 @@ export const descriptor: BrickDescriptor<KoiMiddleware> = {
   aliases: ["permissions"],
   optionsValidator: validatePermissionsDescriptorOptions,
   factory(options, context): KoiMiddleware {
+    // Fail fast on invalid types — the validator should have caught these,
+    // but direct callers of createPatternPermissionBackend() may bypass it.
+    // Silent coercion to [] would cause deny-all without any indication.
+    if (options.allow !== undefined && !isStringArray(options.allow)) {
+      throw new Error(
+        `permissions.allow must be an array of strings, got ${typeof options.allow}. ` +
+          'A typo like allow: "*" silently becomes deny-all.',
+      );
+    }
+    if (options.deny !== undefined && !isStringArray(options.deny)) {
+      throw new Error(`permissions.deny must be an array of strings, got ${typeof options.deny}`);
+    }
+    if (options.ask !== undefined && !isStringArray(options.ask)) {
+      throw new Error(`permissions.ask must be an array of strings, got ${typeof options.ask}`);
+    }
+
     const rules: PermissionRules = {
-      allow: isStringArray(options.allow) ? options.allow : [],
-      deny: isStringArray(options.deny) ? options.deny : [],
-      ask: isStringArray(options.ask) ? options.ask : [],
+      allow: options.allow ?? [],
+      deny: options.deny ?? [],
+      ask: options.ask ?? [],
     };
 
     const backend = createPatternPermissionBackend({ rules });


### PR DESCRIPTION
## Summary

- **resolve-agent**: fix `detectPackagesDir()` to resolve `packages/` root (was resolving `packages/meta/`, disabling dynamic descriptor discovery)
- **serve.ts**: include `arenaBundle.providers` in `createKoi()` — squash tool and memory tools were silently lost; document per-thread sessionId limitation
- **permissions descriptor**: throw on malformed rules (e.g., `allow: "*"`) instead of silently coercing to deny-all
- **delegation-protocol**: use pre-allocated client sessionId instead of hardcoded `"default"` for ACP protocol correctness
- **autonomous**: check `appendAndCheckpoint` Result and throw on failure (was silently losing autonomous state)
- **exec-approvals**: add optional `agentId` to `ExecApprovalRequest` for deterministic multi-agent approval routing
- **governance-stack**: route by `agentId` when present in approval requests (falls back to existing first-handler behavior)
- **arena-factory**: document userId source mismatch between middleware (`SessionContext.userId`) and provider (`agent.pid.ownerId`)
- **chat-sdk**: warn to stderr when multiple platforms configured (only first adapter is used)
- **config-resolution**: treat `channels: []` as explicit zero-channels, distinct from undefined (which falls through to preset)

## Test plan

- [x] All 8 affected package test suites pass (725 tests, 0 failures)
- [x] Full monorepo build succeeds (221/221 packages)
- [x] Layer check passes (zero violations)
- [x] Typecheck passes for all affected packages
- [x] Biome lint/format passes
- [ ] Verify `koi serve` still starts correctly with arena providers wired
- [ ] Verify ACP spawn path works with pre-allocated session IDs