### PR TITLE
Fix init channel default selection

### DIFF
--- a/packages/meta/cli/src/wizard/steps.test.ts
+++ b/packages/meta/cli/src/wizard/steps.test.ts
@@ -253,6 +253,17 @@ describe("selectChannels", () => {
     const state: WizardState = { ...DEFAULT_STATE, template: "copilot" };
     const result = await selectChannels(state, NO_FLAGS);
     expect(result?.channels).toEqual(["telegram", "slack"]);
+    expect(mockMultiselect).toHaveBeenCalledWith({
+      message: "Select channels",
+      options: [
+        { value: "cli", label: "cli" },
+        { value: "telegram", label: "telegram" },
+        { value: "slack", label: "slack" },
+        { value: "discord", label: "discord" },
+      ],
+      initialValues: ["cli"],
+      required: true,
+    });
   });
 
   test("skips prompt for minimal template", async () => {

--- a/packages/meta/cli/src/wizard/steps.ts
+++ b/packages/meta/cli/src/wizard/steps.ts
@@ -158,6 +158,7 @@ export async function selectChannels(state: WizardState, flags: InitFlags): Prom
   const value = await p.multiselect({
     message: "Select channels",
     options: CHANNELS.map((c) => ({ value: c, label: c })),
+    initialValues: [...state.channels],
     required: true,
   });
 


### PR DESCRIPTION
## Summary
- seed the channels multiselect with the existing default channel selection
- add a regression test covering the initial values passed to the prompt

## Testing
- bun test packages/meta/cli/src/wizard/steps.test.ts
- bun run build:cli