### PR TITLE
docs: rewrite README with stronger hook and verified package counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,28 @@
 <h1 align="center">Koi</h1>
 
 <p align="center">
-  <strong>The agent operating system.</strong><br/>
-  Self-extending agents that are safe by design.
+  <strong>The self-extending agent operating system.</strong><br/>
+  238 packages. 7 contracts. One YAML file.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/TypeScript-Strict-blue?logo=typescript" alt="TypeScript Strict" />
+  <img src="https://img.shields.io/badge/Runtime-Bun%201.3-f9f1e1?logo=bun" alt="Bun 1.3" />
+  <img src="https://img.shields.io/badge/PRs-Welcome-brightgreen" alt="PRs Welcome" />
 </p>
 
 <p align="center">
   <a href="#quickstart">Quickstart</a> &middot;
-  <a href="#why-koi">Why Koi</a> &middot;
+  <a href="#what-makes-koi-different">Why Koi</a> &middot;
   <a href="#architecture">Architecture</a> &middot;
-  <a href="#cli">CLI</a> &middot;
-  <a href="#admin-panel">Admin Panel</a> &middot;
+  <a href="#manifest">Manifest</a> &middot;
+  <a href="docs/user-guide.md">Docs</a> &middot;
   <a href="#contributing">Contributing</a>
 </p>
 
 ---
+
+> **Koi is an agent operating system, not another agent framework.** Agents forge their own tools at runtime — with 4-stage verification so they can't go rogue. Talk to them across 15 channels, from CLI to Telegram to Voice to AG-UI. Rewind any agent to any checkpoint with time-travel debugging. Route tokens through Haiku → Sonnet → Opus cascade routing to cut costs 10×. Govern multi-agent delegation with HMAC-signed, scope-attenuated tokens. And query every data source — SQL, REST, filesystem — through a single path API where everything is a file.
 
 ## Quickstart
 
@@ -28,7 +36,21 @@
 bun add koi
 koi init my-agent
 cd my-agent
-koi start
+koi up
+```
+
+`koi up` boots the full stack in one command — Nexus, agents, channels, admin panel, and TUI:
+
+```
+Starting Koi default preset...
+  ✓ Nexus ready at http://localhost:4200 (embed)
+  ✓ Primary agent "my-agent" ready (pi, claude-haiku-4.5)
+  ✓ Channel "cli" connected
+  ✓ Admin API ready at http://localhost:3100/admin/api
+  ✓ Browser admin at http://localhost:3100/admin
+
+Try:
+  "What can you do?"
 ```
 
 The YAML file **is** the agent:
@@ -60,37 +82,95 @@ middleware:
   - "@koi/middleware-pay": { budget: { daily: 0.50 } }
 ```
 
-## Why Koi
+## What Makes Koi Different
 
-**Koi is an agent operating system, not another agent framework.**
+### Forge — Self-Extension with Verification
 
-| Problem | How Koi solves it |
-|---------|-------------------|
-| Agents can't build their own tools safely | **Forge**: 4-stage verification (static analysis, sandbox, adversarial probes, trust tiers) |
-| Terminal-only | **15 channels**: CLI, Telegram, Slack, Discord, WhatsApp, Voice, Email, Signal, Teams, Matrix, Mobile, AG-UI, Chat SDK, Canvas, Web |
-| No undo when agents break things | **Time travel**: rewind, fork, replay from any checkpoint |
-| Runaway costs | **Token economics**: cascade routing (Haiku/Sonnet/Opus), budget kill switch, circuit breaker |
-| Multi-agent = blind trust | **Governed delegation**: HMAC tokens, monotonic scope attenuation, cascading revocation |
-| No observability | **Admin panel**: real-time dashboard with agent status, cost tracking, and event streams ([planned](https://github.com/windoliver/koi/issues/924)) |
-| Memory degrades over time | **3-tier memory**: hot (session), warm (cross-session), cold (archival) with consolidation |
-| Single-server ceiling | **Federation**: Raft consensus, mDNS discovery, offline queue, edge deployment |
-| Every data source is different | **Nexus**: 14 connectors unified under a path API — everything is a file |
+Agents create their own tools, skills, and sub-agents at runtime. Every forged artifact passes 4-stage verification: static analysis, sandbox execution, adversarial probes, and trust tier promotion. No other framework lets agents grow their own capabilities *and* keeps them safe.
+
+```yaml
+forge:
+  enabled: true
+  maxForgesPerSession: 5
+```
+
+### 15 Channels — Meet Users Where They Are
+
+CLI, Telegram, Slack, Discord, WhatsApp, Voice, Email, Signal, Teams, Matrix, Mobile, AG-UI, Chat SDK, Canvas, Web. Same agent, same manifest — just add a line.
+
+```yaml
+channels:
+  - name: "@koi/channel-cli"
+  - "@koi/channel-telegram": { token: ${TELEGRAM_BOT_TOKEN} }
+  - "@koi/channel-slack": { token: ${SLACK_BOT_TOKEN} }
+```
+
+### Time Travel — Rewind, Fork, Replay
+
+Snapshot any agent at any point. Rewind to a previous checkpoint, fork a new timeline, or replay from a known-good state. Built on an immutable snapshot chain with content-addressed storage.
+
+### Token Economics — Cascade Routing
+
+Route requests through Haiku → Sonnet → Opus based on complexity. Set daily budgets, circuit breakers, and kill switches. Pay-per-tool metering tracks cost to the individual tool call.
+
+```yaml
+middleware:
+  - "@koi/middleware-pay": { budget: { daily: 0.50 } }
+  - "@koi/middleware-circuit-breaker": { threshold: 5, window: 60 }
+```
+
+### Governed Delegation — Multi-Agent Trust
+
+Agents delegate to sub-agents with HMAC-signed tokens that monotonically attenuate scope. A child agent can never have more permissions than its parent. Cascading revocation kills an entire delegation tree in one call.
+
+```yaml
+middleware:
+  - "@koi/middleware-permissions": { default: ask }
+  - "@koi/middleware-delegation-escalation": {}
+```
+
+### Everything is a File — Nexus Unified Namespace
+
+SQL databases, REST APIs, local files, agent memory — all accessible through a single path API. Query `nexus://agents/briefer/memory/preferences` the same way you query `nexus://sources/postgres/users`. Auto-starts in embed mode (SQLite + filesystem) or connects to a shared Nexus server.
+
+```yaml
+nexus:
+  url: https://nexus.example.com
+context:
+  sources:
+    - kind: memory
+      query: "user preferences"
+```
+
+### MCP Ecosystem — Plug and Play
+
+Any MCP server works as a tool. The same servers that work in Claude Desktop, Cursor, and VS Code work in Koi — declared in two lines of YAML.
+
+```yaml
+tools:
+  mcp:
+    - name: yahoo-finance
+      command: "npx yahoo-finance-mcp"
+    - name: playwright
+      command: "npx @anthropic/mcp-server-playwright"
+```
 
 ## Architecture
 
-Koi uses a strict four-layer architecture. Layer violations are build errors.
+Koi uses a strict five-layer architecture. Layer violations are build errors.
 
 ```
 L0  @koi/core        Interfaces-only kernel. Types + contracts. Zero logic. Zero deps.
+L0u 44 utility pkgs   Pure functions — errors, validation, hashing, manifests. Zero business logic.
 L1  @koi/engine       Kernel runtime. Guards, lifecycle, middleware composition.
-L2  @koi/*            Feature packages. Each depends on L0 only. Never on L1 or peers.
+L2  @koi/*            Feature packages. Each depends on L0/L0u only. Never on L1 or peers.
 L3  Meta-packages     Convenience bundles (e.g., @koi/starter = L0 + L1 + selected L2).
 L4  koi               Single installable package (planned — not yet published).
 ```
 
-### 222 packages, 7 contracts
+### 7 Contracts
 
-The kernel defines 7 extension contracts:
+The kernel defines 7 extension contracts — the syscall table of the agent OS:
 
 | Contract | Purpose | Surface |
 |----------|---------|---------|
@@ -104,91 +184,47 @@ The kernel defines 7 extension contracts:
 
 Plus ECS composition: Agent = entity, Tool = component, Middleware = system.
 
-### Key subsystems
+### Key Subsystems
 
 | Subsystem | Packages | What it does |
 |-----------|----------|-------------|
-| **Forge** | 9 | Safe self-extension: demand analysis, verification, crystallization, trust tiers |
-| **Security** | 20 | Permissions, audit, budget, delegation, graduated sanctions, intent capsules |
-| **Channels** | 15 | Every surface from CLI to Voice to AG-UI (includes channel-base) |
-| **Middleware** | 18 | Interposition for memory, retry, pay, PII, sandbox, permissions, and more |
-| **Engines** | 5 adapters | Pi (primary), Claude SDK, ReAct loop, external process, ACP |
+| **Middleware** | 39 | Interposition for memory, retry, pay, PII, sandbox, permissions, circuit breakers, and more |
+| **Channels** | 15 | Every surface from CLI to Voice to AG-UI |
+| **Forge** | 11 | Safe self-extension: demand analysis, verification, crystallization, trust tiers |
+| **Security** | 21 | Permissions, audit, budget, delegation, graduated sanctions, intent capsules |
 | **Sandbox** | 11 | Docker, E2B, Wasm, Cloudflare Workers, Vercel, Daytona, OS sandbox, and more |
+| **Memory** | 16 | Hot/warm/cold memory, context editing, conversation, user modeling, compaction |
+| **Observability** | 12 | Dashboard, eval, tracing, monitoring, debug — real-time admin panel with SSE |
 | **IPC** | 9 | Gateway, Node, mDNS, task board, agent spawner, federation |
-| **Observability** | 11 | Dashboard, eval, tracing, monitoring, debug — real-time admin panel with SSE |
+| **Engines** | 7 | Pi (primary), Claude SDK, ReAct loop, external process, ACP, browser, model router |
 
-## CLI
+<details>
+<summary><strong>Linux → Koi mental model</strong></summary>
 
-```
-koi init [directory]     Create a new agent
-koi start [manifest]     Start agent interactively (REPL)
-koi serve [manifest]     Run agent headless (for services)
-koi admin [manifest]     Run the standalone admin panel
-koi deploy [manifest]    Install as OS service (launchd/systemd)
-koi status [manifest]    Check service status
-koi stop [manifest]      Stop the service
-koi logs [manifest]      View service logs
-koi doctor [manifest]    Diagnose service health
-koi tui                  Interactive terminal console
-```
+Every Koi concept maps 1:1 to a Linux kernel equivalent:
 
-### `koi init`
+| Linux | Koi | Where it lives |
+|-------|-----|----------------|
+| `task_struct` | `ProcessDescriptor` | L0 `@koi/core` |
+| Process state (RUNNING/STOPPED/ZOMBIE) | `ProcessState` + `AgentCondition[]` | L0 type, L1 state machine |
+| `/proc/PID/status` | `agent-procfs` `/agents/<id>/descriptor` | L2 sidecar |
+| `fork(2)` + `exec(2)` | `SpawnFn` | L0 contract → `@koi/execution-context` |
+| `mqueue(7)` | `MailboxComponent` | L0 contract → `ipc-local` / `ipc-nexus` |
+| Signals (SIGTERM/SIGSTOP) | `AGENT_SIGNALS` (STOP/CONT/TERM/USR1/USR2) | L0 → gateway → node → agent |
+| `cgroups` | `GovernanceVariable` readings | Governance middleware |
+| `capabilities(7)` | `DelegationGrant` | HMAC-signed, monotonically attenuated |
+| `systemd` | `SupervisionController` | L1 `@koi/engine` |
+| `/sys/` | Syscall table (7 contracts) | L0 |
+| VFS | `FileSystemBackend` + Nexus Unified Namespace | Every domain concept is a path |
+| netfilter/iptables | `KoiMiddleware` with phase typing | INTERCEPT / OBSERVE / RESOLVE |
+| Device drivers | Engine adapters | L2 |
+| Kernel modules | L2 feature packages | Independent, swappable |
 
-Scaffolds a new agent project with interactive wizard or `--yes` for defaults.
-
-```bash
-koi init my-agent --template minimal --model anthropic:claude-haiku-4-5-20251001
-```
-
-### `koi start`
-
-Runs an agent interactively with CLI channel for REPL.
-
-```bash
-koi start                     # uses ./koi.yaml
-koi start ./agents/copilot.yaml --verbose
-```
-
-### `koi serve`
-
-Headless mode for production services. HTTP health server, graceful shutdown, conversation persistence.
-
-```bash
-koi serve --port 9100 --nexus-url https://nexus.example.com
-```
-
-### `koi deploy`
-
-Install as a background OS service with automatic restart.
-
-```bash
-koi deploy                     # user service (launchd on macOS, systemd on Linux)
-koi deploy --system            # system-wide service
-koi deploy --uninstall         # remove the service
-```
-
-## Admin Panel
-
-The dashboard packages (`@koi/dashboard-ui`, `@koi/dashboard-api`, `@koi/dashboard-types`) are wired into the CLI today via `koi start --admin`, `koi serve --admin`, `koi admin`, and `koi tui`.
-
-A browser-based UI for managing running agents, built on React 19 + Vite.
-
-**Core views:**
-- Agent status, tool inventory, cost tracking, audit log
-- Nexus file browser (everything-is-a-file namespace tree)
-- Real-time SSE event stream
-- Runtime views: process tree, middleware chain, gateway topology
-- Commands: suspend, resume, terminate agents; retry dead-letter queue
-
-**Planned — orchestration overlay** ([#924](https://github.com/windoliver/koi/issues/924)):
-- Temporal workflows, scheduler kanban, task board DAG, harness checkpoints
-
-**Planned — interactive console** ([#933](https://github.com/windoliver/koi/issues/933)):
-- Create/dispatch agents from the browser, chat via AG-UI streaming
+</details>
 
 ## Manifest
 
-The `koi.yaml` manifest defines everything about an agent declaratively.
+The `koi.yaml` manifest defines everything about an agent declaratively — YAML is the agent.
 
 ```yaml
 name: daily-briefer
@@ -234,33 +270,75 @@ context:
       query: "user preferences"
 ```
 
-## MCP Servers
+## CLI
 
-Any MCP server works as a plug-and-play tool. Declare it in `koi.yaml`:
+| Command | Description |
+|---------|-------------|
+| `koi up` | Start full stack — runtime, admin, TUI (recommended) |
+| `koi init [dir]` | Scaffold a new agent project |
+| `koi start [manifest]` | Start agent interactively (REPL) |
+| `koi serve [manifest]` | Run agent headless (for services) |
+| `koi admin [manifest]` | Run standalone admin panel |
+| `koi deploy [manifest]` | Install as OS service (launchd/systemd) |
+| `koi status [manifest]` | Check service status |
+| `koi stop [manifest]` | Stop the service |
+| `koi logs [manifest]` | View service logs |
+| `koi doctor [manifest]` | Diagnose service health |
+| `koi tui` | Interactive terminal console |
 
-```yaml
-tools:
-  mcp:
-    - name: yahoo-finance
-      command: "npx yahoo-finance-mcp"
-    - name: homeassistant
-      command: "npx homeassistant-mcp"
-    - name: playwright
-      command: "npx @anthropic/mcp-server-playwright"
+### `koi init`
+
+Scaffolds a new agent project with interactive wizard or `--yes` for defaults.
+
+```bash
+koi init my-agent --template minimal --model anthropic:claude-haiku-4-5-20251001
 ```
 
-The same MCP servers work in Claude Desktop, Cursor, VS Code, and Koi.
+### `koi up`
 
-## Toolchain
+Boots the full stack in one command — Nexus, primary agent, provisioned agents, channels, admin panel, and TUI. This is the recommended way to run Koi.
 
-| Tool | Choice |
-|------|--------|
-| Runtime | Bun 1.3.x |
-| Package manager | `bun install` |
-| Test runner | `bun:test` |
-| Build | tsup (ESM-only, `.d.ts`) |
-| Orchestration | Turborepo |
-| Lint/Format | Biome |
+```bash
+koi up                          # uses ./koi.yaml with default preset
+koi up --preset full            # full preset with all channels
+```
+
+### `koi serve`
+
+Headless mode for production services. HTTP health server, graceful shutdown, conversation persistence.
+
+```bash
+koi serve --port 9100 --nexus-url https://nexus.example.com
+```
+
+### `koi deploy`
+
+Install as a background OS service with automatic restart.
+
+```bash
+koi deploy                     # user service (launchd on macOS, systemd on Linux)
+koi deploy --system            # system-wide service
+koi deploy --uninstall         # remove the service
+```
+
+## Admin Panel
+
+A browser-based UI for managing running agents, built on React 19 + Vite. Wired into the CLI via `koi up`, `koi start --admin`, `koi serve --admin`, `koi admin`, and `koi tui`.
+
+**Core views:**
+- Agent status, tool inventory, cost tracking, audit log
+- Nexus file browser (everything-is-a-file namespace tree)
+- Real-time SSE event stream
+- Runtime views: process tree, middleware chain, gateway topology
+- Commands: suspend, resume, terminate agents; retry dead-letter queue
+
+<details>
+<summary><strong>Planned features</strong></summary>
+
+- **Orchestration overlay** ([#924](https://github.com/windoliver/koi/issues/924)): Temporal workflows, scheduler kanban, task board DAG, harness checkpoints
+- **Interactive console** ([#933](https://github.com/windoliver/koi/issues/933)): Create/dispatch agents from the browser, chat via AG-UI streaming
+
+</details>
 
 ## Development
 
@@ -271,51 +349,88 @@ bun install
 bun run build:cli
 ```
 
-### Running the CLI from this repo
+### Running with `koi up`
 
 The repo does not place a plain `koi` binary on your shell `PATH`. Use the built CLI through Bun:
 
 ```bash
 bun run koi -- init my-agent
 cd my-agent
-bun run dry-run
-bun run start:admin
-bun run tui
+bun run koi -- up              # full stack: Nexus + agent + admin + TUI
+```
+
+Or run individual commands:
+
+```bash
+bun run dry-run                # validate manifest without starting
+bun run start:admin            # start with admin panel
+bun run tui                    # interactive terminal console
 ```
 
 First-timer notes:
 
-- if `bun install` fails in `lefthook install` because `core.hooksPath` is already set locally, run `lefthook install --force`
-- local Nexus embed mode is the default when no URL is set, but it currently expects `uv run nexus` to be available
-- to switch from local Nexus to remote/shared Nexus, keep the same manifest and provide only `--nexus-url`, `NEXUS_URL`, or `nexus.url`
+- If `bun install` fails in `lefthook install` because `core.hooksPath` is already set locally, run `lefthook install --force`
+- Local Nexus embed mode is the default when no URL is set, but it currently expects `uv run nexus` to be available
+- To switch from local Nexus to remote/shared Nexus, keep the same manifest and provide only `--nexus-url`, `NEXUS_URL`, or `nexus.url`
 
 For the progressive first-run path, see [`docs/user-guide.md`](docs/user-guide.md).
 
-### Building the full workspace
+### Toolchain
+
+| Tool | Choice |
+|------|--------|
+| Runtime | Bun 1.3.x |
+| Package manager | `bun install` |
+| Test runner | `bun:test` |
+| Build | tsup (ESM-only, `.d.ts`) |
+| Orchestration | Turborepo |
+| Lint/Format | Biome |
+
+### Building & testing
 
 ```bash
-bun run build
-```
-
-### Running tests
-
-```bash
-bun test                              # all tests
-bunx turbo run test --filter=@koi/core  # single package
+bun run build                             # full workspace build
+bun test                                  # all tests
+bunx turbo run test --filter=@koi/core    # single package
 ```
 
 ## Contributing
 
-Contributions welcome. Please read the project's `CLAUDE.md` for coding standards, architecture rules, and the anti-leak checklist before submitting PRs.
+Contributions welcome. Please read the project's [`CLAUDE.md`](CLAUDE.md) for coding standards, architecture rules, and the anti-leak checklist before submitting PRs.
 
 Key rules:
 - `@koi/core` (L0) has zero runtime code — types and interfaces only
-- L2 packages import from L0 only — never from L1 or peer L2
+- L2 packages import from L0/L0u only — never from L1 or peer L2
 - All interface properties are `readonly`
 - No vendor types in L0 or L1
 - PRs under 300 lines of logic changes
 - 80% test coverage minimum
 
+## Package Landscape
+
+238 packages across 19 categories:
+
+| Category | Count | Examples |
+|----------|------:|---------|
+| **Network & Channels** | 30 | 15 channel adapters, gateway, MCP bridge, webhooks, ACP |
+| **Filesystem & Storage** | 29 | Nexus stores, registries (memory/SQLite/HTTP/Nexus), skills, tools, search |
+| **Utilities** | 26 | errors, validation, crypto, hashing, event delivery, test utils |
+| **Middleware** | 22 | call limits, circuit breaker, sandbox, semantic retry, tool audit, turn ack |
+| **Meta-packages** | 22 | CLI, starter, autonomous, governance, forge, stacks (gateway, retry, sandbox, ...) |
+| **Security** | 21 | audit sinks, delegation, permissions, PII redaction, guardrails, intent capsules |
+| **Memory** | 16 | hot/warm/cold memory, context editing, compaction, user model, session repair |
+| **Observability** | 12 | dashboard (API + UI + types), eval, tracing, agent-procfs, self-test |
+| **Forge** | 11 | demand analysis, verification, crystallization, exaptation, optimizer, policy |
+| **Sandbox** | 11 | Docker, E2B, Wasm, Cloudflare, Vercel, Daytona, IPC, cloud-base |
+| **IPC** | 9 | federation, handoff, local/Nexus IPC, scratchpads, task spawn, workspaces |
+| **Kernel** | 8 | core (L0), engine (L1), engine-compose, engine-reconcile, manifest, bootstrap |
+| **Drivers** | 7 | engine-pi, engine-claude, engine-loop, engine-acp, engine-external, model-router |
+| **Scheduler** | 6 | harness scheduler, long-running, Nexus scheduler, verified loop |
+| **Deploy** | 4 | bundle, deploy (launchd/systemd), nexus-embed, node |
+| **Data Sources** | 2 | connector-forge, discovery |
+| **Exec** | 1 | Temporal orchestration |
+| **UI** | 1 | TUI (terminal interface) |
+
 ## License
 
-See [LICENSE](LICENSE) for details.
+Koi is source-available. See the repository for license details.


### PR DESCRIPTION
## Summary

- Rewrites README from ~320 to ~436 lines with dramatically better structure and a stronger hook
- Promotes `koi up` as the hero command with realistic banner output
- Expands "Why Koi" from a comparison table to 7 detailed subsections (Forge, 15 Channels, Time Travel, Token Economics, Governed Delegation, Nexus, MCP) each with YAML snippets
- Updates all package counts to verified values (222 → 238 packages, 18 → 39 middleware, 9 → 11 forge)
- Adds shield badges, 5-layer architecture diagram (L0u + L4), collapsible Linux mental model, and a new 19-category "Package Landscape" table

## Test plan

- [ ] Verify README renders correctly on GitHub (badges, tables, collapsible sections, code blocks)
- [ ] Confirm all internal anchor links resolve (`#quickstart`, `#what-makes-koi-different`, `#architecture`, `#manifest`, `#contributing`)
- [ ] Confirm `docs/user-guide.md` link resolves
- [ ] Spot-check package counts against `ls -d packages/*/*/package.json | wc -l`