### PR TITLE
feat: add nexus build/source/port flags to koi up

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ context:
 
 | Command | Description |
 |---------|-------------|
-| `koi up` | Start full stack — runtime, admin, TUI (recommended) |
+| `koi up` | Start full stack — Nexus, runtime, admin, TUI (recommended) |
 | `koi init [dir]` | Scaffold a new agent project (interactive wizard) |
 | `koi start [manifest]` | Start agent interactively (CLI only, no admin/TUI) |
 | `koi serve [manifest]` | Run agent headless (for services) |
@@ -333,20 +333,30 @@ context:
 
 ### `koi init`
 
-Interactive wizard that scaffolds a new agent project. Asks for preset, template, name, model, channels, and data sources.
+Interactive wizard that scaffolds a new agent project. Asks for preset, template, name, model, channels, and data sources. The preset determines the infrastructure profile — demo data is seeded later by `koi up`.
 
 ```bash
 koi init my-agent                                    # interactive wizard
 koi init my-agent --preset demo --with telegram      # skip wizard steps
+koi init my-agent --preset local                     # lightweight local (no Docker, no auth)
+koi init my-agent --preset mesh                      # multi-agent orchestration topology
+koi init my-agent --yes                              # accept all defaults non-interactively
 ```
+
+Under the hood, `koi init` also runs `nexus init` to scaffold `nexus.yaml` (Docker Compose config). The Nexus preset maps from the Koi preset: `local` → embedded SQLite, `demo` → Docker with auth, `mesh` → Docker shared/multi-tenant.
 
 ### `koi up`
 
 The primary command. Boots the full stack in one command — Nexus, primary agent, provisioned agents, channels, admin panel, and TUI.
 
 ```bash
-koi up                    # uses ./koi.yaml
-koi up --detach           # run in background
+koi up                                          # uses ./koi.yaml
+koi up --nexus-url https://nexus.example.com    # connect to remote Nexus (skip local)
+koi up --nexus-build --nexus-source ~/nexus      # build Nexus from source
+koi up --nexus-port 3000                        # run Nexus on a custom HTTP port
+koi up --temporal-url grpc://temporal:7233      # connect to remote Temporal
+koi up --detach                                 # run in background
+koi up --verbose --timing                       # debug output + phase timings
 ```
 
 ### `koi start`
@@ -358,6 +368,13 @@ koi start                     # uses ./koi.yaml
 koi start --admin             # add admin panel
 koi start --admin --verbose   # with debug logging
 ```
+
+**Nexus resolution** (priority order): `--nexus-url` flag > `NEXUS_URL` env var > `nexus.url` in koi.yaml > auto-start local embed.
+When any URL is provided, no local Nexus is started.
+
+**`--nexus-build --nexus-source <dir>`** rebuilds the Nexus Docker image from source instead of pulling from GHCR. Point `--nexus-source` to the nexus repo root (uses `<dir>/docker-compose.yml` which has the `build:` directive).
+
+**Port handling**: Nexus auto-resolves port conflicts by default (`--port-strategy=auto`). If port 2026 is taken, it picks the next free port and persists it to `nexus.yaml`. Use `--nexus-port` only when you want a specific port.
 
 ### `koi serve`
 
@@ -431,6 +448,9 @@ bun run doctor        # diagnose health
 - One model provider key (e.g., `ANTHROPIC_API_KEY`)
 - If `bun install` fails at `lefthook install` because `core.hooksPath` is already set, run `lefthook install --force`
 - Local Nexus embed mode is the default when no URL is set
+- To build Nexus from source: `bun run koi -- up --nexus-build --nexus-source ~/nexus`
+- To use a custom port for Nexus: `bun run koi -- up --nexus-port 3000` (port conflicts auto-resolve by default)
+- To connect to remote Nexus: `--nexus-url`, `NEXUS_URL` env var, or `nexus.url` in koi.yaml
 
 ### Toolchain
 

--- a/packages/deploy/nexus-embed/src/index.ts
+++ b/packages/deploy/nexus-embed/src/index.ts
@@ -9,7 +9,7 @@
 export { resolveNexusBinary } from "./binary-resolver.js";
 export { ensureNexusRunning } from "./ensure-running.js";
 export { pollHealth, probeHealth } from "./health-check.js";
-export type { NexusLifecycleOptions, NexusUpResult } from "./nexus-lifecycle.js";
+export type { NexusInitOptions, NexusLifecycleOptions, NexusUpResult } from "./nexus-lifecycle.js";
 export { nexusDown, nexusInit, nexusUp } from "./nexus-lifecycle.js";
 export { stopEmbedNexus } from "./stop.js";
 export type { ConnectionState, EmbedConfig, EmbedResult } from "./types.js";

--- a/packages/deploy/nexus-embed/src/nexus-lifecycle.test.ts
+++ b/packages/deploy/nexus-embed/src/nexus-lifecycle.test.ts
@@ -52,6 +52,25 @@ describe("nexusInit", () => {
     expect(PRESET_MAP.demo).toBe("demo");
     expect(PRESET_MAP.mesh).toBe("shared");
   });
+
+  test("accepts port option without error", async () => {
+    const saved = process.env.NEXUS_COMMAND;
+    process.env.NEXUS_COMMAND = "/nonexistent/nexus-fake-binary";
+    try {
+      // Port option should be accepted even though binary is unavailable
+      const result = await nexusInit("demo", { cwd: tempDir, port: 3000 });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    } finally {
+      if (saved !== undefined) {
+        process.env.NEXUS_COMMAND = saved;
+      } else {
+        delete process.env.NEXUS_COMMAND;
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -103,6 +122,30 @@ describe("nexusUp", () => {
     const port = 3000;
     const baseUrl = `http://127.0.0.1:${String(port)}`;
     expect(baseUrl).toBe("http://127.0.0.1:3000");
+  });
+
+  test("accepts build and portStrategy options without error", async () => {
+    const saved = process.env.NEXUS_COMMAND;
+    process.env.NEXUS_COMMAND = "/nonexistent/nexus-fake-binary";
+    try {
+      const result = await nexusUp({
+        cwd: tempDir,
+        koiPreset: "demo",
+        build: true,
+        portStrategy: "fail",
+        port: 4000,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("NOT_FOUND");
+      }
+    } finally {
+      if (saved !== undefined) {
+        process.env.NEXUS_COMMAND = saved;
+      } else {
+        delete process.env.NEXUS_COMMAND;
+      }
+    }
   });
 });
 

--- a/packages/deploy/nexus-embed/src/nexus-lifecycle.ts
+++ b/packages/deploy/nexus-embed/src/nexus-lifecycle.ts
@@ -13,7 +13,7 @@
  * - `nexusDown()` stops the stack via `nexus down`
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { KoiError, Result } from "@koi/core";
 import { checkBinaryAvailable, resolveNexusBinary } from "./binary-resolver.js";
@@ -29,6 +29,12 @@ export interface NexusLifecycleOptions {
   readonly cwd?: string | undefined;
   /** Emit verbose diagnostics to stderr. Default: false. */
   readonly verbose?: boolean | undefined;
+}
+
+/** Extended options for `nexusInit()`. */
+export interface NexusInitOptions extends NexusLifecycleOptions {
+  /** Override the HTTP port in nexus.yaml (patched after scaffolding). */
+  readonly port?: number | undefined;
 }
 
 /** Result of a successful `nexus up`. */
@@ -60,7 +66,7 @@ const PRESET_MAP: Readonly<Record<string, string>> = {
  */
 export async function nexusInit(
   koiPreset: string,
-  options?: NexusLifecycleOptions | undefined,
+  options?: NexusInitOptions | undefined,
 ): Promise<Result<void, KoiError>> {
   const cwd = options?.cwd ?? process.cwd();
   const verbose = options?.verbose ?? false;
@@ -69,9 +75,18 @@ export async function nexusInit(
   if (!binaryCheck.ok) return binaryCheck;
 
   const nexusPreset = PRESET_MAP[koiPreset] ?? "local";
-  const args = ["init", "--preset", nexusPreset, "--force"];
+  const args: string[] = ["init", "--preset", nexusPreset, "--force"];
 
-  return runNexusCommand(args, cwd, verbose, "nexus init");
+  const result = await runNexusCommand(args, cwd, verbose, "nexus init");
+  if (!result.ok) return result;
+
+  // Nexus init does not accept a --port flag. If a custom port was requested,
+  // patch the generated nexus.yaml to override the default ports.http value.
+  if (options?.port !== undefined) {
+    patchNexusPort(cwd, options.port, verbose);
+  }
+
+  return result;
 }
 
 /**
@@ -94,6 +109,14 @@ export async function nexusUp(
     readonly koiPreset?: string | undefined;
     /** Host override. Default: "127.0.0.1". */
     readonly host?: string | undefined;
+    /** Build images from source (passes --build and --compose-file to `nexus up`). Requires `sourceDir` pointing to the nexus repo root. */
+    readonly build?: boolean | undefined;
+    /** Path to the nexus repo root for --build (derives compose file as `<sourceDir>/docker-compose.yml`). */
+    readonly sourceDir?: string | undefined;
+    /** Port conflict resolution strategy (passes --port-strategy to `nexus up`). Default: "auto". */
+    readonly portStrategy?: "auto" | "prompt" | "fail" | undefined;
+    /** Override the HTTP port (passed to `nexus init` during auto-init). */
+    readonly port?: number | undefined;
   },
 ): Promise<Result<NexusUpResult, KoiError>> {
   const cwd = options?.cwd ?? process.cwd();
@@ -113,7 +136,7 @@ export async function nexusUp(
         `Nexus: nexus.yaml not found, running nexus init --preset ${koiPreset}\n`,
       );
     }
-    const initResult = await nexusInit(koiPreset, { cwd, verbose });
+    const initResult = await nexusInit(koiPreset, { cwd, verbose, port: options?.port });
     if (!initResult.ok) return initResult;
     autoInitialized = true;
     configPath = findNexusConfig(cwd) ?? join(cwd, "nexus.yaml");
@@ -127,7 +150,13 @@ export async function nexusUp(
   delete process.env.NEXUS_API_KEY;
 
   // Run nexus up (blocks until healthy)
-  const upResult = await runNexusCommand(["up"], cwd, verbose, "nexus up");
+  const upArgs: string[] = ["up"];
+  if (options?.sourceDir !== undefined) {
+    upArgs.push("--compose-file", join(options.sourceDir, "docker-compose.yml"));
+  }
+  if (options?.build === true) upArgs.push("--build");
+  if (options?.portStrategy !== undefined) upArgs.push("--port-strategy", options.portStrategy);
+  const upResult = await runNexusCommand(upArgs, cwd, verbose, "nexus up");
 
   // Restore the original env var (may be needed by other code)
   if (savedApiKey !== undefined) {
@@ -159,7 +188,10 @@ export async function nexusUp(
  * Stops the Nexus stack via `nexus down`.
  */
 export async function nexusDown(
-  options?: NexusLifecycleOptions | undefined,
+  options?: NexusLifecycleOptions & {
+    /** Also remove volumes (passes --volumes to `nexus down`). Default: false. */
+    readonly volumes?: boolean | undefined;
+  },
 ): Promise<Result<void, KoiError>> {
   const cwd = options?.cwd ?? process.cwd();
   const verbose = options?.verbose ?? false;
@@ -167,7 +199,10 @@ export async function nexusDown(
   const binaryCheck = await ensureBinary();
   if (!binaryCheck.ok) return binaryCheck;
 
-  return runNexusCommand(["down"], cwd, verbose, "nexus down");
+  const args: string[] = ["down"];
+  if (options?.volumes === true) args.push("--volumes");
+
+  return runNexusCommand(args, cwd, verbose, "nexus down");
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +269,29 @@ async function extractContainerApiKey(cwd: string, verbose: boolean): Promise<st
     // Non-fatal — fall back to nexus.yaml key
   }
   return undefined;
+}
+
+/**
+ * Patches the HTTP port in nexus.yaml after scaffolding.
+ * `nexus init` does not accept a --port flag, so we patch the YAML directly.
+ */
+function patchNexusPort(cwd: string, port: number, verbose: boolean): void {
+  const configPath = findNexusConfig(cwd);
+  if (configPath === undefined) return;
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    // Replace `  http: <number>` under the `ports:` section
+    const patched = raw.replace(/^(\s+http:\s*)\d+/m, `$1${String(port)}`);
+    if (patched !== raw) {
+      writeFileSync(configPath, patched, "utf-8");
+      if (verbose) {
+        process.stderr.write(`Nexus: patched ports.http to ${String(port)} in ${configPath}\n`);
+      }
+    }
+  } catch {
+    // Non-fatal — port will use the default
+  }
 }
 
 /** Values extracted from nexus.yaml after startup. */

--- a/packages/meta/cli/src/args.ts
+++ b/packages/meta/cli/src/args.ts
@@ -116,6 +116,9 @@ export interface UpFlags extends BaseFlags {
   readonly web: boolean;
   readonly timing: boolean;
   readonly nexusUrl: string | undefined;
+  readonly nexusBuild: boolean;
+  readonly nexusSource: string | undefined;
+  readonly nexusPort: number | undefined;
   readonly temporalUrl: string | undefined;
   readonly logFormat: "text" | "json";
 }
@@ -449,6 +452,9 @@ export function parseUpFlags(rest: readonly string[]): UpFlags {
       web: { type: "boolean", default: false },
       timing: { type: "boolean", default: false },
       "nexus-url": { type: "string" },
+      "nexus-build": { type: "boolean", default: false },
+      "nexus-source": { type: "string" },
+      "nexus-port": { type: "string" },
       "temporal-url": { type: "string" },
       "log-format": { type: "string" },
     },
@@ -457,6 +463,7 @@ export function parseUpFlags(rest: readonly string[]): UpFlags {
   });
 
   const positionalManifest = positionals[0] as string | undefined;
+  const nexusPortStr = values["nexus-port"] as string | undefined;
 
   return {
     command: "up" as const,
@@ -467,6 +474,9 @@ export function parseUpFlags(rest: readonly string[]): UpFlags {
     web: (values.web as boolean | undefined) ?? false,
     timing: (values.timing as boolean | undefined) ?? false,
     nexusUrl: values["nexus-url"] as string | undefined,
+    nexusBuild: (values["nexus-build"] as boolean | undefined) ?? false,
+    nexusSource: values["nexus-source"] as string | undefined,
+    nexusPort: nexusPortStr !== undefined ? Number.parseInt(nexusPortStr, 10) : undefined,
     temporalUrl: values["temporal-url"] as string | undefined,
     logFormat: resolveLogFormat(values["log-format"] as string | undefined),
   };

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -305,7 +305,11 @@ export async function runUp(flags: UpFlags): Promise<void> {
   if (nexusBaseUrl === undefined && preset.nexusMode === "embed-auth") {
     output.spinner.start("Starting Nexus...");
     const nexusResult = await timer.time("nexus-up", () =>
-      startNexusStack(workspaceRoot, presetId, flags.verbose),
+      startNexusStack(workspaceRoot, presetId, flags.verbose, {
+        build: flags.nexusBuild || undefined,
+        sourceDir: flags.nexusSource,
+        port: flags.nexusPort,
+      }),
     );
     if (nexusResult !== undefined) {
       nexusBaseUrl = nexusResult.baseUrl;

--- a/packages/meta/cli/src/commands/up/nexus.ts
+++ b/packages/meta/cli/src/commands/up/nexus.ts
@@ -4,6 +4,15 @@
 
 import type { NexusMode } from "@koi/runtime-presets";
 
+export interface NexusStartOptions {
+  /** Build images from source instead of pulling pre-built. Requires `sourceDir`. */
+  readonly build?: boolean | undefined;
+  /** Path to the nexus repo root (derives docker-compose.yml for --build). */
+  readonly sourceDir?: string | undefined;
+  /** Override the Nexus HTTP port. */
+  readonly port?: number | undefined;
+}
+
 export interface NexusStartResult {
   readonly baseUrl: string;
   readonly apiKey: string | undefined;
@@ -17,10 +26,18 @@ export async function startNexusStack(
   workspaceRoot: string,
   koiPreset: string,
   verbose: boolean,
+  nexusOptions?: NexusStartOptions | undefined,
 ): Promise<NexusStartResult | undefined> {
   try {
     const { nexusUp } = await import("@koi/nexus-embed");
-    const result = await nexusUp({ cwd: workspaceRoot, koiPreset, verbose });
+    const result = await nexusUp({
+      cwd: workspaceRoot,
+      koiPreset,
+      verbose,
+      build: nexusOptions?.build,
+      sourceDir: nexusOptions?.sourceDir,
+      port: nexusOptions?.port,
+    });
     if (!result.ok) {
       process.stderr.write(`warn: nexus up failed: ${result.error.message}\n`);
       return undefined;


### PR DESCRIPTION
## Summary

- Add `--nexus-build`, `--nexus-source`, and `--nexus-port` flags to `koi up`
- Pass through `--build`, `--compose-file`, and `--port-strategy` to the nexus CLI (verified against actual nexus Python source)
- `--nexus-port` patches `nexus.yaml` after `nexus init` (no `--port` flag exists on `nexus init`)
- `nexusDown()` now supports `--volumes` passthrough
- Update README with full `koi init` / `koi up` flag documentation, Nexus resolution priority, port handling, and build-from-source workflow

## New `koi up` flags

| Flag | Passes to nexus | Purpose |
|------|----------------|---------|
| `--nexus-build` | `nexus up --build` | Build from Dockerfile instead of pulling GHCR image |
| `--nexus-source <dir>` | `nexus up --compose-file <dir>/docker-compose.yml` | Point to nexus repo root for build context |
| `--nexus-port <n>` | Patches `nexus.yaml` `ports.http` | Set preferred HTTP port (auto-resolves conflicts) |

## Test plan

- [x] `bun test packages/deploy/nexus-embed/src/nexus-lifecycle.test.ts` — 10/10 pass
- [x] CLI flag parsing verified at runtime (`parseUpFlags` returns correct types)
- [ ] Manual: `koi up --nexus-build --nexus-source ~/nexus` builds from local source
- [ ] Manual: `koi up --nexus-port 3000` starts Nexus on port 3000