### PR TITLE
fix: TUI console Enter submit, chat URL encoding, thinking display, ulti-turn conversation

### DIFF
--- a/packages/drivers/engine-pi/src/event-bridge.ts
+++ b/packages/drivers/engine-pi/src/event-bridge.ts
@@ -148,11 +148,7 @@ export function createEventSubscriber(
             queue.push({ kind: "text_delta", delta: assistantEvent.delta });
             break;
           case "thinking_delta":
-            queue.push({
-              kind: "custom",
-              type: "thinking_delta",
-              data: { delta: assistantEvent.delta },
-            });
+            queue.push({ kind: "thinking_delta", delta: assistantEvent.delta });
             break;
           case "toolcall_start": {
             const toolCall = findToolCallAtContentIndex(
@@ -260,7 +256,10 @@ export function createEventSubscriber(
             metrics.addCost(event.message.usage.cost);
           }
           // Track error state from the assistant message for propagation in agent_end
-          const msg = event.message as { readonly stopReason?: string; readonly errorMessage?: string };
+          const msg = event.message as {
+            readonly stopReason?: string;
+            readonly errorMessage?: string;
+          };
           if (msg.stopReason === "error" || msg.errorMessage) {
             lastStopReason = "error";
             lastErrorMessage = msg.errorMessage ?? "Model call failed";
@@ -294,7 +293,7 @@ export function createEventSubscriber(
         const { metrics: finalMetrics, metadata } = metrics.finalizeWithMetadata();
         const mergedMetadata: Record<string, unknown> = { ...metadata };
         if (lastErrorMessage) {
-          mergedMetadata["errorMessage"] = lastErrorMessage;
+          mergedMetadata.errorMessage = lastErrorMessage;
         }
         const output: EngineOutput = {
           content: [],

--- a/packages/meta/cli/src/commands/serve.ts
+++ b/packages/meta/cli/src/commands/serve.ts
@@ -369,12 +369,10 @@ export async function runServe(flags: ServeFlags): Promise<void> {
               }
               const threadId = msg.threadId ?? `chat-${Date.now().toString(36)}`;
 
-              // Set bindings for context extension and forge scoping, but clear
-              // threadKey so conversation middleware skips history injection —
-              // stateless mode already provides full conversation context from
-              // the browser's persisted session history.
+              // Set bindings for context extension, forge scoping, and
+              // conversation middleware history injection.
               currentMessages = [msg];
-              currentThreadKey = undefined;
+              currentThreadKey = threadId;
               currentServeSessionId = threadId;
 
               const input: EngineInput = { kind: "text", text };

--- a/packages/meta/cli/src/commands/up/boot-runtime.ts
+++ b/packages/meta/cli/src/commands/up/boot-runtime.ts
@@ -10,7 +10,7 @@
 
 import { dirname, resolve } from "node:path";
 import { createCliChannel } from "@koi/channel-cli";
-import type { ChannelAdapter, EngineInput } from "@koi/core";
+import type { ChannelAdapter, EngineInput, InboundMessage } from "@koi/core";
 import type { AdminPanelBridgeResult, DashboardHandlerResult } from "@koi/dashboard-api";
 import { createAdminPanelBridge, createDashboardHandler } from "@koi/dashboard-api";
 import type { DashboardEvent } from "@koi/dashboard-types";
@@ -37,6 +37,44 @@ import { buildDemoManifestOverrides, provisionDemoAgents, seedDemoPackIfNeeded }
 import { mapNexusModeToProfile } from "./nexus.js";
 import { extractDemoPack, inferPresetId } from "./preset.js";
 import { activatePresetStacks } from "./stacks.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LABEL_RE = /^\[(user|assistant|system)\]:\s*/;
+
+/**
+ * Expand stateless-normalized content blocks into separate InboundMessages.
+ *
+ * The AG-UI stateless normalizer flattens conversation history into labeled
+ * blocks like `[user]: hello`, `[assistant]: Hi!`. This function splits them
+ * back into individual InboundMessages so the engine adapter can send proper
+ * multi-turn messages to the model API.
+ */
+function expandLabeledBlocks(msg: InboundMessage): readonly InboundMessage[] {
+  const blocks = msg.content.filter(
+    (b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text",
+  );
+
+  // If no blocks match the labeled pattern, return the message as-is.
+  if (blocks.length === 0 || !LABEL_RE.test(blocks[0]?.text ?? "")) {
+    return [msg];
+  }
+
+  return blocks.map((block) => {
+    const match = LABEL_RE.exec(block.text);
+    const role = match?.[1] ?? "user";
+    const text = block.text.replace(LABEL_RE, "");
+    return {
+      content: [{ kind: "text" as const, text }],
+      senderId: role === "user" ? (msg.senderId ?? msg.threadId) : "assistant",
+      threadId: msg.threadId,
+      timestamp: msg.timestamp,
+      metadata: { ...msg.metadata, role },
+    };
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -318,7 +356,11 @@ export async function bootRuntime(options: BootRuntimeOptions): Promise<RuntimeH
       const text = extractTextFromBlocks(msg.content);
       if (text.trim() === "") return;
       const threadId = msg.threadId ?? `chat-${Date.now().toString(36)}`;
-      const input: EngineInput = { kind: "messages", messages: [msg] };
+
+      // Expand stateless-normalized content blocks ([user]: ..., [assistant]: ...)
+      // into separate InboundMessages so the engine sees proper multi-turn history.
+      const messages = expandLabeledBlocks(msg);
+      const input: EngineInput = { kind: "messages", messages };
       const deltas: string[] = [];
       for await (const event of runtime.run(input)) {
         if (event.kind === "text_delta") deltas.push(event.delta);

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -9,7 +9,7 @@ import { dirname, resolve } from "node:path";
 import { createCliChannel } from "@koi/channel-cli";
 import { createCliOutput, createTimer } from "@koi/cli-render";
 import { createContextExtension } from "@koi/context";
-import type { ChannelAdapter, EngineInput } from "@koi/core";
+import type { ChannelAdapter, EngineInput, InboundMessage } from "@koi/core";
 import type { AdminPanelBridgeResult, DashboardHandlerResult } from "@koi/dashboard-api";
 import { createAdminPanelBridge, createDashboardHandler } from "@koi/dashboard-api";
 import type { DashboardEvent } from "@koi/dashboard-types";
@@ -47,6 +47,34 @@ import { runPreflight } from "./preflight.js";
 import { extractDemoPack, inferPresetId } from "./preset.js";
 import { activatePresetStacks } from "./stacks.js";
 import { startTemporalEmbed } from "./temporal.js";
+
+const LABEL_RE = /^\[(user|assistant|system)\]:\s*/;
+
+/**
+ * Expand stateless-normalized content blocks into separate InboundMessages.
+ * Splits `[user]: ...` / `[assistant]: ...` labeled blocks back into
+ * individual messages so the engine sends proper multi-turn conversation.
+ */
+function expandLabeledBlocks(msg: InboundMessage): readonly InboundMessage[] {
+  const blocks = msg.content.filter(
+    (b): b is { readonly kind: "text"; readonly text: string } => b.kind === "text",
+  );
+  if (blocks.length === 0 || !LABEL_RE.test(blocks[0]?.text ?? "")) {
+    return [msg];
+  }
+  return blocks.map((block) => {
+    const match = LABEL_RE.exec(block.text);
+    const role = match?.[1] ?? "user";
+    const text = block.text.replace(LABEL_RE, "");
+    return {
+      content: [{ kind: "text" as const, text }],
+      senderId: role === "assistant" ? "assistant" : (msg.senderId ?? msg.threadId),
+      threadId: msg.threadId,
+      timestamp: msg.timestamp,
+      metadata: { ...msg.metadata, role },
+    };
+  });
+}
 
 /** Creates a forge view data source from a ForgeStore + optional seeded bricks. */
 function createForgeViewSource(
@@ -815,9 +843,10 @@ export async function runUp(flags: UpFlags): Promise<void> {
       const text = extractTextFromBlocks(msg.content);
       if (text.trim() === "") return;
       const threadId = msg.threadId ?? `chat-${Date.now().toString(36)}`;
-      // Use "messages" to preserve AG-UI metadata (runId) so the
-      // AG-UI stream middleware can route SSE events to the right writer.
-      const input: EngineInput = { kind: "messages", messages: [msg] };
+      // Expand stateless-normalized blocks ([user]: ..., [assistant]: ...)
+      // into separate InboundMessages for proper multi-turn conversation.
+      const expanded = expandLabeledBlocks(msg);
+      const input: EngineInput = { kind: "messages", messages: expanded };
       const deltas: string[] = [];
       for await (const event of runtime.run(input)) {
         if (event.kind === "text_delta") deltas.push(event.delta);

--- a/packages/observability/dashboard-api/src/handler.ts
+++ b/packages/observability/dashboard-api/src/handler.ts
@@ -218,10 +218,11 @@ export function createDashboardHandler(
             501,
           );
         }
-        const id = params.id;
-        if (id === undefined) {
+        const rawId = params.id;
+        if (rawId === undefined) {
           return errorResponse("VALIDATION", "Missing agent ID", 400);
         }
+        const id = decodeURIComponent(rawId);
         // Verify agent exists and is not terminated before delegating to chat handler
         const agent = await dataSource.getAgent(toAgentId(id));
         if (agent === undefined) {

--- a/packages/ui/tui/src/views/agui-event-handler.ts
+++ b/packages/ui/tui/src/views/agui-event-handler.ts
@@ -98,11 +98,8 @@ export function createAguiEventHandler(store: TuiStore): {
         break;
 
       case "REASONING_MESSAGE_CONTENT":
-        store.dispatch({ kind: "append_tokens", text: event.delta });
-        break;
-
       case "REASONING_MESSAGE_END":
-        store.dispatch({ kind: "flush_tokens" });
+        // Chain-of-thought reasoning is not shown to users
         break;
 
       default:

--- a/packages/ui/tui/src/views/console-view.tsx
+++ b/packages/ui/tui/src/views/console-view.tsx
@@ -3,10 +3,15 @@
  *
  * Uses ScrollBox for auto-scrolling message list, Markdown for assistant
  * messages (with streaming support), and Textarea for user input.
+ *
+ * Enter submits via useKeyboard (global key listener) rather than the
+ * textarea's onSubmit prop, because OpenTUI's React reconciler drops
+ * onSubmit updates for non-Input renderables on re-render.
  */
 
-import { type SyntaxStyle, type TextareaRenderable } from "@opentui/core";
-import { useCallback, useRef, useState } from "react";
+import type { KeyEvent, SyntaxStyle, TextareaRenderable } from "@opentui/core";
+import { useKeyboard } from "@opentui/react";
+import { useCallback, useRef } from "react";
 import { PanelChrome } from "../components/panel-chrome.js";
 import type { SessionState } from "../state/types.js";
 import { COLORS } from "../theme.js";
@@ -25,17 +30,24 @@ export interface ConsoleViewProps {
 /** Console view with scrollable message list and text input. */
 export function ConsoleView(props: ConsoleViewProps): React.ReactNode {
   const textareaRef = useRef<TextareaRenderable | null>(null);
-  const [inputText, setInputText] = useState("");
 
   const handleSubmit = useCallback((): void => {
-    const text = inputText.trim();
+    if (textareaRef.current === null) return;
+    const text = textareaRef.current.plainText.trim();
     if (text === "") return;
     props.onSubmit(text);
-    setInputText("");
-    if (textareaRef.current !== null) {
-      textareaRef.current.setText("");
+    textareaRef.current.setText("");
+  }, [props.onSubmit]);
+
+  // Handle Enter key via global listener — fires before the textarea's
+  // renderable handler, so we preventDefault to suppress the newline.
+  useKeyboard(useCallback((key: KeyEvent): void => {
+    if (!props.focused) return;
+    if (key.name === "return" && !key.ctrl && !key.meta && !key.shift) {
+      key.preventDefault();
+      handleSubmit();
     }
-  }, [inputText, props.onSubmit]);
+  }, [props.focused, handleSubmit]));
 
   const messages = props.session?.messages ?? [];
   const hasPending = props.pendingText.length > 0;
@@ -91,12 +103,6 @@ export function ConsoleView(props: ConsoleViewProps): React.ReactNode {
         textColor={COLORS.white}
         focusedBackgroundColor="#001a33"
         focusedTextColor={COLORS.white}
-        onContentChange={() => {
-          if (textareaRef.current !== null) {
-            setInputText(textareaRef.current.plainText);
-          }
-        }}
-        onSubmit={handleSubmit}
       />
     </PanelChrome>
   );

--- a/packages/ui/tui/src/views/tui-app.ts
+++ b/packages/ui/tui/src/views/tui-app.ts
@@ -218,11 +218,10 @@ export function createTuiApp(config: TuiAppConfig): TuiAppHandle {
       }));
 
     const chatUrl = client.agentChatUrl(session.agentId);
-    const chatUrlObj = new URL(chatUrl);
     const aguiConfig =
       authToken !== undefined
-        ? { baseUrl: chatUrlObj.origin, path: chatUrlObj.pathname, authToken }
-        : { baseUrl: chatUrlObj.origin, path: chatUrlObj.pathname };
+        ? { baseUrl: chatUrl, path: "", authToken }
+        : { baseUrl: chatUrl, path: "" };
 
     activeChatStream = startChatStream(
       aguiConfig,
@@ -243,11 +242,12 @@ export function createTuiApp(config: TuiAppConfig): TuiAppHandle {
         onError: (error) => {
           store.dispatch({ kind: "flush_tokens" });
           store.dispatch({ kind: "set_error", error });
+          const detail = "message" in error ? ` — ${error.message}` : "";
           store.dispatch({
             kind: "add_message",
             message: {
               kind: "lifecycle",
-              event: `Stream error: ${error.kind}`,
+              event: `Stream error: ${error.kind}${detail}`,
               timestamp: Date.now(),
             },
           });


### PR DESCRIPTION
- Fix Enter key in TUI console: use useKeyboard + preventDefault instead of textarea onSubmit prop (OpenTUI reconciler drops onSubmit updates for non-Input renderables)
- Fix agent ID URL encoding: decodeURIComponent on server-side route params, avoid new URL().pathname which encodes colons in agent IDs
- Fix thinking content leak: hide REASONING_MESSAGE_CONTENT events in TUI, emit thinking_delta as proper EngineEvent kind instead of custom event
- Fix multi-turn conversation: expand stateless-normalized [user]/[assistant] labeled blocks into separate InboundMessages so engine sends proper multi-turn messages to the model API
- Enable conversation middleware thread key in serve command chat bridge
- Show error detail in stream error messages