### PR TITLE
fix: skip CLI channel onMessage when TUI is attached

### DIFF
--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -873,7 +873,12 @@ export async function runUp(flags: UpFlags): Promise<void> {
     }
   });
 
-  const unsubscribers = channels.map((ch) =>
+  // When TUI is attached, skip CLI channel's onMessage — TUI handles chat
+  // via the AG-UI bridge. The CLI readline on stdin conflicts with TUI's
+  // raw-mode keyboard handling, causing spurious "agent is busy" errors.
+  const subscribedChannels = tuiAttached ? channels.filter((ch) => ch.name !== "cli") : channels;
+
+  const unsubscribers = subscribedChannels.map((ch) =>
     ch.onMessage(async (inbound) => {
       const text = extractTextFromBlocks(inbound.content);
       if (text.trim() === "") return;


### PR DESCRIPTION
When TUI is enabled, the CLI channel's readline listener on stdin conflicts with TUI's raw-mode keyboard handling, causing the shared `processing` flag to block TUI chat dispatch with "Agent is busy processing another request". Filter out CLI channel from onMessage subscriptions when TUI is attached since chat is handled via AG-UI.