### PR TITLE
fix: persist chat to Nexus whenever available, skip redundant demo re-seed

### DIFF
--- a/packages/lib/demo-packs/src/packs/self-improvement.ts
+++ b/packages/lib/demo-packs/src/packs/self-improvement.ts
@@ -245,6 +245,18 @@ export const SELF_IMPROVEMENT_PACK: DemoPack = {
     },
   ],
   seed: seedSelfImprovement,
+  staticViews: {
+    seededBricks: BRICK_METADATA.map((entry) => ({
+      brickId: entry.value.brickId as string,
+      name: entry.value.name as string,
+      status: entry.value.status as SeededBrickView["status"],
+      fitness: entry.value.fitness as number,
+      sampleCount: entry.value.sampleCount as number,
+      createdAt: entry.value.createdAt as number,
+      lastUpdatedAt: entry.value.lastUpdatedAt as number,
+    })),
+    seededForgeEvents: FORGE_EVENTS.map((entry) => entry.value),
+  },
   prompts: [
     "Show me the forge activity.",
     "What bricks have been created?",

--- a/packages/lib/demo-packs/src/types.ts
+++ b/packages/lib/demo-packs/src/types.ts
@@ -77,4 +77,11 @@ export interface DemoPack {
   readonly seed: (ctx: SeedContext) => Promise<SeedResult>;
   /** Known-good prompts to suggest after seeding. */
   readonly prompts: readonly string[];
+  /** Static brick/forge views for already-seeded restarts (avoids re-writing to Nexus). */
+  readonly staticViews?:
+    | {
+        readonly seededBricks: readonly SeededBrickView[];
+        readonly seededForgeEvents: readonly Readonly<Record<string, unknown>>[];
+      }
+    | undefined;
 }

--- a/packages/meta/cli/src/commands/up/__tests__/demo.test.ts
+++ b/packages/meta/cli/src/commands/up/__tests__/demo.test.ts
@@ -85,7 +85,7 @@ describe("seedDemoPackIfNeeded", () => {
     expect(mockRunSeed).not.toHaveBeenCalled();
   });
 
-  test("re-seeds with marker file to get brick views and returns prompts", async () => {
+  test("skips re-seed when marker file exists and returns static views", async () => {
     const koiDir = join(tempDir, ".koi");
     await mkdir(koiDir, { recursive: true });
     await writeFile(join(koiDir, ".demo-seeded"), "connected");
@@ -98,8 +98,8 @@ describe("seedDemoPackIfNeeded", () => {
       false,
     );
     expect(result.prompts).toEqual(["What did I learn?", "Show me data."]);
-    // Re-runs seed to get seeded brick views for forge view hydration
-    expect(mockRunSeed).toHaveBeenCalledTimes(1);
+    // Must NOT re-run seed — data is already in Nexus
+    expect(mockRunSeed).not.toHaveBeenCalled();
   });
 
   test("warns and returns empty when nexus client is undefined", async () => {

--- a/packages/meta/cli/src/commands/up/demo.ts
+++ b/packages/meta/cli/src/commands/up/demo.ts
@@ -32,19 +32,14 @@ export async function seedDemoPackIfNeeded(
     const markerPath = join(workspaceRoot, ".koi", ".demo-seeded");
     try {
       await readFile(markerPath, "utf-8");
-      // Already seeded — still return prompts and run seed to get brick views
-      const { getPack, runSeed } = await import("@koi/demo-packs");
+      // Already seeded — return prompts and static brick/forge views without re-writing to Nexus
+      const { getPack } = await import("@koi/demo-packs");
       const pack = getPack(demoPack);
-      // Re-run seed to get seeded brick views (idempotent writes to Nexus)
-      if (nexusClient !== undefined && pack !== undefined) {
-        const result = await runSeed(demoPack, { nexusClient, agentName, workspaceRoot, verbose });
-        return {
-          prompts: pack.prompts,
-          seededBricks: result.seededBricks ?? [],
-          seededForgeEvents: result.seededForgeEvents ?? [],
-        };
-      }
-      return { prompts: pack?.prompts ?? [], seededBricks: [], seededForgeEvents: [] };
+      return {
+        prompts: pack?.prompts ?? [],
+        seededBricks: pack?.staticViews?.seededBricks ?? [],
+        seededForgeEvents: pack?.staticViews?.seededForgeEvents ?? [],
+      };
     } catch {
       // Marker doesn't exist — proceed with seeding
     }

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -284,7 +284,11 @@ async function persistChatToNexus(
     JSON.stringify({ kind: "assistant", text: assistantText, timestamp: Date.now() }),
   ].join("\n");
   const content = existing.length > 0 ? `${existing}\n${entries}\n` : `${entries}\n`;
-  await client.rpc<null>("write", { path, content });
+  const writeResult = await client.rpc<null>("write", { path, content });
+  if (!writeResult.ok) {
+    const err = (writeResult as { readonly error?: { readonly message?: string } }).error;
+    throw new Error(`Nexus write failed: ${err?.message ?? "unknown"}`);
+  }
 }
 
 /** Probe nexus.yaml for an already-running Nexus instance. Returns URL+key if healthy. */
@@ -880,11 +884,11 @@ export async function runUp(flags: UpFlags): Promise<void> {
 
   // 8b. Demo pack seed (before admin so seeded bricks are available for forge view)
   const demoPack = await extractDemoPack(manifestPath);
-  let demoNexusClient: import("@koi/nexus-client").NexusClient | undefined;
-  if (demoPack !== undefined && nexus.baseUrl !== undefined) {
+  let nexusClient: import("@koi/nexus-client").NexusClient | undefined;
+  if (nexus.baseUrl !== undefined) {
     const { createNexusClient } = await import("@koi/nexus-client");
     const apiKey = process.env.NEXUS_API_KEY;
-    demoNexusClient = createNexusClient({
+    nexusClient = createNexusClient({
       baseUrl: nexus.baseUrl,
       ...(apiKey !== undefined ? { apiKey } : {}),
     });
@@ -893,7 +897,7 @@ export async function runUp(flags: UpFlags): Promise<void> {
     demoPack,
     workspaceRoot,
     manifest.name,
-    demoNexusClient,
+    nexusClient,
     flags.verbose,
   );
 
@@ -1184,9 +1188,9 @@ export async function runUp(flags: UpFlags): Promise<void> {
         text,
         deltas.join(""),
       );
-      if (demoNexusClient !== undefined) {
+      if (nexusClient !== undefined) {
         persistChatToNexus(
-          demoNexusClient,
+          nexusClient,
           manifest.name,
           currentSessionId,
           text,
@@ -1258,9 +1262,9 @@ export async function runUp(flags: UpFlags): Promise<void> {
           text,
           deltas.join(""),
         );
-        if (demoNexusClient !== undefined) {
+        if (nexusClient !== undefined) {
           persistChatToNexus(
-            demoNexusClient,
+            nexusClient,
             manifest.name,
             currentSessionId,
             text,


### PR DESCRIPTION
## Summary

- **Chat persistence to Nexus** now works whenever Nexus is available, not just for demo packs (`demoNexusClient` → `nexusClient`, gated on `nexus.baseUrl` only)
- **Write error checking** added to `persistChatToNexus` — was silently swallowing Nexus write failures (returned `Result` but never checked `ok`)
- **Skip re-seeding on restart** — when `.demo-seeded` marker exists, return static brick/forge views instead of calling `runSeed` which re-writes 500+ records to Nexus, exhausting the 300/min rate limit and blocking chat persistence

## Test plan

- [x] Unit tests pass (`bun test packages/meta/cli/`)
- [x] E2E: fresh launch seeds data to Nexus, chat message persisted
- [x] E2E: second launch skips re-seed (0 Nexus writes), chat message persisted
- [x] Nexus Browser shows new chat files after each message