### PR TITLE
design: update TUI theme to Deep Water palette

### DIFF
--- a/packages/ui/tui/src/theme.ts
+++ b/packages/ui/tui/src/theme.ts
@@ -9,17 +9,24 @@ import type { ConnectionStatus } from "./state/types.js";
 
 // ─── Color Constants ─────────────────────────────────────────────────
 
-/** Koi brand colors. */
+/** Koi Deep Water palette. */
 export const COLORS = {
   cyan: "#00CCCC",
-  green: "#00FF00",
-  yellow: "#FFFF00",
-  red: "#FF0000",
+  green: "#22C55E",
+  yellow: "#EAB308",
+  red: "#EF4444",
   blue: "#0088FF",
   magenta: "#FF00FF",
-  white: "#FFFFFF",
-  dim: "#888888",
+  white: "#E2E8F0",
+  dim: "#8899AA",
   bg: "#001122",
+  accent: "#FAF3DE",
+  bgElevated: "#0D1B2A",
+  bgSurface: "#1B2838",
+  bgHover: "#2E3D4E",
+  fgDim: "#4A5568",
+  border: "#2E3D4E",
+  borderSubtle: "#1B2838",
 } as const;
 
 // ─── Status Indicators ──────────────────────────────────────────────
@@ -55,6 +62,6 @@ export function agentStateColor(
     case "suspended":
       return COLORS.magenta;
     case "terminated":
-      return COLORS.dim;
+      return COLORS.fgDim;
   }
 }


### PR DESCRIPTION
## Summary
- Replace neon ANSI colors (green, red, yellow, white, dim) with softer, blue-tinted Deep Water values
- Add 7 new surface/border/accent tokens (`accent`, `bgElevated`, `bgSurface`, `bgHover`, `fgDim`, `border`, `borderSubtle`)
- Update `agentStateColor()` to use `fgDim` for terminated agents

Closes #1035

## Test plan
- [ ] Launch TUI and verify agent list uses softer green/yellow/red status colors
- [ ] Confirm text readability with blue-tinted `#E2E8F0` white and `#8899AA` dim
- [ ] Verify terminated agents render with subdued `#4A5568` fgDim color