### PR TITLE
design: Deep Water palette + Satoshi/Geist fonts for Dashboard

### DIFF
--- a/packages/observability/dashboard-ui/src/components/orchestration/task-dag-tab.tsx
+++ b/packages/observability/dashboard-ui/src/components/orchestration/task-dag-tab.tsx
@@ -20,8 +20,8 @@ import { TaskNodeDetailPanel } from "./task-node-detail-panel.js";
 
 const STATUS_COLORS: Readonly<Record<string, { readonly bg: string; readonly border: string }>> = {
   completed: { bg: "#166534", border: "#22c55e" },
-  running: { bg: "#1e3a5f", border: "#3b82f6" },
-  pending: { bg: "#374151", border: "#6b7280" },
+  running: { bg: "#0D1B2A", border: "#00CCCC" },
+  pending: { bg: "#1B2838", border: "#8899AA" },
   failed: { bg: "#7f1d1d", border: "#ef4444" },
 } as const;
 
@@ -42,7 +42,7 @@ interface TaskNodeData {
   readonly assignedTo?: string | undefined;
 }
 
-const DEFAULT_COLORS = { bg: "#374151", border: "#6b7280" } as const;
+const DEFAULT_COLORS = { bg: "#1B2838", border: "#8899AA" } as const;
 
 const TaskNode = memo(function TaskNode({ data }: NodeProps<TaskNodeData>): React.ReactElement {
   const colors = STATUS_COLORS[data.status] ?? DEFAULT_COLORS;

--- a/packages/observability/dashboard-ui/src/index.css
+++ b/packages/observability/dashboard-ui/src/index.css
@@ -2,24 +2,35 @@
 
 :root,
 [data-theme="dark"] {
-  --color-background: #0a0a0a;
-  --color-foreground: #ededed;
-  --color-muted: #a1a1aa;
-  --color-border: #27272a;
-  --color-card: #18181b;
-  --color-primary: #3b82f6;
+  --color-background: #001122;
+  --color-foreground: #E2E8F0;
+  --color-muted: #8899AA;
+  --color-border: #2E3D4E;
+  --color-card: #0D1B2A;
+  --color-primary: #00CCCC;
+  --color-accent: #FAF3DE;
+  --color-accent-muted: rgba(250, 243, 222, 0.15);
+  --color-surface: #1B2838;
+  --color-hover: #2E3D4E;
+  --color-dim: #4A5568;
+  --color-border-subtle: #1B2838;
+  --color-teal: #00CCCC;
+  --color-teal-muted: rgba(0, 204, 204, 0.15);
   --color-success: #22c55e;
   --color-warning: #eab308;
   --color-error: #ef4444;
 }
 
 [data-theme="light"] {
-  --color-background: #f8f9fa;
-  --color-foreground: #1a1a2e;
-  --color-muted: #6b7280;
-  --color-border: #e5e7eb;
-  --color-card: #ffffff;
-  --color-primary: #2563eb;
+  --color-background: #F5F3EE;
+  --color-foreground: #1B2838;
+  --color-muted: #4A5568;
+  --color-border: #D4CFC5;
+  --color-card: #FFFFFF;
+  --color-primary: #008888;
+  --color-accent: #8B7A3D;
+  --color-surface: #EEEBE4;
+  --color-hover: #E5E1D8;
   --color-success: #16a34a;
   --color-warning: #ca8a04;
   --color-error: #dc2626;


### PR DESCRIPTION
## Summary
- Replace neutral grays with Deep Water blue-tinted tokens in dark and light modes
- Add new semantic color tokens (accent, surface, hover, teal, dim, border-subtle)
- Update hardcoded DAG node colors in `task-dag-tab.tsx` to match palette
- Load Satoshi display font from Fontshare, define `--font-display`, `--font-body`, `--font-mono` CSS variables
- Apply display font to h1-h3 and stat values, mono font to badges, labels, table headers, breadcrumbs, and section headers

Closes #1036
Closes #1037

## Test plan
- [ ] Verify dark mode uses blue-black background (#001122) instead of pure black
- [ ] Verify light mode uses warm off-white (#F5F3EE) instead of cold gray
- [ ] Verify DAG node colors (running/pending) use Deep Water palette
- [ ] Verify Satoshi font loads and renders on headings and stat values
- [ ] Verify mono font (Geist Mono stack) applies to badges, labels, and table headers
- [ ] Verify semantic colors (success/warning/error) are unchanged