### PR TITLE
design: load Satoshi + Geist fonts in Dashboard

### DIFF
--- a/packages/observability/dashboard-ui/index.html
+++ b/packages/observability/dashboard-ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Koi Dashboard</title>
+    <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/packages/observability/dashboard-ui/src/components/agents/agent-status-badge.tsx
+++ b/packages/observability/dashboard-ui/src/components/agents/agent-status-badge.tsx
@@ -25,7 +25,7 @@ export function AgentStatusBadge({
 
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style.bg} ${style.text}`}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-xs font-medium uppercase tracking-wider ${style.bg} ${style.text}`}
     >
       {state}
     </span>

--- a/packages/observability/dashboard-ui/src/components/browser/breadcrumb.tsx
+++ b/packages/observability/dashboard-ui/src/components/browser/breadcrumb.tsx
@@ -32,7 +32,7 @@ export function Breadcrumb(): React.ReactElement {
   const segments = pathSegments(selectedPath);
 
   return (
-    <div className="flex items-center gap-0.5 overflow-x-auto px-3 py-2 text-xs">
+    <div className="flex items-center gap-0.5 overflow-x-auto px-3 py-2 font-mono text-xs">
       <button
         type="button"
         onClick={() => select(null)}

--- a/packages/observability/dashboard-ui/src/components/console/console-header.tsx
+++ b/packages/observability/dashboard-ui/src/components/console/console-header.tsx
@@ -52,7 +52,7 @@ export const ConsoleHeader = memo(function ConsoleHeader({
         <>
           <CircleDot className={`h-3 w-3 ${stateColor(agent.state, agentTerminated)}`} />
           <span className="text-sm font-medium">{agent.name}</span>
-          <span className="rounded bg-[var(--color-primary)]/10 px-2 py-0.5 text-xs text-[var(--color-primary)]">
+          <span className="rounded bg-[var(--color-primary)]/10 px-2 py-0.5 font-mono text-xs font-medium uppercase tracking-wider text-[var(--color-primary)]">
             {agentTerminated ? "terminated" : agent.state}
           </span>
           {agent.model !== undefined && (

--- a/packages/observability/dashboard-ui/src/components/layout/sidebar.tsx
+++ b/packages/observability/dashboard-ui/src/components/layout/sidebar.tsx
@@ -53,7 +53,7 @@ export function Sidebar(): React.ReactElement {
           {/* Panel */}
           <aside className="relative z-10 flex w-64 flex-col border-r border-[var(--color-border)] bg-[var(--color-card)] p-4">
             <div className="mb-4 flex items-center justify-between">
-              <span className="text-lg font-semibold tracking-tight">Koi</span>
+              <span className="text-lg font-bold tracking-tight" style={{ fontFamily: "var(--font-display)" }}>Koi</span>
               <button
                 type="button"
                 className="rounded p-1 text-[var(--color-muted)] hover:text-[var(--color-foreground)]"
@@ -79,10 +79,10 @@ function SidebarContent({
   return (
     <>
       {!collapsed && (
-        <div className="mb-6 text-lg font-semibold tracking-tight">Koi</div>
+        <div className="mb-6 text-lg font-bold tracking-tight" style={{ fontFamily: "var(--font-display)" }}>Koi</div>
       )}
       {collapsed && (
-        <div className="mb-6 text-lg font-semibold tracking-tight">K</div>
+        <div className="mb-6 text-lg font-bold tracking-tight" style={{ fontFamily: "var(--font-display)" }}>K</div>
       )}
       <SidebarNav collapsed={collapsed} />
     </>

--- a/packages/observability/dashboard-ui/src/components/orchestration/task-node-detail-panel.tsx
+++ b/packages/observability/dashboard-ui/src/components/orchestration/task-node-detail-panel.tsx
@@ -75,7 +75,7 @@ export function TaskNodeDetailPanel({
         {/* Result */}
         {node.result !== undefined && (
           <div className="mt-3">
-            <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-muted,#888)]">
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-[var(--color-muted,#888)]">
               Result
             </span>
             <pre className="mt-1 rounded bg-[var(--color-card,#1e1e2e)] p-2 text-[10px] text-[var(--color-foreground,#cdd6f4)] overflow-x-auto">

--- a/packages/observability/dashboard-ui/src/components/orchestration/workflow-detail-panel.tsx
+++ b/packages/observability/dashboard-ui/src/components/orchestration/workflow-detail-panel.tsx
@@ -263,7 +263,7 @@ export function WorkflowDetailPanel({
             {/* State Refs (when available) */}
             {detail.stateRefs !== undefined && (
               <div>
-                <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-muted,#888)]">
+                <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-[var(--color-muted,#888)]">
                   State
                 </span>
                 <div className="mt-1">

--- a/packages/observability/dashboard-ui/src/components/shared/data-table.tsx
+++ b/packages/observability/dashboard-ui/src/components/shared/data-table.tsx
@@ -96,7 +96,7 @@ export function DataTable({
             {columns.map((col) => (
               <th
                 key={col.key}
-                className={`px-3 py-2 text-left text-xs font-medium text-[var(--color-muted)] ${
+                className={`px-3 py-2 text-left font-mono text-xs font-medium uppercase tracking-wider text-[var(--color-muted)] ${
                   col.sortable === true ? "cursor-pointer select-none hover:text-[var(--color-foreground)]" : ""
                 }`}
                 onClick={col.sortable === true ? () => { handleSort(col.key); } : undefined}

--- a/packages/observability/dashboard-ui/src/components/shared/process-state-badge.tsx
+++ b/packages/observability/dashboard-ui/src/components/shared/process-state-badge.tsx
@@ -27,7 +27,7 @@ export function ProcessStateBadge({
   const config = STATE_CONFIG[state] ?? DEFAULT_CONFIG;
 
   return (
-    <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${config.text}`}>
+    <span className={`inline-flex items-center gap-1.5 font-mono text-xs font-medium uppercase tracking-wider ${config.text}`}>
       <span className={`inline-block h-2 w-2 rounded-full ${config.dot}`} />
       {state}
     </span>

--- a/packages/observability/dashboard-ui/src/components/shared/stat-card.tsx
+++ b/packages/observability/dashboard-ui/src/components/shared/stat-card.tsx
@@ -24,13 +24,13 @@ export function StatCard({ label, value, icon: Icon, trend }: StatCardProps): Re
   return (
     <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] p-4">
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[var(--color-muted)]">{label}</span>
+        <span className="font-mono text-xs uppercase tracking-wider text-[var(--color-muted)]">{label}</span>
         {Icon !== undefined && (
           <Icon className="h-4 w-4 text-[var(--color-muted)]" />
         )}
       </div>
       <div className="mt-2 flex items-baseline gap-2">
-        <span className="text-2xl font-semibold text-[var(--color-foreground)]">{value}</span>
+        <span className="text-2xl font-bold tracking-tight text-[var(--color-foreground)]" style={{ fontFamily: "var(--font-display)" }}>{value}</span>
         {trendConfig !== undefined && (
           <trendConfig.Icon className={`h-4 w-4 ${trendConfig.color}`} />
         )}

--- a/packages/observability/dashboard-ui/src/components/viewers/agent-directory-viewer.tsx
+++ b/packages/observability/dashboard-ui/src/components/viewers/agent-directory-viewer.tsx
@@ -110,7 +110,7 @@ export function AgentDirectoryViewer({
         {agent !== undefined && (
           <>
             <ProcessStateBadge state={agent.state} />
-            <span className="rounded bg-[var(--color-primary)]/10 px-2 py-0.5 text-xs text-[var(--color-primary)]">
+            <span className="rounded bg-[var(--color-primary)]/10 px-2 py-0.5 font-mono text-xs font-medium uppercase tracking-wider text-[var(--color-primary)]">
               {agent.agentType}
             </span>
           </>

--- a/packages/observability/dashboard-ui/src/index.css
+++ b/packages/observability/dashboard-ui/src/index.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+:root {
+  --font-display: 'Satoshi', -apple-system, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'Geist Mono', 'JetBrains Mono', 'Fira Code', monospace;
+}
+
 :root,
 [data-theme="dark"] {
   --color-background: #001122;
@@ -40,7 +46,13 @@ body {
   margin: 0;
   background-color: var(--color-background);
   color: var(--color-foreground);
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-    Arial, sans-serif;
+  font-family: var(--font-body);
+}
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+}
+
+.font-mono {
+  font-family: var(--font-mono);
 }


### PR DESCRIPTION
## Summary
- Load Satoshi display font from Fontshare CDN
- Define `--font-display`, `--font-body`, `--font-mono` CSS variables
- Apply display font (Satoshi) to h1-h3 headings and stat values
- Apply mono font (Geist Mono stack) to badges, labels, table headers, breadcrumbs, and detail panel section headers

Closes #1037

## Test plan
- [ ] Verify Satoshi font loads and renders on headings and stat values
- [ ] Verify mono font applies to badges, labels, table headers, and breadcrumbs
- [ ] Verify body text still uses system font stack