### PR TITLE
feat: wire cron scheduler into koi up

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1270,6 +1270,7 @@
         "@koi/tools-web": "workspace:*",
         "@koi/tui": "workspace:*",
         "@temporalio/client": "1.15.0",
+        "croner": "9.0.0",
       },
     },
     "packages/meta/context-arena": {

--- a/packages/meta/cli/package.json
+++ b/packages/meta/cli/package.json
@@ -103,6 +103,7 @@
     "@koi/tools-github": "workspace:*",
     "@koi/tools-web": "workspace:*",
     "@koi/tui": "workspace:*",
-    "@temporalio/client": "1.15.0"
+    "@temporalio/client": "1.15.0",
+    "croner": "9.0.0"
   }
 }

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -1228,6 +1228,33 @@ export async function runUp(flags: UpFlags): Promise<void> {
     output.info("Type a message or Ctrl+C to stop.\n");
   }
 
+  // 12c. Scheduler — activate cron schedule from manifest
+  let schedulerCron: { stop: () => void } | undefined;
+  const scheduleExpr = (manifest as unknown as Record<string, unknown>).schedule as
+    | string
+    | undefined;
+  if (scheduleExpr !== undefined && scheduleExpr.trim() !== "") {
+    try {
+      const { Cron } = await import("croner");
+      const cronJob = new Cron(scheduleExpr, async () => {
+        try {
+          for await (const event of runtime.run({ kind: "text", text: "scheduled run" })) {
+            if (event.kind === "text_delta" && !tuiAttached) {
+              process.stderr.write(event.delta);
+            }
+          }
+        } catch {
+          // Non-fatal — next cron tick will retry
+        }
+      });
+      schedulerCron = { stop: () => cronJob.stop() };
+      output.info(`Scheduler: ${scheduleExpr}`);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      output.warn(`scheduler failed: ${message}`);
+    }
+  }
+
   // 13. REPL + shutdown
   const controller = new AbortController();
   let shuttingDown = false;
@@ -1428,6 +1455,7 @@ export async function runUp(flags: UpFlags): Promise<void> {
   // Cleanup
   process.removeListener("SIGINT", shutdown);
   process.removeListener("SIGTERM", shutdown);
+  if (schedulerCron !== undefined) schedulerCron.stop();
   if (tuiApp !== undefined) await tuiApp.stop();
   for (const unsub of unsubscribers) unsub();
   for (const ch of channels) await ch.disconnect();


### PR DESCRIPTION
## Summary

When koi.yaml contains `schedule: "0 7 * * *"` (cron expression), koi up now creates a cron job that runs runtime.run() on each tick. Enables daily briefings (P1), stock monitoring (P7), health check-ins (P14).

Uses croner for lightweight cron parsing. Follows temporal startup pattern with cleanup on shutdown.

## Test result

- Added `schedule: "*/10 * * * * *"` to koi.yaml
- Agent auto-ran and responded: "I'm online and ready to assist. This is a scheduled check-in."
- Cleanup on shutdown verified

## Also includes

- fix: await async createGhExecutor in tool resolver (from #1055)

Generated with Claude Code