### PR TITLE
fix: resolve 6 runtime bugs found during 40-demo test sweep

### DIFF
--- a/packages/fs/nexus-store/src/ace.ts
+++ b/packages/fs/nexus-store/src/ace.ts
@@ -151,9 +151,20 @@ async function deleteJson(client: NexusClient, path: string): Promise<boolean> {
 }
 
 async function globPaths(client: NexusClient, pattern: string): Promise<readonly string[]> {
-  const r = await client.rpc<readonly string[]>("glob", { pattern });
+  const r = await client.rpc<unknown>("glob", { pattern });
   if (!r.ok) return [];
-  return r.value;
+  const v = r.value;
+  // Nexus glob returns { matches: string[] } — unwrap if needed
+  if (Array.isArray(v)) return v as readonly string[];
+  if (
+    v !== null &&
+    typeof v === "object" &&
+    "matches" in v &&
+    Array.isArray((v as { matches: unknown }).matches)
+  ) {
+    return (v as { matches: readonly string[] }).matches;
+  }
+  return [];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/fs/nexus-store/src/snapshots.ts
+++ b/packages/fs/nexus-store/src/snapshots.ts
@@ -88,12 +88,20 @@ export function createNexusSnapshotStore<T>(
       return r;
     }
     try {
-      return { ok: true, value: JSON.parse(r.value) as ChainMeta };
-    } catch (e: unknown) {
-      return {
-        ok: false,
-        error: wrapNexusError("INTERNAL", `Failed to parse chain meta for ${cid}`, e),
-      };
+      const parsed: unknown = typeof r.value === "string" ? JSON.parse(r.value) : r.value;
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        "nodeIds" in parsed &&
+        Array.isArray((parsed as ChainMeta).nodeIds)
+      ) {
+        return { ok: true, value: parsed as ChainMeta };
+      }
+      // Data doesn't match ChainMeta shape — treat as empty
+      return { ok: true, value: EMPTY_META };
+    } catch {
+      // Corrupted or incompatible meta — treat as empty to avoid blocking persistence
+      return { ok: true, value: EMPTY_META };
     }
   }
 

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -1038,7 +1038,7 @@ export async function runUp(flags: UpFlags): Promise<void> {
   }
 
   // 8b. Demo pack seed (before admin so seeded bricks are available for forge view)
-  const demoPack = await extractDemoPack(manifestPath);
+  const demoPack = (await extractDemoPack(manifestPath)) ?? preset.demoPack;
   let nexusClient: import("@koi/nexus-client").NexusClient | undefined;
   if (nexus.baseUrl !== undefined) {
     const { createNexusClient } = await import("@koi/nexus-client");
@@ -1319,6 +1319,7 @@ export async function runUp(flags: UpFlags): Promise<void> {
     try {
       const { Cron } = await import("croner");
       const cronJob = new Cron(scheduleExpr, async () => {
+        if (tuiProcessing || channelProcessing) return; // skip if agent is busy
         try {
           for await (const event of runtime.run({ kind: "text", text: "scheduled run" })) {
             if (event.kind === "text_delta" && !tuiAttached) {
@@ -1380,11 +1381,13 @@ export async function runUp(flags: UpFlags): Promise<void> {
         if (event.kind === "text_delta") deltas.push(event.delta);
         if (event.kind === "done") {
           if (event.output.stopReason === "error") {
+            const errMeta = event.output.metadata as Record<string, unknown> | undefined;
             const errMsg =
-              event.output.metadata !== undefined &&
-              typeof (event.output.metadata as Record<string, unknown>).errorMessage === "string"
-                ? ((event.output.metadata as Record<string, unknown>).errorMessage as string)
-                : "unknown error";
+              errMeta !== undefined && typeof errMeta.errorMessage === "string"
+                ? errMeta.errorMessage
+                : errMeta !== undefined && typeof errMeta.error === "string"
+                  ? errMeta.error
+                  : "unknown error";
             process.stderr.write(`error: model call failed: ${errMsg}\n`);
           }
           turnCount = event.output.metrics.turns;

--- a/packages/mm/session-repair/src/internal.ts
+++ b/packages/mm/session-repair/src/internal.ts
@@ -13,9 +13,10 @@ export function readStringMeta(
   return typeof value === "string" ? value : undefined;
 }
 
-/** Check if a message is eligible for merging (no callId, not pinned, not synthetic). */
+/** Check if a message is eligible for merging (no callId, not pinned, not synthetic, not tool). */
 export function isMergeable(msg: InboundMessage): boolean {
   if (readStringMeta(msg.metadata, "callId") !== undefined) return false;
+  if (msg.senderId === "tool") return false;
   if (msg.pinned === true) return false;
   if (msg.metadata?.synthetic === true) return false;
   return true;


### PR DESCRIPTION
## Summary

- **Parallel tool_use/tool_result mismatch**: session-repair was merging consecutive tool messages, breaking the 1:1 pairing between tool_use and tool_result blocks. Fixed by excluding `senderId === "tool"` from merge eligibility.
- **ACE onSessionEnd globPaths crash**: Nexus glob RPC returns `{ matches: string[] }` not a flat array. Fixed by unwrapping the `matches` field with graceful fallback.
- **Conversation persistence "Failed to parse chain meta"**: nexus-store readMeta crashed on non-ChainMeta-shaped data from Nexus. Fixed by validating shape before cast and falling back to EMPTY_META on corruption.
- **Demo pack not seeding from preset**: `extractDemoPack()` returned undefined when manifest had no explicit `demo.pack` field. Fixed by falling back to `preset.demoPack`.
- **Scheduler + manual input collision**: Cron callback could fire while user interaction was in progress. Fixed by checking `tuiProcessing`/`channelProcessing` guards.
- **Silent error swallowing**: Error metadata extraction only checked `errorMessage` key but pi adapter uses `error`. Fixed by checking both keys.

## Files changed

| File | Change |
|------|--------|
| `packages/mm/session-repair/src/internal.ts` | Exclude tool messages from merge eligibility |
| `packages/fs/nexus-store/src/ace.ts` | Unwrap Nexus glob `{ matches }` response |
| `packages/fs/nexus-store/src/snapshots.ts` | Validate ChainMeta shape, fallback to EMPTY_META |
| `packages/meta/cli/src/commands/up/index.ts` | Demo pack preset fallback, scheduler guard, error key fallback |

## Test plan

- [x] 17,029 unit tests pass (0 new failures)
- [x] E2E tested across all 3 presets (local, sqlite, demo)
- [x] Verified parallel tool calls no longer produce session corruption
- [x] Verified demo preset auto-seeds connected pack
- [x] Verified scheduler skips when agent is busy
- [x] Verified model errors now surface in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)