### PR TITLE
feat: autonomous push notification on completion (#1061)

### DIFF
--- a/packages/kernel/manifest/src/transform.ts
+++ b/packages/kernel/manifest/src/transform.ts
@@ -44,6 +44,7 @@ const EXTENSION_FIELDS = [
   "nexus",
   "codeSandbox",
   "dataSources",
+  "autonomous",
 ] as const;
 
 /**

--- a/packages/meta/autonomous/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/meta/autonomous/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,10 +1,10 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/autonomous API surface . has stable type surface 1`] = `
-"import { AgentManifest, EngineAdapter, KoiMiddleware, ComponentProvider, BrickId, BrickArtifact, Result, KoiError, AgentResolver, ThreadStore, CheckpointPolicy, InboxPolicy, ForgeStore } from '@koi/core';
+"import { AgentManifest, EngineAdapter, KoiMiddleware, ComponentProvider, BrickId, BrickArtifact, Result, KoiError, AgentResolver, ThreadStore, CheckpointPolicy, InboxPolicy, ForgeStore, AgentId, MailboxComponent } from '@koi/core';
 import { MiddlewareRegistry } from '@koi/starter';
 import { HarnessScheduler } from '@koi/harness-scheduler';
-import { LongRunningHarness } from '@koi/long-running';
+import { LongRunningHarness, OnCompletedCallback, OnFailedCallback } from '@koi/long-running';
 
 /**
  * Agent instantiation from forge brick artifacts.
@@ -170,6 +170,46 @@ interface AutonomousAgent {
 
 declare function createAutonomousAgent(parts: AutonomousAgentParts): AutonomousAgent;
 
-export { type AgentInstantiateConfig, type AgentInstantiateResult, type AutonomousAgent, type AutonomousAgentParts, type SpawnFitnessWrapperConfig, type SpawnHealthRecorder, createAgentFromBrick, createAutonomousAgent, createSpawnFitnessWrapper, embedBrickId };
+/**
+ * Completion notifier — creates harness lifecycle callbacks that send
+ * push notifications to the initiating copilot's inbox on plan
+ * completion or failure.
+ *
+ * Usage:
+ *   const notifier = createCompletionNotifier({ initiatorId, agentId, mailbox });
+ *   const harness = createLongRunningHarness({
+ *     ...config,
+ *     onCompleted: notifier.onCompleted,
+ *     onFailed: notifier.onFailed,
+ *   });
+ *
+ * Follows the "thin event" pattern (Stripe, A2A): the notification carries
+ * status + summary only. The copilot fetches full results via task_synthesize().
+ */
+
+interface CompletionNotifierConfig {
+    /** AgentId of the copilot to notify. */
+    readonly initiatorId: AgentId;
+    /** AgentId of the autonomous agent sending the notification. */
+    readonly agentId: AgentId;
+    /** Mailbox used to deliver the notification message. */
+    readonly mailbox: MailboxComponent;
+}
+interface CompletionNotifierCallbacks {
+    readonly onCompleted: OnCompletedCallback;
+    readonly onFailed: OnFailedCallback;
+}
+/**
+ * Create onCompleted/onFailed callbacks that send push notifications
+ * to the initiating copilot's inbox via the mailbox.
+ *
+ * Designed to be spread into a \`LongRunningConfig\`:
+ *
+ *   const { onCompleted, onFailed } = createCompletionNotifier(notifierConfig);
+ *   const harness = createLongRunningHarness({ ...config, onCompleted, onFailed });
+ */
+declare function createCompletionNotifier(config: CompletionNotifierConfig): CompletionNotifierCallbacks;
+
+export { type AgentInstantiateConfig, type AgentInstantiateResult, type AutonomousAgent, type AutonomousAgentParts, type CompletionNotifierCallbacks, type CompletionNotifierConfig, type SpawnFitnessWrapperConfig, type SpawnHealthRecorder, createAgentFromBrick, createAutonomousAgent, createCompletionNotifier, createSpawnFitnessWrapper, embedBrickId };
 "
 `;

--- a/packages/meta/autonomous/src/__tests__/lifecycle.integration.test.ts
+++ b/packages/meta/autonomous/src/__tests__/lifecycle.integration.test.ts
@@ -298,11 +298,12 @@ describe("AutonomousAgent lifecycle integration", () => {
     expect(mw[1]?.name).toBe("checkpoint-middleware");
     expect(mw[2]?.name).toBe("inbox-middleware");
 
-    // providers: plan_autonomous + autonomous
+    // providers: plan_autonomous + task-tools + autonomous
     const provs = agent.providers();
-    expect(provs).toHaveLength(2);
+    expect(provs).toHaveLength(3);
     expect(provs[0]?.name).toBe("plan-autonomous-provider");
-    expect(provs[1]?.name).toBe("autonomous-provider");
+    expect(provs[1]?.name).toBe("task-tools-provider");
+    expect(provs[2]?.name).toBe("autonomous-provider");
   });
 
   test("thread store + compactor yields 4 middleware in correct order", () => {

--- a/packages/meta/autonomous/src/autonomous.test.ts
+++ b/packages/meta/autonomous/src/autonomous.test.ts
@@ -142,14 +142,15 @@ describe("createAutonomousAgent", () => {
     expect(mw[2]?.name).toBe("collective-memory-mw");
   });
 
-  test("providers returns plan_autonomous provider by default", () => {
+  test("providers returns plan_autonomous and task-tools providers by default", () => {
     const harness = createMockHarness();
     const scheduler = createMockScheduler();
     const agent = createAutonomousAgent({ harness, scheduler });
 
     const provs = agent.providers();
-    expect(provs).toHaveLength(1);
+    expect(provs).toHaveLength(2);
     expect(provs[0]?.name).toBe("plan-autonomous-provider");
+    expect(provs[1]?.name).toBe("task-tools-provider");
   });
 
   test("middleware includes checkpoint + inbox when threadStore provided", () => {
@@ -184,9 +185,10 @@ describe("createAutonomousAgent", () => {
     const agent = createAutonomousAgent({ harness, scheduler, threadStore: fakeStore });
 
     const provs = agent.providers();
-    expect(provs).toHaveLength(2); // plan_autonomous + autonomous
+    expect(provs).toHaveLength(3); // plan_autonomous + task-tools + autonomous
     expect(provs[0]?.name).toBe("plan-autonomous-provider");
-    expect(provs[1]?.name).toBe("autonomous-provider");
+    expect(provs[1]?.name).toBe("task-tools-provider");
+    expect(provs[2]?.name).toBe("autonomous-provider");
   });
 
   test("dispose stops scheduler first, then harness", async () => {

--- a/packages/meta/autonomous/src/autonomous.ts
+++ b/packages/meta/autonomous/src/autonomous.ts
@@ -38,12 +38,14 @@ import { createCatalogAgentResolver } from "@koi/catalog";
 import type {
   Agent,
   AgentResolver,
+  AttachResult,
   ComponentProvider,
   HarnessThreadSnapshot,
   InboxComponent,
   InboxPolicy,
   KoiMiddleware,
   MailboxComponent,
+  TaskItemId,
   ThreadMetrics,
 } from "@koi/core";
 import { agentId, INBOX, MAILBOX, threadId } from "@koi/core";
@@ -53,6 +55,7 @@ import {
   createCheckpointMiddleware,
   createInboxMiddleware,
   createPlanAutonomousProvider,
+  createTaskTools,
 } from "@koi/long-running";
 import type { AutonomousAgent, AutonomousAgentParts } from "./types.js";
 
@@ -176,15 +179,68 @@ export function createAutonomousAgent(parts: AutonomousAgentParts): AutonomousAg
   const providerList: ComponentProvider[] = [];
 
   // Plan autonomous tool provider — always included for self-escalation.
-  // When the agent creates a plan, start the scheduler so the harness
-  // begins polling and auto-resuming sessions.
+  // When the agent creates a plan, start the harness with the task board
+  // then start the scheduler so it begins auto-resuming sessions.
   providerList.push(
     createPlanAutonomousProvider({
-      onPlanCreated: () => {
+      onPlanCreated: async (plan) => {
+        process.stderr.write(
+          `[autonomous] plan created — ${String(plan.items.length)} tasks, starting harness\n`,
+        );
+        const startResult = await parts.harness.start(plan);
+        if (!startResult.ok) {
+          process.stderr.write(`[autonomous] harness start failed: ${startResult.error.message}\n`);
+          return;
+        }
+        // Harness is now active. The copilot's current engine run continues —
+        // the agent can start working on tasks in this same session using
+        // task_complete. When the engine run ends, the CLI auto-pauses the
+        // harness (active → suspended), then the scheduler picks it up and
+        // resumes for subsequent sessions until all tasks are done.
+        process.stderr.write("[autonomous] harness active — scheduler starting\n");
         parts.scheduler.start();
       },
     }),
   );
+
+  // Task tools provider — registers task_complete, task_status, task_synthesize,
+  // task_update, task_review so the agent can manage autonomous plan execution.
+  providerList.push({
+    name: "task-tools-provider",
+    attach: async (_agent: Agent): Promise<AttachResult> => {
+      const allTools = createTaskTools({
+        getTaskBoard: () => parts.harness.status().taskBoard,
+        completeTask: async (tid: TaskItemId, output: string) => {
+          const result = await parts.harness.completeTask(tid, {
+            taskId: tid,
+            output,
+            durationMs: 0,
+          });
+          if (!result.ok) {
+            throw new Error(`completeTask failed: ${result.error.message}`);
+          }
+          const board = parts.harness.status().taskBoard;
+          const remaining = board.items.filter((i) => i.status !== "completed").length;
+          process.stderr.write(
+            `[autonomous] task_complete: ${tid} — ${String(remaining)} remaining\n`,
+          );
+        },
+        updateTask: async () => {
+          // Harness has no updateDescription method — no-op
+        },
+      });
+      // Only register task_complete and task_status — the essential two.
+      // task_update, task_review, task_synthesize can be added later if needed.
+      const tools = allTools.filter(
+        (t) => t.descriptor.name === "task_complete" || t.descriptor.name === "task_status",
+      );
+      const components = new Map<string, unknown>();
+      for (const tool of tools) {
+        components.set(`tool:${tool.descriptor.name}`, tool);
+      }
+      return { components, skipped: [] };
+    },
+  });
 
   // Autonomous provider with inbox — when thread support enabled.
   // The attach() callback captures the agent reference so inbox middleware

--- a/packages/meta/autonomous/src/completion-notifier.test.ts
+++ b/packages/meta/autonomous/src/completion-notifier.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the completion notifier — push notifications on plan completion/failure.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentMessage,
+  AgentMessageInput,
+  HarnessStatus,
+  KoiError,
+  MailboxComponent,
+  MessageId,
+} from "@koi/core";
+import { agentId, harnessId } from "@koi/core";
+import { createCompletionNotifier } from "./completion-notifier.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const INITIATOR_ID = agentId("copilot-001");
+const AGENT_ID = agentId("worker-001");
+
+function createMockMailbox(): MailboxComponent & {
+  readonly sentMessages: AgentMessageInput[];
+  setNextResult: (
+    result: { ok: true; value: AgentMessage } | { ok: false; error: KoiError },
+  ) => void;
+} {
+  const sentMessages: AgentMessageInput[] = [];
+  let nextResult:
+    | { readonly ok: true; readonly value: AgentMessage }
+    | { readonly ok: false; readonly error: KoiError } = {
+    ok: true,
+    value: {
+      id: "msg-1" as MessageId,
+      from: AGENT_ID,
+      to: INITIATOR_ID,
+      kind: "event",
+      type: "test",
+      payload: {},
+      createdAt: new Date().toISOString(),
+    },
+  };
+
+  return {
+    sentMessages,
+    setNextResult(result) {
+      nextResult = result;
+    },
+    send: async (message: AgentMessageInput) => {
+      sentMessages.push(message);
+      return nextResult;
+    },
+    onMessage: () => () => {},
+    list: async () => [],
+  };
+}
+
+function createTestStatus(overrides?: Partial<HarnessStatus>): HarnessStatus {
+  return {
+    harnessId: harnessId("test-harness"),
+    phase: "completed",
+    currentSessionSeq: 3,
+    taskBoard: { items: [], results: [] },
+    metrics: {
+      totalSessions: 3,
+      totalTurns: 15,
+      totalInputTokens: 5000,
+      totalOutputTokens: 2000,
+      completedTaskCount: 3,
+      pendingTaskCount: 0,
+      elapsedMs: 30_000,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createCompletionNotifier", () => {
+  describe("onCompleted", () => {
+    test("sends completion message to initiator via mailbox", async () => {
+      const mailbox = createMockMailbox();
+      const { onCompleted } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const status = createTestStatus();
+      await onCompleted(status);
+
+      expect(mailbox.sentMessages).toHaveLength(1);
+      const msg = mailbox.sentMessages[0];
+      expect(msg?.from).toBe(AGENT_ID);
+      expect(msg?.to).toBe(INITIATOR_ID);
+      expect(msg?.kind).toBe("event");
+      expect(msg?.type).toBe("autonomous.completed");
+    });
+
+    test("includes task counts and summary in payload", async () => {
+      const mailbox = createMockMailbox();
+      const { onCompleted } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const status = createTestStatus({
+        metrics: {
+          totalSessions: 2,
+          totalTurns: 10,
+          totalInputTokens: 3000,
+          totalOutputTokens: 1000,
+          completedTaskCount: 5,
+          pendingTaskCount: 0,
+          elapsedMs: 20_000,
+        },
+      });
+      await onCompleted(status);
+
+      const payload = mailbox.sentMessages[0]?.payload;
+      expect(payload?.completedTaskCount).toBe(5);
+      expect(payload?.totalTaskCount).toBe(5);
+      expect(payload?.summary).toContain("5/5");
+      expect(payload?.summary).toContain("completed");
+    });
+
+    test("uses steer mode for immediate attention", async () => {
+      const mailbox = createMockMailbox();
+      const { onCompleted } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      await onCompleted(createTestStatus());
+
+      const msg = mailbox.sentMessages[0];
+      expect(msg?.metadata?.mode).toBe("steer");
+    });
+
+    test("does not throw when mailbox send fails", async () => {
+      const mailbox = createMockMailbox();
+      mailbox.setNextResult({
+        ok: false,
+        error: { code: "INTERNAL", message: "Mailbox unavailable", retryable: false },
+      });
+
+      const { onCompleted } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      // Should not throw
+      await onCompleted(createTestStatus());
+      expect(mailbox.sentMessages).toHaveLength(1);
+    });
+  });
+
+  describe("onFailed", () => {
+    test("sends failure message to initiator via mailbox", async () => {
+      const mailbox = createMockMailbox();
+      const { onFailed } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const status = createTestStatus({ phase: "failed", failureReason: "Agent timed out" });
+      const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+      await onFailed(status, error);
+
+      expect(mailbox.sentMessages).toHaveLength(1);
+      const msg = mailbox.sentMessages[0];
+      expect(msg?.from).toBe(AGENT_ID);
+      expect(msg?.to).toBe(INITIATOR_ID);
+      expect(msg?.kind).toBe("event");
+      expect(msg?.type).toBe("autonomous.failed");
+    });
+
+    test("includes error details and task counts in payload", async () => {
+      const mailbox = createMockMailbox();
+      const { onFailed } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const status = createTestStatus({
+        phase: "failed",
+        metrics: {
+          totalSessions: 2,
+          totalTurns: 10,
+          totalInputTokens: 3000,
+          totalOutputTokens: 1000,
+          completedTaskCount: 2,
+          pendingTaskCount: 1,
+          elapsedMs: 15_000,
+        },
+      });
+      const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+      await onFailed(status, error);
+
+      const payload = mailbox.sentMessages[0]?.payload;
+      expect(payload?.errorCode).toBe("TIMEOUT");
+      expect(payload?.errorMessage).toBe("Agent timed out");
+      expect(payload?.completedTaskCount).toBe(2);
+      expect(payload?.totalTaskCount).toBe(3);
+      expect(payload?.summary).toContain("failed");
+      expect(payload?.summary).toContain("2/3");
+    });
+
+    test("uses steer mode for immediate attention", async () => {
+      const mailbox = createMockMailbox();
+      const { onFailed } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+      await onFailed(createTestStatus({ phase: "failed" }), error);
+
+      const msg = mailbox.sentMessages[0];
+      expect(msg?.metadata?.mode).toBe("steer");
+    });
+
+    test("does not throw when mailbox send fails", async () => {
+      const mailbox = createMockMailbox();
+      mailbox.setNextResult({
+        ok: false,
+        error: { code: "INTERNAL", message: "Mailbox unavailable", retryable: false },
+      });
+
+      const { onFailed } = createCompletionNotifier({
+        initiatorId: INITIATOR_ID,
+        agentId: AGENT_ID,
+        mailbox,
+      });
+
+      const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+      // Should not throw
+      await onFailed(createTestStatus({ phase: "failed" }), error);
+      expect(mailbox.sentMessages).toHaveLength(1);
+    });
+  });
+});

--- a/packages/meta/autonomous/src/completion-notifier.ts
+++ b/packages/meta/autonomous/src/completion-notifier.ts
@@ -1,0 +1,140 @@
+/**
+ * Completion notifier — creates harness lifecycle callbacks that send
+ * push notifications to the initiating copilot's inbox on plan
+ * completion or failure.
+ *
+ * Usage:
+ *   const notifier = createCompletionNotifier({ initiatorId, agentId, mailbox });
+ *   const harness = createLongRunningHarness({
+ *     ...config,
+ *     onCompleted: notifier.onCompleted,
+ *     onFailed: notifier.onFailed,
+ *   });
+ *
+ * Follows the "thin event" pattern (Stripe, A2A): the notification carries
+ * status + summary only. The copilot fetches full results via task_synthesize().
+ */
+
+import type {
+  AgentId,
+  AgentMessageInput,
+  HarnessStatus,
+  KoiError,
+  MailboxComponent,
+} from "@koi/core";
+import type { OnCompletedCallback, OnFailedCallback } from "@koi/long-running";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface CompletionNotifierConfig {
+  /** AgentId of the copilot to notify. */
+  readonly initiatorId: AgentId;
+  /** AgentId of the autonomous agent sending the notification. */
+  readonly agentId: AgentId;
+  /** Mailbox used to deliver the notification message. */
+  readonly mailbox: MailboxComponent;
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+export interface CompletionNotifierCallbacks {
+  readonly onCompleted: OnCompletedCallback;
+  readonly onFailed: OnFailedCallback;
+}
+
+// ---------------------------------------------------------------------------
+// Message builders
+// ---------------------------------------------------------------------------
+
+function buildCompletionMessage(
+  config: CompletionNotifierConfig,
+  status: HarnessStatus,
+): AgentMessageInput {
+  const { completedTaskCount, pendingTaskCount } = status.metrics;
+  const total = completedTaskCount + pendingTaskCount;
+  return {
+    from: config.agentId,
+    to: config.initiatorId,
+    kind: "event",
+    type: "autonomous.completed",
+    payload: {
+      harnessId: status.harnessId,
+      phase: status.phase,
+      completedTaskCount,
+      totalTaskCount: total,
+      summary: `Autonomous plan completed. ${String(completedTaskCount)}/${String(total)} tasks done.`,
+    },
+    metadata: { mode: "steer" },
+  };
+}
+
+function buildFailureMessage(
+  config: CompletionNotifierConfig,
+  status: HarnessStatus,
+  error: KoiError,
+): AgentMessageInput {
+  const { completedTaskCount, pendingTaskCount } = status.metrics;
+  const total = completedTaskCount + pendingTaskCount;
+  return {
+    from: config.agentId,
+    to: config.initiatorId,
+    kind: "event",
+    type: "autonomous.failed",
+    payload: {
+      harnessId: status.harnessId,
+      phase: status.phase,
+      completedTaskCount,
+      totalTaskCount: total,
+      errorCode: error.code,
+      errorMessage: error.message,
+      summary: `Autonomous plan failed: ${error.message}. ${String(completedTaskCount)}/${String(total)} tasks completed before failure.`,
+    },
+    metadata: { mode: "steer" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create onCompleted/onFailed callbacks that send push notifications
+ * to the initiating copilot's inbox via the mailbox.
+ *
+ * Designed to be spread into a `LongRunningConfig`:
+ *
+ *   const { onCompleted, onFailed } = createCompletionNotifier(notifierConfig);
+ *   const harness = createLongRunningHarness({ ...config, onCompleted, onFailed });
+ */
+export function createCompletionNotifier(
+  config: CompletionNotifierConfig,
+): CompletionNotifierCallbacks {
+  const onCompleted: OnCompletedCallback = async (status: HarnessStatus): Promise<void> => {
+    const message = buildCompletionMessage(config, status);
+    const result = await config.mailbox.send(message);
+    if (!result.ok) {
+      console.warn(
+        `[autonomous] Failed to send completion notification to ${config.initiatorId}: ${result.error.message}`,
+      );
+    }
+  };
+
+  const onFailed: OnFailedCallback = async (
+    status: HarnessStatus,
+    error: KoiError,
+  ): Promise<void> => {
+    const message = buildFailureMessage(config, status, error);
+    const result = await config.mailbox.send(message);
+    if (!result.ok) {
+      console.warn(
+        `[autonomous] Failed to send failure notification to ${config.initiatorId}: ${result.error.message}`,
+      );
+    }
+  };
+
+  return { onCompleted, onFailed };
+}

--- a/packages/meta/autonomous/src/index.ts
+++ b/packages/meta/autonomous/src/index.ts
@@ -7,6 +7,11 @@
 export type { AgentInstantiateConfig, AgentInstantiateResult } from "./agent-instantiate.js";
 export { createAgentFromBrick } from "./agent-instantiate.js";
 export { createAutonomousAgent } from "./autonomous.js";
+export type {
+  CompletionNotifierCallbacks,
+  CompletionNotifierConfig,
+} from "./completion-notifier.js";
+export { createCompletionNotifier } from "./completion-notifier.js";
 export type { SpawnFitnessWrapperConfig, SpawnHealthRecorder } from "./spawn-fitness-wrapper.js";
 export { createSpawnFitnessWrapper, embedBrickId } from "./spawn-fitness-wrapper.js";
 export type { AutonomousAgent, AutonomousAgentParts } from "./types.js";

--- a/packages/meta/cli/src/commands/up/index.ts
+++ b/packages/meta/cli/src/commands/up/index.ts
@@ -1025,6 +1025,50 @@ export async function runUp(flags: UpFlags): Promise<void> {
   output.spinner.stop(undefined);
   output.success("Runtime assembled");
 
+  // Bind autonomous session lifecycle — the runtime is only available after assembly.
+  if (autonomous !== undefined) {
+    // Bind push notifications via copilot's MAILBOX (if attached).
+    const { MAILBOX: MAILBOX_TOKEN } = await import("@koi/core");
+    const copilotMailbox = runtime.agent.component(MAILBOX_TOKEN) as
+      | import("@koi/core").MailboxComponent
+      | undefined;
+    if (copilotMailbox !== undefined) {
+      autonomous.bindNotification(runtime.agent.pid.id, copilotMailbox);
+    }
+
+    // Bind session runner — scheduler calls this after resume() to run engine sub-sessions.
+    autonomous.bindSessionRunner(async (resumeResult: unknown) => {
+      const { engineInput, sessionId } = resumeResult as {
+        engineInput: import("@koi/core").EngineInput;
+        sessionId: string;
+      };
+      process.stderr.write(`[autonomous] running sub-session ${sessionId}...\n`);
+
+      let lastMetrics: import("@koi/core").EngineMetrics | undefined;
+      for await (const event of runtime.run(engineInput)) {
+        if (event.kind === "done") {
+          lastMetrics = event.output.metrics;
+          if (event.output.stopReason === "error") {
+            const errMeta = event.output.metadata as Record<string, unknown> | undefined;
+            const errMsg =
+              errMeta !== undefined && typeof errMeta.errorMessage === "string"
+                ? errMeta.errorMessage
+                : "unknown error";
+            process.stderr.write(`[autonomous] sub-session error: ${errMsg}\n`);
+          }
+        }
+      }
+
+      // Pause harness → suspended so scheduler can resume for next session
+      if (lastMetrics !== undefined) {
+        process.stderr.write(
+          `[autonomous] sub-session done (${String(lastMetrics.turns)} turns) — pausing harness\n`,
+        );
+        await autonomous.pauseHarness({ sessionId, metrics: lastMetrics });
+      }
+    });
+  }
+
   // 8. Prepare channels (connected after TUI decision in step 12b)
   const channels: readonly ChannelAdapter[] = resolved.value.channels ?? [createCliChannel()];
 
@@ -1337,7 +1381,7 @@ export async function runUp(flags: UpFlags): Promise<void> {
     }
 
     stopAdmin = () => {
-      server!.stop(true);
+      server?.stop(true);
       dashboardResult.dispose();
     };
     adminReady = true;
@@ -1587,6 +1631,27 @@ export async function runUp(flags: UpFlags): Promise<void> {
             `warn: Nexus chat persist failed: ${e instanceof Error ? e.message : String(e)}\n`,
           );
         });
+      }
+
+      // Auto-pause harness after copilot run if plan_autonomous was called.
+      // Transitions active → suspended so the scheduler can resume sub-sessions.
+      if (autonomous !== undefined) {
+        const hs = autonomous.harness.status();
+        if (hs.phase === "active") {
+          process.stderr.write(
+            "[autonomous] copilot run finished — pausing harness for scheduler\n",
+          );
+          await autonomous.pauseHarness({
+            sessionId: `copilot-${String(hs.currentSessionSeq ?? 0)}`,
+            metrics: {
+              totalTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              turns: turnCount,
+              durationMs: 0,
+            },
+          });
+        }
       }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/packages/meta/cli/src/compose-middleware.test.ts
+++ b/packages/meta/cli/src/compose-middleware.test.ts
@@ -59,6 +59,9 @@ function createAutonomousResult(): AutonomousResult {
     providers: [mockProvider("autonomous-prov")],
     harness: {} as AutonomousResult["harness"],
     dispose: async () => {},
+    bindNotification: () => {},
+    pauseHarness: async () => ({ ok: true as const, value: undefined }),
+    bindSessionRunner: () => {},
   };
 }
 

--- a/packages/meta/cli/src/resolve-autonomous.ts
+++ b/packages/meta/cli/src/resolve-autonomous.ts
@@ -11,11 +11,18 @@
  */
 
 import type {
+  AgentId,
+  AgentMessageInput,
   ComponentProvider,
+  EngineMetrics,
   HarnessSnapshot,
+  HarnessStatus,
+  KoiError,
   KoiMiddleware,
+  MailboxComponent,
   PendingFrame,
   RecoveryPlan,
+  Result,
   SessionFilter,
   SessionPersistence,
   SessionRecord,
@@ -37,6 +44,27 @@ export interface AutonomousResult {
   readonly providers: readonly ComponentProvider[];
   /** Dispose autonomous agent (scheduler first, then harness). */
   readonly dispose: () => Promise<void>;
+  /**
+   * Bind the notification target after agent assembly. Once bound, the harness
+   * sends a push notification to the initiator's inbox on completion or failure.
+   * Call this after createForgeConfiguredKoi() when the mailbox is available.
+   */
+  readonly bindNotification: (initiatorId: AgentId, mailbox: MailboxComponent) => void;
+  /**
+   * Pause the harness after a session completes. Transitions active → suspended
+   * so the scheduler can resume the next session.
+   */
+  readonly pauseHarness: (sessionResult: {
+    readonly sessionId: string;
+    readonly metrics: EngineMetrics;
+    readonly summary?: string | undefined;
+  }) => Promise<Result<void, KoiError>>;
+  /**
+   * Bind a session runner callback. Called by the scheduler after resume()
+   * to run the engine sub-session. Deferred because the runtime is created
+   * after the scheduler.
+   */
+  readonly bindSessionRunner: (runner: (resumeResult: unknown) => Promise<void>) => void;
 }
 
 /** Autonomous resolution result bundled with contribution metadata. */
@@ -228,14 +256,95 @@ export async function resolveAutonomousOrWarn(
     const harnessStore = createInMemorySnapshotChainStore<HarnessSnapshot>();
     const sessionPersistence = createInMemorySessionPersistence();
 
+    // Deferred notification target — set after agent assembly via bindNotification().
+    // let justified: mutable refs populated post-assembly when mailbox is available.
+    let notifyMailbox: MailboxComponent | undefined;
+    let notifyInitiatorId: AgentId | undefined;
+
     const harness = createLongRunningHarness({
       harnessId: hId,
       agentId: aId,
       harnessStore,
       sessionPersistence,
+      onCompleted: async (status: HarnessStatus) => {
+        const { completedTaskCount, pendingTaskCount } = status.metrics;
+        const total = completedTaskCount + pendingTaskCount;
+        const summary = `Autonomous plan completed. ${String(completedTaskCount)}/${String(total)} tasks done.`;
+
+        if (notifyMailbox !== undefined && notifyInitiatorId !== undefined) {
+          const message: AgentMessageInput = {
+            from: aId,
+            to: notifyInitiatorId,
+            kind: "event",
+            type: "autonomous.completed",
+            payload: {
+              harnessId: status.harnessId,
+              phase: status.phase,
+              completedTaskCount,
+              totalTaskCount: total,
+              summary,
+            },
+            metadata: { mode: "steer" },
+          };
+          const result = await notifyMailbox.send(message);
+          if (!result.ok) {
+            process.stderr.write(
+              `[autonomous] Failed to send completion notification: ${result.error.message}\n`,
+            );
+          }
+        }
+        process.stderr.write(`[autonomous] ✓ ${summary}\n`);
+      },
+      onFailed: async (status: HarnessStatus, error: KoiError) => {
+        const { completedTaskCount, pendingTaskCount } = status.metrics;
+        const total = completedTaskCount + pendingTaskCount;
+        const summary = `Autonomous plan failed: ${error.message}. ${String(completedTaskCount)}/${String(total)} tasks completed.`;
+
+        if (notifyMailbox !== undefined && notifyInitiatorId !== undefined) {
+          const message: AgentMessageInput = {
+            from: aId,
+            to: notifyInitiatorId,
+            kind: "event",
+            type: "autonomous.failed",
+            payload: {
+              harnessId: status.harnessId,
+              phase: status.phase,
+              completedTaskCount,
+              totalTaskCount: total,
+              errorCode: error.code,
+              errorMessage: error.message,
+              summary,
+            },
+            metadata: { mode: "steer" },
+          };
+          const result = await notifyMailbox.send(message);
+          if (!result.ok) {
+            process.stderr.write(
+              `[autonomous] Failed to send failure notification: ${result.error.message}\n`,
+            );
+          }
+        }
+        process.stderr.write(`[autonomous] ✗ ${summary}\n`);
+      },
     });
 
-    const scheduler = createHarnessScheduler({ harness });
+    // Deferred session runner — set after runtime assembly via bindSessionRunner().
+    // let justified: mutable ref populated post-assembly when runtime is available.
+    let boundSessionRunner: ((resumeResult: unknown) => Promise<void>) | undefined;
+
+    const scheduler = createHarnessScheduler({
+      harness,
+      onResumed: async (resumeResult: unknown) => {
+        if (boundSessionRunner === undefined) {
+          process.stderr.write(
+            "[autonomous] warn: scheduler resumed but session runner not bound — skipping\n",
+          );
+          return;
+        }
+        process.stderr.write("[autonomous] scheduler driving sub-session...\n");
+        await boundSessionRunner(resumeResult);
+      },
+    });
 
     const agent = createAutonomousAgent({ harness, scheduler });
 
@@ -250,6 +359,14 @@ export async function resolveAutonomousOrWarn(
       dispose: async () => {
         await agent.dispose();
         sessionPersistence.close();
+      },
+      bindNotification: (initiatorId: AgentId, mailbox: MailboxComponent) => {
+        notifyInitiatorId = initiatorId;
+        notifyMailbox = mailbox;
+      },
+      pauseHarness: (sessionResult) => harness.pause(sessionResult),
+      bindSessionRunner: (runner) => {
+        boundSessionRunner = runner;
       },
     };
 

--- a/packages/sched/harness-scheduler/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/sched/harness-scheduler/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -35,6 +35,15 @@ interface HarnessSchedulerConfig {
     readonly signal?: AbortSignal | undefined;
     /** Injectable delay function for tests. Default: Bun.sleep. */
     readonly delay?: ((ms: number) => Promise<void>) | undefined;
+    /**
+     * Called after a successful resume(). Responsible for running the engine
+     * sub-session and pausing the harness when done. The scheduler awaits this
+     * callback before continuing the poll loop.
+     *
+     * When absent, the scheduler only calls resume() (legacy behavior —
+     * caller is responsible for driving sessions externally).
+     */
+    readonly onResumed?: ((resumeResult: unknown) => Promise<void>) | undefined;
 }
 type SchedulerPhase = "idle" | "running" | "stopped" | "failed";
 interface HarnessSchedulerStatus {

--- a/packages/sched/harness-scheduler/src/scheduler.ts
+++ b/packages/sched/harness-scheduler/src/scheduler.ts
@@ -44,6 +44,7 @@ export function createHarnessScheduler(config: HarnessSchedulerConfig): HarnessS
   const backoffCapMs = config.backoffCapMs ?? DEFAULT_BACKOFF_CAP_MS;
   const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
   const signal = config.signal;
+  const onResumed = config.onResumed;
   const delay =
     config.delay ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
@@ -93,6 +94,27 @@ export function createHarnessScheduler(config: HarnessSchedulerConfig): HarnessS
           retriesRemaining = maxRetries;
           lastError = undefined;
           prevBackoffMs = backoffBaseMs;
+
+          // Drive the engine sub-session if callback provided
+          if (onResumed !== undefined) {
+            try {
+              await onResumed(result.value);
+            } catch (e: unknown) {
+              retriesRemaining -= 1;
+              lastError = {
+                code: "INTERNAL",
+                message: `onResumed failed: ${e instanceof Error ? e.message : String(e)}`,
+                retryable: true,
+                cause: e instanceof Error ? e : undefined,
+              };
+              if (retriesRemaining <= 0) {
+                phase = "failed";
+                return;
+              }
+              prevBackoffMs = computeBackoff(prevBackoffMs, backoffBaseMs, backoffCapMs);
+              await delay(prevBackoffMs);
+            }
+          }
         } else {
           retriesRemaining -= 1;
           lastError = result.error;

--- a/packages/sched/harness-scheduler/src/types.ts
+++ b/packages/sched/harness-scheduler/src/types.ts
@@ -39,6 +39,15 @@ export interface HarnessSchedulerConfig {
   readonly signal?: AbortSignal | undefined;
   /** Injectable delay function for tests. Default: Bun.sleep. */
   readonly delay?: ((ms: number) => Promise<void>) | undefined;
+  /**
+   * Called after a successful resume(). Responsible for running the engine
+   * sub-session and pausing the harness when done. The scheduler awaits this
+   * callback before continuing the poll loop.
+   *
+   * When absent, the scheduler only calls resume() (legacy behavior —
+   * caller is responsible for driving sessions externally).
+   */
+  readonly onResumed?: ((resumeResult: unknown) => Promise<void>) | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sched/long-running/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/sched/long-running/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`@koi/long-running API surface . has stable type surface 1`] = `
-"import { InboxPolicy, InboxComponent, ComponentProvider, CheckpointPolicy, KoiMiddleware, HarnessId, TaskBoardSnapshot, HarnessSnapshot, Result, InboundMessage, KoiError, PruningPolicy, AgentId, HarnessSnapshotStore, SessionPersistence, EngineState, AgentRegistry, EngineInput, EngineMetrics, TaskItemId, TaskResult, HarnessStatus, ProcessState, TransitionReason, HarnessPhase, MailboxComponent, Tool, ThreadPruningPolicy, ChainCompactor, ThreadSnapshot } from '@koi/core';
+"import { InboxPolicy, InboxComponent, ComponentProvider, CheckpointPolicy, KoiMiddleware, HarnessId, TaskBoardSnapshot, HarnessSnapshot, Result, InboundMessage, KoiError, PruningPolicy, AgentId, HarnessSnapshotStore, SessionPersistence, EngineState, AgentRegistry, HarnessStatus, EngineInput, EngineMetrics, TaskItemId, TaskResult, ProcessState, TransitionReason, HarnessPhase, MailboxComponent, Tool, ThreadPruningPolicy, ChainCompactor, ThreadSnapshot } from '@koi/core';
 
 /**
  * Autonomous provider — attaches InboxComponent to agents (Decision 4C).
@@ -108,6 +108,18 @@ declare function buildResumeContext(snapshot: HarnessSnapshot, config: {
  * These types are internal to the package — L0 types live in @koi/core/harness.
  */
 
+/**
+ * Called when the harness transitions to "completed" (all tasks done).
+ * Receives the final HarnessStatus snapshot. Errors are caught and logged
+ * — they never prevent the completion from succeeding.
+ */
+type OnCompletedCallback = (status: HarnessStatus) => void | Promise<void>;
+/**
+ * Called when the harness transitions to "failed".
+ * Receives the final HarnessStatus snapshot and the triggering error.
+ * Errors are caught and logged — they never prevent the failure from recording.
+ */
+type OnFailedCallback = (status: HarnessStatus, error: KoiError) => void | Promise<void>;
 /** Optional callback to capture real engine state during soft checkpoints. */
 type SaveStateCallback = () => EngineState | Promise<EngineState>;
 interface LongRunningConfig {
@@ -123,6 +135,10 @@ interface LongRunningConfig {
     readonly saveState?: SaveStateCallback | undefined;
     /** Optional agent registry for CAS-based lifecycle transitions. */
     readonly registry?: AgentRegistry | undefined;
+    /** Called when the harness transitions to "completed". Best-effort — errors are logged, not propagated. */
+    readonly onCompleted?: OnCompletedCallback | undefined;
+    /** Called when the harness transitions to "failed". Best-effort — errors are logged, not propagated. */
+    readonly onFailed?: OnFailedCallback | undefined;
 }
 interface LongRunningHarness {
     readonly harnessId: HarnessId;
@@ -278,6 +294,6 @@ declare function createTaskTools(config: TaskToolsConfig): readonly Tool[];
  */
 declare function createThreadCompactor(policy?: ThreadPruningPolicy): ChainCompactor<ThreadSnapshot>;
 
-export { type AutonomousProviderConfig, type CheckpointMiddlewareConfig, DEFAULT_LONG_RUNNING_CONFIG, type InboxMiddlewareConfig, type LongRunningConfig, type LongRunningHarness, type PlanAutonomousConfig, type ResumeResult, type SaveStateCallback, type SessionResult, type StartResult, type TaskToolsConfig, buildInitialPrompt, buildResumeContext, computeCheckpointId, createAutonomousProvider, createCheckpointMiddleware, createInboxMiddleware, createLongRunningHarness, createPlanAutonomousProvider, createTaskTools, createThreadCompactor, mapProcessStateToHarnessPhase, shouldSoftCheckpoint };
+export { type AutonomousProviderConfig, type CheckpointMiddlewareConfig, DEFAULT_LONG_RUNNING_CONFIG, type InboxMiddlewareConfig, type LongRunningConfig, type LongRunningHarness, type OnCompletedCallback, type OnFailedCallback, type PlanAutonomousConfig, type ResumeResult, type SaveStateCallback, type SessionResult, type StartResult, type TaskToolsConfig, buildInitialPrompt, buildResumeContext, computeCheckpointId, createAutonomousProvider, createCheckpointMiddleware, createInboxMiddleware, createLongRunningHarness, createPlanAutonomousProvider, createTaskTools, createThreadCompactor, mapProcessStateToHarnessPhase, shouldSoftCheckpoint };
 "
 `;

--- a/packages/sched/long-running/src/harness.test.ts
+++ b/packages/sched/long-running/src/harness.test.ts
@@ -688,6 +688,124 @@ describe("createMiddleware", () => {
 });
 
 // ---------------------------------------------------------------------------
+// onCompleted / onFailed callbacks
+// ---------------------------------------------------------------------------
+
+describe("onCompleted callback", () => {
+  test("fires with HarnessStatus when all tasks complete", async () => {
+    let receivedStatus: import("@koi/core").HarnessStatus | undefined;
+    const testHarness = createTestHarness({
+      onCompleted: (status) => {
+        receivedStatus = status;
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    await testHarness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await testHarness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    expect(receivedStatus).toBeUndefined(); // not yet — 1 task remains
+
+    await testHarness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    expect(receivedStatus).toBeDefined();
+    expect(receivedStatus?.phase).toBe("completed");
+    expect(receivedStatus?.metrics.completedTaskCount).toBe(3);
+  });
+
+  test("does not fire when tasks remain", async () => {
+    let called = false;
+    const testHarness = createTestHarness({
+      onCompleted: () => {
+        called = true;
+      },
+    });
+    await testHarness.start(createTestPlan());
+    await testHarness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    expect(called).toBe(false);
+  });
+
+  test("callback error does not prevent completion", async () => {
+    const testHarness = createTestHarness({
+      onCompleted: () => {
+        throw new Error("callback boom");
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    await testHarness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await testHarness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    const result = await testHarness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    assertOk(result);
+    expect(testHarness.status().phase).toBe("completed");
+  });
+
+  test("async callback error does not prevent completion", async () => {
+    const testHarness = createTestHarness({
+      onCompleted: async () => {
+        throw new Error("async callback boom");
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    await testHarness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await testHarness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    const result = await testHarness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    assertOk(result);
+    expect(testHarness.status().phase).toBe("completed");
+  });
+});
+
+describe("onFailed callback", () => {
+  test("fires with HarnessStatus and KoiError on failure", async () => {
+    let receivedStatus: import("@koi/core").HarnessStatus | undefined;
+    let receivedError: KoiError | undefined;
+    const testHarness = createTestHarness({
+      onFailed: (status, error) => {
+        receivedStatus = status;
+        receivedError = error;
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    const error: KoiError = { code: "TIMEOUT", message: "Agent timed out", retryable: false };
+    await testHarness.fail(error);
+
+    expect(receivedStatus).toBeDefined();
+    expect(receivedStatus?.phase).toBe("failed");
+    expect(receivedStatus?.failureReason).toBe("Agent timed out");
+    expect(receivedError).toBe(error);
+  });
+
+  test("callback error does not prevent failure recording", async () => {
+    const testHarness = createTestHarness({
+      onFailed: () => {
+        throw new Error("callback boom");
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    const error: KoiError = { code: "TIMEOUT", message: "Timed out", retryable: false };
+    const result = await testHarness.fail(error);
+    assertOk(result);
+    expect(testHarness.status().phase).toBe("failed");
+  });
+
+  test("does not fire on completion", async () => {
+    let called = false;
+    const testHarness = createTestHarness({
+      onFailed: () => {
+        called = true;
+      },
+    });
+    await testHarness.start(createTestPlan());
+
+    await testHarness.completeTask(taskItemId("task-1"), createTaskResult("task-1"));
+    await testHarness.completeTask(taskItemId("task-2"), createTaskResult("task-2"));
+    await testHarness.completeTask(taskItemId("task-3"), createTaskResult("task-3"));
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // dispose()
 // ---------------------------------------------------------------------------
 

--- a/packages/sched/long-running/src/harness.ts
+++ b/packages/sched/long-running/src/harness.ts
@@ -41,6 +41,8 @@ import { buildInitialPrompt, buildResumeContext } from "./context-bridge.js";
 import type {
   LongRunningConfig,
   LongRunningHarness,
+  OnCompletedCallback,
+  OnFailedCallback,
   ResumeResult,
   SaveStateCallback,
   SessionResult,
@@ -143,6 +145,8 @@ export function createLongRunningHarness(config: LongRunningConfig): LongRunning
   const artifactToolNames = config.artifactToolNames ?? [];
   const pruningPolicy = config.pruningPolicy ?? DEFAULT_LONG_RUNNING_CONFIG.pruningPolicy;
   const saveState: SaveStateCallback | undefined = config.saveState;
+  const onCompleted: OnCompletedCallback | undefined = config.onCompleted;
+  const onFailed: OnFailedCallback | undefined = config.onFailed;
 
   const cid = chainId(harnessId);
 
@@ -575,6 +579,17 @@ export function createLongRunningHarness(config: LongRunningConfig): LongRunning
       const transResult = await registryTransition("terminated", { kind: "completed" });
       if (!transResult.ok) return transResult;
       phase = "completed";
+
+      // Fire completion callback — best-effort, errors logged but never propagated
+      if (onCompleted !== undefined) {
+        try {
+          await onCompleted(status());
+        } catch (e: unknown) {
+          console.warn(
+            `[long-running] onCompleted callback failed for harness ${harnessId}: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      }
     }
 
     return { ok: true, value: undefined };
@@ -615,6 +630,18 @@ export function createLongRunningHarness(config: LongRunningConfig): LongRunning
     });
     if (!transResult.ok) return transResult;
     phase = "failed";
+
+    // Fire failure callback — best-effort, errors logged but never propagated
+    if (onFailed !== undefined) {
+      try {
+        await onFailed(status(), error);
+      } catch (e: unknown) {
+        console.warn(
+          `[long-running] onFailed callback failed for harness ${harnessId}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+
     return { ok: true, value: undefined };
   };
 

--- a/packages/sched/long-running/src/index.ts
+++ b/packages/sched/long-running/src/index.ts
@@ -23,6 +23,8 @@ export { createThreadCompactor } from "./thread-compactor.js";
 export type {
   LongRunningConfig,
   LongRunningHarness,
+  OnCompletedCallback,
+  OnFailedCallback,
   ResumeResult,
   SaveStateCallback,
   SessionResult,

--- a/packages/sched/long-running/src/plan-autonomous-tool.test.ts
+++ b/packages/sched/long-running/src/plan-autonomous-tool.test.ts
@@ -66,7 +66,7 @@ describe("createPlanAutonomousProvider", () => {
 
     expect(capturedPlan).toBeDefined();
     expect(capturedPlan?.items).toHaveLength(2);
-    expect(capturedPlan?.items[0]?.status).toBe("pending");
+    expect(capturedPlan?.items[0]?.status).toBe("assigned");
     expect(capturedPlan?.items[1]?.dependencies).toEqual([taskItemId("t1")]);
     expect(output).toEqual({
       status: "plan_created",

--- a/packages/sched/long-running/src/plan-autonomous-tool.ts
+++ b/packages/sched/long-running/src/plan-autonomous-tool.ts
@@ -242,7 +242,9 @@ export function createPlanAutonomousProvider(config: PlanAutonomousConfig): Comp
             priority: 0,
             maxRetries: 3,
             retries: 0,
-            status: "pending",
+            // "assigned" — in self-escalation mode the copilot IS the worker,
+            // so tasks are immediately assignable. completeTask() requires "assigned".
+            status: "assigned",
           })),
           results: [],
         };

--- a/packages/sched/long-running/src/types.ts
+++ b/packages/sched/long-running/src/types.ts
@@ -24,6 +24,24 @@ import type {
 } from "@koi/core";
 
 // ---------------------------------------------------------------------------
+// Lifecycle callbacks
+// ---------------------------------------------------------------------------
+
+/**
+ * Called when the harness transitions to "completed" (all tasks done).
+ * Receives the final HarnessStatus snapshot. Errors are caught and logged
+ * — they never prevent the completion from succeeding.
+ */
+export type OnCompletedCallback = (status: HarnessStatus) => void | Promise<void>;
+
+/**
+ * Called when the harness transitions to "failed".
+ * Receives the final HarnessStatus snapshot and the triggering error.
+ * Errors are caught and logged — they never prevent the failure from recording.
+ */
+export type OnFailedCallback = (status: HarnessStatus, error: KoiError) => void | Promise<void>;
+
+// ---------------------------------------------------------------------------
 // Save-state callback for soft checkpoints
 // ---------------------------------------------------------------------------
 
@@ -47,6 +65,10 @@ export interface LongRunningConfig {
   readonly saveState?: SaveStateCallback | undefined;
   /** Optional agent registry for CAS-based lifecycle transitions. */
   readonly registry?: AgentRegistry | undefined;
+  /** Called when the harness transitions to "completed". Best-effort — errors are logged, not propagated. */
+  readonly onCompleted?: OnCompletedCallback | undefined;
+  /** Called when the harness transitions to "failed". Best-effort — errors are logged, not propagated. */
+  readonly onFailed?: OnFailedCallback | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/e2e-autonomous-copilot-flow.ts
+++ b/scripts/e2e-autonomous-copilot-flow.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env bun
+
+/**
+ * E2E: Copilot autonomous flow — same agent, multi-session, self-delegation.
+ *
+ * Real flow:
+ *   Session 1: User asks copilot → copilot calls plan_autonomous → agent works
+ *              tasks via task_complete in the SAME session → engine run ends →
+ *              harness auto-pauses (active → suspended)
+ *   Session 2: User asks unrelated question → copilot answers (not blocked)
+ *   If tasks remain: Scheduler resumes → onResumed drives next engine run →
+ *              agent continues → auto-pause → repeat
+ *   All done: onCompleted fires → copilot notified
+ *
+ * Uses real LLM (OpenRouter).
+ */
+
+import { createPiAdapter } from "../packages/drivers/engine-pi/src/adapter.js";
+import type {
+  EngineInput,
+  EngineOutput,
+  HarnessSnapshot,
+  HarnessStatus,
+  KoiError,
+} from "../packages/kernel/core/src/index.js";
+import { agentId, harnessId } from "../packages/kernel/core/src/index.js";
+import { createKoi } from "../packages/kernel/engine/src/koi.js";
+import { createAutonomousAgent } from "../packages/meta/autonomous/src/autonomous.js";
+import { createInMemorySnapshotChainStore } from "../packages/mm/snapshot-chain-store/src/memory-store.js";
+import { createHarnessScheduler } from "../packages/sched/harness-scheduler/src/scheduler.js";
+import { createLongRunningHarness } from "../packages/sched/long-running/src/harness.js";
+
+// ---------------------------------------------------------------------------
+// Preflight
+// ---------------------------------------------------------------------------
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+if (!API_KEY) {
+  console.error("OPENROUTER_API_KEY not set");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Test infra
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+function assert(name: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    passed++;
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+function step(msg: string): void {
+  console.log(`\n\x1b[36m══ ${msg} ══\x1b[0m`);
+}
+
+// ---------------------------------------------------------------------------
+// Minimal persistence
+// ---------------------------------------------------------------------------
+function createMinimalPersistence() {
+  const s = new Map<string, unknown>();
+  return {
+    saveSession: (r: { sessionId: string }) => {
+      s.set(r.sessionId, r);
+      return { ok: true as const, value: undefined };
+    },
+    loadSession: (sid: string) => {
+      const r = s.get(sid);
+      return r
+        ? { ok: true as const, value: r }
+        : {
+            ok: false as const,
+            error: { code: "NOT_FOUND" as const, message: "nf", retryable: false },
+          };
+    },
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tracking
+// ---------------------------------------------------------------------------
+let completedFired = false;
+let _completedStatus: HarnessStatus | undefined;
+let schedulerResumeCount = 0;
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+console.log("[e2e] Copilot autonomous — self-delegation, scheduler-driven sessions\n");
+step("Setup");
+
+const store = createInMemorySnapshotChainStore<HarnessSnapshot>();
+const harness = createLongRunningHarness({
+  harnessId: harnessId("copilot-harness"),
+  agentId: agentId("copilot"),
+  harnessStore: store,
+  sessionPersistence: createMinimalPersistence() as never,
+  onCompleted: (status: HarnessStatus) => {
+    completedFired = true;
+    _completedStatus = status;
+    console.log(
+      `\n  [onCompleted] ✓ phase=${status.phase} completed=${status.metrics.completedTaskCount}`,
+    );
+  },
+  onFailed: (_: HarnessStatus, err: KoiError) => {
+    console.log(`\n  [onFailed] ✗ ${err.message}`);
+  },
+});
+
+// Helper: run engine and auto-pause harness when done
+async function runSessionAndPause(
+  engine: {
+    run: (input: EngineInput) => AsyncIterable<{
+      kind: string;
+      delta?: string;
+      output?: EngineOutput;
+      [k: string]: unknown;
+    }>;
+  },
+  input: EngineInput,
+  label: string,
+): Promise<EngineOutput | undefined> {
+  let output: EngineOutput | undefined;
+  const deltas: string[] = [];
+  for await (const event of engine.run(input) as AsyncIterable<Record<string, unknown>>) {
+    if (event.kind === "text_delta" && typeof event.delta === "string") {
+      deltas.push(event.delta);
+      process.stdout.write(event.delta);
+    }
+    if (event.kind === "done") output = event.output as EngineOutput;
+  }
+  if (deltas.length > 0) console.log("");
+
+  // Auto-pause: if harness is active after engine run, pause it
+  const phase = harness.status().phase;
+  if (phase === "active" && output !== undefined) {
+    await harness.pause({ sessionId: label, metrics: output.metrics });
+    console.log(`  [${label}] harness paused → ${harness.status().phase}`);
+  }
+  return output;
+}
+
+// Scheduler with onResumed that drives resumed sessions
+const scheduler = createHarnessScheduler({
+  harness,
+  pollIntervalMs: 2000,
+  maxRetries: 5,
+  delay: (ms: number) => new Promise<void>((r) => setTimeout(r, Math.min(ms, 1000))),
+  onResumed: async (resumeResult: unknown) => {
+    schedulerResumeCount++;
+    const rr = resumeResult as { engineInput: EngineInput; sessionId: string };
+    console.log(`\n  [scheduler] resume #${schedulerResumeCount} — session ${rr.sessionId}`);
+    await runSessionAndPause(engine, rr.engineInput, `scheduler-${schedulerResumeCount}`);
+  },
+});
+
+const agent = createAutonomousAgent({ harness, scheduler });
+
+const adapter = createPiAdapter({ model: "openrouter:anthropic/claude-sonnet-4" });
+const engine = await createKoi({
+  manifest: {
+    name: "copilot",
+    version: "0.0.1",
+    model: { name: "openrouter:anthropic/claude-sonnet-4" },
+  },
+  adapter,
+  middleware: [...agent.middleware()],
+  providers: [...agent.providers()],
+  limits: { maxTurns: 10, maxDurationMs: 120_000, maxTokens: 50_000 },
+});
+
+console.log(
+  `  providers: ${agent
+    .providers()
+    .map((p) => p.name)
+    .join(", ")}`,
+);
+
+// ---------------------------------------------------------------------------
+// Session 1: User asks copilot to plan + execute tasks
+// ---------------------------------------------------------------------------
+
+step("Session 1: User asks copilot to plan work");
+
+const s1 = await runSessionAndPause(
+  engine as never,
+  {
+    kind: "text",
+    text: "Use plan_autonomous to create 2 tasks: (1) write a haiku about the ocean, (2) write a haiku about mountains. Then complete each task using task_complete with the haiku as output.",
+  } as EngineInput,
+  "copilot-s1",
+);
+
+assert("session 1 completed", s1?.stopReason !== "error", `stopReason=${s1?.stopReason}`);
+assert("harness activated", harness.status().phase !== "idle", `phase=${harness.status().phase}`);
+
+// ---------------------------------------------------------------------------
+// Session 2: User asks unrelated question (not blocked)
+// ---------------------------------------------------------------------------
+
+step("Session 2: Copilot answers unrelated question");
+
+// Reset engine for a fresh conversational turn
+const s2 = await runSessionAndPause(
+  engine as never,
+  {
+    kind: "text",
+    text: "What is the capital of Japan?",
+  } as EngineInput,
+  "copilot-s2",
+);
+
+assert(
+  "session 2 completed (not blocked)",
+  s2?.stopReason !== "error",
+  `stopReason=${s2?.stopReason}`,
+);
+
+// ---------------------------------------------------------------------------
+// Wait for background completion
+// ---------------------------------------------------------------------------
+
+step("Waiting for tasks to complete...");
+
+const deadline = Date.now() + 60_000;
+while (
+  harness.status().phase !== "completed" &&
+  harness.status().phase !== "failed" &&
+  Date.now() < deadline
+) {
+  await new Promise((r) => setTimeout(r, 1000));
+  const h = harness.status();
+  process.stdout.write(
+    `\r  phase=${h.phase} done=${h.metrics.completedTaskCount}/${h.taskBoard.items.length}  `,
+  );
+}
+console.log("");
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+step("Verify");
+
+const final = harness.status();
+assert("harness completed", final.phase === "completed", `phase=${final.phase}`);
+assert(
+  "2 tasks done",
+  final.metrics.completedTaskCount === 2,
+  `done=${final.metrics.completedTaskCount}`,
+);
+assert("onCompleted fired", completedFired);
+assert("copilot was not blocked (session 2 worked)", s2?.stopReason !== "error");
+
+// Cleanup
+await engine.dispose();
+await scheduler.dispose();
+await harness.dispose();
+
+console.log(`\n${"=".repeat(60)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${"=".repeat(60)}`);
+if (failed > 0) process.exit(1);

--- a/scripts/e2e-autonomous-notification.ts
+++ b/scripts/e2e-autonomous-notification.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env bun
+
+/**
+ * E2E: Autonomous completion notification flow.
+ *
+ * Tests the full lifecycle WITHOUT an LLM — uses manual task completion
+ * to validate the harness→scheduler→pause→resume→complete→notify flow.
+ *
+ * Flow:
+ *   1. Create harness with onCompleted/onFailed callbacks
+ *   2. Start harness with task plan (3 tasks)
+ *   3. Pause harness (simulates copilot run ending)
+ *   4. Scheduler resumes via onResumed callback
+ *   5. onResumed callback completes tasks and pauses
+ *   6. Scheduler resumes again, completes remaining tasks
+ *   7. onCompleted callback fires → notification logged
+ *
+ * Usage:
+ *   bun scripts/e2e-autonomous-notification.ts
+ */
+
+import type {
+  HarnessSnapshot,
+  HarnessStatus,
+  KoiError,
+} from "../packages/kernel/core/src/index.js";
+import { agentId, harnessId, taskItemId } from "../packages/kernel/core/src/index.js";
+import { createInMemorySnapshotChainStore } from "../packages/mm/snapshot-chain-store/src/memory-store.js";
+import { createHarnessScheduler } from "../packages/sched/harness-scheduler/src/scheduler.js";
+import { createLongRunningHarness } from "../packages/sched/long-running/src/harness.js";
+import type { LongRunningHarness } from "../packages/sched/long-running/src/types.js";
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+
+function assert(name: string, condition: boolean, detail?: string): void {
+  if (condition) {
+    passed++;
+    console.log(`  \x1b[32mPASS\x1b[0m  ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31mFAIL\x1b[0m  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function step(msg: string): void {
+  console.log(`\n\x1b[36m[step]\x1b[0m ${msg}`);
+}
+
+// ---------------------------------------------------------------------------
+// In-memory session persistence (minimal)
+// ---------------------------------------------------------------------------
+
+function createMinimalPersistence() {
+  const sessions = new Map<string, unknown>();
+  return {
+    saveSession: (record: { sessionId: string }) => {
+      sessions.set(record.sessionId, record);
+      return { ok: true as const, value: undefined };
+    },
+    loadSession: (sid: string) => {
+      const record = sessions.get(sid);
+      if (record === undefined) {
+        return {
+          ok: false as const,
+          error: { code: "NOT_FOUND" as const, message: "Not found", retryable: false },
+        };
+      }
+      return { ok: true as const, value: record };
+    },
+    removeSession: () => ({ ok: true as const, value: undefined }),
+    listSessions: () => ({ ok: true as const, value: [] }),
+    savePendingFrame: () => ({ ok: true as const, value: undefined }),
+    loadPendingFrames: () => ({ ok: true as const, value: [] }),
+    clearPendingFrames: () => ({ ok: true as const, value: undefined }),
+    removePendingFrame: () => ({ ok: true as const, value: undefined }),
+    recover: () => ({
+      ok: true as const,
+      value: { sessions: [], pendingFrames: new Map(), skipped: [] },
+    }),
+    close: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main test
+// ---------------------------------------------------------------------------
+
+console.log("[e2e] Autonomous completion notification flow\n");
+
+// Track callback invocations
+let completedCallbackFired = false;
+let completedStatus: HarnessStatus | undefined;
+let failedCallbackFired = false;
+let resumeCount = 0;
+
+const hId = harnessId("e2e-notify-harness");
+const aId = agentId("e2e-notify-agent");
+const harnessStore = createInMemorySnapshotChainStore<HarnessSnapshot>();
+const persistence = createMinimalPersistence();
+
+// Step 1: Create harness with callbacks
+step("1. Create harness with onCompleted/onFailed callbacks");
+
+const harness: LongRunningHarness = createLongRunningHarness({
+  harnessId: hId,
+  agentId: aId,
+  harnessStore,
+  sessionPersistence: persistence as never, // structural compatibility
+  onCompleted: (status: HarnessStatus) => {
+    completedCallbackFired = true;
+    completedStatus = status;
+    console.log(
+      `  [callback] onCompleted fired — phase: ${status.phase}, tasks: ${status.metrics.completedTaskCount}`,
+    );
+  },
+  onFailed: (_status: HarnessStatus, error: KoiError) => {
+    failedCallbackFired = true;
+    console.log(`  [callback] onFailed fired — ${error.message}`);
+  },
+});
+
+assert("harness created", harness.status().phase === "idle");
+
+// Step 2: Create task plan and start harness
+step("2. Start harness with 3 tasks (t1, t2, t3 depends on t1+t2)");
+
+const taskPlan = {
+  items: [
+    {
+      id: taskItemId("t1"),
+      description: "say hello",
+      dependencies: [],
+      priority: 0,
+      maxRetries: 3,
+      retries: 0,
+      status: "assigned" as const,
+    },
+    {
+      id: taskItemId("t2"),
+      description: "say goodbye",
+      dependencies: [],
+      priority: 1,
+      maxRetries: 3,
+      retries: 0,
+      status: "assigned" as const,
+    },
+    {
+      id: taskItemId("t3"),
+      description: "combine greetings",
+      dependencies: [taskItemId("t1"), taskItemId("t2")],
+      priority: 2,
+      maxRetries: 3,
+      retries: 0,
+      status: "assigned" as const,
+    },
+  ],
+  results: [],
+};
+
+const startResult = await harness.start(taskPlan);
+assert("harness started OK", startResult.ok === true);
+assert("phase is active", harness.status().phase === "active");
+
+// Step 3: Pause harness (simulates copilot's initial run ending)
+step("3. Pause harness (copilot run finished)");
+
+const metrics = { totalTokens: 100, inputTokens: 60, outputTokens: 40, turns: 1, durationMs: 1000 };
+const pauseResult = await harness.pause({ sessionId: "session-1", metrics });
+assert("pause OK", pauseResult.ok === true);
+assert("phase is suspended", harness.status().phase === "suspended");
+
+// Step 4: Create scheduler with onResumed that simulates engine sub-sessions
+step("4. Create scheduler with onResumed callback");
+
+const scheduler = createHarnessScheduler({
+  harness,
+  pollIntervalMs: 100, // fast polling for test
+  maxRetries: 3,
+  delay: (ms: number) => new Promise<void>((r) => setTimeout(r, Math.min(ms, 100))),
+  onResumed: async (_resumeResult: unknown) => {
+    resumeCount++;
+    console.log(`  [onResumed] resume #${resumeCount} — driving sub-session`);
+
+    // Simulate engine sub-session: complete one or two tasks per session
+    const board = harness.status().taskBoard;
+    const remaining = board.items.filter((i) => i.status === "assigned");
+
+    for (const task of remaining.slice(0, 2)) {
+      console.log(`  [onResumed] completing task: ${task.id}`);
+      const cr = await harness.completeTask(task.id, {
+        taskId: task.id,
+        output: `Output for ${task.id}`,
+        durationMs: 500,
+      });
+      if (!cr.ok) {
+        console.log(`  [onResumed] completeTask failed: ${cr.error.message}`);
+      }
+    }
+
+    // Check if all done — if not, pause for next cycle
+    if (harness.status().phase !== "completed") {
+      const pauseR = await harness.pause({
+        sessionId: `sub-session-${resumeCount}`,
+        metrics: { totalTokens: 50, inputTokens: 30, outputTokens: 20, turns: 1, durationMs: 500 },
+      });
+      if (!pauseR.ok) {
+        console.log(`  [onResumed] pause failed: ${pauseR.error.message}`);
+      }
+    }
+  },
+});
+
+// Step 5: Start scheduler and wait for completion
+step("5. Start scheduler — should resume, complete tasks, fire onCompleted");
+
+scheduler.start();
+
+// Wait for completion (max 10s)
+const deadline = Date.now() + 10_000;
+while (
+  harness.status().phase !== "completed" &&
+  harness.status().phase !== "failed" &&
+  Date.now() < deadline
+) {
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+const finalPhase = harness.status().phase;
+const schedulerStatus = scheduler.status();
+
+step("6. Verify results");
+
+assert("harness reached completed phase", finalPhase === "completed", `got: ${finalPhase}`);
+assert("scheduler stopped", schedulerStatus.phase === "stopped", `got: ${schedulerStatus.phase}`);
+assert(
+  "all 3 tasks completed",
+  harness.status().metrics.completedTaskCount === 3,
+  `got: ${harness.status().metrics.completedTaskCount}`,
+);
+assert("onCompleted callback fired", completedCallbackFired === true);
+assert("onCompleted received correct status", completedStatus?.phase === "completed");
+assert("onCompleted has correct task count", completedStatus?.metrics.completedTaskCount === 3);
+assert("onFailed did NOT fire", failedCallbackFired === false);
+assert("scheduler resumed at least once", resumeCount >= 1, `resumeCount: ${resumeCount}`);
+
+// Cleanup
+await scheduler.dispose();
+await harness.dispose();
+
+// Summary
+console.log(`\n${"=".repeat(60)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log(`${"=".repeat(60)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds push notification when autonomous plan completes/fails (closes #1061)
- Copilot calls `plan_autonomous` → agent completes tasks → `onCompleted` fires → copilot notified via mailbox
- Copilot continues working normally while tasks execute (non-blocking)

## What changed

**Harness lifecycle callbacks** (`@koi/long-running`):
- `onCompleted`/`onFailed` callbacks on `LongRunningConfig`
- Fire at terminal phase transitions, errors caught and logged

**Task tools registration** (`@koi/autonomous`):
- `task_complete`, `task_status`, `task_update`, `task_review`, `task_synthesize` now auto-registered
- Tasks created as `"assigned"` for self-delegation (copilot IS the worker)
- `harness.start(plan)` called in `onPlanCreated` (was missing)

**Scheduler sub-session driving** (`@koi/harness-scheduler`):
- `onResumed` callback drives engine sessions after resume
- Auto-pause harness after copilot runs for scheduler pickup

**CLI integration** (`@koi/cli`):
- `bindNotification` / `bindSessionRunner` / `pauseHarness` on `AutonomousResult`
- Deferred mailbox binding after runtime assembly
- `"autonomous"` added to manifest `EXTENSION_FIELDS` (was being dropped)

**Standalone notifier helper** (`@koi/autonomous`):
- `createCompletionNotifier` builds mailbox messages for non-CLI callers

## Test plan

- [x] 481 unit tests pass (harness-scheduler, long-running, autonomous, manifest)
- [x] API e2e: `scripts/e2e-autonomous-notification.ts` — 13/13 pass (harness→scheduler→complete→notify)
- [x] Copilot e2e: `scripts/e2e-autonomous-copilot-flow.ts` — 7/7 pass with real LLM:
  - Session 1: copilot calls `plan_autonomous`, completes tasks via `task_complete`
  - Session 2: copilot answers "capital of Japan?" = Tokyo (not blocked)
  - `onCompleted` fires with `phase=completed tasks=2`

## Follow-up

- #1078: Wire delegation bridge for spawn-to-worker task dispatch