### PR TITLE
fix: add name-based forge dedup and E2E coverage (#1081)

### DIFF
--- a/packages/forge/crystallize/src/auto-forge-middleware.test.ts
+++ b/packages/forge/crystallize/src/auto-forge-middleware.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
   BrickArtifact,
   ForgeDemandSignal,
+  ForgeQuery,
   ForgeStore,
   KoiError,
   Result,
@@ -257,6 +258,34 @@ describe("createAutoForgeMiddleware", () => {
     expect(store.save).toHaveBeenCalledTimes(1);
   });
 
+  test("skips save when active brick with same name already exists", async () => {
+    const candidates = [createCandidate(["fetch", "parse"], 5, 1000)];
+    const handle = createMockCrystallizeHandle(candidates);
+
+    const existingBrick = createTestToolArtifact({ name: "fetch-then-parse" });
+    const storeWithExisting = createMockForgeStore({
+      search: mock(
+        async (): Promise<Result<readonly BrickArtifact[], KoiError>> => ({
+          ok: true,
+          value: [existingBrick],
+        }),
+      ),
+    });
+
+    const mw = createAutoForgeMiddleware({
+      crystallizeHandle: handle,
+      forgeStore: storeWithExisting,
+      scope: "agent",
+      confidenceThreshold: 0.0,
+      clock: () => 1000,
+    });
+
+    await mw.onAfterTurn?.(createMockTurnContext() as never);
+    await flush();
+
+    expect(storeWithExisting.save).not.toHaveBeenCalled();
+  });
+
   test("saved brick has correct shape", async () => {
     const candidates = [createCandidate(["fetch", "parse"], 5, 1000)];
     const handle = createMockCrystallizeHandle(candidates);
@@ -386,6 +415,40 @@ describe("demand trigger-based dedup", () => {
     expect(searchCall.triggerText).toBe("visualize theorem");
     expect(searchCall.text).toBeUndefined();
     void descriptionOnlyBrick; // referenced for documentation
+  });
+
+  test("skips demand forge when active brick with same name exists", async () => {
+    const searchMock = mock(async (query: ForgeQuery) => {
+      if (query.name !== undefined) {
+        return {
+          ok: true as const,
+          value: [
+            createTestToolArtifact({ name: "pioneer-visualize-theorem" }),
+          ] as readonly BrickArtifact[],
+        };
+      }
+      return { ok: true as const, value: [] as readonly BrickArtifact[] };
+    });
+    const store = createMockForgeStore({
+      search: searchMock,
+    });
+    const signal = createDemandSignal();
+    const demandHandle = createDemandHandle([signal]);
+    const handle = createMockCrystallizeHandle();
+
+    const mw = createAutoForgeMiddleware({
+      crystallizeHandle: handle,
+      forgeStore: store,
+      scope: "agent",
+      demandHandle,
+      demandBudget: { ...DEFAULT_FORGE_BUDGET, demandThreshold: 0.5 },
+    });
+
+    await mw.onAfterTurn?.(createMockTurnContext() as never);
+    await flush();
+
+    expect(demandHandle.dismiss).toHaveBeenCalledWith("demand-1");
+    expect(store.save).not.toHaveBeenCalled();
   });
 
   test("proceeds with forge when no existing brick matches", async () => {

--- a/packages/forge/crystallize/src/auto-forge-middleware.ts
+++ b/packages/forge/crystallize/src/auto-forge-middleware.ts
@@ -314,6 +314,14 @@ export function createAutoForgeMiddleware(config: AutoForgeConfig): KoiMiddlewar
         // Save to store — StoreChangeEvent triggers hot-attach in L1
         const brick = mapDescriptorToBrick(descriptor, now);
 
+        // Name-based dedup — skip if an active brick with the same name exists
+        const nameCheck = await config.forgeStore.search({
+          name: brick.name,
+          lifecycle: "active",
+          limit: 1,
+        });
+        if (nameCheck.ok && nameCheck.value.length > 0) continue;
+
         // Pre-save gate (e.g., mutation pressure check injected by L3)
         if (config.beforeSave !== undefined) {
           const allowed = await config.beforeSave(brick);
@@ -455,6 +463,17 @@ export function createAutoForgeMiddleware(config: AutoForgeConfig): KoiMiddlewar
       scope: config.scope,
       provenance,
     });
+
+    // Name-based dedup — skip if an active brick with the same name exists
+    const nameCheck = await config.forgeStore.search({
+      name: brick.name,
+      lifecycle: "active",
+      limit: 1,
+    });
+    if (nameCheck.ok && nameCheck.value.length > 0) {
+      config.demandHandle?.dismiss(signal.id);
+      return;
+    }
 
     // Pre-save gate (e.g., mutation pressure check injected by L3)
     if (config.beforeSave !== undefined) {

--- a/packages/kernel/core/src/brick-store.ts
+++ b/packages/kernel/core/src/brick-store.ts
@@ -351,6 +351,8 @@ export interface ForgeQuery {
   readonly createdBy?: string;
   readonly classification?: DataClassification;
   readonly contentMarkers?: readonly ContentMarker[];
+  /** Exact case-insensitive match against brick name. Used for name-based dedup. */
+  readonly name?: string;
   /** Case-insensitive substring match against brick name and description. */
   readonly text?: string;
   readonly limit?: number;

--- a/packages/lib/validation/src/query-match.test.ts
+++ b/packages/lib/validation/src/query-match.test.ts
@@ -153,6 +153,22 @@ describe("matchesBrickQuery", () => {
     expect(matchesBrickQuery(brick, query)).toBe(true);
   });
 
+  // --- name matching (exact, case-insensitive) ---
+
+  test("filters by name (exact case-insensitive match)", () => {
+    const brick = createBrickBase({ name: "pioneer-api-fetch" });
+    expect(matchesBrickQuery(brick, { name: "pioneer-api-fetch" })).toBe(true);
+    expect(matchesBrickQuery(brick, { name: "Pioneer-API-Fetch" })).toBe(true);
+    expect(matchesBrickQuery(brick, { name: "pioneer-api" })).toBe(false);
+    expect(matchesBrickQuery(brick, { name: "other-tool" })).toBe(false);
+  });
+
+  test("name filter combines with lifecycle filter", () => {
+    const brick = createBrickBase({ name: "pioneer-exec", lifecycle: "active" });
+    expect(matchesBrickQuery(brick, { name: "pioneer-exec", lifecycle: "active" })).toBe(true);
+    expect(matchesBrickQuery(brick, { name: "pioneer-exec", lifecycle: "deprecated" })).toBe(false);
+  });
+
   // --- triggerText matching ---
 
   test("filters by triggerText (case-insensitive substring on trigger array)", () => {

--- a/packages/lib/validation/src/query-match.ts
+++ b/packages/lib/validation/src/query-match.ts
@@ -46,6 +46,10 @@ export function matchesBrickQuery(brick: BrickArtifactBase, query: ForgeQuery): 
       }
     }
   }
+  // Exact case-insensitive name match (used for name-based dedup)
+  if (query.name !== undefined && brick.name.toLowerCase() !== query.name.toLowerCase()) {
+    return false;
+  }
   // Case-insensitive substring match against name + description + trigger patterns
   if (query.text !== undefined && query.text.length > 0) {
     const lower = query.text.toLowerCase();

--- a/packages/meta/forge/src/__tests__/e2e-forge-events.test.ts
+++ b/packages/meta/forge/src/__tests__/e2e-forge-events.test.ts
@@ -1,0 +1,309 @@
+/**
+ * E2E test — forge event bridge subKind dispatch and microtask batching.
+ *
+ * Covers: every ForgeDashboardEvent subKind, microtask batching semantics,
+ * payload correctness, error isolation, and ignored policy actions.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { BrickArtifact, ForgeDemandSignal } from "@koi/core";
+import { brickId } from "@koi/core";
+import type { CrystallizationCandidate, CrystallizedToolDescriptor } from "@koi/crystallize";
+import type { ForgeDashboardEvent } from "@koi/dashboard-types";
+import type { OptimizationResult } from "@koi/forge-optimizer";
+import { createForgeEventBridge } from "../forge-event-bridge.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockCandidate(): CrystallizationCandidate {
+  return {
+    ngram: { steps: [{ toolId: "fetch" }, { toolId: "parse" }], key: "fetch|parse" },
+    occurrences: 5,
+    turnIndices: [0, 1, 2, 3, 4],
+    detectedAt: 1000,
+    suggestedName: "fetch-then-parse",
+    score: 0.95,
+  };
+}
+
+function createMockDescriptor(): CrystallizedToolDescriptor {
+  return {
+    name: "fetch-then-parse",
+    description: "Fetches and parses data",
+    implementation: "// code",
+    inputSchema: {},
+    scope: "agent",
+    origin: "forged",
+    policy: { sandbox: true, maxRetries: 3, timeoutMs: 5000 },
+    provenance: {
+      source: "crystallize",
+      ngramKey: "fetch|parse",
+      occurrences: 5,
+      score: 0.95,
+    },
+  } as unknown as CrystallizedToolDescriptor;
+}
+
+function createMockDemandSignal(): ForgeDemandSignal {
+  return {
+    id: "demand-1",
+    kind: "forge_demand",
+    trigger: { kind: "no_matching_tool", query: "visualize", attempts: 1 },
+    confidence: 0.9,
+    suggestedBrickKind: "tool",
+    context: { failureCount: 1, failedToolCalls: [] },
+    emittedAt: 1000,
+  };
+}
+
+function createMockBrickArtifact(): BrickArtifact {
+  return {
+    id: brickId("sha256:abc123"),
+    kind: "tool",
+    name: "visualize-tool",
+    description: "Visualizes data",
+    scope: "agent",
+    origin: "demand",
+    policy: { sandbox: true, maxRetries: 3, timeoutMs: 5000 },
+    lifecycle: "active",
+    provenance: { source: { origin: "forged", forgedBy: "demand", sessionId: "s-1" } },
+    implementation: "// code",
+    inputSchema: {},
+  } as unknown as BrickArtifact;
+}
+
+function createOptimizationResult(action: OptimizationResult["action"]): OptimizationResult {
+  return {
+    brickId: brickId("brick-1"),
+    action,
+    fitnessOriginal: 0.85,
+    reason: `action: ${action}`,
+  } as OptimizationResult;
+}
+
+/** Flush the microtask queue so batched events are delivered. */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("forge event bridge", () => {
+  // ---- 1. Each subKind fires correctly ----
+
+  describe("subKind dispatch", () => {
+    test("onCandidatesDetected emits crystallize_candidate", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onCandidatesDetected([createMockCandidate()]);
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("crystallize_candidate");
+    });
+
+    test("onDemand emits demand_detected", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onDemand(createMockDemandSignal());
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("demand_detected");
+    });
+
+    test("onForged emits brick_forged", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onForged(createMockDescriptor());
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("brick_forged");
+    });
+
+    test("onDemandForged emits brick_demand_forged", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onDemandForged(createMockDemandSignal(), createMockBrickArtifact());
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("brick_demand_forged");
+    });
+
+    test("onPolicyPromotion with deprecate emits brick_deprecated", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onPolicyPromotion("brick-1", createOptimizationResult("deprecate"));
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("brick_deprecated");
+    });
+
+    test("onPolicyPromotion with promote_to_policy emits brick_promoted", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onPolicyPromotion("brick-1", createOptimizationResult("promote_to_policy"));
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("brick_promoted");
+    });
+
+    test("onQuarantine emits brick_quarantined", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onQuarantine("brick-1");
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("brick_quarantined");
+    });
+
+    test("onFitnessFlush emits fitness_flushed", async () => {
+      const received: readonly ForgeDashboardEvent[][] = [];
+      const bridge = createForgeEventBridge({
+        onDashboardEvent: (events) => {
+          (received as ForgeDashboardEvent[][]).push([...events]);
+        },
+        clock: () => 1000,
+      });
+
+      bridge.onFitnessFlush("brick-1", 0.95, 42);
+      await flushMicrotasks();
+
+      expect(received.length).toBe(1);
+      expect(received[0]?.[0]?.subKind).toBe("fitness_flushed");
+    });
+  });
+
+  // ---- 2. Microtask batching ----
+
+  test("multiple synchronous events are batched into a single delivery", async () => {
+    const onDashboardEvent = mock((_events: readonly ForgeDashboardEvent[]) => {});
+    const bridge = createForgeEventBridge({
+      onDashboardEvent,
+      clock: () => 1000,
+    });
+
+    // Fire three events synchronously — no awaits between them
+    bridge.onQuarantine("brick-a");
+    bridge.onQuarantine("brick-b");
+    bridge.onFitnessFlush("brick-c", 0.8, 10);
+
+    await flushMicrotasks();
+
+    // All three should arrive in a single batch call
+    expect(onDashboardEvent).toHaveBeenCalledTimes(1);
+    const batch = onDashboardEvent.mock.calls[0]?.[0];
+    expect(batch?.length).toBe(3);
+  });
+
+  // ---- 3. fitness_flushed payload ----
+
+  test("fitness_flushed contains correct brickId, successRate, and sampleCount", async () => {
+    const received: ForgeDashboardEvent[] = [];
+    const bridge = createForgeEventBridge({
+      onDashboardEvent: (events) => {
+        for (const e of events) (received as ForgeDashboardEvent[]).push(e);
+      },
+      clock: () => 2000,
+    });
+
+    bridge.onFitnessFlush("brick-1", 0.95, 42);
+    await flushMicrotasks();
+
+    expect(received.length).toBe(1);
+    const event = received[0] as Record<string, unknown>;
+    expect(event.subKind).toBe("fitness_flushed");
+    expect(event.brickId).toBe("brick-1");
+    expect(event.successRate).toBe(0.95);
+    expect(event.sampleCount).toBe(42);
+    expect(event.timestamp).toBe(2000);
+  });
+
+  // ---- 4. Bridge error isolation ----
+
+  test("onDashboardEvent throwing does not propagate; onBridgeError catches it", async () => {
+    const thrownError = new Error("dashboard kaboom");
+    const onBridgeError = mock((_err: unknown) => {});
+
+    const bridge = createForgeEventBridge({
+      onDashboardEvent: () => {
+        throw thrownError;
+      },
+      onBridgeError,
+      clock: () => 1000,
+    });
+
+    // Should not throw
+    bridge.onQuarantine("brick-1");
+    await flushMicrotasks();
+
+    expect(onBridgeError).toHaveBeenCalledTimes(1);
+    expect(onBridgeError.mock.calls[0]?.[0]).toBe(thrownError);
+  });
+
+  // ---- 5. onPolicyPromotion ignores non-deprecate/promote actions ----
+
+  test("onPolicyPromotion with keep action emits no event", async () => {
+    const onDashboardEvent = mock((_events: readonly ForgeDashboardEvent[]) => {});
+    const bridge = createForgeEventBridge({
+      onDashboardEvent,
+      clock: () => 1000,
+    });
+
+    bridge.onPolicyPromotion("brick-1", createOptimizationResult("keep"));
+    await flushMicrotasks();
+
+    expect(onDashboardEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/meta/forge/src/__tests__/e2e-middleware-pipeline.test.ts
+++ b/packages/meta/forge/src/__tests__/e2e-middleware-pipeline.test.ts
@@ -1,0 +1,296 @@
+/**
+ * E2E integration test — Forge middleware pipeline without real LLM calls.
+ *
+ * Tests the full createForgeMiddlewareStack pipeline:
+ *   1. Demand detector emits signal on repeated tool failures
+ *   2. Demand signal triggers auto-forge -> pioneer brick saved
+ *   3. Optimizer session-end sweep deprecates low-fitness brick
+ *   4. Cooldown prevents re-signaling while a signal is pending
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { KoiError, Result, TurnTrace } from "@koi/core";
+import { brickId } from "@koi/core";
+import type { DashboardEvent, ForgeDashboardEvent } from "@koi/dashboard-types";
+import { createInMemoryForgeStore } from "@koi/forge-tools";
+import { createDefaultForgeConfig } from "@koi/forge-types";
+import {
+  createMockSessionContext,
+  createMockTurnContext,
+  createTestToolArtifact,
+  DEFAULT_PROVENANCE,
+} from "@koi/test-utils";
+import { createForgeMiddlewareStack } from "../create-forge-middleware-stack.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyTraces(): Promise<Result<readonly TurnTrace[], KoiError>> {
+  return Promise.resolve({ ok: true, value: [] });
+}
+
+function noopResolveBrickId(): string | undefined {
+  return undefined;
+}
+
+/** Flush fire-and-forget promises (microtask batching + setTimeout). */
+async function flush(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 20));
+}
+
+function createToolRequest(toolId: string): {
+  readonly toolId: string;
+  readonly input: Readonly<Record<string, unknown>>;
+} {
+  return { toolId, input: {} };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: forge middleware pipeline (no LLM)", () => {
+  test("demand detector emits signal on repeated tool failures", async () => {
+    const store = createInMemoryForgeStore();
+    const events: ForgeDashboardEvent[] = [];
+
+    const { middlewares } = createForgeMiddlewareStack({
+      forgeStore: store,
+      forgeConfig: createDefaultForgeConfig(),
+      scope: "agent",
+      readTraces: emptyTraces,
+      resolveBrickId: noopResolveBrickId,
+      onDashboardEvent: (event: DashboardEvent) => {
+        if (event.kind === "forge") {
+          events.push(event);
+        }
+      },
+    });
+
+    const demandMiddleware = middlewares.find((m) => m.name === "forge-demand-detector");
+    expect(demandMiddleware).toBeDefined();
+
+    const ctx = createMockTurnContext();
+    const failNext = async (): Promise<never> => {
+      throw new Error("connection timeout");
+    };
+
+    // Simulate 3 consecutive failures on the same tool (default repeatedFailureCount: 3)
+    for (let i = 0; i < 3; i++) {
+      try {
+        await demandMiddleware?.wrapToolCall?.(ctx, createToolRequest("api-fetch"), failNext);
+      } catch {
+        // expected — tool call failure propagates
+      }
+    }
+
+    // Flush microtask-batched bridge events
+    await flush();
+
+    const demandEvents = events.filter((e) => e.subKind === "demand_detected");
+    expect(demandEvents.length).toBe(1);
+    expect(demandEvents[0]?.subKind).toBe("demand_detected");
+  });
+
+  test("demand signal triggers auto-forge and saves pioneer brick", async () => {
+    const store = createInMemoryForgeStore();
+    const events: ForgeDashboardEvent[] = [];
+
+    const { middlewares } = createForgeMiddlewareStack({
+      forgeStore: store,
+      forgeConfig: createDefaultForgeConfig(),
+      scope: "agent",
+      readTraces: emptyTraces,
+      resolveBrickId: noopResolveBrickId,
+      onDashboardEvent: (event: DashboardEvent) => {
+        if (event.kind === "forge") {
+          events.push(event);
+        }
+      },
+    });
+
+    const demandMiddleware = middlewares.find((m) => m.name === "forge-demand-detector");
+    const autoForgeMiddleware = middlewares.find((m) => m.name === "auto-forge");
+    expect(demandMiddleware).toBeDefined();
+    expect(autoForgeMiddleware).toBeDefined();
+
+    const ctx = createMockTurnContext();
+    const failNext = async (): Promise<never> => {
+      throw new Error("connection timeout");
+    };
+
+    // Trigger demand with 3 consecutive failures
+    for (let i = 0; i < 3; i++) {
+      try {
+        await demandMiddleware?.wrapToolCall?.(ctx, createToolRequest("api-fetch"), failNext);
+      } catch {
+        // expected
+      }
+    }
+
+    // Process demand signals in auto-forge's onAfterTurn
+    await autoForgeMiddleware?.onAfterTurn?.(ctx as never);
+    await flush();
+
+    // Verify a pioneer brick was saved to the store
+    const searchResult = await store.search({ lifecycle: "active" });
+    expect(searchResult.ok).toBe(true);
+    if (searchResult.ok) {
+      const pioneers = searchResult.value.filter((b) => b.name.startsWith("pioneer-"));
+      expect(pioneers.length).toBeGreaterThanOrEqual(1);
+    }
+
+    // Verify brick_demand_forged dashboard event
+    const demandForgedEvents = events.filter((e) => e.subKind === "brick_demand_forged");
+    expect(demandForgedEvents.length).toBe(1);
+  });
+
+  test("optimizer session-end sweep deprecates low-fitness brick", async () => {
+    const store = createInMemoryForgeStore();
+    const now = Date.now();
+
+    // Seed store with a crystallized brick that has bad fitness metrics.
+    // The ngramKey "fetch|parse" tells the optimizer to compare against
+    // component tools named "fetch" and "parse".
+    const badBrick = createTestToolArtifact({
+      id: brickId("sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"),
+      name: "test-crystallized-tool",
+      lifecycle: "active",
+      tags: ["crystallized", "auto-forged"],
+      fitness: {
+        successCount: 1,
+        errorCount: 19,
+        latency: { samples: [500], count: 1, cap: 200 },
+        lastUsedAt: now,
+      },
+      provenance: {
+        ...DEFAULT_PROVENANCE,
+        source: { origin: "forged", forgedBy: "auto-forge-middleware", sessionId: "s-1" },
+        buildDefinition: {
+          buildType: "koi.crystallize/composite/v1",
+          externalParameters: {
+            ngramKey: "fetch|parse",
+            occurrences: 5,
+            score: 10,
+          },
+        },
+      },
+    });
+    await store.save(badBrick);
+
+    // Seed component tools with much better fitness (so composite gets deprecated)
+    const fetchBrick = createTestToolArtifact({
+      id: brickId("component-fetch-001"),
+      name: "fetch",
+      lifecycle: "active",
+      fitness: {
+        successCount: 30,
+        errorCount: 0,
+        latency: { samples: [50], count: 1, cap: 200 },
+        lastUsedAt: now,
+      },
+    });
+    const parseBrick = createTestToolArtifact({
+      id: brickId("component-parse-001"),
+      name: "parse",
+      lifecycle: "active",
+      fitness: {
+        successCount: 25,
+        errorCount: 0,
+        latency: { samples: [30], count: 1, cap: 200 },
+        lastUsedAt: now,
+      },
+    });
+    await store.save(fetchBrick);
+    await store.save(parseBrick);
+
+    const { middlewares } = createForgeMiddlewareStack({
+      forgeStore: store,
+      forgeConfig: createDefaultForgeConfig(),
+      scope: "agent",
+      readTraces: emptyTraces,
+      resolveBrickId: noopResolveBrickId,
+      clock: () => now,
+    });
+
+    const optimizerMiddleware = middlewares.find((m) => m.name === "forge-optimizer");
+    expect(optimizerMiddleware).toBeDefined();
+
+    // Trigger optimizer sweep via onSessionEnd
+    const sessionCtx = createMockSessionContext();
+    await optimizerMiddleware?.onSessionEnd?.(sessionCtx as never);
+    await flush();
+
+    // Verify brick lifecycle changed to "deprecated" in store
+    const loadResult = await store.load(badBrick.id);
+    expect(loadResult.ok).toBe(true);
+    if (loadResult.ok) {
+      expect(loadResult.value.lifecycle).toBe("deprecated");
+    }
+
+    // Component bricks should remain active
+    const fetchResult = await store.load(fetchBrick.id);
+    expect(fetchResult.ok).toBe(true);
+    if (fetchResult.ok) {
+      expect(fetchResult.value.lifecycle).toBe("active");
+    }
+  });
+
+  test("demand cooldown prevents re-signaling while a signal is pending", async () => {
+    const store = createInMemoryForgeStore();
+    const events: ForgeDashboardEvent[] = [];
+
+    const { middlewares, handles } = createForgeMiddlewareStack({
+      forgeStore: store,
+      forgeConfig: createDefaultForgeConfig(),
+      scope: "agent",
+      readTraces: emptyTraces,
+      resolveBrickId: noopResolveBrickId,
+      onDashboardEvent: (event: DashboardEvent) => {
+        if (event.kind === "forge") {
+          events.push(event);
+        }
+      },
+    });
+
+    const demandMiddleware = middlewares.find((m) => m.name === "forge-demand-detector");
+    expect(demandMiddleware).toBeDefined();
+
+    const ctx = createMockTurnContext();
+    const failNext = async (): Promise<never> => {
+      throw new Error("connection timeout");
+    };
+
+    // First batch: trigger demand with 3 failures on "api-fetch"
+    for (let i = 0; i < 3; i++) {
+      try {
+        await demandMiddleware?.wrapToolCall?.(ctx, createToolRequest("api-fetch"), failNext);
+      } catch {
+        // expected
+      }
+    }
+    await flush();
+
+    // Should have exactly 1 pending signal
+    expect(handles.demand.getSignals().length).toBe(1);
+    expect(handles.demand.getActiveSignalCount()).toBe(1);
+
+    // Second batch: 3 more failures on the same tool while first signal is pending
+    for (let i = 0; i < 3; i++) {
+      try {
+        await demandMiddleware?.wrapToolCall?.(ctx, createToolRequest("api-fetch"), failNext);
+      } catch {
+        // expected
+      }
+    }
+    await flush();
+
+    // Cooldown blocks the second signal — still only 1 pending
+    expect(handles.demand.getSignals().length).toBe(1);
+
+    // Only 1 demand_detected event total
+    const demandDetectedEvents = events.filter((e) => e.subKind === "demand_detected");
+    expect(demandDetectedEvents.length).toBe(1);
+  });
+});

--- a/packages/middleware/middleware-feedback-loop/src/__tests__/e2e-quarantine.test.ts
+++ b/packages/middleware/middleware-feedback-loop/src/__tests__/e2e-quarantine.test.ts
@@ -1,0 +1,268 @@
+/**
+ * E2E: Quarantine flow — when error rate exceeds threshold, the brick gets quarantined.
+ *
+ * Validates:
+ *   1. Error rate exceeds quarantine threshold → brick is quarantined in store
+ *   2. Quarantined tool is blocked by feedback loop middleware (returns error feedback)
+ *   3. Quarantine fires onQuarantine callback with correct brickId
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  BrickArtifact,
+  SnapshotStore,
+  ToolRequest,
+  ToolResponse,
+  TurnContext,
+} from "@koi/core";
+import { brickId, DEFAULT_UNSANDBOXED_POLICY } from "@koi/core";
+import { createInMemoryForgeStore } from "@koi/forge-tools";
+import type { ForgeHealthConfig } from "../config.js";
+import { createFeedbackLoopMiddleware } from "../feedback-loop.js";
+import { createToolHealthTracker } from "../tool-health.js";
+import type { ForgeToolErrorFeedback } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FORGED_TOOL_BRICK_ID = brickId("sha256:quarantine-test-tool-001");
+const FORGED_TOOL_ID = "forged_quarantine_calc";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createForgedBrick(overrides?: Partial<BrickArtifact>): BrickArtifact {
+  return {
+    id: FORGED_TOOL_BRICK_ID,
+    kind: "tool",
+    name: FORGED_TOOL_ID,
+    description: "A tool for quarantine flow testing",
+    scope: "agent",
+    origin: "primordial",
+    policy: DEFAULT_UNSANDBOXED_POLICY,
+    lifecycle: "active",
+    provenance: { kind: "system", metadata: {} },
+    version: "0.1.0",
+    tags: ["quarantine-test"],
+    usageCount: 20,
+    implementation: "function calc(a, b) { return a + b; }",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number" },
+        b: { type: "number" },
+      },
+      required: ["a", "b"],
+    },
+    ...overrides,
+  } as BrickArtifact;
+}
+
+function createMockSnapshotStore(): SnapshotStore {
+  return {
+    record: mock(() => Promise.resolve({ ok: true as const, value: undefined })),
+    get: mock(() => Promise.resolve({ ok: true as const, value: {} as never })),
+    list: mock(() => Promise.resolve({ ok: true as const, value: [] as never })),
+    history: mock(() => Promise.resolve({ ok: true as const, value: [] as never })),
+    latest: mock(() => Promise.resolve({ ok: true as const, value: {} as never })),
+  };
+}
+
+function resolveBrickId(toolId: string): string | undefined {
+  if (toolId === FORGED_TOOL_ID) return FORGED_TOOL_BRICK_ID;
+  return undefined;
+}
+
+/** Minimal TurnContext stub for middleware wrapToolCall. */
+function createMockTurnContext(): TurnContext {
+  return {
+    agentId: "test-agent",
+    turnNumber: 1,
+    sessionId: "test-session",
+    get: () => undefined,
+  } as unknown as TurnContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("e2e: quarantine flow", () => {
+  // let: shared per-test mutable state, reset in beforeEach
+  let forgeStore: ReturnType<typeof createInMemoryForgeStore>;
+  let snapshotStore: SnapshotStore;
+
+  beforeEach(async () => {
+    forgeStore = createInMemoryForgeStore();
+    snapshotStore = createMockSnapshotStore();
+    await forgeStore.save(createForgedBrick());
+  });
+
+  // -- Test 1: Error rate exceeds quarantine threshold → brick is quarantined --
+
+  test("quarantines brick when error rate exceeds threshold", async () => {
+    const tracker = createToolHealthTracker({
+      resolveBrickId,
+      forgeStore,
+      snapshotStore,
+      windowSize: 4,
+      quarantineThreshold: 0.5,
+      clock: () => Date.now(),
+    });
+
+    // Record 4 failures → 100% error rate > 50% threshold
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "timeout-1");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "timeout-2");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "timeout-3");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "timeout-4");
+
+    // checkAndQuarantine persists the quarantine state to the store
+    const quarantined = await tracker.checkAndQuarantine(FORGED_TOOL_ID);
+    expect(quarantined).toBe(true);
+    expect(tracker.isQuarantined(FORGED_TOOL_ID)).toBe(true);
+
+    // Verify the store was updated with lifecycle: "failed" (quarantine terminal state)
+    const loadResult = await forgeStore.load(FORGED_TOOL_BRICK_ID);
+    expect(loadResult.ok).toBe(true);
+    if (loadResult.ok) {
+      expect(loadResult.value.lifecycle).toBe("failed");
+    }
+
+    // Verify snapshot was recorded
+    expect(snapshotStore.record).toHaveBeenCalledTimes(1);
+  });
+
+  // -- Test 2: Quarantined tool is blocked by feedback loop middleware --
+
+  test("quarantined tool returns error feedback and does not call next", async () => {
+    const forgeHealth: ForgeHealthConfig = {
+      resolveBrickId,
+      forgeStore,
+      snapshotStore,
+      windowSize: 2,
+      quarantineThreshold: 0.5,
+    };
+
+    // Pre-quarantine: record failures and persist quarantine
+    const tracker = createToolHealthTracker(forgeHealth);
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "err-a");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "err-b");
+    await tracker.checkAndQuarantine(FORGED_TOOL_ID);
+    expect(tracker.isQuarantined(FORGED_TOOL_ID)).toBe(true);
+
+    // Create middleware — it will create its own tracker but should detect
+    // quarantine via isQuarantinedAsync (falls back to ForgeStore lifecycle)
+    const { middleware } = createFeedbackLoopMiddleware({ forgeHealth });
+
+    const nextFn = mock(
+      (_req: ToolRequest): Promise<ToolResponse> =>
+        Promise.resolve({ output: "should not be called" }),
+    );
+
+    const request: ToolRequest = {
+      toolId: FORGED_TOOL_ID,
+      input: { a: 1, b: 2 },
+    };
+
+    const ctx = createMockTurnContext();
+
+    // wrapToolCall should return error feedback without calling next
+    const response = await middleware.wrapToolCall?.(ctx, request, nextFn);
+
+    expect(nextFn).not.toHaveBeenCalled();
+
+    expect(response).toBeDefined();
+    const feedback = response?.output as ForgeToolErrorFeedback;
+    expect(feedback.error).toContain("quarantined");
+    expect(feedback.suggestion).toContain("re-forge");
+  });
+
+  // -- Test 3: Quarantine fires onQuarantine callback --
+
+  test("onQuarantine callback fires with correct brickId", async () => {
+    const onQuarantine = mock((_brickId: string) => {});
+
+    const tracker = createToolHealthTracker({
+      resolveBrickId,
+      forgeStore,
+      snapshotStore,
+      onQuarantine,
+      windowSize: 3,
+      quarantineThreshold: 0.5,
+      clock: () => Date.now(),
+    });
+
+    // Record 3 failures → 100% error rate > 50% threshold
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "fail-1");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "fail-2");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "fail-3");
+
+    await tracker.checkAndQuarantine(FORGED_TOOL_ID);
+
+    expect(onQuarantine).toHaveBeenCalledTimes(1);
+    expect(onQuarantine).toHaveBeenCalledWith(FORGED_TOOL_BRICK_ID);
+  });
+
+  // -- Test 4: Below threshold does not quarantine --
+
+  test("does not quarantine when error rate is below threshold", async () => {
+    const onQuarantine = mock((_brickId: string) => {});
+
+    const tracker = createToolHealthTracker({
+      resolveBrickId,
+      forgeStore,
+      snapshotStore,
+      onQuarantine,
+      windowSize: 4,
+      quarantineThreshold: 0.5,
+      clock: () => Date.now(),
+    });
+
+    // Record 1 failure + 3 successes → 25% error rate < 50% threshold
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "one-off-error");
+    tracker.recordSuccess(FORGED_TOOL_ID, 10);
+    tracker.recordSuccess(FORGED_TOOL_ID, 10);
+    tracker.recordSuccess(FORGED_TOOL_ID, 10);
+
+    const quarantined = await tracker.checkAndQuarantine(FORGED_TOOL_ID);
+    expect(quarantined).toBe(false);
+    expect(tracker.isQuarantined(FORGED_TOOL_ID)).toBe(false);
+
+    // Store lifecycle unchanged
+    const loadResult = await forgeStore.load(FORGED_TOOL_BRICK_ID);
+    expect(loadResult.ok).toBe(true);
+    if (loadResult.ok) {
+      expect(loadResult.value.lifecycle).toBe("active");
+    }
+
+    expect(onQuarantine).not.toHaveBeenCalled();
+  });
+
+  // -- Test 5: Quarantine is terminal — further records are ignored --
+
+  test("quarantine is terminal — further records do not change state", async () => {
+    const tracker = createToolHealthTracker({
+      resolveBrickId,
+      forgeStore,
+      snapshotStore,
+      windowSize: 2,
+      quarantineThreshold: 0.5,
+      clock: () => Date.now(),
+    });
+
+    // Trigger quarantine
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "err-1");
+    tracker.recordFailure(FORGED_TOOL_ID, 10, "err-2");
+    await tracker.checkAndQuarantine(FORGED_TOOL_ID);
+    expect(tracker.isQuarantined(FORGED_TOOL_ID)).toBe(true);
+
+    // Record successes after quarantine — state should remain quarantined
+    tracker.recordSuccess(FORGED_TOOL_ID, 5);
+    tracker.recordSuccess(FORGED_TOOL_ID, 5);
+    tracker.recordSuccess(FORGED_TOOL_ID, 5);
+
+    expect(tracker.isQuarantined(FORGED_TOOL_ID)).toBe(true);
+  });
+});

--- a/packages/observability/dashboard-api/src/routes/commands.test.ts
+++ b/packages/observability/dashboard-api/src/routes/commands.test.ts
@@ -7,8 +7,11 @@ import type { KoiError, KoiErrorCode, Result } from "@koi/core";
 import { agentId } from "@koi/core";
 import type { CommandDispatcher, DispatchAgentResponse } from "@koi/dashboard-types";
 import {
+  handleDemoteBrick,
   handleDispatchAgent,
   handleListMailbox,
+  handlePromoteBrick,
+  handleQuarantineBrick,
   handleResumeAgent,
   handleRetryDeadLetter,
   handleSuspendAgent,
@@ -305,5 +308,105 @@ describe("handleDispatchAgent", () => {
       commands,
     );
     expect(capturedName).toBe("padded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Brick lifecycle commands (promote / demote / quarantine)
+// ---------------------------------------------------------------------------
+
+describe("handlePromoteBrick", () => {
+  test("returns 200 on success", async () => {
+    const commands = createMockCommands({ promoteBrick: () => ok() });
+    const res = await handlePromoteBrick(
+      makeReq("/cmd/forge/bricks/b1/promote"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("returns 400 when id is missing", async () => {
+    const commands = createMockCommands({ promoteBrick: () => ok() });
+    const res = await handlePromoteBrick(makeReq("/cmd/forge/bricks//promote"), {}, commands);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 501 when not implemented", async () => {
+    const commands = createMockCommands();
+    const res = await handlePromoteBrick(
+      makeReq("/cmd/forge/bricks/b1/promote"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(501);
+  });
+
+  test("returns 404 on NOT_FOUND error", async () => {
+    const commands = createMockCommands({
+      promoteBrick: () => err("NOT_FOUND", "Brick not found"),
+    });
+    const res = await handlePromoteBrick(
+      makeReq("/cmd/forge/bricks/x/promote"),
+      { id: "x" },
+      commands,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("handleDemoteBrick", () => {
+  test("returns 200 on success", async () => {
+    const commands = createMockCommands({ demoteBrick: () => ok() });
+    const res = await handleDemoteBrick(
+      makeReq("/cmd/forge/bricks/b1/demote"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("returns 400 when id is missing", async () => {
+    const commands = createMockCommands({ demoteBrick: () => ok() });
+    const res = await handleDemoteBrick(makeReq("/cmd/forge/bricks//demote"), {}, commands);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 501 when not implemented", async () => {
+    const commands = createMockCommands();
+    const res = await handleDemoteBrick(
+      makeReq("/cmd/forge/bricks/b1/demote"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(501);
+  });
+});
+
+describe("handleQuarantineBrick", () => {
+  test("returns 200 on success", async () => {
+    const commands = createMockCommands({ quarantineBrick: () => ok() });
+    const res = await handleQuarantineBrick(
+      makeReq("/cmd/forge/bricks/b1/quarantine"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  test("returns 400 when id is missing", async () => {
+    const commands = createMockCommands({ quarantineBrick: () => ok() });
+    const res = await handleQuarantineBrick(makeReq("/cmd/forge/bricks//quarantine"), {}, commands);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 501 when not implemented", async () => {
+    const commands = createMockCommands();
+    const res = await handleQuarantineBrick(
+      makeReq("/cmd/forge/bricks/b1/quarantine"),
+      { id: "b1" },
+      commands,
+    );
+    expect(res.status).toBe(501);
   });
 });


### PR DESCRIPTION
## Summary
- **Name-based dedup**: Added `ForgeQuery.name` field for exact case-insensitive matching, and name-based dedup checks before saving in both crystallize and demand forge paths — prevents duplicate brick forging when content hashes differ but names are the same
- **E2E test coverage**: Added 36 new tests across 4 areas: middleware pipeline (demand→forge→optimizer), quarantine flow, forge event bridge (all 8 event subKinds + batching + error isolation), and brick lifecycle API commands (promote/demote/quarantine)

## Test plan
- [x] `bun test packages/lib/validation/src/query-match.test.ts` — 24 pass (2 new name filter tests)
- [x] `bun test packages/forge/crystallize/src/auto-forge-middleware.test.ts` — 14 pass (2 new dedup tests)
- [x] `bun test packages/meta/forge/src/__tests__/e2e-middleware-pipeline.test.ts` — 4 pass (new)
- [x] `bun test packages/meta/forge/src/__tests__/e2e-forge-events.test.ts` — 12 pass (new)
- [x] `bun test packages/middleware/middleware-feedback-loop/src/__tests__/e2e-quarantine.test.ts` — 5 pass (new)
- [x] `bun test packages/observability/dashboard-api/src/routes/commands.test.ts` — 28 pass (11 new)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Biome lint/format passes

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)