### PR TITLE
fix: command palette text filter not working

### DIFF
--- a/packages/ui/tui/src/views/command-palette-view.tsx
+++ b/packages/ui/tui/src/views/command-palette-view.tsx
@@ -3,10 +3,13 @@
  *
  * Renders as an absolutely positioned box with a search input and a filtered
  * Select list of available commands. Shown when view === "palette".
+ *
+ * Focus goes to the <input> so printable keys filter the list. Arrow keys
+ * and Enter are routed from the TuiRoot keyboard handler via signal props.
  */
 
 import type { SelectOption } from "@opentui/core";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TuiCapabilities } from "../state/domain-types.js";
 import { COLORS } from "../theme.js";
 import { DEFAULT_COMMANDS, filterCommandsByCapabilities } from "./command-palette.js";
@@ -26,11 +29,20 @@ export interface CommandPaletteViewProps {
   readonly onCancel: () => void;
   readonly focused: boolean;
   readonly capabilities?: TuiCapabilities | null | undefined;
+  /** Incremented by the keyboard handler when down arrow is pressed. */
+  readonly navigateDown?: number | undefined;
+  /** Incremented by the keyboard handler when up arrow is pressed. */
+  readonly navigateUp?: number | undefined;
+  /** Incremented by the keyboard handler when Enter is pressed. */
+  readonly confirmSignal?: number | undefined;
 }
 
 /** Command palette — overlay select with filtering. */
 export function CommandPaletteView(props: CommandPaletteViewProps): React.ReactNode {
   const [filter, setFilter] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  // Incremented on each open to force <input> remount (clears internal buffer)
+  const [inputKey, setInputKey] = useState(0);
 
   const commandOptions = useMemo((): readonly SelectOption[] => {
     const caps = props.capabilities ?? null;
@@ -46,6 +58,59 @@ export function CommandPaletteView(props: CommandPaletteViewProps): React.ReactN
     if (filter === "") return commandOptions;
     return commandOptions.filter((opt) => matchesFilter(opt, filter));
   }, [filter, commandOptions]);
+
+  // Reset selection when filter changes
+  const prevFilterRef = useRef(filter);
+  useEffect(() => {
+    if (prevFilterRef.current !== filter) {
+      prevFilterRef.current = filter;
+      setSelectedIndex(0);
+    }
+  }, [filter]);
+
+  // Reset filter and index when palette opens — remount input to clear buffer
+  useEffect(() => {
+    if (props.visible) {
+      setFilter("");
+      setSelectedIndex(0);
+      setInputKey((k) => k + 1);
+    }
+  }, [props.visible]);
+
+  // Navigate down signal
+  const prevDownRef = useRef(props.navigateDown ?? 0);
+  useEffect(() => {
+    const current = props.navigateDown ?? 0;
+    if (current !== prevDownRef.current) {
+      prevDownRef.current = current;
+      setSelectedIndex((prev) => (prev + 1) % Math.max(filteredOptions.length, 1));
+    }
+  }, [props.navigateDown, filteredOptions.length]);
+
+  // Navigate up signal
+  const prevUpRef = useRef(props.navigateUp ?? 0);
+  useEffect(() => {
+    const current = props.navigateUp ?? 0;
+    if (current !== prevUpRef.current) {
+      prevUpRef.current = current;
+      setSelectedIndex((prev) =>
+        (prev - 1 + Math.max(filteredOptions.length, 1)) % Math.max(filteredOptions.length, 1),
+      );
+    }
+  }, [props.navigateUp, filteredOptions.length]);
+
+  // Confirm selection signal
+  const prevConfirmRef = useRef(props.confirmSignal ?? 0);
+  useEffect(() => {
+    const current = props.confirmSignal ?? 0;
+    if (current !== prevConfirmRef.current) {
+      prevConfirmRef.current = current;
+      const option = filteredOptions[selectedIndex];
+      if (option?.value !== undefined) {
+        props.onSelect(option.value as string);
+      }
+    }
+  }, [props.confirmSignal, filteredOptions, selectedIndex, props.onSelect]);
 
   const handleInput = useCallback((value: string) => { setFilter(value); }, []);
 
@@ -70,6 +135,7 @@ export function CommandPaletteView(props: CommandPaletteViewProps): React.ReactN
 
       <box height={1}>
         <input
+          key={`palette-input-${String(inputKey)}`}
           focused={props.focused}
           placeholder="Type to filter…"
           placeholderColor={COLORS.dim}
@@ -82,7 +148,8 @@ export function CommandPaletteView(props: CommandPaletteViewProps): React.ReactN
       {filteredOptions.length > 0 ? (
         <select
           options={filteredOptions as SelectOption[]}
-          focused={props.focused}
+          focused={false}
+          selectedIndex={selectedIndex}
           showDescription={true}
           wrapSelection={true}
           flexGrow={1}

--- a/packages/ui/tui/src/views/tui-root.tsx
+++ b/packages/ui/tui/src/views/tui-root.tsx
@@ -7,7 +7,7 @@
 
 import type { KeyEvent, SyntaxStyle } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { AgentSplitPane, type AgentPaneData } from "../components/agent-split-pane.js";
 import type { TuiStore } from "../state/store.js";
 import type { PresetInfo } from "../state/types.js";
@@ -112,12 +112,23 @@ function mapKeyEventToSequence(key: KeyEvent, paletteActive?: boolean): string |
 export function TuiRoot(props: TuiRootProps): React.ReactNode {
   const state = useStoreState(props.store);
 
+  // Signal counters for palette navigation — incremented to trigger effects
+  const [paletteNavDown, setPaletteNavDown] = useState(0);
+  const [paletteNavUp, setPaletteNavUp] = useState(0);
+  const [paletteConfirm, setPaletteConfirm] = useState(0);
+
   useKeyboard((key: KeyEvent) => {
     // In palette mode, only intercept control keys — let printable chars
     // fall through to the palette's <input> for filter typing.
     const inPalette = state.view === "palette";
     const seq = mapKeyEventToSequence(key, inPalette);
     if (seq !== null) {
+      // Intercept arrows and Enter in palette mode for select navigation
+      if (inPalette) {
+        if (seq === "\x1b[B") { setPaletteNavDown((c) => c + 1); return; }
+        if (seq === "\x1b[A") { setPaletteNavUp((c) => c + 1); return; }
+        if (seq === "\r") { setPaletteConfirm((c) => c + 1); return; }
+      }
       props.onKeyInput(seq);
     }
   });
@@ -499,6 +510,9 @@ export function TuiRoot(props: TuiRootProps): React.ReactNode {
           onCancel={props.onPaletteCancel}
           focused={isPalette}
           capabilities={state.capabilities}
+          navigateDown={paletteNavDown}
+          navigateUp={paletteNavUp}
+          confirmSignal={paletteConfirm}
         />
 
         </>)}


### PR DESCRIPTION
## Summary
- Fixed command palette `<input>` filter being non-functional because `<select>` consumed all keyboard events when both had `focused={true}`
- Set `<select focused={false}>` and route arrow/Enter navigation via signal counter props from `TuiRoot`
- Force `<input>` remount on palette reopen to clear stale internal buffer

## Test plan
- [x] Open command palette (Ctrl+P), type "ski" → list filters to `/skills`
- [x] Press Enter → skills view opens without crash
- [x] Arrow keys navigate the filtered list
- [x] Close and reopen palette → filter is cleared
- [x] Type "cost" → filters to `/cost`, Enter selects it
- [x] All 18 domain views tested via palette selection
- [x] Existing unit tests pass (29 tests)
- [x] Typecheck passes for `@koi/tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)