### PR TITLE
fix: skip demo seed if data already exists in Nexus

### DIFF
--- a/packages/lib/demo-packs/src/packs/base.ts
+++ b/packages/lib/demo-packs/src/packs/base.ts
@@ -75,7 +75,7 @@ async function seedBase(ctx: SeedContext): Promise<SeedResult> {
   const nexusCount = nexusResult.ok ? nexusResult.value.succeeded : 0;
 
   const counts: Record<string, number> = { files: 2, nexus: nexusCount };
-  const summary = ["Bootstrap files ready in .koi/" + (nexusCount > 0 ? " and Nexus" : "")];
+  const summary = [`Bootstrap files ready in .koi/${nexusCount > 0 ? " and Nexus" : ""}`];
 
   if (ctx.verbose) {
     summary.push(`  wrote ${instructionsPath}`);
@@ -91,6 +91,13 @@ async function seedBase(ctx: SeedContext): Promise<SeedResult> {
   return { ok: true, counts, summary };
 }
 
+async function checkBaseSeeded(ctx: SeedContext): Promise<boolean> {
+  const result = await ctx.nexusClient.rpc<{ readonly exists: boolean }>("exists", {
+    path: `/agents/${ctx.agentName}/SOUL.md`,
+  });
+  return result.ok && result.value.exists;
+}
+
 export const BASE_PACK: DemoPack = {
   id: "base",
   name: "Base",
@@ -98,5 +105,6 @@ export const BASE_PACK: DemoPack = {
   requires: [],
   agentRoles: [],
   seed: seedBase,
+  checkSeeded: checkBaseSeeded,
   prompts: ["What can you help me with?", "Describe your capabilities."],
 } as const;

--- a/packages/lib/demo-packs/src/packs/connected.ts
+++ b/packages/lib/demo-packs/src/packs/connected.ts
@@ -150,6 +150,16 @@ async function seedConnected(ctx: SeedContext): Promise<SeedResult> {
   return { ok: allSeeded, counts, summary };
 }
 
+/** Check if the first employee entity exists as a sentinel for the connected pack. */
+async function checkConnectedSeeded(ctx: SeedContext): Promise<boolean> {
+  const sentinel = HERB_EMPLOYEES[0];
+  if (sentinel === undefined) return false;
+  const result = await ctx.nexusClient.rpc<{ readonly exists: boolean }>("exists", {
+    path: `/agents/${ctx.agentName}/datasources/herb-employees/${sentinel.id}`,
+  });
+  return result.ok && result.value.exists;
+}
+
 export const CONNECTED_PACK: DemoPack = {
   id: "connected",
   name: "Connected (HERB Enterprise)",
@@ -169,6 +179,7 @@ export const CONNECTED_PACK: DemoPack = {
     // communication wired. Re-enable when mesh/gateway multi-agent is ready.
   ],
   seed: seedConnected,
+  checkSeeded: checkConnectedSeeded,
   prompts: [
     "How many employees does HERB have in Engineering?",
     "Which enterprise customers have the highest churn risk?",

--- a/packages/lib/demo-packs/src/packs/self-improvement.ts
+++ b/packages/lib/demo-packs/src/packs/self-improvement.ts
@@ -452,6 +452,16 @@ async function seedSelfImprovement(ctx: SeedContext): Promise<SeedResult> {
   return { ok: allSeeded, counts, summary, seededBricks, seededForgeEvents };
 }
 
+/** Check if the first forge event exists as a sentinel for the self-improvement pack. */
+async function checkSelfImprovementSeeded(ctx: SeedContext): Promise<boolean> {
+  const sentinel = FORGE_EVENTS[0];
+  if (sentinel === undefined) return false;
+  const result = await ctx.nexusClient.rpc<{ readonly exists: boolean }>("exists", {
+    path: `/agents/${ctx.agentName}/events/forge/${sentinel.key}`,
+  });
+  return result.ok && result.value.exists;
+}
+
 export const SELF_IMPROVEMENT_PACK: DemoPack = {
   id: "self-improvement",
   name: "Self-Improvement",
@@ -467,6 +477,7 @@ export const SELF_IMPROVEMENT_PACK: DemoPack = {
     },
   ],
   seed: seedSelfImprovement,
+  checkSeeded: checkSelfImprovementSeeded,
   staticViews: {
     seededBricks: BRICK_METADATA.map((entry) => ({
       brickId: entry.value.brickId as string,

--- a/packages/lib/demo-packs/src/types.ts
+++ b/packages/lib/demo-packs/src/types.ts
@@ -75,6 +75,14 @@ export interface DemoPack {
   readonly agentRoles: readonly AgentRole[];
   /** The seed function that provisions demo data. */
   readonly seed: (ctx: SeedContext) => Promise<SeedResult>;
+  /**
+   * Check whether this pack's data already exists in Nexus.
+   *
+   * Used as a server-side fallback when the local marker file is missing —
+   * e.g., after workspace cleanup or when Nexus data persists across Docker
+   * restarts. Returns true if a sentinel entity is present.
+   */
+  readonly checkSeeded?: ((ctx: SeedContext) => Promise<boolean>) | undefined;
   /** Known-good prompts to suggest after seeding. */
   readonly prompts: readonly string[];
   /** Static brick/forge views for already-seeded restarts (avoids re-writing to Nexus). */

--- a/packages/meta/cli/src/commands/up/__tests__/demo.test.ts
+++ b/packages/meta/cli/src/commands/up/__tests__/demo.test.ts
@@ -18,6 +18,8 @@ const mockRunSeed = mock(
   }),
 );
 
+const mockCheckSeeded = mock(async (): Promise<boolean> => false);
+
 const mockGetPack = mock((id: string) => {
   if (id === "connected") {
     return {
@@ -36,6 +38,7 @@ const mockGetPack = mock((id: string) => {
         },
       ],
       seed: mockRunSeed,
+      checkSeeded: mockCheckSeeded,
       prompts: ["What did I learn?", "Show me data."],
     };
   }
@@ -59,6 +62,8 @@ beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "demo-seed-test-"));
   mockRunSeed.mockClear();
   mockGetPack.mockClear();
+  mockCheckSeeded.mockClear();
+  mockCheckSeeded.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -179,6 +184,77 @@ describe("seedDemoPackIfNeeded", () => {
     const markerPath = join(tempDir, ".koi", ".demo-seeded");
     expect(existsSync(markerPath)).toBe(false);
   });
+
+  test("skips seed and restores marker when checkSeeded returns true (Nexus fallback)", async () => {
+    // No marker file exists, but Nexus already has the data
+    mockCheckSeeded.mockResolvedValueOnce(true);
+
+    const result = await seedDemoPackIfNeeded(
+      "connected",
+      tempDir,
+      "test-agent",
+      makeSuccessClient(),
+      false,
+    );
+
+    expect(result.prompts).toEqual(["What did I learn?", "Show me data."]);
+    expect(mockRunSeed).not.toHaveBeenCalled();
+    expect(mockCheckSeeded).toHaveBeenCalledTimes(1);
+
+    // Marker should be restored for future fast-path
+    const markerPath = join(tempDir, ".koi", ".demo-seeded");
+    expect(existsSync(markerPath)).toBe(true);
+    expect(readFileSync(markerPath, "utf-8")).toBe("connected");
+  });
+
+  test("proceeds with seed when checkSeeded returns false", async () => {
+    mockCheckSeeded.mockResolvedValueOnce(false);
+
+    const result = await seedDemoPackIfNeeded(
+      "connected",
+      tempDir,
+      "test-agent",
+      makeSuccessClient(),
+      false,
+    );
+
+    expect(result.prompts).toEqual(["What did I learn?", "Show me data."]);
+    expect(mockCheckSeeded).toHaveBeenCalledTimes(1);
+    expect(mockRunSeed).toHaveBeenCalledTimes(1);
+  });
+
+  test("proceeds with seed when checkSeeded throws", async () => {
+    mockCheckSeeded.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await seedDemoPackIfNeeded(
+      "connected",
+      tempDir,
+      "test-agent",
+      makeSuccessClient(),
+      false,
+    );
+
+    expect(result.prompts).toEqual(["What did I learn?", "Show me data."]);
+    expect(mockRunSeed).toHaveBeenCalledTimes(1);
+  });
+
+  test("proceeds with seed when checkSeeded times out", async () => {
+    // Simulate a hung Nexus that never resolves
+    mockCheckSeeded.mockImplementationOnce(
+      () => new Promise<boolean>(() => {}), // never resolves
+    );
+
+    const result = await seedDemoPackIfNeeded(
+      "connected",
+      tempDir,
+      "test-agent",
+      makeSuccessClient(),
+      false,
+    );
+
+    expect(result.prompts).toEqual(["What did I learn?", "Show me data."]);
+    expect(mockRunSeed).toHaveBeenCalledTimes(1);
+  }, 10_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/meta/cli/src/commands/up/demo.ts
+++ b/packages/meta/cli/src/commands/up/demo.ts
@@ -41,7 +41,7 @@ export async function seedDemoPackIfNeeded(
         seededForgeEvents: pack?.staticViews?.seededForgeEvents ?? [],
       };
     } catch {
-      // Marker doesn't exist — proceed with seeding
+      // Marker doesn't exist — fall through to Nexus check
     }
 
     if (nexusClient === undefined) {
@@ -51,6 +51,35 @@ export async function seedDemoPackIfNeeded(
 
     const { getPack, runSeed } = await import("@koi/demo-packs");
     const pack = getPack(demoPack);
+
+    // Nexus-side fallback: if the local marker is missing but Nexus already
+    // has the data (e.g., marker lost after workspace cleanup, or Nexus data
+    // persists across Docker restarts), skip seeding and restore the marker.
+    const CHECK_SEEDED_TIMEOUT_MS = 3_000;
+    if (pack?.checkSeeded !== undefined) {
+      try {
+        const alreadySeeded = await Promise.race([
+          pack.checkSeeded({ nexusClient, agentName, workspaceRoot, verbose }),
+          new Promise<false>((resolve) =>
+            setTimeout(() => resolve(false), CHECK_SEEDED_TIMEOUT_MS),
+          ),
+        ]);
+        if (alreadySeeded) {
+          if (verbose) process.stderr.write("  Demo data already in Nexus — skipping seed\n");
+          // Restore the marker so future boots take the fast path
+          const { mkdir, writeFile } = await import("node:fs/promises");
+          await mkdir(join(workspaceRoot, ".koi"), { recursive: true });
+          await writeFile(markerPath, demoPack);
+          return {
+            prompts: pack.prompts,
+            seededBricks: pack.staticViews?.seededBricks ?? [],
+            seededForgeEvents: pack.staticViews?.seededForgeEvents ?? [],
+          };
+        }
+      } catch {
+        // Check failed (network error, etc.) — proceed with seeding
+      }
+    }
 
     if (pack === undefined) {
       process.stderr.write(`Unknown demo pack "${demoPack}". Run 'koi demo list'.\n`);


### PR DESCRIPTION
## Summary

Fixes #1108 — `koi up` with demo preset no longer wastes 30s on every startup when demo data already exists in Nexus.

- Add optional `checkSeeded()` method to `DemoPack` interface for server-side existence checks
- Implement sentinel-based checks for all 3 packs (base→SOUL.md, connected→first employee, self-improvement→first forge event)
- Add Nexus fallback path in `seedDemoPackIfNeeded` between marker check and seed attempt, with 3s timeout
- Restore local marker file when Nexus fallback detects data, so future boots take the instant path

### Detection flow
```
koi up → marker exists? ──yes──→ skip (0ms, no network)
                │
                no
                │
         checkSeeded()? ──yes──→ restore marker + skip (~15ms)
          (3s timeout)    │
                          no/timeout/error
                          │
                    run seed (30s timeout) → write marker on success
```

### Bug found during e2e testing
Nexus `exists` RPC returns `{ exists: boolean }`, not plain `boolean`. Initial code used `rpc<boolean>` which made the check always truthy (object). Fixed to `rpc<{ readonly exists: boolean }>` and `result.value.exists`. This was invisible in unit tests (mocks return plain booleans) — only caught by e2e against real Nexus.

## Test plan
- [x] 13 unit tests pass (29 assertions) — includes 4 new tests for Nexus fallback paths
- [x] E2E validated via `koi up` with real Nexus (workspace's own Docker container)
  - Marker fast path: instant skip
  - Nexus fallback (marker deleted): 15ms detection + marker restored
- [x] Biome lint clean
- [x] Full monorepo build passes (198/198 tasks)