### PR TITLE
fix: skill system type safety and error handling

### DIFF
--- a/packages/fs/skills/src/provider.ts
+++ b/packages/fs/skills/src/provider.ts
@@ -497,9 +497,11 @@ export function createSkillComponentProvider(
     mountFindingCallback?: (name: string, findings: readonly ScanFinding[]) => void,
   ): Promise<Result<void, KoiError>> => {
     const op = pending.then(() => mountImpl(skill, mountBasePath, mountFindingCallback));
+    // Resolve the chain on both success and failure to maintain serialization.
+    // Callers observe errors via the returned `op` promise.
     pending = op.then(
-      () => {},
-      () => {},
+      () => undefined,
+      () => undefined,
     );
     return op;
   };

--- a/packages/meta/skill-stack/src/skill-stack.ts
+++ b/packages/meta/skill-stack/src/skill-stack.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ComponentEvent, KoiError, KoiMiddleware, Result, SkillConfig } from "@koi/core";
-import { fsSkill } from "@koi/core";
+import { brickId, fsSkill } from "@koi/core";
 import type { ScanFinding } from "@koi/skill-scanner";
 import {
   createSkillActivatorMiddleware,
@@ -100,12 +100,25 @@ export async function createSkillStack(config: SkillStackConfig): Promise<SkillS
     forgeUnsub = forgeProvider.watch((event: ComponentEvent) => {
       if (event.kind === "attached" && event.componentKey.startsWith("brick:skill:")) {
         const name = event.componentKey.slice("brick:skill:".length);
-        // Create a forged skill config and mount it
+        if (name.length === 0) return;
         const skill: SkillConfig = {
           name,
-          source: { kind: "forged", brickId: name as never },
+          source: { kind: "forged", brickId: brickId(name) },
         };
-        void provider.mount(skill, basePath, findingCallback);
+        provider.mount(skill, basePath, findingCallback).then(
+          (result) => {
+            if (!result.ok) {
+              console.warn(
+                `[skill-stack] Failed to mount forged skill "${name}": ${result.error.message}`,
+              );
+            }
+          },
+          (err: unknown) => {
+            console.warn(
+              `[skill-stack] Mount error for forged skill "${name}": ${err instanceof Error ? err.message : String(err)}`,
+            );
+          },
+        );
       }
     });
     disposables.push(() => forgeUnsub?.());


### PR DESCRIPTION
## Summary
- Replace unsafe `as never` cast with proper `brickId()` branded constructor in forge→mount bridge
- Validate extracted skill name is non-empty before mounting forged skills
- Handle mount result errors with logging instead of silent fire-and-forget `void`
- Clarify mount/unmount serialization chain intent in provider comments

## Test plan
- [x] All 436 skill system tests pass
- [x] Typecheck passes for `@koi/skill-stack`, `@koi/skills`, `@koi/skill-scanner`
- [x] Empty skill name from forge event is rejected (guard added)
- [x] Mount failures now log warnings instead of being silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)