### PR TITLE
fix(search-forge): blend retriever relevance with fitness score in ranking

### DIFF
--- a/packages/forge/forge-tools/src/tools/search-forge.test.ts
+++ b/packages/forge/forge-tools/src/tools/search-forge.test.ts
@@ -627,6 +627,104 @@ describe("search_forge — trigger matching", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Blended ranking tests — retriever relevance × fitness
+// ---------------------------------------------------------------------------
+
+describe("search_forge — blended ranking", () => {
+  test("high-fitness brick outranks high-relevance brick at default alpha", async () => {
+    const nowMs = Date.now();
+    // highRelevance: retriever score 0.95 but low fitness (2 success, 8 errors)
+    const highRelevance = createTestToolArtifact({
+      id: brickId("hr"),
+      name: "high-relevance",
+      fitness: {
+        successCount: 2,
+        errorCount: 8,
+        latency: { samples: [100], count: 10, cap: 200 },
+        lastUsedAt: nowMs,
+      },
+    });
+    // highFitness: retriever score 0.70 but high fitness (90 success, 0 errors)
+    const highFitness = createTestToolArtifact({
+      id: brickId("hf"),
+      name: "high-fitness",
+      fitness: {
+        successCount: 90,
+        errorCount: 0,
+        latency: { samples: [50], count: 90, cap: 200 },
+        lastUsedAt: nowMs,
+      },
+    });
+    const store = mockStore([highRelevance, highFitness]);
+    const retriever = mockRetriever([
+      { id: "hr" as string, score: 0.95, content: "high-relevance", metadata: {}, source: "nexus" },
+      { id: "hf" as string, score: 0.7, content: "high-fitness", metadata: {}, source: "nexus" },
+    ]);
+    (store.load as ReturnType<typeof mock>).mockImplementation(async (id: BrickId) => {
+      if (id === brickId("hr")) return { ok: true, value: highRelevance };
+      if (id === brickId("hf")) return { ok: true, value: highFitness };
+      return { ok: false, error: { code: "NOT_FOUND", message: "not found", retryable: false } };
+    });
+    const pipeline = mockPipeline();
+    const deps = makeDeps({ store, retriever, pipeline });
+
+    const result = await executeSearch(deps, { query: "some tool" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBe(2);
+      // highFitness should outrank highRelevance due to blended score
+      expect(result.value[0]?.name).toBe("high-fitness");
+      expect(result.value[1]?.name).toBe("high-relevance");
+    }
+  });
+
+  test("alpha=1.0 gives pure relevance ranking (backward compatible)", async () => {
+    const nowMs = Date.now();
+    const lowRelevance = createTestToolArtifact({
+      id: brickId("lr"),
+      name: "low-relevance",
+      fitness: {
+        successCount: 100,
+        errorCount: 0,
+        latency: { samples: [10], count: 100, cap: 200 },
+        lastUsedAt: nowMs,
+      },
+    });
+    const highRelevance = createTestToolArtifact({
+      id: brickId("hr"),
+      name: "high-relevance",
+      fitness: {
+        successCount: 1,
+        errorCount: 9,
+        latency: { samples: [500], count: 10, cap: 200 },
+        lastUsedAt: nowMs,
+      },
+    });
+    const store = mockStore([lowRelevance, highRelevance]);
+    const retriever = mockRetriever([
+      { id: "hr" as string, score: 0.99, content: "high-relevance", metadata: {}, source: "nexus" },
+      { id: "lr" as string, score: 0.3, content: "low-relevance", metadata: {}, source: "nexus" },
+    ]);
+    (store.load as ReturnType<typeof mock>).mockImplementation(async (id: BrickId) => {
+      if (id === brickId("lr")) return { ok: true, value: lowRelevance };
+      if (id === brickId("hr")) return { ok: true, value: highRelevance };
+      return { ok: false, error: { code: "NOT_FOUND", message: "not found", retryable: false } };
+    });
+    const pipeline = mockPipeline();
+    const deps = makeDeps({ store, retriever, pipeline });
+
+    const result = await executeSearch(deps, { query: "some tool", rankingAlpha: 1.0 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBe(2);
+      // Pure relevance: highRelevance (0.99) > lowRelevance (0.30)
+      expect(result.value[0]?.name).toBe("high-relevance");
+      expect(result.value[1]?.name).toBe("low-relevance");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Mock pipeline for governance pre-check bypass
 // ---------------------------------------------------------------------------
 

--- a/packages/forge/forge-tools/src/tools/search-forge.ts
+++ b/packages/forge/forge-tools/src/tools/search-forge.ts
@@ -24,6 +24,9 @@ const VALID_ORDER_BY = new Set(["fitness", "recency", "usage"]);
 /** Over-fetch multiplier for retriever results to compensate for post-filtering. */
 const DEFAULT_OVER_FETCH_MULTIPLIER = 2;
 
+/** Default blend weight: 60% retriever relevance, 40% fitness. */
+const DEFAULT_RANKING_ALPHA = 0.6;
+
 // ---------------------------------------------------------------------------
 // Zod input schema (replaces unsafe `as ForgeQuery` cast)
 // ---------------------------------------------------------------------------
@@ -42,6 +45,7 @@ const searchInputSchema = z
     limit: z.number().optional(),
     orderBy: z.string().optional(),
     minFitnessScore: z.number().optional(),
+    rankingAlpha: z.number().min(0).max(1).optional(),
     detail: z.enum(["full", "summary"]).optional(),
   })
   .optional();
@@ -80,6 +84,11 @@ const SEARCH_FORGE_CONFIG: ForgeToolConfig = {
       minFitnessScore: {
         type: "number",
         description: "Minimum fitness score (0-1). Bricks below this threshold are excluded.",
+      },
+      rankingAlpha: {
+        type: "number",
+        description:
+          "Blend weight for retriever results: 0-1. 1.0 = pure relevance, 0.0 = pure fitness. Default: 0.6.",
       },
       detail: {
         type: "string",
@@ -133,9 +142,11 @@ async function searchForgeHandler(
   const clampedMin =
     raw.minFitnessScore !== undefined ? Math.max(0, Math.min(1, raw.minFitnessScore)) : undefined;
 
+  const alpha = raw?.rankingAlpha ?? DEFAULT_RANKING_ALPHA;
+
   // --- Retriever path: hybrid BM25+vector search ---
   if (query !== undefined && query.length > 0 && deps.retriever !== undefined) {
-    const retrieverResult = await retrieverSearch(query, limit, raw, detail, deps);
+    const retrieverResult = await retrieverSearch(query, limit, alpha, raw, detail, deps);
     if (retrieverResult !== undefined) {
       return retrieverResult;
     }
@@ -157,6 +168,7 @@ async function searchForgeHandler(
 async function retrieverSearch(
   query: string,
   limit: number,
+  alpha: number,
   raw: NonNullable<SearchInput>,
   detail: "full" | "summary",
   deps: ForgeDeps,
@@ -183,6 +195,12 @@ async function retrieverSearch(
       return undefined;
     }
 
+    // Build retriever score map: brickId → relevance score (0-1)
+    const retrieverScores = new Map<string, number>();
+    for (const r of searchResult.value.results) {
+      retrieverScores.set(r.id, r.score);
+    }
+
     // Resolve result IDs → BrickArtifact[] via parallel store.load()
     const loadPromises = searchResult.value.results.map(async (r) => {
       const loadResult = await deps.store.load(r.id as BrickId);
@@ -190,7 +208,7 @@ async function retrieverSearch(
     });
     const loaded = await Promise.all(loadPromises);
 
-    // Filter out failed loads, preserving retriever relevance ordering
+    // Filter out failed loads
     let bricks: readonly BrickArtifact[] = loaded.filter(
       (b): b is BrickArtifact => b !== undefined,
     );
@@ -204,17 +222,28 @@ async function retrieverSearch(
     // Canonical fitness filtering — uses the same composite score as sortBricks
     // (successRate^exponent × recencyDecay × usageNorm × latencyFactor),
     // not raw success ratio, to stay consistent with the store path.
+    const nowMs = Date.now();
     if (raw.minFitnessScore !== undefined) {
       const min = Math.max(0, Math.min(1, raw.minFitnessScore));
-      const nowMs = Date.now();
       bricks = bricks.filter((b) => {
         const score = computeBrickFitness(b.fitness ?? DEFAULT_BRICK_FITNESS, nowMs);
         return score >= min;
       });
     }
 
-    // Truncate to requested limit (relevance ordering preserved from retriever)
-    const truncated = bricks.slice(0, limit);
+    // Re-rank by blended score: alpha × relevance + (1 - alpha) × fitness
+    const ranked = [...bricks].sort((a, b) => {
+      const relA = retrieverScores.get(a.id) ?? 0;
+      const relB = retrieverScores.get(b.id) ?? 0;
+      const fitA = computeBrickFitness(a.fitness ?? DEFAULT_BRICK_FITNESS, nowMs);
+      const fitB = computeBrickFitness(b.fitness ?? DEFAULT_BRICK_FITNESS, nowMs);
+      const scoreA = alpha * relA + (1 - alpha) * fitA;
+      const scoreB = alpha * relB + (1 - alpha) * fitB;
+      return scoreB - scoreA;
+    });
+
+    // Truncate to requested limit
+    const truncated = ranked.slice(0, limit);
 
     // Summary mode: project to lightweight BrickSummary[] (~20 tokens/brick)
     if (detail === "summary") {


### PR DESCRIPTION
## Summary
- Re-rank retriever results by blended score: `alpha × relevance + (1 - alpha) × fitness`
- Add `rankingAlpha` input parameter (default 0.6: 60% relevance, 40% fitness)
- High-fitness bricks now surface even with slightly lower text relevance
- `alpha=1.0` preserves pure relevance ranking for backward compatibility
- Store fallback path unchanged

Closes #1127

## Test plan
- [x] High-fitness + low-relevance beats low-fitness + high-relevance at default alpha
- [x] alpha=1.0 gives pure relevance ranking (backward compatible)
- [x] All 23 search_forge tests pass (21 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)