### PR TITLE
fix(forge): allow version bumps through forge_tool when name matches (#1170)

### DIFF
--- a/packages/forge/forge-tools/src/tools/shared.ts
+++ b/packages/forge/forge-tools/src/tools/shared.ts
@@ -510,49 +510,11 @@ export async function runForgePipeline(
     }
   }
 
-  // Name-based dedup: prevent duplicate bricks with the same name.
-  // Checked before verification to save compute on known duplicates.
-  // Content dedup (hash, checked post-verify) misses bricks with slightly
-  // different implementations that serve the same logical purpose.
-  const nameSearchResult = await deps.store.search({
-    text: forgeInput.name,
-    kind: forgeInput.kind,
-    lifecycle: "active",
-    limit: 5,
-  });
-  if (nameSearchResult.ok && nameSearchResult.value.some((b) => b.name === forgeInput.name)) {
-    const existing = nameSearchResult.value.find((b) => b.name === forgeInput.name);
-    if (existing !== undefined) {
-      const forgeResult: ForgeResult = {
-        id: existing.id,
-        kind: forgeInput.kind,
-        name: forgeInput.name,
-        descriptor: {
-          name: forgeInput.name,
-          description: forgeInput.description,
-          inputSchema: forgeInput.kind === "tool" ? forgeInput.inputSchema : {},
-        },
-        origin: "forged",
-        policy: existing.policy,
-        scope: deps.config.defaultScope,
-        lifecycle: "active",
-        verificationReport: {
-          passed: true,
-          sandbox: existing.policy.sandbox,
-          totalDurationMs: 0,
-          stages: [],
-        },
-        metadata: {
-          forgedAt: startedAt,
-          forgedBy: deps.context.agentId,
-          sessionId: deps.context.sessionId,
-          depth: deps.context.depth,
-        },
-        forgesConsumed: 0,
-      };
-      return { ok: true, value: forgeResult };
-    }
-  }
+  // Name-based dedup removed from agent-initiated forge_tool path.
+  // When an agent calls forge_tool with the same name as an existing brick,
+  // the intent is to create a new version (e.g., after forge_edit failure).
+  // Content-hash dedup (post-verify) still prevents true duplicates.
+  // Automated paths (crystallize, demand) retain name dedup in auto-forge-middleware.
 
   const verifyResult = await pipeline.verify(
     forgeInput,


### PR DESCRIPTION
## Summary
- Remove name-based dedup from the agent-initiated forge_tool path in shared.ts
- When an agent calls forge_tool with the same name as an existing brick, the intent is to create a new version (e.g., after forge_edit fails and agent retries from scratch)
- Content-hash dedup still prevents true duplicates (identical implementations)
- Automated paths (crystallize, demand) retain name dedup in auto-forge-middleware to prevent runaway pioneer creation

## Test plan
- [x] bun test packages/forge/forge-tools/ — 126 pass
- [x] Biome lint passes

Closes #1170

Generated with [Claude Code](https://claude.com/claude-code)