### PR TITLE
feat: query-engine turn state machine (#1233)

### DIFF
--- a/docs/L2/query-engine.md
+++ b/docs/L2/query-engine.md
@@ -1,6 +1,6 @@
 # @koi/query-engine
 
-Stream consumer that maps `AsyncIterable<ModelChunk>` to `AsyncGenerator<EngineEvent>`, accumulating streamed tool-call argument deltas into parsed payloads.
+Stream consumer and turn state machine for the model→tool→model loop.
 
 ## Layer
 
@@ -29,8 +29,28 @@ Async generator. Yields `EngineEvent`s in the same order chunks arrive.
 - Malformed JSON in tool-call args yields a deterministic error event (does not throw).
 - The error includes the `callId` and raw string for diagnostics.
 
+## Turn State Machine
+
+Pure state machine driving the model→tool→model loop (#1233).
+
+### States (TurnPhase)
+
+`idle` → `model` → `tool_execution` → `continue` → `model` (loop) or `complete` (done)
+
+### Public API
+
+- `createTurnState(turnIndex?)` — factory for initial idle state.
+- `transitionTurn(state, input)` — pure transition function, throws on invalid transitions.
+- `runTurn(config)` — async generator that drives the turn loop via `ComposedCallHandlers`, yielding `EngineEvent`s.
+- `validateToolArgs(args, descriptor)` — lightweight JSON Schema validation (allowlist-based, fail-closed on unsupported keywords).
+
+### Types
+
+- `TurnPhase` — `"idle" | "model" | "tool_execution" | "continue" | "complete"`
+- `TurnInput` — discriminated union: `start`, `model_done`, `tools_done`, `abort`, `error`, `max_turns`
+- `TurnState` — `{ phase, turnIndex, modelCalls, stopReason }`
+- `TurnRunnerConfig` — `{ callHandlers, messages, signal?, maxTurns? }`
+
 ## Not in scope
 
-- Turn lifecycle (handled by #1233 turn state machine).
-- Tool execution — this package only reassembles the request payload.
 - Agent lifecycle events (`spawn_requested`, `agent_spawned`, `agent_status_changed`) — those originate from engine internals, not the model stream.

--- a/packages/lib/query-engine/src/consume-stream.test.ts
+++ b/packages/lib/query-engine/src/consume-stream.test.ts
@@ -175,7 +175,7 @@ describe("consumeModelStream", () => {
     expect((end2.result as { readonly parsedArgs: unknown }).parsedArgs).toEqual({ b: 2 });
   });
 
-  test("usage chunks are not yielded as separate events", async () => {
+  test("usage chunks are yielded as custom events for partial tracking", async () => {
     const chunks: readonly ModelChunk[] = [
       { kind: "text_delta", delta: "hi" },
       { kind: "usage", inputTokens: 10, outputTokens: 5 },
@@ -185,8 +185,9 @@ describe("consumeModelStream", () => {
     const events = await collect(consumeModelStream(toStream(chunks)));
     const kinds = events.map((e) => e.kind);
 
+    // Usage is yielded as "custom" with type "usage", not as raw "usage"
     expect(kinds).not.toContain("usage");
-    expect(kinds).toEqual(["text_delta", "done"]);
+    expect(kinds).toEqual(["text_delta", "custom", "done"]);
   });
 
   test("final done usage overrides incremental usage totals", async () => {

--- a/packages/lib/query-engine/src/consume-stream.ts
+++ b/packages/lib/query-engine/src/consume-stream.ts
@@ -112,7 +112,14 @@ export async function* consumeModelStream(
       case "usage": {
         inputTokens += chunk.inputTokens;
         outputTokens += chunk.outputTokens;
-        // Not yielded — folded into done event
+        // Yield as custom event so callers can track partial usage
+        // on early exit (abort/error/truncation). Still folded into
+        // the done event metrics for the normal completion path.
+        yield {
+          kind: "custom",
+          type: "usage",
+          data: { inputTokens: chunk.inputTokens, outputTokens: chunk.outputTokens },
+        };
         break;
       }
 

--- a/packages/lib/query-engine/src/index.ts
+++ b/packages/lib/query-engine/src/index.ts
@@ -1,2 +1,7 @@
 export { consumeModelStream } from "./consume-stream.js";
+export type { TurnInput, TurnPhase, TurnState } from "./turn-machine.js";
+export { createTurnState, transitionTurn } from "./turn-machine.js";
+export type { TurnRunnerConfig } from "./turn-runner.js";
+export { runTurn } from "./turn-runner.js";
 export type { AccumulatedToolCall, StreamConsumerResult, ToolCallAccumulator } from "./types.js";
+export { validateToolArgs } from "./validate-tool-args.js";

--- a/packages/lib/query-engine/src/turn-machine.test.ts
+++ b/packages/lib/query-engine/src/turn-machine.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import type { TurnState } from "./turn-machine.js";
+import { createTurnState, transitionTurn } from "./turn-machine.js";
+
+describe("createTurnState", () => {
+  test("returns idle state with default turnIndex 0", () => {
+    const state = createTurnState();
+    expect(state).toEqual({
+      phase: "idle",
+      turnIndex: 0,
+      modelCalls: 0,
+      stopReason: undefined,
+    });
+  });
+
+  test("accepts custom turnIndex", () => {
+    const state = createTurnState(5);
+    expect(state.turnIndex).toBe(5);
+    expect(state.phase).toBe("idle");
+  });
+});
+
+describe("transitionTurn", () => {
+  // -----------------------------------------------------------------------
+  // Happy paths
+  // -----------------------------------------------------------------------
+
+  test("idle -> start -> model", () => {
+    const state = createTurnState();
+    const next = transitionTurn(state, { kind: "start" });
+    expect(next.phase).toBe("model");
+    expect(next.modelCalls).toBe(1);
+  });
+
+  test("model -> model_done (no tools) -> complete with stopReason completed", () => {
+    const state = transitionTurn(createTurnState(), { kind: "start" });
+    const next = transitionTurn(state, { kind: "model_done", hasToolCalls: false });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("completed");
+  });
+
+  test("model -> model_done (has tools) -> tool_execution", () => {
+    const state = transitionTurn(createTurnState(), { kind: "start" });
+    const next = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    expect(next.phase).toBe("tool_execution");
+    expect(next.stopReason).toBeUndefined();
+  });
+
+  test("tool_execution -> tools_done -> continue with turnIndex incremented", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    expect(state.turnIndex).toBe(0);
+    const next = transitionTurn(state, { kind: "tools_done" });
+    expect(next.phase).toBe("continue");
+    expect(next.turnIndex).toBe(1);
+  });
+
+  test("continue -> start -> model (loop continuation)", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    state = transitionTurn(state, { kind: "tools_done" });
+    const next = transitionTurn(state, { kind: "start" });
+    expect(next.phase).toBe("model");
+    expect(next.modelCalls).toBe(2);
+  });
+
+  test("continue -> max_turns -> complete with stopReason max_turns", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    state = transitionTurn(state, { kind: "tools_done" });
+    const next = transitionTurn(state, { kind: "max_turns" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("max_turns");
+  });
+
+  // -----------------------------------------------------------------------
+  // Abort transitions
+  // -----------------------------------------------------------------------
+
+  test("model -> abort -> complete with stopReason interrupted", () => {
+    const state = transitionTurn(createTurnState(), { kind: "start" });
+    const next = transitionTurn(state, { kind: "abort" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("interrupted");
+  });
+
+  test("tool_execution -> abort -> complete with stopReason interrupted", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    const next = transitionTurn(state, { kind: "abort" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("interrupted");
+  });
+
+  test("continue -> abort -> complete with stopReason interrupted", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    state = transitionTurn(state, { kind: "tools_done" });
+    const next = transitionTurn(state, { kind: "abort" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("interrupted");
+  });
+
+  // -----------------------------------------------------------------------
+  // Error transitions
+  // -----------------------------------------------------------------------
+
+  test("model -> error -> complete with stopReason error", () => {
+    const state = transitionTurn(createTurnState(), { kind: "start" });
+    const next = transitionTurn(state, { kind: "error", message: "boom" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("error");
+  });
+
+  test("tool_execution -> error -> complete with stopReason error", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    const next = transitionTurn(state, { kind: "error", message: "tool failed" });
+    expect(next.phase).toBe("complete");
+    expect(next.stopReason).toBe("error");
+  });
+
+  // -----------------------------------------------------------------------
+  // Invalid transitions
+  // -----------------------------------------------------------------------
+
+  test("idle -> tools_done throws", () => {
+    expect(() => transitionTurn(createTurnState(), { kind: "tools_done" })).toThrow(
+      /Invalid turn transition/,
+    );
+  });
+
+  test("idle -> model_done throws", () => {
+    expect(() =>
+      transitionTurn(createTurnState(), { kind: "model_done", hasToolCalls: false }),
+    ).toThrow(/Invalid turn transition/);
+  });
+
+  test("model -> start throws", () => {
+    const state = transitionTurn(createTurnState(), { kind: "start" });
+    expect(() => transitionTurn(state, { kind: "start" })).toThrow(/Invalid turn transition/);
+  });
+
+  test("complete -> start throws", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: false });
+    expect(state.phase).toBe("complete");
+    expect(() => transitionTurn(state, { kind: "start" })).toThrow(/Invalid turn transition/);
+  });
+
+  test("continue -> tools_done throws", () => {
+    let state: TurnState = createTurnState();
+    state = transitionTurn(state, { kind: "start" });
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    state = transitionTurn(state, { kind: "tools_done" });
+    expect(() => transitionTurn(state, { kind: "tools_done" })).toThrow(/Invalid turn transition/);
+  });
+
+  // -----------------------------------------------------------------------
+  // Immutability
+  // -----------------------------------------------------------------------
+
+  test("transition returns new object, original unchanged", () => {
+    const original = createTurnState();
+    const next = transitionTurn(original, { kind: "start" });
+    expect(original.phase).toBe("idle");
+    expect(next.phase).toBe("model");
+    expect(original).not.toBe(next);
+  });
+
+  // -----------------------------------------------------------------------
+  // Full loop: idle -> model -> tool_execution -> continue -> model -> complete
+  // -----------------------------------------------------------------------
+
+  test("full two-turn loop", () => {
+    let state: TurnState = createTurnState();
+
+    // Turn 0: model call with tool calls
+    state = transitionTurn(state, { kind: "start" });
+    expect(state).toMatchObject({ phase: "model", turnIndex: 0, modelCalls: 1 });
+
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: true });
+    expect(state.phase).toBe("tool_execution");
+
+    state = transitionTurn(state, { kind: "tools_done" });
+    expect(state).toMatchObject({ phase: "continue", turnIndex: 1 });
+
+    // Turn 1: model call with text-only response
+    state = transitionTurn(state, { kind: "start" });
+    expect(state).toMatchObject({ phase: "model", turnIndex: 1, modelCalls: 2 });
+
+    state = transitionTurn(state, { kind: "model_done", hasToolCalls: false });
+    expect(state).toMatchObject({ phase: "complete", stopReason: "completed" });
+  });
+});

--- a/packages/lib/query-engine/src/turn-machine.ts
+++ b/packages/lib/query-engine/src/turn-machine.ts
@@ -1,0 +1,125 @@
+/**
+ * Turn state machine — pure transition function.
+ *
+ * States: idle → model → tool_execution → continue → model (loop)
+ *                                                  → complete (done)
+ *               → complete (text-only / error / abort)
+ *
+ * All transitions are pure: transitionTurn(state, input) → new state.
+ * Invalid transitions throw — bugs are immediately visible.
+ */
+
+import type { EngineStopReason } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Turn phases
+// ---------------------------------------------------------------------------
+
+export type TurnPhase = "idle" | "model" | "tool_execution" | "continue" | "complete";
+
+// ---------------------------------------------------------------------------
+// Turn inputs (events that drive transitions)
+// ---------------------------------------------------------------------------
+
+export type TurnInput =
+  | { readonly kind: "start" }
+  | { readonly kind: "model_done"; readonly hasToolCalls: boolean }
+  | { readonly kind: "tools_done" }
+  | { readonly kind: "abort" }
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "max_turns" };
+
+// ---------------------------------------------------------------------------
+// Turn state
+// ---------------------------------------------------------------------------
+
+export interface TurnState {
+  readonly phase: TurnPhase;
+  readonly turnIndex: number;
+  readonly modelCalls: number;
+  readonly stopReason: EngineStopReason | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createTurnState(turnIndex: number = 0): TurnState {
+  return { phase: "idle", turnIndex, modelCalls: 0, stopReason: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function complete(state: TurnState, stopReason: EngineStopReason): TurnState {
+  return { ...state, phase: "complete", stopReason };
+}
+
+function invalidTransition(phase: TurnPhase, inputKind: string): never {
+  throw new Error(`Invalid turn transition: "${phase}" + "${inputKind}"`);
+}
+
+// ---------------------------------------------------------------------------
+// Pure transition function
+// ---------------------------------------------------------------------------
+
+export function transitionTurn(state: TurnState, input: TurnInput): TurnState {
+  switch (state.phase) {
+    case "idle": {
+      if (input.kind === "start") {
+        return { ...state, phase: "model", modelCalls: state.modelCalls + 1 };
+      }
+      return invalidTransition(state.phase, input.kind);
+    }
+
+    case "model": {
+      switch (input.kind) {
+        case "model_done":
+          return input.hasToolCalls
+            ? { ...state, phase: "tool_execution" }
+            : complete(state, "completed");
+        case "abort":
+          return complete(state, "interrupted");
+        case "error":
+          return complete(state, "error");
+        default:
+          return invalidTransition(state.phase, input.kind);
+      }
+    }
+
+    case "tool_execution": {
+      switch (input.kind) {
+        case "tools_done":
+          return { ...state, phase: "continue", turnIndex: state.turnIndex + 1 };
+        case "abort":
+          return complete(state, "interrupted");
+        case "error":
+          return complete(state, "error");
+        default:
+          return invalidTransition(state.phase, input.kind);
+      }
+    }
+
+    case "continue": {
+      switch (input.kind) {
+        case "start":
+          return { ...state, phase: "model", modelCalls: state.modelCalls + 1 };
+        case "max_turns":
+          return complete(state, "max_turns");
+        case "abort":
+          return complete(state, "interrupted");
+        default:
+          return invalidTransition(state.phase, input.kind);
+      }
+    }
+
+    case "complete":
+      return invalidTransition(state.phase, input.kind);
+
+    default: {
+      const _exhaustive: never = state.phase;
+      throw new Error(`Unhandled phase: ${_exhaustive}`);
+    }
+  }
+}

--- a/packages/lib/query-engine/src/turn-runner.test.ts
+++ b/packages/lib/query-engine/src/turn-runner.test.ts
@@ -1,0 +1,944 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ComposedCallHandlers,
+  EngineEvent,
+  ModelChunk,
+  ModelRequest,
+  ModelResponse,
+  ToolCallId,
+  ToolRequest,
+  ToolResponse,
+} from "@koi/core";
+import { runTurn } from "./turn-runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function callId(id: string): ToolCallId {
+  return id as ToolCallId;
+}
+
+async function collect(stream: AsyncIterable<EngineEvent>): Promise<readonly EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+const DONE_RESPONSE: ModelResponse = {
+  content: "",
+  model: "test-model",
+  usage: { inputTokens: 10, outputTokens: 5 },
+} as const;
+
+function createTextStream(text: string): () => AsyncIterable<ModelChunk> {
+  return () => textStream(text);
+}
+
+async function* textStream(text: string): AsyncIterable<ModelChunk> {
+  yield { kind: "text_delta", delta: text };
+  yield { kind: "done", response: DONE_RESPONSE };
+}
+
+function createToolCallStream(
+  toolName: string,
+  toolCallId: string,
+  args: string,
+): () => AsyncIterable<ModelChunk> {
+  return () => toolCallStreamGen(toolName, toolCallId, args);
+}
+
+async function* toolCallStreamGen(
+  toolName: string,
+  id: string,
+  args: string,
+): AsyncIterable<ModelChunk> {
+  yield { kind: "tool_call_start", toolName, callId: callId(id) };
+  yield { kind: "tool_call_delta", callId: callId(id), delta: args };
+  yield { kind: "tool_call_end", callId: callId(id) };
+  yield { kind: "done", response: DONE_RESPONSE };
+}
+
+/** Shorthand for declaring a tool descriptor in tests. */
+function toolDesc(name: string): {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Record<string, never>;
+} {
+  return { name, description: "", inputSchema: {} };
+}
+
+function createMockHandlers(options: {
+  readonly modelStreams: ReadonlyArray<() => AsyncIterable<ModelChunk>>;
+  readonly toolCall?: (request: ToolRequest) => Promise<ToolResponse>;
+  readonly tools?: ComposedCallHandlers["tools"];
+}): ComposedCallHandlers {
+  // let justified: mutable call counter for cycling through modelStreams
+  let streamCallIndex = 0;
+
+  return {
+    modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+    modelStream: (_request: ModelRequest): AsyncIterable<ModelChunk> => {
+      const streamFactory = options.modelStreams[streamCallIndex];
+      if (streamFactory === undefined) {
+        throw new Error(`Unexpected model stream call #${streamCallIndex}`);
+      }
+      streamCallIndex += 1;
+      return streamFactory();
+    },
+    toolCall:
+      options.toolCall ??
+      (async (_request: ToolRequest): Promise<ToolResponse> => ({
+        output: "tool-result",
+      })),
+    tools: options.tools ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runTurn", () => {
+  test("single-turn text -> done", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [createTextStream("hello world")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(["turn_start", "text_delta", "turn_end", "done"]);
+
+    // Verify turn_start
+    expect(events[0]).toMatchObject({ kind: "turn_start", turnIndex: 0 });
+
+    // Verify done
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("completed");
+      expect(done.output.metrics.turns).toBe(1);
+    }
+  });
+
+  test("tool call -> continue -> done", async () => {
+    const toolCalls: string[] = [];
+    const handlers = createMockHandlers({
+      modelStreams: [
+        // Turn 0: model returns a tool call
+        createToolCallStream("readFile", "tc-1", '{"path":"/foo"}'),
+        // Turn 1: model returns text
+        createTextStream("done reading"),
+      ],
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        toolCalls.push(request.toolId);
+        return { output: "file-content" };
+      },
+      tools: [toolDesc("readFile")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      // Turn 0
+      "turn_start",
+      "tool_call_start",
+      "tool_call_delta",
+      "tool_call_end",
+      "turn_end",
+      // Turn 1
+      "turn_start",
+      "text_delta",
+      "turn_end",
+      // Final
+      "done",
+    ]);
+
+    // Verify tool was called
+    expect(toolCalls).toEqual(["readFile"]);
+
+    // Verify turn indices
+    expect(events[0]).toMatchObject({ kind: "turn_start", turnIndex: 0 });
+    expect(events[5]).toMatchObject({ kind: "turn_start", turnIndex: 1 });
+
+    // Verify done
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("completed");
+      expect(done.output.metrics.turns).toBe(2);
+    }
+  });
+
+  test("abort signal -> interrupted done", async () => {
+    const controller = new AbortController();
+
+    // Model stream that aborts after yielding first delta
+    async function* abortingStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "partial" };
+      controller.abort();
+      // Yield more — runner should check abort and stop
+      yield { kind: "text_delta", delta: " more" };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => abortingStream()],
+    });
+
+    const events = await collect(
+      runTurn({
+        callHandlers: handlers,
+        messages: [],
+        signal: controller.signal,
+      }),
+    );
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("interrupted");
+    }
+  });
+
+  test("max turns -> max_turns stop reason", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [
+        // Turn 0: always returns tool calls
+        createToolCallStream("readFile", "tc-1", '{"path":"/a"}'),
+        // Turn 1 would be another tool call, but maxTurns=1 stops it
+      ],
+      tools: [toolDesc("readFile")],
+    });
+
+    const events = await collect(
+      runTurn({
+        callHandlers: handlers,
+        messages: [],
+        maxTurns: 1,
+      }),
+    );
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("max_turns");
+    }
+  });
+
+  test("model error produces error done", async () => {
+    async function* errorStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "error", message: "rate limited" };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => errorStream()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("model stream throws produces error done", async () => {
+    async function* throwingStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "partial" };
+      throw new Error("connection reset");
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => throwingStream()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("non-streaming fallback uses modelCall", async () => {
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => ({
+        content: "hello from modelCall",
+        model: "test-model",
+        usage: { inputTokens: 5, outputTokens: 3 },
+      }),
+      // No modelStream — runner should fall back to modelCall
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => ({
+        output: "unused",
+      }),
+      tools: [],
+    };
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(["turn_start", "text_delta", "turn_end", "done"]);
+
+    const textDelta = events.find((e) => e.kind === "text_delta");
+    if (textDelta?.kind === "text_delta") {
+      expect(textDelta.delta).toBe("hello from modelCall");
+    }
+  });
+
+  test("tool execution error produces error done", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [createToolCallStream("failTool", "tc-1", '{"x":1}')],
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => {
+        throw new Error("tool exploded");
+      },
+      tools: [toolDesc("failTool")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("usage metrics accumulate across turns", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [createToolCallStream("tool1", "tc-1", '{"a":1}'), createTextStream("final")],
+      tools: [toolDesc("tool1")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    if (done?.kind === "done") {
+      // Each DONE_RESPONSE has inputTokens: 10, outputTokens: 5
+      // Two model calls → 20 input, 10 output
+      expect(done.output.metrics.inputTokens).toBe(20);
+      expect(done.output.metrics.outputTokens).toBe(10);
+      expect(done.output.metrics.totalTokens).toBe(30);
+    }
+  });
+
+  test("malformed tool call args fails closed instead of executing", async () => {
+    // Stream with tool call that has invalid JSON args
+    async function* malformedToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "tool_call_start", toolName: "readFile", callId: callId("tc-bad") };
+      yield { kind: "tool_call_delta", callId: callId("tc-bad"), delta: "{invalid json" };
+      yield { kind: "tool_call_end", callId: callId("tc-bad") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const toolCalls: string[] = [];
+    const handlers = createMockHandlers({
+      modelStreams: [() => malformedToolStream()],
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        toolCalls.push(request.toolId);
+        return { output: "should-not-run" };
+      },
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Tool must NOT have been called
+    expect(toolCalls).toEqual([]);
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("tool results are passed as messages to next model call", async () => {
+    const receivedRequests: ModelRequest[] = [];
+
+    // let justified: mutable call counter for cycling through responses
+    let modelCallIndex = 0;
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (request: ModelRequest): AsyncIterable<ModelChunk> => {
+        receivedRequests.push(request);
+        const index = modelCallIndex;
+        modelCallIndex += 1;
+        if (index === 0) {
+          return toolCallStreamGen("readFile", "tc-1", '{"path":"/foo"}');
+        }
+        return textStream("done");
+      },
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => ({
+        output: "file-content-here",
+      }),
+      tools: [toolDesc("readFile")],
+    };
+
+    await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Second model call should have tool result messages
+    expect(receivedRequests.length).toBe(2);
+    const secondRequest = receivedRequests[1];
+    expect(secondRequest).toBeDefined();
+    if (secondRequest !== undefined) {
+      // Tool results encoded as messages with senderId "tool:<name>"
+      const toolMessages = secondRequest.messages.filter((m) => m.senderId === "tool");
+      expect(toolMessages.length).toBe(1);
+      const toolMsg = toolMessages[0];
+      if (toolMsg !== undefined) {
+        expect(toolMsg.senderId).toBe("tool");
+        const textBlock = toolMsg.content[0];
+        if (textBlock?.kind === "text") {
+          const parsed: unknown = JSON.parse(textBlock.text);
+          expect(parsed).toMatchObject({ callId: "tc-1", output: "file-content-here" });
+        }
+      }
+    }
+  });
+
+  test("truncated stream without terminal chunk produces error done", async () => {
+    // Stream that yields text but never emits done/error
+    async function* truncatedStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "partial response" };
+      // No done/error — stream just ends
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => truncatedStream()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("done.output.content contains accumulated text", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [createTextStream("hello world")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.content.length).toBe(1);
+      const block = done.output.content[0];
+      if (block?.kind === "text") {
+        expect(block.text).toBe("hello world");
+      }
+    }
+  });
+
+  test("done.output.content is empty when no text emitted", async () => {
+    // Stream with only tool calls, no text
+    const handlers = createMockHandlers({
+      modelStreams: [createToolCallStream("tool1", "tc-1", '{"a":1}'), createTextStream("")],
+      tools: [toolDesc("tool1")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      // The second turn emits empty text, so content should be empty
+      expect(done.output.content.length).toBe(0);
+    }
+  });
+
+  test("transcript accumulates across turns for model context", async () => {
+    const receivedRequests: ModelRequest[] = [];
+
+    // let justified: mutable call counter for cycling through responses
+    let modelCallIndex = 0;
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (request: ModelRequest): AsyncIterable<ModelChunk> => {
+        receivedRequests.push(request);
+        const index = modelCallIndex;
+        modelCallIndex += 1;
+        if (index === 0) {
+          return toolCallStreamGen("readFile", "tc-1", '{"path":"/foo"}');
+        }
+        return textStream("final answer");
+      },
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => ({
+        output: "file-content",
+      }),
+      tools: [toolDesc("readFile")],
+    };
+
+    await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Second model call should include assistant message + tool result
+    expect(receivedRequests.length).toBe(2);
+    const secondRequest = receivedRequests[1];
+    expect(secondRequest).toBeDefined();
+    if (secondRequest !== undefined) {
+      // Should have assistant turn (with tool call intent) + tool result
+      const assistantMsgs = secondRequest.messages.filter((m) => m.senderId === "assistant");
+      const toolMsgs = secondRequest.messages.filter((m) => m.senderId === "tool");
+      expect(assistantMsgs.length).toBe(1);
+      expect(toolMsgs.length).toBe(1);
+    }
+  });
+
+  test("tool calls execute sequentially preserving order", async () => {
+    const executionOrder: string[] = [];
+
+    async function* multiToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "tool_call_start", toolName: "first", callId: callId("tc-1") };
+      yield { kind: "tool_call_delta", callId: callId("tc-1"), delta: '{"n":1}' };
+      yield { kind: "tool_call_end", callId: callId("tc-1") };
+      yield { kind: "tool_call_start", toolName: "second", callId: callId("tc-2") };
+      yield { kind: "tool_call_delta", callId: callId("tc-2"), delta: '{"n":2}' };
+      yield { kind: "tool_call_end", callId: callId("tc-2") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => multiToolStream(), createTextStream("done")],
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        executionOrder.push(request.toolId);
+        return { output: `result-${request.toolId}` };
+      },
+      tools: [toolDesc("first"), toolDesc("second")],
+    });
+
+    await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Must execute in model-emitted order, not interleaved
+    expect(executionOrder).toEqual(["first", "second"]);
+  });
+
+  test("done.output.content contains only terminal turn text, not all turns", async () => {
+    // Turn 0 emits "thinking..." then tool call, turn 1 emits "final answer"
+    async function* thinkingThenToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "thinking..." };
+      yield { kind: "tool_call_start", toolName: "search", callId: callId("tc-1") };
+      yield { kind: "tool_call_delta", callId: callId("tc-1"), delta: '{"q":"x"}' };
+      yield { kind: "tool_call_end", callId: callId("tc-1") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => thinkingThenToolStream(), createTextStream("final answer")],
+      tools: [toolDesc("search")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      // Should only contain the terminal turn's text, not "thinking...final answer"
+      expect(done.output.content.length).toBe(1);
+      const block = done.output.content[0];
+      if (block?.kind === "text") {
+        expect(block.text).toBe("final answer");
+      }
+    }
+  });
+
+  test("non-JSON-serializable tool output does not crash the runner", async () => {
+    const handlers = createMockHandlers({
+      modelStreams: [createToolCallStream("tool1", "tc-1", '{"a":1}'), createTextStream("ok")],
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => {
+        // BigInt is not JSON-serializable
+        return { output: BigInt(42) };
+      },
+      tools: [toolDesc("tool1")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Should complete without crashing — safe serializer falls back to String()
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("completed");
+    }
+  });
+
+  test("undeclared tool calls are rejected before execution", async () => {
+    const toolCalls: string[] = [];
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (_request: ModelRequest): AsyncIterable<ModelChunk> => {
+        return toolCallStreamGen("secretTool", "tc-1", '{"x":1}');
+      },
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        toolCalls.push(request.toolId);
+        return { output: "should-not-run" };
+      },
+      // Only "readFile" is declared — "secretTool" is not
+      tools: [{ name: "readFile", description: "read a file", inputSchema: {} }],
+    };
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    // Tool must NOT have been called
+    expect(toolCalls).toEqual([]);
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("abort during tool execution stops remaining tools", async () => {
+    const controller = new AbortController();
+    const executedTools: string[] = [];
+
+    async function* twoToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "tool_call_start", toolName: "first", callId: callId("tc-1") };
+      yield { kind: "tool_call_delta", callId: callId("tc-1"), delta: '{"n":1}' };
+      yield { kind: "tool_call_end", callId: callId("tc-1") };
+      yield { kind: "tool_call_start", toolName: "second", callId: callId("tc-2") };
+      yield { kind: "tool_call_delta", callId: callId("tc-2"), delta: '{"n":2}' };
+      yield { kind: "tool_call_end", callId: callId("tc-2") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (_request: ModelRequest): AsyncIterable<ModelChunk> => twoToolStream(),
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        executedTools.push(request.toolId);
+        // Abort after first tool completes
+        if (request.toolId === "first") {
+          controller.abort();
+        }
+        return { output: `result-${request.toolId}` };
+      },
+      tools: [
+        { name: "first", description: "", inputSchema: {} },
+        { name: "second", description: "", inputSchema: {} },
+      ],
+    };
+
+    const events = await collect(
+      runTurn({ callHandlers: handlers, messages: [], signal: controller.signal }),
+    );
+
+    // Only the first tool should have executed
+    expect(executedTools).toEqual(["first"]);
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("interrupted");
+    }
+  });
+
+  test("pre-aborted signal produces interrupted done without model call", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    // let justified: mutable flag to detect if model was called
+    let modelCalled = false;
+    const handlers = createMockHandlers({
+      modelStreams: [
+        () => {
+          modelCalled = true;
+          return textStream("should not run");
+        },
+      ],
+    });
+
+    const events = await collect(
+      runTurn({ callHandlers: handlers, messages: [], signal: controller.signal }),
+    );
+
+    expect(modelCalled).toBe(false);
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(["done"]);
+    const done = events[0];
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("interrupted");
+      expect(done.output.metrics.turns).toBe(0);
+    }
+  });
+
+  test("maxTurns 0 produces max_turns done without model call", async () => {
+    // let justified: mutable flag to detect if model was called
+    let modelCalled = false;
+    const handlers = createMockHandlers({
+      modelStreams: [
+        () => {
+          modelCalled = true;
+          return textStream("should not run");
+        },
+      ],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [], maxTurns: 0 }));
+
+    expect(modelCalled).toBe(false);
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toEqual(["done"]);
+    const done = events[0];
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("max_turns");
+      expect(done.output.metrics.turns).toBe(0);
+    }
+  });
+
+  test("tool args missing required fields are rejected before execution", async () => {
+    const toolCalls: string[] = [];
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (_request: ModelRequest): AsyncIterable<ModelChunk> => {
+        // Tool call with args missing the required "path" field
+        return toolCallStreamGen("readFile", "tc-1", '{"encoding":"utf8"}');
+      },
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        toolCalls.push(request.toolId);
+        return { output: "should-not-run" };
+      },
+      tools: [
+        {
+          name: "readFile",
+          description: "read a file",
+          inputSchema: {
+            type: "object",
+            required: ["path"],
+            properties: { path: { type: "string" } },
+          },
+        },
+      ],
+    };
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    expect(toolCalls).toEqual([]);
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+      // Error metadata should identify schema validation as the source
+      expect(done.output.metadata).toBeDefined();
+      if (done.output.metadata !== undefined) {
+        expect(done.output.metadata.source).toBe("schema_validation");
+      }
+    }
+  });
+
+  test("tool args with wrong type are rejected before execution", async () => {
+    const toolCalls: string[] = [];
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (_request: ModelRequest): AsyncIterable<ModelChunk> => {
+        // path should be string but model sent number
+        return toolCallStreamGen("readFile", "tc-1", '{"path":123}');
+      },
+      toolCall: async (request: ToolRequest): Promise<ToolResponse> => {
+        toolCalls.push(request.toolId);
+        return { output: "should-not-run" };
+      },
+      tools: [
+        {
+          name: "readFile",
+          description: "read a file",
+          inputSchema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+        },
+      ],
+    };
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    expect(toolCalls).toEqual([]);
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+    }
+  });
+
+  test("error metadata is included in done event for model stream errors", async () => {
+    async function* errorStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "error", message: "rate limited" };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => errorStream()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+      expect(done.output.metadata).toBeDefined();
+      if (done.output.metadata !== undefined) {
+        expect(done.output.metadata.source).toBe("model_stream");
+      }
+    }
+  });
+
+  test("abort after tool execution still records the tool result", async () => {
+    const controller = new AbortController();
+
+    async function* singleToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "tool_call_start", toolName: "write", callId: callId("tc-1") };
+      yield { kind: "tool_call_delta", callId: callId("tc-1"), delta: '{"data":"x"}' };
+      yield { kind: "tool_call_end", callId: callId("tc-1") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const transcript: ModelRequest[] = [];
+    const handlers: ComposedCallHandlers = {
+      modelCall: async (_request: ModelRequest): Promise<ModelResponse> => DONE_RESPONSE,
+      modelStream: (request: ModelRequest): AsyncIterable<ModelChunk> => {
+        transcript.push(request);
+        return singleToolStream();
+      },
+      toolCall: async (_request: ToolRequest): Promise<ToolResponse> => {
+        // Abort after tool completes
+        controller.abort();
+        return { output: "written" };
+      },
+      tools: [{ name: "write", description: "", inputSchema: {} }],
+    };
+
+    const events = await collect(
+      runTurn({ callHandlers: handlers, messages: [], signal: controller.signal }),
+    );
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("interrupted");
+    }
+
+    // The key assertion: despite abort, the tool result must be in the event stream
+    // (turn_end was emitted, meaning the transcript was updated before abort)
+    const turnEnd = events.find((e) => e.kind === "turn_end");
+    expect(turnEnd).toBeDefined();
+  });
+
+  test("failed terminal turn reports its own text, not previous turn", async () => {
+    async function* textThenToolStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "tool_call_start", toolName: "tool1", callId: callId("tc-1") };
+      yield { kind: "tool_call_delta", callId: callId("tc-1"), delta: '{"a":1}' };
+      yield { kind: "tool_call_end", callId: callId("tc-1") };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    async function* failingStream(): AsyncIterable<ModelChunk> {
+      yield { kind: "text_delta", delta: "partial from failing turn" };
+      throw new Error("connection lost");
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => textThenToolStream(), () => failingStream()],
+      tools: [toolDesc("tool1")],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+      // Should contain the failing turn's text, not empty or previous turn's
+      expect(done.output.content.length).toBe(1);
+      const block = done.output.content[0];
+      if (block?.kind === "text") {
+        expect(block.text).toBe("partial from failing turn");
+      }
+    }
+  });
+
+  test("partial usage is preserved when stream is aborted before done", async () => {
+    const controller = new AbortController();
+
+    async function* streamWithUsage(): AsyncIterable<ModelChunk> {
+      yield { kind: "usage", inputTokens: 15, outputTokens: 8 };
+      yield { kind: "text_delta", delta: "partial" };
+      controller.abort();
+      yield { kind: "text_delta", delta: " more" };
+      yield { kind: "done", response: DONE_RESPONSE };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => streamWithUsage()],
+    });
+
+    const events = await collect(
+      runTurn({ callHandlers: handlers, messages: [], signal: controller.signal }),
+    );
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("interrupted");
+      // Partial usage from before abort should be preserved
+      expect(done.output.metrics.inputTokens).toBe(15);
+      expect(done.output.metrics.outputTokens).toBe(8);
+    }
+  });
+
+  test("partial usage is preserved when stream throws", async () => {
+    async function* streamWithUsageThenError(): AsyncIterable<ModelChunk> {
+      yield { kind: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { kind: "text_delta", delta: "partial" };
+      throw new Error("connection lost");
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => streamWithUsageThenError()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+      expect(done.output.metrics.inputTokens).toBe(20);
+      expect(done.output.metrics.outputTokens).toBe(10);
+    }
+  });
+
+  test("model error with usage does not double-count tokens", async () => {
+    async function* streamWithUsageThenModelError(): AsyncIterable<ModelChunk> {
+      yield { kind: "usage", inputTokens: 15, outputTokens: 8 };
+      yield { kind: "text_delta", delta: "partial" };
+      // Error chunk with authoritative usage — should NOT be added on top
+      yield { kind: "error", message: "rate limited", usage: { inputTokens: 15, outputTokens: 8 } };
+    }
+
+    const handlers = createMockHandlers({
+      modelStreams: [() => streamWithUsageThenModelError()],
+    });
+
+    const events = await collect(runTurn({ callHandlers: handlers, messages: [] }));
+
+    const done = events.find((e) => e.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done.output.stopReason).toBe("error");
+      // Must be 15/8, NOT 30/16 (double-counted)
+      expect(done.output.metrics.inputTokens).toBe(15);
+      expect(done.output.metrics.outputTokens).toBe(8);
+      expect(done.output.metrics.totalTokens).toBe(23);
+    }
+  });
+});

--- a/packages/lib/query-engine/src/turn-runner.ts
+++ b/packages/lib/query-engine/src/turn-runner.ts
@@ -1,0 +1,479 @@
+/**
+ * Turn runner — async generator that drives the model→tool→model loop.
+ *
+ * Uses the pure turn state machine for transitions and `consumeModelStream`
+ * for stream consumption. Interacts with the engine through `ComposedCallHandlers`.
+ */
+
+import type {
+  ComposedCallHandlers,
+  ContentBlock,
+  EngineEvent,
+  InboundMessage,
+  JsonObject,
+  ModelRequest,
+} from "@koi/core";
+import { consumeModelStream } from "./consume-stream.js";
+import type { TurnState } from "./turn-machine.js";
+import { createTurnState, transitionTurn } from "./turn-machine.js";
+import type { AccumulatedToolCall } from "./types.js";
+import { validateToolArgs } from "./validate-tool-args.js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface TurnRunnerConfig {
+  readonly callHandlers: ComposedCallHandlers;
+  readonly messages: readonly InboundMessage[];
+  readonly signal?: AbortSignal | undefined;
+  readonly maxTurns?: number | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export async function* runTurn(config: TurnRunnerConfig): AsyncGenerator<EngineEvent> {
+  const { callHandlers, messages, signal, maxTurns } = config;
+
+  // let justified: mutable state driven by pure transition function
+  let state: TurnState = createTurnState(0);
+  // let justified: mutable conversation transcript, grows across turns
+  const transcript: InboundMessage[] = [...messages];
+  // let justified: mutable usage accumulators
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  // let justified: mutable ref to the last (terminal) turn's text for done.output.content
+  let lastTurnText: readonly string[] = [];
+  // let justified: mutable error metadata for structured error reporting in done event
+  let errorMetadata: JsonObject | undefined;
+  const startTime = performance.now();
+
+  // Pre-flight: handle already-aborted signal before entering the state machine.
+  // The idle state only accepts "start", so we short-circuit here.
+  if (isAborted(signal)) {
+    state = { ...state, phase: "complete", stopReason: "interrupted" };
+  }
+
+  // Pre-flight: enforce zero-turn budget before any work.
+  if (state.phase !== "complete" && maxTurns !== undefined && maxTurns <= 0) {
+    state = { ...state, phase: "complete", stopReason: "max_turns" };
+  }
+
+  while (state.phase !== "complete") {
+    // Check abort before each model call
+    if (isAborted(signal)) {
+      state = transitionTurn(state, { kind: "abort" });
+      break;
+    }
+
+    // Check max turns at continue boundary
+    if (state.phase === "continue" && maxTurns !== undefined && state.turnIndex >= maxTurns) {
+      state = transitionTurn(state, { kind: "max_turns" });
+      break;
+    }
+
+    // idle/continue → model
+    state = transitionTurn(state, { kind: "start" });
+    yield { kind: "turn_start", turnIndex: state.turnIndex };
+
+    // Build model request from accumulated transcript.
+    // Snapshot the tool descriptors at request time — validation uses this
+    // immutable set, not the live callHandlers.tools which can change.
+    //
+    // Note: middleware can further filter modelRequest.tools before the model
+    // sees them. This runner validates against the pre-middleware snapshot.
+    // Defense-in-depth: callHandlers.toolCall also goes through the middleware
+    // chain, so middleware-filtered tools are rejected at execution time too.
+    // Defensive clone — prevents middleware or getter mutations from
+    // affecting the allowlist/schema snapshot used for validation.
+    const advertisedTools = [...callHandlers.tools];
+    const advertisedToolIds = new Set(advertisedTools.map((t) => t.name));
+    const modelRequest = buildModelRequest(transcript, advertisedTools, signal);
+
+    // Stream model response and collect tool calls
+    const toolCalls: AccumulatedToolCall[] = [];
+    // let justified: mutable per-turn text for transcript accumulation
+    const turnText: string[] = [];
+    // let justified: mutable sentinel — true only when a terminal done/error chunk was seen
+    let sawTerminal = false;
+    // let justified: mutable flag — true when terminal done already committed metrics
+    let terminalMetricsCommitted = false;
+    // let justified: mutable per-turn usage tracked from custom events
+    let turnInputTokens = 0;
+    let turnOutputTokens = 0;
+
+    try {
+      const stream =
+        callHandlers.modelStream !== undefined
+          ? callHandlers.modelStream(modelRequest)
+          : synthesizeStream(callHandlers, modelRequest);
+
+      for await (const event of consumeModelStream(stream)) {
+        if (isAborted(signal)) {
+          state = transitionTurn(state, { kind: "abort" });
+          yield { kind: "turn_end", turnIndex: state.turnIndex };
+          break;
+        }
+
+        if (event.kind === "done") {
+          sawTerminal = true;
+          // Intercept done — runner owns the final done event.
+          // Propagate non-completed stop reasons as errors.
+          // Use authoritative terminal metrics for this turn (supersedes
+          // incremental custom events). Add to cross-turn totals.
+          if (event.output.metrics) {
+            totalInputTokens += event.output.metrics.inputTokens;
+            totalOutputTokens += event.output.metrics.outputTokens;
+            terminalMetricsCommitted = true;
+          } else {
+            // No terminal metrics — fall back to incrementally tracked usage
+            totalInputTokens += turnInputTokens;
+            totalOutputTokens += turnOutputTokens;
+            terminalMetricsCommitted = true;
+          }
+          if (event.output.stopReason !== "completed") {
+            errorMetadata = {
+              source: "model_stream",
+              originalStopReason: event.output.stopReason,
+              ...(event.output.metadata !== undefined
+                ? { providerDetail: event.output.metadata }
+                : {}),
+            };
+            state = transitionTurn(state, {
+              kind: "error",
+              message: `model stream ended with stopReason: ${event.output.stopReason}`,
+            });
+          }
+          break;
+        }
+
+        // Intercept usage custom events for partial usage tracking.
+        // Per-turn usage is tracked so early exits (abort/error) still
+        // report consumed tokens. Not forwarded to the consumer.
+        if (event.kind === "custom" && event.type === "usage") {
+          const usage = event.data as {
+            readonly inputTokens: number;
+            readonly outputTokens: number;
+          };
+          turnInputTokens += usage.inputTokens;
+          turnOutputTokens += usage.outputTokens;
+          continue;
+        }
+
+        // Accumulate per-turn text for transcript
+        if (event.kind === "text_delta") {
+          turnText.push(event.delta);
+        }
+
+        if (event.kind === "tool_call_end") {
+          const accumulated = event.result as AccumulatedToolCall;
+          toolCalls.push(accumulated);
+        }
+
+        yield event;
+      }
+    } catch (e: unknown) {
+      lastTurnText = turnText;
+      // Preserve partial usage from this turn on early exit
+      totalInputTokens += turnInputTokens;
+      totalOutputTokens += turnOutputTokens;
+      const msg = e instanceof Error ? e.message : String(e);
+      errorMetadata = { source: "stream_exception", message: msg };
+      state = transitionTurn(state, { kind: "error", message: msg });
+      yield { kind: "turn_end", turnIndex: state.turnIndex };
+      break;
+    }
+
+    // Update lastTurnText eagerly so error/abort breaks report
+    // the current turn's text, not a previous turn's.
+    lastTurnText = turnText;
+
+    // If abort or stream error happened, we already transitioned.
+    // Preserve partial usage only if terminal metrics weren't already committed.
+    if (state.phase === "complete") {
+      if (!terminalMetricsCommitted) {
+        totalInputTokens += turnInputTokens;
+        totalOutputTokens += turnOutputTokens;
+      }
+      break;
+    }
+
+    // Fail if stream ended without a terminal done/error chunk (truncated)
+    if (!sawTerminal) {
+      totalInputTokens += turnInputTokens;
+      totalOutputTokens += turnOutputTokens;
+      errorMetadata = { source: "truncated_stream" };
+      state = transitionTurn(state, {
+        kind: "error",
+        message: "model stream ended without a terminal done/error chunk",
+      });
+      yield { kind: "turn_end", turnIndex: state.turnIndex };
+      break;
+    }
+
+    // Validate tool calls — fail closed on malformed/orphaned calls
+    const validToolCalls = toolCalls.filter(
+      (tc) => tc.toolName !== "unknown" && tc.parsedArgs !== undefined,
+    );
+    if (validToolCalls.length < toolCalls.length) {
+      const invalidCount = toolCalls.length - validToolCalls.length;
+      errorMetadata = { source: "malformed_tool_call", invalidCount };
+      state = transitionTurn(state, {
+        kind: "error",
+        message: `${invalidCount} tool call(s) had malformed or missing arguments — failing closed`,
+      });
+      yield { kind: "turn_end", turnIndex: state.turnIndex };
+      break;
+    }
+
+    // Validate tool calls against the advertised snapshot — fail closed on
+    // undeclared tool IDs to prevent model hallucination or prompt injection
+    // from reaching internal/undeclared tools.
+    // When no tools were advertised, any model-issued tool call is undeclared.
+    if (validToolCalls.length > 0) {
+      const undeclared = validToolCalls.filter((tc) => !advertisedToolIds.has(tc.toolName));
+      if (undeclared.length > 0) {
+        const names = undeclared.map((tc) => tc.toolName).join(", ");
+        errorMetadata = { source: "undeclared_tool", tools: names };
+        state = transitionTurn(state, {
+          kind: "error",
+          message: `tool call(s) for undeclared tool(s): ${names} — failing closed`,
+        });
+        yield { kind: "turn_end", turnIndex: state.turnIndex };
+        break;
+      }
+    }
+
+    // Validate tool arguments against advertised inputSchema
+    if (validToolCalls.length > 0) {
+      const descriptorMap = new Map(advertisedTools.map((t) => [t.name, t]));
+      const schemaErrors: string[] = [];
+      for (const tc of validToolCalls) {
+        const descriptor = descriptorMap.get(tc.toolName);
+        if (descriptor !== undefined) {
+          const error = validateToolArgs(tc.parsedArgs as JsonObject, descriptor);
+          if (error !== undefined) {
+            schemaErrors.push(`${tc.toolName}: ${error}`);
+          }
+        }
+      }
+      if (schemaErrors.length > 0) {
+        errorMetadata = { source: "schema_validation", errors: schemaErrors };
+        state = transitionTurn(state, {
+          kind: "error",
+          message: `tool argument validation failed — ${schemaErrors.join("; ")}`,
+        });
+        yield { kind: "turn_end", turnIndex: state.turnIndex };
+        break;
+      }
+    }
+
+    // Transition based on model response
+    state = transitionTurn(state, {
+      kind: "model_done",
+      hasToolCalls: validToolCalls.length > 0,
+    });
+
+    if (state.phase === "tool_execution") {
+      // Append assistant message (text + tool call intents) to transcript
+      appendAssistantTurn(transcript, turnText, validToolCalls);
+
+      // Execute tool calls sequentially to preserve model-emitted order
+      // and avoid racing side effects between dependent operations.
+      // Check abort before each tool call to stop dispatching on cancellation.
+      try {
+        const results: ToolResult[] = [];
+        for (const tc of validToolCalls) {
+          if (isAborted(signal)) {
+            state = transitionTurn(state, { kind: "abort" });
+            break;
+          }
+          const response = await callHandlers.toolCall({
+            toolId: tc.toolName,
+            // parsedArgs is guaranteed defined by the filter above
+            input: tc.parsedArgs as import("@koi/core").JsonObject,
+            ...(signal !== undefined ? { signal } : {}),
+          });
+          // Record result BEFORE checking abort — the tool already ran and
+          // committed side effects, so the transcript must reflect that.
+          const result: ToolResult = {
+            callId: tc.callId,
+            toolName: tc.toolName,
+            output: response.output,
+          };
+          results.push(result);
+          appendToolResult(transcript, result);
+          if (isAborted(signal)) {
+            state = transitionTurn(state, { kind: "abort" });
+            break;
+          }
+        }
+        if (state.phase === "tool_execution") {
+          state = transitionTurn(state, { kind: "tools_done" });
+        }
+      } catch (e: unknown) {
+        if (state.phase !== "complete") {
+          const msg = e instanceof Error ? e.message : String(e);
+          errorMetadata = { source: "tool_execution", message: msg };
+          state = transitionTurn(state, { kind: "error", message: msg });
+        }
+      }
+    } else if (turnText.length > 0) {
+      // Text-only turn — append assistant message to transcript
+      appendAssistantTurn(transcript, turnText, []);
+    }
+
+    yield {
+      kind: "turn_end",
+      turnIndex: state.phase === "continue" ? state.turnIndex - 1 : state.turnIndex,
+    };
+  }
+
+  // Final done event — only the terminal turn's text, not all turns concatenated
+  const durationMs = performance.now() - startTime;
+  const finalText = lastTurnText.join("");
+  const content: readonly ContentBlock[] =
+    finalText.length > 0 ? [{ kind: "text", text: finalText }] : [];
+  yield {
+    kind: "done",
+    output: {
+      content,
+      stopReason: state.stopReason ?? "completed",
+      metrics: {
+        totalTokens: totalInputTokens + totalOutputTokens,
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        turns: state.modelCalls,
+        durationMs,
+      },
+      ...(errorMetadata !== undefined ? { metadata: errorMetadata } : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Check abort without TS narrowing the signal type for subsequent checks. */
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+interface ToolResult {
+  readonly callId: string;
+  readonly toolName: string;
+  readonly output: unknown;
+}
+
+function buildModelRequest(
+  transcript: readonly InboundMessage[],
+  tools: ComposedCallHandlers["tools"],
+  signal: AbortSignal | undefined,
+): ModelRequest {
+  return {
+    // Snapshot the transcript so later mutations don't affect this request
+    messages: [...transcript],
+    tools,
+    ...(signal !== undefined ? { signal } : {}),
+  };
+}
+
+/**
+ * Append assistant turn messages to the transcript.
+ *
+ * Text-only content is a single message with no callId.
+ * Each tool-use intent is a separate message with `metadata.callId`
+ * matching the session-repair pairing contract.
+ */
+function appendAssistantTurn(
+  transcript: InboundMessage[],
+  textParts: readonly string[],
+  toolCalls: readonly AccumulatedToolCall[],
+): void {
+  const text = textParts.join("");
+  if (text.length > 0) {
+    transcript.push({
+      senderId: "assistant",
+      content: [{ kind: "text", text }],
+      timestamp: Date.now(),
+    });
+  }
+  // Each tool-use intent gets its own message with metadata.callId
+  // so session-repair can pair it with the corresponding tool result.
+  for (const tc of toolCalls) {
+    transcript.push({
+      senderId: "assistant",
+      content: [
+        {
+          kind: "text",
+          text: JSON.stringify({ toolCall: tc.toolName, args: tc.parsedArgs }),
+        },
+      ],
+      timestamp: Date.now(),
+      metadata: { callId: tc.callId, toolName: tc.toolName },
+    });
+  }
+}
+
+/**
+ * Append a tool result to the transcript.
+ *
+ * Uses `senderId: "tool"` and `metadata.callId` to match the
+ * session-repair pairing contract (map-call-id-pairs.ts).
+ */
+function appendToolResult(transcript: InboundMessage[], result: ToolResult): void {
+  transcript.push({
+    senderId: "tool",
+    content: [
+      {
+        kind: "text",
+        text: safeStringify({ callId: result.callId, output: result.output }),
+      },
+    ],
+    timestamp: Date.now(),
+    metadata: { callId: result.callId, toolName: result.toolName },
+  });
+}
+
+/**
+ * Serialize a value to JSON. On non-serializable values (BigInt, circular refs),
+ * returns a structured error envelope so the model can see serialization failed
+ * rather than reasoning over a lossy `[object Object]` string.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (e: unknown) {
+    return JSON.stringify({
+      __serialization_error: true,
+      type: typeof value,
+      message: e instanceof Error ? e.message : "JSON serialization failed",
+      preview: truncate(String(value), 200),
+    });
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+/**
+ * Fallback for non-streaming model calls. Calls modelCall and synthesizes
+ * a minimal ModelChunk stream from the response.
+ */
+async function* synthesizeStream(
+  callHandlers: ComposedCallHandlers,
+  request: ModelRequest,
+): AsyncIterable<import("@koi/core").ModelChunk> {
+  const response = await callHandlers.modelCall(request);
+  if (response.content) {
+    yield { kind: "text_delta", delta: response.content };
+  }
+  yield {
+    kind: "done",
+    response,
+  };
+}

--- a/packages/lib/query-engine/src/validate-tool-args.test.ts
+++ b/packages/lib/query-engine/src/validate-tool-args.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolDescriptor } from "@koi/core";
+import { validateToolArgs } from "./validate-tool-args.js";
+
+function desc(schema: Record<string, unknown>): ToolDescriptor {
+  return { name: "test", description: "", inputSchema: schema };
+}
+
+describe("validateToolArgs", () => {
+  test("passes when no schema constraints", () => {
+    expect(validateToolArgs({ anything: "goes" }, desc({}))).toBeUndefined();
+  });
+
+  test("passes when required fields are present", () => {
+    const result = validateToolArgs(
+      { path: "/foo", encoding: "utf8" },
+      desc({ required: ["path", "encoding"] }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects missing required fields", () => {
+    const result = validateToolArgs({ encoding: "utf8" }, desc({ required: ["path", "encoding"] }));
+    expect(result).toContain("missing required field(s): path");
+  });
+
+  test("rejects wrong type: expected string got number", () => {
+    const result = validateToolArgs(
+      { path: 123 },
+      desc({ properties: { path: { type: "string" } } }),
+    );
+    expect(result).toContain('field "path" expected string, got number');
+  });
+
+  test("rejects wrong type: expected number got string", () => {
+    const result = validateToolArgs(
+      { count: "five" },
+      desc({ properties: { count: { type: "number" } } }),
+    );
+    expect(result).toContain('field "count" expected number, got string');
+  });
+
+  test("rejects float when integer expected", () => {
+    const result = validateToolArgs(
+      { count: 3.14 },
+      desc({ properties: { count: { type: "integer" } } }),
+    );
+    expect(result).toContain("expected integer, got float");
+  });
+
+  test("rejects wrong type: expected boolean got string", () => {
+    const result = validateToolArgs(
+      { flag: "true" },
+      desc({ properties: { flag: { type: "boolean" } } }),
+    );
+    expect(result).toContain('field "flag" expected boolean, got string');
+  });
+
+  test("rejects wrong type: expected array got object", () => {
+    const result = validateToolArgs(
+      { items: {} },
+      desc({ properties: { items: { type: "array" } } }),
+    );
+    expect(result).toContain('field "items" expected array, got object');
+  });
+
+  test("rejects wrong type: expected object got array", () => {
+    const result = validateToolArgs(
+      { config: [] },
+      desc({ properties: { config: { type: "object" } } }),
+    );
+    expect(result).toContain('field "config" expected object, got array');
+  });
+
+  test("passes correct types", () => {
+    const result = validateToolArgs(
+      { name: "foo", count: 5, flag: true, items: [1], config: { a: 1 } },
+      desc({
+        properties: {
+          name: { type: "string" },
+          count: { type: "integer" },
+          flag: { type: "boolean" },
+          items: { type: "array" },
+          config: { type: "object" },
+        },
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects additional properties when disallowed", () => {
+    const result = validateToolArgs(
+      { path: "/foo", secret: "key" },
+      desc({
+        properties: { path: { type: "string" } },
+        additionalProperties: false,
+      }),
+    );
+    expect(result).toContain("unexpected additional field(s): secret");
+  });
+
+  test("allows additional properties when not restricted", () => {
+    const result = validateToolArgs(
+      { path: "/foo", extra: "ok" },
+      desc({ properties: { path: { type: "string" } } }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("skips type check for missing optional fields", () => {
+    const result = validateToolArgs({}, desc({ properties: { optional: { type: "string" } } }));
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects schema with unsupported root keyword oneOf", () => {
+    const result = validateToolArgs(
+      { x: 1 },
+      desc({ oneOf: [{ type: "string" }, { type: "number" }] }),
+    );
+    expect(result).toContain('unsupported keyword "oneOf"');
+  });
+
+  test("rejects schema with unsupported root keyword anyOf", () => {
+    const result = validateToolArgs({ x: 1 }, desc({ anyOf: [{}] }));
+    expect(result).toContain('unsupported keyword "anyOf"');
+  });
+
+  test("rejects schema with unsupported root keyword allOf", () => {
+    const result = validateToolArgs({ x: 1 }, desc({ allOf: [{}] }));
+    expect(result).toContain('unsupported keyword "allOf"');
+  });
+
+  test("rejects property with enum keyword", () => {
+    const result = validateToolArgs(
+      { mode: "fast" },
+      desc({ properties: { mode: { type: "string", enum: ["fast", "slow"] } } }),
+    );
+    expect(result).toContain('property "mode" uses unsupported keyword "enum"');
+  });
+
+  test("rejects property with pattern keyword", () => {
+    const result = validateToolArgs(
+      { id: "abc" },
+      desc({ properties: { id: { type: "string", pattern: "^[0-9]+$" } } }),
+    );
+    expect(result).toContain('property "id" uses unsupported keyword "pattern"');
+  });
+
+  test("rejects additionalProperties as subschema object", () => {
+    const result = validateToolArgs(
+      { name: "foo", extra: "bar" },
+      desc({
+        properties: { name: { type: "string" } },
+        additionalProperties: { type: "string" },
+      }),
+    );
+    expect(result).toContain("additionalProperties");
+    expect(result).toContain("subschema");
+  });
+
+  test("allows additionalProperties: true", () => {
+    const result = validateToolArgs(
+      { name: "foo", extra: "bar" },
+      desc({
+        properties: { name: { type: "string" } },
+        additionalProperties: true,
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("additionalProperties: false without properties rejects any keys", () => {
+    const result = validateToolArgs({ unexpected: "value" }, desc({ additionalProperties: false }));
+    expect(result).toContain("unexpected additional field(s): unexpected");
+  });
+
+  test("additionalProperties: false without properties allows empty args", () => {
+    const result = validateToolArgs({}, desc({ additionalProperties: false }));
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects unsupported type value (typo)", () => {
+    const result = validateToolArgs(
+      { name: "foo" },
+      desc({ properties: { name: { type: "strng" } } }),
+    );
+    expect(result).toContain('unsupported type "strng"');
+  });
+
+  test("rejects union type array", () => {
+    const result = validateToolArgs(
+      { value: "foo" },
+      desc({ properties: { value: { type: ["string", "null"] } } }),
+    );
+    expect(result).toContain("unsupported type");
+  });
+});

--- a/packages/lib/query-engine/src/validate-tool-args.ts
+++ b/packages/lib/query-engine/src/validate-tool-args.ts
@@ -1,0 +1,129 @@
+/**
+ * Lightweight JSON Schema validation for tool arguments.
+ *
+ * Validates required fields, top-level property types, and
+ * additionalProperties constraints. Does not handle nested schemas,
+ * oneOf/anyOf/allOf, or format validators — those require a full
+ * JSON Schema library (e.g., Ajv) if/when one is added as a dependency.
+ */
+
+import type { JsonObject, ToolDescriptor } from "@koi/core";
+
+/**
+ * Allowlisted schema keywords this validator can evaluate.
+ * Any keyword NOT in this set is rejected (fail-closed).
+ */
+const SUPPORTED_ROOT_KEYWORDS = new Set([
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  "description",
+  "title",
+  "$schema",
+  "$id",
+  "default",
+]);
+
+const SUPPORTED_PROPERTY_KEYWORDS = new Set(["type", "description", "title", "default"]);
+
+/**
+ * Validate tool arguments against the descriptor's inputSchema.
+ * Returns an error string on failure, undefined on success.
+ *
+ * Fails closed on unsupported schema keywords — if the schema uses
+ * features this validator cannot evaluate, the tool call is rejected
+ * rather than silently bypassed.
+ */
+export function validateToolArgs(args: JsonObject, descriptor: ToolDescriptor): string | undefined {
+  const schema = descriptor.inputSchema;
+
+  // Fail closed on any root keyword not in the supported allowlist
+  for (const key of Object.keys(schema)) {
+    if (!SUPPORTED_ROOT_KEYWORDS.has(key)) {
+      return `schema uses unsupported keyword "${key}" — cannot validate safely`;
+    }
+  }
+
+  // Check required fields
+  const required = schema.required;
+  if (Array.isArray(required)) {
+    const missing = required.filter((field) => typeof field === "string" && !(field in args));
+    if (missing.length > 0) {
+      return `missing required field(s): ${missing.join(", ")}`;
+    }
+  }
+
+  // Check property types when schema.properties is defined
+  const properties = schema.properties;
+  if (typeof properties === "object" && properties !== null) {
+    for (const [key, schemaDef] of Object.entries(properties)) {
+      if (!(key in args)) continue; // missing fields are caught by required check
+      const value = args[key];
+      if (typeof schemaDef === "object" && schemaDef !== null) {
+        // Fail closed on any property keyword not in the supported allowlist
+        for (const kw of Object.keys(schemaDef)) {
+          if (!SUPPORTED_PROPERTY_KEYWORDS.has(kw)) {
+            return `property "${key}" uses unsupported keyword "${kw}" — cannot validate safely`;
+          }
+        }
+        if ("type" in schemaDef) {
+          const error = checkType(key, value, String(schemaDef.type));
+          if (error !== undefined) return error;
+        }
+      }
+    }
+  }
+
+  // Check additionalProperties
+  if (schema.additionalProperties !== undefined && schema.additionalProperties !== true) {
+    if (typeof schema.additionalProperties === "object" && schema.additionalProperties !== null) {
+      // additionalProperties as a subschema — cannot validate, fail closed
+      return 'schema uses "additionalProperties" as a subschema — cannot validate safely';
+    }
+    if (schema.additionalProperties === false) {
+      // When properties is absent, no keys are allowed (empty allowed set)
+      const allowed =
+        typeof properties === "object" && properties !== null
+          ? new Set(Object.keys(properties))
+          : new Set<string>();
+      const extra = Object.keys(args).filter((k) => !allowed.has(k));
+      if (extra.length > 0) {
+        return `unexpected additional field(s): ${extra.join(", ")}`;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function checkType(key: string, value: unknown, expectedType: string): string | undefined {
+  switch (expectedType) {
+    case "string":
+      if (typeof value !== "string") return `field "${key}" expected string, got ${typeof value}`;
+      break;
+    case "number":
+    case "integer":
+      if (typeof value !== "number")
+        return `field "${key}" expected ${expectedType}, got ${typeof value}`;
+      if (expectedType === "integer" && !Number.isInteger(value))
+        return `field "${key}" expected integer, got float`;
+      break;
+    case "boolean":
+      if (typeof value !== "boolean") return `field "${key}" expected boolean, got ${typeof value}`;
+      break;
+    case "array":
+      if (!Array.isArray(value)) return `field "${key}" expected array, got ${typeof value}`;
+      break;
+    case "object":
+      if (typeof value !== "object" || value === null || Array.isArray(value))
+        return `field "${key}" expected object, got ${Array.isArray(value) ? "array" : typeof value}`;
+      break;
+    case "null":
+      if (value !== null) return `field "${key}" expected null, got ${typeof value}`;
+      break;
+    default:
+      return `field "${key}" has unsupported type "${expectedType}" — cannot validate safely`;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Pure turn state machine (`transitionTurn`) with 5 phases: idle → model → tool_execution → continue → complete
- Async turn runner (`runTurn`) that drives the model→tool→model loop via `ComposedCallHandlers`, yielding `EngineEvent`s
- Reuses existing `consumeModelStream` for stream consumption; handles abort, max_turns, and error transitions

## Test plan
- [x] 20 state machine unit tests (all transitions, invalid transitions, immutability)
- [x] 9 runner integration tests (single-turn, tool loop, abort, max_turns, error, non-streaming fallback, metrics)
- [x] Typecheck passes (strict TS)
- [x] Biome lint clean
- [x] Layer check passes (L2 depends on L0 only)

Closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)