### PR TITLE
feat: add @koi/api-client — Anthropic SDK transport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,15 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/drivers/api-client": {
+      "name": "@koi/api-client",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.39.0",
+        "@koi/core": "workspace:*",
+        "@koi/errors": "workspace:*",
+      },
+    },
     "packages/kernel/core": {
       "name": "@koi/core",
       "version": "0.0.0",
@@ -137,6 +146,8 @@
     "esbuild",
   ],
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.39.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -278,6 +289,8 @@
     "@jscpd/html-reporter": ["@jscpd/html-reporter@4.0.4", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "^11.2.0", "pug": "^3.0.3" } }, "sha512-YiepyeYkeH74Kx59PJRdUdonznct0wHPFkf6FLQN+mCBoy6leAWCcOfHtcexnp+UsBFDlItG5nRdKrDSxSH+Kg=="],
 
     "@jscpd/tokenizer": ["@jscpd/tokenizer@4.0.4", "", { "dependencies": { "@jscpd/core": "4.0.4", "reprism": "^0.0.11", "spark-md5": "^3.0.2" } }, "sha512-xxYYY/qaLah/FlwogEbGIxx9CjDO+G9E6qawcy26WwrflzJb6wsnhjwdneN6Wb0RNCDsqvzY+bzG453jsin4UQ=="],
+
+    "@koi/api-client": ["@koi/api-client@workspace:packages/drivers/api-client"],
 
     "@koi/core": ["@koi/core@workspace:packages/kernel/core"],
 
@@ -445,9 +458,15 @@
 
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
     "@types/sarif": ["@types/sarif@2.1.7", "", {}, "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -462,6 +481,8 @@
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
     "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "babel-walk": ["babel-walk@3.0.0-canary-5", "", { "dependencies": { "@babel/types": "^7.9.6" } }, "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw=="],
 
@@ -495,6 +516,8 @@
 
     "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
@@ -506,6 +529,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
@@ -527,9 +552,13 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -551,7 +580,13 @@
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
@@ -584,6 +619,8 @@
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
     "human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -675,6 +712,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -688,6 +729,10 @@
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-sarif-builder": ["node-sarif-builder@3.4.0", "", { "dependencies": { "@types/sarif": "^2.1.7", "fs-extra": "^11.1.1" } }, "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg=="],
 
@@ -843,6 +888,8 @@
 
     "token-stream": ["token-stream@1.0.0", "", {}, "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
@@ -879,6 +926,12 @@
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "with": ["with@7.0.2", "", { "dependencies": { "@babel/parser": "^7.9.6", "@babel/types": "^7.9.6", "assert-never": "^1.2.1", "babel-walk": "3.0.0-canary-5" } }, "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w=="],
@@ -888,6 +941,8 @@
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@jscpd/badge-reporter/fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
@@ -918,6 +973,8 @@
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@jscpd/badge-reporter/fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 

--- a/docs/L2/api-client.md
+++ b/docs/L2/api-client.md
@@ -1,0 +1,156 @@
+# @koi/api-client — Anthropic SDK Transport
+
+Wraps `@anthropic-ai/sdk` to provide `ModelHandler` and `ModelStreamHandler` implementations for Koi's middleware pipeline. Supports direct API, AWS Bedrock, and Google Vertex as transport backends via a single factory function.
+
+---
+
+## Why It Exists
+
+Koi's middleware pipeline (`KoiMiddleware.wrapModelCall` / `wrapModelStream`) terminates at a `ModelHandler` / `ModelStreamHandler` — the innermost onion layer that actually talks to the LLM. This package is that innermost layer for Anthropic models.
+
+The v1 adapter used raw `fetch` + manual SSE parsing (~400 lines). Using the official SDK eliminates SSE parsing, retry header handling, and multi-provider auth complexity, while gaining typed responses and native Bedrock/Vertex support.
+
+---
+
+## What This Enables
+
+```
+BEFORE: raw fetch adapter (v1)
+═══════════════════════════════
+  ModelRequest → manual HTTP → SSE parsing → ModelChunk
+  • ~400 lines of fetch/SSE/timeout code
+  • No Bedrock/Vertex support
+  • Manual error mapping
+
+AFTER: SDK-backed adapter (v2)
+═══════════════════════════════
+  ModelRequest → @anthropic-ai/sdk → ModelChunk
+  • SDK handles SSE, timeouts, auth
+  • Bedrock + Vertex via SDK constructors
+  • Typed streaming events
+```
+
+---
+
+## Architecture
+
+**Layer**: L2 (feature package)
+**Depends on**: `@koi/core` (L0), `@koi/errors` (L0u), `@anthropic-ai/sdk` (external)
+**Implements**: `ModelHandler` and `ModelStreamHandler` function types from `@koi/core`
+
+### Module Map
+
+```
+@koi/api-client/src/
+├── client.ts        # createAnthropicClient() → { complete, stream }
+├── config.ts        # AnthropicClientConfig type + DEFAULT_CLIENT_CONFIG
+├── normalize.ts     # InboundMessage[] → Anthropic messages (system extraction, content blocks)
+├── map-request.ts   # ModelRequest → SDK MessageCreateParams
+├── map-response.ts  # SDK Message → ModelResponse
+├── map-stream.ts    # SDK stream events → AsyncIterable<ModelChunk>
+├── map-error.ts     # SDK errors → KoiRuntimeError
+├── map-tools.ts     # ToolDescriptor[] → Anthropic Tool[]
+└── index.ts         # Public exports
+```
+
+### Data Flow
+
+```
+ModelRequest (from middleware pipeline)
+    │
+    ▼
+  normalize.ts          extract system messages, map content blocks
+    │
+    ▼
+  map-request.ts        assemble SDK MessageCreateParams
+    │
+    ▼
+  @anthropic-ai/sdk     messages.create() or messages.create({ stream: true })
+    │
+    ├── non-streaming ──▶ map-response.ts ──▶ ModelResponse
+    │
+    └── streaming ──────▶ map-stream.ts ───▶ AsyncIterable<ModelChunk>
+```
+
+---
+
+## Key APIs
+
+### Factory
+
+```typescript
+function createAnthropicClient(config?: AnthropicClientConfig): {
+  readonly complete: ModelHandler;
+  readonly stream: ModelStreamHandler;
+}
+```
+
+Returns a pair of handlers that can be passed to L1 as the innermost model call layer.
+
+### Configuration
+
+```typescript
+type AnthropicProvider = "direct" | "bedrock" | "vertex";
+
+interface AnthropicClientConfig {
+  readonly provider?: AnthropicProvider;   // default: "direct"
+  readonly apiKey?: string;                // direct only; env ANTHROPIC_API_KEY
+  readonly model?: string;                 // default: "claude-sonnet-4-5-20250929"
+  readonly fallbackModel?: string;         // one retry with this model on failure
+  readonly maxTokens?: number;             // default: 4096
+  readonly timeoutMs?: number;             // default: 120_000
+  readonly baseUrl?: string;               // override base URL
+  readonly awsRegion?: string;             // bedrock
+  readonly googleProjectId?: string;       // vertex
+  readonly googleRegion?: string;          // vertex
+  readonly retryConfig?: RetryConfig;      // from @koi/errors
+}
+```
+
+### Wiring (via L3 harness)
+
+```typescript
+// In @koi/harness (L3) — NOT in this package
+const { complete, stream } = createAnthropicClient({ provider: "direct" });
+const engine = createQueryEngine({ modelCall: complete, modelStream: stream });
+```
+
+---
+
+## Error Handling
+
+SDK errors are mapped to `KoiRuntimeError` from `@koi/errors`:
+
+| SDK Error | KoiErrorCode | Retryable |
+|-----------|-------------|-----------|
+| 401 Unauthorized | PERMISSION | No |
+| 404 Not Found | NOT_FOUND | No |
+| 429 Rate Limited | RATE_LIMIT | Yes |
+| 529 Overloaded | RATE_LIMIT | Yes |
+| 500+ Server Error | EXTERNAL | Yes |
+| AbortError | TIMEOUT | No |
+
+Non-streaming calls use `withRetry` from `@koi/errors`. Streaming does not retry at this level — that's a middleware concern.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| SDK vs raw fetch | `@anthropic-ai/sdk` | Eliminates ~150 lines of SSE/timeout code; native multi-provider |
+| Single factory | `createAnthropicClient({ provider })` | SDK clients share identical `messages.create()` interface |
+| No class | Closure-captured SDK client | Matches codebase conventions |
+| Retry scope | `complete` only, not `stream` | Stream retry belongs to middleware layer |
+| Cache hints | Deferred | Requires `@koi/middleware-prompt-cache` coordination |
+
+---
+
+## Layer Compliance
+
+- [x] Imports only from `@koi/core` (L0) and `@koi/errors` (L0u)
+- [x] No L1 (`@koi/engine`) imports
+- [x] No peer L2 imports
+- [x] All interface properties are `readonly`
+- [x] No vendor-specific types in public API (SDK types internal only)
+- [x] `ModelHandler` and `ModelStreamHandler` contracts fully implemented

--- a/packages/drivers/api-client/package.json
+++ b/packages/drivers/api-client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/api-client",
+  "description": "Anthropic SDK adapter providing ModelHandler and ModelStreamHandler",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/errors": "workspace:*",
+    "@anthropic-ai/sdk": "0.39.0"
+  }
+}

--- a/packages/drivers/api-client/src/__tests__/client.test.ts
+++ b/packages/drivers/api-client/src/__tests__/client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelRequest } from "@koi/core";
+import { createAnthropicClient } from "../client.js";
+
+const ts = Date.now();
+
+function simpleRequest(text: string): ModelRequest {
+  return {
+    messages: [{ content: [{ kind: "text", text }], senderId: "user-1", timestamp: ts }],
+  };
+}
+
+describe("createAnthropicClient", () => {
+  test("creates a client with complete and stream handlers", async () => {
+    const client = await createAnthropicClient({ apiKey: "test-key" });
+    expect(typeof client.complete).toBe("function");
+    expect(typeof client.stream).toBe("function");
+  });
+
+  test("complete and stream are defined", async () => {
+    const client = await createAnthropicClient({ apiKey: "test-key" });
+    expect(client.complete).toBeDefined();
+    expect(client.stream).toBeDefined();
+  });
+});
+
+describe("createAnthropicClient integration shape", () => {
+  test("stream handler returns an AsyncIterable", async () => {
+    const client = await createAnthropicClient({ apiKey: "test-key" });
+    const request = simpleRequest("Hello");
+    const iterable = client.stream(request);
+
+    // Should be an async iterable
+    expect(Symbol.asyncIterator in Object(iterable)).toBe(true);
+  });
+
+  test("respects config defaults", async () => {
+    const client = await createAnthropicClient({
+      apiKey: "test-key",
+      model: "claude-haiku-3-5-20241022",
+      maxTokens: 1024,
+    });
+
+    expect(client.complete).toBeDefined();
+    expect(client.stream).toBeDefined();
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/map-error.test.ts
+++ b/packages/drivers/api-client/src/__tests__/map-error.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import Anthropic from "@anthropic-ai/sdk";
+import { mapAnthropicError, mapStatusToKoiCode } from "../map-error.js";
+
+describe("mapStatusToKoiCode", () => {
+  test("maps 401 to PERMISSION", () => {
+    expect(mapStatusToKoiCode(401)).toBe("PERMISSION");
+  });
+
+  test("maps 403 to PERMISSION", () => {
+    expect(mapStatusToKoiCode(403)).toBe("PERMISSION");
+  });
+
+  test("maps 404 to NOT_FOUND", () => {
+    expect(mapStatusToKoiCode(404)).toBe("NOT_FOUND");
+  });
+
+  test("maps 429 to RATE_LIMIT", () => {
+    expect(mapStatusToKoiCode(429)).toBe("RATE_LIMIT");
+  });
+
+  test("maps 529 to RATE_LIMIT", () => {
+    expect(mapStatusToKoiCode(529)).toBe("RATE_LIMIT");
+  });
+
+  test("maps 408 to TIMEOUT", () => {
+    expect(mapStatusToKoiCode(408)).toBe("TIMEOUT");
+  });
+
+  test("maps 504 to TIMEOUT", () => {
+    expect(mapStatusToKoiCode(504)).toBe("TIMEOUT");
+  });
+
+  test("maps 500 to EXTERNAL", () => {
+    expect(mapStatusToKoiCode(500)).toBe("EXTERNAL");
+  });
+
+  test("maps undefined to EXTERNAL", () => {
+    expect(mapStatusToKoiCode(undefined)).toBe("EXTERNAL");
+  });
+});
+
+/**
+ * Create headers for SDK error constructors.
+ * Bun's Headers type is structurally incompatible with the SDK's internal Headers type,
+ * so we cast through unknown. Runtime behavior is identical.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-unknown
+function sdkHeaders(init?: Record<string, string>): never {
+  return new Headers(init) as never;
+}
+
+describe("mapAnthropicError", () => {
+  test("maps SDK APIError to KoiRuntimeError", () => {
+    const apiError = new Anthropic.APIError(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Too many requests" } },
+      "Too many requests",
+      sdkHeaders(),
+    );
+
+    const result = mapAnthropicError(apiError);
+    expect(result.code).toBe("RATE_LIMIT");
+    expect(result.retryable).toBe(true);
+    expect(result.context).toEqual({ statusCode: 429 });
+  });
+
+  test("maps SDK AuthenticationError", () => {
+    const error = new Anthropic.AuthenticationError(
+      401,
+      { type: "error", error: { type: "authentication_error", message: "Invalid key" } },
+      "Invalid key",
+      sdkHeaders(),
+    );
+
+    const result = mapAnthropicError(error);
+    expect(result.code).toBe("PERMISSION");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps SDK RateLimitError with retry-after header", () => {
+    const error = new Anthropic.RateLimitError(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Rate limited" } },
+      "Rate limited",
+      sdkHeaders({ "retry-after": "30" }),
+    );
+
+    const result = mapAnthropicError(error);
+    expect(result.code).toBe("RATE_LIMIT");
+    expect(result.retryable).toBe(true);
+    expect(result.retryAfterMs).toBe(30_000);
+  });
+
+  test("maps AbortError to TIMEOUT", () => {
+    const error = new DOMException("The operation was aborted", "AbortError");
+
+    const result = mapAnthropicError(error);
+    expect(result.code).toBe("TIMEOUT");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps generic Error to EXTERNAL", () => {
+    const error = new Error("Network failure");
+
+    const result = mapAnthropicError(error);
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("Network failure");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps non-Error values to EXTERNAL", () => {
+    const result = mapAnthropicError("something went wrong");
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("something went wrong");
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/map-request.test.ts
+++ b/packages/drivers/api-client/src/__tests__/map-request.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { InboundMessage, ModelRequest } from "@koi/core";
+import { toAnthropicParams, toAnthropicStreamParams } from "../map-request.js";
+
+const ts = Date.now();
+const defaults = { model: "claude-sonnet-4-5-20250929", maxTokens: 4096 };
+
+function userMsg(text: string): InboundMessage {
+  return { content: [{ kind: "text", text }], senderId: "user-1", timestamp: ts };
+}
+
+describe("toAnthropicParams", () => {
+  test("uses defaults when request fields are omitted", () => {
+    const request: ModelRequest = { messages: [userMsg("Hello")] };
+    const result = toAnthropicParams(request, defaults);
+
+    expect(result.model).toBe("claude-sonnet-4-5-20250929");
+    expect(result.max_tokens).toBe(4096);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  test("overrides model and maxTokens from request", () => {
+    const request: ModelRequest = {
+      messages: [userMsg("Hi")],
+      model: "claude-haiku-3-5-20241022",
+      maxTokens: 1024,
+    };
+    const result = toAnthropicParams(request, defaults);
+
+    expect(result.model).toBe("claude-haiku-3-5-20241022");
+    expect(result.max_tokens).toBe(1024);
+  });
+
+  test("includes temperature when provided", () => {
+    const request: ModelRequest = {
+      messages: [userMsg("Hi")],
+      temperature: 0.7,
+    };
+    const result = toAnthropicParams(request, defaults);
+    expect(result.temperature).toBe(0.7);
+  });
+
+  test("omits temperature when not provided", () => {
+    const request: ModelRequest = { messages: [userMsg("Hi")] };
+    const result = toAnthropicParams(request, defaults);
+    expect("temperature" in result).toBe(false);
+  });
+
+  test("includes system prompt from system messages", () => {
+    const request: ModelRequest = {
+      messages: [
+        { content: [{ kind: "text", text: "Be helpful" }], senderId: "system", timestamp: ts },
+        userMsg("Hi"),
+      ],
+    };
+    const result = toAnthropicParams(request, defaults);
+    expect(result.system).toBe("Be helpful");
+  });
+
+  test("includes tools when provided", () => {
+    const request: ModelRequest = {
+      messages: [userMsg("Hi")],
+      tools: [{ name: "read", description: "Read file", inputSchema: { type: "object" } }],
+    };
+    const result = toAnthropicParams(request, defaults);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools?.[0]?.name).toBe("read");
+  });
+
+  test("omits tools when empty array", () => {
+    const request: ModelRequest = { messages: [userMsg("Hi")], tools: [] };
+    const result = toAnthropicParams(request, defaults);
+    expect("tools" in result).toBe(false);
+  });
+});
+
+describe("toAnthropicStreamParams", () => {
+  test("adds stream: true", () => {
+    const request: ModelRequest = { messages: [userMsg("Hi")] };
+    const result = toAnthropicStreamParams(request, defaults);
+    expect(result.stream).toBe(true);
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/map-response.test.ts
+++ b/packages/drivers/api-client/src/__tests__/map-response.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import { fromAnthropicMessage } from "../map-response.js";
+
+describe("fromAnthropicMessage", () => {
+  test("extracts text content from response", () => {
+    const msg: Anthropic.Message = {
+      id: "msg_123",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      content: [{ type: "text", text: "Hello!", citations: null }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    };
+
+    const result = fromAnthropicMessage(msg);
+    expect(result.content).toBe("Hello!");
+    expect(result.model).toBe("claude-sonnet-4-5-20250929");
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+  });
+
+  test("joins multiple text blocks", () => {
+    const msg: Anthropic.Message = {
+      id: "msg_456",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      content: [
+        { type: "text", text: "Part 1 ", citations: null },
+        { type: "text", text: "Part 2", citations: null },
+      ],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 20,
+        output_tokens: 10,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    };
+
+    const result = fromAnthropicMessage(msg);
+    expect(result.content).toBe("Part 1 Part 2");
+  });
+
+  test("filters out non-text blocks (tool_use)", () => {
+    const msg: Anthropic.Message = {
+      id: "msg_789",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      content: [
+        { type: "text", text: "Let me help.", citations: null },
+        { type: "tool_use", id: "call_1", name: "read_file", input: { path: "/tmp" } },
+      ],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 15,
+        output_tokens: 8,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    };
+
+    const result = fromAnthropicMessage(msg);
+    expect(result.content).toBe("Let me help.");
+  });
+
+  test("returns empty string when no text blocks", () => {
+    const msg: Anthropic.Message = {
+      id: "msg_empty",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      content: [{ type: "tool_use", id: "call_1", name: "search", input: {} }],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 5,
+        output_tokens: 3,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    };
+
+    const result = fromAnthropicMessage(msg);
+    expect(result.content).toBe("");
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/map-stream.test.ts
+++ b/packages/drivers/api-client/src/__tests__/map-stream.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ModelChunk } from "@koi/core";
+import { mapAnthropicStream } from "../map-stream.js";
+
+type RawEvent = Anthropic.RawMessageStreamEvent;
+
+/** Helper to collect all chunks from the stream mapper. */
+async function collectChunks(events: readonly RawEvent[]): Promise<readonly ModelChunk[]> {
+  async function* generate(): AsyncIterable<RawEvent> {
+    for (const event of events) {
+      yield event;
+    }
+  }
+
+  const chunks: ModelChunk[] = [];
+  for await (const chunk of mapAnthropicStream(generate(), "claude-sonnet-4-5-20250929")) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe("mapAnthropicStream", () => {
+  test("maps text_delta events", async () => {
+    const events: readonly RawEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "", citations: null },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: " world" },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 5 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const chunks = await collectChunks(events);
+
+    // Should have text deltas + usage + done
+    const textDeltas = chunks.filter((c) => c.kind === "text_delta");
+    expect(textDeltas).toHaveLength(2);
+    expect(textDeltas[0]?.kind === "text_delta" && textDeltas[0]?.delta).toBe("Hello");
+    expect(textDeltas[1]?.kind === "text_delta" && textDeltas[1]?.delta).toBe(" world");
+
+    // Final done chunk
+    const done = chunks.find((c) => c.kind === "done");
+    expect(done).toBeDefined();
+    if (done?.kind === "done") {
+      expect(done?.response.content).toBe("Hello world");
+      expect(done?.response.model).toBe("claude-sonnet-4-5-20250929");
+    }
+  });
+
+  test("maps tool_use streaming events", async () => {
+    const events: readonly RawEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_2",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "call_1", name: "read_file", input: {} },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"path":' },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '"/tmp"}' },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 8 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const chunks = await collectChunks(events);
+
+    const toolStart = chunks.find((c) => c.kind === "tool_call_start");
+    expect(toolStart).toBeDefined();
+    if (toolStart?.kind === "tool_call_start") {
+      expect(toolStart?.toolName).toBe("read_file");
+    }
+
+    const toolDeltas = chunks.filter((c) => c.kind === "tool_call_delta");
+    expect(toolDeltas).toHaveLength(2);
+
+    const toolEnd = chunks.find((c) => c.kind === "tool_call_end");
+    expect(toolEnd).toBeDefined();
+  });
+
+  test("maps thinking_delta events", async () => {
+    const events: readonly RawEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_3",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 5,
+            output_tokens: 0,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "thinking", thinking: "", signature: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "Let me think..." },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 3 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const chunks = await collectChunks(events);
+
+    const thinkingDeltas = chunks.filter((c) => c.kind === "thinking_delta");
+    expect(thinkingDeltas).toHaveLength(1);
+    if (thinkingDeltas[0]?.kind === "thinking_delta") {
+      expect(thinkingDeltas[0]?.delta).toBe("Let me think...");
+    }
+  });
+
+  test("emits usage chunk from message_delta", async () => {
+    const events: readonly RawEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_4",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 0,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 42 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const chunks = await collectChunks(events);
+    const usageChunk = chunks.find((c) => c.kind === "usage");
+    expect(usageChunk).toBeDefined();
+    if (usageChunk?.kind === "usage") {
+      expect(usageChunk?.outputTokens).toBe(42);
+    }
+  });
+
+  test("always emits a done chunk at the end", async () => {
+    const events: readonly RawEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_5",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-5-20250929",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 0,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      { type: "message_stop" },
+    ];
+
+    const chunks = await collectChunks(events);
+    const last = chunks[chunks.length - 1];
+    expect(last?.kind).toBe("done");
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/map-tools.test.ts
+++ b/packages/drivers/api-client/src/__tests__/map-tools.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolDescriptor } from "@koi/core";
+import { toAnthropicTools } from "../map-tools.js";
+
+describe("toAnthropicTools", () => {
+  test("maps a single tool descriptor", () => {
+    const tools: readonly ToolDescriptor[] = [
+      {
+        name: "read_file",
+        description: "Read a file from disk",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+      },
+    ];
+
+    const result = toAnthropicTools(tools);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("read_file");
+    expect(result[0]?.description).toBe("Read a file from disk");
+    expect(result[0]?.input_schema).toEqual({
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    });
+  });
+
+  test("maps multiple tool descriptors", () => {
+    const tools: readonly ToolDescriptor[] = [
+      { name: "tool_a", description: "A", inputSchema: { type: "object" } },
+      { name: "tool_b", description: "B", inputSchema: { type: "object" } },
+    ];
+
+    const result = toAnthropicTools(tools);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.name).toBe("tool_a");
+    expect(result[1]?.name).toBe("tool_b");
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(toAnthropicTools([])).toEqual([]);
+  });
+});

--- a/packages/drivers/api-client/src/__tests__/normalize.test.ts
+++ b/packages/drivers/api-client/src/__tests__/normalize.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import type { InboundMessage } from "@koi/core";
+import { extractSystemAndMessages, mapSenderIdToRole, toAnthropicContent } from "../normalize.js";
+
+// ---------------------------------------------------------------------------
+// mapSenderIdToRole
+// ---------------------------------------------------------------------------
+
+describe("mapSenderIdToRole", () => {
+  test("maps 'assistant' to assistant", () => {
+    expect(mapSenderIdToRole("assistant")).toBe("assistant");
+  });
+
+  test("maps 'system' to system", () => {
+    expect(mapSenderIdToRole("system")).toBe("system");
+  });
+
+  test("maps 'system:*' prefix to system", () => {
+    expect(mapSenderIdToRole("system:instructions")).toBe("system");
+  });
+
+  test("maps any other senderId to user", () => {
+    expect(mapSenderIdToRole("user-123")).toBe("user");
+    expect(mapSenderIdToRole("channel-abc")).toBe("user");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAnthropicContent
+// ---------------------------------------------------------------------------
+
+describe("toAnthropicContent", () => {
+  test("returns plain string for text-only content", () => {
+    const result = toAnthropicContent([
+      { kind: "text", text: "Hello " },
+      { kind: "text", text: "world" },
+    ]);
+    expect(result).toBe("Hello world");
+  });
+
+  test("returns array with image blocks for mixed content", () => {
+    const result = toAnthropicContent([
+      { kind: "text", text: "Look at this:" },
+      { kind: "image", url: "https://example.com/img.png" },
+    ]);
+    expect(Array.isArray(result)).toBe(true);
+    const parts = result as readonly { type: string }[];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]?.type).toBe("text");
+    expect(parts[1]?.type).toBe("image");
+  });
+
+  test("handles base64 data URL images", () => {
+    const result = toAnthropicContent([{ kind: "image", url: "data:image/png;base64,abc123" }]);
+    const parts = result as readonly { type: string; source?: { type: string } }[];
+    expect(parts[0]?.type).toBe("image");
+    expect(parts[0]?.source?.type).toBe("base64");
+  });
+
+  test("converts file blocks to text fallback", () => {
+    const result = toAnthropicContent([
+      { kind: "file", url: "file:///doc.pdf", mimeType: "application/pdf", name: "doc.pdf" },
+    ]);
+    expect(result).toBe("[file: doc.pdf]");
+  });
+
+  test("converts button blocks to text fallback", () => {
+    const result = toAnthropicContent([{ kind: "button", label: "Click me", action: "submit" }]);
+    expect(result).toBe("[button: Click me]");
+  });
+
+  test("converts custom blocks to text fallback", () => {
+    const result = toAnthropicContent([{ kind: "custom", type: "widget", data: {} }]);
+    expect(result).toBe("[widget]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSystemAndMessages
+// ---------------------------------------------------------------------------
+
+describe("extractSystemAndMessages", () => {
+  const ts = Date.now();
+
+  function msg(senderId: string, text: string): InboundMessage {
+    return {
+      content: [{ kind: "text", text }],
+      senderId,
+      timestamp: ts,
+    };
+  }
+
+  test("extracts system messages into system string", () => {
+    const result = extractSystemAndMessages([
+      msg("system", "You are helpful."),
+      msg("user-1", "Hello"),
+    ]);
+
+    expect(result.system).toBe("You are helpful.");
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
+  });
+
+  test("joins multiple system messages", () => {
+    const result = extractSystemAndMessages([
+      msg("system", "Rule 1"),
+      msg("system:extra", "Rule 2"),
+      msg("user-1", "Hi"),
+    ]);
+
+    expect(result.system).toBe("Rule 1\n\nRule 2");
+  });
+
+  test("returns undefined system when no system messages", () => {
+    const result = extractSystemAndMessages([msg("user-1", "Hello"), msg("assistant", "Hi there")]);
+
+    expect(result.system).toBeUndefined();
+  });
+
+  test("merges consecutive same-role messages", () => {
+    const result = extractSystemAndMessages([
+      msg("user-1", "First"),
+      msg("user-2", "Second"),
+      msg("assistant", "Reply"),
+    ]);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]?.role).toBe("user");
+    expect(result.messages[0]?.content).toBe("First\nSecond");
+    expect(result.messages[1]?.role).toBe("assistant");
+  });
+
+  test("preserves alternating roles", () => {
+    const result = extractSystemAndMessages([
+      msg("user-1", "Q1"),
+      msg("assistant", "A1"),
+      msg("user-1", "Q2"),
+      msg("assistant", "A2"),
+    ]);
+
+    expect(result.messages).toHaveLength(4);
+  });
+
+  test("handles empty messages array", () => {
+    const result = extractSystemAndMessages([]);
+    expect(result.system).toBeUndefined();
+    expect(result.messages).toHaveLength(0);
+  });
+});

--- a/packages/drivers/api-client/src/client.ts
+++ b/packages/drivers/api-client/src/client.ts
@@ -1,0 +1,130 @@
+/**
+ * Factory for creating Anthropic SDK-backed ModelHandler and ModelStreamHandler.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { ModelChunk, ModelHandler, ModelRequest, ModelStreamHandler } from "@koi/core";
+import { DEFAULT_RETRY_CONFIG, type RetryConfig, withRetry } from "@koi/errors";
+import type { AnthropicClientConfig } from "./config.js";
+import { DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_TIMEOUT_MS } from "./config.js";
+import { mapAnthropicError } from "./map-error.js";
+import { toAnthropicParams, toAnthropicStreamParams } from "./map-request.js";
+import { fromAnthropicMessage } from "./map-response.js";
+import { mapAnthropicStream } from "./map-stream.js";
+
+/** Return type of the factory — a pair of L0-compatible handlers. */
+export interface AnthropicClient {
+  readonly complete: ModelHandler;
+  readonly stream: ModelStreamHandler;
+}
+
+/**
+ * Create the underlying SDK client based on provider config.
+ *
+ * Bedrock and Vertex require separate SDK packages (@anthropic-ai/bedrock-sdk,
+ * @anthropic-ai/vertex-sdk) and are loaded dynamically to keep them optional.
+ */
+async function createSdkClient(config: AnthropicClientConfig): Promise<Anthropic> {
+  const timeout = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  switch (config.provider ?? "direct") {
+    case "bedrock": {
+      // @ts-expect-error — optional peer dependency, not installed by default
+      const { default: AnthropicBedrock } = await import("@anthropic-ai/bedrock-sdk");
+      return new AnthropicBedrock({
+        awsRegion: config.awsRegion,
+        awsAccessKey: config.awsAccessKey,
+        awsSecretKey: config.awsSecretKey,
+        awsSessionToken: config.awsSessionToken,
+        timeout,
+      }) as unknown as Anthropic;
+    }
+    case "vertex": {
+      // @ts-expect-error — optional peer dependency, not installed by default
+      const { default: AnthropicVertex } = await import("@anthropic-ai/vertex-sdk");
+      return new AnthropicVertex({
+        projectId: config.googleProjectId,
+        region: config.googleRegion,
+        timeout,
+      }) as unknown as Anthropic;
+    }
+    default:
+      return new Anthropic({
+        apiKey: config.apiKey,
+        ...(config.baseUrl !== undefined ? { baseURL: config.baseUrl } : {}),
+        timeout,
+      });
+  }
+}
+
+/**
+ * Create an Anthropic SDK-backed client providing ModelHandler and ModelStreamHandler.
+ *
+ * The `complete` handler wraps `messages.create()` with retry logic.
+ * The `stream` handler wraps `messages.stream()` and yields ModelChunk values.
+ *
+ * Async because Bedrock/Vertex providers require dynamic imports.
+ */
+export async function createAnthropicClient(
+  config: AnthropicClientConfig = {},
+): Promise<AnthropicClient> {
+  const sdk = await createSdkClient(config);
+  const model = config.model ?? DEFAULT_MODEL;
+  const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const retryConfig: RetryConfig = config.retryConfig ?? DEFAULT_RETRY_CONFIG;
+  const defaults = { model, maxTokens };
+
+  const complete: ModelHandler = async (request: ModelRequest) => {
+    const params = toAnthropicParams(request, defaults);
+
+    const executeCall = async (): Promise<Anthropic.Message> => {
+      try {
+        return await sdk.messages.create(params, {
+          signal: request.signal ?? undefined,
+        });
+      } catch (error: unknown) {
+        throw mapAnthropicError(error);
+      }
+    };
+
+    try {
+      const message = await withRetry(executeCall, retryConfig);
+      return fromAnthropicMessage(message);
+    } catch (error: unknown) {
+      // Fallback model: one attempt with alternate model
+      if (config.fallbackModel !== undefined) {
+        const fallbackParams = { ...params, model: config.fallbackModel };
+        try {
+          const message = await sdk.messages.create(fallbackParams, {
+            signal: request.signal ?? undefined,
+          });
+          return fromAnthropicMessage(message);
+        } catch (fallbackError: unknown) {
+          throw mapAnthropicError(fallbackError);
+        }
+      }
+      throw error;
+    }
+  };
+
+  const stream: ModelStreamHandler = (request: ModelRequest): AsyncIterable<ModelChunk> => {
+    const streamParams = toAnthropicStreamParams(request, defaults);
+
+    async function* generate(): AsyncIterable<ModelChunk> {
+      try {
+        const sdkStream = sdk.messages.stream(streamParams, {
+          signal: request.signal ?? undefined,
+        });
+
+        yield* mapAnthropicStream(sdkStream, model);
+      } catch (error: unknown) {
+        const mapped = mapAnthropicError(error);
+        yield { kind: "error", message: mapped.message };
+      }
+    }
+
+    return generate();
+  };
+
+  return { complete, stream };
+}

--- a/packages/drivers/api-client/src/config.ts
+++ b/packages/drivers/api-client/src/config.ts
@@ -1,0 +1,43 @@
+/**
+ * Configuration types and defaults for @koi/api-client.
+ */
+
+import type { RetryConfig } from "@koi/errors";
+
+/** Supported Anthropic SDK transport backends. */
+export type AnthropicProvider = "direct" | "bedrock" | "vertex";
+
+export interface AnthropicClientConfig {
+  /** Transport backend. Default: "direct". */
+  readonly provider?: AnthropicProvider | undefined;
+  /** API key for direct provider. Falls back to ANTHROPIC_API_KEY env. */
+  readonly apiKey?: string | undefined;
+  /** Default model ID. Default: "claude-sonnet-4-5-20250929". */
+  readonly model?: string | undefined;
+  /** Fallback model for retry after primary exhausts retries. */
+  readonly fallbackModel?: string | undefined;
+  /** Default max tokens. Default: 4096. */
+  readonly maxTokens?: number | undefined;
+  /** Request timeout in ms. Default: 120_000. */
+  readonly timeoutMs?: number | undefined;
+  /** Override base URL for direct provider. */
+  readonly baseUrl?: string | undefined;
+  /** AWS region for Bedrock provider. */
+  readonly awsRegion?: string | undefined;
+  /** AWS access key for Bedrock provider. */
+  readonly awsAccessKey?: string | undefined;
+  /** AWS secret key for Bedrock provider. */
+  readonly awsSecretKey?: string | undefined;
+  /** AWS session token for Bedrock provider. */
+  readonly awsSessionToken?: string | undefined;
+  /** Google Cloud project ID for Vertex provider. */
+  readonly googleProjectId?: string | undefined;
+  /** Google Cloud region for Vertex provider. */
+  readonly googleRegion?: string | undefined;
+  /** Retry configuration for non-streaming calls. Uses @koi/errors defaults when omitted. */
+  readonly retryConfig?: RetryConfig | undefined;
+}
+
+export const DEFAULT_MODEL = "claude-sonnet-4-5-20250929" as const;
+export const DEFAULT_MAX_TOKENS = 4096 as const;
+export const DEFAULT_TIMEOUT_MS = 120_000 as const;

--- a/packages/drivers/api-client/src/index.ts
+++ b/packages/drivers/api-client/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @koi/api-client — Anthropic SDK adapter for Koi.
+ *
+ * Provides ModelHandler and ModelStreamHandler implementations
+ * via the @anthropic-ai/sdk package.
+ */
+
+export type { AnthropicClient } from "./client.js";
+// Factory
+export { createAnthropicClient } from "./client.js";
+
+// Config
+export type { AnthropicClientConfig, AnthropicProvider } from "./config.js";
+export { DEFAULT_MAX_TOKENS, DEFAULT_MODEL, DEFAULT_TIMEOUT_MS } from "./config.js";
+export { mapAnthropicError, mapStatusToKoiCode } from "./map-error.js";
+// Pure mappers (reusable by model-router or tests)
+export { toAnthropicParams, toAnthropicStreamParams } from "./map-request.js";
+export { fromAnthropicMessage } from "./map-response.js";
+export { mapAnthropicStream } from "./map-stream.js";
+export { toAnthropicTools } from "./map-tools.js";
+export { extractSystemAndMessages, mapSenderIdToRole, toAnthropicContent } from "./normalize.js";

--- a/packages/drivers/api-client/src/map-error.ts
+++ b/packages/drivers/api-client/src/map-error.ts
@@ -1,0 +1,78 @@
+/**
+ * Map Anthropic SDK errors to KoiRuntimeError.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { KoiErrorCode } from "@koi/core";
+import { KoiRuntimeError } from "@koi/errors";
+
+/** Map an HTTP status code to a KoiErrorCode. */
+export function mapStatusToKoiCode(status: number | undefined): KoiErrorCode {
+  if (status === undefined) return "EXTERNAL";
+  if (status === 401) return "PERMISSION";
+  if (status === 403) return "PERMISSION";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 429 || status === 529) return "RATE_LIMIT";
+  if (status === 408 || status === 504) return "TIMEOUT";
+  if (status >= 500) return "EXTERNAL";
+  return "EXTERNAL";
+}
+
+/** Determine if an HTTP status indicates a retryable error. */
+function isRetryableStatus(status: number | undefined): boolean {
+  if (status === undefined) return false;
+  return status === 429 || status === 529 || status >= 500;
+}
+
+/** Extract retry-after header value in milliseconds from SDK error headers. */
+function parseRetryAfterFromHeaders(headers: Headers | undefined): number | undefined {
+  if (headers === undefined) return undefined;
+  const value = headers.get("retry-after");
+  if (value === null) return undefined;
+
+  const seconds = Number(value);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+
+  // Try parsing as HTTP date
+  const date = Date.parse(value);
+  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+
+  return undefined;
+}
+
+/**
+ * Map an unknown error (typically from the Anthropic SDK) to a KoiRuntimeError.
+ *
+ * Handles:
+ * - SDK APIError subclasses (with status codes and headers)
+ * - AbortError (signal cancellation)
+ * - Generic errors
+ */
+export function mapAnthropicError(error: unknown): KoiRuntimeError {
+  if (error instanceof Anthropic.APIError) {
+    const code = mapStatusToKoiCode(error.status);
+    const retryAfterMs = parseRetryAfterFromHeaders(error.headers as Headers | undefined);
+
+    return KoiRuntimeError.from(code, error.message, {
+      cause: error,
+      retryable: isRetryableStatus(error.status),
+      context: { statusCode: error.status },
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // AbortError from signal cancellation
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return KoiRuntimeError.from("TIMEOUT", "Request aborted", {
+      cause: error,
+      retryable: false,
+    });
+  }
+
+  // Generic error fallback
+  const message = error instanceof Error ? error.message : String(error);
+  return KoiRuntimeError.from("EXTERNAL", `Anthropic client error: ${message}`, {
+    cause: error,
+    retryable: false,
+  });
+}

--- a/packages/drivers/api-client/src/map-request.ts
+++ b/packages/drivers/api-client/src/map-request.ts
@@ -1,0 +1,44 @@
+/**
+ * Assemble Anthropic SDK MessageCreateParams from a Koi ModelRequest.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ModelRequest } from "@koi/core";
+import { toAnthropicTools } from "./map-tools.js";
+import { extractSystemAndMessages } from "./normalize.js";
+
+/** Defaults applied when ModelRequest fields are omitted. */
+export interface RequestDefaults {
+  readonly model: string;
+  readonly maxTokens: number;
+}
+
+/** Convert a Koi ModelRequest to Anthropic SDK message create params. */
+export function toAnthropicParams(
+  request: ModelRequest,
+  defaults: RequestDefaults,
+): Anthropic.MessageCreateParamsNonStreaming {
+  const { system, messages } = extractSystemAndMessages(request.messages);
+
+  return {
+    model: request.model ?? defaults.model,
+    messages: messages as Anthropic.MessageParam[],
+    max_tokens: request.maxTokens ?? defaults.maxTokens,
+    ...(request.temperature !== undefined ? { temperature: request.temperature } : {}),
+    ...(system !== undefined ? { system } : {}),
+    ...(request.tools !== undefined && request.tools.length > 0
+      ? { tools: toAnthropicTools(request.tools) as Anthropic.Tool[] }
+      : {}),
+  };
+}
+
+/** Convert a Koi ModelRequest to streaming params. */
+export function toAnthropicStreamParams(
+  request: ModelRequest,
+  defaults: RequestDefaults,
+): Anthropic.MessageCreateParamsStreaming {
+  return {
+    ...toAnthropicParams(request, defaults),
+    stream: true,
+  } as Anthropic.MessageCreateParamsStreaming;
+}

--- a/packages/drivers/api-client/src/map-response.ts
+++ b/packages/drivers/api-client/src/map-response.ts
@@ -1,0 +1,23 @@
+/**
+ * Map Anthropic SDK Message to Koi ModelResponse.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ModelResponse } from "@koi/core";
+
+/** Convert an Anthropic SDK Message to a Koi ModelResponse. */
+export function fromAnthropicMessage(msg: Anthropic.Message): ModelResponse {
+  const textContent = msg.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+
+  return {
+    content: textContent,
+    model: msg.model,
+    usage: {
+      inputTokens: msg.usage.input_tokens,
+      outputTokens: msg.usage.output_tokens,
+    },
+  };
+}

--- a/packages/drivers/api-client/src/map-stream.ts
+++ b/packages/drivers/api-client/src/map-stream.ts
@@ -1,0 +1,147 @@
+/**
+ * Map Anthropic SDK streaming events to Koi ModelChunk async iterable.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ModelChunk, ModelResponse } from "@koi/core";
+import { toolCallId } from "@koi/core";
+
+type RawEvent = Anthropic.RawMessageStreamEvent;
+
+/**
+ * Transform an async iterable of Anthropic SDK streaming events into
+ * an async iterable of Koi ModelChunk values.
+ *
+ * Tracks accumulated text and usage across the stream to produce the
+ * final "done" chunk with a complete ModelResponse.
+ */
+export async function* mapAnthropicStream(
+  events: AsyncIterable<RawEvent>,
+  defaultModel: string,
+): AsyncIterable<ModelChunk> {
+  let accumulatedText = "";
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let model = defaultModel;
+
+  // Track active tool calls by content block index
+  const activeToolCalls = new Map<number, string>();
+
+  for await (const event of events) {
+    const chunks = mapSingleEvent(
+      event,
+      activeToolCalls,
+      (text) => {
+        accumulatedText += text;
+      },
+      (m) => {
+        model = m;
+      },
+      (input, output) => {
+        inputTokens = input;
+        outputTokens = output;
+      },
+    );
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  }
+
+  // Emit final done chunk
+  const response: ModelResponse = {
+    content: accumulatedText,
+    model,
+    usage: { inputTokens, outputTokens },
+  };
+  yield { kind: "done", response };
+}
+
+/** Map a single SDK event to zero or more ModelChunk values. */
+function mapSingleEvent(
+  event: RawEvent,
+  activeToolCalls: Map<number, string>,
+  appendText: (text: string) => void,
+  setModel: (model: string) => void,
+  setUsage: (input: number, output: number) => void,
+): readonly ModelChunk[] {
+  switch (event.type) {
+    case "message_start": {
+      setModel(event.message.model);
+      setUsage(event.message.usage.input_tokens, event.message.usage.output_tokens);
+      return [];
+    }
+
+    case "content_block_start": {
+      if (event.content_block.type === "tool_use") {
+        const callId = event.content_block.id;
+        activeToolCalls.set(event.index, callId);
+        return [
+          {
+            kind: "tool_call_start",
+            toolName: event.content_block.name,
+            callId: toolCallId(callId),
+          },
+        ];
+      }
+      return [];
+    }
+
+    case "content_block_delta": {
+      return mapDelta(event, activeToolCalls, appendText);
+    }
+
+    case "content_block_stop": {
+      const callId = activeToolCalls.get(event.index);
+      if (callId !== undefined) {
+        activeToolCalls.delete(event.index);
+        return [{ kind: "tool_call_end", callId: toolCallId(callId) }];
+      }
+      return [];
+    }
+
+    case "message_delta": {
+      const usage = event.usage;
+      if (usage !== undefined) {
+        setUsage(0, usage.output_tokens);
+        return [{ kind: "usage", inputTokens: 0, outputTokens: usage.output_tokens }];
+      }
+      return [];
+    }
+
+    case "message_stop":
+      // Done is emitted after the loop in mapAnthropicStream
+      return [];
+
+    default:
+      return [];
+  }
+}
+
+/** Map a content_block_delta event to ModelChunk(s). */
+function mapDelta(
+  event: Anthropic.RawContentBlockDeltaEvent,
+  activeToolCalls: Map<number, string>,
+  appendText: (text: string) => void,
+): readonly ModelChunk[] {
+  const delta = event.delta;
+
+  switch (delta.type) {
+    case "text_delta": {
+      appendText(delta.text);
+      return [{ kind: "text_delta", delta: delta.text }];
+    }
+    case "thinking_delta": {
+      return [{ kind: "thinking_delta", delta: delta.thinking }];
+    }
+    case "input_json_delta": {
+      const callId = activeToolCalls.get(event.index);
+      if (callId !== undefined) {
+        return [{ kind: "tool_call_delta", callId: toolCallId(callId), delta: delta.partial_json }];
+      }
+      return [];
+    }
+    default:
+      // signature_delta, citations_delta — no Koi mapping needed
+      return [];
+  }
+}

--- a/packages/drivers/api-client/src/map-tools.ts
+++ b/packages/drivers/api-client/src/map-tools.ts
@@ -1,0 +1,15 @@
+/**
+ * Map Koi ToolDescriptor[] to Anthropic SDK Tool format.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ToolDescriptor } from "@koi/core";
+
+/** Convert Koi tool descriptors to Anthropic tool parameters. */
+export function toAnthropicTools(tools: readonly ToolDescriptor[]): readonly Anthropic.Tool[] {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+  }));
+}

--- a/packages/drivers/api-client/src/normalize.ts
+++ b/packages/drivers/api-client/src/normalize.ts
@@ -1,0 +1,138 @@
+/**
+ * Normalize Koi InboundMessage[] into Anthropic SDK message format.
+ *
+ * Responsibilities:
+ * - Map senderId to Anthropic role (user/assistant/system)
+ * - Extract system messages into a separate string
+ * - Convert ContentBlock[] to Anthropic content parts
+ * - Merge consecutive same-role messages (Anthropic API requirement)
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ContentBlock, InboundMessage } from "@koi/core";
+
+type MessageParam = Anthropic.MessageParam;
+type ContentBlockParam = Anthropic.ContentBlockParam;
+
+/** Map a Koi senderId to an Anthropic-compatible role. */
+export function mapSenderIdToRole(senderId: string): "user" | "assistant" | "system" {
+  if (senderId === "assistant") return "assistant";
+  if (senderId === "system" || senderId.startsWith("system:")) return "system";
+  return "user";
+}
+
+/** Parse a data URL into base64 components. */
+function parseDataUrl(
+  url: string,
+): { readonly data: string; readonly mediaType: string } | undefined {
+  const match = url.match(/^data:([^;]+);base64,(.+)$/);
+  if (match?.[1] !== undefined && match[2] !== undefined) {
+    return { mediaType: match[1], data: match[2] };
+  }
+  return undefined;
+}
+
+/** Convert a single Koi ContentBlock to an Anthropic content part. */
+function contentBlockToAnthropicPart(block: ContentBlock): ContentBlockParam {
+  switch (block.kind) {
+    case "text":
+      return { type: "text", text: block.text };
+    case "image": {
+      const parsed = parseDataUrl(block.url);
+      if (parsed !== undefined) {
+        return {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: parsed.mediaType as Anthropic.Base64ImageSource["media_type"],
+            data: parsed.data,
+          },
+        };
+      }
+      return { type: "image", source: { type: "url", url: block.url } };
+    }
+    default:
+      // file, button, custom → text fallback
+      return { type: "text", text: contentBlockToPlainText(block) };
+  }
+}
+
+/** Plain text fallback for non-text/image content blocks. */
+function contentBlockToPlainText(block: ContentBlock): string {
+  switch (block.kind) {
+    case "text":
+      return block.text;
+    case "file":
+      return `[file: ${block.name ?? block.url}]`;
+    case "image":
+      return `[image: ${block.alt ?? block.url}]`;
+    case "button":
+      return `[button: ${block.label}]`;
+    case "custom":
+      return `[${block.type}]`;
+  }
+}
+
+/** Convert Koi ContentBlock[] to Anthropic content format. */
+export function toAnthropicContent(content: readonly ContentBlock[]): string | ContentBlockParam[] {
+  const hasRichContent = content.some((b) => b.kind === "image");
+  if (!hasRichContent) {
+    return content.map(contentBlockToPlainText).join("");
+  }
+  return content.map(contentBlockToAnthropicPart);
+}
+
+/** Result of extracting system messages from the conversation. */
+export interface ExtractedMessages {
+  readonly system: string | undefined;
+  readonly messages: readonly MessageParam[];
+}
+
+/**
+ * Extract system messages and produce Anthropic-compatible message params.
+ *
+ * - System-role messages are extracted into a single `system` string
+ * - Remaining messages are role-mapped and consecutive same-role messages are merged
+ */
+export function extractSystemAndMessages(messages: readonly InboundMessage[]): ExtractedMessages {
+  const systemTexts: string[] = [];
+  const anthropicMessages: MessageParam[] = [];
+
+  for (const msg of messages) {
+    const role = mapSenderIdToRole(msg.senderId);
+
+    if (role === "system") {
+      systemTexts.push(msg.content.map(contentBlockToPlainText).join(""));
+      continue;
+    }
+
+    const content = toAnthropicContent(msg.content);
+    const last = anthropicMessages[anthropicMessages.length - 1];
+
+    // Merge consecutive same-role messages (Anthropic API requirement)
+    if (last !== undefined && last.role === role) {
+      const merged = mergeContent(last.content, content);
+      anthropicMessages[anthropicMessages.length - 1] = { role, content: merged } as MessageParam;
+    } else {
+      anthropicMessages.push({ role, content } as MessageParam);
+    }
+  }
+
+  return {
+    system: systemTexts.length > 0 ? systemTexts.join("\n\n") : undefined,
+    messages: anthropicMessages,
+  };
+}
+
+/** Merge two Anthropic content values into one. */
+function mergeContent(
+  a: string | ContentBlockParam[],
+  b: string | ContentBlockParam[],
+): string | ContentBlockParam[] {
+  if (typeof a === "string" && typeof b === "string") {
+    return `${a}\n${b}`;
+  }
+  const aParts: ContentBlockParam[] = typeof a === "string" ? [{ type: "text", text: a }] : a;
+  const bParts: ContentBlockParam[] = typeof b === "string" ? [{ type: "text", text: b }] : b;
+  return [...aParts, ...bParts];
+}

--- a/packages/drivers/api-client/tsconfig.json
+++ b/packages/drivers/api-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../../kernel/core" }, { "path": "../../lib/errors" }]
+}

--- a/packages/drivers/api-client/tsup.config.ts
+++ b/packages/drivers/api-client/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+  external: ["@anthropic-ai/bedrock-sdk", "@anthropic-ai/vertex-sdk"],
+});


### PR DESCRIPTION
## Summary

- Adds `@koi/api-client` (L2 driver) wrapping `@anthropic-ai/sdk` to provide `ModelHandler` and `ModelStreamHandler` implementations
- Supports direct API, Bedrock, and Vertex providers via a single `createAnthropicClient()` async factory
- Maps Koi `InboundMessage`/`ContentBlock` to Anthropic SDK format, and SDK streaming events to `ModelChunk` discriminated union
- Retry via `@koi/errors` `withRetry` on non-streaming calls, with optional fallback model
- All pure mappers exported for reuse by model-router

Closes #1181

## Test plan

- [x] 55 unit tests covering all modules (normalize, map-request, map-response, map-stream, map-error, map-tools, client)
- [x] `tsc --noEmit` clean
- [x] `biome check .` clean
- [x] `tsup` build succeeds (dist/index.js 11.37 KB, dist/index.d.ts 6.31 KB)
- [x] `check:layers` passes — no layer violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)