### PR TITLE
chore: ignore generated tsup bundled config artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .turbo/
 coverage/
 *.tsbuildinfo
+tsup.config.bundled_*.mjs
 .env
 .env.*
 !.env.example


### PR DESCRIPTION
## Summary

- Add `tsup.config.bundled_*.mjs` to `.gitignore` to prevent committing generated build artifacts that embed developer-local absolute paths in inline source maps

Flagged by Codex adversarial review — these files leak `/Users/.../private/koi/...` paths and produce noisy machine-specific diffs.

## Test plan

- [x] No code changes — gitignore only
- [x] Verified no tracked files match the new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)