### PR TITLE
feat: add @koi/tools-builtin — glob, grep, tool-search

### DIFF
--- a/docs/L2/tools-builtin.md
+++ b/docs/L2/tools-builtin.md
@@ -1,16 +1,24 @@
-# @koi/tools-builtin — Built-in filesystem tools for Koi agents
+# @koi/tools-builtin
 
-Layer 2 package — primordial filesystem tools (read, edit, write) implementing the L0 `Tool` contract.
+Layer 2 package — Built-in tools (filesystem + search) implementing the L0 `Tool` contract.
 
 ## Purpose
 
-Provides the three core file manipulation tools that every Koi agent needs:
+Provides the core tools that every Koi agent needs:
+
+### Filesystem Tools
 
 - **read** — Read file content with optional line offset/limit
 - **edit** — Search-and-replace with uniqueness preflight (oldText must exist exactly once)
 - **write** — Create or overwrite files with optional directory creation
 
 These are "primordial" tools — bundled at build time, highest trust level. They delegate all I/O to a `FileSystemBackend` (L0 contract), keeping the tools themselves pure argument validation + dispatch.
+
+### Search Tools
+
+- **Glob** — Fast file pattern matching with mtime sort
+- **Grep** — Content search with rg backend + native literal fallback
+- **ToolSearch** — Keyword/select search over available tool summaries
 
 ## Architecture
 
@@ -23,15 +31,17 @@ L0u @koi/file-resolution  path safety, token budgets (future: read enhancements)
 L2  @koi/tools-builtin  ← this package
         │
         ├── parse-args.ts         arg validation (no as-casts)
-        └── tools/
-            ├── read.ts           createFsReadTool(backend, prefix, policy)
-            ├── edit.ts           createFsEditTool(backend, prefix, policy)
-            └── write.ts          createFsWriteTool(backend, prefix, policy)
+        ├── tools/
+        │   ├── read.ts           createFsReadTool(backend, prefix, policy)
+        │   ├── edit.ts           createFsEditTool(backend, prefix, policy)
+        │   └── write.ts          createFsWriteTool(backend, prefix, policy)
+        ├── glob-tool.ts          createGlobTool(config)
+        ├── grep-tool.ts          createGrepTool(config)
+        ├── tool-search-tool.ts   createToolSearchTool(config)
+        └── builtin-search-provider.ts  ComponentProvider for search tools
 ```
 
-## Public API
-
-### Tool Factories
+## Filesystem Tool API
 
 Each factory takes `(backend: FileSystemBackend, prefix: string, policy: ToolPolicy)` and returns a `Tool`.
 
@@ -70,6 +80,25 @@ Reusable parse helpers that return `ParseResult<T>` (discriminated union) instea
 - `parseOptionalNumber(args, key)` — optional number
 - `parseOptionalBoolean(args, key)` — optional boolean
 - `parseArray(args, key)` — required array
+
+## Search Tool API
+
+### `createGlobTool(config: { cwd: string; policy?: ToolPolicy }): Tool`
+
+Input: `{ pattern, path? }`. Returns `{ paths, truncated, total }` sorted by mtime descending.
+
+### `createGrepTool(config: { cwd: string; policy?: ToolPolicy }): Tool`
+
+Input: `{ pattern, path?, glob?, type?, output_mode?, multiline?, context?, head_limit?, offset?, -A?, -B?, -C?, -i?, -n? }`.
+Returns `{ result, mode, truncated, warnings }`. Mode is `"rg"` or `"literal"`.
+
+### `createToolSearchTool(config: { getTools: () => readonly ToolSummary[]; policy?: ToolPolicy }): Tool`
+
+Input: `{ query, max_results? }`. Returns `ToolSummary[]`.
+
+### `createBuiltinSearchProvider(config): ComponentProvider`
+
+Bundles Glob, Grep, ToolSearch under `toolToken()` keys.
 
 ## Layer Compliance
 

--- a/packages/lib/tools-builtin/package.json
+++ b/packages/lib/tools-builtin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koi/tools-builtin",
-  "description": "Built-in filesystem tools (read, edit, write) for Koi agents",
+  "description": "Built-in tools: filesystem (read, edit, write) + search (glob, grep, tool-search)",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/lib/tools-builtin/src/builtin-search-provider.ts
+++ b/packages/lib/tools-builtin/src/builtin-search-provider.ts
@@ -1,0 +1,44 @@
+import type { ComponentProvider, JsonObject, ToolPolicy, ToolSummary } from "@koi/core";
+import { COMPONENT_PRIORITY, DEFAULT_UNSANDBOXED_POLICY, toolToken } from "@koi/core";
+import type { BuiltinSearchOperation } from "./constants.js";
+import { BUILTIN_SEARCH_OPERATIONS } from "./constants.js";
+import { createGlobTool } from "./glob-tool.js";
+import { createGrepTool } from "./grep-tool.js";
+import { createToolSearchTool } from "./tool-search-tool.js";
+
+export interface BuiltinSearchProviderConfig {
+  readonly cwd: string;
+  readonly getTools?: () => readonly ToolSummary[];
+  readonly policy?: ToolPolicy;
+  readonly operations?: readonly BuiltinSearchOperation[];
+}
+
+export function createBuiltinSearchProvider(
+  config: BuiltinSearchProviderConfig,
+): ComponentProvider {
+  const {
+    cwd,
+    getTools = () => [],
+    policy = DEFAULT_UNSANDBOXED_POLICY,
+    operations = BUILTIN_SEARCH_OPERATIONS,
+  } = config;
+
+  const factories: Record<BuiltinSearchOperation, () => JsonObject> = {
+    Glob: () => createGlobTool({ cwd, policy }) as unknown as JsonObject,
+    Grep: () => createGrepTool({ cwd, policy }) as unknown as JsonObject,
+    ToolSearch: () => createToolSearchTool({ getTools, policy }) as unknown as JsonObject,
+  };
+
+  return {
+    name: "builtin-search",
+    priority: COMPONENT_PRIORITY.BUNDLED,
+    attach: async (): Promise<ReadonlyMap<string, unknown>> => {
+      const entries: [string, unknown][] = [];
+      for (const op of operations) {
+        const factory = factories[op];
+        entries.push([toolToken(op), factory()]);
+      }
+      return new Map(entries);
+    },
+  };
+}

--- a/packages/lib/tools-builtin/src/constants.ts
+++ b/packages/lib/tools-builtin/src/constants.ts
@@ -1,0 +1,67 @@
+import { realpathSync } from "node:fs";
+import { resolve, sep } from "node:path";
+
+export const BUILTIN_SEARCH_OPERATIONS = ["Glob", "Grep", "ToolSearch"] as const;
+export type BuiltinSearchOperation = (typeof BUILTIN_SEARCH_OPERATIONS)[number];
+
+export const DEFAULT_HEAD_LIMIT = 250;
+export const DEFAULT_MAX_RESULTS = 5;
+
+/** Max file size (bytes) the native grep fallback will read. Skip binary/huge files. */
+export const MAX_NATIVE_GREP_FILE_SIZE = 1_048_576; // 1 MiB
+
+type ClampResult =
+  | { readonly ok: true; readonly path: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Resolve a user-supplied path and clamp it to the workspace root.
+ * Resolves symlinks via realpath so a symlinked path that points
+ * outside the workspace is rejected.
+ */
+export function clampPath(raw: string, cwd: string): ClampResult {
+  const resolved = resolve(cwd, raw);
+
+  // Lexical check first (catches ../traversal without needing the path to exist)
+  if (resolved !== cwd && !resolved.startsWith(cwd + sep)) {
+    return { ok: false, error: `Path "${raw}" escapes the workspace root` };
+  }
+
+  // Canonical (symlink-resolved) check — the target must also be under cwd
+  try {
+    const canonicalCwd = realpathSync(cwd);
+    const canonicalTarget = realpathSync(resolved);
+    if (canonicalTarget !== canonicalCwd && !canonicalTarget.startsWith(canonicalCwd + sep)) {
+      return { ok: false, error: `Path "${raw}" resolves outside the workspace root (symlink)` };
+    }
+  } catch {
+    // Path doesn't exist yet — lexical check above is sufficient
+  }
+
+  return { ok: true, path: resolved };
+}
+
+/** Traversal segments that can escape the scan root when embedded in a glob pattern. */
+const TRAVERSAL_RE = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
+
+/**
+ * Reject glob patterns that contain path traversal (`..`) or are absolute paths.
+ * Returns an error string if the pattern is unsafe, or undefined if safe.
+ */
+export function validateGlobPattern(pattern: string): string | undefined {
+  if (pattern.startsWith("/") || /^[A-Za-z]:[\\/]/.test(pattern)) {
+    return `Glob pattern "${pattern}" must be relative, not absolute`;
+  }
+  if (TRAVERSAL_RE.test(pattern)) {
+    return `Glob pattern "${pattern}" must not contain ".." traversal segments`;
+  }
+  return undefined;
+}
+
+/** Common regex metacharacters that indicate the pattern needs a real regex engine. */
+const REGEX_META_RE = /[\\^$.|?*+()[\]{}]/;
+
+/** Returns true if the pattern contains regex metacharacters that literal matching cannot honor. */
+export function looksLikeRegex(pattern: string): boolean {
+  return REGEX_META_RE.test(pattern);
+}

--- a/packages/lib/tools-builtin/src/glob-tool.ts
+++ b/packages/lib/tools-builtin/src/glob-tool.ts
@@ -1,0 +1,115 @@
+import { statSync } from "node:fs";
+import { join, relative } from "node:path";
+import type { JsonObject, Tool, ToolExecuteOptions, ToolPolicy } from "@koi/core";
+import { DEFAULT_UNSANDBOXED_POLICY } from "@koi/core";
+import { clampPath, validateGlobPattern } from "./constants.js";
+
+export interface GlobToolConfig {
+  readonly cwd: string;
+  readonly policy?: ToolPolicy;
+}
+
+export function createGlobTool(config: GlobToolConfig): Tool {
+  const { cwd, policy = DEFAULT_UNSANDBOXED_POLICY } = config;
+
+  return {
+    descriptor: {
+      name: "Glob",
+      description:
+        "Fast file pattern matching. Returns matching file paths sorted by " +
+        "modification time (most recent first).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pattern: {
+            type: "string",
+            description: 'Glob pattern to match files (e.g. "**/*.ts", "src/**/*.test.ts")',
+          },
+          path: {
+            type: "string",
+            description: "Directory to search in. Defaults to the working directory.",
+          },
+        },
+        required: ["pattern"],
+      } as JsonObject,
+    },
+    origin: "primordial",
+    policy,
+    execute: async (args: JsonObject, options?: ToolExecuteOptions): Promise<unknown> => {
+      const pattern = args.pattern;
+      if (typeof pattern !== "string" || pattern.trim() === "") {
+        return { error: "pattern must be a non-empty string" };
+      }
+
+      const patternError = validateGlobPattern(pattern.trim());
+      if (patternError) return { error: patternError };
+
+      let basePath = cwd;
+      if (typeof args.path === "string") {
+        const clamped = clampPath(args.path, cwd);
+        if (!clamped.ok) return { error: clamped.error };
+        basePath = clamped.path;
+      }
+
+      const signal = options?.signal;
+      signal?.throwIfAborted();
+
+      // Cap scan collection to bound memory/CPU. We collect up to
+      // MAX_SCAN entries, stat them, sort by mtime, then return the
+      // top MAX_RESULTS. This bounds total work while preserving
+      // the "most recent first" guarantee within the scanned set.
+      const MAX_SCAN = 50_000;
+      const MAX_RESULTS = 10_000;
+
+      const glob = new Bun.Glob(pattern.trim());
+      const paths: string[] = [];
+      let scanTruncated = false;
+      try {
+        for await (const match of glob.scan({
+          cwd: basePath,
+          onlyFiles: true,
+          followSymlinks: false,
+        })) {
+          signal?.throwIfAborted();
+          const fullPath = join(basePath, match);
+          if (!clampPath(fullPath, cwd).ok) continue;
+          // Normalize to workspace-relative so paths are usable from cwd
+          paths.push(relative(cwd, fullPath));
+          if (paths.length >= MAX_SCAN) {
+            scanTruncated = true;
+            break;
+          }
+        }
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === "AbortError") throw e;
+        const msg = e instanceof Error ? e.message : String(e);
+        return { error: `Glob scan failed: ${msg}` };
+      }
+
+      signal?.throwIfAborted();
+
+      const withMtime: { readonly path: string; readonly mtime: number }[] = [];
+      for (const p of paths) {
+        signal?.throwIfAborted();
+        try {
+          const stat = statSync(join(cwd, p));
+          withMtime.push({ path: p, mtime: stat.mtimeMs });
+        } catch {
+          withMtime.push({ path: p, mtime: 0 });
+        }
+      }
+
+      withMtime.sort((a, b) => b.mtime - a.mtime);
+
+      const truncated = scanTruncated || withMtime.length > MAX_RESULTS;
+      const final = withMtime.length > MAX_RESULTS ? withMtime.slice(0, MAX_RESULTS) : withMtime;
+
+      // Always return the same envelope shape
+      return {
+        paths: final.map((entry) => entry.path),
+        truncated,
+        total: scanTruncated ? undefined : withMtime.length,
+      };
+    },
+  };
+}

--- a/packages/lib/tools-builtin/src/grep-tool.ts
+++ b/packages/lib/tools-builtin/src/grep-tool.ts
@@ -1,0 +1,505 @@
+import { readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import type { JsonObject, Tool, ToolExecuteOptions, ToolPolicy } from "@koi/core";
+import { DEFAULT_UNSANDBOXED_POLICY } from "@koi/core";
+import {
+  clampPath,
+  DEFAULT_HEAD_LIMIT,
+  looksLikeRegex,
+  MAX_NATIVE_GREP_FILE_SIZE,
+  validateGlobPattern,
+} from "./constants.js";
+
+export interface GrepToolConfig {
+  readonly cwd: string;
+  readonly policy?: ToolPolicy;
+}
+
+export function createGrepTool(config: GrepToolConfig): Tool {
+  const { cwd, policy = DEFAULT_UNSANDBOXED_POLICY } = config;
+
+  return {
+    descriptor: {
+      name: "Grep",
+      description:
+        "Content search powered by ripgrep (with native fallback). Supports regex, " +
+        "file type filtering, multiline matching, context lines, and paginated output.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          pattern: { type: "string", description: "Regex pattern to search for" },
+          path: { type: "string", description: "File or directory to search in" },
+          glob: { type: "string", description: 'Glob filter for files (e.g. "*.ts")' },
+          type: { type: "string", description: 'File type filter (e.g. "ts", "py")' },
+          output_mode: {
+            type: "string",
+            enum: ["content", "files_with_matches", "count"],
+            description: "Output mode (default: files_with_matches)",
+          },
+          multiline: { type: "boolean", description: "Enable multiline matching" },
+          context: { type: "number", description: "Lines of context before and after" },
+          head_limit: {
+            type: "number",
+            description: `Max output lines (default ${DEFAULT_HEAD_LIMIT}, 0 for unlimited)`,
+          },
+          offset: { type: "number", description: "Skip first N lines" },
+          "-A": { type: "number", description: "Lines after each match" },
+          "-B": { type: "number", description: "Lines before each match" },
+          "-C": { type: "number", description: "Alias for context" },
+          "-i": { type: "boolean", description: "Case-insensitive search" },
+          "-n": { type: "boolean", description: "Show line numbers (default true)" },
+        },
+        required: ["pattern"],
+      } as JsonObject,
+    },
+    origin: "primordial",
+    policy,
+    execute: async (args: JsonObject, options?: ToolExecuteOptions): Promise<unknown> => {
+      const signal = options?.signal;
+      signal?.throwIfAborted();
+
+      const pattern = args.pattern;
+      if (typeof pattern !== "string" || pattern.trim() === "") {
+        return { error: "pattern must be a non-empty string" };
+      }
+
+      // Clamp path to workspace root
+      if (typeof args.path === "string") {
+        const clamped = clampPath(args.path, cwd);
+        if (!clamped.ok) return { error: clamped.error };
+      }
+
+      // Reject glob filters with traversal segments
+      if (typeof args.glob === "string") {
+        const globError = validateGlobPattern(args.glob);
+        if (globError) return { error: globError };
+      }
+
+      const rgResult = await tryRg(args, cwd, signal);
+      if (rgResult.available) {
+        if (!rgResult.ok) return { error: rgResult.error };
+        const paginated = applyPagination(rgResult.stdout, args);
+        return {
+          result: paginated,
+          mode: "rg" as const,
+          truncated: rgResult.truncated,
+          warnings: rgResult.warnings,
+        };
+      }
+
+      // rg not installed — fail closed if pattern needs regex semantics
+      if (looksLikeRegex(pattern.trim())) {
+        return {
+          error:
+            "ripgrep (rg) is not installed. This pattern contains regex metacharacters " +
+            "that cannot be matched with the literal-string fallback. Install rg or use a plain literal pattern.",
+        };
+      }
+
+      // Native literal-search fallback (plain strings only)
+      try {
+        const maxOutputLines = computeMaxOutputLines(args);
+        const { output, skippedFiles, truncated } = await nativeGrep(
+          args,
+          cwd,
+          maxOutputLines,
+          signal,
+        );
+        const paginated = applyPagination(output, args);
+        const warnings: string[] = [
+          "rg unavailable — results use literal string matching, not regex",
+        ];
+        if (skippedFiles.length > 0) {
+          warnings.push(
+            `${skippedFiles.length} file(s) skipped (too large, binary, or unreadable)`,
+          );
+        }
+        return {
+          result: paginated,
+          mode: "literal" as const,
+          truncated,
+          warnings,
+        };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { error: `Grep fallback failed: ${msg}` };
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ripgrep backend (preferred)
+// ---------------------------------------------------------------------------
+
+type RgResult =
+  | {
+      readonly available: true;
+      readonly ok: true;
+      readonly stdout: string;
+      readonly truncated: boolean;
+      readonly warnings: readonly string[];
+    }
+  | { readonly available: true; readonly ok: false; readonly error: string }
+  | { readonly available: false };
+
+async function tryRg(args: JsonObject, cwd: string, signal?: AbortSignal): Promise<RgResult> {
+  try {
+    signal?.throwIfAborted();
+
+    const rgArgs = buildRgArgs(args, cwd);
+    const proc = Bun.spawn(["rg", ...rgArgs], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Kill rg when the engine signals abort/timeout
+    const onAbort = (): void => {
+      try {
+        proc.kill();
+      } catch {
+        // Already exited
+      }
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    // Close spawn/listener race: if signal was aborted between the
+    // throwIfAborted() check and addEventListener, kill immediately
+    if (signal?.aborted) {
+      onAbort();
+    }
+
+    const headLimit = typeof args.head_limit === "number" ? args.head_limit : DEFAULT_HEAD_LIMIT;
+    const offset = typeof args.offset === "number" && args.offset > 0 ? args.offset : 0;
+    const maxLines = headLimit > 0 ? offset + headLimit : 0; // 0 = unlimited
+
+    // Drain stderr concurrently to prevent pipe buffer deadlock.
+    // If rg emits many warnings (unreadable files, etc.) and stderr
+    // fills up, rg blocks. Reading both streams concurrently avoids this.
+    const stderrPromise = new Response(proc.stderr).text();
+
+    const collectedLines: string[] = [];
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let partial = "";
+    let killedByUs = false;
+
+    // eslint-disable-next-line no-constant-condition -- stream loop
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      partial += decoder.decode(chunk.value, { stream: true });
+      const parts = partial.split("\n");
+      partial = parts.pop() ?? "";
+      let limitReached = false;
+      for (const line of parts) {
+        collectedLines.push(line);
+        if (maxLines > 0 && collectedLines.length >= maxLines) {
+          limitReached = true;
+          break;
+        }
+      }
+      if (limitReached) {
+        killedByUs = true;
+        try {
+          proc.kill();
+        } catch {
+          // Already exited
+        }
+        break;
+      }
+    }
+    if (partial && !killedByUs) collectedLines.push(partial);
+
+    const stderrTrimmed = (await stderrPromise).trim();
+    const exitCode = await proc.exited;
+    signal?.removeEventListener("abort", onAbort);
+
+    // Check if we were aborted by the engine signal (not our own head-limit kill)
+    if (signal?.aborted && !killedByUs) {
+      throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+
+    const warnings: string[] = [];
+    if (killedByUs)
+      warnings.push("Results truncated — search killed after collecting enough lines");
+    if (stderrTrimmed) warnings.push(stderrTrimmed);
+
+    const normalExit = exitCode === 0 || exitCode === 1;
+    const isSuccess = normalExit || (killedByUs && !hasRgError(stderrTrimmed));
+
+    if (isSuccess) {
+      return {
+        available: true,
+        ok: true,
+        stdout: collectedLines.join("\n"),
+        truncated: killedByUs,
+        warnings,
+      };
+    }
+    return {
+      available: true,
+      ok: false,
+      error: stderrTrimmed || `rg exited with code ${exitCode}`,
+    };
+  } catch (e: unknown) {
+    // Only treat ENOENT (binary not found) as "rg unavailable".
+    // Other spawn failures (permissions, resource exhaustion) are real errors.
+    const msg = e instanceof Error ? e.message : String(e);
+    const code = e instanceof Error && "code" in e ? (e as { code: string }).code : "";
+    if (code === "ENOENT" || msg.includes("ENOENT")) {
+      return { available: false };
+    }
+    return { available: true, ok: false, error: msg };
+  }
+}
+
+/** Check if rg stderr contains a real error (not just per-file warnings). */
+function hasRgError(stderr: string): boolean {
+  if (!stderr) return false;
+  // rg per-file warnings start with the file path; real errors are typically
+  // "error:" prefixed or contain "No such file" for bad arguments.
+  return stderr.includes("error:") || stderr.includes("No such file or directory");
+}
+
+// ---------------------------------------------------------------------------
+// Native Bun fallback (no rg dependency)
+// ---------------------------------------------------------------------------
+
+interface NativeGrepResult {
+  readonly output: string;
+  readonly skippedFiles: readonly string[];
+  readonly truncated: boolean;
+}
+
+function computeMaxOutputLines(args: JsonObject): number {
+  const headLimit = typeof args.head_limit === "number" ? args.head_limit : DEFAULT_HEAD_LIMIT;
+  const offset = typeof args.offset === "number" && args.offset > 0 ? args.offset : 0;
+  return headLimit > 0 ? offset + headLimit : 0; // 0 = unlimited
+}
+
+async function nativeGrep(
+  args: JsonObject,
+  cwd: string,
+  maxOutputLines: number,
+  signal?: AbortSignal,
+): Promise<NativeGrepResult> {
+  // Native fallback uses literal string matching only (not regex).
+  // This guarantees linear-time execution and prevents catastrophic
+  // backtracking that could hang the process. Regex patterns are
+  // treated as literal strings; full regex support requires rg.
+  const patternStr = (args.pattern as string).trim();
+  const caseInsensitive = args["-i"] === true;
+  const needle = caseInsensitive ? patternStr.toLowerCase() : patternStr;
+
+  const searchPath =
+    typeof args.path === "string" ? clampPath(args.path, cwd) : { ok: true as const, path: cwd };
+  if (!searchPath.ok) return { output: "", skippedFiles: [], truncated: false };
+  const resolvedPath = searchPath.path;
+
+  const mode = typeof args.output_mode === "string" ? args.output_mode : "files_with_matches";
+
+  const fileGlob =
+    typeof args.glob === "string"
+      ? args.glob
+      : typeof args.type === "string"
+        ? `**/*.${args.type}`
+        : "**/*";
+
+  const glob = new Bun.Glob(fileGlob);
+  const isFile = statSync(resolvedPath, { throwIfNoEntry: false })?.isFile() ?? false;
+
+  signal?.throwIfAborted();
+
+  // Stream files directly from the glob iterator into the search loop
+  // instead of pre-collecting all files. Hard cap on files scanned to
+  // bound work in degraded mode (no rg).
+  const MAX_FILES_SCANNED = 50_000;
+
+  const outputLines: string[] = [];
+  const skippedFiles: string[] = [];
+  const isMultiline = args.multiline === true;
+  let truncated = false;
+  let filesScanned = 0;
+
+  // File source: either a single file or streamed from glob
+  async function* fileSource(): AsyncGenerator<string> {
+    if (isFile) {
+      yield resolvedPath;
+    } else {
+      for await (const match of glob.scan({
+        cwd: resolvedPath,
+        onlyFiles: true,
+        followSymlinks: false,
+      })) {
+        yield match;
+      }
+    }
+  }
+
+  for await (const file of fileSource()) {
+    signal?.throwIfAborted();
+    if (filesScanned >= MAX_FILES_SCANNED) {
+      truncated = true;
+      break;
+    }
+    filesScanned++;
+    const fullPath = isFile ? file : join(resolvedPath, file);
+    // Always normalize to workspace-relative paths for consistent output
+    const relPath = relative(cwd, fullPath);
+
+    // Re-clamp each matched file to catch descendant symlinks escaping cwd
+    const fileClamp = clampPath(fullPath, cwd);
+    if (!fileClamp.ok) {
+      skippedFiles.push(`${relPath} (symlink escape)`);
+      continue;
+    }
+
+    const fileStat = statSync(fullPath, { throwIfNoEntry: false });
+    if (!fileStat || fileStat.size > MAX_NATIVE_GREP_FILE_SIZE) {
+      skippedFiles.push(relPath);
+      continue;
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(fullPath, "utf-8");
+    } catch {
+      skippedFiles.push(relPath);
+      continue;
+    }
+
+    if (content.slice(0, 8192).includes("\0")) {
+      skippedFiles.push(relPath);
+      continue;
+    }
+
+    const lines = content.split("\n");
+    const matchingLineNums: number[] = [];
+
+    if (isMultiline) {
+      // Multiline: search full content for literal needle
+      const haystack = caseInsensitive ? content.toLowerCase() : content;
+      let searchFrom = 0;
+      while (searchFrom < haystack.length) {
+        const idx = haystack.indexOf(needle, searchFrom);
+        if (idx === -1) break;
+        // Map byte offset to line number
+        let lineNum = 0;
+        let charCount = 0;
+        for (let i = 0; i < lines.length; i++) {
+          if (charCount + (lines[i]?.length ?? 0) >= idx) {
+            lineNum = i;
+            break;
+          }
+          charCount += (lines[i]?.length ?? 0) + 1;
+        }
+        if (!matchingLineNums.includes(lineNum)) {
+          matchingLineNums.push(lineNum);
+        }
+        searchFrom = idx + Math.max(1, needle.length);
+      }
+    } else {
+      for (let i = 0; i < lines.length; i++) {
+        const line = caseInsensitive ? (lines[i] ?? "").toLowerCase() : (lines[i] ?? "");
+        if (line.includes(needle)) {
+          matchingLineNums.push(i);
+        }
+      }
+    }
+
+    if (matchingLineNums.length === 0) continue;
+
+    if (mode === "files_with_matches") {
+      outputLines.push(relPath);
+    } else if (mode === "count") {
+      outputLines.push(`${relPath}:${matchingLineNums.length}`);
+    } else {
+      const contextBefore = typeof args["-B"] === "number" ? args["-B"] : 0;
+      const contextAfter = typeof args["-A"] === "number" ? args["-A"] : 0;
+      const contextBoth =
+        typeof args["-C"] === "number"
+          ? args["-C"]
+          : typeof args.context === "number"
+            ? args.context
+            : 0;
+      const before = Math.max(contextBefore, contextBoth);
+      const after = Math.max(contextAfter, contextBoth);
+      const showN = args["-n"] !== false;
+
+      const emittedLines = new Set<number>();
+      for (const lineNum of matchingLineNums) {
+        const start = Math.max(0, lineNum - before);
+        const end = Math.min(lines.length - 1, lineNum + after);
+        for (let i = start; i <= end; i++) emittedLines.add(i);
+      }
+
+      const sortedLines = [...emittedLines].sort((a, b) => a - b);
+      for (const idx of sortedLines) {
+        const prefix = showN ? `${idx + 1}:` : "";
+        outputLines.push(`${relPath}:${prefix}${lines[idx]}`);
+      }
+    }
+
+    // Early termination: stop scanning files once we have enough output
+    if (maxOutputLines > 0 && outputLines.length >= maxOutputLines) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return { output: outputLines.join("\n"), skippedFiles, truncated };
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function buildRgArgs(args: JsonObject, cwd: string): readonly string[] {
+  const rgArgs: string[] = [];
+  const pattern = args.pattern as string;
+
+  const mode = typeof args.output_mode === "string" ? args.output_mode : "files_with_matches";
+  if (mode === "files_with_matches") rgArgs.push("-l");
+  else if (mode === "count") rgArgs.push("-c");
+
+  if (args.multiline === true) rgArgs.push("-U", "--multiline-dotall");
+  if (args["-i"] === true) rgArgs.push("-i");
+
+  const showLineNumbers = args["-n"] !== false && mode === "content";
+  if (showLineNumbers) rgArgs.push("-n");
+
+  const contextVal = typeof args["-C"] === "number" ? args["-C"] : args.context;
+  if (typeof contextVal === "number") rgArgs.push("-C", String(contextVal));
+  if (typeof args["-A"] === "number") rgArgs.push("-A", String(args["-A"]));
+  if (typeof args["-B"] === "number") rgArgs.push("-B", String(args["-B"]));
+
+  if (typeof args.glob === "string") rgArgs.push("--glob", args.glob);
+  if (typeof args.type === "string") rgArgs.push("--type", args.type);
+
+  rgArgs.push("--", pattern.trim());
+
+  // Normalize search path to cwd-relative so rg output is workspace-relative.
+  // Path is already clamped by execute().
+  if (typeof args.path === "string") {
+    rgArgs.push(relative(cwd, resolve(cwd, args.path)));
+  } else {
+    rgArgs.push(".");
+  }
+
+  return rgArgs;
+}
+
+function applyPagination(stdout: string, args: JsonObject): string {
+  const headLimit = typeof args.head_limit === "number" ? args.head_limit : DEFAULT_HEAD_LIMIT;
+  const offset = typeof args.offset === "number" && args.offset > 0 ? args.offset : 0;
+
+  const lines = stdout.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  const sliced = offset > 0 ? lines.slice(offset) : lines;
+  const limited = headLimit > 0 ? sliced.slice(0, headLimit) : sliced;
+  return limited.join("\n");
+}

--- a/packages/lib/tools-builtin/src/index.ts
+++ b/packages/lib/tools-builtin/src/index.ts
@@ -1,11 +1,23 @@
 /**
- * @koi/tools-builtin — Built-in filesystem tools for Koi agents.
+ * @koi/tools-builtin — Built-in tools for Koi agents.
  *
- * Exports factory functions that create primordial Tool instances
- * backed by a FileSystemBackend (L0 contract).
+ * Filesystem tools: primordial Tool instances backed by FileSystemBackend.
+ * Search tools: glob, grep, tool-search for codebase exploration.
  */
 
+// Search tools
+export type { BuiltinSearchProviderConfig } from "./builtin-search-provider.js";
+export { createBuiltinSearchProvider } from "./builtin-search-provider.js";
+export type { BuiltinSearchOperation } from "./constants.js";
+export { BUILTIN_SEARCH_OPERATIONS } from "./constants.js";
+export type { GlobToolConfig } from "./glob-tool.js";
+export { createGlobTool } from "./glob-tool.js";
+export type { GrepToolConfig } from "./grep-tool.js";
+export { createGrepTool } from "./grep-tool.js";
+// Filesystem tools
 export type { ParseResult } from "./parse-args.js";
+export type { ToolSearchConfig } from "./tool-search-tool.js";
+export { createToolSearchTool } from "./tool-search-tool.js";
 export { createFsEditTool } from "./tools/edit.js";
 export { createFsReadTool } from "./tools/read.js";
 export { createFsWriteTool } from "./tools/write.js";

--- a/packages/lib/tools-builtin/src/search.test.ts
+++ b/packages/lib/tools-builtin/src/search.test.ts
@@ -1,0 +1,471 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ToolSummary } from "@koi/core";
+import { isAttachResult } from "@koi/core";
+import { createBuiltinSearchProvider } from "./builtin-search-provider.js";
+import { createGlobTool } from "./glob-tool.js";
+import { createGrepTool } from "./grep-tool.js";
+import { createToolSearchTool } from "./tool-search-tool.js";
+
+// ---------------------------------------------------------------------------
+// Test fixture: temp directory with known files
+// ---------------------------------------------------------------------------
+
+const TMP = join(import.meta.dir, "__test-fixtures__");
+
+const TMP_OUTSIDE = join(import.meta.dir, "__test-outside__");
+
+beforeAll(() => {
+  mkdirSync(join(TMP, "sub"), { recursive: true });
+  // Create files with staggered writes so mtime ordering is deterministic.
+  writeFileSync(join(TMP, "alpha.ts"), "export const a = 1;\n");
+  writeFileSync(join(TMP, "beta.ts"), "export const b = 2;\nexport const bb = 22;\n");
+  writeFileSync(join(TMP, "sub", "gamma.ts"), "export const g = 3;\n");
+  writeFileSync(join(TMP, "readme.md"), "# Hello\n");
+
+  // Symlink escape fixture: directory outside workspace linked inside
+  mkdirSync(TMP_OUTSIDE, { recursive: true });
+  writeFileSync(join(TMP_OUTSIDE, "secret.ts"), "export const secret = true;\n");
+  try {
+    symlinkSync(TMP_OUTSIDE, join(TMP, "escape-link"), "dir");
+  } catch {
+    // Symlink may already exist from prior run
+  }
+
+  // Large file for fallback skip test (> 1 MiB)
+  writeFileSync(join(TMP, "huge.bin"), "x".repeat(1_100_000));
+});
+
+afterAll(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  rmSync(TMP_OUTSIDE, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Glob tool
+// ---------------------------------------------------------------------------
+
+describe("createGlobTool", () => {
+  const tool = createGlobTool({ cwd: TMP });
+
+  test("descriptor has correct shape", () => {
+    expect(tool.descriptor.name).toBe("Glob");
+    expect(tool.descriptor.description).toBeString();
+    expect(tool.descriptor.inputSchema).toBeObject();
+    expect(tool.origin).toBe("primordial");
+  });
+
+  test("matches files with glob pattern", async () => {
+    const result = (await tool.execute({ pattern: "**/*.ts" })) as {
+      readonly paths: readonly string[];
+      readonly truncated: boolean;
+    };
+    expect(result.paths).toBeArray();
+    expect(result.paths.length).toBe(3);
+    expect(result.paths).toContain("alpha.ts");
+    expect(result.paths).toContain("beta.ts");
+    expect(result.paths).toContain(join("sub", "gamma.ts"));
+    expect(result.truncated).toBe(false);
+  });
+
+  test("respects path parameter and returns workspace-relative paths", async () => {
+    const result = (await tool.execute({
+      pattern: "*.ts",
+      path: join(TMP, "sub"),
+    })) as { readonly paths: readonly string[] };
+    expect(result.paths.length).toBe(1);
+    // Path should be workspace-relative (sub/gamma.ts), not just gamma.ts
+    expect(result.paths[0]).toBe(join("sub", "gamma.ts"));
+  });
+
+  test("returns empty paths for no matches", async () => {
+    const result = (await tool.execute({ pattern: "**/*.xyz" })) as {
+      readonly paths: readonly string[];
+    };
+    expect(result.paths).toEqual([]);
+  });
+
+  test("rejects empty pattern", async () => {
+    const result = (await tool.execute({ pattern: "" })) as { readonly error: string };
+    expect(result.error).toBeString();
+  });
+
+  test("rejects path that escapes workspace root", async () => {
+    const result = (await tool.execute({
+      pattern: "**/*.ts",
+      path: "/etc",
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects relative path traversal", async () => {
+    const result = (await tool.execute({
+      pattern: "**/*.ts",
+      path: "../../etc",
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects sibling path with same prefix", async () => {
+    // If cwd is /foo/bar, then /foo/bar-evil should be rejected
+    const tool2 = createGlobTool({ cwd: TMP });
+    const result = (await tool2.execute({
+      pattern: "**/*",
+      path: `${TMP}-evil`,
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects symlink that escapes workspace", async () => {
+    const result = (await tool.execute({
+      pattern: "**/*.ts",
+      path: join(TMP, "escape-link"),
+    })) as { readonly error: string };
+    expect(result.error).toContain("outside the workspace");
+  });
+
+  test("rejects pattern with .. traversal", async () => {
+    const result = (await tool.execute({ pattern: "../*.ts" })) as { readonly error: string };
+    expect(result.error).toContain("..");
+  });
+
+  test("rejects absolute pattern", async () => {
+    const result = (await tool.execute({ pattern: "/etc/**/*" })) as { readonly error: string };
+    expect(result.error).toContain("absolute");
+  });
+
+  test("returns error for nonexistent in-workspace path", async () => {
+    const result = (await tool.execute({
+      pattern: "**/*.ts",
+      path: join(TMP, "does-not-exist"),
+    })) as { readonly error: string };
+    expect(result.error).toBeString();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grep tool
+// ---------------------------------------------------------------------------
+
+// Helper: extract result text from unified grep output
+interface GrepOutput {
+  readonly result: string;
+  readonly mode: "rg" | "literal";
+  readonly truncated: boolean;
+  readonly warnings: readonly string[];
+}
+function grepText(raw: unknown): string {
+  if (typeof raw === "object" && raw !== null && "result" in raw) {
+    return (raw as GrepOutput).result;
+  }
+  return String(raw);
+}
+function grepOutput(raw: unknown): GrepOutput {
+  return raw as GrepOutput;
+}
+
+describe("createGrepTool", () => {
+  const tool = createGrepTool({ cwd: TMP });
+
+  test("descriptor has correct shape", () => {
+    expect(tool.descriptor.name).toBe("Grep");
+    expect(tool.descriptor.description).toBeString();
+    expect(tool.descriptor.inputSchema).toBeObject();
+    expect(tool.origin).toBe("primordial");
+  });
+
+  test("returns matching files in files_with_matches mode", async () => {
+    const result = grepText(await tool.execute({ pattern: "export const" }));
+    expect(result).toContain("alpha.ts");
+    expect(result).toContain("beta.ts");
+  });
+
+  test("returns content lines in content mode", async () => {
+    const result = grepText(
+      await tool.execute({ pattern: "export const a", output_mode: "content" }),
+    );
+    expect(result).toContain("export const a = 1");
+  });
+
+  test("returns counts in count mode", async () => {
+    const result = grepText(await tool.execute({ pattern: "export const", output_mode: "count" }));
+    expect(result).toContain("beta.ts");
+  });
+
+  test("respects head_limit", async () => {
+    const result = grepText(
+      await tool.execute({
+        pattern: "export const",
+        output_mode: "content",
+        head_limit: 1,
+        glob: "*.ts",
+      }),
+    );
+    const dataLines = result.trim().split("\n").filter(Boolean);
+    expect(dataLines.length).toBe(1);
+  });
+
+  test("respects offset", async () => {
+    const all = grepText(
+      await tool.execute({
+        pattern: "export const",
+        output_mode: "content",
+        head_limit: 0,
+        glob: "*.ts",
+      }),
+    );
+    const allLines = all.trim().split("\n").filter(Boolean);
+
+    const withOffset = grepText(
+      await tool.execute({
+        pattern: "export const",
+        output_mode: "content",
+        offset: 1,
+        head_limit: 0,
+        glob: "*.ts",
+      }),
+    );
+    const offsetLines = withOffset.trim().split("\n").filter(Boolean);
+
+    expect(offsetLines.length).toBe(allLines.length - 1);
+  });
+
+  test("supports case-insensitive search", async () => {
+    const result = grepText(
+      await tool.execute({
+        pattern: "EXPORT CONST",
+        output_mode: "files_with_matches",
+        "-i": true,
+      }),
+    );
+    expect(result).toContain("alpha.ts");
+  });
+
+  test("supports glob filter", async () => {
+    const result = grepText(await tool.execute({ pattern: "export const", glob: "*.md" }));
+    expect(result.trim()).toBe("");
+  });
+
+  test("rejects empty pattern", async () => {
+    const result = (await tool.execute({ pattern: "" })) as { readonly error: string };
+    expect(result.error).toBeString();
+  });
+
+  test("rejects path that escapes workspace root", async () => {
+    const result = (await tool.execute({
+      pattern: "export",
+      path: "/etc",
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects relative path traversal", async () => {
+    const result = (await tool.execute({
+      pattern: "export",
+      path: "../../../etc/passwd",
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects sibling path with same prefix", async () => {
+    const result = (await tool.execute({
+      pattern: "export",
+      path: `${TMP}-evil`,
+    })) as { readonly error: string };
+    expect(result.error).toContain("escapes");
+  });
+
+  test("rejects symlink that escapes workspace", async () => {
+    const result = (await tool.execute({
+      pattern: "secret",
+      path: join(TMP, "escape-link"),
+    })) as { readonly error: string };
+    expect(result.error).toContain("outside the workspace");
+  });
+
+  test("rejects glob filter with .. traversal", async () => {
+    const result = (await tool.execute({
+      pattern: "export",
+      glob: "../*.ts",
+    })) as { readonly error: string };
+    expect(result.error).toContain("..");
+  });
+
+  test("returns unified structured result", async () => {
+    const out = grepOutput(await tool.execute({ pattern: "export const" }));
+    expect(out.result).toBeString();
+    expect(["rg", "literal"]).toContain(out.mode);
+    expect(typeof out.truncated).toBe("boolean");
+    expect(out.warnings).toBeArray();
+  });
+
+  test("fallback uses literal mode with warning", async () => {
+    const out = grepOutput(await tool.execute({ pattern: "export const" }));
+    // In this env rg is missing, so mode should be "literal"
+    if (out.mode === "literal") {
+      expect(out.warnings.some((w) => w.includes("literal"))).toBe(true);
+    }
+  });
+
+  test("multiline literal match across lines in fallback", async () => {
+    const result = grepText(
+      await tool.execute({
+        pattern: "b = 2;\nexport",
+        output_mode: "files_with_matches",
+        multiline: true,
+      }),
+    );
+    expect(result).toContain("beta.ts");
+  });
+
+  test("fallback reports skipped files in warnings", async () => {
+    const out = grepOutput(await tool.execute({ pattern: "x", output_mode: "files_with_matches" }));
+    if (out.mode === "literal") {
+      expect(out.warnings.some((w) => w.includes("skipped"))).toBe(true);
+    }
+  });
+
+  test("returns error for nonexistent in-workspace path", async () => {
+    const result = (await tool.execute({
+      pattern: "export",
+      path: join(TMP, "does-not-exist"),
+    })) as { readonly error: string };
+    expect(result.error).toBeString();
+  });
+
+  test("fails closed for regex patterns when rg unavailable", async () => {
+    // "(" contains regex metacharacters — should error, not silently degrade
+    const result = (await tool.execute({ pattern: "(" })) as { readonly error: string };
+    expect(result.error).toContain("regex");
+  });
+
+  test("fails closed for complex regex patterns when rg unavailable", async () => {
+    const result = (await tool.execute({
+      pattern: "(a+)+$",
+      output_mode: "files_with_matches",
+      glob: "*.ts",
+    })) as { readonly error: string };
+    expect(result.error).toContain("regex");
+  });
+
+  test("fallback supports context lines", async () => {
+    const result = grepText(
+      await tool.execute({
+        pattern: "const b =",
+        output_mode: "content",
+        "-A": 1,
+        glob: "*.ts",
+      }),
+    );
+    expect(result).toContain("const b = 2");
+    expect(result).toContain("const bb = 22");
+  });
+
+  test("fallback type filter searches recursively", async () => {
+    // sub/gamma.ts should be found when using type: "ts"
+    const result = grepText(
+      await tool.execute({
+        pattern: "const g",
+        output_mode: "files_with_matches",
+        type: "ts",
+      }),
+    );
+    expect(result).toContain("gamma.ts");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToolSearch tool
+// ---------------------------------------------------------------------------
+
+const MOCK_TOOLS: readonly ToolSummary[] = [
+  { name: "Read", description: "Read a file from the filesystem" },
+  { name: "Edit", description: "Edit a file with search-replace" },
+  { name: "Write", description: "Write a new file to the filesystem" },
+  { name: "Glob", description: "Fast file pattern matching" },
+  { name: "Grep", description: "Content search with ripgrep" },
+];
+
+describe("createToolSearchTool", () => {
+  const tool = createToolSearchTool({ getTools: () => MOCK_TOOLS });
+
+  test("descriptor has correct shape", () => {
+    expect(tool.descriptor.name).toBe("ToolSearch");
+    expect(tool.descriptor.description).toBeString();
+    expect(tool.origin).toBe("primordial");
+  });
+
+  test("select: returns exact tools by name", async () => {
+    const result = (await tool.execute({ query: "select:Read,Edit" })) as readonly ToolSummary[];
+    expect(result.length).toBe(2);
+    expect(result[0]?.name).toBe("Read");
+    expect(result[1]?.name).toBe("Edit");
+  });
+
+  test("keyword search matches tool names", async () => {
+    const result = (await tool.execute({ query: "Glob" })) as readonly ToolSummary[];
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]?.name).toBe("Glob");
+  });
+
+  test("keyword search matches tool descriptions", async () => {
+    const result = (await tool.execute({ query: "filesystem" })) as readonly ToolSummary[];
+    expect(result.length).toBeGreaterThan(0);
+    const names = result.map((t) => t.name);
+    expect(names).toContain("Read");
+  });
+
+  test("respects max_results", async () => {
+    const result = (await tool.execute({
+      query: "file",
+      max_results: 2,
+    })) as readonly ToolSummary[];
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  test("returns empty array for no matches", async () => {
+    const result = (await tool.execute({ query: "nonexistent-xyz" })) as readonly ToolSummary[];
+    expect(result).toEqual([]);
+  });
+
+  test("rejects empty query", async () => {
+    const result = (await tool.execute({ query: "" })) as { readonly error: string };
+    expect(result.error).toBeString();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ComponentProvider
+// ---------------------------------------------------------------------------
+
+describe("createBuiltinSearchProvider", () => {
+  test("attaches all 3 tools", async () => {
+    const provider = createBuiltinSearchProvider({
+      cwd: TMP,
+      getTools: () => MOCK_TOOLS,
+    });
+    expect(provider.name).toBe("builtin-search");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only: Agent stub
+    const result = await provider.attach({} as never);
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has("tool:Glob")).toBe(true);
+    expect(components.has("tool:Grep")).toBe(true);
+    expect(components.has("tool:ToolSearch")).toBe(true);
+  });
+
+  test("respects operations filter", async () => {
+    const provider = createBuiltinSearchProvider({
+      cwd: TMP,
+      getTools: () => MOCK_TOOLS,
+      operations: ["Glob", "ToolSearch"],
+    });
+
+    const result = await provider.attach({} as never);
+    const components = isAttachResult(result) ? result.components : result;
+    expect(components.has("tool:Glob")).toBe(true);
+    expect(components.has("tool:Grep")).toBe(false);
+    expect(components.has("tool:ToolSearch")).toBe(true);
+  });
+});

--- a/packages/lib/tools-builtin/src/tool-search-tool.ts
+++ b/packages/lib/tools-builtin/src/tool-search-tool.ts
@@ -1,0 +1,78 @@
+import type { JsonObject, Tool, ToolPolicy, ToolSummary } from "@koi/core";
+import { DEFAULT_UNSANDBOXED_POLICY } from "@koi/core";
+import { DEFAULT_MAX_RESULTS } from "./constants.js";
+
+export interface ToolSearchConfig {
+  readonly getTools: () => readonly ToolSummary[];
+  readonly policy?: ToolPolicy;
+}
+
+export function createToolSearchTool(config: ToolSearchConfig): Tool {
+  const { getTools, policy = DEFAULT_UNSANDBOXED_POLICY } = config;
+
+  return {
+    descriptor: {
+      name: "ToolSearch",
+      description:
+        "Search available tools by keyword or fetch exact tools by name. " +
+        'Use "select:Name1,Name2" for exact lookup, or keywords for fuzzy search.',
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              'Search query. Use "select:Read,Edit" for exact names, or keywords to search.',
+          },
+          max_results: {
+            type: "number",
+            description: `Maximum results to return (default ${DEFAULT_MAX_RESULTS})`,
+          },
+        },
+        required: ["query"],
+      } as JsonObject,
+    },
+    origin: "primordial",
+    policy,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const query = args.query;
+      if (typeof query !== "string" || query.trim() === "") {
+        return { error: "query must be a non-empty string" };
+      }
+
+      const maxResults =
+        typeof args.max_results === "number" && args.max_results > 0
+          ? args.max_results
+          : DEFAULT_MAX_RESULTS;
+
+      const tools = getTools();
+      const trimmed = query.trim();
+
+      if (trimmed.startsWith("select:")) {
+        const names = trimmed
+          .slice(7)
+          .split(",")
+          .map((n) => n.trim())
+          .filter(Boolean);
+        return tools.filter((t) => names.includes(t.name));
+      }
+
+      const tokens = trimmed.toLowerCase().split(/\s+/);
+      const scored: readonly { readonly tool: ToolSummary; readonly score: number }[] = tools
+        .map((tool) => {
+          const nameLower = tool.name.toLowerCase();
+          const descLower = (tool.description ?? "").toLowerCase();
+          let score = 0;
+          for (const token of tokens) {
+            if (nameLower.includes(token)) score += 2;
+            if (descLower.includes(token)) score += 1;
+          }
+          return { tool, score } as const;
+        })
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score);
+
+      return scored.slice(0, maxResults).map((entry) => entry.tool);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1227

Adds three search tools to `@koi/tools-builtin`, alongside the existing filesystem tools (#1292):

- **Glob** — file pattern matching via `Bun.Glob.scan()` with mtime sort, workspace-relative paths, `{ paths, truncated, total }` envelope
- **Grep** — content search with streaming `rg` backend + native literal fallback, unified `{ result, mode, truncated, warnings }` return type
- **ToolSearch** — keyword/select search over `ToolSummary[]` for progressive tool disclosure

### Security hardening (17 rounds of adversarial review)

- Path clamping with symlink resolution (`realpathSync`)
- Glob pattern traversal rejection (`..` segments, absolute paths)
- Per-file symlink re-clamping after scan + `followSymlinks: false`
- Fail closed for regex patterns when `rg` unavailable (`looksLikeRegex()`)
- Streaming `rg` output with early kill + concurrent stderr drain
- Spawn/abort race closure (immediate `signal.aborted` check after listener)
- `AbortSignal` wired through both tools (`ToolExecuteOptions.signal`)
- Scan caps (50k files glob, 50k files grep fallback) + result cap (10k glob)
- Sort-before-cap preserves mtime ordering guarantee
- Structured degraded result when `rg` unavailable (callers see `mode: "literal"`)
- `rg` fallback detection tightened to `ENOENT` only (not broad spawn errors)
- `hasRgError()` distinguishes truncation from real `rg` failures in stderr
- Workspace-relative path normalization in both backends

## Test plan

- [x] 44 unit tests (85 total with filesystem tools)
- [x] 46 E2E tests via tmux covering all corner cases:
  - Glob: happy path (5), validation (2), security (7)
  - Grep: happy path (10), security + error handling (11)
  - ToolSearch: happy path + validation (9)
  - ComponentProvider: wiring + filter (2)
- [x] `bun run typecheck` — strict TS
- [x] `bun run lint` — Biome clean
- [x] `bun run check:layers` — L0/L1/L2 boundaries
- [x] `bun run check:orphans` — marked optional
- [x] `bun run build` — ESM output

🤖 Generated with [Claude Code](https://claude.com/claude-code)