### PR TITLE
feat: @koi/cli — entry point + argument parsing (#1262)

### DIFF
--- a/packages/kernel/core/src/model-adapter.test.ts
+++ b/packages/kernel/core/src/model-adapter.test.ts
@@ -27,6 +27,8 @@ function stopReasonLabel(reason: ModelStopReason): string {
       return "tool_use";
     case "error":
       return "error";
+    case "hook_blocked":
+      return "hook_blocked";
     default: {
       const _exhaustive: never = reason;
       return String(_exhaustive);
@@ -49,6 +51,10 @@ describe("ModelStopReason exhaustiveness", () => {
 
   test("error", () => {
     expect(stopReasonLabel("error")).toBe("error");
+  });
+
+  test("hook_blocked", () => {
+    expect(stopReasonLabel("hook_blocked")).toBe("hook_blocked");
   });
 });
 

--- a/packages/kernel/core/src/model-adapter.ts
+++ b/packages/kernel/core/src/model-adapter.ts
@@ -17,12 +17,13 @@ import type { ModelCapabilities } from "./model-provider.js";
 /**
  * Why the model stopped generating.
  *
- * - "stop"     — natural end of generation
- * - "length"   — hit max tokens
- * - "tool_use" — model wants to call a tool
- * - "error"    — provider-side error during generation
+ * - "stop"         — natural end of generation
+ * - "length"       — hit max tokens
+ * - "tool_use"     — model wants to call a tool
+ * - "error"        — provider-side error during generation
+ * - "hook_blocked" — pre-call hook denied the request
  */
-export type ModelStopReason = "stop" | "length" | "tool_use" | "error";
+export type ModelStopReason = "stop" | "length" | "tool_use" | "error" | "hook_blocked";
 
 // ---------------------------------------------------------------------------
 // Model content blocks (rich response content)

--- a/packages/lib/hooks/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/lib/hooks/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -110,8 +110,8 @@ declare function loadHooksWithDiagnostics(raw: unknown): Result<LoadHooksResult,
  *   onBeforeTurn    → "turn.started"    (blocking — throws on block decision)
  *   onAfterTurn     → "turn.ended"      (fire-and-forget, drained on session end)
  *   wrapToolCall    → "tool.before" (blocking) + "tool.succeeded" (fire-and-forget, drained)
- *   wrapModelCall   → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
- *   wrapModelStream → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelCall   → "compact.before" (blocking — throws on block) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelStream → "compact.before" (blocking — yields error chunk on block) + "compact.after" (fire-and-forget, drained)
  *
  * Pre-call hooks block and aggregate decisions (block > modify > continue).
  * Post-call hooks are fire-and-forget during the turn but drained with a bounded

--- a/packages/lib/hooks/src/middleware.test.ts
+++ b/packages/lib/hooks/src/middleware.test.ts
@@ -573,7 +573,7 @@ describe("wrapModelCall", () => {
     expect(passedRequest.systemPrompt).toBe("original");
   });
 
-  it("blocks model call when hook returns block decision", async () => {
+  it("throws when hook returns block decision (consistent with onBeforeTurn)", async () => {
     const mw = createHookMiddleware({ hooks: TEST_HOOKS });
     await startSessionThen(mw, executeSpy, [
       successResult("guard", { kind: "block", reason: "context too large" }),
@@ -585,12 +585,11 @@ describe("wrapModelCall", () => {
     });
 
     const request: ModelRequest = { messages: [], model: "test-model" };
-    const result = await mw.wrapModelCall?.(makeTurnCtx(), request, nextFn);
-    assertDefined(result);
 
+    await expect(mw.wrapModelCall?.(makeTurnCtx(), request, nextFn)).rejects.toThrow(
+      "Model call blocked by hook: context too large",
+    );
     expect(nextFn).not.toHaveBeenCalled();
-    expect(result.content).toContain("context too large");
-    expect(result.metadata).toEqual({ blockedByHook: true });
   });
 });
 
@@ -649,6 +648,8 @@ describe("wrapModelStream", () => {
     expect(chunks[0]?.kind).toBe("error");
     if (chunks[0]?.kind === "error") {
       expect(chunks[0].message).toContain("not today");
+      expect(chunks[0].code).toBe("PERMISSION");
+      expect(chunks[0].retryable).toBe(false);
     }
   });
 

--- a/packages/lib/hooks/src/middleware.ts
+++ b/packages/lib/hooks/src/middleware.ts
@@ -7,8 +7,8 @@
  *   onBeforeTurn    → "turn.started"    (blocking — throws on block decision)
  *   onAfterTurn     → "turn.ended"      (fire-and-forget, drained on session end)
  *   wrapToolCall    → "tool.before" (blocking) + "tool.succeeded" (fire-and-forget, drained)
- *   wrapModelCall   → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
- *   wrapModelStream → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelCall   → "compact.before" (blocking — throws on block) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelStream → "compact.before" (blocking — yields error chunk on block) + "compact.after" (fire-and-forget, drained)
  *
  * Pre-call hooks block and aggregate decisions (block > modify > continue).
  * Post-call hooks are fire-and-forget during the turn but drained with a bounded
@@ -332,11 +332,7 @@ export function createHookMiddleware(options: CreateHookMiddlewareOptions): KoiM
       const preResult = await dispatchModelPre(sessionId, ctx, request);
 
       if (preResult.blocked) {
-        return {
-          content: `[Hook blocked model call: ${preResult.reason}]`,
-          model: request.model ?? "unknown",
-          metadata: { blockedByHook: true },
-        };
+        throw new Error(`Model call blocked by hook: ${preResult.reason}`);
       }
 
       const response = await next(preResult.request);
@@ -362,6 +358,8 @@ export function createHookMiddleware(options: CreateHookMiddlewareOptions): KoiM
         yield {
           kind: "error",
           message: `Hook blocked model stream: ${preResult.reason}`,
+          code: "PERMISSION",
+          retryable: false,
         };
         return;
       }


### PR DESCRIPTION
## Summary
- Bootstrap `@koi/cli` as L3 meta-package with argument parsing for 10 subcommands
- `args.ts`: discriminated union flags, `node:util parseArgs`, type guards, command registry
- `bin.ts`: entry point with `--version`/`--help` fast-path, stub dispatch for known commands
- Register `@koi/cli` in `L3_PACKAGES` and regenerate labeler

## Test plan
- [x] 55 unit tests pass, 100% line/function coverage on `args.ts`
- [x] Typecheck clean (`tsc --noEmit`)
- [x] `check:layers` passes
- [x] `check:doc-sync` passes
- [x] Manual smoke: `--version`, `--help`, all 10 subcommands, unknown command

Closes #1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)