### PR TITLE
fix: hook-blocked model calls use explicit failure channel (#1293)

### DIFF
--- a/packages/kernel/core/src/model-adapter.test.ts
+++ b/packages/kernel/core/src/model-adapter.test.ts
@@ -27,6 +27,8 @@ function stopReasonLabel(reason: ModelStopReason): string {
       return "tool_use";
     case "error":
       return "error";
+    case "hook_blocked":
+      return "hook_blocked";
     default: {
       const _exhaustive: never = reason;
       return String(_exhaustive);
@@ -49,6 +51,10 @@ describe("ModelStopReason exhaustiveness", () => {
 
   test("error", () => {
     expect(stopReasonLabel("error")).toBe("error");
+  });
+
+  test("hook_blocked", () => {
+    expect(stopReasonLabel("hook_blocked")).toBe("hook_blocked");
   });
 });
 

--- a/packages/kernel/core/src/model-adapter.ts
+++ b/packages/kernel/core/src/model-adapter.ts
@@ -17,12 +17,13 @@ import type { ModelCapabilities } from "./model-provider.js";
 /**
  * Why the model stopped generating.
  *
- * - "stop"     — natural end of generation
- * - "length"   — hit max tokens
- * - "tool_use" — model wants to call a tool
- * - "error"    — provider-side error during generation
+ * - "stop"         — natural end of generation
+ * - "length"       — hit max tokens
+ * - "tool_use"     — model wants to call a tool
+ * - "error"        — provider-side error during generation
+ * - "hook_blocked" — pre-call hook denied the request
  */
-export type ModelStopReason = "stop" | "length" | "tool_use" | "error";
+export type ModelStopReason = "stop" | "length" | "tool_use" | "error" | "hook_blocked";
 
 // ---------------------------------------------------------------------------
 // Model content blocks (rich response content)

--- a/packages/lib/hooks/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/lib/hooks/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -110,8 +110,8 @@ declare function loadHooksWithDiagnostics(raw: unknown): Result<LoadHooksResult,
  *   onBeforeTurn    → "turn.started"    (blocking — throws on block decision)
  *   onAfterTurn     → "turn.ended"      (fire-and-forget, drained on session end)
  *   wrapToolCall    → "tool.before" (blocking) + "tool.succeeded" (fire-and-forget, drained)
- *   wrapModelCall   → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
- *   wrapModelStream → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelCall   → "compact.before" (blocking — throws on block) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelStream → "compact.before" (blocking — yields error chunk on block) + "compact.after" (fire-and-forget, drained)
  *
  * Pre-call hooks block and aggregate decisions (block > modify > continue).
  * Post-call hooks are fire-and-forget during the turn but drained with a bounded

--- a/packages/lib/hooks/src/middleware.test.ts
+++ b/packages/lib/hooks/src/middleware.test.ts
@@ -573,7 +573,7 @@ describe("wrapModelCall", () => {
     expect(passedRequest.systemPrompt).toBe("original");
   });
 
-  it("blocks model call when hook returns block decision", async () => {
+  it("throws when hook returns block decision (consistent with onBeforeTurn)", async () => {
     const mw = createHookMiddleware({ hooks: TEST_HOOKS });
     await startSessionThen(mw, executeSpy, [
       successResult("guard", { kind: "block", reason: "context too large" }),
@@ -585,12 +585,11 @@ describe("wrapModelCall", () => {
     });
 
     const request: ModelRequest = { messages: [], model: "test-model" };
-    const result = await mw.wrapModelCall?.(makeTurnCtx(), request, nextFn);
-    assertDefined(result);
 
+    await expect(mw.wrapModelCall?.(makeTurnCtx(), request, nextFn)).rejects.toThrow(
+      "Model call blocked by hook: context too large",
+    );
     expect(nextFn).not.toHaveBeenCalled();
-    expect(result.content).toContain("context too large");
-    expect(result.metadata).toEqual({ blockedByHook: true });
   });
 });
 
@@ -649,6 +648,8 @@ describe("wrapModelStream", () => {
     expect(chunks[0]?.kind).toBe("error");
     if (chunks[0]?.kind === "error") {
       expect(chunks[0].message).toContain("not today");
+      expect(chunks[0].code).toBe("PERMISSION");
+      expect(chunks[0].retryable).toBe(false);
     }
   });
 

--- a/packages/lib/hooks/src/middleware.ts
+++ b/packages/lib/hooks/src/middleware.ts
@@ -7,8 +7,8 @@
  *   onBeforeTurn    → "turn.started"    (blocking — throws on block decision)
  *   onAfterTurn     → "turn.ended"      (fire-and-forget, drained on session end)
  *   wrapToolCall    → "tool.before" (blocking) + "tool.succeeded" (fire-and-forget, drained)
- *   wrapModelCall   → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
- *   wrapModelStream → "compact.before" (blocking) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelCall   → "compact.before" (blocking — throws on block) + "compact.after" (fire-and-forget, drained)
+ *   wrapModelStream → "compact.before" (blocking — yields error chunk on block) + "compact.after" (fire-and-forget, drained)
  *
  * Pre-call hooks block and aggregate decisions (block > modify > continue).
  * Post-call hooks are fire-and-forget during the turn but drained with a bounded
@@ -332,11 +332,7 @@ export function createHookMiddleware(options: CreateHookMiddlewareOptions): KoiM
       const preResult = await dispatchModelPre(sessionId, ctx, request);
 
       if (preResult.blocked) {
-        return {
-          content: `[Hook blocked model call: ${preResult.reason}]`,
-          model: request.model ?? "unknown",
-          metadata: { blockedByHook: true },
-        };
+        throw new Error(`Model call blocked by hook: ${preResult.reason}`);
       }
 
       const response = await next(preResult.request);
@@ -362,6 +358,8 @@ export function createHookMiddleware(options: CreateHookMiddlewareOptions): KoiM
         yield {
           kind: "error",
           message: `Hook blocked model stream: ${preResult.reason}`,
+          code: "PERMISSION",
+          retryable: false,
         };
         return;
       }


### PR DESCRIPTION
## Summary

When a `model.pre` hook returns `block`, `wrapModelCall()` previously returned a synthetic `ModelResponse` with fake assistant text (`[Hook blocked model call: <reason>]`). This disguised a policy denial as a successful model completion.

**Changes:**
- `wrapModelCall` now **throws** on block decisions, consistent with `onSessionStart` and `onBeforeTurn` block paths
- `wrapModelStream` error chunk now includes `code: "PERMISSION"` and `retryable: false`
- Added `"hook_blocked"` to L0 `ModelStopReason` type

Closes #1293

## Test plan

- [x] `bun test packages/lib/hooks/src/middleware.test.ts` -- block throws with correct message, next() not called
- [x] `bun test packages/kernel/core/src/model-adapter.test.ts` -- hook_blocked in ModelStopReason
- [x] API surface snapshots pass
- [x] `bun run typecheck` -- passes
- [x] `bun run check:layers` -- no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
