### PR TITLE
test: restore hook-redaction recorder path + document dispatch split-brain (closes #1491)

### DIFF
--- a/packages/meta/runtime/scripts/record-cassettes.ts
+++ b/packages/meta/runtime/scripts/record-cassettes.ts
@@ -12,6 +12,7 @@
  *   permission-deny       — permissions default mode denies add_numbers
  *   denial-escalation    — repeated execution-time denials trigger auto-deny escalation
  *   hook-blocked         — pre-call hook blocks model call, stopReason: hook_blocked, Glob allowed
+ *   hook-redaction       — agent hook on tool.succeeded, forwardRawPayload + default redaction
  *
  * ALL L2 packages wired across queries:
  *   @koi/model-openai-compat  — model adapter
@@ -157,6 +158,27 @@ if (!addToolResult.ok) {
   process.exit(1);
 }
 const addTool = addToolResult.value;
+
+// ---------------------------------------------------------------------------
+// Credentials tool (for hook-redaction golden query)
+// ---------------------------------------------------------------------------
+
+const credentialsToolResult = buildTool({
+  name: "get_credentials",
+  description: "Retrieve database credentials for the current environment",
+  inputSchema: { type: "object", properties: {} },
+  origin: "primordial",
+  execute: async (): Promise<unknown> => ({
+    apiKey: `sk-ant-api03-${"A".repeat(85)}`,
+    dbPassword: "super-secret-pw-123",
+    host: "db.example.com",
+  }),
+});
+if (!credentialsToolResult.ok) {
+  console.error(`buildTool(get_credentials) failed: ${credentialsToolResult.error.message}`);
+  process.exit(1);
+}
+const credentialsTool = credentialsToolResult.value;
 
 // send_message — tool with a string field for exfiltration guard testing
 const sendMessageToolResult = buildTool({
@@ -526,13 +548,29 @@ interface QueryConfig {
   readonly permissionMode: "bypass" | "default";
   readonly permissionRules: readonly SourcedRule[];
   readonly permissionDescription: string;
-  readonly hooks: readonly {
-    readonly kind: "command";
-    readonly name: string;
-    readonly cmd: readonly string[];
-    readonly filter: { readonly events: readonly string[] };
-    readonly once?: boolean;
-  }[];
+  readonly hooks: readonly (
+    | {
+        readonly kind: "command";
+        readonly name: string;
+        readonly cmd: readonly string[];
+        readonly filter: { readonly events: readonly string[] };
+        readonly once?: boolean;
+      }
+    | {
+        readonly kind: "agent";
+        readonly name: string;
+        readonly prompt: string;
+        readonly model?: string;
+        readonly filter: { readonly events: readonly string[] };
+        readonly forwardRawPayload?: boolean;
+        readonly redaction?: {
+          readonly enabled?: boolean;
+          readonly censor?: string;
+          readonly sensitiveFields?: readonly string[];
+        };
+        readonly once?: boolean;
+      }
+  )[];
   readonly providers: readonly ComponentProvider[];
   /** Max model→tool turns. Default 1. Set to 0 for text-only (no tool loop). */
   readonly maxTurns?: number;
@@ -597,9 +635,56 @@ async function recordTrajectory(config: QueryConfig): Promise<void> {
   });
 
   // @koi/hooks — core hook middleware for model pre/post hooks (compact.before/after/blocked)
+  // Also fires tool.before/tool.succeeded with payload data via its internal registry;
+  // agent hooks on tool events dispatch here, not through @koi/runtime's hook-dispatch.
+  // TODO(hook-dispatch-unification): consolidate with hook-dispatch.ts per Claude Code's
+  // single-dispatcher + observer-tap pattern. Tracked as a follow-up to #1491.
   const hookResult = loadHooks([...config.hooks]);
   const loadedHooks = hookResult.ok ? hookResult.value : [];
-  const coreHookMw = createHookMiddleware({ hooks: loadedHooks });
+
+  // Provide a spawnFn for agent hooks — uses the same OpenRouter model adapter.
+  const hasAgentHooks = config.hooks.some((h) => h.kind === "agent");
+  const spawnFn: SpawnFn | undefined = hasAgentHooks
+    ? async (request) => {
+        try {
+          const response = await modelAdapter.complete({
+            messages: [
+              {
+                senderId: "system",
+                timestamp: Date.now(),
+                content: [{ kind: "text", text: request.systemPrompt ?? "" }],
+              },
+              {
+                senderId: "user",
+                timestamp: Date.now(),
+                content: [{ kind: "text", text: request.description }],
+              },
+            ],
+            model: MODEL,
+          });
+          const textContent = response.content
+            .filter((c): c is { readonly kind: "text"; readonly text: string } => c.kind === "text")
+            .map((c) => c.text)
+            .join("");
+          return { ok: true, output: textContent };
+        } catch (err: unknown) {
+          return {
+            ok: false,
+            error: {
+              code: "SPAWN_FAILED" as const,
+              message: err instanceof Error ? err.message : String(err),
+              retryable: false,
+              context: {},
+            },
+          };
+        }
+      }
+    : undefined;
+
+  const coreHookMw = createHookMiddleware({
+    hooks: loadedHooks,
+    ...(spawnFn !== undefined ? { spawnFn } : {}),
+  });
 
   // Optional registry for once-hook lifecycle tracking
   // let justified: mutable — created conditionally
@@ -1718,6 +1803,36 @@ const queries: readonly QueryConfig[] = [
     modelAdapter: sonnetAdapter,
     modelName: SONNET_MODEL,
   },
+
+  // 16. hook-redaction: agent hook on tool.succeeded with forwardRawPayload + default redaction.
+  //     Proves that raw secrets in tool output never reach observable ATIF steps or the
+  //     agent-hook verifier's prompt — redaction runs before prompt assembly in @koi/hooks.
+  {
+    name: "hook-redaction",
+    prompt:
+      "Use the get_credentials tool to retrieve the database credentials. Report the host name.",
+    permissionMode: "bypass",
+    permissionRules: BYPASS_RULES,
+    permissionDescription: "bypass (allow all)",
+    hooks: [
+      {
+        kind: "agent" as const,
+        name: "secret-scanner",
+        prompt:
+          "Verify the tool output does not contain any exposed secrets or credentials. If secrets are properly redacted, continue. If you see raw secrets, block.",
+        filter: { events: ["tool.succeeded"] },
+        forwardRawPayload: true,
+      },
+    ],
+    providers: [
+      createSingleToolProvider({
+        name: "credentials",
+        toolName: "get_credentials",
+        createTool: () => credentialsTool,
+      }),
+    ],
+    maxTurns: 2,
+  },
 ];
 
 // =========================================================================
@@ -1879,6 +1994,24 @@ await recordCassette("memory-recall", () =>
   }),
 );
 
+await recordCassette("hook-redaction", () =>
+  modelAdapter.stream({
+    messages: [
+      {
+        senderId: "user",
+        timestamp: Date.now(),
+        content: [
+          {
+            kind: "text",
+            text: "Use the get_credentials tool to retrieve the database credentials. Report the host name.",
+          },
+        ],
+      },
+    ],
+    tools: [credentialsTool.descriptor],
+  }),
+);
+
 // Inject MCP provider for the mcp-tool-use query (needs async setup)
 const mcpSetup = await createMcpProvider();
 const mcpQuery = queries.find((q) => q.name === "mcp-tool-use");
@@ -1946,6 +2079,7 @@ console.log("  fixtures/simple-text.cassette.json");
 console.log("  fixtures/tool-use.cassette.json");
 console.log("  fixtures/task-tools.cassette.json");
 console.log("  fixtures/spawn-tools.cassette.json");
+console.log("  fixtures/hook-redaction.cassette.json");
 console.log("  fixtures/mcp-tool-use.cassette.json");
 for (const q of queries) {
   console.log(`  fixtures/${q.name}.trajectory.json`);

--- a/packages/meta/runtime/src/middleware/hook-dispatch.ts
+++ b/packages/meta/runtime/src/middleware/hook-dispatch.ts
@@ -11,6 +11,21 @@
  * - block: throws an error to prevent the operation
  * - modify: patches the request input before proceeding
  * - continue: no-op, proceed normally
+ *
+ * TODO(hook-dispatch-unification): this middleware currently runs in parallel
+ * with @koi/hooks createHookMiddleware, which dispatches the same tool events
+ * with full payload data and an agentExecutor wired via spawnFn. That path
+ * handles agent hooks; this path only handles command/http hooks (calls
+ * executeHooks with no agentExecutor) and records ATIF steps. The split means
+ * tool events fire twice per call, agent hooks silently no-op here, and
+ * observability is wired to the weaker dispatcher.
+ *
+ * Claude Code's production hook system uses a single dispatcher per event
+ * (see src/utils/hooks.ts:3450 executePostToolHooks) with full payload + an
+ * observer tap (src/utils/hooks/hookEvents.ts:61). We should mirror that:
+ * make @koi/hooks the sole dispatcher and turn this middleware into a pure
+ * observer that subscribes to hook-execution events and only records ATIF
+ * steps. Tracked as a follow-up to #1491.
  */
 
 import type {


### PR DESCRIPTION
## Summary

Restores the agent-hook-on-tool-event recording path in `record-cassettes.ts` that #1450 removed, closing #1491. Also documents (but does not fix) an architectural split-brain in hook dispatch that made the broken path easy to misdiagnose.

Supersedes the original deletion approach on this branch (commits 95bdd1cf → reverted in 7caa261b). See commit history for the reasoning.

## What was broken

#1450 narrowed `QueryConfig.hooks` to `kind: "command"` only and deleted the `spawnFn` wiring, leaving `fixtures/hook-redaction.trajectory.json` stranded: the recorder could no longer regenerate it, and `golden-replay.test.ts:1859` kept asserting against a static artifact — the false-green flagged in #1491.

## Why not just delete the fixture (the first attempt)?

My initial resolution (commit 95bdd1cf) was to delete the fixture + test, on the assumption that agent-hook-on-tool-event was never actually wired. The checked-in trajectory contradicted that: inspecting `HEAD~1:fixtures/hook-redaction.trajectory.json` showed a real `hook_execution` step with `hookName: "secret-scanner"` and **zero occurrences** of `sk-ant-api03-` or `super-secret-pw-123` anywhere in the JSON. The agent hook was firing and payload redaction was working end-to-end through `@koi/hooks` `createHookMiddleware` — just not through `@koi/runtime` `hook-dispatch`, which is what I'd been looking at.

The deletion was the wrong call. Reverted.

## What this restores

- `QueryConfig.hooks` re-widened to `command | agent`
- `spawnFn` constructed from `modelAdapter.complete` and passed into `createHookMiddleware` when a query has agent hooks
- `credentialsTool` (`get_credentials`) producing raw `sk-ant-api03-…` / `super-secret-pw-123`
- `hook-redaction` query entry with the `secret-scanner` agent hook on `tool.succeeded`, `forwardRawPayload: true`, default redaction
- `recordCassette("hook-redaction", …)` call

Existing fixtures remain on disk. Running `OPENROUTER_API_KEY=… FORCE_RECORD=true bun run packages/meta/runtime/scripts/record-cassettes.ts` on this branch regenerates both `hook-redaction.cassette.json` and `hook-redaction.trajectory.json` through the restored live path, closing the regen gap cited in #1491.

## The dispatch split-brain (documented, not fixed)

Two middlewares fire the same tool events:

1. `@koi/hooks` `createHookMiddleware` at `packages/lib/hooks/src/middleware.ts:468-475` — fires `tool.succeeded` with full payload `data: { input, output }`, uses an internal registry with `agentExecutor` wired from `spawnFn` (middleware.ts:255-257). This is where agent hooks actually execute.
2. `@koi/runtime` `createHookDispatchMiddleware` at `packages/meta/runtime/src/middleware/hook-dispatch.ts:315` — fires `tool.succeeded` with `data: undefined`, calls `executeHooks` with no `agentExecutor`, records ATIF steps.

Consequences: tool events fire twice per tool call, agent hooks silently no-op in path #2, ATIF observability is wired to the weaker dispatcher, and two separate registries can drift on once-hook consumption.

Claude Code's production hook system uses a **single dispatcher** per event (`executePostToolHooks` at `claude-code-source-code/src/utils/hooks.ts:3450` passes `tool_input + tool_response`) called from exactly one place (`services/tools/toolHooks.ts:56`), plus an observer tap (`hookEvents.ts:61`). Koi should mirror that: make `@koi/hooks` the sole dispatcher and turn `hook-dispatch` into a pure observer recording ATIF steps.

Added `TODO(hook-dispatch-unification)` comments at both sites. I will file a separate issue for the unification redesign — it crosses L2 contract boundaries and should not ride along with this fixture restoration.

## Test plan

- [ ] `bun run packages/meta/runtime/scripts/record-cassettes.ts` completes successfully (requires `OPENROUTER_API_KEY`)
- [ ] Fresh `hook-redaction.trajectory.json` contains `hookName: "secret-scanner"` in a `hook_execution` step
- [ ] Fresh trajectory JSON contains neither `sk-ant-api03-` nor `super-secret-pw-123`
- [ ] `golden-replay.test.ts "Golden: hook-redaction trajectory"` passes against the fresh fixture
- [ ] `check:golden-queries`, `check:layers`, `typecheck`, `lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
