### PR TITLE
docs: add from-source and koi start instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,17 @@ export OPENROUTER_API_KEY=sk-or-...
 export OPENAI_API_KEY=sk-...
 
 koi tui          # open interactive terminal console
+koi start        # headless REPL (no TUI)
 ```
 
 Inside the TUI: type a message and press Enter, or type `/` for slash commands.
+
+**From source** (without global install):
+
+```bash
+bun run packages/meta/cli/src/bin.ts tui      # TUI from source
+bun run packages/meta/cli/src/bin.ts start     # headless REPL from source
+```
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add `koi start` command to Quickstart section alongside `koi tui`
- Add "From source" subsection showing how to run TUI and REPL directly via `bun run` without global install

## Context
The README was missing instructions for running from source (without `bun link`) and didn't mention `koi start` as an entry point.

Also: the release workflow failed because the repo-level setting **"Allow GitHub Actions to create and approve pull requests"** is disabled — the workflow YAML already has `pull-requests: write`, so just toggle that checkbox in Settings > Actions > General.

## Test plan
- [ ] Verify `bun run packages/meta/cli/src/bin.ts tui` launches TUI from source checkout
- [ ] Verify `bun run packages/meta/cli/src/bin.ts start` launches headless REPL