### PR TITLE
ci(release): switch to tag-based releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags: ["v*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,12 +10,11 @@ concurrency:
 
 jobs:
   release:
-    name: Changesets Release
+    name: Publish & Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -36,14 +35,12 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Create Release PR or Publish
-        uses: changesets/action@v1
-        with:
-          version: bun run changeset:version
-          publish: bun run changeset:publish
-          title: "chore: version packages"
-          commit: "chore: version packages"
-          createGithubReleases: true
+      - name: Publish to npm
+        run: bunx changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace changesets PR flow with simple tag-based releases
- Push a `v*` tag → build → publish to npm → create GitHub Release
- No more bot PRs that can't pass CI

## How to release
```bash
git tag v0.1.0
git push origin v0.1.0
```

## Test plan
- [ ] Merge this PR, tag `v0.1.0`, push tag, verify GitHub Release is created