### PR TITLE
fix(ci): configure .npmrc for npm publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,11 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
       - name: Publish to npm
         run: bunx changeset publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         run: gh release create "${{ github.ref_name }}" --generate-notes


### PR DESCRIPTION
## Summary
- Add `.npmrc` setup step so `npm publish` (via `changeset publish`) can authenticate with the `NPM_TOKEN` secret

## Context
The previous two release attempts failed with `ENEEDAUTH` because `changeset publish` calls `npm publish` which reads auth from `.npmrc`, not from env vars.

## Test plan
- [ ] Merge, delete v0.1.0 tag, re-tag, push — verify npm publish succeeds