### PR TITLE
feat(skills-runtime): add bundled concise skill

### DIFF
--- a/packages/lib/skills-runtime/bundled/concise/SKILL.md
+++ b/packages/lib/skills-runtime/bundled/concise/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: concise
+description: Keep responses short and direct — maximum 3 sentences.
+tags:
+  - style
+  - output-format
+---
+
+Keep responses short and direct. Maximum 3 sentences per response. Lead with the answer, not the reasoning.


### PR DESCRIPTION
## Summary
- Adds the first bundled skill (`concise`) to `@koi/skills-runtime` at `bundled/concise/SKILL.md`
- Instructs the model to keep responses short and direct (max 3 sentences)
- Auto-discovered via `defaultBundledRoot()` — no config needed

## Test plan
- [x] Verified skill discovery from CLI context (`createSkillsRuntime()` finds `concise` as `bundled` tier)
- [x] Verified in `koi tui` via tmux: model confirmed skill content present in system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)