### PR TITLE
chore: refine skill descriptions for better triggering

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -1,6 +1,10 @@
 ---
 name: cleanup
-description: Clean up unused worktrees, merged local branches, and orphaned Codex broker processes to free memory and reduce fseventsd load.
+description: >
+  Clean up unused worktrees, merged local branches, and orphaned Codex broker
+  processes. Use when the system feels slow, fseventsd is using too much memory,
+  or after finishing a batch of PRs. Triggers on: "clean up", "free memory",
+  "remove old worktrees", "prune branches", "kill orphaned processes".
 allowed-tools: Bash Read Glob Grep
 ---
 

--- a/.claude/commands/golden-check.md
+++ b/.claude/commands/golden-check.md
@@ -1,6 +1,11 @@
 ---
 name: golden-check
-description: Check if the current branch's PR needs golden queries and trajectories, record missing ones, and validate until correct.
+description: >
+  Audit the current branch for missing golden query and trajectory coverage.
+  Records missing cassettes/trajectories and validates until CI passes.
+  Use before opening a PR that adds or modifies an L2 package.
+  Triggers on: "golden check", "check golden queries", "check trajectories",
+  "are golden queries covered", "record cassettes".
 allowed-tools: Bash Read Write Edit Glob Grep Agent
 ---
 

--- a/.claude/commands/review-loop-SKILL.md
+++ b/.claude/commands/review-loop-SKILL.md
@@ -3,8 +3,9 @@ name: review-loop
 description: >
   Adversarial review-fix convergence loop. Runs Codex adversarial-review,
   fixes every finding, then reviews again — up to 10 rounds or until clean.
-  Use when asked to "review loop", "review and fix", "harden this code",
-  or "keep reviewing until clean".
+  Triggers on: "review loop", "review and fix", "harden this code",
+  "keep reviewing until clean", "adversarial review", "codex review".
+allowed-tools: Bash Read Write Edit Glob Grep Agent
 ---
 
 # Adversarial Review-Fix Loop

--- a/.claude/commands/tui-test.md
+++ b/.claude/commands/tui-test.md
@@ -1,6 +1,10 @@
 ---
 name: tui-test
-description: Automatically test the current branch's changes in koi tui via tmux. Detects what changed, designs a test, runs it, and fixes bugs until it passes.
+description: >
+  E2E test the current branch in koi tui via tmux. Auto-detects what changed,
+  designs a test prompt, runs it, and fixes bugs until the test passes.
+  Triggers on: "test with tui", "tui test", "test in tui", "test feature in tui",
+  "tmux test", "e2e test".
 allowed-tools: Bash Read Write Edit Glob Grep Agent
 ---
 


### PR DESCRIPTION
## Summary
- Improved descriptions on all 4 project skills with explicit trigger phrases for auto-loading accuracy
- Added missing `allowed-tools` to `/review-loop` (was undefined — could silently fail)
- Added use-case context to descriptions so Claude knows *when* to suggest each skill

## Changes
| Skill | What changed |
|-------|-------------|
| `/cleanup` | Added trigger phrases + use-case context |
| `/golden-check` | Added trigger phrases + pre-PR context |
| `/review-loop` | Added `allowed-tools`, refined trigger phrases |
| `/tui-test` | Added common phrasings for triggering |

🤖 Generated with [Claude Code](https://claude.com/claude-code)