### PR TITLE
feat(core): #1625 L0 schema deltas + L2 doc-gate for checkpoint/rewind

### DIFF
--- a/docs/L2/checkpoint.md
+++ b/docs/L2/checkpoint.md
@@ -1,0 +1,206 @@
+# @koi/checkpoint
+
+Session-level rollback: capture conversation history + file-system state at every turn boundary, restore atomically with `/rewind <n>`.
+
+## Purpose
+
+Implements the capture and restore halves of #1625. At end of every turn, snapshots the agent's conversation + the file operations the agent performed during that turn. On `/rewind n`, walks the snapshot chain back n steps and restores both conversation and tracked files to that point with crash-safe convergence semantics.
+
+## Layered architecture
+
+```
+@koi/checkpoint              (L2, this package)
+   │
+   ├─ @koi/snapshot-store-sqlite   (L2, storage adapter)
+   ├─ @koi/core                    (L0, types: AgentSnapshot, FileOpRecord, CompensatingOp, SNAPSHOT_STATUS_KEY)
+   ├─ @koi/hash                    (L0u, content hashing)
+   ├─ @koi/git-utils                (L0u, git status for drift detection)
+   └─ @koi/errors                   (L0u)
+```
+
+This package owns three concerns:
+
+1. **Capture** — engine middleware that hooks turn-complete and intercepts Edit/Write/MultiEdit
+2. **CAS blob store** — content-addressed file storage for the bytes referenced by `FileOpRecord` and `CompensatingOp.restore`
+3. **UX** — `/rewind` slash command, queueing protocol for in-flight requests, TUI markers
+
+The chain storage layer (`@koi/snapshot-store-sqlite`) is a separate L2 adapter so the deterministic-replay sibling package can reuse it.
+
+## CAS blob store
+
+File contents are stored in a content-addressed directory:
+
+```
+~/.koi/file-history/
+  {first-2-hex-of-hash}/
+    {full-sha256-hex}     ← raw file bytes
+```
+
+| Property | Value |
+|---|---|
+| Hash | SHA-256 |
+| Chunk size | 64 KB streaming via `Bun.file(path).stream()` |
+| Memory bound | ~64 KB regardless of file size |
+| Dedup | Automatic — same content across snapshots/sessions = one blob |
+| Binary safe | Yes — hash operates on bytes, not strings |
+
+Blobs are referenced by `FileOpRecord.preContentHash` / `postContentHash` (defined in `@koi/core`) and by `CompensatingOp.restore.contentHash`.
+
+## Capture: end-of-turn snapshot
+
+Capture happens **after** the model and all tool calls have quiesced, before the next user message is accepted. This avoids the empty-snapshot race other agent runtimes have shipped with (where capture-on-user-message-receipt completes before async edit tools fire).
+
+```
+turn N:
+  user message received
+  → engine streams model output
+  → tool calls execute (Edit/Write/MultiEdit append FileOpRecord to in-memory buffer)
+  → model produces final message
+  → engine becomes idle
+  → checkpoint middleware: end-of-turn capture
+       1. Hash any new content (streaming)
+       2. Write blobs to CAS
+       3. Insert SnapshotNode with FileOpRecord[] payload
+  → ready for turn N+1
+```
+
+### Two-phase capture (latency budget)
+
+The user-perceived critical path between turn N and turn N+1 must stay fast (~10–20 ms typical). Capture is split:
+
+| Phase | Work | Budget |
+|---|---|---|
+| Critical (sync) | Hash files, write blobs to CAS, insert chain node | ~10–20 ms |
+| Deferred (microtask) | `git status` for drift detection, blob existence verification, prune + GC | ~80 ms, runs in background |
+
+Drift warnings appear on the snapshot a beat after creation. The rewind UI does not need them until the user actually rewinds.
+
+### Op-kind capture matrix
+
+`FileOpRecord` is a discriminated union by `kind`:
+
+| Kind | Captured fields | Compensating op on rewind |
+|---|---|---|
+| `create` | `postContentHash` | `delete` (file did not exist before) |
+| `edit` | `preContentHash`, `postContentHash` | `restore preContentHash` |
+| `delete` | `preContentHash` | `restore preContentHash` |
+
+Renames are captured as a `delete + create` pair sharing a `renameId`. The rewind UI may present them as a single operation; the storage layer treats them as two independent ops.
+
+## Restore protocol
+
+`/rewind n` restores both file state and conversation atomically via an **ordered + idempotent** protocol — no two-phase commit:
+
+```
+1. Walk N steps back through the chain → identify target SnapshotNode
+2. For each FileOpRecord between target and head, compute compensating op
+3. Apply compensating ops to filesystem (CAS writes are no-ops on hash match)
+4. Write new conversation log to <session>.jsonl.tmp + fsync
+5. Atomic rename(2) over <session>.jsonl
+6. Update chain head pointer in SQLite
+```
+
+Crash safety comes from **idempotency**, not from a coordinator: re-running `restore(N)` after a crash converges on the target state because every step is a fixed point. Files are restored by hash (CAS write of an existing blob is a no-op), and the conversation log uses tmp+rename which is atomic at the OS level.
+
+## Soft-fail contract
+
+If the capture step fails at end of turn (disk full, store error, etc.), the turn proceeds. The snapshot is recorded with `SNAPSHOT_STATUS_KEY = "incomplete"` in its metadata and is **skipped on rewind** with a user-visible warning. Checkpoint failure does NOT abort the agent loop — it is a recovery feature, not a correctness feature.
+
+## In-flight contract (queue between turns)
+
+Rewind requests received during a tool call are queued; they fire when the engine returns to `idle`. The UI shows a "rewind queued" indicator. There is no mid-turn rewind — this sidesteps the per-tool cancellation problem (Bash subprocesses cannot be safely cancelled mid-syscall).
+
+| Engine state | Rewind request | Behavior |
+|---|---|---|
+| `idle` | Immediate | Fires immediately |
+| `tool-call running` | Queued | Fires after current tool completes and engine returns to idle |
+| `model streaming` | Queued | Fires after model completes |
+
+## Cache neutrality
+
+The middleware truncates the conversation log to the snapshot point and does **nothing else** with messages. Provider-side prompt cache is unaffected by this package; the restored prefix is exact, and providers treat exact prefixes as cache hits naturally.
+
+This requires the system prompt to stay free of dynamic content (timestamps, turn counters, mutating tool lists). That precondition is enforced elsewhere — the checkpoint package does not police it.
+
+## Drift warnings
+
+`git status --porcelain` runs in the deferred phase of capture. Any changes that don't correspond to a tracked `FileOpRecord` from the current turn are recorded as `AgentSnapshot.driftWarnings: readonly string[]` (typically `M path/to/file.ts`, `?? new-untracked.ts`).
+
+On `/rewind`, the UI surfaces these:
+
+```
+Rewinding 3 turns...
+✓ Restored 5 tracked files
+⚠ 2 files were modified outside checkpoint tracking and will not be restored:
+    M src/build.sh
+    ?? generated/output.json
+```
+
+Drifted files are NOT restored. The user is informed.
+
+## Configuration
+
+| Key | Default | Description |
+|---|---|---|
+| `maxSnapshots` | 500 per chain | Chain prune cap |
+| `maxBlobBudgetBytes` | 2 GiB | CAS storage budget; mark-and-sweep GC triggers when exceeded |
+| `retentionDays` | 30 | Time-based prune cutoff |
+| `streamingChunkSize` | 65536 (64 KB) | Hash chunk size |
+
+## API
+
+```typescript
+import { createCheckpointMiddleware } from "@koi/checkpoint";
+import { createSnapshotStoreSqlite } from "@koi/snapshot-store-sqlite";
+import type { AgentSnapshot } from "@koi/core";
+
+const store = await createSnapshotStoreSqlite<AgentSnapshot>({
+  path: "~/.koi/snapshots.sqlite",
+  blobDir: "~/.koi/file-history",
+  extractBlobRefs: extractBlobRefsFromAgentSnapshot,
+});
+
+const checkpoint = createCheckpointMiddleware({
+  store,
+  blobDir: "~/.koi/file-history",
+  config: {
+    maxSnapshots: 500,
+    maxBlobBudgetBytes: 2 * 1024 * 1024 * 1024,
+  },
+});
+
+const koi = createKoi({
+  middleware: [checkpoint /* others */],
+});
+
+// Programmatic rewind (also exposed as the /rewind slash command)
+await koi.checkpoint.rewind(3);                    // rewind 3 turns
+await koi.checkpoint.rewindTo("snapshot-id-abc");  // rewind to a specific node
+```
+
+## Testing
+
+The package ships with four mandatory test suites (per #1625 acceptance criteria):
+
+| Suite | What | Approx tests |
+|---|---|---|
+| **Crash injection** | Inject failure at every protocol step boundary, assert re-run convergence | 10–15 |
+| **Op-kind matrix** | create/edit/delete × empty/text/binary/chunk-boundary/large + targeted tests for rename, symlink, mode bits, unicode paths | ~30 |
+| **In-flight queue** | Rewind during tool-call / model-streaming / quiescent → queued state → fires on idle | 3 |
+| **Negative path** | Drift detection, soft-fail, missing blob, corrupt SQLite, disk full, eviction with head protection, store error | ~12 |
+
+Plus one happy-path round-trip: agent edits 3 files across 5 turns, rewind 2, exact intermediate state restored.
+
+The crash-injection harness is the test that validates the entire ordered+idempotent atomicity strategy. It is not optional.
+
+## Out of scope
+
+- Restoring bash-mediated changes (`rm`, `mv`, `sed -i`, build artifacts) — surfaced as drift warnings only
+- Restoring directory creation/deletion — CAS captures file content only
+- Restoring permission/ownership changes beyond what `FileOpRecord` records
+- Re-warming provider-side prompt cache — providers don't expose this
+- Cross-session restore — each session's chain is independent
+
+## Layer
+
+L2 — depends on `@koi/core` (L0), `@koi/snapshot-store-sqlite` (L2 storage adapter), `@koi/hash` (L0u), `@koi/git-utils` (L0u), `@koi/errors` (L0u).

--- a/docs/L2/snapshot-store-sqlite.md
+++ b/docs/L2/snapshot-store-sqlite.md
@@ -1,316 +1,278 @@
-# @koi/snapshot-store-sqlite — Persistent DAG Snapshot Storage
+# @koi/snapshot-store-sqlite
 
-SQLite-backed `SnapshotChainStore<T>` with WAL mode, content-hash deduplication, full DAG topology (ancestor walking, forking, pruning), and in-memory head tracking for O(1) lookups. Drop-in replacement for the in-memory store from `@koi/snapshot-chain-store`.
+L2 storage adapter implementing `SnapshotChainStore<T>` from `@koi/core` over SQLite.
+
+Persistent DAG snapshot storage with WAL mode, content-hash deduplication, full DAG topology (ancestor walking, forking, pruning), in-memory head tracking for O(1) lookups, recursive-CTE ancestor queries, and integrated mark-and-sweep CAS blob garbage collection.
 
 ---
 
 ## Why It Exists
 
-`@koi/snapshot-chain-store` provides an in-memory `SnapshotChainStore<T>` — fast but volatile. State vanishes on process exit. For autonomous agents that operate over hours or days, losing harness snapshots means losing all task progress, summaries, and artifacts.
+Generic snapshot DAG storage that two unrelated L2 packages need:
 
-`@koi/snapshot-store-sqlite` adds **durable persistence** to the same L0 interface:
+- **`@koi/checkpoint`** (#1625) — uses `T = AgentSnapshot` for session-level rollback (`/rewind <n>`)
+- **deterministic-replay** (sibling of #1625) — uses the same chain topology to record/replay engine traces
 
-- **Survives restarts** — snapshots persist across process exits and crashes
-- **WAL mode** — concurrent reads during writes, no reader blocking
-- **Content-hash dedup** — `skipIfUnchanged` avoids redundant writes when data hasn't changed
-- **Configurable durability** — "process" (default, fast) or "os" (FULL sync for power-loss safety)
-- **Same interface** — consumers see `SnapshotChainStore<T>`, unaware of the backing store
+Without a shared L2 adapter, both packages would reinvent the same SQLite schema. The store is generic over `T`, so both consumers use the same tables and the same `SnapshotChainStore<T>` interface from `@koi/core`.
 
-Without this package, long-running agents would lose all semantic history on restart.
+Ports the v1 SQLite schema from `archive/v1/packages/mm/snapshot-chain-store/src/sqlite-store.ts` with two improvements driven by the #1625 design review:
+
+- **Recursive-CTE ancestor walks** — replaces v1's BFS with N+1 queries (Issue 16)
+- **Mark-and-sweep blob GC integrated into prune** — v1 left orphan blob cleanup to callers (Issue 13)
 
 ---
 
 ## Architecture
 
-`@koi/snapshot-store-sqlite` is an **L0u utility package** — it depends on L0 (`@koi/core`) and peer L0u packages (`@koi/hash`, `@koi/sqlite-utils`).
-
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  @koi/snapshot-store-sqlite  (L0u)                                │
+│  @koi/snapshot-store-sqlite  (L2 storage adapter)                 │
 │                                                                    │
 │  types.ts            ← SqliteSnapshotStoreConfig                   │
-│  sqlite-store.ts     ← createSqliteSnapshotStore<T>() factory      │
-│  index.ts            ← Public API surface                          │
+│  sqlite-store.ts     ← createSnapshotStoreSqlite<T>() factory      │
+│  schema.ts           ← table DDL, pragmas                          │
+│  cte.ts              ← recursive ancestor walk query               │
+│  gc.ts               ← mark-and-sweep blob sweeper                 │
+│  index.ts            ← public API                                  │
 │                                                                    │
-├──────────────────────────────────────────────────────────────────  │
+├────────────────────────────────────────────────────────────────── │
 │  Dependencies                                                      │
 │                                                                    │
 │  @koi/core          (L0)   ChainId, NodeId, SnapshotNode,          │
 │                             SnapshotChainStore, PruningPolicy,      │
 │                             ForkRef, AncestorQuery, Result, KoiError│
-│  @koi/hash          (L0u)  computeContentHash()                    │
-│  @koi/sqlite-utils  (L0u)  openDb(), mapSqliteError()              │
+│  @koi/errors        (L0u)  KoiError factories                       │
+│  bun:sqlite         (Bun built-in, not an npm dep)                 │
 └──────────────────────────────────────────────────────────────────  ┘
 ```
 
 ---
 
-## How It Works
+## Schema
 
-The store uses two tables: a **nodes table** for snapshot data and a **members table** for chain membership. A node can belong to multiple chains (via fork). Heads and sequence counters are tracked in-memory for O(1) lookup, initialized from the DB on construction.
+Three tables, deliberately small:
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                    SQLite Database (WAL mode)                      │
-│                                                                    │
-│  ┌──────────────────────────────────────────────────────────┐    │
-│  │  snapshot_nodes                                            │    │
-│  │  ┌──────────┬────────────┬──────────────┬──────┬───────┐ │    │
-│  │  │ node_id  │ parent_ids │ content_hash │ data │ meta  │ │    │
-│  │  │ (PK)     │ JSON[]     │ SHA-256      │ JSON │ JSON  │ │    │
-│  │  └──────────┴────────────┴──────────────┴──────┴───────┘ │    │
-│  └──────────────────────────────────────────────────────────┘    │
-│                                                                    │
-│  ┌──────────────────────────────────────────────────────────┐    │
-│  │  snapshot_nodes_members                                    │    │
-│  │  ┌──────────┬─────────┬────────────┬─────┐               │    │
-│  │  │ chain_id │ node_id │ created_at │ seq │               │    │
-│  │  │ (PK)     │ (PK)    │ DESC index │     │               │    │
-│  │  └──────────┴─────────┴────────────┴─────┘               │    │
-│  └──────────────────────────────────────────────────────────┘    │
-│                                                                    │
-├──────────────────────────────────────────────────────────────────│
-│  In-Memory Cache                                                   │
-│                                                                    │
-│  chainHeads: Map<ChainId, NodeId>     ← O(1) head lookup          │
-│  chainSeqs:  Map<ChainId, number>     ← monotonic seq counter     │
-│                                                                    │
-│  Loaded from DB on construction, updated on put/fork/prune         │
-└──────────────────────────────────────────────────────────────────┘
+```sql
+CREATE TABLE snapshot_nodes (
+  node_id      TEXT PRIMARY KEY,
+  parent_ids   TEXT NOT NULL,            -- JSON array of NodeId
+  content_hash TEXT NOT NULL,            -- SHA-256 of payload, for skip-if-unchanged
+  data         TEXT NOT NULL,            -- JSON-serialized payload T
+  created_at   INTEGER NOT NULL,         -- Unix ms
+  metadata     TEXT NOT NULL             -- JSON; includes SNAPSHOT_STATUS_KEY
+);
+
+CREATE TABLE chain_members (
+  chain_id     TEXT NOT NULL,
+  node_id      TEXT NOT NULL REFERENCES snapshot_nodes(node_id),
+  created_at   INTEGER NOT NULL,
+  seq          INTEGER NOT NULL,         -- monotonic per-chain ordering
+  PRIMARY KEY (chain_id, node_id)
+);
+CREATE INDEX idx_chain_members ON chain_members(chain_id, created_at DESC, seq DESC);
+
+CREATE TABLE chain_heads (
+  chain_id TEXT PRIMARY KEY,
+  node_id  TEXT NOT NULL REFERENCES snapshot_nodes(node_id)
+);
 ```
 
-### Key Operations
+The `chain_members` bridge table is what enables forks: a single `snapshot_nodes` row can belong to multiple `chain_members` rows pointing at it from different chains. The `chain_heads` table makes `head(chainId)` an O(1) lookup.
 
+---
+
+## SQLite Settings
+
+| Pragma | Value | Why |
+|---|---|---|
+| `journal_mode` | `WAL` | Concurrent reads while writing |
+| `synchronous` | `NORMAL` (default) / `FULL` (config: `durability = "os"`) | NORMAL is durable against app crash; FULL against power loss |
+| `wal_autocheckpoint` | `1000` | Bound WAL file growth |
+| `foreign_keys` | `ON` | Enforce parent constraints |
+
+---
+
+## In-Memory Caches
+
+Two maps initialized at construction time from a single JOIN query:
+
+```typescript
+const chainHeads = new Map<ChainId, NodeId>();    // chainId → current head
+const chainSeqs  = new Map<ChainId, number>();    // chainId → next seq
 ```
-put(chainId, data, parentIds, metadata)
-  │
-  ├── validate parent IDs exist
-  ├── computeContentHash(data) → hash
-  ├── skipIfUnchanged? compare hash with head's content_hash
-  ├── INSERT INTO snapshot_nodes (node_id, parent_ids, hash, data, ...)
-  ├── INSERT INTO snapshot_nodes_members (chain_id, node_id, seq)
-  └── update chainHeads + chainSeqs in memory
 
-ancestors(query)
-  │
-  ├── BFS from startNodeId
-  ├── follow parent_ids links (index-based queue, O(1) dequeue)
-  ├── respect maxDepth limit
-  └── return visited nodes in BFS order
+`head(chainId)` is O(1) — looks up the in-memory map, then a single indexed `SELECT ... WHERE node_id = ?`. Caches are kept consistent with the DB by every `put` / `fork` / `prune` operation.
 
-fork(sourceNodeId, newChainId)
-  │
-  ├── verify source node exists
-  ├── INSERT INTO members (newChainId, sourceNodeId, ...)
-  └── new chain shares the source node as its head
+---
 
-prune(chainId, policy)
-  │
-  ├── list chain members (newest first)
-  ├── mark removable by retainCount and/or retainDuration
-  ├── protect chain head if retainBranches !== false
-  ├── DELETE memberships, DELETE orphaned nodes
-  └── re-derive head from remaining members
+## Ancestor Walk: Recursive CTE
+
+V1 used a JS-side BFS that issued one `SELECT` per parent (N+1 queries). For deep walks (rewind 50+ turns) this crossed the perceptible-latency threshold. This adapter uses a single recursive CTE:
+
+```sql
+WITH RECURSIVE ancestors(node_id, depth) AS (
+    SELECT :start_id, 0
+  UNION
+    SELECT json_each.value, ancestors.depth + 1
+    FROM ancestors
+    JOIN snapshot_nodes ON snapshot_nodes.node_id = ancestors.node_id
+    JOIN json_each(snapshot_nodes.parent_ids)
+    WHERE ancestors.depth < :max_depth
+)
+SELECT n.* FROM snapshot_nodes n
+JOIN ancestors a ON n.node_id = a.node_id
+ORDER BY a.depth ASC;
 ```
+
+`UNION` (not `UNION ALL`) deduplicates DAG diamonds where a node has multiple paths to the same ancestor. **One round-trip regardless of depth.** Replaces v1's BFS-with-N+1 pattern.
+
+---
+
+## Mark-and-Sweep Blob GC
+
+The store accepts an optional `blobDir: string` and a payload-side function `extractBlobRefs: (data: T) => readonly string[]`. When `prune()` runs, it:
+
+1. Computes the set of nodes to delete based on the `PruningPolicy`
+2. Deletes them in a single transaction (along with the chain head pointer update)
+3. Walks all *remaining* live nodes, calls `extractBlobRefs(node.data)`, builds a `Set<string>` of referenced blob hashes
+4. Lists the blob directory; deletes any blob whose hash is not in the set
+
+The CAS sweep is **idempotent** — re-running it converges. If `blobDir` is not provided, the GC step is skipped (the deterministic-replay package may not need blob storage at all).
+
+The store does NOT read or write blob *contents* — that's the consumer's responsibility (e.g., `@koi/checkpoint` writes blobs to CAS). The store only owns the blob *directory listing* during GC.
+
+---
+
+## Crash Safety
+
+Per #1625 design review issue 9, the package ships a crash-injection test harness that kills the process between every protocol step and asserts re-run convergence.
+
+| Scenario | Behavior |
+|---|---|
+| Crash mid-`put` | SQLite transaction rolls back; chain head unchanged |
+| Crash mid-`prune` (chain step) | Transaction rolls back; nothing deleted |
+| Crash mid-blob-sweep | Some orphan blobs may persist; next prune cleans them up |
+| Corrupt SQLite (torn header) | Fail-closed at startup with explicit error |
+| Missing blob referenced by snapshot | Restore fails gracefully with `BLOB_MISSING` error, never silently corrupts state |
 
 ---
 
 ## Configuration
 
 ```typescript
-interface SqliteSnapshotStoreConfig {
-  readonly dbPath: string;                    // ":memory:" for tests, file path for persistence
-  readonly durability?: "process" | "os";     // Default: "process" (PRAGMA synchronous = NORMAL)
-  readonly tableName?: string;                // Default: "snapshot_nodes" — multiple stores per DB
+interface SqliteSnapshotStoreConfig<T> {
+  /** Path to SQLite file. Use `:memory:` for tests. */
+  readonly path: string;
+  /**
+   * Optional CAS blob directory. If set, prune sweeps it for orphan blobs
+   * referenced by no live snapshot.
+   */
+  readonly blobDir?: string;
+  /**
+   * Function to extract blob hashes from a payload, used by GC.
+   * Required if `blobDir` is set.
+   */
+  readonly extractBlobRefs?: (data: T) => readonly string[];
+  /**
+   * Durability level. "process" = synchronous=NORMAL (app-crash safe).
+   * "os" = synchronous=FULL (power-loss safe). Default: "process".
+   */
+  readonly durability?: "process" | "os";
 }
 ```
 
 ### Durability Modes
 
 | Mode | SQLite PRAGMA | Survives | Use Case |
-|------|---------------|----------|----------|
-| `"process"` (default) | `synchronous = NORMAL` | Process crashes | Development, most production |
+|---|---|---|---|
+| `"process"` (default) | `synchronous = NORMAL` | App crashes | Development, most production |
 | `"os"` | `synchronous = FULL` | OS crashes, power loss | Critical data, compliance |
 
-Both modes use WAL journal mode (set by `@koi/sqlite-utils`).
+Both modes use WAL journal mode.
 
 ---
 
-## Examples
-
-### Basic — Persistent Harness Store
+## API
 
 ```typescript
-import { createSqliteSnapshotStore } from "@koi/snapshot-store-sqlite";
-import type { HarnessSnapshot, ChainId, NodeId } from "@koi/core";
+import { createSnapshotStoreSqlite } from "@koi/snapshot-store-sqlite";
+import { chainId, type AgentSnapshot } from "@koi/core";
 
-const store = createSqliteSnapshotStore<HarnessSnapshot>({
-  dbPath: "./data/harness-snapshots.db",
+const store = await createSnapshotStoreSqlite<AgentSnapshot>({
+  path: "~/.koi/snapshots.sqlite",
+  blobDir: "~/.koi/file-history",
+  extractBlobRefs: extractBlobRefsFromAgentSnapshot,
+  durability: "process",
 });
 
-const chainId = "agent-1-main" as ChainId;
+// Implements SnapshotChainStore<AgentSnapshot> from @koi/core
+const head = await store.head(chainId("session-abc"));
 
-// Put a snapshot
-const result = store.put(chainId, snapshot, [], { session: 1 });
-if (!result.ok) throw new Error(result.error.message);
+const ancestors = await store.ancestors({
+  startNodeId: head.value!.nodeId,
+  maxDepth: 10,
+});
 
-const node = result.value; // SnapshotNode<HarnessSnapshot>
-
-// Get the chain head
-const head = store.head(chainId);
-// head.ok === true, head.value === node
-
-// Clean up
-store.close();
-```
-
-### Skip Unchanged — Avoid Redundant Writes
-
-```typescript
-// First put: stores the snapshot
-store.put(chainId, snapshot, [], {}, { skipIfUnchanged: true });
-
-// Second put with identical data: returns undefined (no write)
-const result = store.put(chainId, snapshot, [firstNodeId], {}, { skipIfUnchanged: true });
-// result.ok === true, result.value === undefined
-```
-
-### Fork and Prune
-
-```typescript
-// Fork a chain at a specific node
-const forkResult = store.fork(nodeId, "agent-1-branch" as ChainId, "experiment");
-// forkResult.value.parentNodeId === nodeId
-
-// Prune old snapshots, keeping the latest 5
-const pruned = store.prune(chainId, { retainCount: 5 });
-// pruned.value === number of nodes removed
+await store.prune(chainId("session-abc"), { retainCount: 500 });
+await store.close();
 ```
 
 ### In-Memory for Tests
 
 ```typescript
-const store = createSqliteSnapshotStore<HarnessSnapshot>({
-  dbPath: ":memory:",
+const store = await createSnapshotStoreSqlite<AgentSnapshot>({
+  path: ":memory:",
 });
-// Identical API — no file I/O
-```
-
-### With Autonomous Agent
-
-```typescript
-import { createSqliteSnapshotStore } from "@koi/snapshot-store-sqlite";
-import { createLongRunningHarness } from "@koi/long-running";
-import { createHarnessScheduler } from "@koi/harness-scheduler";
-import { createAutonomousAgent } from "@koi/autonomous";
-
-const snapshotStore = createSqliteSnapshotStore<HarnessSnapshot>({
-  dbPath: "./data/snapshots.db",
-  durability: "os",  // maximum durability
-});
-
-const harness = createLongRunningHarness({
-  harnessId: harnessId("agent-1"),
-  agentId: agentId("agent-1"),
-  harnessStore: snapshotStore,   // ← persistent store
-  sessionPersistence,
-});
-
-const scheduler = createHarnessScheduler({ harness });
-const agent = createAutonomousAgent({ harness, scheduler });
+// Identical API — no file I/O, no GC (no blobDir set)
 ```
 
 ---
 
-## API Reference
-
-### Factory Functions
-
-| Function | Returns | Description |
-|----------|---------|-------------|
-| `createSqliteSnapshotStore<T>(config)` | `SnapshotChainStore<T> & { close }` | Creates a persistent snapshot store |
-
-### Store Methods
+## Store Methods
 
 | Method | Signature | Description |
-|--------|-----------|-------------|
-| `put(cid, data, parentIds, meta?, opts?)` | `(ChainId, T, NodeId[], Record?, PutOptions?) → Result<SnapshotNode<T> \| undefined>` | Insert snapshot, returns undefined if skipped |
+|---|---|---|
+| `put(cid, data, parentIds, meta?, opts?)` | `(ChainId, T, NodeId[], Record?, PutOptions?) → Result<SnapshotNode<T> \| undefined>` | Insert snapshot; returns undefined if `skipIfUnchanged` matched |
 | `get(nid)` | `(NodeId) → Result<SnapshotNode<T>>` | Retrieve node by ID |
 | `head(cid)` | `(ChainId) → Result<SnapshotNode<T> \| undefined>` | Get chain head (O(1) from cache) |
 | `list(cid)` | `(ChainId) → Result<readonly SnapshotNode<T>[]>` | All nodes in chain, newest first |
-| `ancestors(query)` | `(AncestorQuery) → Result<readonly SnapshotNode<T>[]>` | BFS ancestor walk with maxDepth |
+| `ancestors(query)` | `(AncestorQuery) → Result<readonly SnapshotNode<T>[]>` | Recursive-CTE ancestor walk with maxDepth |
 | `fork(sourceId, newChainId, label)` | `(NodeId, ChainId, string) → Result<ForkRef>` | Fork chain at a node |
-| `prune(cid, policy)` | `(ChainId, PruningPolicy) → Result<number>` | Remove old nodes, return count |
-| `close()` | `() → void` | Close DB connection, reject further operations |
+| `prune(cid, policy)` | `(ChainId, PruningPolicy) → Result<number>` | Remove old nodes + sweep orphan blobs; returns chain-node count removed |
+| `close()` | `() → void \| Promise<void>` | Close DB connection, reject further operations |
 
-### Types
+---
 
-| Type | Description |
-|------|-------------|
-| `SqliteSnapshotStoreConfig` | `{ dbPath, durability?, tableName? }` |
-| `SnapshotChainStore<T>` | L0 interface — put, get, head, list, ancestors, fork, prune |
-| `SnapshotNode<T>` | `{ nodeId, chainId, parentIds, contentHash, data, createdAt, metadata }` |
-| `PutOptions` | `{ skipIfUnchanged? }` |
-| `PruningPolicy` | `{ retainCount?, retainDuration?, retainBranches? }` |
-| `ForkRef` | `{ parentNodeId, label }` |
-| `AncestorQuery` | `{ startNodeId, maxDepth? }` |
+## Testing
+
+| Suite | What | Tests |
+|---|---|---|
+| **Contract suite** | Ported from v1 — put/get/head/ancestors/prune/fork/close behavior | ~14 |
+| **Crash injection** | Kill process between every protocol step, assert re-run convergence | ~10–15 |
+| **CTE correctness** | Linear chain, deep chain, DAG diamond (no double-visit), depth limit | 4 |
+| **Blob GC sweep** | All-orphan, none-orphan, partial, head-protected | 4 |
+| **Negative path** | Missing blob, corrupt SQLite, foreign-key violation, fail-closed startup | ~6 |
+
+The crash-injection harness is the test that validates the ordered+idempotent atomicity strategy used by `@koi/checkpoint`. It is not optional.
 
 ---
 
 ## Design Decisions
 
 | Decision | Rationale |
-|----------|-----------|
-| Two tables (nodes + members) | A node can belong to multiple chains via fork — avoids data duplication |
+|---|---|
+| Three tables (nodes + members + heads) | A node can belong to multiple chains via fork — avoids data duplication |
 | In-memory head cache | O(1) head lookup without hitting SQLite on every `head()` call |
 | Monotonic `seq` counter per chain | Deterministic ordering within the same millisecond |
-| Prepared statements for all queries | Avoids re-parsing SQL on every call — significant perf improvement |
-| Index-based BFS for ancestors | Avoids O(n) `Array.shift()` — uses `queueIdx` pointer instead |
-| Table name validation regex | Prevents SQL injection via crafted table names |
-| `computeContentHash` for dedup | Deterministic serialization (sorted keys) ensures identical objects hash identically |
-| Store owns DB connection | Single `openDb()` call at construction, `close()` for cleanup |
+| Prepared statements for all hot queries | Avoids re-parsing SQL on every call |
+| Recursive CTE for ancestors | One round-trip regardless of depth; replaces v1 BFS-with-N+1 |
+| Mark-and-sweep GC inside prune transaction | Idempotent, crash-safe, no separate background task |
+| `extractBlobRefs` is consumer-supplied | Decouples store from payload schema; deterministic-replay can omit blob handling entirely |
+| Store does NOT touch blob bytes | CAS reads/writes are the consumer's job; store only owns the blob *directory listing* during GC |
+| `bun:sqlite` (no npm dep) | Bun built-in; zero install footprint; same API as `better-sqlite3` |
 
 ---
 
-## Swappable Backends
+## Layer
 
-Both `@koi/snapshot-chain-store` (in-memory) and `@koi/snapshot-store-sqlite` implement the same L0 `SnapshotChainStore<T>` interface. Consumers never know which backend is active:
-
-```
-                    SnapshotChainStore<T>   (L0 interface)
-                           │
-              ┌────────────┴────────────┐
-              ▼                         ▼
-  @koi/snapshot-chain-store    @koi/snapshot-store-sqlite
-  (in-memory, volatile)       (SQLite, persistent)
-                                        │
-                              Future: @koi/store-nexus
-                              (remote JSON-RPC, distributed)
-```
-
----
-
-## Layer Compliance
-
-```
-L0  @koi/core ──────────────────────────────────────────────────┐
-    ChainId, NodeId, SnapshotNode, SnapshotChainStore,           │
-    PruningPolicy, ForkRef, AncestorQuery, PutOptions,           │
-    Result, KoiError                                              │
-                                                                   │
-L0u @koi/hash ──────────────────────────────────────────────────│
-    computeContentHash()                                          │
-                                                                   │
-L0u @koi/sqlite-utils ──────────────────────────────────────────│
-    openDb(), mapSqliteError()                                    │
-                                                                   ▼
-L0u @koi/snapshot-store-sqlite <─────────────────────────────────┘
-    imports from L0 and L0u only
-    x never imports @koi/engine (L1)
-    x never imports peer L2 packages
-    ~ package.json: {
-        "@koi/core": "workspace:*",
-        "@koi/hash": "workspace:*",
-        "@koi/sqlite-utils": "workspace:*"
-      }
-```
+L2 — depends on `@koi/core` (L0) and `@koi/errors` (L0u) only. Uses `bun:sqlite` (Bun built-in, not an npm dependency).

--- a/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -179,6 +179,19 @@ interface AgentSnapshot {
     readonly components: ReadonlyMap<string, BrickRef>;
     /** Agent configuration snapshot (opaque, agent-defined). */
     readonly config: unknown;
+    /**
+     * Drift warnings recorded at checkpoint creation. Each entry describes a
+     * filesystem change observed by \`git status --porcelain\` that did NOT come
+     * through the tracked Edit/Write/MultiEdit pipeline (e.g., bash-mediated
+     * changes like \`rm\`, \`mv\`, \`sed -i\`, build artifacts).
+     *
+     * These changes are NOT restored on rewind. The list exists so the rewind
+     * UI can surface what the rewind cannot undo, rather than silently losing
+     * the user's mental model of file state. Empty array = no drift detected.
+     *
+     * See \`docs/L2/checkpoint.md\` § "Drift warnings".
+     */
+    readonly driftWarnings: readonly string[];
     /** Arbitrary metadata (e.g., trigger reason). */
     readonly metadata: Readonly<Record<string, unknown>>;
 }
@@ -1732,42 +1745,99 @@ interface SessionPersistence {
  * Time-travel types — filesystem side-effect journal, backtrack constraints,
  * and per-event trace types for rewind, guided retry, and event-level granularity.
  *
- * Used by L2 middleware packages:
- *   - @koi/middleware-fs-rollback (FileOpRecord, CompensatingOp)
+ * Used by L2 packages:
+ *   - @koi/checkpoint (FileOpRecord, CompensatingOp, SnapshotStatus, SNAPSHOT_STATUS_KEY)
+ *   - @koi/snapshot-store-sqlite (storage adapter for SnapshotChainStore<AgentSnapshot>)
  *   - @koi/middleware-guided-retry (BacktrackReason, BacktrackConstraint)
  *   - @koi/middleware-event-trace (TraceEventKind, TraceEvent, TurnTrace, EventCursor)
+ *
+ * File content is referenced by SHA-256 content hash, never literal bytes — the
+ * actual contents live in a content-addressed blob store managed by the L2
+ * checkpoint package. This keeps L0 free of binary file concerns and lets the
+ * snapshot chain store dedup file content automatically.
  */
 
 /** Kind of filesystem operation that can be rewound. */
-type FileOpKind = "write" | "edit";
-/** Record of a single file operation captured during a tool call. */
-interface FileOpRecord {
+type FileOpKind = "create" | "edit" | "delete";
+/**
+ * Fields shared by every FileOpRecord variant. Per-kind fields (content
+ * hashes) are added by the discriminated union below.
+ */
+interface FileOpRecordBase {
     /** Identifier of the tool call that produced this operation. */
     readonly callId: ToolCallId;
-    /** Kind of file operation. */
-    readonly kind: FileOpKind;
     /** Absolute path to the affected file. */
     readonly path: string;
-    /** File content before the operation. undefined = file did not exist. */
-    readonly previousContent: string | undefined;
-    /** File content after the operation. */
-    readonly newContent: string;
     /** Which turn this operation occurred in. */
     readonly turnIndex: number;
     /** Index within the event trace for cross-feature correlation. -1 = uncorrelated. */
     readonly eventIndex: number;
     /** Unix timestamp ms when this operation was captured. */
     readonly timestamp: number;
+    /**
+     * Optional shared identifier when a delete + create pair originated as a
+     * rename. Lets the rewind UI present them as one operation.
+     */
+    readonly renameId?: string;
 }
-/** Action needed to undo a file operation. */
+/**
+ * Record of a single file operation captured during a tool call.
+ *
+ * Discriminated by \`kind\`. Content is stored as a SHA-256 hex hash that
+ * dereferences to a blob in the CAS store managed by \`@koi/checkpoint\`; the
+ * L0 type itself never carries file bytes (so binary files are supported and
+ * large files don't bloat snapshot payloads).
+ *
+ * Renames are modeled as a \`delete + create\` pair sharing a \`renameId\` rather
+ * than a fourth \`kind: "rename"\` — Rule of Three: don't add a primitive until
+ * a third operation needs it.
+ */
+type FileOpRecord = (FileOpRecordBase & {
+    readonly kind: "create";
+    /** SHA-256 hex of the file content after creation. */
+    readonly postContentHash: string;
+}) | (FileOpRecordBase & {
+    readonly kind: "edit";
+    /** SHA-256 hex of the file content before the edit. */
+    readonly preContentHash: string;
+    /** SHA-256 hex of the file content after the edit. */
+    readonly postContentHash: string;
+}) | (FileOpRecordBase & {
+    readonly kind: "delete";
+    /** SHA-256 hex of the file content before deletion. */
+    readonly preContentHash: string;
+});
+/**
+ * Action needed to undo a file operation.
+ *
+ * \`restore\` carries a content hash that the L2 checkpoint package looks up in
+ * its CAS blob store. This avoids inlining file bytes in the L0 type and lets
+ * the same hash be reused across many compensating ops without duplication.
+ */
 type CompensatingOp = {
     readonly kind: "restore";
     readonly path: string;
-    readonly content: string;
+    readonly contentHash: string;
 } | {
     readonly kind: "delete";
     readonly path: string;
 };
+/**
+ * Status of a snapshot record. Snapshots are written to the chain store
+ * regardless of whether their capture step fully succeeded; failed captures
+ * are recorded as \`incomplete\` and skipped on rewind with a user-visible
+ * warning. This is the soft-fail contract documented in \`docs/L2/checkpoint.md\`
+ * — checkpoint creation MUST NOT abort the agent loop.
+ *
+ * The status is stored in \`SnapshotNode.metadata\` under \`SNAPSHOT_STATUS_KEY\`.
+ * Absent or \`"complete"\` means the snapshot is restorable.
+ */
+type SnapshotStatus = "complete" | "incomplete";
+/**
+ * Metadata key used to store SnapshotStatus on \`SnapshotNode.metadata\`.
+ * Convention: \`koi:\` prefix for framework-owned keys.
+ */
+declare const SNAPSHOT_STATUS_KEY: "koi:snapshot_status";
 /** Why a backtrack/fork was triggered. */
 type BacktrackReasonKind = "validation_failure" | "gate_failure" | "user_rejection" | "timeout" | "error" | "manual";
 /** Structured reason for a backtrack event. */
@@ -2169,7 +2239,7 @@ declare function validateSessionIdSyntax(id: string, name?: string): Result<void
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CompactResult, type CompensatingOp, ComponentProvider, type ContentReplacement, type ContextSummary, type ContextSummaryRef, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MessageThreadSnapshot, type NexusPath, type NodeCapability, type NodeId, type OutcomeReport, type OutcomeReportInput, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PendingFrame, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, SubsystemToken, TaskBoardSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TuiAdapter, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validation };
+export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CompactResult, type CompensatingOp, ComponentProvider, type ContentReplacement, type ContextSummary, type ContextSummaryRef, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MessageThreadSnapshot, type NexusPath, type NodeCapability, type NodeId, type OutcomeReport, type OutcomeReportInput, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PendingFrame, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, SNAPSHOT_STATUS_KEY, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, type SnapshotStatus, SubsystemToken, TaskBoardSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TuiAdapter, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validation };
 "
 `;
 

--- a/packages/kernel/core/src/agent-snapshot.ts
+++ b/packages/kernel/core/src/agent-snapshot.ts
@@ -35,6 +35,19 @@ export interface AgentSnapshot {
   readonly components: ReadonlyMap<string, BrickRef>;
   /** Agent configuration snapshot (opaque, agent-defined). */
   readonly config: unknown;
+  /**
+   * Drift warnings recorded at checkpoint creation. Each entry describes a
+   * filesystem change observed by `git status --porcelain` that did NOT come
+   * through the tracked Edit/Write/MultiEdit pipeline (e.g., bash-mediated
+   * changes like `rm`, `mv`, `sed -i`, build artifacts).
+   *
+   * These changes are NOT restored on rewind. The list exists so the rewind
+   * UI can surface what the rewind cannot undo, rather than silently losing
+   * the user's mental model of file state. Empty array = no drift detected.
+   *
+   * See `docs/L2/checkpoint.md` § "Drift warnings".
+   */
+  readonly driftWarnings: readonly string[];
   /** Arbitrary metadata (e.g., trigger reason). */
   readonly metadata: Readonly<Record<string, unknown>>;
 }

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -1009,11 +1009,12 @@ export type {
   EventCursor,
   FileOpKind,
   FileOpRecord,
+  SnapshotStatus,
   TraceEvent,
   TraceEventKind,
   TurnTrace,
 } from "./snapshot-time-travel.js";
-export { BACKTRACK_REASON_KEY } from "./snapshot-time-travel.js";
+export { BACKTRACK_REASON_KEY, SNAPSHOT_STATUS_KEY } from "./snapshot-time-travel.js";
 // spawn — unified spawn types for all agent-spawning patterns
 export type {
   SpawnFn,

--- a/packages/kernel/core/src/snapshot-time-travel.test.ts
+++ b/packages/kernel/core/src/snapshot-time-travel.test.ts
@@ -6,53 +6,160 @@ import type {
   CompensatingOp,
   EventCursor,
   FileOpRecord,
+  SnapshotStatus,
   TraceEvent,
   TraceEventKind,
   TurnTrace,
 } from "./snapshot-time-travel.js";
-import { BACKTRACK_REASON_KEY } from "./snapshot-time-travel.js";
+import { BACKTRACK_REASON_KEY, SNAPSHOT_STATUS_KEY } from "./snapshot-time-travel.js";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const HASH_C = "c".repeat(64);
 
 describe("snapshot-time-travel types", () => {
   describe("FileOpRecord", () => {
-    test("write op with no previous content", () => {
+    test("create op records post-content hash only", () => {
       const record: FileOpRecord = {
+        kind: "create",
         callId: toolCallId("call-1"),
-        kind: "write",
         path: "/tmp/test.txt",
-        previousContent: undefined,
-        newContent: "hello",
+        postContentHash: HASH_A,
         turnIndex: 0,
         eventIndex: 3,
         timestamp: Date.now(),
       };
-      expect(record.kind).toBe("write");
-      expect(record.previousContent).toBeUndefined();
+      expect(record.kind).toBe("create");
+      if (record.kind === "create") {
+        expect(record.postContentHash).toBe(HASH_A);
+      }
     });
 
-    test("edit op with previous content", () => {
+    test("edit op records both pre and post content hashes", () => {
       const record: FileOpRecord = {
-        callId: toolCallId("call-2"),
         kind: "edit",
+        callId: toolCallId("call-2"),
         path: "/tmp/existing.txt",
-        previousContent: "old content",
-        newContent: "new content",
+        preContentHash: HASH_A,
+        postContentHash: HASH_B,
         turnIndex: 1,
         eventIndex: 7,
         timestamp: Date.now(),
       };
       expect(record.kind).toBe("edit");
-      expect(record.previousContent).toBe("old content");
+      if (record.kind === "edit") {
+        expect(record.preContentHash).toBe(HASH_A);
+        expect(record.postContentHash).toBe(HASH_B);
+      }
+    });
+
+    test("delete op records pre-content hash only", () => {
+      const record: FileOpRecord = {
+        kind: "delete",
+        callId: toolCallId("call-3"),
+        path: "/tmp/removed.txt",
+        preContentHash: HASH_C,
+        turnIndex: 2,
+        eventIndex: 11,
+        timestamp: Date.now(),
+      };
+      expect(record.kind).toBe("delete");
+      if (record.kind === "delete") {
+        expect(record.preContentHash).toBe(HASH_C);
+      }
+    });
+
+    test("rename is modeled as delete + create with shared renameId", () => {
+      const renameId = "rename-xyz";
+      const now = Date.now();
+
+      const removed: FileOpRecord = {
+        kind: "delete",
+        callId: toolCallId("call-4"),
+        path: "/tmp/old-name.txt",
+        preContentHash: HASH_A,
+        turnIndex: 3,
+        eventIndex: 13,
+        timestamp: now,
+        renameId,
+      };
+
+      const added: FileOpRecord = {
+        kind: "create",
+        callId: toolCallId("call-4"),
+        path: "/tmp/new-name.txt",
+        postContentHash: HASH_A,
+        turnIndex: 3,
+        eventIndex: 14,
+        timestamp: now,
+        renameId,
+      };
+
+      expect(removed.renameId).toBe(renameId);
+      expect(added.renameId).toBe(renameId);
+      // Same content hash on both halves of a content-preserving rename:
+      if (removed.kind === "delete" && added.kind === "create") {
+        expect(removed.preContentHash).toBe(added.postContentHash);
+      }
+    });
+
+    test("exhaustive kind check compiles", () => {
+      const records: readonly FileOpRecord[] = [
+        {
+          kind: "create",
+          callId: toolCallId("c"),
+          path: "/x",
+          postContentHash: HASH_A,
+          turnIndex: 0,
+          eventIndex: 0,
+          timestamp: 0,
+        },
+        {
+          kind: "edit",
+          callId: toolCallId("c"),
+          path: "/x",
+          preContentHash: HASH_A,
+          postContentHash: HASH_B,
+          turnIndex: 0,
+          eventIndex: 0,
+          timestamp: 0,
+        },
+        {
+          kind: "delete",
+          callId: toolCallId("c"),
+          path: "/x",
+          preContentHash: HASH_A,
+          turnIndex: 0,
+          eventIndex: 0,
+          timestamp: 0,
+        },
+      ];
+      for (const record of records) {
+        switch (record.kind) {
+          case "create":
+          case "edit":
+          case "delete":
+            break;
+          default: {
+            const _exhaustive: never = record;
+            throw new Error(`Unhandled: ${String(_exhaustive)}`);
+          }
+        }
+      }
     });
   });
 
   describe("CompensatingOp", () => {
-    test("restore op restores file content", () => {
+    test("restore op references content by hash, not literal bytes", () => {
       const op: CompensatingOp = {
         kind: "restore",
         path: "/tmp/test.txt",
-        content: "original",
+        contentHash: HASH_A,
       };
       expect(op.kind).toBe("restore");
+      if (op.kind === "restore") {
+        expect(op.contentHash).toBe(HASH_A);
+      }
     });
 
     test("delete op removes created file", () => {
@@ -66,7 +173,7 @@ describe("snapshot-time-travel types", () => {
     test("exhaustive kind check compiles", () => {
       const ops: readonly CompensatingOp[] = [
         { kind: "delete", path: "/tmp/x" },
-        { kind: "restore", path: "/tmp/y", content: "c" },
+        { kind: "restore", path: "/tmp/y", contentHash: HASH_B },
       ];
       for (const op of ops) {
         switch (op.kind) {
@@ -76,6 +183,41 @@ describe("snapshot-time-travel types", () => {
             break;
           default: {
             const _exhaustive: never = op;
+            throw new Error(`Unhandled: ${String(_exhaustive)}`);
+          }
+        }
+      }
+    });
+  });
+
+  describe("SnapshotStatus + SNAPSHOT_STATUS_KEY", () => {
+    test("SNAPSHOT_STATUS_KEY has correct value", () => {
+      expect(SNAPSHOT_STATUS_KEY).toBe("koi:snapshot_status");
+    });
+
+    test("complete and incomplete are valid statuses", () => {
+      const complete: SnapshotStatus = "complete";
+      const incomplete: SnapshotStatus = "incomplete";
+      expect(complete).toBe("complete");
+      expect(incomplete).toBe("incomplete");
+    });
+
+    test("can be used as metadata key on SnapshotNode", () => {
+      const metadata: Readonly<Record<string, unknown>> = {
+        [SNAPSHOT_STATUS_KEY]: "incomplete" satisfies SnapshotStatus,
+      };
+      expect(metadata[SNAPSHOT_STATUS_KEY]).toBe("incomplete");
+    });
+
+    test("exhaustive status check compiles", () => {
+      const statuses: readonly SnapshotStatus[] = ["complete", "incomplete"];
+      for (const status of statuses) {
+        switch (status) {
+          case "complete":
+          case "incomplete":
+            break;
+          default: {
+            const _exhaustive: never = status;
             throw new Error(`Unhandled: ${String(_exhaustive)}`);
           }
         }

--- a/packages/kernel/core/src/snapshot-time-travel.ts
+++ b/packages/kernel/core/src/snapshot-time-travel.ts
@@ -2,10 +2,16 @@
  * Time-travel types — filesystem side-effect journal, backtrack constraints,
  * and per-event trace types for rewind, guided retry, and event-level granularity.
  *
- * Used by L2 middleware packages:
- *   - @koi/middleware-fs-rollback (FileOpRecord, CompensatingOp)
+ * Used by L2 packages:
+ *   - @koi/checkpoint (FileOpRecord, CompensatingOp, SnapshotStatus, SNAPSHOT_STATUS_KEY)
+ *   - @koi/snapshot-store-sqlite (storage adapter for SnapshotChainStore<AgentSnapshot>)
  *   - @koi/middleware-guided-retry (BacktrackReason, BacktrackConstraint)
  *   - @koi/middleware-event-trace (TraceEventKind, TraceEvent, TurnTrace, EventCursor)
+ *
+ * File content is referenced by SHA-256 content hash, never literal bytes — the
+ * actual contents live in a content-addressed blob store managed by the L2
+ * checkpoint package. This keeps L0 free of binary file concerns and lets the
+ * snapshot chain store dedup file content automatically.
  */
 
 import type { SessionId, ToolCallId } from "./ecs.js";
@@ -15,32 +21,93 @@ import type { SessionId, ToolCallId } from "./ecs.js";
 // ---------------------------------------------------------------------------
 
 /** Kind of filesystem operation that can be rewound. */
-export type FileOpKind = "write" | "edit";
+export type FileOpKind = "create" | "edit" | "delete";
 
-/** Record of a single file operation captured during a tool call. */
-export interface FileOpRecord {
+/**
+ * Fields shared by every FileOpRecord variant. Per-kind fields (content
+ * hashes) are added by the discriminated union below.
+ */
+interface FileOpRecordBase {
   /** Identifier of the tool call that produced this operation. */
   readonly callId: ToolCallId;
-  /** Kind of file operation. */
-  readonly kind: FileOpKind;
   /** Absolute path to the affected file. */
   readonly path: string;
-  /** File content before the operation. undefined = file did not exist. */
-  readonly previousContent: string | undefined;
-  /** File content after the operation. */
-  readonly newContent: string;
   /** Which turn this operation occurred in. */
   readonly turnIndex: number;
   /** Index within the event trace for cross-feature correlation. -1 = uncorrelated. */
   readonly eventIndex: number;
   /** Unix timestamp ms when this operation was captured. */
   readonly timestamp: number;
+  /**
+   * Optional shared identifier when a delete + create pair originated as a
+   * rename. Lets the rewind UI present them as one operation.
+   */
+  readonly renameId?: string;
 }
 
-/** Action needed to undo a file operation. */
+/**
+ * Record of a single file operation captured during a tool call.
+ *
+ * Discriminated by `kind`. Content is stored as a SHA-256 hex hash that
+ * dereferences to a blob in the CAS store managed by `@koi/checkpoint`; the
+ * L0 type itself never carries file bytes (so binary files are supported and
+ * large files don't bloat snapshot payloads).
+ *
+ * Renames are modeled as a `delete + create` pair sharing a `renameId` rather
+ * than a fourth `kind: "rename"` — Rule of Three: don't add a primitive until
+ * a third operation needs it.
+ */
+export type FileOpRecord =
+  | (FileOpRecordBase & {
+      readonly kind: "create";
+      /** SHA-256 hex of the file content after creation. */
+      readonly postContentHash: string;
+    })
+  | (FileOpRecordBase & {
+      readonly kind: "edit";
+      /** SHA-256 hex of the file content before the edit. */
+      readonly preContentHash: string;
+      /** SHA-256 hex of the file content after the edit. */
+      readonly postContentHash: string;
+    })
+  | (FileOpRecordBase & {
+      readonly kind: "delete";
+      /** SHA-256 hex of the file content before deletion. */
+      readonly preContentHash: string;
+    });
+
+/**
+ * Action needed to undo a file operation.
+ *
+ * `restore` carries a content hash that the L2 checkpoint package looks up in
+ * its CAS blob store. This avoids inlining file bytes in the L0 type and lets
+ * the same hash be reused across many compensating ops without duplication.
+ */
 export type CompensatingOp =
-  | { readonly kind: "restore"; readonly path: string; readonly content: string }
+  | { readonly kind: "restore"; readonly path: string; readonly contentHash: string }
   | { readonly kind: "delete"; readonly path: string };
+
+// ---------------------------------------------------------------------------
+// Feature 1b: Snapshot status (soft-fail contract)
+// ---------------------------------------------------------------------------
+
+/**
+ * Status of a snapshot record. Snapshots are written to the chain store
+ * regardless of whether their capture step fully succeeded; failed captures
+ * are recorded as `incomplete` and skipped on rewind with a user-visible
+ * warning. This is the soft-fail contract documented in `docs/L2/checkpoint.md`
+ * — checkpoint creation MUST NOT abort the agent loop.
+ *
+ * The status is stored in `SnapshotNode.metadata` under `SNAPSHOT_STATUS_KEY`.
+ * Absent or `"complete"` means the snapshot is restorable.
+ */
+export type SnapshotStatus = "complete" | "incomplete";
+
+/**
+ * Metadata key used to store SnapshotStatus on `SnapshotNode.metadata`.
+ * Convention: `koi:` prefix for framework-owned keys.
+ */
+export const SNAPSHOT_STATUS_KEY = "koi:snapshot_status" as const;
 
 // ---------------------------------------------------------------------------
 // Feature 2: Backtrack reason + constraint


### PR DESCRIPTION
## Summary

Doc-gate prerequisite for #1625 (session-level rollback). Adds the two L2 specs (`docs/L2/checkpoint.md`, `docs/L2/snapshot-store-sqlite.md`) and the L0 schema deltas they depend on, with no L1/L2 implementation yet.

This is the first of three PRs implementing #1625:

| # | Scope | Status |
|---|---|---|
| 1 | L0 schema + L2 doc-gate (this PR) | this PR |
| 2 | `@koi/snapshot-store-sqlite` (storage adapter) | follow-up |
| 3 | `@koi/checkpoint` (capture middleware + `/rewind` UX) | follow-up |

## L0 schema changes (`@koi/core`)

1. **`FileOpRecord` becomes a discriminated union** by `kind: "create" | "edit" | "delete"`. Per-variant fields use SHA-256 content hashes (`preContentHash`, `postContentHash`), never literal bytes — content lives in a CAS blob store managed by `@koi/checkpoint`. Binary-safe; large files don't bloat snapshot payloads. Renames are modeled as a `delete + create` pair with shared `renameId` (Rule of Three: don't add a fourth `kind` until needed).

2. **`CompensatingOp.restore`** replaces `content: string` with `contentHash: string` for the same reason.

3. **`AgentSnapshot.driftWarnings: readonly string[]`** so the rewind UI can surface bash-mediated and other untracked changes that the checkpoint cannot restore (per the design review's drift-detection contract).

4. **`SnapshotStatus` + `SNAPSHOT_STATUS_KEY`** — implements the soft-fail contract: failed checkpoint captures are recorded as `incomplete` and skipped on rewind, never aborting the agent loop.

## Why this shape

The full design review with 16 numbered decisions is captured in #1625's rewritten body. Highlights driving these L0 changes:

- **CAS storage** (decision 1A) requires content-hash references, not literal content
- **First-class create/edit/delete records** (decision 6A) avoid the "rewind offers to undo deletions it can't restore" failure class
- **Drift warnings** (decision 7A) acknowledge bash-mediated changes honestly rather than silently losing them
- **Soft-fail contract** (decision 8A) treats checkpoint failure as a recovery feature failure, not an agent loop failure

## Compatibility

Verified via grep across `packages/` (excluding `archive/`): **no L1 or L2 package currently consumes `FileOpRecord`, `CompensatingOp`, or `AgentSnapshot` outside of `@koi/core` itself.** The two consumers are introduced in PRs 2 and 3. Safe schema redesign.

## Tests

- 12 new tests in `snapshot-time-travel.test.ts` covering:
  - Each `FileOpRecord` variant (`create`, `edit`, `delete`)
  - Rename pair (`delete + create` with shared `renameId`, content hash matches on both halves)
  - Exhaustive `kind` switches (compile-time enforcement via `never`)
  - `CompensatingOp.restore` with `contentHash`
  - `SnapshotStatus` + `SNAPSHOT_STATUS_KEY` round-trips
- `api-surface.test.ts.snap` regenerates to reflect the new public API (~85 lines added, all matching the intended schema deltas — no surprise drift)

## Test plan

- [x] `bun run --filter '@koi/core' typecheck` passes
- [x] `bun run --filter '@koi/core' test` — 826 pass, 0 fail
- [x] `bun run --filter '@koi/core' build` clean
- [x] `bun run check:layers` passes
- [x] Pre-commit hooks (lefthook, biome) pass on both commits
- [ ] CI green
- [ ] Verify api-surface snapshot diff is exactly the intended schema deltas