### PR TITLE
feat(snapshot-store-sqlite): #1625 L2 storage adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -283,6 +283,14 @@
         "zod": "4.3.6",
       },
     },
+    "packages/lib/snapshot-store-sqlite": {
+      "name": "@koi/snapshot-store-sqlite",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/hash": "workspace:*",
+      },
+    },
     "packages/lib/spawn-tools": {
       "name": "@koi/spawn-tools",
       "version": "0.0.0",
@@ -1002,6 +1010,8 @@
     "@koi/skill-tool": ["@koi/skill-tool@workspace:packages/lib/skill-tool"],
 
     "@koi/skills-runtime": ["@koi/skills-runtime@workspace:packages/lib/skills-runtime"],
+
+    "@koi/snapshot-store-sqlite": ["@koi/snapshot-store-sqlite@workspace:packages/lib/snapshot-store-sqlite"],
 
     "@koi/spawn-tools": ["@koi/spawn-tools@workspace:packages/lib/spawn-tools"],
 

--- a/docs/L2/snapshot-store-sqlite.md
+++ b/docs/L2/snapshot-store-sqlite.md
@@ -55,21 +55,23 @@ Three tables, deliberately small:
 ```sql
 CREATE TABLE snapshot_nodes (
   node_id      TEXT PRIMARY KEY,
-  parent_ids   TEXT NOT NULL,            -- JSON array of NodeId
-  content_hash TEXT NOT NULL,            -- SHA-256 of payload, for skip-if-unchanged
-  data         TEXT NOT NULL,            -- JSON-serialized payload T
-  created_at   INTEGER NOT NULL,         -- Unix ms
-  metadata     TEXT NOT NULL             -- JSON; includes SNAPSHOT_STATUS_KEY
+  chain_id     TEXT NOT NULL,              -- "home" chain returned by get()
+  parent_ids   TEXT NOT NULL DEFAULT '[]', -- JSON array of NodeId
+  content_hash TEXT NOT NULL,              -- SHA-256 of payload, for skip-if-unchanged
+  data         TEXT NOT NULL,              -- JSON-serialized payload T
+  created_at   INTEGER NOT NULL,           -- Unix ms
+  metadata     TEXT NOT NULL DEFAULT '{}'  -- JSON; includes SNAPSHOT_STATUS_KEY
 );
+CREATE INDEX idx_snapshot_nodes_chain ON snapshot_nodes(chain_id);
 
 CREATE TABLE chain_members (
-  chain_id     TEXT NOT NULL,
-  node_id      TEXT NOT NULL REFERENCES snapshot_nodes(node_id),
-  created_at   INTEGER NOT NULL,
-  seq          INTEGER NOT NULL,         -- monotonic per-chain ordering
+  chain_id   TEXT NOT NULL,
+  node_id    TEXT NOT NULL REFERENCES snapshot_nodes(node_id),
+  created_at INTEGER NOT NULL,
+  seq        INTEGER NOT NULL DEFAULT 0,   -- monotonic per-chain ordering
   PRIMARY KEY (chain_id, node_id)
 );
-CREATE INDEX idx_chain_members ON chain_members(chain_id, created_at DESC, seq DESC);
+CREATE INDEX idx_chain_members_chain ON chain_members(chain_id, created_at DESC, seq DESC);
 
 CREATE TABLE chain_heads (
   chain_id TEXT PRIMARY KEY,
@@ -77,7 +79,9 @@ CREATE TABLE chain_heads (
 );
 ```
 
-The `chain_members` bridge table is what enables forks: a single `snapshot_nodes` row can belong to multiple `chain_members` rows pointing at it from different chains. The `chain_heads` table makes `head(chainId)` an O(1) lookup.
+The `chain_members` bridge table is what enables forks: a single `snapshot_nodes` row can belong to multiple `chain_members` rows from different chains. The `chain_heads` table holds the head pointer per chain.
+
+The `snapshot_nodes.chain_id` column records the *home chain* — the chain a node was originally `put` into. It is what `get()` returns in `SnapshotNode<T>.chainId` and never changes after creation, even when the node is forked into other chains. Forks insert into `chain_members` only; they never rewrite `chain_id`.
 
 ---
 
@@ -194,11 +198,13 @@ Both modes use WAL journal mode.
 
 ## API
 
+The factory returns a sync-narrowed view of `SnapshotChainStore<T>` — exposed as `SqliteSnapshotStore<T>`. Every method is sync, but the type is structurally compatible with the L0 union interface so callers may upcast for portability.
+
 ```typescript
 import { createSnapshotStoreSqlite } from "@koi/snapshot-store-sqlite";
 import { chainId, type AgentSnapshot } from "@koi/core";
 
-const store = await createSnapshotStoreSqlite<AgentSnapshot>({
+const store = createSnapshotStoreSqlite<AgentSnapshot>({
   path: "~/.koi/snapshots.sqlite",
   blobDir: "~/.koi/file-history",
   extractBlobRefs: extractBlobRefsFromAgentSnapshot,
@@ -206,21 +212,22 @@ const store = await createSnapshotStoreSqlite<AgentSnapshot>({
 });
 
 // Implements SnapshotChainStore<AgentSnapshot> from @koi/core
-const head = await store.head(chainId("session-abc"));
+const head = store.head(chainId("session-abc"));
+if (!head.ok || head.value === undefined) throw new Error("empty chain");
 
-const ancestors = await store.ancestors({
-  startNodeId: head.value!.nodeId,
+const ancestors = store.ancestors({
+  startNodeId: head.value.nodeId,
   maxDepth: 10,
 });
 
-await store.prune(chainId("session-abc"), { retainCount: 500 });
-await store.close();
+store.prune(chainId("session-abc"), { retainCount: 500 });
+store.close();
 ```
 
 ### In-Memory for Tests
 
 ```typescript
-const store = await createSnapshotStoreSqlite<AgentSnapshot>({
+const store = createSnapshotStoreSqlite<AgentSnapshot>({
   path: ":memory:",
 });
 // Identical API — no file I/O, no GC (no blobDir set)

--- a/packages/lib/snapshot-store-sqlite/package.json
+++ b/packages/lib/snapshot-store-sqlite/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/snapshot-store-sqlite",
+  "description": "L2 storage adapter implementing SnapshotChainStore<T> over SQLite with recursive-CTE ancestor walks and mark-and-sweep blob GC",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --vcs-enabled=false src/",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/hash": "workspace:*"
+  },
+  "devDependencies": {},
+  "koi": {}
+}

--- a/packages/lib/snapshot-store-sqlite/src/__tests__/contract.test.ts
+++ b/packages/lib/snapshot-store-sqlite/src/__tests__/contract.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Contract test suite — ports the 14 v1 tests from
+ * `archive/v1/packages/mm/snapshot-chain-store/src/__tests__/store-contract.test.ts`.
+ *
+ * These tests verify the core `SnapshotChainStore<T>` semantics: put/get/head,
+ * list ordering, parent validation, content-hash dedup, ancestor walking,
+ * fork, and prune (with retainCount, retainDuration, head protection,
+ * retainBranches=false).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChainId, NodeId } from "@koi/core";
+import { chainId, nodeId } from "@koi/core";
+import { createSnapshotStoreSqlite, type SqliteSnapshotStore } from "../sqlite-store.js";
+
+function makeTempPath(): string {
+  return join(tmpdir(), `koi-snapshot-store-test-${crypto.randomUUID()}.db`);
+}
+
+describe("SnapshotChainStore [sqlite] — contract", () => {
+  let store: SqliteSnapshotStore<string>;
+
+  afterEach(() => {
+    store?.close();
+  });
+
+  const c1: ChainId = chainId("chain-1");
+  const c2: ChainId = chainId("chain-2");
+
+  test("put and get a single node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const putResult = store.put(c1, "hello", []);
+    expect(putResult.ok).toBe(true);
+    if (!putResult.ok || putResult.value === undefined) return;
+
+    const getResult = store.get(putResult.value.nodeId);
+    expect(getResult.ok).toBe(true);
+    if (getResult.ok) {
+      expect(getResult.value.data).toBe("hello");
+      expect(getResult.value.chainId).toBe(c1);
+      expect(getResult.value.parentIds).toEqual([]);
+    }
+  });
+
+  test("head returns latest node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    store.put(c1, "first", []);
+    const r2 = store.put(c1, "second", []);
+    expect(r2.ok).toBe(true);
+    if (!r2.ok || r2.value === undefined) return;
+
+    const headResult = store.head(c1);
+    expect(headResult.ok).toBe(true);
+    if (headResult.ok) {
+      expect(headResult.value?.nodeId).toBe(r2.value.nodeId);
+      expect(headResult.value?.data).toBe("second");
+    }
+  });
+
+  test("head returns undefined for empty chain", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.head(c1);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBeUndefined();
+    }
+  });
+
+  test("list returns nodes newest-first", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const r1 = store.put(c1, "first", []);
+    const r2 = store.put(c1, "second", []);
+    const r3 = store.put(c1, "third", []);
+    expect(r1.ok && r2.ok && r3.ok).toBe(true);
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(3);
+      if (r3.ok && r3.value !== undefined) {
+        expect(listResult.value[0]?.nodeId).toBe(r3.value.nodeId);
+      }
+      if (r1.ok && r1.value !== undefined) {
+        expect(listResult.value[2]?.nodeId).toBe(r1.value.nodeId);
+      }
+    }
+  });
+
+  test("put with parentIds validates parents exist", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.put(c1, "orphan", [nodeId("nonexistent")]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION");
+    }
+  });
+
+  test("put with skipIfUnchanged skips when content unchanged", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const r1 = store.put(c1, "stable", [], undefined, { skipIfUnchanged: true });
+    expect(r1.ok).toBe(true);
+    if (r1.ok) expect(r1.value).toBeDefined();
+
+    const r2 = store.put(c1, "stable", [], undefined, { skipIfUnchanged: true });
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.value).toBeUndefined();
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) expect(listResult.value.length).toBe(1);
+  });
+
+  test("ancestors walks parent chain (BFS order)", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const r1 = store.put(c1, "root", []);
+    if (!r1.ok || r1.value === undefined) throw new Error("r1 failed");
+    const r2 = store.put(c1, "child", [r1.value.nodeId]);
+    if (!r2.ok || r2.value === undefined) throw new Error("r2 failed");
+    const r3 = store.put(c1, "grandchild", [r2.value.nodeId]);
+    if (!r3.ok || r3.value === undefined) throw new Error("r3 failed");
+
+    const result = store.ancestors({ startNodeId: r3.value.nodeId });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBe(3);
+      // Ordered by depth ASC: start node first, then parents.
+      expect(result.value[0]?.nodeId).toBe(r3.value.nodeId);
+      expect(result.value[1]?.nodeId).toBe(r2.value.nodeId);
+      expect(result.value[2]?.nodeId).toBe(r1.value.nodeId);
+    }
+  });
+
+  test("ancestors respects maxDepth", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    let lastNodeId: NodeId | undefined;
+    for (let i = 0; i < 5; i++) {
+      const parents = lastNodeId !== undefined ? [lastNodeId] : [];
+      const r = store.put(c1, `node-${i}`, parents);
+      expect(r.ok).toBe(true);
+      if (r.ok && r.value !== undefined) {
+        lastNodeId = r.value.nodeId;
+      }
+    }
+    if (lastNodeId === undefined) throw new Error("no nodes created");
+
+    // maxDepth=2 → return start (depth 0) + 1 ancestor (depth 1) + 1 (depth 2)
+    // == 3 nodes total. The CTE walks up to depth <= maxDepth.
+    const result = store.ancestors({ startNodeId: lastNodeId, maxDepth: 2 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBe(3);
+    }
+  });
+
+  test("fork creates new chain from existing node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const r1 = store.put(c1, "origin", []);
+    if (!r1.ok || r1.value === undefined) throw new Error("r1 failed");
+
+    const forkResult = store.fork(r1.value.nodeId, c2, "experiment");
+    expect(forkResult.ok).toBe(true);
+    if (forkResult.ok) {
+      expect(forkResult.value.parentNodeId).toBe(r1.value.nodeId);
+      expect(forkResult.value.label).toBe("experiment");
+    }
+
+    const headResult = store.head(c2);
+    expect(headResult.ok).toBe(true);
+    if (headResult.ok) {
+      expect(headResult.value).toBeDefined();
+      expect(headResult.value?.nodeId).toBe(r1.value.nodeId);
+    }
+
+    const listResult = store.list(c2);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(1);
+    }
+  });
+
+  test("prune with retainCount keeps newest N", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    for (let i = 0; i < 5; i++) {
+      store.put(c1, `node-${i}`, []);
+    }
+
+    const pruneResult = store.prune(c1, { retainCount: 3 });
+    expect(pruneResult.ok).toBe(true);
+    if (pruneResult.ok) {
+      expect(pruneResult.value).toBe(2);
+    }
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(3);
+    }
+  });
+
+  test("prune with retainDuration preserves recent nodes", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    for (let i = 0; i < 3; i++) {
+      store.put(c1, `node-${i}`, []);
+    }
+
+    // 1-hour window — all nodes are recent, nothing should be pruned.
+    const result = store.prune(c1, { retainDuration: 3600000 });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(0);
+    }
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(3);
+    }
+  });
+
+  test("prune protects branch heads by default", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    for (let i = 0; i < 5; i++) {
+      store.put(c1, `node-${i}`, []);
+    }
+
+    // retainCount=0 + default retainBranches=true → head is still preserved
+    const pruneResult = store.prune(c1, { retainCount: 0 });
+    expect(pruneResult.ok).toBe(true);
+    if (pruneResult.ok) {
+      expect(pruneResult.value).toBe(4);
+    }
+
+    const headResult = store.head(c1);
+    expect(headResult.ok).toBe(true);
+    if (headResult.ok) {
+      expect(headResult.value).toBeDefined();
+    }
+  });
+
+  test("prune with retainBranches: false updates head when head is removed", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    for (let i = 0; i < 3; i++) {
+      store.put(c1, `node-${i}`, []);
+    }
+
+    const pruneResult = store.prune(c1, { retainCount: 1, retainBranches: false });
+    expect(pruneResult.ok).toBe(true);
+    if (pruneResult.ok) {
+      expect(pruneResult.value).toBe(2);
+    }
+
+    const headResult = store.head(c1);
+    expect(headResult.ok).toBe(true);
+    if (headResult.ok) {
+      expect(headResult.value).toBeDefined();
+      expect(headResult.value?.data).toBe("node-2");
+    }
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(1);
+    }
+  });
+
+  test("close releases resources and is idempotent", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    store.put(c1, "before-close", []);
+    store.close();
+    store.close(); // double-close must not throw
+  });
+
+  test("close prevents further operations", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    store.close();
+    const result = store.put(c1, "after-close", []);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("INTERNAL");
+    }
+  });
+});

--- a/packages/lib/snapshot-store-sqlite/src/__tests__/cte.test.ts
+++ b/packages/lib/snapshot-store-sqlite/src/__tests__/cte.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Recursive-CTE correctness tests for the ancestor walk.
+ *
+ * Per #1625 design review issue 16A, the SQLite store replaces v1's
+ * BFS-with-N+1-queries pattern with a single recursive CTE. These tests
+ * verify the CTE returns correct results for the four shapes that matter:
+ *
+ *   - Linear chain (one parent per node)
+ *   - Deep chain (depth limit must work even for tall histories)
+ *   - DAG diamond (a node reachable via multiple paths must be visited once)
+ *   - Depth-bounded walk (maxDepth must clip the result)
+ *
+ * The CTE uses `UNION` (not `UNION ALL`) for diamond dedup; the tests pin
+ * that behavior so a future "optimization" to UNION ALL would break loudly.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChainId, NodeId } from "@koi/core";
+import { chainId } from "@koi/core";
+import { createSnapshotStoreSqlite, type SqliteSnapshotStore } from "../sqlite-store.js";
+
+function makeTempPath(): string {
+  return join(tmpdir(), `koi-snapshot-store-cte-${crypto.randomUUID()}.db`);
+}
+
+describe("ancestor CTE", () => {
+  let store: SqliteSnapshotStore<string>;
+  const c1: ChainId = chainId("chain-cte");
+
+  afterEach(() => {
+    store?.close();
+  });
+
+  test("linear chain returns nodes in depth order", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const a = store.put(c1, "a", []);
+    if (!a.ok || a.value === undefined) throw new Error("a failed");
+    const b = store.put(c1, "b", [a.value.nodeId]);
+    if (!b.ok || b.value === undefined) throw new Error("b failed");
+    const c = store.put(c1, "c", [b.value.nodeId]);
+    if (!c.ok || c.value === undefined) throw new Error("c failed");
+
+    const result = store.ancestors({ startNodeId: c.value.nodeId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.map((n) => n.data)).toEqual(["c", "b", "a"]);
+  });
+
+  test("deep chain (depth 50) walks to root without N+1", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    let parent: NodeId | undefined;
+    let last: NodeId | undefined;
+    for (let i = 0; i < 50; i++) {
+      const r = store.put(c1, `n${i}`, parent !== undefined ? [parent] : []);
+      if (!r.ok || r.value === undefined) throw new Error(`n${i} failed`);
+      parent = r.value.nodeId;
+      last = r.value.nodeId;
+    }
+    if (last === undefined) throw new Error("no last");
+
+    const result = store.ancestors({ startNodeId: last });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.length).toBe(50);
+    // First entry is the start (newest); last entry is the root (oldest).
+    expect(result.value[0]?.data).toBe("n49");
+    expect(result.value[49]?.data).toBe("n0");
+  });
+
+  test("DAG diamond visits the shared ancestor exactly once", () => {
+    // Diamond:
+    //        bottom
+    //         /  \
+    //      left  right
+    //         \  /
+    //         top
+    //
+    // Walking ancestors from `bottom` should hit `top` exactly once even
+    // though there are two paths (via left and via right).
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const top = store.put(c1, "top", []);
+    if (!top.ok || top.value === undefined) throw new Error("top failed");
+    const left = store.put(c1, "left", [top.value.nodeId]);
+    if (!left.ok || left.value === undefined) throw new Error("left failed");
+    const right = store.put(c1, "right", [top.value.nodeId]);
+    if (!right.ok || right.value === undefined) throw new Error("right failed");
+    const bottom = store.put(c1, "bottom", [left.value.nodeId, right.value.nodeId]);
+    if (!bottom.ok || bottom.value === undefined) throw new Error("bottom failed");
+
+    const result = store.ancestors({ startNodeId: bottom.value.nodeId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // 4 distinct nodes — top is visited once even though it's reached twice.
+    expect(result.value.length).toBe(4);
+    const labels = result.value.map((n) => n.data).sort();
+    expect(labels).toEqual(["bottom", "left", "right", "top"]);
+  });
+
+  test("maxDepth clips the walk", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    let parent: NodeId | undefined;
+    let last: NodeId | undefined;
+    for (let i = 0; i < 10; i++) {
+      const r = store.put(c1, `n${i}`, parent !== undefined ? [parent] : []);
+      if (!r.ok || r.value === undefined) throw new Error(`n${i} failed`);
+      parent = r.value.nodeId;
+      last = r.value.nodeId;
+    }
+    if (last === undefined) throw new Error("no last");
+
+    // maxDepth=3 → start (depth 0) + 3 ancestors (depths 1,2,3) = 4 nodes
+    const result = store.ancestors({ startNodeId: last, maxDepth: 3 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.length).toBe(4);
+    expect(result.value[0]?.data).toBe("n9");
+    expect(result.value[3]?.data).toBe("n6");
+  });
+});

--- a/packages/lib/snapshot-store-sqlite/src/__tests__/gc.test.ts
+++ b/packages/lib/snapshot-store-sqlite/src/__tests__/gc.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Mark-and-sweep blob GC tests.
+ *
+ * Per #1625 design review issue 13A, prune sweeps orphan blobs from the
+ * CAS blob directory. The tests cover:
+ *
+ *   - All-orphan: every blob is unreferenced → all deleted
+ *   - None-orphan: every blob is referenced → none deleted
+ *   - Partial: some referenced, some not → only orphans deleted
+ *   - Head-protected: pruned chain head is still referenced via cache → blobs preserved
+ *   - GC disabled when blobDir is omitted (no-op safe)
+ *   - Sharded layout: <blobDir>/<2-hex>/<full-hash>
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChainId } from "@koi/core";
+import { chainId } from "@koi/core";
+import { createSnapshotStoreSqlite } from "../sqlite-store.js";
+
+interface BlobPayload {
+  readonly label: string;
+  readonly blobs: readonly string[];
+}
+
+function makeTempPath(): string {
+  return join(tmpdir(), `koi-snapshot-store-gc-${crypto.randomUUID()}.db`);
+}
+
+function makeBlobDir(): string {
+  const dir = join(tmpdir(), `koi-snapshot-store-blobs-${crypto.randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeBlob(blobDir: string, hash: string, content = ""): void {
+  // Flat layout for tests: <blobDir>/<full-hash>
+  writeFileSync(join(blobDir, hash), content);
+}
+
+function writeShardedBlob(blobDir: string, hash: string, content = ""): void {
+  // Sharded layout: <blobDir>/<first-2>/<full-hash>
+  const shardDir = join(blobDir, hash.slice(0, 2));
+  mkdirSync(shardDir, { recursive: true });
+  writeFileSync(join(shardDir, hash), content);
+}
+
+describe("blob GC", () => {
+  let blobDir: string;
+  let dbPath: string;
+  const c1: ChainId = chainId("chain-gc");
+  let store: ReturnType<typeof createSnapshotStoreSqlite<BlobPayload>>;
+
+  beforeEach(() => {
+    blobDir = makeBlobDir();
+    dbPath = makeTempPath();
+  });
+
+  afterEach(() => {
+    store?.close();
+    rmSync(blobDir, { recursive: true, force: true });
+  });
+
+  test("all-orphan: prune deletes every blob when nothing is referenced", () => {
+    // No snapshots at all, but blobs sitting in the dir.
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      blobDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    writeBlob(blobDir, "a".repeat(64));
+    writeBlob(blobDir, "b".repeat(64));
+
+    // Put one snapshot referencing nothing, then prune (with default retain).
+    store.put(c1, { label: "empty", blobs: [] }, []);
+    const pruneResult = store.prune(c1, { retainCount: 100 });
+    expect(pruneResult.ok).toBe(true);
+
+    expect(readdirSync(blobDir).length).toBe(0);
+  });
+
+  test("none-orphan: prune preserves all referenced blobs", () => {
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      blobDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    const hashA = "a".repeat(64);
+    const hashB = "b".repeat(64);
+    writeBlob(blobDir, hashA);
+    writeBlob(blobDir, hashB);
+
+    store.put(c1, { label: "uses-a-and-b", blobs: [hashA, hashB] }, []);
+    store.prune(c1, { retainCount: 100 });
+
+    const remaining = readdirSync(blobDir).sort();
+    expect(remaining).toEqual([hashA, hashB]);
+  });
+
+  test("partial: only unreferenced blobs are deleted", () => {
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      blobDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    const hashLive = "1".repeat(64);
+    const hashOrphan = "2".repeat(64);
+    writeBlob(blobDir, hashLive);
+    writeBlob(blobDir, hashOrphan);
+
+    store.put(c1, { label: "uses-live", blobs: [hashLive] }, []);
+    store.prune(c1, { retainCount: 100 });
+
+    const remaining = readdirSync(blobDir);
+    expect(remaining).toEqual([hashLive]);
+  });
+
+  test("head protection keeps the head's blobs after retainCount=0", () => {
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      blobDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    const hashOld = "3".repeat(64);
+    const hashHead = "4".repeat(64);
+    writeBlob(blobDir, hashOld);
+    writeBlob(blobDir, hashHead);
+
+    store.put(c1, { label: "old", blobs: [hashOld] }, []);
+    store.put(c1, { label: "head", blobs: [hashHead] }, []);
+
+    // retainCount=0 + default retainBranches=true → head survives, old is pruned.
+    store.prune(c1, { retainCount: 0 });
+
+    const remaining = readdirSync(blobDir);
+    // Old blob is now an orphan (only the head's snapshot row remains alive).
+    expect(remaining).toEqual([hashHead]);
+  });
+
+  test("GC is a no-op when blobDir is omitted", () => {
+    // No blobDir → GC should never touch the filesystem; we verify this by
+    // pre-populating a directory and confirming nothing changes.
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      // intentionally no blobDir or extractBlobRefs
+    });
+    const orphan = "5".repeat(64);
+    writeBlob(blobDir, orphan);
+
+    store.put(c1, { label: "x", blobs: [] }, []);
+    store.prune(c1, { retainCount: 100 });
+
+    // The orphan is still there because GC was disabled.
+    expect(readdirSync(blobDir)).toEqual([orphan]);
+  });
+
+  test("sharded layout: walks <blobDir>/<2-hex>/<full-hash>", () => {
+    store = createSnapshotStoreSqlite<BlobPayload>({
+      path: dbPath,
+      blobDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    const live = "ab".padEnd(64, "0");
+    const orphan = "cd".padEnd(64, "0");
+    writeShardedBlob(blobDir, live);
+    writeShardedBlob(blobDir, orphan);
+
+    store.put(c1, { label: "x", blobs: [live] }, []);
+    store.prune(c1, { retainCount: 100 });
+
+    // The live blob's shard dir should still hold its file; the orphan shard
+    // dir is empty (we don't rmdir empty shards — that's a separate concern).
+    const liveShard = readdirSync(join(blobDir, live.slice(0, 2)));
+    expect(liveShard).toEqual([live]);
+    const orphanShard = readdirSync(join(blobDir, orphan.slice(0, 2)));
+    expect(orphanShard).toEqual([]);
+  });
+});

--- a/packages/lib/snapshot-store-sqlite/src/__tests__/negative.test.ts
+++ b/packages/lib/snapshot-store-sqlite/src/__tests__/negative.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Negative-path tests — failure modes that the store must handle gracefully.
+ *
+ * Per #1625 design review issue 12A, the store must:
+ *   - Return NOT_FOUND for missing nodes
+ *   - Return VALIDATION for orphan parent IDs
+ *   - Tolerate get() on a chain that doesn't exist
+ *   - Tolerate ancestors() on a missing start node
+ *   - Reject operations after close()
+ *   - Tolerate empty chain_members during prune
+ *   - Handle GC when the blob directory does not exist
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChainId } from "@koi/core";
+import { chainId, nodeId } from "@koi/core";
+import { createSnapshotStoreSqlite, type SqliteSnapshotStore } from "../sqlite-store.js";
+
+function makeTempPath(): string {
+  return join(tmpdir(), `koi-snapshot-store-neg-${crypto.randomUUID()}.db`);
+}
+
+describe("negative paths", () => {
+  let store: SqliteSnapshotStore<string>;
+
+  afterEach(() => {
+    store?.close();
+  });
+
+  test("get returns NOT_FOUND for missing node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.get(nodeId("does-not-exist"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("ancestors returns NOT_FOUND for missing start node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.ancestors({ startNodeId: nodeId("missing-root") });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("fork returns NOT_FOUND for missing source node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.fork(nodeId("nope"), chainId("c"), "label");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("list on a non-existent chain returns empty array", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.list(chainId("never-existed"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+  });
+
+  test("head on a non-existent chain returns undefined (not an error)", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.head(chainId("never-existed"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBeUndefined();
+  });
+
+  test("prune on an empty chain returns 0 without error", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    const result = store.prune(chainId("empty"), { retainCount: 10 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(0);
+  });
+
+  test("operations after close return INTERNAL", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    store.close();
+
+    const c: ChainId = chainId("c");
+    expect(store.put(c, "x", []).ok).toBe(false);
+    expect(store.head(c).ok).toBe(false);
+    expect(store.list(c).ok).toBe(false);
+    expect(store.get(nodeId("x")).ok).toBe(false);
+    expect(store.ancestors({ startNodeId: nodeId("x") }).ok).toBe(false);
+    expect(store.fork(nodeId("x"), c, "l").ok).toBe(false);
+    expect(store.prune(c, {}).ok).toBe(false);
+  });
+
+  test("GC tolerates a missing blob directory (no crash)", () => {
+    const missingDir = join(tmpdir(), `koi-missing-${crypto.randomUUID()}`);
+    // Intentionally do not create missingDir.
+    // Local store variable since this test uses a different payload type.
+    const blobStore = createSnapshotStoreSqlite<{ readonly blobs: readonly string[] }>({
+      path: makeTempPath(),
+      blobDir: missingDir,
+      extractBlobRefs: (p) => p.blobs,
+    });
+    try {
+      const c: ChainId = chainId("c");
+      blobStore.put(c, { blobs: ["aa".repeat(32)] }, []);
+      const result = blobStore.prune(c, { retainCount: 100 });
+      expect(result.ok).toBe(true);
+    } finally {
+      blobStore.close();
+      try {
+        rmSync(missingDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  });
+});

--- a/packages/lib/snapshot-store-sqlite/src/__tests__/transactions.test.ts
+++ b/packages/lib/snapshot-store-sqlite/src/__tests__/transactions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Transaction-rollback tests — the SQLite-store flavor of Issue 9A's
+ * crash-injection test harness.
+ *
+ * The full crash-injection harness from #1625 design review issue 9 lives
+ * in @koi/checkpoint, where it covers the multi-step restore protocol
+ * (file restore → conversation truncate → head update). For the SQLite
+ * store, the equivalent property is "every multi-statement operation is
+ * wrapped in a transaction so a mid-operation failure leaves the DB
+ * untouched."
+ *
+ * These tests prove that property by triggering errors mid-transaction and
+ * verifying the DB state matches the pre-operation state.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChainId, NodeId } from "@koi/core";
+import { chainId, nodeId } from "@koi/core";
+import { createSnapshotStoreSqlite, type SqliteSnapshotStore } from "../sqlite-store.js";
+
+function makeTempPath(): string {
+  return join(tmpdir(), `koi-snapshot-store-tx-${crypto.randomUUID()}.db`);
+}
+
+describe("transaction safety", () => {
+  let store: SqliteSnapshotStore<string>;
+  const c1: ChainId = chainId("chain-tx");
+
+  afterEach(() => {
+    store?.close();
+  });
+
+  test("put with bad parent returns VALIDATION before any write", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    // Create a baseline node so we can verify nothing else gets committed.
+    const baseline = store.put(c1, "baseline", []);
+    if (!baseline.ok || baseline.value === undefined) throw new Error("baseline failed");
+    const baselineId = baseline.value.nodeId;
+
+    const bad = store.put(c1, "child-of-nothing", [nodeId("does-not-exist")]);
+    expect(bad.ok).toBe(false);
+    if (bad.ok) throw new Error("expected failure");
+    expect(bad.error.code).toBe("VALIDATION");
+
+    // The baseline must still be the head and nothing else was added.
+    const headResult = store.head(c1);
+    expect(headResult.ok).toBe(true);
+    if (!headResult.ok) return;
+    expect(headResult.value?.nodeId).toBe(baselineId);
+
+    const listResult = store.list(c1);
+    expect(listResult.ok).toBe(true);
+    if (!listResult.ok) return;
+    expect(listResult.value.length).toBe(1);
+  });
+
+  test("put survives sqlite reopen — committed state persists across processes", () => {
+    // The two-handle pattern simulates "process crash, then restart" without
+    // killing -9. We close the first store cleanly, then reopen on the same
+    // file and check the data is intact.
+    const path = makeTempPath();
+    store = createSnapshotStoreSqlite<string>({ path });
+    const r1 = store.put(c1, "first", []);
+    if (!r1.ok || r1.value === undefined) throw new Error("r1 failed");
+    const r2 = store.put(c1, "second", []);
+    if (!r2.ok || r2.value === undefined) throw new Error("r2 failed");
+    store.close();
+
+    // Reopen — chain heads and seqs should be reconstructed from the DB.
+    store = createSnapshotStoreSqlite<string>({ path });
+    const head = store.head(c1);
+    expect(head.ok).toBe(true);
+    if (!head.ok) return;
+    expect(head.value?.nodeId).toBe(r2.value.nodeId);
+
+    // The seq counter should resume past the highest existing seq, so a new
+    // put gets a fresh ordering slot rather than colliding.
+    const r3 = store.put(c1, "third", []);
+    expect(r3.ok).toBe(true);
+
+    const list = store.list(c1);
+    expect(list.ok).toBe(true);
+    if (!list.ok) return;
+    expect(list.value.length).toBe(3);
+    expect(list.value[0]?.data).toBe("third");
+  });
+
+  test("put rolled back on a synthetic FK violation leaves chain unchanged", () => {
+    // Open the database directly to inject an inconsistent state mid-test
+    // (the store's prepared statements are insulated from this), then
+    // reopen via the store factory and verify it tolerates the inconsistency.
+    const path = makeTempPath();
+    store = createSnapshotStoreSqlite<string>({ path });
+    const baseline = store.put(c1, "baseline", []);
+    if (!baseline.ok || baseline.value === undefined) throw new Error("baseline failed");
+    store.close();
+
+    // Inject a "torn" insert: a chain_members row pointing at a missing
+    // node. The schema's FK constraint should reject this, but we wrap in
+    // a savepoint that we then ROLLBACK, simulating a transaction abort.
+    const raw = new Database(path);
+    raw.run("PRAGMA foreign_keys = ON");
+    let threw = false;
+    try {
+      raw.transaction(() => {
+        raw.run(
+          "INSERT INTO chain_members (chain_id, node_id, created_at, seq) VALUES ('chain-tx', 'fake-node', 0, 999)",
+        );
+      })();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    raw.close();
+
+    // Reopen via the store and confirm the baseline is intact.
+    store = createSnapshotStoreSqlite<string>({ path });
+    const list = store.list(c1);
+    expect(list.ok).toBe(true);
+    if (!list.ok) return;
+    expect(list.value.length).toBe(1);
+    expect(list.value[0]?.data).toBe("baseline");
+  });
+
+  test("prune is atomic across the chain — head pointer never points at a deleted node", () => {
+    store = createSnapshotStoreSqlite<string>({ path: makeTempPath() });
+    let last: NodeId | undefined;
+    for (let i = 0; i < 10; i++) {
+      const r = store.put(c1, `n${i}`, last !== undefined ? [last] : []);
+      if (!r.ok || r.value === undefined) throw new Error(`n${i}`);
+      last = r.value.nodeId;
+    }
+
+    const pruneResult = store.prune(c1, { retainCount: 3, retainBranches: false });
+    expect(pruneResult.ok).toBe(true);
+
+    // After prune, the head must reference a node that still exists.
+    const headResult = store.head(c1);
+    expect(headResult.ok).toBe(true);
+    if (!headResult.ok) return;
+    expect(headResult.value).toBeDefined();
+    if (headResult.value === undefined) return;
+
+    // Verify the head's nodeId actually resolves via get().
+    const getResult = store.get(headResult.value.nodeId);
+    expect(getResult.ok).toBe(true);
+  });
+});

--- a/packages/lib/snapshot-store-sqlite/src/cte.ts
+++ b/packages/lib/snapshot-store-sqlite/src/cte.ts
@@ -1,0 +1,62 @@
+/**
+ * Recursive CTE for ancestor walks.
+ *
+ * Replaces the v1 BFS-with-N+1-queries pattern with a single recursive SQL
+ * query that walks parent hashes via `json_each` over the `parent_ids` JSON
+ * column.
+ *
+ * `UNION` (not `UNION ALL`) deduplicates DAG diamonds where a node has
+ * multiple paths to the same ancestor. The depth column is propagated so we
+ * can return ancestors in BFS order (start node first, then by distance).
+ */
+
+import type { Database } from "bun:sqlite";
+
+export interface AncestorRow {
+  readonly node_id: string;
+  readonly chain_id: string;
+  readonly parent_ids: string;
+  readonly content_hash: string;
+  readonly data: string;
+  readonly created_at: number;
+  readonly metadata: string;
+  readonly depth: number;
+}
+
+/**
+ * Walk ancestors from `startNodeId` up to `maxDepth` (inclusive). Depth 0 is
+ * the start node itself; depth 1 is its parents; etc.
+ *
+ * If `maxDepth` is undefined, walks to the root. We pass a sentinel value
+ * (`Number.MAX_SAFE_INTEGER`) to keep the SQL query a single static string
+ * — using a parameter sidesteps the SQLite recursion-depth quirk while
+ * keeping the prepared statement cacheable.
+ */
+export function walkAncestors(
+  db: Database,
+  startNodeId: string,
+  maxDepth: number | undefined,
+): readonly AncestorRow[] {
+  // The CTE walks from startNodeId outward through json_each(parent_ids).
+  // depth=0 is the start; depth=1 is its parents; etc. We bound depth via
+  // a SQL parameter so the query plan stays cached.
+  //
+  // UNION (not UNION ALL) collapses DAG diamonds — same node reached via
+  // two paths at different depths is visited once at the smaller depth.
+  const stmt = db.query<AncestorRow, [string, number]>(`
+    WITH RECURSIVE ancestors(node_id, depth) AS (
+        SELECT ?, 0
+      UNION
+        SELECT json_each.value, ancestors.depth + 1
+        FROM ancestors
+        JOIN snapshot_nodes ON snapshot_nodes.node_id = ancestors.node_id
+        JOIN json_each(snapshot_nodes.parent_ids)
+        WHERE ancestors.depth < ?
+    )
+    SELECT n.*, a.depth FROM snapshot_nodes n
+    JOIN ancestors a ON n.node_id = a.node_id
+    ORDER BY a.depth ASC, n.created_at DESC
+  `);
+  const cap = maxDepth ?? Number.MAX_SAFE_INTEGER;
+  return stmt.all(startNodeId, cap);
+}

--- a/packages/lib/snapshot-store-sqlite/src/gc.ts
+++ b/packages/lib/snapshot-store-sqlite/src/gc.ts
@@ -1,0 +1,118 @@
+/**
+ * Mark-and-sweep blob garbage collection.
+ *
+ * Called from `prune()` after the chain transaction commits. Walks every
+ * remaining live `snapshot_nodes.data` payload, calls the consumer-supplied
+ * `extractBlobRefs(data)` to gather all referenced blob hashes, then lists
+ * the blob directory and deletes any blob whose hash is not in the live set.
+ *
+ * Idempotent — re-running converges. The sweep runs OUTSIDE the SQLite
+ * transaction (filesystem ops cannot be rolled back by SQL), so a crash
+ * mid-sweep may leave some orphan blobs that the next prune cleans up.
+ */
+
+import type { Database } from "bun:sqlite";
+import { readdirSync, type Stats, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+interface PayloadRow {
+  readonly data: string;
+}
+
+/**
+ * Sweep orphan blobs from `blobDir` based on the current live snapshot set.
+ *
+ * @returns The number of blob files deleted.
+ */
+export function sweepOrphanBlobs<T>(
+  db: Database,
+  blobDir: string,
+  extractBlobRefs: (data: T) => readonly string[],
+): number {
+  // Build the set of in-use blob hashes by scanning every live snapshot's
+  // payload. For typical workloads (a few hundred snapshots) this is fast;
+  // the alternative (per-blob refcount columns) is faster but drifts on
+  // crash, so we accept the O(N) sweep for crash safety.
+  const liveHashes = new Set<string>();
+  const rows = db.query<PayloadRow, []>("SELECT data FROM snapshot_nodes").all();
+  for (const row of rows) {
+    let parsed: T;
+    try {
+      parsed = JSON.parse(row.data) as T;
+    } catch {
+      // A row we can't parse can't be reasoned about — be conservative and
+      // skip it (its blobs will not be considered orphans).
+      continue;
+    }
+    for (const hash of extractBlobRefs(parsed)) {
+      liveHashes.add(hash);
+    }
+  }
+
+  return deleteOrphans(blobDir, liveHashes);
+}
+
+/**
+ * Walk the blob directory and delete files whose hash is not in `liveHashes`.
+ *
+ * The expected layout is content-addressed:
+ *   <blobDir>/<first-2-hex-chars>/<full-sha256-hex>
+ * but we also support a flat layout for tests:
+ *   <blobDir>/<full-sha256-hex>
+ *
+ * Either way, we treat each leaf filename as the blob hash. Sub-directory
+ * names are not interpreted as hashes.
+ */
+function deleteOrphans(blobDir: string, liveHashes: ReadonlySet<string>): number {
+  let deleted = 0;
+  let entries: readonly string[];
+  try {
+    entries = readdirSync(blobDir);
+  } catch {
+    // Blob dir doesn't exist yet — nothing to sweep.
+    return 0;
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(blobDir, entry);
+    let entryStat: Stats;
+    try {
+      entryStat = statSync(entryPath);
+    } catch {
+      continue;
+    }
+
+    if (entryStat.isDirectory()) {
+      // Sharded layout: <blobDir>/<2-char-prefix>/<full-hash>
+      let children: readonly string[];
+      try {
+        children = readdirSync(entryPath);
+      } catch {
+        continue;
+      }
+      for (const child of children) {
+        if (!liveHashes.has(child)) {
+          try {
+            unlinkSync(join(entryPath, child));
+            deleted += 1;
+          } catch {
+            // Best effort — a missing file is fine, a permission error is
+            // surfaced indirectly via the count being lower than expected.
+          }
+        }
+      }
+    } else if (entryStat.isFile()) {
+      // Flat layout: <blobDir>/<full-hash>
+      if (!liveHashes.has(entry)) {
+        try {
+          unlinkSync(entryPath);
+          deleted += 1;
+        } catch {
+          // Best effort.
+        }
+      }
+    }
+  }
+
+  return deleted;
+}

--- a/packages/lib/snapshot-store-sqlite/src/index.ts
+++ b/packages/lib/snapshot-store-sqlite/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @koi/snapshot-store-sqlite — L2 storage adapter implementing
+ * `SnapshotChainStore<T>` from `@koi/core` over SQLite.
+ *
+ * Spec: docs/L2/snapshot-store-sqlite.md
+ */
+
+export type { SqliteSnapshotStore } from "./sqlite-store.js";
+export { createSnapshotStoreSqlite } from "./sqlite-store.js";
+export type { SqliteSnapshotStoreConfig } from "./types.js";

--- a/packages/lib/snapshot-store-sqlite/src/schema.ts
+++ b/packages/lib/snapshot-store-sqlite/src/schema.ts
@@ -1,0 +1,71 @@
+/**
+ * SQLite schema and PRAGMAs for the snapshot store.
+ *
+ * Three tables:
+ * - `snapshot_nodes`: immutable DAG nodes; `parent_ids` is a JSON array so the
+ *   recursive CTE in `cte.ts` can walk parents with a single query.
+ * - `chain_members`: bridge table — a single node can belong to multiple
+ *   chains via fork. The `seq` column is a per-chain monotonic counter for
+ *   deterministic ordering within the same millisecond.
+ * - `chain_heads`: O(1) head pointer per chain.
+ *
+ * The `chain_id` column on `snapshot_nodes` records the *home* chain (the
+ * chain a node was originally `put` into). It is what `get()` returns in
+ * `SnapshotNode<T>.chainId` and never changes after creation, even when the
+ * node is forked into other chains.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * Apply the schema to a database. Idempotent — uses `CREATE TABLE IF NOT EXISTS`.
+ */
+export function applySchema(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS snapshot_nodes (
+      node_id      TEXT PRIMARY KEY,
+      chain_id     TEXT NOT NULL,
+      parent_ids   TEXT NOT NULL DEFAULT '[]',
+      content_hash TEXT NOT NULL,
+      data         TEXT NOT NULL,
+      created_at   INTEGER NOT NULL,
+      metadata     TEXT NOT NULL DEFAULT '{}'
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS chain_members (
+      chain_id   TEXT NOT NULL,
+      node_id    TEXT NOT NULL REFERENCES snapshot_nodes(node_id),
+      created_at INTEGER NOT NULL,
+      seq        INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (chain_id, node_id)
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS chain_heads (
+      chain_id TEXT PRIMARY KEY,
+      node_id  TEXT NOT NULL REFERENCES snapshot_nodes(node_id)
+    )
+  `);
+
+  db.run("CREATE INDEX IF NOT EXISTS idx_snapshot_nodes_chain ON snapshot_nodes(chain_id)");
+  db.run(
+    "CREATE INDEX IF NOT EXISTS idx_chain_members_chain ON chain_members(chain_id, created_at DESC, seq DESC)",
+  );
+}
+
+/**
+ * Apply pragmas. WAL mode is required for concurrent reads + GC sweeps.
+ */
+export function applyPragmas(db: Database, durability: "process" | "os"): void {
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA foreign_keys = ON");
+  db.run("PRAGMA wal_autocheckpoint = 1000");
+  if (durability === "os") {
+    db.run("PRAGMA synchronous = FULL");
+  } else {
+    db.run("PRAGMA synchronous = NORMAL");
+  }
+}

--- a/packages/lib/snapshot-store-sqlite/src/sqlite-store.ts
+++ b/packages/lib/snapshot-store-sqlite/src/sqlite-store.ts
@@ -1,0 +1,532 @@
+/**
+ * SQLite-backed `SnapshotChainStore<T>` factory.
+ *
+ * Ports the v1 SQLite chain store from `archive/v1/packages/mm/snapshot-chain-store/`
+ * with three changes per the #1625 design review:
+ *
+ * 1. Recursive CTE for ancestor walks (replaces v1 BFS-with-N+1 queries)
+ * 2. Mark-and-sweep blob GC integrated into `prune` (v1 left this to callers)
+ * 3. `parent_ids` stored as a JSON array column on `snapshot_nodes` rather
+ *    than a separate `snapshot_parents` bridge table (so the CTE can use
+ *    `json_each` in a single query)
+ *
+ * This file holds the wiring (statement preparation, in-memory caches,
+ * factory closure). The recursive CTE lives in `cte.ts` and the blob sweeper
+ * lives in `gc.ts`.
+ */
+
+import { Database } from "bun:sqlite";
+import type {
+  AncestorQuery,
+  ChainId,
+  ForkRef,
+  KoiError,
+  NodeId,
+  PruningPolicy,
+  PutOptions,
+  Result,
+  SnapshotChainStore,
+  SnapshotNode,
+} from "@koi/core";
+import { internal, notFound, validation } from "@koi/core";
+import { computeContentHash } from "@koi/hash";
+import { walkAncestors } from "./cte.js";
+import { sweepOrphanBlobs } from "./gc.js";
+import { applyPragmas, applySchema } from "./schema.js";
+import type { SqliteSnapshotStoreConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Sync narrowing
+// ---------------------------------------------------------------------------
+
+/**
+ * Mapped type that narrows every method on a `SnapshotChainStore<T>` from
+ * its L0 sync-or-async return type (`R | Promise<R>`) to the sync-only `R`.
+ *
+ * The L0 interface uses unions so adapters can be sync (in-memory, SQLite)
+ * or async (network) without changing the interface. This SQLite adapter is
+ * always sync, so the factory advertises that fact at the type level —
+ * callers and tests don't need `await` (though they may add it for L0
+ * portability).
+ */
+type SyncOps<T> = {
+  readonly [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (...args: A) => Awaited<R>
+    : T[K];
+};
+
+/** Sync-narrowed view of `SnapshotChainStore<T>`. */
+export type SqliteSnapshotStore<T> = SyncOps<SnapshotChainStore<T>>;
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+interface NodeRow {
+  readonly node_id: string;
+  readonly chain_id: string;
+  readonly parent_ids: string;
+  readonly content_hash: string;
+  readonly data: string;
+  readonly created_at: number;
+  readonly metadata: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateNodeId(): NodeId {
+  return `node-${crypto.randomUUID()}` as NodeId;
+}
+
+function rowToNode<T>(row: NodeRow): SnapshotNode<T> {
+  return {
+    nodeId: row.node_id as NodeId,
+    chainId: row.chain_id as ChainId,
+    parentIds: (JSON.parse(row.parent_ids) as readonly string[]).map((p) => p as NodeId),
+    contentHash: row.content_hash,
+    data: JSON.parse(row.data) as T,
+    createdAt: row.created_at,
+    metadata: JSON.parse(row.metadata) as Readonly<Record<string, unknown>>,
+  };
+}
+
+function sqlError(e: unknown, context: string): { readonly ok: false; readonly error: KoiError } {
+  return { ok: false, error: internal(`snapshot-store-sqlite: ${context}`, e) };
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a SQLite-backed `SnapshotChainStore<T>`.
+ *
+ * Generic over the payload type `T`. If `blobDir` and `extractBlobRefs` are
+ * both provided, `prune()` runs mark-and-sweep blob GC against the directory.
+ */
+export function createSnapshotStoreSqlite<T>(
+  config: SqliteSnapshotStoreConfig<T>,
+): SqliteSnapshotStore<T> {
+  const db = new Database(config.path, { create: true });
+  applyPragmas(db, config.durability ?? "process");
+  applySchema(db);
+
+  // -- Prepared statements --------------------------------------------------
+
+  const insertNodeStmt = db.prepare(`
+    INSERT INTO snapshot_nodes (node_id, chain_id, parent_ids, content_hash, data, created_at, metadata)
+    VALUES ($node_id, $chain_id, $parent_ids, $content_hash, $data, $created_at, $metadata)
+  `);
+
+  const insertMemberStmt = db.prepare(`
+    INSERT OR IGNORE INTO chain_members (chain_id, node_id, created_at, seq)
+    VALUES ($chain_id, $node_id, $created_at, $seq)
+  `);
+
+  const upsertHeadStmt = db.prepare(`
+    INSERT INTO chain_heads (chain_id, node_id) VALUES ($chain_id, $node_id)
+    ON CONFLICT(chain_id) DO UPDATE SET node_id = excluded.node_id
+  `);
+
+  const selectNodeStmt = db.query<NodeRow, [string]>(
+    "SELECT * FROM snapshot_nodes WHERE node_id = ?",
+  );
+
+  const selectChainNodesStmt = db.query<NodeRow, [string]>(
+    `SELECT n.* FROM snapshot_nodes n
+     INNER JOIN chain_members m ON n.node_id = m.node_id
+     WHERE m.chain_id = ?
+     ORDER BY m.created_at DESC, m.seq DESC`,
+  );
+
+  const selectNewestSurvivorStmt = db.query<{ readonly node_id: string }, [string]>(
+    `SELECT node_id FROM chain_members
+     WHERE chain_id = ?
+     ORDER BY created_at DESC, seq DESC
+     LIMIT 1`,
+  );
+
+  const deleteMemberStmt = db.prepare(
+    "DELETE FROM chain_members WHERE chain_id = ? AND node_id = ?",
+  );
+
+  const countMemberRefsStmt = db.query<{ readonly cnt: number }, [string]>(
+    "SELECT COUNT(*) AS cnt FROM chain_members WHERE node_id = ?",
+  );
+
+  const deleteNodeStmt = db.prepare("DELETE FROM snapshot_nodes WHERE node_id = ?");
+  const deleteHeadStmt = db.prepare("DELETE FROM chain_heads WHERE chain_id = ?");
+
+  // -- In-memory caches -----------------------------------------------------
+
+  // chain head pointer cache: chainId → nodeId. Initialized from chain_heads
+  // at construction; updated on put/fork/prune so head() is O(1) lookup
+  // followed by a single indexed SELECT on snapshot_nodes.
+  const chainHeads = new Map<string, string>();
+  const initHeadRows = db
+    .query<{ readonly chain_id: string; readonly node_id: string }, []>(
+      "SELECT chain_id, node_id FROM chain_heads",
+    )
+    .all();
+  for (const row of initHeadRows) {
+    chainHeads.set(row.chain_id, row.node_id);
+  }
+
+  // Per-chain seq counter for deterministic ordering within the same ms.
+  // Initialized from chain_members on construction.
+  const chainSeqs = new Map<string, number>();
+  const initSeqRows = db
+    .query<{ readonly chain_id: string; readonly max_seq: number }, []>(
+      "SELECT chain_id, MAX(seq) AS max_seq FROM chain_members GROUP BY chain_id",
+    )
+    .all();
+  for (const row of initSeqRows) {
+    chainSeqs.set(row.chain_id, row.max_seq);
+  }
+
+  function nextSeq(cid: string): number {
+    const current = chainSeqs.get(cid) ?? -1;
+    const next = current + 1;
+    chainSeqs.set(cid, next);
+    return next;
+  }
+
+  let closed = false;
+
+  function ensureOpen(): void {
+    if (closed) {
+      throw new Error("snapshot-store-sqlite: store is closed");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // put
+  // -----------------------------------------------------------------------
+
+  const put = (
+    cid: ChainId,
+    data: T,
+    parentIds: readonly NodeId[],
+    metadata?: Readonly<Record<string, unknown>>,
+    options?: PutOptions,
+  ): Result<SnapshotNode<T> | undefined, KoiError> => {
+    try {
+      ensureOpen();
+
+      // Validate parent IDs exist before computing the content hash so a
+      // bad input fails fast without doing extra work.
+      for (const pid of parentIds) {
+        const row = selectNodeStmt.get(pid);
+        if (row === null) {
+          return {
+            ok: false,
+            error: validation(`Parent node not found: ${pid}`),
+          };
+        }
+      }
+
+      const hash = computeContentHash(data);
+
+      // skipIfUnchanged: if the head's content hash matches, return the
+      // current head without writing. Caller treats `value === undefined`
+      // as "no change, your existing reference is still current".
+      if (options?.skipIfUnchanged === true) {
+        const headNodeId = chainHeads.get(cid);
+        if (headNodeId !== undefined) {
+          const headRow = selectNodeStmt.get(headNodeId);
+          if (headRow !== null && headRow.content_hash === hash) {
+            return { ok: true, value: undefined };
+          }
+        }
+      }
+
+      const nid = generateNodeId();
+      const now = Date.now();
+      const seq = nextSeq(cid);
+
+      db.transaction(() => {
+        insertNodeStmt.run({
+          $node_id: nid,
+          $chain_id: cid,
+          $parent_ids: JSON.stringify(parentIds),
+          $content_hash: hash,
+          $data: JSON.stringify(data),
+          $created_at: now,
+          $metadata: JSON.stringify(metadata ?? {}),
+        });
+        insertMemberStmt.run({
+          $chain_id: cid,
+          $node_id: nid,
+          $created_at: now,
+          $seq: seq,
+        });
+        upsertHeadStmt.run({ $chain_id: cid, $node_id: nid });
+      })();
+
+      chainHeads.set(cid, nid);
+
+      const node: SnapshotNode<T> = {
+        nodeId: nid,
+        chainId: cid,
+        parentIds: [...parentIds],
+        contentHash: hash,
+        data,
+        createdAt: now,
+        metadata: metadata ?? {},
+      };
+
+      return { ok: true, value: node };
+    } catch (e: unknown) {
+      return sqlError(e, "put");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // get
+  // -----------------------------------------------------------------------
+
+  const getNode = (nid: NodeId): Result<SnapshotNode<T>, KoiError> => {
+    try {
+      ensureOpen();
+      const row = selectNodeStmt.get(nid);
+      if (row === null) {
+        return {
+          ok: false,
+          error: notFound(nid, `Snapshot node not found: ${nid}`),
+        };
+      }
+      return { ok: true, value: rowToNode<T>(row) };
+    } catch (e: unknown) {
+      return sqlError(e, "get");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // head
+  // -----------------------------------------------------------------------
+
+  const head = (cid: ChainId): Result<SnapshotNode<T> | undefined, KoiError> => {
+    try {
+      ensureOpen();
+      const headNodeId = chainHeads.get(cid);
+      if (headNodeId === undefined) {
+        return { ok: true, value: undefined };
+      }
+      const row = selectNodeStmt.get(headNodeId);
+      if (row === null) {
+        // Cache and DB disagree — should not happen, but tolerate it.
+        chainHeads.delete(cid);
+        return { ok: true, value: undefined };
+      }
+      return { ok: true, value: rowToNode<T>(row) };
+    } catch (e: unknown) {
+      return sqlError(e, "head");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // list
+  // -----------------------------------------------------------------------
+
+  const list = (cid: ChainId): Result<readonly SnapshotNode<T>[], KoiError> => {
+    try {
+      ensureOpen();
+      const rows = selectChainNodesStmt.all(cid);
+      return { ok: true, value: rows.map((r) => rowToNode<T>(r)) };
+    } catch (e: unknown) {
+      return sqlError(e, "list");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // ancestors (recursive CTE — see cte.ts)
+  // -----------------------------------------------------------------------
+
+  const ancestors = (query: AncestorQuery): Result<readonly SnapshotNode<T>[], KoiError> => {
+    try {
+      ensureOpen();
+
+      // Verify the start node exists so we return NOT_FOUND instead of an
+      // empty list when the caller passes a bad ID.
+      const startRow = selectNodeStmt.get(query.startNodeId);
+      if (startRow === null) {
+        return {
+          ok: false,
+          error: notFound(query.startNodeId, `Start node not found: ${query.startNodeId}`),
+        };
+      }
+
+      const ancestorRows = walkAncestors(db, query.startNodeId, query.maxDepth);
+      const result = ancestorRows.map((r) =>
+        rowToNode<T>({
+          node_id: r.node_id,
+          chain_id: r.chain_id,
+          parent_ids: r.parent_ids,
+          content_hash: r.content_hash,
+          data: r.data,
+          created_at: r.created_at,
+          metadata: r.metadata,
+        }),
+      );
+      return { ok: true, value: result };
+    } catch (e: unknown) {
+      return sqlError(e, "ancestors");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // fork
+  // -----------------------------------------------------------------------
+
+  const fork = (
+    sourceNodeId: NodeId,
+    newChainId: ChainId,
+    label: string,
+  ): Result<ForkRef, KoiError> => {
+    try {
+      ensureOpen();
+      const sourceRow = selectNodeStmt.get(sourceNodeId);
+      if (sourceRow === null) {
+        return {
+          ok: false,
+          error: notFound(sourceNodeId, `Source node not found: ${sourceNodeId}`),
+        };
+      }
+
+      const seq = nextSeq(newChainId);
+
+      db.transaction(() => {
+        insertMemberStmt.run({
+          $chain_id: newChainId,
+          $node_id: sourceNodeId,
+          $created_at: sourceRow.created_at,
+          $seq: seq,
+        });
+        upsertHeadStmt.run({ $chain_id: newChainId, $node_id: sourceNodeId });
+      })();
+
+      chainHeads.set(newChainId, sourceNodeId);
+
+      return { ok: true, value: { parentNodeId: sourceNodeId, label } };
+    } catch (e: unknown) {
+      return sqlError(e, "fork");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // prune (chain prune + mark-and-sweep blob GC)
+  // -----------------------------------------------------------------------
+
+  const prune = (cid: ChainId, policy: PruningPolicy): Result<number, KoiError> => {
+    try {
+      ensureOpen();
+      const rows = selectChainNodesStmt.all(cid);
+      if (rows.length === 0) {
+        return { ok: true, value: 0 };
+      }
+
+      const now = Date.now();
+      const toRemove = new Set<number>();
+
+      // retainCount: keep the newest N (rows are newest-first), drop the rest.
+      if (policy.retainCount !== undefined && rows.length > policy.retainCount) {
+        for (let i = policy.retainCount; i < rows.length; i++) {
+          toRemove.add(i);
+        }
+      }
+
+      // retainDuration: drop nodes older than the cutoff.
+      if (policy.retainDuration !== undefined) {
+        const cutoff = now - policy.retainDuration;
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          if (row !== undefined && row.created_at < cutoff) {
+            toRemove.add(i);
+          }
+        }
+      }
+
+      // Protect head if retainBranches !== false (default true). Index 0 is
+      // the newest = the chain head.
+      if (policy.retainBranches !== false) {
+        toRemove.delete(0);
+      }
+
+      let removedCount = 0;
+
+      db.transaction(() => {
+        for (const idx of toRemove) {
+          const row = rows[idx];
+          if (row === undefined) continue;
+          const nid = row.node_id;
+
+          // Drop this chain's membership for the node.
+          deleteMemberStmt.run(cid, nid);
+
+          // If no other chain references the node, delete it entirely so
+          // mark-and-sweep can pick up its blobs.
+          const refRow = countMemberRefsStmt.get(nid);
+          const totalRefs = refRow?.cnt ?? 0;
+          if (totalRefs === 0) {
+            deleteNodeStmt.run(nid);
+          }
+
+          removedCount += 1;
+        }
+
+        // Update head pointer if it changed:
+        // - all members removed → drop head row
+        // - head member removed → point to newest survivor (or drop)
+        if (removedCount === rows.length) {
+          deleteHeadStmt.run(cid);
+          chainHeads.delete(cid);
+        } else if (toRemove.has(0)) {
+          const newHeadRow = selectNewestSurvivorStmt.get(cid);
+          if (newHeadRow !== null) {
+            upsertHeadStmt.run({ $chain_id: cid, $node_id: newHeadRow.node_id });
+            chainHeads.set(cid, newHeadRow.node_id);
+          } else {
+            deleteHeadStmt.run(cid);
+            chainHeads.delete(cid);
+          }
+        }
+      })();
+
+      // Mark-and-sweep blob GC. Runs OUTSIDE the transaction because
+      // filesystem ops cannot be rolled back by SQL. Idempotent — a crash
+      // mid-sweep just leaves orphan blobs for the next prune to clean up.
+      if (config.blobDir !== undefined && config.extractBlobRefs !== undefined) {
+        sweepOrphanBlobs(db, config.blobDir, config.extractBlobRefs);
+      }
+
+      return { ok: true, value: removedCount };
+    } catch (e: unknown) {
+      return sqlError(e, "prune");
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // close
+  // -----------------------------------------------------------------------
+
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    chainHeads.clear();
+    chainSeqs.clear();
+    db.close();
+  };
+
+  return {
+    put,
+    get: getNode,
+    head,
+    list,
+    ancestors,
+    fork,
+    prune,
+    close,
+  };
+}

--- a/packages/lib/snapshot-store-sqlite/src/types.ts
+++ b/packages/lib/snapshot-store-sqlite/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Configuration types for the SQLite snapshot store.
+ */
+
+/**
+ * Configuration for `createSnapshotStoreSqlite`.
+ *
+ * The store is generic over the payload type `T`. If `blobDir` and
+ * `extractBlobRefs` are both provided, the store will sweep orphan blobs
+ * during `prune()` (mark-and-sweep GC). Otherwise blob GC is skipped.
+ */
+export interface SqliteSnapshotStoreConfig<T> {
+  /**
+   * Path to the SQLite database file. Use `":memory:"` for in-memory tests.
+   */
+  readonly path: string;
+
+  /**
+   * Optional content-addressed blob directory. If set, prune sweeps it for
+   * orphan blobs not referenced by any live snapshot.
+   *
+   * The store does NOT read or write blob *contents* — that is the consumer's
+   * responsibility (e.g., `@koi/checkpoint` writes blobs to CAS). The store
+   * only owns the directory listing during GC.
+   */
+  readonly blobDir?: string;
+
+  /**
+   * Function used by GC to extract blob hashes from a payload. Required if
+   * `blobDir` is set; ignored otherwise.
+   */
+  readonly extractBlobRefs?: (data: T) => readonly string[];
+
+  /**
+   * Durability level.
+   * - `"process"` (default): `synchronous=NORMAL`. Survives app crashes.
+   * - `"os"`: `synchronous=FULL`. Survives OS crashes and power loss.
+   *
+   * Both modes use WAL journal mode.
+   */
+  readonly durability?: "process" | "os";
+}

--- a/packages/lib/snapshot-store-sqlite/tsconfig.json
+++ b/packages/lib/snapshot-store-sqlite/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../kernel/core"
+    },
+    {
+      "path": "../hash"
+    }
+  ]
+}

--- a/packages/lib/snapshot-store-sqlite/tsup.config.ts
+++ b/packages/lib/snapshot-store-sqlite/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  // bun:sqlite is a Bun built-in — esbuild can't resolve it, so mark external.
+  external: ["bun:sqlite"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -50,6 +50,7 @@ export const L2_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/session",
   "@koi/skill-tool",
   "@koi/skills-runtime",
+  "@koi/snapshot-store-sqlite",
   "@koi/task-tools",
   "@koi/tasks",
   "@koi/tools-bash",


### PR DESCRIPTION
## Summary

Second PR for #1625. Adds the L2 storage adapter `@koi/snapshot-store-sqlite` that implements `SnapshotChainStore<T>` from `@koi/core` over SQLite. Stacks on top of #1665 (L0 schema + doc-gate).

| # | Scope | Status |
|---|---|---|
| 1 | L0 schema + L2 doc-gate | #1665 |
| 2 | `@koi/snapshot-store-sqlite` (storage adapter) | **this PR** |
| 3 | `@koi/checkpoint` (capture middleware + `/rewind` UX) | follow-up |

## What this delivers

Generic over the payload type `T`, so it serves both `@koi/checkpoint` (with `T = AgentSnapshot`) and the deterministic-replay sibling. Ports the v1 SQLite chain store from `archive/v1/packages/mm/snapshot-chain-store/` with three improvements driven by the design review:

1. **Recursive CTE for ancestor walks** (Issue 16A) — replaces v1's BFS-with-N+1 queries. Single SQL round-trip regardless of depth. `UNION` (not `UNION ALL`) collapses DAG diamonds. Lives in `cte.ts`.

2. **Mark-and-sweep blob GC integrated into prune** (Issue 13A) — when the consumer supplies `blobDir` + `extractBlobRefs`, prune walks the live snapshot set, builds a referenced-hash set, and deletes any blob in the directory whose hash is not in the set. Idempotent, crash-safe via re-run convergence. Supports both flat and sharded directory layouts. Lives in `gc.ts`.

3. **`parent_ids` as a JSON array column on `snapshot_nodes`** rather than a separate `snapshot_parents` bridge table — required so the recursive CTE can use `json_each()` in a single statement.

## Implementation notes

- The factory returns `SqliteSnapshotStore<T>`, a sync-narrowed view of `SnapshotChainStore<T>` built via a small TypeScript mapped type that unwraps the L0 sync-or-async return union. **Zero method-signature duplication** — the type derives from L0. Structurally compatible with the L0 union interface, so callers can upcast for portability.
- `snapshot_nodes.chain_id` records the *home chain* — the chain a node was originally `put` into. Returned by `get()` so `SnapshotNode<T>.chainId` always has a meaningful value, even after forks add the node to other chains via `chain_members`.
- `bun:sqlite` is a Bun built-in (not an npm dep) so `tsup.config.ts` marks it external.
- `@koi/snapshot-store-sqlite` added to `L2_PACKAGES` in `scripts/layers.ts`.
- `docs/L2/snapshot-store-sqlite.md` (introduced in #1665) updated to reflect the actual schema (now includes `chain_id` column) and the `SqliteSnapshotStore<T>` sync-narrowed type.

## Tests — 37 total, 0 fail

| Suite | What | Tests |
|---|---|---|
| `contract.test.ts` | Port of v1 contract suite — put/get/head, list ordering, parent validation, skipIfUnchanged dedup, ancestors walk, fork, prune (retainCount/retainDuration/head protection/retainBranches=false), close, post-close rejection | 14 |
| `cte.test.ts` | Linear chain, deep chain (50 nodes), DAG diamond dedup, maxDepth clipping. Pins UNION-not-UNION-ALL semantics | 4 |
| `gc.test.ts` | All-orphan, none-orphan, partial, head-protected, GC-disabled-without-blobDir, sharded layout | 6 |
| `transactions.test.ts` | VALIDATION before write, reopen survives process boundary, FK-violation rollback, head never points at deleted node after prune | 4 |
| `negative.test.ts` | NOT_FOUND on missing node/start/source, empty list/head on missing chain, empty prune, post-close rejection on every method, GC tolerates missing blob dir | 9 |

## Test plan

- [x] `bun run --filter '@koi/snapshot-store-sqlite' typecheck` clean
- [x] `bun run --filter '@koi/snapshot-store-sqlite' lint` clean
- [x] `bun run --filter '@koi/snapshot-store-sqlite' test` — 37 pass, 0 fail
- [x] `bun run --filter '@koi/snapshot-store-sqlite' build` clean (tsup ESM + DTS)
- [x] `bun run check:layers` passes
- [x] `bun run --filter '@koi/core' test` still 826/0 (no regression)
- [ ] CI green

## Note on PR ordering

This PR is **stacked on #1665**. Merge #1665 first, then this. After #1665 merges, GitHub will auto-update this PR's base to `main`. The two are functionally independent — `@koi/snapshot-store-sqlite` doesn't import any of the new L0 types from #1665 — but the doc tweak to `docs/L2/snapshot-store-sqlite.md` here builds on the rewritten doc from #1665, so stacking avoids a merge conflict.