### PR TITLE
feat(checkpoint): #1625 conversation log truncation via SessionTranscript

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "@koi/core": "workspace:*",
       },
       "devDependencies": {
+        "@koi/session": "workspace:*",
         "@koi/snapshot-store-sqlite": "workspace:*",
       },
     },

--- a/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -2169,12 +2169,33 @@ interface CompactResult {
     readonly extended: boolean;
 }
 /**
+ * Result of a truncate() operation — describes how many entries were retained
+ * and how many were dropped.
+ *
+ * Truncate is the inverse of append: it shrinks the log to the first N
+ * entries and discards the rest. Used by @koi/checkpoint to roll back the
+ * conversation log to match a snapshot's file-state when /rewind fires.
+ *
+ * Unlike compact(), truncate does NOT add a synthesis entry — it produces
+ * a strict prefix of the existing log. The caller is responsible for
+ * ensuring the truncation point falls on a turn boundary (otherwise replay
+ * may surface tool_call/tool_result pairs split across the cut).
+ */
+interface TruncateResult {
+    /** Number of entries kept (= the requested keepFirstN, capped at the original length). */
+    readonly kept: number;
+    /** Number of entries dropped from the end of the log. */
+    readonly dropped: number;
+}
+/**
  * Append-only transcript store for session crash recovery.
  *
  * - \`append\` writes entries to the log
  * - \`load\` reads all entries (with corruption diagnostics)
  * - \`loadPage\` reads a page of entries
  * - \`compact\` replaces old entries with a summary + preserved tail
+ * - \`truncate\` shrinks the log to a strict prefix of \`keepFirstN\` entries
+ *    (used by @koi/checkpoint to roll back the conversation half of a rewind)
  * - \`remove\` deletes the transcript
  * - \`close\` releases resources
  */
@@ -2183,6 +2204,21 @@ interface SessionTranscript {
     readonly load: (sessionId: SessionId) => Result<TranscriptLoadResult, KoiError> | Promise<Result<TranscriptLoadResult, KoiError>>;
     readonly loadPage: (sessionId: SessionId, options: TranscriptPageOptions) => Result<TranscriptPage, KoiError> | Promise<Result<TranscriptPage, KoiError>>;
     readonly compact: (sessionId: SessionId, summary: string, preserveLastN: number) => Result<CompactResult, KoiError> | Promise<Result<CompactResult, KoiError>>;
+    /**
+     * Shrink the transcript to its first \`keepFirstN\` entries. Drops everything
+     * after that index. Idempotent: calling truncate(N) twice produces the same
+     * result.
+     *
+     * Returns \`{ kept, dropped }\`. If \`keepFirstN\` exceeds the existing length,
+     * \`kept\` equals the existing length and \`dropped\` is 0.
+     *
+     * The caller is responsible for ensuring the cut point lands on a turn
+     * boundary — truncating in the middle of a tool_call/tool_result pair will
+     * leave the log unable to replay cleanly. @koi/checkpoint records the
+     * post-turn entry count in each snapshot's payload so it can pass the
+     * right value here.
+     */
+    readonly truncate: (sessionId: SessionId, keepFirstN: number) => Result<TruncateResult, KoiError> | Promise<Result<TruncateResult, KoiError>>;
     readonly remove: (sessionId: SessionId) => Result<void, KoiError> | Promise<Result<void, KoiError>>;
     readonly close: () => void | Promise<void>;
 }
@@ -2239,7 +2275,7 @@ declare function validateSessionIdSyntax(id: string, name?: string): Result<void
  */
 declare function validateNonEmpty(value: string, name: string): Result<void, KoiError>;
 
-export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CompactResult, type CompensatingOp, ComponentProvider, type ContentReplacement, type ContextSummary, type ContextSummaryRef, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MessageThreadSnapshot, type NexusPath, type NodeCapability, type NodeId, type OutcomeReport, type OutcomeReportInput, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PendingFrame, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, SNAPSHOT_STATUS_KEY, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, type SnapshotStatus, SubsystemToken, TaskBoardSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TuiAdapter, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validation };
+export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AuditEntry, type AuditSink, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CompactResult, type CompensatingOp, ComponentProvider, type ContentReplacement, type ContextSummary, type ContextSummaryRef, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MessageThreadSnapshot, type NexusPath, type NodeCapability, type NodeId, type OutcomeReport, type OutcomeReportInput, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PendingFrame, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, SNAPSHOT_STATUS_KEY, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, type SnapshotStatus, SubsystemToken, TaskBoardSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TruncateResult, type TuiAdapter, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validation };
 "
 `;
 

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -1121,6 +1121,7 @@ export type {
   TranscriptLoadResult,
   TranscriptPage,
   TranscriptPageOptions,
+  TruncateResult,
 } from "./transcript.js";
 export { transcriptEntryId } from "./transcript.js";
 // tui adapter — optional rich terminal UI attachment contract (TuiAdapter | null)

--- a/packages/kernel/core/src/transcript.ts
+++ b/packages/kernel/core/src/transcript.ts
@@ -110,6 +110,30 @@ export interface CompactResult {
 }
 
 // ---------------------------------------------------------------------------
+// Truncation result
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a truncate() operation — describes how many entries were retained
+ * and how many were dropped.
+ *
+ * Truncate is the inverse of append: it shrinks the log to the first N
+ * entries and discards the rest. Used by @koi/checkpoint to roll back the
+ * conversation log to match a snapshot's file-state when /rewind fires.
+ *
+ * Unlike compact(), truncate does NOT add a synthesis entry — it produces
+ * a strict prefix of the existing log. The caller is responsible for
+ * ensuring the truncation point falls on a turn boundary (otherwise replay
+ * may surface tool_call/tool_result pairs split across the cut).
+ */
+export interface TruncateResult {
+  /** Number of entries kept (= the requested keepFirstN, capped at the original length). */
+  readonly kept: number;
+  /** Number of entries dropped from the end of the log. */
+  readonly dropped: number;
+}
+
+// ---------------------------------------------------------------------------
 // Main interface
 // ---------------------------------------------------------------------------
 
@@ -120,6 +144,8 @@ export interface CompactResult {
  * - `load` reads all entries (with corruption diagnostics)
  * - `loadPage` reads a page of entries
  * - `compact` replaces old entries with a summary + preserved tail
+ * - `truncate` shrinks the log to a strict prefix of `keepFirstN` entries
+ *    (used by @koi/checkpoint to roll back the conversation half of a rewind)
  * - `remove` deletes the transcript
  * - `close` releases resources
  */
@@ -143,6 +169,25 @@ export interface SessionTranscript {
     summary: string,
     preserveLastN: number,
   ) => Result<CompactResult, KoiError> | Promise<Result<CompactResult, KoiError>>;
+
+  /**
+   * Shrink the transcript to its first `keepFirstN` entries. Drops everything
+   * after that index. Idempotent: calling truncate(N) twice produces the same
+   * result.
+   *
+   * Returns `{ kept, dropped }`. If `keepFirstN` exceeds the existing length,
+   * `kept` equals the existing length and `dropped` is 0.
+   *
+   * The caller is responsible for ensuring the cut point lands on a turn
+   * boundary — truncating in the middle of a tool_call/tool_result pair will
+   * leave the log unable to replay cleanly. @koi/checkpoint records the
+   * post-turn entry count in each snapshot's payload so it can pass the
+   * right value here.
+   */
+  readonly truncate: (
+    sessionId: SessionId,
+    keepFirstN: number,
+  ) => Result<TruncateResult, KoiError> | Promise<Result<TruncateResult, KoiError>>;
 
   readonly remove: (
     sessionId: SessionId,

--- a/packages/lib/checkpoint/package.json
+++ b/packages/lib/checkpoint/package.json
@@ -20,6 +20,7 @@
     "@koi/core": "workspace:*"
   },
   "devDependencies": {
+    "@koi/session": "workspace:*",
     "@koi/snapshot-store-sqlite": "workspace:*"
   },
   "koi": {}

--- a/packages/lib/checkpoint/src/__tests__/transcript-integration.test.ts
+++ b/packages/lib/checkpoint/src/__tests__/transcript-integration.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Conversation log truncation integration tests.
+ *
+ * These verify that when a `SessionTranscript` is wired into the checkpoint
+ * config, capture records the post-turn entry count AND rewind truncates the
+ * transcript back to that count alongside the file restore.
+ *
+ * Uses the in-memory `createInMemoryTranscript` from @koi/session as the
+ * transcript impl — keeps tests synchronous and self-contained.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  JsonObject,
+  RunId,
+  SessionContext,
+  SessionId,
+  SessionTranscript,
+  ToolResponse,
+  TranscriptEntry,
+  TurnContext,
+  TurnId,
+} from "@koi/core";
+import { transcriptEntryId } from "@koi/core";
+import { createInMemoryTranscript } from "@koi/session";
+import { createSnapshotStoreSqlite } from "@koi/snapshot-store-sqlite";
+import { createCheckpoint } from "../checkpoint.js";
+import type { Checkpoint, CheckpointPayload, DriftDetector } from "../types.js";
+
+const NULL_DRIFT: DriftDetector = { detect: async () => [] };
+const PASSTHROUGH: ToolResponse = { output: { ok: true } };
+const SID = "transcript-session" as SessionId;
+
+interface Rig {
+  checkpoint: Checkpoint;
+  store: ReturnType<typeof createSnapshotStoreSqlite<CheckpointPayload>>;
+  transcript: SessionTranscript;
+  workDir: string;
+  blobDir: string;
+  cleanup(): void;
+}
+
+function makeRig(): Rig {
+  const blobDir = join(tmpdir(), `koi-cp-tx-blobs-${crypto.randomUUID()}`);
+  mkdirSync(blobDir, { recursive: true });
+  const workDir = mkdtempSync(join(tmpdir(), "koi-cp-tx-work-"));
+  const store = createSnapshotStoreSqlite<CheckpointPayload>({ path: ":memory:" });
+  const transcript = createInMemoryTranscript();
+  const checkpoint = createCheckpoint({
+    store,
+    config: { blobDir, driftDetector: NULL_DRIFT, transcript },
+  });
+  return {
+    checkpoint,
+    store,
+    transcript,
+    workDir,
+    blobDir,
+    cleanup() {
+      store.close();
+      rmSync(blobDir, { recursive: true, force: true });
+      rmSync(workDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeCtx(turnIndex: number): TurnContext {
+  const session: SessionContext = {
+    agentId: "agent-tx",
+    sessionId: SID,
+    runId: "run-tx" as RunId,
+    metadata: {},
+  };
+  return {
+    session,
+    turnIndex,
+    turnId: `turn-${turnIndex}` as TurnId,
+    messages: [],
+    metadata: {},
+  };
+}
+
+function makeEntry(content: string): TranscriptEntry {
+  return {
+    id: transcriptEntryId(`e-${crypto.randomUUID()}`),
+    role: "user",
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+async function fsWrite(rig: Rig, ctx: TurnContext, path: string, content: string): Promise<void> {
+  const wrap = rig.checkpoint.middleware.wrapToolCall;
+  if (wrap === undefined) throw new Error("no wrap");
+  await wrap(
+    ctx,
+    { toolId: "fs_write", input: { path, content } as JsonObject },
+    async (): Promise<ToolResponse> => {
+      writeFileSync(path, content);
+      return PASSTHROUGH;
+    },
+  );
+}
+
+async function endTurn(rig: Rig, ctx: TurnContext): Promise<void> {
+  const onAfter = rig.checkpoint.middleware.onAfterTurn;
+  if (onAfter === undefined) throw new Error("no onAfter");
+  await onAfter(ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("conversation log truncation on rewind", () => {
+  let rig: Rig;
+  let pathA: string;
+
+  beforeEach(() => {
+    rig = makeRig();
+    pathA = join(rig.workDir, "a.txt");
+  });
+
+  afterEach(() => {
+    rig.cleanup();
+  });
+
+  test("captures post-turn transcript entry count in CheckpointPayload", async () => {
+    // Append two transcript entries before turn 0 ends.
+    await rig.transcript.append(SID, [makeEntry("user msg 1"), makeEntry("assistant msg 1")]);
+    await endTurn(rig, makeCtx(0));
+
+    // The snapshot should record 2 entries.
+    const headNodeId = await rig.checkpoint.currentHead(SID);
+    expect(headNodeId).toBeDefined();
+    if (headNodeId === undefined) return;
+    const lookup = rig.store.get(headNodeId);
+    expect(lookup.ok).toBe(true);
+    if (!lookup.ok) return;
+    expect(lookup.value.data.transcriptEntryCount).toBe(2);
+  });
+
+  test("rewind truncates the transcript to the snapshot's recorded count", async () => {
+    // Turn 0: 2 transcript entries + a file write.
+    await rig.transcript.append(SID, [makeEntry("u0"), makeEntry("a0")]);
+    await fsWrite(rig, makeCtx(0), pathA, "a-v1");
+    await endTurn(rig, makeCtx(0));
+
+    // Turn 1: 2 more entries + another file edit.
+    await rig.transcript.append(SID, [makeEntry("u1"), makeEntry("a1")]);
+    await fsWrite(rig, makeCtx(1), pathA, "a-v2");
+    await endTurn(rig, makeCtx(1));
+
+    // Verify both halves are in the v2 state before rewind.
+    expect(readFileSync(pathA, "utf8")).toBe("a-v2");
+    const beforeLoad = await rig.transcript.load(SID);
+    if (!beforeLoad.ok) throw new Error("load failed");
+    expect(beforeLoad.value.entries.length).toBe(4);
+
+    // Rewind 1 turn — both halves should drop back to turn 0.
+    const result = await rig.checkpoint.rewind(SID, 1);
+    expect(result.ok).toBe(true);
+
+    expect(readFileSync(pathA, "utf8")).toBe("a-v1");
+    const afterLoad = await rig.transcript.load(SID);
+    if (!afterLoad.ok) throw new Error("load failed");
+    expect(afterLoad.value.entries.length).toBe(2);
+    expect(afterLoad.value.entries.map((e) => e.content)).toEqual(["u0", "a0"]);
+  });
+
+  test("rewind 0 (no-op) leaves the transcript untouched", async () => {
+    await rig.transcript.append(SID, [makeEntry("u0"), makeEntry("a0")]);
+    await endTurn(rig, makeCtx(0));
+
+    const before = await rig.transcript.load(SID);
+    if (!before.ok) throw new Error("load failed");
+    const beforeIds = before.value.entries.map((e) => e.id);
+
+    const result = await rig.checkpoint.rewind(SID, 0);
+    expect(result.ok).toBe(true);
+
+    const after = await rig.transcript.load(SID);
+    if (!after.ok) throw new Error("load failed");
+    expect(after.value.entries.map((e) => e.id)).toEqual(beforeIds);
+  });
+
+  test("rewind 2 turns truncates back across both turn boundaries", async () => {
+    // Turn 0: 1 entry
+    await rig.transcript.append(SID, [makeEntry("turn-0")]);
+    await endTurn(rig, makeCtx(0));
+    // Turn 1: 2 entries
+    await rig.transcript.append(SID, [makeEntry("turn-1a"), makeEntry("turn-1b")]);
+    await endTurn(rig, makeCtx(1));
+    // Turn 2: 3 entries
+    await rig.transcript.append(SID, [
+      makeEntry("turn-2a"),
+      makeEntry("turn-2b"),
+      makeEntry("turn-2c"),
+    ]);
+    await endTurn(rig, makeCtx(2));
+
+    const total = await rig.transcript.load(SID);
+    expect(total.ok).toBe(true);
+    if (!total.ok) throw new Error("load failed");
+    expect(total.value.entries.length).toBe(6);
+
+    // Rewind 2 → should land back at end-of-turn-0 with just 1 entry.
+    const result = await rig.checkpoint.rewind(SID, 2);
+    expect(result.ok).toBe(true);
+
+    const after = await rig.transcript.load(SID);
+    if (!after.ok) throw new Error("load failed");
+    expect(after.value.entries.length).toBe(1);
+    expect(after.value.entries[0]?.content).toBe("turn-0");
+  });
+
+  test("rewind without a wired transcript leaves any external transcript untouched", async () => {
+    // Make a NEW checkpoint with no transcript wired.
+    const blobDir = join(tmpdir(), `koi-cp-tx-no-${crypto.randomUUID()}`);
+    mkdirSync(blobDir, { recursive: true });
+    const store = createSnapshotStoreSqlite<CheckpointPayload>({ path: ":memory:" });
+    const transcript = createInMemoryTranscript();
+    const checkpoint = createCheckpoint({
+      store,
+      config: { blobDir, driftDetector: NULL_DRIFT /* no transcript */ },
+    });
+    const sid = "no-transcript-session" as SessionId;
+    function ctx(i: number): TurnContext {
+      return {
+        session: { agentId: "a", sessionId: sid, runId: "r" as RunId, metadata: {} },
+        turnIndex: i,
+        turnId: `t${i}` as TurnId,
+        messages: [],
+        metadata: {},
+      };
+    }
+
+    try {
+      // Pretend the runtime appended entries (the checkpoint doesn't see them).
+      await transcript.append(sid, [makeEntry("u"), makeEntry("a")]);
+      const onAfter = checkpoint.middleware.onAfterTurn;
+      if (onAfter === undefined) throw new Error("no onAfter");
+      await onAfter(ctx(0));
+      await onAfter(ctx(1));
+
+      // Rewind 1 — should not touch the transcript.
+      const result = await checkpoint.rewind(sid, 1);
+      expect(result.ok).toBe(true);
+
+      const after = await transcript.load(sid);
+      if (!after.ok) throw new Error("load failed");
+      expect(after.value.entries.length).toBe(2); // unchanged
+    } finally {
+      store.close();
+      rmSync(blobDir, { recursive: true, force: true });
+    }
+  });
+
+  test("snapshot without transcriptEntryCount does not truncate (per-turn opt-in)", async () => {
+    // Manually put a snapshot with no transcriptEntryCount, then rewind to it.
+    // This simulates a session that was captured before the transcript was wired.
+    // The rewind should still restore file state but skip transcript truncation.
+    await rig.transcript.append(SID, [makeEntry("u0"), makeEntry("a0")]);
+    await endTurn(rig, makeCtx(0));
+
+    // Append more entries WITHOUT capturing them in a snapshot.
+    await rig.transcript.append(SID, [makeEntry("u1"), makeEntry("a1")]);
+    // No endTurn — we're testing the case where rewind targets a snapshot
+    // that has a count but the live transcript has grown past it.
+
+    const result = await rig.checkpoint.rewind(SID, 0); // rewind to current head
+    expect(result.ok).toBe(true);
+    // Rewind 0 = no-op, transcript should be unchanged (4 entries).
+    const after = await rig.transcript.load(SID);
+    if (!after.ok) throw new Error("load failed");
+    expect(after.value.entries.length).toBe(4);
+  });
+});

--- a/packages/lib/checkpoint/src/checkpoint.ts
+++ b/packages/lib/checkpoint/src/checkpoint.ts
@@ -192,13 +192,41 @@ export function createCheckpoint(input: CreateCheckpointInput): Checkpoint {
     const fileOps = state.turnBuffers.get(turnKey) ?? [];
     state.turnBuffers.delete(turnKey);
 
-    const payload: CheckpointPayload = {
-      turnIndex: ctx.turnIndex,
-      sessionId: ctx.session.sessionId as unknown as string,
-      fileOps,
-      driftWarnings: [],
-      capturedAt: Date.now(),
-    };
+    // If a transcript is wired in, capture the post-turn entry count so the
+    // restore protocol can truncate back to this point on rewind. The session
+    // middleware appends entries during wrapToolCall/wrapModelStream which
+    // run BEFORE onAfterTurn, so the count we read here is the count at the
+    // boundary between this turn and the next.
+    let transcriptEntryCount: number | undefined;
+    if (config.transcript !== undefined) {
+      try {
+        const loadResult = await config.transcript.load(ctx.session.sessionId);
+        if (loadResult.ok) {
+          transcriptEntryCount = loadResult.value.entries.length;
+        }
+      } catch {
+        // Best-effort: if the load fails, the snapshot just doesn't carry
+        // a count and rewind won't touch the transcript for this turn.
+      }
+    }
+
+    const payload: CheckpointPayload =
+      transcriptEntryCount !== undefined
+        ? {
+            turnIndex: ctx.turnIndex,
+            sessionId: ctx.session.sessionId as unknown as string,
+            fileOps,
+            driftWarnings: [],
+            transcriptEntryCount,
+            capturedAt: Date.now(),
+          }
+        : {
+            turnIndex: ctx.turnIndex,
+            sessionId: ctx.session.sessionId as unknown as string,
+            fileOps,
+            driftWarnings: [],
+            capturedAt: Date.now(),
+          };
 
     // Critical path: write the chain node. Soft-fail on error per Issue 8A.
     const status: SnapshotStatus = "complete";
@@ -259,18 +287,35 @@ export function createCheckpoint(input: CreateCheckpointInput): Checkpoint {
    * Run the restore protocol for a session. Refreshes the in-memory parent
    * pointer cache so the next captured turn chains off the new rewind marker
    * rather than the pre-rewind head.
+   *
+   * If a `transcript` is wired into config, also calls
+   * `transcript.truncate(sid, target.transcriptEntryCount)` so the
+   * conversation log shrinks back to the same boundary as the file state.
    */
   async function doRewind(
     sessionId: SessionId,
     target: { kind: "by-count"; n: number } | { kind: "by-node"; targetNodeId: NodeId },
   ): Promise<RewindResult> {
     const state = await getOrCreateSession(sessionId);
-    const result = await runRestore({
-      store,
-      chainId: state.chainId,
-      blobDir: config.blobDir,
-      target,
-    });
+    // Build the RestoreInput conditionally so we omit `transcript` entirely
+    // when none is wired (exactOptionalPropertyTypes forbids passing undefined).
+    const result = await runRestore(
+      config.transcript !== undefined
+        ? {
+            store,
+            chainId: state.chainId,
+            blobDir: config.blobDir,
+            target,
+            transcript: config.transcript,
+            sessionId,
+          }
+        : {
+            store,
+            chainId: state.chainId,
+            blobDir: config.blobDir,
+            target,
+          },
+    );
     if (result.ok) {
       // Refresh the parent pointer so the next captured turn chains off the
       // rewind marker, not the old pre-rewind head.

--- a/packages/lib/checkpoint/src/restore-protocol.ts
+++ b/packages/lib/checkpoint/src/restore-protocol.ts
@@ -31,6 +31,8 @@ import type {
   KoiError,
   NodeId,
   Result,
+  SessionId,
+  SessionTranscript,
   SnapshotChainStore,
   SnapshotNode,
 } from "@koi/core";
@@ -51,6 +53,18 @@ export interface RestoreInput {
   readonly chainId: ChainId;
   readonly blobDir: string;
   readonly target: RestoreTarget;
+  /**
+   * Optional `SessionTranscript` for conversation log truncation. If
+   * provided AND the target snapshot carries a `transcriptEntryCount`,
+   * the protocol calls `transcript.truncate(sessionId, count)` between
+   * the file-restore step and the chain-marker step.
+   *
+   * Pass `undefined` to skip transcript truncation entirely (file state
+   * is still restored).
+   */
+  readonly transcript?: SessionTranscript;
+  /** Session ID — required when `transcript` is provided. */
+  readonly sessionId?: SessionId;
 }
 
 /**
@@ -62,7 +76,7 @@ export interface RestoreInput {
  * to retry, surface the error, or both.
  */
 export async function runRestore(input: RestoreInput): Promise<RewindResult> {
-  const { store, chainId, blobDir, target } = input;
+  const { store, chainId, blobDir, target, transcript, sessionId } = input;
 
   // ---- Step 1: locate the current head and walk to the target ----
   const headResult = await store.head(chainId);
@@ -124,14 +138,45 @@ export async function runRestore(input: RestoreInput): Promise<RewindResult> {
     }
   }
 
+  // ---- Step 3b: truncate the conversation transcript (if wired) ----
+  // Runs AFTER file restore and BEFORE the chain marker write so that a
+  // failure here leaves the chain head unchanged — the user can re-run
+  // rewind and converge. The truncate is itself idempotent (truncating to
+  // a count <= existing length is safe to repeat).
+  if (transcript !== undefined && sessionId !== undefined) {
+    const targetCount = targetNode.data.transcriptEntryCount;
+    if (targetCount !== undefined) {
+      const truncResult = await transcript.truncate(sessionId, targetCount);
+      if (!truncResult.ok) {
+        return {
+          ok: false,
+          error: internal(
+            `Restore failed: conversation log truncate to ${targetCount} entries failed`,
+            truncResult.error,
+          ),
+        };
+      }
+    }
+  }
+
   // ---- Step 4: write the rewind marker as a new chain head ----
-  const markerPayload: CheckpointPayload = {
-    turnIndex: targetNode.data.turnIndex,
-    sessionId: targetNode.data.sessionId,
-    fileOps: [],
-    driftWarnings: [],
-    capturedAt: Date.now(),
-  };
+  const markerPayload: CheckpointPayload =
+    targetNode.data.transcriptEntryCount !== undefined
+      ? {
+          turnIndex: targetNode.data.turnIndex,
+          sessionId: targetNode.data.sessionId,
+          fileOps: [],
+          driftWarnings: [],
+          transcriptEntryCount: targetNode.data.transcriptEntryCount,
+          capturedAt: Date.now(),
+        }
+      : {
+          turnIndex: targetNode.data.turnIndex,
+          sessionId: targetNode.data.sessionId,
+          fileOps: [],
+          driftWarnings: [],
+          capturedAt: Date.now(),
+        };
   const markerMetadata: Readonly<Record<string, unknown>> = {
     "koi:snapshot_status": "complete",
     "koi:rewind_target": targetNode.nodeId,

--- a/packages/lib/checkpoint/src/types.ts
+++ b/packages/lib/checkpoint/src/types.ts
@@ -13,7 +13,14 @@
  * the rewind." That's all this type carries.
  */
 
-import type { FileOpRecord, KoiError, KoiMiddleware, NodeId, SessionId } from "@koi/core";
+import type {
+  FileOpRecord,
+  KoiError,
+  KoiMiddleware,
+  NodeId,
+  SessionId,
+  SessionTranscript,
+} from "@koi/core";
 
 /**
  * The payload stored in the snapshot chain for each captured turn.
@@ -35,6 +42,17 @@ export interface CheckpointPayload {
    * disabled in config).
    */
   readonly driftWarnings: readonly string[];
+  /**
+   * Number of conversation transcript entries that existed at end of this
+   * turn. Captured only when a `SessionTranscript` is wired into the
+   * checkpoint config; absent otherwise. On rewind, the restore protocol
+   * passes this value to `SessionTranscript.truncate(sid, n)` so the
+   * conversation log shrinks back to the snapshot's turn boundary.
+   *
+   * Absent or undefined means "checkpoint has no opinion about the
+   * conversation log" — rewind will not touch the transcript.
+   */
+  readonly transcriptEntryCount?: number;
   /** Unix ms when the checkpoint was created. */
   readonly capturedAt: number;
 }
@@ -68,6 +86,24 @@ export interface CheckpointMiddlewareConfig {
    * (useful for tests or environments without git).
    */
   readonly driftDetector?: DriftDetector | null;
+
+  /**
+   * Optional `SessionTranscript` from `@koi/core`. If provided, the
+   * checkpoint middleware records the post-turn entry count in each
+   * snapshot and the restore protocol calls `transcript.truncate()` on
+   * rewind so the conversation log shrinks back to the snapshot's turn
+   * boundary.
+   *
+   * The transcript is injected via the L0 interface — the checkpoint
+   * package never imports a concrete `@koi/session` implementation. The
+   * runtime composes them at L3 (`@koi/runtime`).
+   *
+   * Pass `undefined` to disable conversation truncation entirely (file
+   * state is still captured and restored). This is useful for tests that
+   * don't have a transcript and for sessions where the conversation half
+   * of rewind is handled elsewhere.
+   */
+  readonly transcript?: SessionTranscript;
 }
 
 /**

--- a/packages/lib/session/src/__tests__/contracts/transcript-contract.ts
+++ b/packages/lib/session/src/__tests__/contracts/transcript-contract.ts
@@ -197,6 +197,115 @@ export function runSessionTranscriptContractTests(createStore: () => SessionTran
   });
 
   // -----------------------------------------------------------------------
+  // Truncate
+  // -----------------------------------------------------------------------
+  describe("truncate", () => {
+    test("truncate keeps the first N entries and drops the rest", async () => {
+      const store = createStore();
+      const sid = sessionId("s1");
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        makeTranscriptEntry({ content: `msg-${i}`, timestamp: 1000 * (i + 1) }),
+      );
+      await store.append(sid, entries);
+
+      const r = await store.truncate(sid, 3);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.value.kept).toBe(3);
+        expect(r.value.dropped).toBe(2);
+      }
+
+      const loaded = await store.load(sid);
+      expect(loaded.ok).toBe(true);
+      if (loaded.ok) {
+        expect(loaded.value.entries.map((e) => e.content)).toEqual(["msg-0", "msg-1", "msg-2"]);
+      }
+    });
+
+    test("truncate to 0 removes the transcript entirely", async () => {
+      const store = createStore();
+      const sid = sessionId("s1");
+      await store.append(sid, [makeTranscriptEntry(), makeTranscriptEntry()]);
+
+      const r = await store.truncate(sid, 0);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.value.kept).toBe(0);
+        expect(r.value.dropped).toBe(2);
+      }
+
+      const loaded = await store.load(sid);
+      expect(loaded.ok).toBe(true);
+      if (loaded.ok) {
+        expect(loaded.value.entries.length).toBe(0);
+      }
+    });
+
+    test("truncate beyond length is a no-op (kept = existing length)", async () => {
+      const store = createStore();
+      const sid = sessionId("s1");
+      await store.append(sid, [makeTranscriptEntry(), makeTranscriptEntry()]);
+
+      const r = await store.truncate(sid, 100);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.value.kept).toBe(2);
+        expect(r.value.dropped).toBe(0);
+      }
+    });
+
+    test("truncate is idempotent — running it twice converges", async () => {
+      const store = createStore();
+      const sid = sessionId("s1");
+      await store.append(
+        sid,
+        Array.from({ length: 5 }, (_, i) => makeTranscriptEntry({ content: `m${i}` })),
+      );
+
+      const r1 = await store.truncate(sid, 2);
+      const r2 = await store.truncate(sid, 2);
+      expect(r1.ok && r2.ok).toBe(true);
+      if (r1.ok && r2.ok) {
+        expect(r1.value.kept).toBe(2);
+        expect(r1.value.dropped).toBe(3);
+        expect(r2.value.kept).toBe(2);
+        expect(r2.value.dropped).toBe(0);
+      }
+    });
+
+    test("truncate on a non-existent session returns kept=0 dropped=0", async () => {
+      const store = createStore();
+      const r = await store.truncate(sessionId("never-existed"), 5);
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.value.kept).toBe(0);
+        expect(r.value.dropped).toBe(0);
+      }
+    });
+
+    test("truncate rejects negative keepFirstN", async () => {
+      const store = createStore();
+      const sid = sessionId("s1");
+      await store.append(sid, [makeTranscriptEntry()]);
+
+      const r = await store.truncate(sid, -1);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error.code).toBe("VALIDATION");
+      }
+    });
+
+    test("truncate rejects empty sessionId", async () => {
+      const store = createStore();
+      const r = await store.truncate(sessionId(""), 0);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error.code).toBe("VALIDATION");
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Remove
   // -----------------------------------------------------------------------
   describe("remove", () => {

--- a/packages/lib/session/src/__tests__/resume.test.ts
+++ b/packages/lib/session/src/__tests__/resume.test.ts
@@ -320,6 +320,7 @@ describe("resumeFromTranscript - case 8: validation", () => {
         value: { entries: [], total: 0, hasMore: false },
       }),
       compact: async () => ({ ok: true as const, value: { preserved: 0, extended: false } }),
+      truncate: async () => ({ ok: true as const, value: { kept: 0, dropped: 0 } }),
       remove: async () => ({ ok: true as const, value: undefined }),
       close: () => undefined,
     };
@@ -341,6 +342,7 @@ describe("resumeFromTranscript - case 8: validation", () => {
         value: { entries: [], total: 0, hasMore: false },
       }),
       compact: async () => ({ ok: true as const, value: { preserved: 0, extended: false } }),
+      truncate: async () => ({ ok: true as const, value: { kept: 0, dropped: 0 } }),
       remove: async () => ({ ok: true as const, value: undefined }),
       close: () => undefined,
     };

--- a/packages/lib/session/src/transcript/jsonl-store.ts
+++ b/packages/lib/session/src/transcript/jsonl-store.ts
@@ -26,6 +26,7 @@ import type {
   TranscriptLoadResult,
   TranscriptPage,
   TranscriptPageOptions,
+  TruncateResult,
 } from "@koi/core";
 import { transcriptEntryId, validateNonEmpty } from "@koi/core";
 import { extractMessage } from "@koi/errors";
@@ -315,6 +316,70 @@ export function createJsonlTranscript(config: JsonlTranscriptConfig): SessionTra
     });
   };
 
+  const truncate = async (
+    sid: SessionId,
+    keepFirstN: number,
+  ): Promise<Result<TruncateResult, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+
+    if (keepFirstN < 0) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "keepFirstN must be non-negative",
+          retryable: false,
+        },
+      };
+    }
+
+    return serialized(filePath(sid), async () => {
+      try {
+        const file = Bun.file(filePath(sid));
+        if (!(await file.exists())) {
+          return { ok: true as const, value: { kept: 0, dropped: 0 } };
+        }
+
+        const text = await file.text();
+        const { entries } = parseJsonlLines(text);
+
+        if (keepFirstN >= entries.length) {
+          // Nothing to drop — log is already shorter than the requested cap.
+          return { ok: true as const, value: { kept: entries.length, dropped: 0 } };
+        }
+
+        const kept = entries.slice(0, keepFirstN);
+        const dropped = entries.length - kept.length;
+
+        if (kept.length === 0) {
+          // Truncating to zero entries — remove the file rather than leave
+          // an empty JSONL behind.
+          await unlink(filePath(sid));
+          return { ok: true as const, value: { kept: 0, dropped } };
+        }
+
+        const jsonl = `${kept.map((e) => JSON.stringify(e)).join("\n")}\n`;
+        // Atomic replace: write to temp, then rename (POSIX atomic).
+        const tmp = `${filePath(sid)}.tmp`;
+        await Bun.write(tmp, jsonl);
+        await rename(tmp, filePath(sid));
+
+        return { ok: true as const, value: { kept: kept.length, dropped } };
+      } catch (e: unknown) {
+        return {
+          ok: false as const,
+          error: {
+            code: "INTERNAL" as const,
+            message: `Failed to truncate transcript: ${extractMessage(e)}`,
+            retryable: false,
+            cause: e,
+          },
+        };
+      }
+    });
+  };
+
   const remove = async (sid: SessionId): Promise<Result<void, KoiError>> => {
     const check = validateNonEmpty(sid, "Session ID");
     if (!check.ok) return check;
@@ -346,5 +411,5 @@ export function createJsonlTranscript(config: JsonlTranscriptConfig): SessionTra
     // No resources to release for file-based store
   };
 
-  return { append, load, loadPage, compact, remove, close };
+  return { append, load, loadPage, compact, truncate, remove, close };
 }

--- a/packages/lib/session/src/transcript/memory-store.ts
+++ b/packages/lib/session/src/transcript/memory-store.ts
@@ -13,6 +13,7 @@ import type {
   TranscriptLoadResult,
   TranscriptPage,
   TranscriptPageOptions,
+  TruncateResult,
 } from "@koi/core";
 import { transcriptEntryId, validateNonEmpty } from "@koi/core";
 
@@ -95,6 +96,38 @@ export function createInMemoryTranscript(): SessionTranscript {
     return { ok: true, value: { preserved: preserved.length, extended } };
   };
 
+  const truncate = (sid: SessionId, keepFirstN: number): Result<TruncateResult, KoiError> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+
+    if (keepFirstN < 0) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "keepFirstN must be non-negative",
+          retryable: false,
+        },
+      };
+    }
+
+    const existing = store.get(sid) ?? [];
+    if (keepFirstN >= existing.length) {
+      // Already shorter than the cap — nothing to drop.
+      return { ok: true, value: { kept: existing.length, dropped: 0 } };
+    }
+
+    const kept = existing.slice(0, keepFirstN);
+    const dropped = existing.length - kept.length;
+    if (kept.length === 0) {
+      // Truncating to zero — remove the entry entirely.
+      store.delete(sid);
+    } else {
+      store.set(sid, kept);
+    }
+    return { ok: true, value: { kept: kept.length, dropped } };
+  };
+
   const remove = (sid: SessionId): Result<void, KoiError> => {
     const check = validateNonEmpty(sid, "Session ID");
     if (!check.ok) return check;
@@ -107,5 +140,5 @@ export function createInMemoryTranscript(): SessionTranscript {
     store.clear();
   };
 
-  return { append, load, loadPage, compact, remove, close };
+  return { append, load, loadPage, compact, truncate, remove, close };
 }


### PR DESCRIPTION
## Summary

Adds the **conversation half** of #1625's session rollback. When a `SessionTranscript` is wired into the checkpoint config, `/rewind` now truncates the conversation log alongside the file restore — both halves snap back to the same turn boundary.

Stacks on #1669 (file-state restore protocol).

| # | PR | What |
|---|---|---|
| 1 | #1665 | L0 schema + L2 doc-gate |
| 2 | #1666 | `@koi/snapshot-store-sqlite` storage adapter |
| 3 | #1667 | `@koi/checkpoint` capture half |
| 4 | #1669 | `@koi/checkpoint` restore half + rewind API + in-flight queue |
| 5 | **this PR** | **Conversation log truncation via L0 `SessionTranscript`** |

## L0 changes (`@koi/core`)

- New `TruncateResult` interface `{ kept, dropped }`
- New `SessionTranscript.truncate(sessionId, keepFirstN)` method — shrinks the log to its first N entries (the inverse of append). Lives on the L0 contract so any conformant transcript impl serves checkpoint without an L2→L2 dependency.

## `@koi/session` changes

- Implement `truncate()` in `createJsonlTranscript`: load + slice + atomic tmp+rename. Removes the file entirely when `keepFirstN` is 0. Reuses the per-file `serialized()` queue so truncate is safe under concurrent append/compact.
- Implement `truncate()` in `createInMemoryTranscript`: array slice + Map set/delete.
- 7 new contract-suite truncate tests run against both impls (14 invocations).

## `@koi/checkpoint` changes

- Add optional `transcript?: SessionTranscript` to `CheckpointMiddlewareConfig`. **Injected via the L0 interface** — no L2→L2 dep.
- Add optional `transcriptEntryCount?: number` to `CheckpointPayload`. Captured by `onAfterTurn` when a transcript is wired.
- Wire transcript truncation into the restore protocol as **step 3b** between file restore and chain marker write. A failure at 3b leaves the chain head unchanged so re-running converges (truncate is itself idempotent).

## Tests

| Package | Result |
|---|---|
| `@koi/core` | 826 pass, 0 fail (api-surface snapshot regenerated) |
| `@koi/session` | **176 pass, 0 fail** (164 existing + 14 new) |
| `@koi/checkpoint` | **127 pass, 0 fail** (121 existing + 6 new transcript integration tests) |

## Verified locally

- [x] typecheck clean (core, session, checkpoint)
- [x] all tests pass
- [x] lint clean
- [x] build clean
- [x] `bun run check:layers` passes (no L2→L2; integration via L0 interface)
- [ ] CI green

## Stacking

#1665 → #1666 → #1667 → #1669 → **this PR**. Merge in order.