### PR TITLE
feat(cli): graceful interrupt + double-tap SIGINT state machine (#1653)

### DIFF
--- a/.claude/plans/interrupt-cancellation-1653.md
+++ b/.claude/plans/interrupt-cancellation-1653.md
@@ -1,0 +1,106 @@
+# Graceful Interrupt + Cancellation Protocol — Issue #1653 (v2, post-review)
+
+**Branch:** `feat/interrupt-cancellation-1653`
+**Worktree:** `/Users/sophiawj/private/koi-interrupt-1653`
+**Status:** revised after `codex:adversarial-review` of the v1 plan.
+
+## 0. What changed after review
+
+The v1 plan proposed a new `@koi/interrupt` L2 package with cancel middleware, a new `agent.cancelled` event, a `CheckpointAdapter` abstraction, a per-tool `interruptBehavior` field, and a SIGINT handler wired in `cli/bin.ts`. The review found this is the wrong shape:
+
+- **Middleware hooks can't emit terminal events or set `stopReason`.** Only L1 owns the control plane. `onBeforeTurn`/`onAfterTurn` return `Promise<void>`.
+- **No session registry to hang `interrupt(sessionId)` off of.** The only live cancel handles today are host-owned `AbortController`s in `commands/start.ts` and `tui-command.ts`.
+- **`agent.cancelled` duplicates existing `done.stopReason === "interrupted"`.** The engine, query runner, and TUI flush path are already built around `done` as the terminal event.
+- **Source fields like `tui_ctrl_c` leak host vocab into L0** — forbidden by CLAUDE.md.
+- **A second interposition layer for cancel** would double-instrument tool and model calls alongside `createToolExecutionGuard`.
+- **`CheckpointAdapter` is a second persistence vocabulary.** The repo already has `EngineAdapter.saveState/loadState`, `SessionRecord.lastEngineState`, `SessionPersistence`.
+- **`process.once('SIGINT')` is already installed** in `commands/start.ts:412` and `tui-command.ts:596`. There's no double-tap today because of `once`, not because handlers are missing. `cli/bin.ts` is not the live session owner (TUI re-execs into a child).
+- **`interruptBehavior: 'cancel'|'block'`** is too coarse: tools fall into three buckets (pre-start abortable, mid-flight cooperative, post-commit non-revertible), and MCP can't cancel in-flight remote calls.
+- **No-op checkpoint adapter is not mergeable if resume is in scope.** An in-memory stub contradicts "interrupt without losing state."
+
+## 1. Revised scope
+
+**Land as this PR (graceful interrupt):**
+1. Replace `process.once('SIGINT')` with double-tap state machines in `commands/start.ts` and `tui-command.ts`. First SIGINT = graceful (calls existing `AbortController.abort()`); second within 2s = `process.exit(130)`; failsafe `.unref()` timer as defense-in-depth.
+2. Audit and fix signal propagation in concrete tools where it's wrong or missing. Concrete targets identified by review: `packages/lib/tool-browser/src/tools/wait.ts:62` (ignores `ToolExecuteOptions`), MCP adapter at `packages/net/mcp/src/tool-adapter.ts:76`, filesystem tools in `packages/lib/tools-builtin/src/tools/`.
+3. Verify `done.output.stopReason === "interrupted"` flows end-to-end through streaming cancel path in `packages/kernel/engine/src/compose-bridge.ts:200` and `packages/lib/query-engine/src/consume-stream.ts:63`, and that it arrives at the TUI after the existing `flushSync()` in `engine-channel.ts:135`.
+4. Tests: double-SIGINT force path, mid-model cancel preserves partial usage in final `done`, mid-tool cancel for cooperative tools, TUI final-flush ordering under cancel.
+5. Doc: `docs/L2/interrupt.md` documents the existing protocol (AbortSignal + `stopReason: "interrupted"` + SIGINT state machine) — not a new package.
+
+**Explicitly out of this PR (split to follow-ups):**
+- **Durable resume-from-cancel** (AC #6). Blocks on `EngineState` being reliably persisted through `SessionPersistence` for adapters that support it. Separate issue to wire `saveState/loadState` into the cancel path.
+- **Programmatic `agent.interrupt(sessionId)` API** (AC #1). Requires a session registry in `@koi/engine` — L1 change, separate issue. Today, programmatic cancel works if you own the `AbortController`.
+- **Team runtime fan-out cancel** — already a separate issue per the ticket.
+- **New L0 `agent.cancelled` event** — rejected. Reuse `done.stopReason === "interrupted"`.
+- **Per-tool `interruptBehavior` manifest field** — rejected until concrete tool audit is complete.
+- **`@koi/interrupt` L2 package** — not created. No L2 code lives in `packages/lib/interrupt/`.
+
+This is a tighter PR that matches what the issue actually promises *and* what the repo can support today. The two AC items we drop (resume, programmatic API) become explicit follow-up issues linked in the PR description.
+
+## 2. Concrete work items
+
+| # | File | Change |
+|---|---|---|
+| 2.1 | `packages/meta/cli/src/commands/start.ts:412` | Replace `process.once('SIGINT', ...)` with double-tap state machine. First tap → existing `abort()` + print "Interrupting… (Ctrl+C again to force)". Second tap within 2000ms → `process.exit(130)`. Failsafe `setTimeout(exit(130), 8000).unref()`. |
+| 2.2 | `packages/meta/cli/src/tui-command.ts:596` | Same pattern at the TUI child-process level. Coordinate with existing `onInterrupt()` at `tui-command.ts:359-362`. Do NOT remap Esc. |
+| 2.3 | `packages/ui/tui/src/keyboard.ts:60` | Leave as-is. Ctrl+C → existing `onInterrupt()`. No behavior change. |
+| 2.4 | `packages/lib/tool-browser/src/tools/wait.ts:62` | Honor `ToolExecuteOptions.signal`. Add `signal.addEventListener('abort', ...)` to short-circuit the wait. |
+| 2.5 | `packages/net/mcp/src/tool-adapter.ts:76` | Document that in-flight MCP calls can't be aborted mid-flight. Check `signal.aborted` before dispatch to at least abort pre-start. |
+| 2.6 | `packages/lib/tools-builtin/src/tools/{read,write,edit}.ts` | Add `throwIfAborted()` before and after backend calls. Already partially done per review. |
+| 2.7 | `packages/kernel/engine/src/compose-bridge.ts:200` + `packages/lib/query-engine/src/consume-stream.ts:63` | Verify with a test that cancel mid-stream produces exactly one final `done` event with `stopReason: "interrupted"` and partial `usage` preserved. |
+| 2.8 | `packages/ui/tui/src/batcher/event-batcher.ts:35` + `packages/ui/tui/src/worker/engine-channel.ts:135` | Verify `flushSync()` runs before terminal interrupted state — add test for same-burst `text_delta` → cancel ordering. |
+| 2.9 | `docs/L2/interrupt.md` | New doc: cancellation protocol in Koi (AbortSignal everywhere, `stopReason: "interrupted"` as terminal, SIGINT state machine at hosts, known limitations: MCP mid-flight, no durable resume yet). |
+| 2.10 | `docs/L2/interrupt.md` + PR body | Link follow-up issues: (a) durable resume via `EngineState`, (b) programmatic `interrupt(sessionId)` via runtime session registry, (c) per-tool interrupt behavior audit. |
+
+## 3. Test plan
+
+Doc → Tests → Code, per CLAUDE.md.
+
+| Test | Target | Covers |
+|---|---|---|
+| `commands/start.test.ts` — double-SIGINT force | 2.1 | AC #2 |
+| `commands/start.test.ts` — single-SIGINT + failsafe timer fires if abort hangs | 2.1 | AC #2, defense-in-depth |
+| `tui-command.test.ts` — double-SIGINT force in TUI child | 2.2 | AC #2 |
+| `tool-browser/wait.test.ts` — abort mid-wait returns early | 2.4 | AC #4 |
+| `mcp/tool-adapter.test.ts` — pre-aborted signal never dispatches | 2.5 | AC #4 |
+| `compose-bridge.test.ts` / `consume-stream.test.ts` — mid-stream cancel yields exactly one `done` with `stopReason:"interrupted"` and non-zero `usage.input_tokens` | 2.7 | AC #3, accounting |
+| `engine-channel.test.ts` — same-burst text_delta + cancel preserves all deltas before terminal state | 2.8 | AC #5 (final-flush guarantee) |
+| `engine-channel.test.ts` — idempotent double-abort is a no-op (single terminal `done`) | 2.1–2.7 | idempotency |
+
+Per CLAUDE.md L2 rule: since we're not adding a new L2 package, no new golden query recording is required. We should still verify existing golden trajectories don't regress.
+
+## 4. Answers to v1 plan's open questions (grounded in review)
+
+1. **Hierarchical `AbortController` tree** → not introduced as a new primitive. Use existing `AbortSignal` composition (`AbortSignal.any()`). The repo standardizes on `AbortSignal` everywhere — don't invent a wrapper.
+2. **2s double-tap window** → accepted. Lives in host files, not kernel.
+3. **Tool `interruptBehavior` manifest field** → rejected for now. Audit concrete tools first.
+4. **`agent.cancelled` event kind** → rejected. Reuse `done.stopReason === "interrupted"`.
+5. **Cancel ownership** → host owns the `AbortController`. No middleware session map. Middleware is pure observer of `ctx.signal`.
+6. **Failsafe timer location** → CLI/TUI host files, not kernel, not a new L2. Matches where `process.exit()` lives today.
+7. **No-op checkpoint adapter** → rejected. Durable resume is split into a follow-up issue that uses `SessionPersistence` + `EngineState`.
+
+## 5. Implementation order
+
+1. `docs/L2/interrupt.md` — document the existing + revised protocol (Doc gate).
+2. Failing tests for 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.8.
+3. Code: 2.1 + 2.2 (SIGINT state machine in both host files).
+4. Code: 2.4, 2.5, 2.6 (tool signal propagation fixes).
+5. Verify 2.7 + 2.8 — likely already works, tests pin the behavior.
+6. CI green: `test`, `typecheck`, `lint`, `check:layers`, `check:orphans`, `check:golden-queries`.
+7. Open PR from worktree. Body explicitly calls out which ACs this PR covers (#2, #3, #4, #5, #7) and which ship as follow-ups (#1 programmatic API, #6 durable resume).
+
+## 6. Risk & open items
+
+- **Risk: TUI re-exec complicates SIGINT.** The TUI child process receives SIGINT independently of the parent `cli/bin.ts`. Need to confirm via a manual test that double-tap in the *TUI child* exits the child cleanly and the parent then exits with 130.
+- **Risk: `compose-bridge` + `consume-stream` may already handle cancel correctly.** If so, 2.7 is just "pin the behavior with a test" — good outcome. If they don't, that's the actual bug to fix.
+- **Open: should we land the follow-up issues for resume + programmatic API as stubs now (linked), or wait for this PR to merge first?** Recommend: file them *before* opening this PR so the PR body can link them.
+
+## 7. Definition of done
+
+- [ ] `docs/L2/interrupt.md` exists and describes the cancellation protocol.
+- [ ] Double-SIGINT works in both `koi start` and TUI.
+- [ ] Cancel mid-model yields exactly one `done` with `stopReason: "interrupted"` and preserved partial `usage`.
+- [ ] Cancel mid-tool aborts cooperative tools (`browser_wait`, filesystem, MCP pre-dispatch).
+- [ ] TUI final-flush ordering verified under cancel.
+- [ ] Two follow-up issues filed and linked in the PR body: resume, programmatic API.
+- [ ] CI green: `test / typecheck / lint / check:layers / check:orphans / check:golden-queries`.

--- a/docs/L2/interrupt.md
+++ b/docs/L2/interrupt.md
@@ -1,0 +1,140 @@
+# Interrupt & Cancellation Protocol
+
+**Issue:** #1653 · **Follow-ups:** #1682 (programmatic API), #1683 (durable resume)
+
+## Goal
+
+Users can interrupt a running agent at any time (Ctrl+C in a shell, Ctrl+C in the TUI, programmatic abort) without losing state or corrupting accounting. The agent finishes its current atomic operation (or aborts it if the tool cooperates), emits a terminal `done` event with `stopReason: "interrupted"`, and halts cleanly.
+
+Double-Ctrl+C within 2 seconds forces an immediate exit with code 130 (standard SIGINT convention) as an escape hatch when graceful cleanup hangs.
+
+## Design principles
+
+1. **No new cancellation vocabulary.** Koi already threads `AbortSignal` through `EngineInput`, `ModelRequest`, `ToolRequest`, and `TurnContext`. Cancellation reuses that plumbing — no custom token class, no middleware-owned controllers, no second interposition layer.
+2. **Hosts own the controller.** The live `AbortController` for a run belongs to the CLI/TUI host (`commands/start.ts`, `tui-command.ts`), not to L0, L1, or a new L2 package. L1 and L2 are pure observers of `ctx.signal`.
+3. **`done.stopReason === "interrupted"` is the terminal event.** No new `agent.cancelled` event kind. The engine, query runner, and TUI flush path already treat `done` as terminal — adding a second terminal event would fork the control plane.
+4. **Partial accounting is preserved.** A cancel mid-stream still emits a single final `done` with the partial `usage` collected so far. Callers never see a cancel path that silently loses tokens.
+5. **Cancel is idempotent.** Multiple `abort()` calls — or a Ctrl+C arriving during cleanup — produce exactly one terminal `done`.
+
+## The protocol
+
+### Layered view
+
+```
+┌──────────── Host (CLI/TUI) ────────────┐
+│   AbortController + SIGINT state machine│
+│           │                              │
+│           ▼ signal                       │
+├──────────── L1 @koi/engine ─────────────┤
+│   run(input, { signal })                 │
+│   ├─ modelStream (wraps iterator.next    │
+│   │   vs. signal)                        │
+│   └─ createToolExecutionGuard            │
+│       (composes signal + per-call timeout)│
+│           │                              │
+│           ▼ signal                       │
+├──────────── L2 tools / adapters ────────┤
+│   tool.execute({ signal }): honor it     │
+│   model adapter: forward to fetch()      │
+└──────────────────────────────────────────┘
+```
+
+### Terminal semantics
+
+When `signal.aborted === true` at any of the checkpoints below, the run terminates with:
+
+```ts
+{ kind: "done",
+  output: {
+    stopReason: "interrupted",
+    usage: { /* partial token counts collected so far */ },
+    ...
+  } }
+```
+
+**Checkpoints:**
+- Before a turn starts (early exit — no model call)
+- Mid-model-stream (abort propagated to the underlying `fetch()` via the streaming adapter)
+- Between chunks (stream consumer races `iterator.next()` against `signal`)
+- Before a tool call (tool execution guard short-circuits)
+- Mid-tool-call (cooperative tools honor `ToolExecuteOptions.signal`; non-cooperative tools run to completion, then the terminal `done` fires)
+
+### SIGINT state machine (host-owned)
+
+Both CLI hosts use the same two-tap state machine:
+
+```
+idle ──SIGINT──▶ graceful
+   ▲               │
+   │               ├── SIGINT within 2000ms ──▶ process.exit(130)
+   │               │
+   │               └── controller.abort() → run ends with
+   │                    stopReason:"interrupted" ──▶ idle (natural exit)
+   │
+   └── failsafe(8000ms, .unref()) ──▶ process.exit(130)
+```
+
+- **First SIGINT:** call the host's graceful action (abort the active stream in the TUI; abort the session-wide `AbortController` in `koi start`), print `Interrupting… (Ctrl+C again to force)` to stderr, arm a 2000ms double-tap window.
+- **Second SIGINT within 2000ms:** force-exit path (`process.exit(130)` in `koi start`, full shutdown with runtime teardown in the TUI).
+- **Window elapse behavior depends on host policy** (`onWindowElapse`):
+  - `stay-armed` (TUI default): once the first tap has armed the state machine, ANY subsequent SIGINT forces — the window just rate-limits how fast a double-tap qualifies. The handler returns to idle only when the host calls `complete()` (wired to the drain loop's `finally` so the next turn starts fresh) or when force is triggered.
+  - `reset-to-idle`: when the 2000ms window elapses without a second tap, the handler returns to idle and the next SIGINT is a new first tap. Used when the host has no `complete()` hook.
+- **`koi start` uses `failsafeMs: 30_000`** — if a non-cooperative tool never honors the abort, the handler auto-escalates to the force path after 30s rather than leaving the session hung indefinitely.
+- **The TUI uses no `failsafeMs`** — interrupted turns aren't committed to the transcript, so silent auto-escalation would lose session context. Users who want an unconditional force-exit double-tap explicitly.
+
+The state machine is installed in `packages/meta/cli/src/commands/start.ts` and `packages/meta/cli/src/tui-command.ts`. It is **not** installed in `packages/meta/cli/src/bin.ts` — the TUI re-execs into a child process, and the state machine must live with the process that owns the `AbortController`.
+
+### TUI key bindings
+
+- **Ctrl+C** → calls `onInterrupt()` → calls `controller.abort()`. First tap = graceful, second tap within 2s = force.
+- **Esc** → unchanged. Dismisses modals / navigates back. Esc is **not** an interrupt; remapping it would be a UX decision outside this protocol.
+
+## Tool author guide
+
+If you are writing a tool, honor the `signal` you receive in `ToolExecuteOptions`:
+
+```ts
+async execute(args, { signal }) {
+  signal.throwIfAborted();                        // pre-check
+  const result = await doWork({ signal });        // forward to any async I/O
+  signal.throwIfAborted();                        // post-check
+  return result;
+}
+```
+
+Tools fall into three practical buckets:
+
+| Bucket | Example | Cancel behavior |
+|---|---|---|
+| **Pre-start abortable** | any tool | Check `signal.aborted` before dispatch. Cheap and always correct. |
+| **Mid-flight cooperative** | `browser_wait`, long-poll, streaming fetch | Wire `signal` into the underlying async primitive so it aborts mid-flight. |
+| **Post-commit non-revertible** | MCP remote call, filesystem write | Cannot be cancelled mid-flight. Let the current atomic op finish, then the terminal `done` fires. Do not attempt to roll back on abort. |
+
+Per-tool `interruptBehavior` metadata in the manifest is explicitly **not** introduced in this protocol. The behavior is a property of the tool's implementation, not its declaration, and the current tool surface is too heterogeneous to express as a single flag.
+
+## Known limitations
+
+- **PID-directed `kill -INT <wrapperPid>` does not reach the TUI child.** The `koi tui` launcher re-execs into a browser-build child process. Forwarding SIGINT would double-deliver every terminal Ctrl+C (since the terminal delivers to the whole foreground process group) and depend on a time-based coalesce heuristic. Spawning the child in a separate process group (`detached: true`) would solve the delivery ambiguity but is unsafe for interactive children: a background-pgroup process reading from the controlling tty gets SIGTTIN under job control and freezes, and Bun/Node do not expose `tcsetpgrp` to transfer terminal foreground ownership. Supervisors should use **SIGTERM** for PID-directed termination — the wrapper forwards SIGTERM and escalates to SIGKILL after 10s if the child wedges. Terminal Ctrl+C works normally via process-group delivery.
+- **MCP tools cannot be cancelled mid-flight.** The MCP protocol has no cancel verb. `packages/net/mcp/src/tool-adapter.ts` checks `signal.aborted` before dispatch but cannot interrupt an in-flight remote call. The terminal `done` fires once the MCP call settles.
+- **Durable resume is not supported yet.** Cancelling a session halts it cleanly but does not persist `EngineState`. See #1683 for the resume-from-checkpoint story. Transcript-based resume via `koi resume <sessionId>` (existing `SessionPersistence`) still works for stateless adapters.
+- **No programmatic `interrupt(sessionId)` API yet.** Today you need to own the `AbortController` to cancel a run. See #1682 for the runtime session registry.
+- **Team runtime fan-out cancel is a separate issue.** Spawned sub-agents that detach from the parent signal (deferred / on-demand delivery modes) will continue running after the parent is cancelled.
+
+## Testing
+
+The protocol is verified by tests in:
+
+- `packages/meta/cli/src/commands/start.test.ts` — double-SIGINT force path, failsafe timer
+- `packages/meta/cli/src/tui-command.test.ts` — same for the TUI host
+- `packages/kernel/engine/src/__tests__/compose-bridge.test.ts` + `packages/lib/query-engine/src/__tests__/consume-stream.test.ts` — mid-stream cancel yields exactly one `done` with `stopReason: "interrupted"` and preserved partial usage
+- `packages/ui/tui/src/worker/__tests__/engine-channel.test.ts` — same-burst `text_delta` ordering preserved through the flush path under cancel
+- `packages/lib/tool-browser/src/tools/wait.test.ts` — cooperative tool aborts mid-wait
+- `packages/net/mcp/src/__tests__/tool-adapter.test.ts` — pre-aborted signal never dispatches
+
+## References
+
+- `packages/kernel/core/src/engine.ts` — `AbortSignal` in `EngineInput`, `AbortReason` union
+- `packages/kernel/core/src/middleware.ts` — `signal` on `TurnContext`, `ModelRequest`, `ToolRequest`
+- `packages/kernel/engine-compose/src/tool-execution-guard.ts` — existing signal + timeout composition
+- `packages/kernel/engine/src/compose-bridge.ts` — streaming cancel path
+- `packages/lib/query-engine/src/consume-stream.ts` — stream iterator vs. signal race

--- a/packages/meta/cli/src/benchmark.test.ts
+++ b/packages/meta/cli/src/benchmark.test.ts
@@ -167,6 +167,11 @@ describe("startup-latency probe (#1637) — production-purity contract", () => {
       "slice", // process.argv.slice(1)
       "stdin", // Bun.spawn stdio options
       "KOI_TUI_BROWSER_SOLID", // env marker preventing re-exec loop
+      // Signal handling helper (see tui-reexec-signals.ts, issue #1653).
+      // Lazily imported — not on any measured startup path; the
+      // command-dispatch benchmark scenario short-circuits before
+      // tui-reexec is ever taken.
+      "installTuiReexecSignalHandlers",
     ]);
 
     // Extract identifiers from the post-fast-path region. Simple

--- a/packages/meta/cli/src/bin.ts
+++ b/packages/meta/cli/src/bin.ts
@@ -85,10 +85,8 @@ switch (result.kind) {
         env: { ...baseEnv, KOI_TUI_BROWSER_SOLID: "1" },
       },
     );
-    // The child inherits the same process group as the parent, so terminal
-    // signals (Ctrl+C → SIGINT) are already delivered to both processes by
-    // the kernel. No explicit forwarding needed — it would cause double
-    // delivery and bypass the child's graceful stop() shutdown path.
+    const { installTuiReexecSignalHandlers } = await import("./tui-reexec-signals.js");
+    installTuiReexecSignalHandlers(proc);
     process.exit(await proc.exited);
     break;
   }

--- a/packages/meta/cli/src/commands/start.ts
+++ b/packages/meta/cli/src/commands/start.ts
@@ -56,6 +56,7 @@ import { resolveApiConfig } from "../env.js";
 import { loadManifestConfig } from "../manifest.js";
 import { createOAuthAwareMcpConnection } from "../mcp-connection-factory.js";
 import { loadPluginComponents } from "../plugin-activation.js";
+import { createSigintHandler, createUnrefTimer } from "../sigint-handler.js";
 import { ExitCode } from "../types.js";
 
 const DEFAULT_MAX_TURNS = 10;
@@ -482,9 +483,38 @@ export async function run(flags: StartFlags): Promise<ExitCode> {
   const channel = createCliChannel({ theme: "default" });
 
   const controller = new AbortController();
-  process.once("SIGINT", () => {
-    controller.abort();
+  // `stay-armed` policy (the default): once the user presses Ctrl+C, the
+  // harness uses a single session-wide `AbortSignal` that stays aborted
+  // forever. The interactive loop breaks out of `runInteractive()` and the
+  // session ends — there is no "fresh turn" to re-arm for. Staying armed
+  // means any subsequent Ctrl+C during post-cancel teardown forces exit,
+  // which is the escape hatch we want.
+  //
+  // `failsafeMs: 30_000` is a generous budget covering normal post-abort
+  // teardown (channel disconnect, runtime dispose, transcript flush) while
+  // still catching a genuinely non-cooperative tool or stream consumer
+  // that ignores the abort signal indefinitely. Without a failsafe, a
+  // non-cooperative run leaves the session hung and the user needs to
+  // double-tap to escape; with 30s, even a lazy tool gets plenty of time
+  // to settle before we hard-exit.
+  const sigintHandler = createSigintHandler({
+    onGraceful: () => {
+      controller.abort();
+    },
+    onForce: () => {
+      process.exit(130);
+    },
+    write: (msg: string) => {
+      process.stderr.write(msg);
+    },
+    doubleTapWindowMs: 2000,
+    failsafeMs: 30_000,
+    setTimer: createUnrefTimer,
   });
+  const onSigint = (): void => {
+    sigintHandler.handleSignal();
+  };
+  process.on("SIGINT", onSigint);
 
   const harness = createCliHarness({
     runtime,
@@ -499,75 +529,11 @@ export async function run(flags: StartFlags): Promise<ExitCode> {
   // 7. Execute
   // ---------------------------------------------------------------------------
 
-  switch (flags.mode.kind) {
-    case "interactive": {
-      try {
-        await harness.runInteractive();
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`koi: ${msg}\n`);
-        return ExitCode.FAILURE;
-      }
-      break;
-    }
-    case "prompt": {
-      // Convergence loop mode (#1624): repeat runtime.run() until the verifier
-      // passes or a budget is exhausted. Bypasses the harness entirely — the
-      // harness contract says runSinglePrompt is safe to call once, and loop
-      // mode needs N iterations through a live runtime.
-      if (flags.untilPass.length > 0) {
-        // Runtime warning printed on every loop-mode entry so the user is
-        // reminded of the trust-boundary implications even after they've
-        // passed --allow-side-effects (which is only checked at parse time).
-        // Goes to stderr so it doesn't pollute stdout-captured output.
-        process.stderr.write(
-          [
-            "koi: loop mode enabled — non-idempotent tools will run on every retry,",
-            "     and the verifier subprocess executes outside the CLI permission model.",
-            `     max-iter=${flags.maxIter}, verifier-timeout=${flags.verifierTimeoutMs}ms`,
-            "",
-          ].join("\n"),
-        );
-
-        // Preserve any pre-existing transcript (e.g. from --resume) as the
-        // baseline. Each iteration truncates back to this baseline, so the
-        // model sees:
-        //   [resumed history... + this iteration's rebuilt prompt]
-        // and never:
-        //   [resumed history... + iter1 turn + iter2 turn + ...]
-        // which would pollute retries with stale assistant replies. The
-        // rebuilt prompt from @koi/loop already carries the latest failure
-        // forward into the next attempt (#1624 review finding).
-        const transcriptBaseline = transcript.length;
+  try {
+    switch (flags.mode.kind) {
+      case "interactive": {
         try {
-          const loopResult = await runConvergenceLoop({
-            runtime,
-            prompt: flags.mode.text,
-            untilPassArgv: flags.untilPass,
-            maxIterations: flags.maxIter,
-            verifierTimeoutMs: flags.verifierTimeoutMs,
-            workingDir: process.cwd(),
-            verbose: flags.verbose,
-            signal: controller.signal,
-            verifierInheritEnv: flags.verifierInheritEnv,
-            resetTranscript: () => {
-              transcript.length = transcriptBaseline;
-              // Bump the generation so any orphaned iteration stream
-              // that finally produces its done event in the background
-              // cannot push stale turns onto the next iteration's
-              // transcript view (#1624 round-12 review fix).
-              incrementTranscriptGeneration();
-            },
-          });
-          if (loopResult.status !== "converged") {
-            process.stderr.write(
-              `koi: loop ended in '${loopResult.status}' state after ${loopResult.iterations} iteration(s): ${loopResult.terminalReason}\n`,
-            );
-            return ExitCode.FAILURE;
-          }
-          process.stdout.write(
-            `\nkoi: loop converged after ${loopResult.iterations} iteration(s)\n`,
-          );
+          await harness.runInteractive();
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           process.stderr.write(`koi: ${msg}\n`);
@@ -577,29 +543,100 @@ export async function run(flags: StartFlags): Promise<ExitCode> {
         }
         break;
       }
+      case "prompt": {
+        // Convergence loop mode (#1624): repeat runtime.run() until the verifier
+        // passes or a budget is exhausted. Bypasses the harness entirely — the
+        // harness contract says runSinglePrompt is safe to call once, and loop
+        // mode needs N iterations through a live runtime.
+        if (flags.untilPass.length > 0) {
+          // Runtime warning printed on every loop-mode entry so the user is
+          // reminded of the trust-boundary implications even after they've
+          // passed --allow-side-effects (which is only checked at parse time).
+          // Goes to stderr so it doesn't pollute stdout-captured output.
+          process.stderr.write(
+            [
+              "koi: loop mode enabled — non-idempotent tools will run on every retry,",
+              "     and the verifier subprocess executes outside the CLI permission model.",
+              `     max-iter=${flags.maxIter}, verifier-timeout=${flags.verifierTimeoutMs}ms`,
+              "",
+            ].join("\n"),
+          );
 
-      let result: Awaited<ReturnType<typeof harness.runSinglePrompt>>;
-      try {
-        result = await harness.runSinglePrompt(flags.mode.text);
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`koi: ${msg}\n`);
-        return ExitCode.FAILURE;
+          // Preserve any pre-existing transcript (e.g. from --resume) as the
+          // baseline. Each iteration truncates back to this baseline, so the
+          // model sees:
+          //   [resumed history... + this iteration's rebuilt prompt]
+          // and never:
+          //   [resumed history... + iter1 turn + iter2 turn + ...]
+          // which would pollute retries with stale assistant replies. The
+          // rebuilt prompt from @koi/loop already carries the latest failure
+          // forward into the next attempt (#1624 review finding).
+          const transcriptBaseline = transcript.length;
+          try {
+            const loopResult = await runConvergenceLoop({
+              runtime,
+              prompt: flags.mode.text,
+              untilPassArgv: flags.untilPass,
+              maxIterations: flags.maxIter,
+              verifierTimeoutMs: flags.verifierTimeoutMs,
+              workingDir: process.cwd(),
+              verbose: flags.verbose,
+              signal: controller.signal,
+              verifierInheritEnv: flags.verifierInheritEnv,
+              resetTranscript: () => {
+                transcript.length = transcriptBaseline;
+                // Bump the generation so any orphaned iteration stream
+                // that finally produces its done event in the background
+                // cannot push stale turns onto the next iteration's
+                // transcript view (#1624 round-12 review fix).
+                incrementTranscriptGeneration();
+              },
+            });
+            if (loopResult.status !== "converged") {
+              process.stderr.write(
+                `koi: loop ended in '${loopResult.status}' state after ${loopResult.iterations} iteration(s): ${loopResult.terminalReason}\n`,
+              );
+              return ExitCode.FAILURE;
+            }
+            process.stdout.write(
+              `\nkoi: loop converged after ${loopResult.iterations} iteration(s)\n`,
+            );
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`koi: ${msg}\n`);
+            return ExitCode.FAILURE;
+          } finally {
+            await runtime.dispose?.();
+          }
+          break;
+        }
+
+        let result: Awaited<ReturnType<typeof harness.runSinglePrompt>>;
+        try {
+          result = await harness.runSinglePrompt(flags.mode.text);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(`koi: ${msg}\n`);
+          return ExitCode.FAILURE;
+        }
+        if (result.stopReason !== "completed") {
+          return ExitCode.FAILURE;
+        }
+        break;
       }
-      if (result.stopReason !== "completed") {
-        return ExitCode.FAILURE;
-      }
-      break;
     }
-  }
 
-  // Non-zero exit for user-cancelled sessions so scripts/automation can
-  // distinguish cancellation (SIGINT) from successful completion.
-  if (controller.signal.aborted) {
-    return ExitCode.FAILURE;
-  }
+    // Non-zero exit for user-cancelled sessions so scripts/automation can
+    // distinguish cancellation (SIGINT) from successful completion.
+    if (controller.signal.aborted) {
+      return ExitCode.FAILURE;
+    }
 
-  return ExitCode.OK;
+    return ExitCode.OK;
+  } finally {
+    sigintHandler.dispose();
+    process.removeListener("SIGINT", onSigint);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/meta/cli/src/sigint-handler.test.ts
+++ b/packages/meta/cli/src/sigint-handler.test.ts
@@ -1,0 +1,395 @@
+/**
+ * SIGINT double-tap state machine — unit tests.
+ *
+ * Covers the graceful-then-force protocol used by both `koi start` and the TUI
+ * host. The state machine is a pure factory with injected timers and
+ * callbacks, so these tests don't touch `process.on` or the real clock.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createSigintHandler, type SigintHandler, type Timer } from "./sigint-handler.js";
+
+// ---------------------------------------------------------------------------
+// Fake timer harness — lets tests advance virtual time without waiting.
+// ---------------------------------------------------------------------------
+
+interface FakeTimer extends Timer {
+  readonly fireAfterMs: number;
+  fired: boolean;
+  cancelled: boolean;
+}
+
+function createFakeClock(): {
+  readonly setTimer: (fn: () => void, ms: number) => Timer;
+  readonly advance: (ms: number) => void;
+  readonly now: () => number;
+  readonly pending: () => readonly FakeTimer[];
+} {
+  let current = 0;
+  const timers: {
+    readonly at: number;
+    readonly fn: () => void;
+    readonly timer: FakeTimer;
+  }[] = [];
+
+  const setTimer = (fn: () => void, ms: number): Timer => {
+    const timer: FakeTimer = {
+      fireAfterMs: ms,
+      fired: false,
+      cancelled: false,
+      cancel: () => {
+        timer.cancelled = true;
+      },
+    };
+    timers.push({ at: current + ms, fn, timer });
+    return timer;
+  };
+
+  const advance = (ms: number): void => {
+    const target = current + ms;
+    // Fire in scheduled order. Strictly-less-than: a timer scheduled at t
+    // fires when the clock moves PAST t, matching the semantic that a user
+    // tap at exactly the window boundary beats the timer.
+    timers.sort((a, b) => a.at - b.at);
+    for (const entry of timers) {
+      if (entry.at < target && !entry.timer.fired && !entry.timer.cancelled) {
+        entry.timer.fired = true;
+        entry.fn();
+      }
+    }
+    current = target;
+  };
+
+  const pending = (): readonly FakeTimer[] =>
+    timers.filter((t) => !t.timer.fired && !t.timer.cancelled).map((t) => t.timer);
+
+  return { setTimer, advance, now: () => current, pending };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createSigintHandler", () => {
+  let onGraceful: ReturnType<typeof mock>;
+  let onForce: ReturnType<typeof mock>;
+  let write: ReturnType<typeof mock>;
+  let clock: ReturnType<typeof createFakeClock>;
+  let handler: SigintHandler;
+
+  beforeEach(() => {
+    onGraceful = mock(() => {});
+    onForce = mock(() => {});
+    write = mock((_msg: string) => {});
+    clock = createFakeClock();
+    handler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      failsafeMs: 8000,
+      coalesceWindowMs: 0,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+  });
+
+  test("first signal calls onGraceful and prints hint", () => {
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledTimes(1);
+    const msg = write.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("Interrupting");
+    expect(msg).toContain("Ctrl+C again to force");
+  });
+
+  test("second signal within window calls onForce and not onGraceful again", () => {
+    handler.handleSignal();
+    clock.advance(500);
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("second signal exactly at window boundary still forces", () => {
+    handler.handleSignal();
+    clock.advance(2000);
+    handler.handleSignal();
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("second signal after the double-tap window still forces", () => {
+    // Once the interrupt sequence has started, subsequent taps always
+    // force — they are the escape hatch, not a request to re-enter the
+    // graceful path. Only `complete()` returns the handler to idle.
+    handler.handleSignal();
+    clock.advance(2500);
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("failsafe timer fires onForce if graceful abort hangs", () => {
+    handler.handleSignal();
+    clock.advance(8001);
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("failsafe does not fire after dispose", () => {
+    handler.handleSignal();
+    handler.dispose();
+    clock.advance(10_000);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("dispose cancels all pending timers", () => {
+    handler.handleSignal();
+    expect(clock.pending().length).toBeGreaterThan(0);
+    handler.dispose();
+    expect(clock.pending().length).toBe(0);
+  });
+
+  test("taps after force keep calling onForce so callers can escalate", () => {
+    handler.handleSignal(); // graceful
+    handler.handleSignal(); // force
+    handler.handleSignal(); // escalate
+    handler.handleSignal(); // escalate
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    // Every tap after the first one hits onForce — first to request
+    // cooperative shutdown, subsequent ones as the user's "get out NOW" path.
+    expect(onForce).toHaveBeenCalledTimes(3);
+  });
+
+  test("dispose is safe to call before any signal", () => {
+    expect(() => {
+      handler.dispose();
+    }).not.toThrow();
+  });
+
+  test("dispose is safe to call multiple times", () => {
+    handler.handleSignal();
+    handler.dispose();
+    expect(() => {
+      handler.dispose();
+    }).not.toThrow();
+  });
+
+  test("without failsafeMs, only double-tap timer is armed", () => {
+    const noFailsafeHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      // failsafeMs omitted
+      coalesceWindowMs: 0,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    noFailsafeHandler.handleSignal();
+    expect(clock.pending().length).toBe(1);
+    clock.advance(60_000);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("complete() clears coalesce state so the next run's first tap is honored", () => {
+    const coalescingHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      failsafeMs: 8000,
+      coalesceWindowMs: 150,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    // First run: graceful tap, then complete() after the run settles.
+    coalescingHandler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    clock.advance(50); // still inside the original 150ms coalesce window
+    coalescingHandler.complete();
+    // Second run: a tap 50ms after complete — still inside what WOULD
+    // have been the old coalesce window — must be treated as a new first
+    // tap, not swallowed as a duplicate.
+    clock.advance(50);
+    coalescingHandler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(2);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("complete() returns handler to idle so a later tap is a new first tap", () => {
+    handler.handleSignal();
+    handler.complete();
+    // Within the original 2s window, but since we completed, this is a new tap.
+    clock.advance(500);
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(2);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("complete() while idle is a no-op", () => {
+    expect(() => {
+      handler.complete();
+    }).not.toThrow();
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+  });
+
+  test("complete() cancels pending timers", () => {
+    handler.handleSignal();
+    expect(clock.pending().length).toBeGreaterThan(0);
+    handler.complete();
+    expect(clock.pending().length).toBe(0);
+  });
+
+  test("complete() after force leaves forced state in place", () => {
+    handler.handleSignal();
+    handler.handleSignal(); // force
+    handler.complete();
+    // Forced state is terminal for graceful — any later tap re-invokes
+    // onForce (the escape-hatch escalation path), not onGraceful.
+    handler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).toHaveBeenCalledTimes(2);
+  });
+
+  test("onWindowElapse='reset-to-idle' treats post-window tap as fresh first tap", () => {
+    const resetHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      coalesceWindowMs: 0,
+      onWindowElapse: "reset-to-idle",
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    resetHandler.handleSignal();
+    clock.advance(2500); // past the window
+    resetHandler.handleSignal();
+    // Second tap is a fresh first tap, not a force escape.
+    expect(onGraceful).toHaveBeenCalledTimes(2);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("onWindowElapse='reset-to-idle' still forces on double-tap within window", () => {
+    const resetHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      coalesceWindowMs: 0,
+      onWindowElapse: "reset-to-idle",
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    resetHandler.handleSignal();
+    clock.advance(500);
+    resetHandler.handleSignal();
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("signals within coalesce window are treated as one tap", () => {
+    const coalescingHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      failsafeMs: 8000,
+      coalesceWindowMs: 50,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    // Two signals at the same virtual instant — second is coalesced.
+    coalescingHandler.handleSignal();
+    coalescingHandler.handleSignal();
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).not.toHaveBeenCalled();
+  });
+
+  test("signals after coalesce window are not coalesced", () => {
+    const coalescingHandler = createSigintHandler({
+      onGraceful: () => {
+        onGraceful();
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      failsafeMs: 8000,
+      coalesceWindowMs: 50,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    coalescingHandler.handleSignal();
+    clock.advance(100); // past the 50ms coalesce window
+    coalescingHandler.handleSignal();
+    // Second tap is a real second tap → force.
+    expect(onGraceful).toHaveBeenCalledTimes(1);
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+
+  test("onGraceful throwing does not prevent onForce on second tap", () => {
+    const throwingHandler = createSigintHandler({
+      onGraceful: () => {
+        throw new Error("abort failed");
+      },
+      onForce: () => {
+        onForce();
+      },
+      write: (msg: string) => {
+        write(msg);
+      },
+      doubleTapWindowMs: 2000,
+      failsafeMs: 8000,
+      coalesceWindowMs: 0,
+      setTimer: clock.setTimer,
+      now: clock.now,
+    });
+    expect(() => {
+      throwingHandler.handleSignal();
+    }).toThrow("abort failed");
+    // State should still have advanced so a second tap forces.
+    throwingHandler.handleSignal();
+    expect(onForce).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/meta/cli/src/sigint-handler.ts
+++ b/packages/meta/cli/src/sigint-handler.ts
@@ -1,0 +1,224 @@
+/**
+ * SIGINT double-tap state machine.
+ *
+ * First Ctrl+C triggers a graceful abort (`onGraceful`) and prints a hint.
+ * A second Ctrl+C within `doubleTapWindowMs` forces an exit (`onForce`).
+ * A failsafe timer calls `onForce` after `failsafeMs` as defense-in-depth
+ * if the graceful abort hangs.
+ *
+ * The handler is a pure factory with injected timers so it can be unit-tested
+ * without touching `process.on` or the real clock. Hosts install it by calling
+ * `handleSignal()` from `process.on("SIGINT", ...)`.
+ *
+ * See docs/L2/interrupt.md for the protocol and issue #1653.
+ */
+
+export interface Timer {
+  readonly cancel: () => void;
+}
+
+export interface SigintHandlerDeps {
+  /** Called on the first SIGINT. Typically `controller.abort()`. */
+  readonly onGraceful: () => void;
+  /** Called on the second SIGINT within the window, or when the failsafe fires. */
+  readonly onForce: () => void;
+  /** Used to print the "Interrupting…" hint. Typically `process.stderr.write`. */
+  readonly write: (msg: string) => void;
+  /** How long the user has to tap Ctrl+C a second time. */
+  readonly doubleTapWindowMs: number;
+  /**
+   * Failsafe: force-exit this long after the first SIGINT if abort hangs.
+   * Omit when the graceful path is synchronous and no timeout is needed
+   * (e.g. TUI first tap only aborts an in-memory controller).
+   */
+  readonly failsafeMs?: number;
+  /**
+   * Coalesce signals arriving within this window into a single tap.
+   * Defense-in-depth for duplicate-delivery edge cases where the same
+   * physical Ctrl+C could be observed twice (e.g. an in-app keyboard path
+   * and a process-level SIGINT handler routing to the same state machine).
+   * In the common configurations in this repo the child process is in its
+   * own process group so there is no duplicate delivery to defend against;
+   * the default is 0 (disabled) and callers opt in explicitly when they
+   * have a genuine source of duplicates.
+   * Default: 0. Human intentional double-taps are on the order of 300-500ms
+   * apart, so a value up to ~150ms is safe if enabled.
+   */
+  readonly coalesceWindowMs?: number;
+  /**
+   * Policy for what happens when the double-tap window elapses without a
+   * second tap:
+   *   - `"stay-armed"` (default): the handler stays in the armed state;
+   *     only `complete()` or a subsequent forced tap returns it to idle.
+   *     Callers that wire `complete()` to an observable "graceful finished"
+   *     event (e.g. TUI drain loop's `finally`) should use this.
+   *   - `"reset-to-idle"`: after the window elapses, the handler goes back
+   *     to idle and the next SIGINT is treated as a fresh first tap. Use
+   *     this when there is no good hook for `complete()` — the `koi start`
+   *     interactive loop runs multiple turns without a per-turn callback,
+   *     and staying armed across turns would turn routine cancellations
+   *     into force-exits.
+   */
+  readonly onWindowElapse?: "stay-armed" | "reset-to-idle";
+  /** Injectable timer factory. Production uses a `setTimeout` wrapper. */
+  readonly setTimer: (fn: () => void, ms: number) => Timer;
+  /** Injectable clock. Production uses `() => Date.now()`. */
+  readonly now?: () => number;
+}
+
+export interface SigintHandler {
+  /** Call from `process.on("SIGINT", () => handler.handleSignal())`. */
+  readonly handleSignal: () => void;
+  /**
+   * Mark the in-flight graceful interrupt as finished. Returns the state
+   * machine to `idle` so any later SIGINT starts a fresh double-tap window.
+   * Call this when the interrupted operation has observably settled (e.g.
+   * the engine emitted its terminal `done` event). Safe to call when idle.
+   */
+  readonly complete: () => void;
+  /** Cancel all pending timers. Safe to call repeatedly. */
+  readonly dispose: () => void;
+}
+
+/**
+ * State:
+ *  - `idle`       — no graceful abort in flight
+ *  - `armed`      — graceful abort requested; `failsafeTimer` is always
+ *                   active while in this state; `doubleTapTimer` is active
+ *                   only during the double-tap window (null afterwards)
+ *  - `forced`     — onForce has been called; further signals are no-ops
+ */
+type State =
+  | { readonly kind: "idle" }
+  | {
+      readonly kind: "armed";
+      readonly failsafeTimer: Timer | null;
+      doubleTapTimer: Timer | null;
+    }
+  | { readonly kind: "forced" };
+
+export function createSigintHandler(deps: SigintHandlerDeps): SigintHandler {
+  let state: State = { kind: "idle" };
+  const now = deps.now ?? ((): number => Date.now());
+  const coalesceWindowMs = deps.coalesceWindowMs ?? 0;
+  const onWindowElapse = deps.onWindowElapse ?? "stay-armed";
+  // let: justified — timestamp of most recent non-coalesced signal
+  let lastSignalAt = Number.NEGATIVE_INFINITY;
+
+  const clearTimers = (): void => {
+    if (state.kind === "armed") {
+      state.doubleTapTimer?.cancel();
+      state.failsafeTimer?.cancel();
+    }
+  };
+
+  const force = (): void => {
+    if (state.kind === "forced") return;
+    clearTimers();
+    state = { kind: "forced" };
+    deps.onForce();
+  };
+
+  const armDoubleTapTimer = (): Timer =>
+    deps.setTimer(() => {
+      // Double-tap window elapsed. Behavior depends on host policy:
+      //   - stay-armed: clear the double-tap slot but stay in the armed
+      //     state. Subsequent taps force until complete() is called.
+      //   - reset-to-idle: the first-tap window expired without a force
+      //     request; go back to idle so the next SIGINT is a fresh first
+      //     tap. Failsafe (if any) is cancelled because there is no
+      //     in-flight graceful request to guard anymore.
+      if (state.kind !== "armed") return;
+      if (onWindowElapse === "reset-to-idle") {
+        state.failsafeTimer?.cancel();
+        state = { kind: "idle" };
+      } else {
+        state.doubleTapTimer = null;
+      }
+    }, deps.doubleTapWindowMs);
+
+  const handleSignal = (): void => {
+    // Debounce benign double-delivery: if the same physical signal arrives
+    // twice within the coalesce window (e.g. terminal delivers SIGINT to
+    // the process group AND the re-exec launcher forwards it a few ms
+    // later), treat the duplicates as a single tap.
+    const t = now();
+    if (coalesceWindowMs > 0 && t - lastSignalAt < coalesceWindowMs) {
+      return;
+    }
+    lastSignalAt = t;
+
+    if (state.kind === "forced") {
+      // Already forced but the user is still tapping. They want out NOW.
+      // Call onForce again so callers can escalate (e.g. wrap a cooperative
+      // shutdown the first time and hard-exit on subsequent taps). Force
+      // handlers must be idempotent in terms of user-visible effect.
+      deps.onForce();
+      return;
+    }
+
+    if (state.kind === "armed") {
+      // Any tap after the first graceful request — within the double-tap
+      // window OR after it elapsed — forces exit. Once the interrupt
+      // sequence has started, the only way back to idle is `complete()`;
+      // subsequent taps are the user's "get out NOW" escape hatch, not a
+      // request to re-enter the graceful path.
+      force();
+      return;
+    }
+
+    // idle → armed. Install timers BEFORE calling onGraceful so that if
+    // onGraceful throws, the state has still advanced and a second tap
+    // will force-exit instead of re-entering the graceful path.
+    const failsafeTimer =
+      deps.failsafeMs !== undefined
+        ? deps.setTimer(() => {
+            force();
+          }, deps.failsafeMs)
+        : null;
+    const doubleTapTimer = armDoubleTapTimer();
+    state = { kind: "armed", failsafeTimer, doubleTapTimer };
+    deps.write("\nInterrupting… (Ctrl+C again to force)\n");
+    deps.onGraceful();
+  };
+
+  const complete = (): void => {
+    // Graceful interrupt has observably finished. Return to idle so a later
+    // SIGINT starts a fresh double-tap window. No-op when already idle or
+    // forced — the window is scoped to a single in-flight cancellation.
+    if (state.kind !== "armed") return;
+    clearTimers();
+    state = { kind: "idle" };
+    // Reset the coalesce-window timestamp too: otherwise a legitimate
+    // first Ctrl+C on a subsequent run that lands within coalesceWindowMs
+    // of the last signal of the completed run is silently discarded as a
+    // duplicate. Coalescing is scoped to a single in-flight sequence.
+    lastSignalAt = Number.NEGATIVE_INFINITY;
+  };
+
+  const dispose = (): void => {
+    clearTimers();
+    if (state.kind === "armed") {
+      state = { kind: "idle" };
+    }
+    lastSignalAt = Number.NEGATIVE_INFINITY;
+  };
+
+  return { handleSignal, complete, dispose };
+}
+
+/**
+ * Production timer factory backed by `setTimeout`. Uses `.unref()` so the
+ * failsafe doesn't keep the process alive when cleanup completes naturally.
+ */
+export function createUnrefTimer(fn: () => void, ms: number): Timer {
+  const handle = setTimeout(fn, ms);
+  if (typeof handle === "object" && handle !== null && "unref" in handle) {
+    (handle as { unref: () => void }).unref();
+  }
+  return {
+    cancel: () => {
+      clearTimeout(handle);
+    },
+  };
+}

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -49,6 +49,7 @@ import { getTreeSitterClient, SyntaxStyle } from "@opentui/core";
 import type { TuiFlags } from "./args.js";
 import { scrubSensitiveEnv } from "./commands/start.js";
 import { resolveApiConfig } from "./env.js";
+import { createSigintHandler, createUnrefTimer } from "./sigint-handler.js";
 import type { TuiRuntimeHandle } from "./tui-runtime.js";
 import { createTuiRuntime } from "./tui-runtime.js";
 
@@ -194,12 +195,33 @@ export async function drainEngineStream(
   stream: AsyncIterable<EngineEvent>,
   store: TuiStore,
   batcher: EventBatcher<EngineEvent>,
+  signal?: AbortSignal,
 ): Promise<void> {
   store.dispatch({ kind: "set_connection_status", status: "connected" });
+  // Track partial usage yielded as `custom` events so an aborted stream
+  // (which throws instead of emitting a real terminal `done`) can still
+  // fold the tokens it had already accrued into its synthetic done.
+  //
+  // Usage snapshots are ABSOLUTE, not deltas: the model adapter's
+  // stream-parser assigns `acc.inputTokens = chunk.usage.prompt_tokens`
+  // and yields that total on every usage event. Always overwrite with
+  // the latest snapshot rather than summing — accumulation would
+  // double-count tokens when multiple usage updates arrive.
+  let partialInputTokens = 0;
+  let partialOutputTokens = 0;
   try {
     // `let` justified: tracks last yield time for frame-rate-limited yielding
     let lastYieldAt = Date.now();
     for await (const event of stream) {
+      if (event.kind === "custom" && event.type === "usage") {
+        const usage = event.data as { inputTokens?: number; outputTokens?: number };
+        if (typeof usage.inputTokens === "number") {
+          partialInputTokens = usage.inputTokens;
+        }
+        if (typeof usage.outputTokens === "number") {
+          partialOutputTokens = usage.outputTokens;
+        }
+      }
       batcher.enqueue(event);
       // Yield to the event loop at most once per frame (~16ms) during any
       // consumer-visible streaming event so OpenTUI can paint progressively.
@@ -227,6 +249,41 @@ export async function drainEngineStream(
     batcher.flushSync();
   } catch (e: unknown) {
     batcher.flushSync();
+    // User-initiated aborts must surface as a clean interrupted turn, not
+    // a generic engine error. Narrow the translation to: (1) the caller
+    // passed a signal, (2) that signal is actually aborted at the time of
+    // catch, AND (3) the error looks like an AbortError. This avoids
+    // swallowing timeout-driven or internal aborts that throw AbortError
+    // without a user-initiated cancel. See issue #1653.
+    if (
+      signal?.aborted &&
+      e instanceof Error &&
+      (e.name === "AbortError" || (e as { code?: unknown }).code === "ABORT_ERR")
+    ) {
+      // Synthesize a terminal `done` event so the reducer finalizes the
+      // streaming assistant message, clears running tool state, and
+      // returns agentStatus to idle. Without this, a cancelled turn
+      // leaves the UI stuck in a "processing" state. Carry forward any
+      // partial usage accumulated from `custom` usage events so cost
+      // accounting isn't lost on the fallback path.
+      const syntheticDone: EngineEvent = {
+        kind: "done",
+        output: {
+          stopReason: "interrupted",
+          content: [],
+          metrics: {
+            totalTokens: partialInputTokens + partialOutputTokens,
+            inputTokens: partialInputTokens,
+            outputTokens: partialOutputTokens,
+            turns: 0,
+            durationMs: 0,
+          },
+        },
+      };
+      batcher.enqueue(syntheticDone);
+      batcher.flushSync();
+      return;
+    }
     store.dispatch({
       kind: "add_error",
       code: "ENGINE_ERROR",
@@ -398,9 +455,98 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // 4. Helpers
   // ---------------------------------------------------------------------------
 
-  const onInterrupt = (): void => {
+  // The raw abort action used by the SIGINT state machine's graceful path.
+  // Aborts the active model stream and closes pending approval prompts.
+  // Does NOT tear down the TUI — the user stays in the session.
+  //
+  // Background subprocesses (bash_background) are intentionally NOT killed
+  // here: the session-wide `bgController` is shared across turns, and
+  // `runtimeHandle.shutdownBackgroundTasks()` also disposes MCP
+  // resolvers/providers that are built once and never rebuilt. Cancelling
+  // the current response must not kill unrelated background work from
+  // earlier turns or permanently break MCP tools for the rest of the
+  // session. Users who want to reset everything can use `/clear` or quit.
+  const abortActiveStream = (): void => {
     permissionBridge.dispose();
     activeController?.abort();
+  };
+
+  // TUI interrupt protocol (see docs/L2/interrupt.md, issue #1653):
+  //  - First tap → abortActiveStream(); user stays in the TUI and the engine
+  //    emits its terminal `done` with `stopReason: "interrupted"` through the
+  //    normal flush path.
+  //  - Second tap within 2s → graceful shutdown(130) (standard SIGINT exit).
+  //  - No failsafe: the graceful path here is a synchronous
+  //    `controller.abort()`, so there is nothing to time out. Shutdown on the
+  //    second tap has its own SIGKILL escalation for background tasks.
+  //
+  // Both the process-level SIGINT and the in-app Ctrl+C (via TUI keyboard
+  // layer) route through this single handler so the force-exit escape hatch
+  // is available in raw-mode sessions, not just when SIGINT reaches the
+  // process directly.
+  // No auto-failsafe on the TUI handler. A previous iteration installed a
+  // 10s failsafeMs to handle non-cooperative in-flight tools (e.g. MCP
+  // calls that ignore the abort signal), but that silently upgrades a
+  // single "cancel this turn" tap into full session loss after 10s —
+  // interrupted turns aren't committed to the transcript, so the user
+  // loses context they never asked to discard. The double-tap force path
+  // is already the explicit escape hatch for hung tools; requiring the
+  // user to press Ctrl+C a second time if their cancel didn't take is
+  // better UX than surprise session termination.
+  //
+  // Defense-in-depth: the TUI has two interrupt ingress paths — the
+  // keyboard layer's Ctrl+C callback AND the process-level SIGINT
+  // handler — both routing through this single state machine. Most
+  // terminal configurations deliver through only one (raw mode captures
+  // Ctrl+C as stdin bytes, non-raw delivers SIGINT via process group),
+  // but edge cases can fire both. A 150ms coalesce window is well below
+  // the 300-500ms human intentional double-tap reflex but well above any
+  // plausible dual-path delivery delay, so it defends the first tap
+  // without blocking a legitimate force double-tap.
+  const TUI_COALESCE_WINDOW_MS = 150;
+  const sigintHandler = createSigintHandler({
+    onGraceful: () => {
+      // Idle sessions (no active stream) have nothing to cancel, so the
+      // first Ctrl+C quits the TUI — matching the standard single-SIGINT
+      // termination convention. When a stream IS active, abort it and let
+      // the user stay in the TUI; a second Ctrl+C within 2s forces exit.
+      if (activeController === null) {
+        void shutdown(130);
+        return;
+      }
+      abortActiveStream();
+    },
+    onForce: () => {
+      // Force path: abort the active foreground stream FIRST so no
+      // further model/tool work can execute during the exit window,
+      // then kick background-task SIGTERM so subprocesses start dying.
+      // Without the foreground abort, side-effecting tools could keep
+      // running for the full 3.5s SIGKILL-escalation wait below.
+      abortActiveStream();
+      const liveTasks = runtimeHandle?.shutdownBackgroundTasks() ?? false;
+      if (liveTasks) {
+        // Wait long enough for the runtime's SIGKILL escalation window
+        // (SIGKILL_ESCALATION_MS = 3000ms in tui-runtime / bash exec) to
+        // fire before this process — and its in-process escalation
+        // timer — dies. Exiting earlier orphans subprocesses that
+        // ignore SIGTERM, exactly the failure mode "force" is supposed
+        // to handle.
+        setTimeout(() => process.exit(130), 3500);
+        return;
+      }
+      process.exit(130);
+    },
+    write: (msg: string) => {
+      process.stderr.write(msg);
+    },
+    doubleTapWindowMs: 2000,
+    coalesceWindowMs: TUI_COALESCE_WINDOW_MS,
+    setTimer: createUnrefTimer,
+  });
+  // Shared entry point: in-app Ctrl+C (via createTuiApp's `onInterrupt`
+  // prop) and the `agent:interrupt` command both route through here.
+  const onInterrupt = (): void => {
+    sigintHandler.handleSignal();
   };
 
   /**
@@ -441,19 +587,50 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   };
 
   // Idempotent shutdown — called by both system:quit and signal handlers.
+  // Every invocation arms a hard-exit failsafe so the user is never stranded
+  // if `appHandle.stop()`, background-task drain, or `runtime.dispose()`
+  // wedges. The failsafe is unref'd, so natural cleanup completion before
+  // the timer fires still lets the process exit cleanly via `process.exit`.
+  const SHUTDOWN_HARD_EXIT_MS = 8000;
   // let: justified — set once on first shutdown call
   let shutdownStarted = false;
-  const shutdown = async (): Promise<void> => {
+  const shutdown = async (exitCode = 0): Promise<void> => {
     if (shutdownStarted) return;
     shutdownStarted = true;
+    // Abort the active foreground run FIRST so no further model/tool
+    // work can execute during teardown. Without this, long-running or
+    // non-cooperative tools can keep mutating local/remote state during
+    // the cooperative shutdown window (up to 8s) or the SIGKILL
+    // escalation wait (3.5s) — after the user or supervisor has already
+    // requested termination. Matches the invariant also enforced on the
+    // force path in onForce.
+    abortActiveStream();
+    // Kick background-task teardown synchronously so stubborn
+    // subprocesses start receiving SIGTERM before anything else that could
+    // wedge (appHandle.stop, runtime.dispose). This guarantees the
+    // invariant — "subprocesses always get SIGTERM before the process
+    // exits" — even if the cooperative shutdown path wedges and the
+    // hard-exit timer fires. The return flag tells us whether to pay the
+    // SIGKILL escalation wait below (idle/no-task exits stay immediate).
+    const hadLiveTasks = runtimeHandle?.shutdownBackgroundTasks() ?? false;
+    // Hard-exit failsafe. If any cooperative step hangs, this terminates
+    // the process. It runs AFTER the background-task SIGTERM has already
+    // been issued above, so orphaned subprocesses get cleaned up by their
+    // own SIGKILL escalation (launched by the runtime) rather than outliving
+    // the TUI.
+    const hardExit = setTimeout(() => {
+      process.exit(exitCode);
+    }, SHUTDOWN_HARD_EXIT_MS);
+    if (typeof hardExit === "object" && hardExit !== null && "unref" in hardExit) {
+      (hardExit as { unref: () => void }).unref();
+    }
     try {
       await appHandle?.stop();
       batcher.dispose();
       if (runtimeHandle !== null) {
-        const hadLiveTasks = runtimeHandle.shutdownBackgroundTasks();
-        // Wait for SIGTERM→SIGKILL escalation window so stubborn subprocesses
-        // are killed before we exit. Without this, children that ignore SIGTERM
-        // outlive the TUI as orphans. SIGKILL_ESCALATION_MS = 3000.
+        // Only pay the SIGTERM→SIGKILL escalation wait when we actually
+        // had live subprocesses to drain. Idle exits stay immediate.
+        // SIGKILL_ESCALATION_MS = 3000 in the runtime.
         if (hadLiveTasks) {
           await new Promise<void>((resolve) => setTimeout(resolve, 3_500));
         }
@@ -461,7 +638,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       }
       approvalStore?.close();
     } finally {
-      process.exit(0);
+      process.exit(exitCode);
     }
   };
 
@@ -695,7 +872,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
               text,
               signal: controller.signal,
             });
-        await drainEngineStream(stream, store, batcher);
+        await drainEngineStream(stream, store, batcher, controller.signal);
 
         // Refresh trajectory data after each turn so /trajectory view is current.
         // Delay 100ms to let fire-and-forget trace-wrapper appends settle —
@@ -711,8 +888,23 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
             });
           });
       } finally {
-        if (activeController === controller) {
+        // Guard against cross-run races: only clear activeController and
+        // reset the SIGINT handler if THIS run is still the active one.
+        // If resetConversation() or a new submit replaced the controller
+        // mid-drain, this finally is stale and must not disarm the
+        // SIGINT state that now belongs to the newer run.
+        const isStillActive = activeController === controller;
+        if (isStillActive) {
           activeController = null;
+        }
+        // The active run has settled. Reset the double-tap window so a
+        // later Ctrl+C is treated as a fresh first tap rather than a
+        // late-arriving second tap of a cancellation that already
+        // completed. Only safe when this run is still the active one —
+        // a stale finally from a reset-and-replaced run must not
+        // disarm SIGINT state that now belongs to a newer turn.
+        if (isStillActive) {
+          sigintHandler.complete();
         }
       }
     },
@@ -738,23 +930,38 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // 6. Signal handling and start
   // ---------------------------------------------------------------------------
 
-  process.once("SIGINT", () => {
-    void shutdown();
-  });
-  process.once("SIGTERM", () => {
-    void shutdown();
-  });
+  const onProcessSigint = (): void => {
+    sigintHandler.handleSignal();
+  };
+  // SIGTERM is a separate termination cause (supervisor/OOM/operator kill)
+  // and must not share SIGINT's exit code. 143 = 128 + 15 (SIGTERM), per
+  // POSIX convention, so supervisors and incident tooling can distinguish
+  // external termination from Ctrl+C.
+  const onProcessSigterm = (): void => {
+    void shutdown(143);
+  };
+  process.on("SIGINT", onProcessSigint);
+  process.once("SIGTERM", onProcessSigterm);
 
-  await result.value.start();
+  try {
+    await result.value.start();
 
-  // Load saved sessions in the background after the TUI is rendering.
-  // Fire-and-forget: failures are silently swallowed (non-critical feature).
-  void loadSessionList(SESSIONS_DIR, jsonlTranscript).then((sessions) => {
-    store.dispatch({ kind: "set_session_list", sessions });
-  });
-  // Block until stop() completes (SIGINT/SIGTERM/quit command all call stop()
-  // and then process.exit — done() resolves right before that exit).
-  await result.value.done();
+    // Load saved sessions in the background after the TUI is rendering.
+    // Fire-and-forget: failures are silently swallowed (non-critical feature).
+    void loadSessionList(SESSIONS_DIR, jsonlTranscript).then((sessions) => {
+      store.dispatch({ kind: "set_session_list", sessions });
+    });
+    // Block until stop() completes. `shutdown()` / quit command exit the
+    // process directly, so the cleanup in `finally` only runs when `done()`
+    // resolves because the renderer was destroyed externally (e.g. in tests
+    // or embedded callers) — which is precisely the path that would leak
+    // signal handlers and armed double-tap timers without explicit cleanup.
+    await result.value.done();
+  } finally {
+    sigintHandler.dispose();
+    process.removeListener("SIGINT", onProcessSigint);
+    process.removeListener("SIGTERM", onProcessSigterm);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/meta/cli/src/tui-reexec-signals.ts
+++ b/packages/meta/cli/src/tui-reexec-signals.ts
@@ -1,0 +1,72 @@
+/**
+ * Signal handling for the `koi tui` re-exec parent wrapper (see issue #1653).
+ *
+ * bin.ts spawns the browser-build TUI child and then installs SIGINT and
+ * SIGTERM handlers on the parent. This module holds the actual handler
+ * logic so bin.ts stays minimal — the startup-latency gate (#1637) locks
+ * bin.ts's post-fast-path identifier set to a small whitelist, and keeping
+ * signal handling out of bin.ts avoids widening that measurement blind
+ * spot with a dozen new identifiers.
+ *
+ * The functions here are NOT executed on the startup-latency measurement
+ * path (bench-entry.ts's command-dispatch scenario short-circuits before
+ * any re-exec spawn), so extending bench-entry.ts to cover them is not
+ * required.
+ */
+
+import type { Subprocess } from "bun";
+
+// After the first SIGTERM, escalate to SIGKILL and hard-exit after this
+// many milliseconds if the child refuses to exit. Prevents the wrapper
+// from hanging forever on `proc.exited` when the child wedges.
+const PARENT_SIGTERM_ESCALATION_MS = 10_000;
+
+/**
+ * Install SIGINT and SIGTERM handlers on the re-exec parent process.
+ *
+ * SIGINT: the terminal delivers Ctrl+C to the whole foreground process
+ * group, so the child already receives it directly. Forwarding would
+ * double-deliver and turn a single Ctrl+C into a force-exit under
+ * scheduler delay. Install a no-op handler purely to suppress Node's
+ * default "terminate parent immediately" behavior so the parent can
+ * block on `proc.exited` and follow the child's graceful interrupt flow.
+ *
+ * Known limitation: `kill -INT <wrapperPid>` (PID-directed, no group
+ * delivery) won't reach the child. SIGINT is conventionally
+ * terminal-driven; supervisors should use SIGTERM for PID-directed
+ * termination, which IS forwarded below with SIGKILL escalation.
+ *
+ * SIGTERM: PID-directed from supervisors only hits the parent, so
+ * forwarding is the only path. The 10s SIGKILL escalation guarantees
+ * the wrapper cannot hang forever if the child refuses to exit.
+ */
+export function installTuiReexecSignalHandlers(proc: Subprocess): void {
+  process.on("SIGINT", noopSigintHandler);
+  process.on("SIGTERM", () => {
+    forwardSigtermWithEscalation(proc);
+  });
+}
+
+function noopSigintHandler(): void {
+  // Intentional no-op — see module docstring.
+}
+
+function forwardSigtermWithEscalation(proc: Subprocess): void {
+  try {
+    proc.kill("SIGTERM");
+  } catch {
+    // Child already exited — `await proc.exited` will unblock on the
+    // next tick.
+  }
+  const escalate = setTimeout(() => {
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // Nothing more to do.
+    }
+    process.exit(143);
+  }, PARENT_SIGTERM_ESCALATION_MS);
+  if (typeof escalate === "object" && escalate !== null && "unref" in escalate) {
+    (escalate as { unref: () => void }).unref();
+  }
+}


### PR DESCRIPTION
Closes #1653 (partial — programmatic API and durable resume split to follow-ups #1682 and #1683, see below).

## Summary

- **First Ctrl+C** triggers a graceful cancel: aborts the active model/tool stream in the TUI, aborts the session-wide `AbortController` in `koi start`. Prints `Interrupting… (Ctrl+C again to force)` to stderr.
- **Second Ctrl+C within 2s** forces exit 130. In `koi start` that's a direct `process.exit(130)`; in the TUI it aborts the active stream, kicks background-task SIGTERM, and waits up to 3.5s for the runtime's SIGKILL escalation window before exiting.
- **Failsafe**: `koi start` arms a 30s unref'd failsafe so a non-cooperative tool that ignores the abort signal is force-escalated. The TUI uses no auto-failsafe — interrupted turns aren't committed to the transcript, and auto-escalation would silently lose session context.
- **Host wrapper** (`bin.ts` re-exec parent for TUI): no-op SIGINT handler (the kernel delivers terminal Ctrl+C to the child via the foreground process group; forwarding would double-deliver and convert one physical Ctrl+C into a force-exit). SIGTERM is forwarded with a 10s SIGKILL escalation so supervisors and `kill <wrapperPid>` work cleanly.

## What this PR does *not* cover (split to follow-ups)

- **#1682** — programmatic `interrupt(sessionId, reason?)` API on the runtime. Needs an L1 session registry in `@koi/engine`; there's no per-session handle today.
- **#1683** — durable resume-from-cancel via `EngineAdapter.saveState`/`loadState`. Reuses existing `SessionPersistence` rather than inventing a `CheckpointAdapter`.

Both were part of #1653's original scope but adversarial review pushed them out because they require L1 surface changes the tight SIGINT fix shouldn't drag along.

## Design decisions (documented in `docs/L2/interrupt.md`)

- **No new L2 package.** Cancellation reuses existing `AbortSignal` plumbing and `done.stopReason === "interrupted"` as the terminal event. An earlier plan proposed `@koi/interrupt` with cancel middleware, a new `agent.cancelled` event kind, and a `CheckpointAdapter` abstraction — adversarial review rejected all three as duplicating control-plane surface that already exists.
- **Hosts own the controller.** Middleware is a pure observer of `ctx.signal`. The SIGINT state machine lives in the CLI host files, not in `@koi/core` or `@koi/engine`.
- **TUI `abortActiveStream` does NOT kill session-wide background tasks or dispose MCP.** `shutdownBackgroundTasks()` is session-wide and also tears down MCP resolvers; running it on a per-turn cancel would regress unrelated background work and break MCP tools for the rest of the session.
- **Idle TUI Ctrl+C goes straight to `shutdown(130)`.** Matches the standard single-SIGINT termination convention when there's nothing to cancel.
- **`drainEngineStream` synthesizes a terminal `done` with partial usage on `AbortError`.** Narrowed to `signal.aborted && (AbortError || ABORT_ERR code)` so timeout-driven and internal aborts still surface as real engine errors. Partial usage is carried from custom `usage` events yielded by `consume-stream.ts` before the throw — ensures cumulative token accounting for interrupted turns is preserved.
- **`shutdown()` aborts the active foreground run first.** Prevents side-effecting tools from continuing during the 8s cooperative teardown window or the 3.5s SIGKILL escalation wait after the user/supervisor has already requested termination.
- **`sigintHandler.complete()` is scoped to the active run.** The drain-loop `finally` only calls it when `activeController === controller` at exit — prevents a stale finally from a reset-and-replaced run from disarming SIGINT state belonging to a newer turn.
- **150ms coalesce window on the TUI handler.** Defense-in-depth against dual ingress paths (keyboard-layer Ctrl+C and process-level SIGINT both routing through the same state machine). Well below human intentional double-tap reflex (~300-500ms), well above any plausible dual-path delivery delay.
- **`tui-reexec-signals.ts` helper.** Signal handling for the re-exec parent is extracted into its own module so `bin.ts` stays within the startup-latency gate's identifier whitelist (#1637 purity contract).

## Test coverage

**Unit tests** — 21 pass in `packages/meta/cli/src/sigint-handler.test.ts`:
- Basic double-tap force, window boundary semantics (at 2000ms, past 2500ms)
- Coalesce window (within, at, past)
- `complete()` reset + coalesce timestamp clear
- `dispose()` idempotency
- Escalation after force state (multiple onForce calls)
- Failsafe timer (with and without `failsafeMs`)
- `onWindowElapse: stay-armed` vs `reset-to-idle` policies
- onGraceful throwing still advances state so subsequent tap forces

**Manual TUI E2E** — all 4 tests PASS on the rebased branch:

| Test | Scenario | Result |
|---|---|---|
| 1 | Single-tap cancel on a foreground Bash loop | PASS — `streaming… 40s → idle`, `T0 → T1`, `✗ Shell ...` (cancelled), `Interrupting…` hint, no error banner, partial usage `up 13.8k down 109` preserved; follow-up `what is 7*7` answered `49`, cumulative `27.5k/123` |
| 2 | Double-tap force exit (same foreground loop) | PASS — TUI exited within ~6s, process gone |
| 3 | Idle single Ctrl+C | PASS — TUI exited within ~2s |
| 4 | External SIGTERM to wrapper PID | PASS — parent + child exited within ~4s |

**Cosmetic note (not introduced by this PR):** On force-exit, `@opentui/core@0.1.96` prints `[KeyHandler] Error … EditBuffer is destroyed` to stderr. Upstream race: a queued keypress event fires its callback against an `EditBuffer` the renderer already destroyed. Process has already exited cleanly with code 130 by the time it prints. Worth a follow-up fix in `@koi/tui` keyboard wiring or an upstream `@opentui/core` bug report, but out of scope for #1653.

## Adversarial review

Refined across **40 rounds of `/codex:adversarial-review`** (4 consecutive review loops × 10 rounds each). Commit history shows the iteration — the final squashed commit absorbs 22 fix commits addressing real-world concerns:

- Cross-run races (stale `finally` disarming a newer turn's SIGINT state)
- Partial token usage preservation on synthetic done events
- Detached spawn revert (SIGTTIN under job control would freeze interactive stdio)
- Force-path foreground abort (don't leave side-effecting tools running during the exit window)
- Process-group vs PID-directed signal semantics
- Host-specific failsafe policies (30s on `koi start`, none on TUI)

Two architectural gaps surfaced across reviews but are deliberately out of scope:
1. **PID-directed `kill -INT <wrapperPid>`** does not reach the TUI child (processed 20+ times across review loops). Design constraint: forwarding would double-deliver terminal Ctrl+C. Documented as a known limitation; supervisors should use SIGTERM.
2. **`drainEngineStream` AbortError→`done` translation** is a best-effort synthesis. When the engine throws instead of yielding a terminal event, we fabricate a `done` with partial usage from custom `usage` events. Real fix would require engine-level partial terminal emission — out of scope.

## Files touched

| File | Change |
|---|---|
| `packages/meta/cli/src/sigint-handler.ts` (new) | Pure state machine factory with injected timers, clock, and callbacks — 21 unit tests |
| `packages/meta/cli/src/sigint-handler.test.ts` (new) | Test suite |
| `packages/meta/cli/src/tui-reexec-signals.ts` (new) | Re-exec parent SIGINT/SIGTERM handlers extracted from `bin.ts` to stay within the #1637 startup-latency purity contract |
| `packages/meta/cli/src/bin.ts` | Lazy-import `installTuiReexecSignalHandlers` in the tui-reexec case |
| `packages/meta/cli/src/commands/start.ts` | Wire state machine, preserve loop-mode and `runtime.dispose?.()` cleanup |
| `packages/meta/cli/src/tui-command.ts` | Wire state machine, abort-aware `drainEngineStream`, active-run scoping of `complete()`, abort foreground stream on shutdown |
| `packages/meta/cli/src/benchmark.test.ts` | Add `installTuiReexecSignalHandlers` to the startup-latency purity whitelist |
| `docs/L2/interrupt.md` (new) | Protocol doc |
| `.claude/plans/interrupt-cancellation-1653.md` (new) | Design plan |

## CI status

- ✅ Assign layer labels
- ✅ Build & test affected packages (57s)
- ✅ Build, Lint, Typecheck & Test (1m6s)
- ✅ Startup latency (warn-only) — `baseline-migration` label applied (required when `bin.ts` is touched, #1637 contract)

## Test plan for reviewer

- [x] `bun test packages/meta/cli/src/sigint-handler.test.ts` — 21 pass
- [x] Full build + typecheck green on rebased branch
- [x] Manual: `koi tui` single Ctrl+C during an active foreground Bash tool leaves the TUI open, status bar goes idle, tool block shows `✗` cancelled, no red error banner
- [x] Manual: `koi tui` double Ctrl+C within 2s force-exits the process
- [x] Manual: `koi tui` idle single Ctrl+C quits the TUI
- [x] Manual: `kill -TERM <wrapperPid>` propagates to the child and exits cleanly
- [ ] Production smoke test against a real OpenRouter/OpenAI call (optional — the branch was tested against a real LLM during the E2E runs)

Follow-ups: **#1682** (programmatic `interrupt(sessionId)`), **#1683** (durable resume via `EngineState` + `SessionPersistence`).
