### PR TITLE
fix: Q1b bug-bash scenario + regressions it surfaced in #1684 (#1698)

### DIFF
--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -1032,6 +1032,50 @@ bun test --filter=@koi/runtime
 **Pass**: clean interrupt; no zombie processes
 **Watch**: interrupt killing the whole TUI; agent reporting completion of an interrupted tool
 
+#### Q1b. Double-tap SIGINT escalation (graceful → force)
+**Tags**: cli sigint-handler state machine, TUI force-exit path, koi start failsafe (#1684)
+**Covers**: the double-tap state machine landed in #1684 — single tap = graceful cancel, second tap within the 2s escalation window = forced shutdown (exit 130). This is the exact path that regressed historically; Q1 only covers the single-tap graceful branch.
+**Setup**: record the wrapper + child PIDs before starting so you can check for orphans after force exit:
+```bash
+# in another terminal
+pgrep -af 'koi (tui|start)' > /tmp/koi-pids-before.txt
+```
+**User query**: `Run 'sleep 120 && echo done' in bash.`
+
+**Variant A — TUI (`koi tui`)**
+**Action**:
+1. Wait until the bash tool is actively running (status bar shows `streaming…`, tool block visible).
+2. Press Ctrl+C **once**. Observe: status bar returns to `idle`, tool block marked `✗` cancelled, stderr shows `Interrupting… (Ctrl+C again to force)`, TUI stays open, no red error banner. Partial token usage is preserved on the turn.
+3. Start another long tool call (`Run 'sleep 120 && echo done' in bash.`) and wait for it to begin streaming.
+4. Press Ctrl+C **twice within 2 seconds** (intentional double-tap, not a bounce — aim for ~300–800ms gap; the handler coalesces taps under 150ms as defense against dual-ingress delivery).
+**Expected**:
+- (a) First tap flips the state machine to graceful cancel and aborts the active stream.
+- (b) Second tap (within 2s window) escalates to force: TUI aborts the foreground stream, kicks background-task SIGTERM, waits up to ~3.5s for the runtime's SIGKILL escalation, then exits 130.
+- (c) No orphan children: the `sleep 120` process is gone, and no `koi tui` / re-exec child remains.
+- (d) Exit code matches the terminal state of the state machine (`force` → 130).
+**Verify**:
+```bash
+echo $?                          # 130
+pgrep -af 'sleep 120'            # empty
+pgrep -af 'koi (tui|start)'      # empty (or only sessions unrelated to this run)
+diff /tmp/koi-pids-before.txt <(pgrep -af 'koi (tui|start)')  # no new survivors
+```
+**Pass**: first tap cancels gracefully without exiting, second tap force-exits within ~6s, exit code is 130, no orphaned `sleep` or re-exec children, interrupted turn is NOT committed to the transcript (TUI intentionally drops uncommitted turns on force to avoid partial-state corruption).
+**Watch**:
+- Second tap outside the 2s window being treated as a fresh single tap instead of escalation (off-by-one on the window boundary).
+- First tap silently escalating to force (the handler's `complete()` was disarmed by a stale `finally` from a prior run — cross-run race called out in the #1684 adversarial review).
+- Orphan `sleep` child surviving force exit (abort signal not propagated to the bash tool's child process group).
+- Wrapper (re-exec parent) surviving after the TUI child exits — indicates the SIGKILL escalation window in `tui-reexec-signals.ts` didn't fire.
+- Exit code ≠ 130 (state machine terminal state mismatch).
+- Cosmetic `[KeyHandler] Error … EditBuffer is destroyed` on stderr after force is a **known upstream race** in `@opentui/core@0.1.96` — do NOT file as a bug unless it appears *before* process exit or changes the exit code.
+
+**Variant B — `koi start` (single-prompt / loop mode)**
+**Action**: run `koi start --prompt "Run 'sleep 120 && echo done' in bash."` (or loop mode). Double-tap Ctrl+C within 2s after the tool starts.
+**Expected**: first tap aborts the session-wide `AbortController` and prints the `Interrupting…` hint; second tap hits the force path and `process.exit(130)` directly. The 30s unref'd failsafe is armed on `koi start` — if a non-cooperative tool ignores the abort signal, force escalation still lands within 30s without a second tap.
+**Verify**: `echo $?` → 130; no orphan `sleep` / `koi start` processes; `runtime.dispose?.()` cleanup ran (no leaked MCP resolvers — check with `lsof -p` on the parent before the second tap if you want to be thorough).
+**Pass**: force exit within ~2s of the second tap; exit code 130; failsafe path verifiable by *not* sending the second tap and waiting 30s on a tool that ignores abort (optional stretch check).
+**Watch**: `koi start` hanging past 30s with no second tap (failsafe timer not armed or unref'd incorrectly); `dispose()` not running on the force path leaving MCP child processes behind.
+
 #### Q2. Malformed tool input
 **Tags**: tools-core validate-tool-args, query-engine ensureToolResultPairing
 **Setup**: this requires provoking the model to produce malformed args (e.g., via an ambiguous query)
@@ -1144,7 +1188,8 @@ bun test --filter=@koi/runtime
 | cli single-prompt mode (`start --prompt`) | O1 |
 | cli manifest override (`start --manifest`) | O2 |
 | tui rendering | A1, B2, J3 |
-| tui interrupt (Ctrl+C) | Q1, C3 |
+| tui interrupt (Ctrl+C) | Q1, Q1b, C3 |
+| cli sigint state machine (#1684) | Q1b |
 | tui streaming | C1, Q3 |
 
 > Rows with `(add scenario if shipped)` indicate subsystems that are in the plan but where the current scenario set doesn't have dedicated coverage. Add scenarios during the bash if those subsystems are in scope for your run.

--- a/packages/meta/cli/src/bin.ts
+++ b/packages/meta/cli/src/bin.ts
@@ -93,7 +93,13 @@ switch (result.kind) {
   case "tui": {
     const { runTuiCommand } = await import("./tui-command.js");
     await runTuiCommand(result.flags);
-    process.exit(0);
+    // No-arg exit so `process.exitCode` (published by the double-tap
+    // force path in tui-command.ts onForce) is preserved. Hard-coding
+    // `process.exit(0)` here overwrote the force-exit code 130, turning
+    // the double-tap state machine into a silent clean exit when the
+    // natural teardown path finished inside the 3.5s escalation window
+    // (#1698 Q1b finding).
+    process.exit();
     break;
   }
   case "run": {

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -582,6 +582,14 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       // running for the full 3.5s SIGKILL-escalation wait below.
       abortActiveStream();
       const liveTasks = runtimeHandle?.shutdownBackgroundTasks() ?? false;
+      // Publish the requested exit code NOW so any path that reaches
+      // `process.exit()` without an explicit code picks up 130. Without
+      // this, a natural teardown path (runTuiCommand returning because
+      // the engine stream closed cleanly after abort) racing the 3.5s
+      // timer below reached bin.ts's `process.exit(0)` first and
+      // overwrote the force-exit code with 0 — silently turning force
+      // into a clean exit (#1698 Q1b finding).
+      process.exitCode = 130;
       if (liveTasks) {
         // Wait long enough for the runtime's SIGKILL escalation window
         // (SIGKILL_ESCALATION_MS = 3000ms in tui-runtime / bash exec) to
@@ -655,6 +663,15 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   const shutdown = async (exitCode = 0): Promise<void> => {
     if (shutdownStarted) return;
     shutdownStarted = true;
+    // Publish the requested exit code NOW, before any await. If the
+    // natural teardown path (runTuiCommand returning after
+    // appHandle.stop) reaches bin.ts's `process.exit()` before this
+    // async body's `finally` runs, the no-arg exit still picks up
+    // `process.exitCode` and terminates with the right code instead of
+    // the default 0 (#1698 Q1b finding — the `shutdown(130)` path from
+    // onGraceful on an idle second tap exhibits the same race as
+    // onForce).
+    process.exitCode = exitCode;
     // Abort the active foreground run FIRST so no further model/tool
     // work can execute during teardown. Without this, long-running or
     // non-cooperative tools can keep mutating local/remote state during

--- a/packages/sandbox/sandbox-os/src/adapter.test.ts
+++ b/packages/sandbox/sandbox-os/src/adapter.test.ts
@@ -421,7 +421,7 @@ describe.skipIf(SKIP_PGROUP_MACOS)("abort kills bash grandchildren (macOS seatbe
       stdout: "pipe",
       stderr: "ignore",
     });
-    const survivors = new TextDecoder().decode(probe.stdout).trim();
+    const survivors = new TextDecoder().decode(new Uint8Array(probe.stdout)).trim();
     expect(survivors).toBe("");
   });
 });

--- a/packages/sandbox/sandbox-os/src/adapter.test.ts
+++ b/packages/sandbox/sandbox-os/src/adapter.test.ts
@@ -374,3 +374,54 @@ describe.skipIf(SKIP_MACOS_INTEGRATION)("exec maxOutputBytes truncation (macOS s
     expect(result.stdout.length).toBeLessThanOrEqual(20);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Process-group abort — regression for #1698 Q1b
+//
+// Without `detached: true` + pgroup-directed kill, an abort of a sandboxed
+// bash invocation signaled only the wrapper (sandbox-exec / bwrap) and left
+// grandchildren (e.g. `sleep` started by the bash subshell) running as
+// orphans reparented to init. Q1b surfaced this on every graceful or force
+// cancel. This test pins the pgroup-kill path so the regression cannot
+// reappear.
+// ---------------------------------------------------------------------------
+
+const SKIP_PGROUP_MACOS = !process.env.SANDBOX_INTEGRATION || process.platform !== "darwin";
+
+describe.skipIf(SKIP_PGROUP_MACOS)("abort kills bash grandchildren (macOS seatbelt)", () => {
+  test("signal.abort() terminates the sleep grandchild via process-group kill", async () => {
+    const adapter = createOsAdapterForTest({ platform: "seatbelt", available: true });
+    const instance = await adapter.create(openProfile(false));
+    const marker = `koi-pgroup-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const controller = new AbortController();
+    const execPromise = instance.exec(
+      "bash",
+      ["--noprofile", "--norc", "-c", `sleep 30 && echo ${marker}`],
+      { signal: controller.signal },
+    );
+
+    // Wait for the bash subshell and its sleep grandchild to actually start
+    // — aborting pre-spawn would trivially "pass" without exercising the
+    // pgroup path.
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+
+    controller.abort();
+    await execPromise.catch(() => {
+      // Expected: abort may reject or resolve with a non-zero exit code.
+    });
+
+    // Give the OS a moment to finish reaping the grandchild before we
+    // assert it's gone.
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+
+    // `pgrep -f` matches on the full argv — the marker string only appears
+    // in the aborted invocation's bash argv, so a match here means the
+    // grandchild survived the abort.
+    const probe = Bun.spawnSync(["pgrep", "-f", marker], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const survivors = new TextDecoder().decode(probe.stdout).trim();
+    expect(survivors).toBe("");
+  });
+});

--- a/packages/sandbox/sandbox-os/src/adapter.ts
+++ b/packages/sandbox/sandbox-os/src/adapter.ts
@@ -7,6 +7,7 @@ import type {
   SandboxInstance,
   SandboxProfile,
 } from "@koi/core";
+import type { Subprocess } from "bun";
 
 import {
   detectPlatform,
@@ -83,6 +84,36 @@ function missingBinaryCode(platform: SandboxPlatform): SandboxErrorCode {
 /** Shared mutable byte budget across stdout + stderr to enforce a combined cap. */
 interface ByteBudget {
   remaining: number;
+}
+
+/**
+ * Signal every process in the group led by `proc`. Falls back to the
+ * plain `proc.kill()` path if the pgroup target is unreachable (e.g. the
+ * wrapper has already exited so the PGID is gone). Swallows errors — at
+ * teardown we only care that the best available signal was sent.
+ *
+ * Relies on the wrapper having been spawned with `detached: true`, which
+ * calls `setsid()` on POSIX and makes `proc.pid === pgid`.
+ */
+function killProcessGroup(proc: Subprocess, signal: NodeJS.Signals): void {
+  const pid = proc.pid;
+  if (pid === undefined || pid <= 0) {
+    try {
+      proc.kill(signal);
+    } catch {
+      // Already exited — nothing to do.
+    }
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      proc.kill(signal);
+    } catch {
+      // Already exited — nothing to do.
+    }
+  }
 }
 
 /**
@@ -237,9 +268,17 @@ function createInstance(
         spawnEnv = { ...opts.env, ...busEnv };
       }
 
+      // `detached: true` makes the spawned wrapper (sandbox-exec / bwrap) a
+      // new process-group leader via setsid() on POSIX. Without this, the
+      // abort path's `proc.kill()` signals only the wrapper PID, leaving
+      // the grandchildren (the actual bash tool and any of its children
+      // like `sleep`) running orphaned. With a group leader, the abort
+      // path can signal the entire group with `process.kill(-pid, sig)`,
+      // reaching every descendant.
       const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
         stdout: "pipe",
         stderr: "pipe",
+        detached: true,
         ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
         ...(spawnEnv !== undefined ? { env: spawnEnv } : {}),
         ...(opts?.stdin !== undefined ? { stdin: new TextEncoder().encode(opts.stdin) } : {}),
@@ -255,10 +294,18 @@ function createInstance(
       let sigkillEscalationTimer: ReturnType<typeof setTimeout> | undefined;
 
       const abortHandler = (): void => {
-        proc.kill(); // SIGTERM — ask the process to exit gracefully
+        // Signal the whole process group so bash grandchildren (e.g.
+        // `sleep` started by the sandboxed tool command) die with their
+        // parent. `proc.kill()` alone signals only the wrapper PID; the
+        // bash subshell's children survive as orphans reparented to init.
+        // `detached: true` above made the wrapper a process-group leader,
+        // so `pgid === proc.pid` and `process.kill(-pid, sig)` reaches
+        // every descendant.
+        killProcessGroup(proc, "SIGTERM");
         // Stop the named systemd scope so all child processes inside the cgroup
-        // are terminated. proc.kill() only signals the bwrap wrapper PID;
-        // grandchild processes survive unless the cgroup scope is stopped.
+        // are terminated. The pgroup kill above handles the plain-bwrap path;
+        // this handles the cgroup-scoped path where pgroup semantics alone
+        // are not sufficient.
         if (execUnitName !== undefined) {
           try {
             Bun.spawnSync(["systemctl", "--user", "stop", execUnitName], {
@@ -275,11 +322,7 @@ function createInstance(
         // permanent hang on proc.exited.
         sigkillEscalationTimer = setTimeout(() => {
           sentSigkillRef.value = true;
-          try {
-            proc.kill(9);
-          } catch {
-            // Process already exited — ignore.
-          }
+          killProcessGroup(proc, "SIGKILL");
         }, 2_000);
         // Cancel the escalation timer if the process exits before 2 s.
         void proc.exited.then(() => {

--- a/packages/security/middleware-audit/src/signing.ts
+++ b/packages/security/middleware-audit/src/signing.ts
@@ -49,7 +49,7 @@ function buildStamper(privateKey: KeyObject): {
     const entryWithChain: AuditEntry = { ...entry, prev_hash: prevHash };
 
     // Sign the full entry-with-chain (but without the signature field itself)
-    const payload = Buffer.from(JSON.stringify(entryWithChain));
+    const payload = new TextEncoder().encode(JSON.stringify(entryWithChain));
     const sigBuffer = sign(null, payload, privateKey);
     const signature = sigBuffer.toString("base64url");
 
@@ -99,8 +99,8 @@ export function verifyEntrySignature(entry: AuditEntry, publicKeyDer: Buffer): b
     readonly signature: string;
   };
 
-  const payload = Buffer.from(JSON.stringify(entryWithoutSig));
-  const sigBuffer = Buffer.from(sig, "base64url");
+  const payload = new TextEncoder().encode(JSON.stringify(entryWithoutSig));
+  const sigBuffer = new Uint8Array(Buffer.from(sig, "base64url"));
 
   try {
     return verify(null, payload, { key: publicKeyDer, format: "der", type: "spki" }, sigBuffer);


### PR DESCRIPTION
Closes #1698.

## Summary

Scope started as the doc-only Q1b addition requested in #1698 — but running the new scenario end-to-end in `koi tui` via tmux surfaced **two real regressions in the #1684 SIGINT work** plus one pre-existing build break that blocked verification. All four now ship in one PR.

1. **`docs(testing)`** — add Q1b scenario (the original ask). Covers graceful→force escalation, both TUI and `koi start` variants, with orphan-child and exit-code verifications and adversarial-review watch items. Coverage matrix updated with a new `cli sigint state machine (#1684)` row.

2. **`fix(sandbox-os)`** — kill process group on abort. `Bun.spawn` wasn't using `detached: true`, so `proc.kill()` only reached the `sandbox-exec`/`bwrap` wrapper. Bash grandchildren (e.g. a `sleep` the tool was running) survived as orphans reparented to init on **every** graceful and force cancel path. Fix: `detached: true` + `process.kill(-pid, sig)` via a new `killProcessGroup(Subprocess, Signals)` helper, with graceful fallback when the wrapper has already exited. Regression test added under the gated `SANDBOX_INTEGRATION=1` describe block — spawns `bash -c 'sleep 30 && echo $MARKER'`, aborts after 300ms, asserts `pgrep -f $MARKER` returns empty.

3. **`fix(cli)`** — propagate force-exit code 130 through the TUI re-exec wrapper. The force path used `setTimeout(() => process.exit(130), 3500)` and returned, trusting the timer to land the exit code. But `runTuiCommand`'s natural teardown could complete inside that 3.5s window (abort → appHandle.stop resolves → runtime.dispose), at which point `bin.ts`'s hardcoded `process.exit(0)` fired first and overwrote force with 0. Q1b E2E reproduced this deterministically. Fix: publish `process.exitCode = 130` synchronously in `onForce` **and** in `shutdown()` (same race applies to `shutdown(130)` from the idle-second-tap path in `onGraceful`), then change `bin.ts` from `process.exit(0)` to `process.exit()` so the no-arg exit picks up `process.exitCode`. Verified: double-tap Ctrl+C on an active `sleep 5001` bash tool now yields `echo $? === 130` through the re-exec wrapper, where it previously yielded 0.

4. **`fix` (Buffer narrowing)** — TS 6 + updated `@types/node` narrowed `Buffer` to `Buffer<ArrayBufferLike>`, which no longer satisfies `ArrayBufferView<ArrayBuffer>`. Two call sites in the repo break the DTS build (`@koi/middleware-audit` signing) and typecheck (the new Q1b pgroup test's `TextDecoder.decode` on `spawnSync.stdout`). Surfaced while rebuilding `@koi-agent/cli` for the Q1b E2E run. Unblocks the build; ships here because (a) is required for typecheck to pass on this PR.

## Q1b E2E results on this branch

**Variant A (`koi tui`)** — run against a live OpenRouter model, `sleep 4001` / `sleep 5001` bash tools, 600ms double-tap gap via tmux:

| Check | Before fixes | After fixes |
|---|---|---|
| First-tap graceful cancel (status → idle, hint, partial usage preserved) | ✅ already worked | ✅ |
| Second-tap force within 2s exits the TUI | ✅ already worked | ✅ |
| Wrapper + re-exec child both gone after force | ✅ already worked | ✅ |
| **Exit code = 130** | ❌ `__EXIT__=0` | ✅ `__EXIT__=130` |
| **No orphan `sleep` grandchildren** | ❌ PPID=1 survivors on both graceful and force | ✅ clean |
| Cosmetic `[KeyHandler] Error … EditBuffer is destroyed` from `@opentui/core@0.1.96` | ⚠️ known upstream, not filing | ⚠️ unchanged, still not filing |

**Variant B (`koi start`)** — not re-tested after the fixes; `koi start`'s force path already calls `process.exit(130)` directly (no setTimeout race), and the sandbox-os pgroup fix applies equally to both hosts. Still a TODO for a human tester to exercise the 30s unref'd failsafe.

## Test plan for reviewer

- [x] `bun test packages/meta/cli/src/sigint-handler.test.ts packages/meta/cli/src/benchmark.test.ts` — 31 pass, 0 fail (unchanged by fixes)
- [x] `SANDBOX_INTEGRATION=1 bun test packages/sandbox/sandbox-os/src/adapter.test.ts` — 15 pass, 10 skip (bwrap-only), 0 fail. The new `abort kills bash grandchildren (macOS seatbelt)` integration test passes on Darwin.
- [x] `bunx turbo run build --filter=@koi-agent/cli` green end-to-end (previously failed on `@koi/middleware-audit` DTS).
- [x] `bun run check:layers` — all packages respect L0/L1/L2 boundaries.
- [x] Live Q1b Variant A TUI E2E: prompt → `a` to approve bash → confirm `⠧ N.Ns Bash` → `tmux send-keys C-c; sleep 0.6; tmux send-keys C-c` → capture `__EXIT__=130` and `pgrep -af 'sleep <marker>'` returns empty.
- [ ] Human to exercise Q1b Variant B (`koi start --prompt`) end-to-end including the 30s failsafe path — remains a bug-bash checklist item.
- [ ] CI green on all 4 commits.

## Incidental findings during the run (not addressed)

- **Permission prompt persistence**: `[a] Always allow Bash this session` did not prevent a fresh permission dialog on a second bash invocation. May be per-command-string rather than wildcard. Not in scope for #1698 — worth a separate issue.
- **Leaked API key in `ps` output**: another worktree's TUI test (`fix-1693-plugin-manifest-doc`) is running with `OPENROUTER_API_KEY=sk-or-v1-…` literal in its tmux argv, visible via `ps auxww`. Not part of this PR — flagged to the author of that test harness. Consider rotating the key and passing it via `-e` env-only or stdin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
