### PR TITLE
docs(testing): inline minimum plugin.json for bug-bash §L1 (#1693)

### DIFF
--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -694,7 +694,7 @@ jq -r 'select(.role=="tool_call") | .content' "$SESSION_FILE" | grep -oE 'task_(
 
 #### L1. Plugin manifest loads
 **Tags**: plugins loader, manifest parsing
-**Setup**: the plugin loader reads `plugin.json` (NOT `plugin.yaml` — see `packages/lib/plugins/src/loader.ts`). Create a minimal JSON manifest in the per-tester HOME:
+**Setup**: the plugin loader reads `plugin.json` (NOT `plugin.yaml` — schema lives in `packages/lib/plugins/src/schema.ts`, read by `packages/lib/plugins/src/loader.ts`). Create a minimal JSON manifest in the per-tester HOME:
 ```bash
 mkdir -p "$KOI_HOME/.koi/plugins/hello-plugin"
 cat > "$KOI_HOME/.koi/plugins/hello-plugin/plugin.json" <<'EOF'
@@ -705,7 +705,10 @@ cat > "$KOI_HOME/.koi/plugins/hello-plugin/plugin.json" <<'EOF'
 }
 EOF
 ```
-(Add whatever other required fields the current plugin manifest schema enforces — check `packages/lib/plugins/src/loader.ts` for the minimum set.)
+<!-- Maintainers: if packages/lib/plugins/src/schema.ts changes, update the required/optional field lists below. -->
+The three fields above (`name`, `version`, `description`) are the **entire** required set per the Zod schema at `packages/lib/plugins/src/schema.ts:20-32`. The loader accepts this exact manifest without error — no other fields are required. Constraints: `name` must match `^[a-z][a-z0-9-]*$` (kebab-case, starts with lowercase letter); `version` and `description` must each be non-empty.
+
+Optional fields available for tests that want to exercise more surface area: `author` (string), `keywords` (string[]), `skills` (string[]), `hooks` (string path, e.g. `./hooks/hooks.json`), `mcpServers` (string path, e.g. `./.mcp.json`), `middleware` (string[]).
 **Action**: restart TUI with the isolated HOME (§1.7 reset).
 **Expected**: plugin discovered at startup (no ENOENT on the manifest) and enumerated by the loader
 **Verify**: `tmux capture-pane -t "$KOI_SESSION" -p | grep hello-plugin`


### PR DESCRIPTION
## Summary

Fixes #1693 — `docs/testing/phase-2-bug-bash.md` §L1 ("Plugin manifest loads") told testers to "check `packages/lib/plugins/src/loader.ts` for the minimum set" of required plugin.json fields, which was doubly stale:

1. The three fields already shown in the example (`name`, `version`, `description`) **are** the entire required set per `packages/lib/plugins/src/schema.ts:20-32`. Every other field on the Zod schema is `.optional()`. There was nothing for testers to add.
2. The schema lives in `schema.ts`, not `loader.ts`. `loader.ts` imports `validatePluginManifest` from `schema.ts` — so the doc was pointing at the reader, not the source of truth.

Result: every tester would re-read source to confirm an empty diff (or worse, invent fields the schema rejects). L1 was not reliably reproducible.

## Fix

Single hunk in `docs/testing/phase-2-bug-bash.md`:

- Cross-reference at line 697 now points at `schema.ts` (authoritative) while still naming `loader.ts` as the reader.
- The stale parenthetical is replaced by an authoritative declaration that names the 3 required fields, cites `schema.ts:20-32`, lists every optional field with its type (`author`, `keywords`, `skills`, `hooks`, `mcpServers`, `middleware`) so testers who want to exercise more surface area don't need to grep, and calls out the kebab-case `name` constraint (`^[a-z][a-z0-9-]*$`) that's easy to trip over.
- An HTML comment next to the block points maintainers back at `schema.ts` so this section stays honest when the schema evolves — addresses the issue body's "update whenever the schema changes" ask.

## Files

| File | Change |
|------|--------|
| `docs/testing/phase-2-bug-bash.md` | Swap stale parenthetical for authoritative note + fix `loader.ts` → `schema.ts` cross-ref + maintenance comment. 5 lines added, 2 removed. |

## Gate results

- `bun test packages/lib/plugins/src/schema.test.ts` — **10 pass, 0 fail** (confirms the 3-field manifest inlined in the doc validates end-to-end).
- `bun run lint` (repo-wide) ✅
- `bun run check:layers` ✅ (pre-existing middleware session-state warnings unrelated)
- `bun run check:doc-wiring` — N/A (pure testing doc, not L2/L3 package docs)

## Test plan

- [x] Verify `schema.ts:20-32` shows exactly 3 required fields (name/version/description), all others `.optional()` — confirmed inline in the fix rationale.
- [x] `bun test packages/lib/plugins/src/schema.test.ts` passes against the exact example in the doc.
- [x] Repo lint + layer check clean.
- [ ] Reviewer: eyeball the §L1 block renders as intended (no broken code fence, HTML comment hidden).
- [ ] Reviewer: if the schema is ever extended with new required fields, confirm the maintenance comment + `schema.ts:20-32` anchor makes the update obvious.

## Out of scope

- Other sections of the bug-bash doc — only §L1 is in scope.
- Adding a real fixture file elsewhere in the repo; inlining is what the issue explicitly asks for and avoids fixture drift.
- Auto-generating the required-field list from the Zod schema at build time — heavier infrastructure for a one-line drift concern; the inline maintenance comment is the simple first step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
