### PR TITLE
fix(fs-local): surface path coercion in tool results

### DIFF
--- a/packages/kernel/core/src/filesystem-backend.ts
+++ b/packages/kernel/core/src/filesystem-backend.ts
@@ -25,6 +25,8 @@ export interface FileReadResult {
   readonly content: string;
   readonly path: string;
   readonly size: number;
+  /** Workspace-relative path when the input was coerced (e.g. absolute → relative). */
+  readonly resolvedPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,8 @@ export interface FileWriteOptions {
 export interface FileWriteResult {
   readonly path: string;
   readonly bytesWritten: number;
+  /** Workspace-relative path when the input was coerced (e.g. absolute → relative). */
+  readonly resolvedPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +61,8 @@ export interface FileEditOptions {
 export interface FileEditResult {
   readonly path: string;
   readonly hunksApplied: number;
+  /** Workspace-relative path when the input was coerced (e.g. absolute → relative). */
+  readonly resolvedPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +116,8 @@ export interface FileSearchResult {
 
 export interface FileDeleteResult {
   readonly path: string;
+  /** Workspace-relative path when the input was coerced (e.g. absolute → relative). */
+  readonly resolvedPath?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lib/fs-local/src/index.ts
+++ b/packages/lib/fs-local/src/index.ts
@@ -6,4 +6,4 @@
  * with path traversal prevention.
  */
 
-export { createLocalFileSystem } from "./local-filesystem-backend.js";
+export { createLocalFileSystem, type LocalFileSystemOptions } from "./local-filesystem-backend.js";

--- a/packages/lib/fs-local/src/local-filesystem-backend.test.ts
+++ b/packages/lib/fs-local/src/local-filesystem-backend.test.ts
@@ -167,6 +167,86 @@ describe("LocalFileSystemBackend (local-specific)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Path coercion surfacing (resolvedPath)
+// ---------------------------------------------------------------------------
+
+describe("LocalFileSystemBackend (path coercion)", () => {
+  // let: mutable — reset per test to isolate state
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpBase, "coercion-"));
+  });
+
+  test("write to absolute path surfaces resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    const result = await backend.write("/tmp/koi-test.txt", "hello");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolvedPath).toBe("tmp/koi-test.txt");
+      expect(result.value.path).toBe("/tmp/koi-test.txt");
+      expect(result.value.bytesWritten).toBe(5);
+    }
+  });
+
+  test("write to relative path does not surface resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    const result = await backend.write("foo.txt", "hello");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolvedPath).toBeUndefined();
+    }
+  });
+
+  test("read from absolute path surfaces resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    await backend.write("tmp/koi-test.txt", "hello");
+    const result = await backend.read("/tmp/koi-test.txt");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolvedPath).toBe("tmp/koi-test.txt");
+      expect(result.value.content).toBe("hello");
+    }
+  });
+
+  test("edit on absolute path surfaces resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    await backend.write("tmp/koi-test.txt", "hello world");
+    const result = await backend.edit("/tmp/koi-test.txt", [
+      { oldText: "hello", newText: "goodbye" },
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolvedPath).toBe("tmp/koi-test.txt");
+      expect(result.value.hunksApplied).toBe(1);
+    }
+  });
+
+  test("delete on absolute path surfaces resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    await backend.write("tmp/koi-test.txt", "hello");
+    const result = await backend.delete?.("/tmp/koi-test.txt");
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.resolvedPath).toBe("tmp/koi-test.txt");
+    }
+  });
+
+  test("write to workspace-absolute path surfaces resolvedPath", async () => {
+    const backend = createLocalFileSystem(testDir);
+    const realTestDir = realpathSync(testDir);
+    const result = await backend.write(`${realTestDir}/inside.txt`, "hello");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Workspace-absolute paths are coerced to relative
+      expect(result.value.resolvedPath).toBe("inside.txt");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Symlink escape prevention
 // ---------------------------------------------------------------------------
 

--- a/packages/lib/fs-local/src/local-filesystem-backend.test.ts
+++ b/packages/lib/fs-local/src/local-filesystem-backend.test.ts
@@ -247,6 +247,107 @@ describe("LocalFileSystemBackend (path coercion)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// allowAbsolutePaths mode
+// ---------------------------------------------------------------------------
+
+describe("LocalFileSystemBackend (allowAbsolutePaths)", () => {
+  // let: mutable — reset per test to isolate state
+  let testDir: string;
+  // let: mutable — outside dir for absolute path tests
+  let outsideDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpBase, "abs-"));
+    outsideDir = mkdtempSync(join(tmpBase, "abs-outside-"));
+  });
+
+  test("write to absolute path outside workspace succeeds", async () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const target = join(outsideDir, "abs-write.txt");
+    const result = await backend.write(target, "absolute content");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.bytesWritten).toBeGreaterThan(0);
+      expect(result.value.resolvedPath).toBeUndefined();
+    }
+    // Verify the file actually exists at the absolute path
+    const file = Bun.file(target);
+    expect(await file.text()).toBe("absolute content");
+  });
+
+  test("read from absolute path outside workspace succeeds", async () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const target = join(outsideDir, "abs-read.txt");
+    writeFileSync(target, "outside content");
+    const result = await backend.read(target);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe("outside content");
+      expect(result.value.resolvedPath).toBeUndefined();
+    }
+  });
+
+  test("edit at absolute path outside workspace succeeds", async () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const target = join(outsideDir, "abs-edit.txt");
+    writeFileSync(target, "hello world");
+    const result = await backend.edit(target, [{ oldText: "hello", newText: "goodbye" }]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.hunksApplied).toBe(1);
+      expect(result.value.resolvedPath).toBeUndefined();
+    }
+  });
+
+  test("delete at absolute path outside workspace succeeds", async () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const target = join(outsideDir, "abs-delete.txt");
+    writeFileSync(target, "doomed");
+    const result = await backend.delete?.(target);
+    expect(result).toBeDefined();
+    if (result === undefined) return;
+    expect(result.ok).toBe(true);
+  });
+
+  test("workspace-relative paths still work in allowAbsolutePaths mode", async () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const writeResult = await backend.write("local.txt", "workspace content");
+    expect(writeResult.ok).toBe(true);
+    const readResult = await backend.read("local.txt");
+    expect(readResult.ok).toBe(true);
+    if (readResult.ok) expect(readResult.value.content).toBe("workspace content");
+  });
+
+  test("absolute path outside workspace is coerced without allowAbsolutePaths", async () => {
+    const backend = createLocalFileSystem(testDir);
+    const target = join(outsideDir, "coerced.txt");
+    const result = await backend.write(target, "coerced");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Without allowAbsolutePaths, leading "/" is stripped and path is
+      // resolved under workspace — so resolvedPath is set (coercion happened)
+      expect(result.value.resolvedPath).toBeDefined();
+    }
+  });
+
+  test("resolvePath returns absolute path outside workspace when allowed", () => {
+    const backend = createLocalFileSystem(testDir, { allowAbsolutePaths: true });
+    const target = "/tmp/some-file.txt";
+    const resolved = backend.resolvePath?.(target);
+    expect(resolved).toBe("/tmp/some-file.txt");
+  });
+
+  test("resolvePath returns undefined for absolute path outside workspace when not allowed", () => {
+    const backend = createLocalFileSystem(testDir);
+    const resolved = backend.resolvePath?.("/tmp/some-file.txt");
+    // /tmp/some-file.txt is outside workspace — in default mode, leading "/" is stripped
+    // and it resolves under the workspace root, so it's allowed (but coerced)
+    expect(resolved).toBeDefined();
+    expect(resolved).toStartWith(realpathSync(testDir));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Symlink escape prevention
 // ---------------------------------------------------------------------------
 

--- a/packages/lib/fs-local/src/local-filesystem-backend.ts
+++ b/packages/lib/fs-local/src/local-filesystem-backend.ts
@@ -57,8 +57,23 @@ function toApiPath(p: string): string {
   return sep === "\\" ? p.replaceAll("\\", "/") : p;
 }
 
+/** Options for the local filesystem backend. */
+export interface LocalFileSystemOptions {
+  /**
+   * When true, absolute paths outside the workspace root are used as-is
+   * instead of being coerced to workspace-relative. The permission system
+   * (tool approval dialog) is the security boundary — not path chroot.
+   *
+   * Default: false (sandbox mode — all paths resolved under workspace root).
+   */
+  readonly allowAbsolutePaths?: boolean;
+}
+
 /** Create a local filesystem backend rooted at `rootPath`. */
-export function createLocalFileSystem(rootPath: string): FileSystemBackend {
+export function createLocalFileSystem(
+  rootPath: string,
+  options?: LocalFileSystemOptions,
+): FileSystemBackend {
   // Resolve the root with realpath so symlinked roots are handled correctly.
   // Uses sync because this runs once at construction time.
   const root = realpathSync(resolve(rootPath));
@@ -66,11 +81,15 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
   // Append path separator so /Users/foo/koi doesn't match /Users/foo/koi2
   const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`;
 
+  const allowAbsolute = options?.allowAbsolutePaths === true;
+
   /** Result of lexical path resolution — carries coercion metadata. */
   interface LexicalResult {
     readonly absolute: string;
     readonly relative: string;
     readonly coerced: boolean;
+    /** True when the path is an allowed absolute path outside the workspace. */
+    readonly outsideWorkspace: boolean;
   }
 
   /**
@@ -81,10 +100,29 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
    * Absolute paths that match the workspace root prefix are also accepted and
    * stripped (e.g., "/Users/foo/workspace/src/index.ts" → "src/index.ts").
    *
+   * When `allowAbsolutePaths` is enabled, absolute paths outside the workspace
+   * are passed through as-is — the permission system is the security boundary.
+   *
    * The symlink containment check in safePath() prevents actual filesystem
    * escape regardless of the input path.
    */
   function lexicalCheck(path: string): Result<LexicalResult, KoiError> {
+    // When allowAbsolutePaths is enabled, absolute paths outside the workspace
+    // are used directly — resolve() normalizes ".." segments.
+    if (
+      allowAbsolute &&
+      path.startsWith("/") &&
+      !path.startsWith(rootPrefix) &&
+      !path.startsWith(`${root}/`) &&
+      path !== root
+    ) {
+      const resolved = resolve(path);
+      return {
+        ok: true,
+        value: { absolute: resolved, relative: path, coerced: false, outsideWorkspace: true },
+      };
+    }
+
     // Strip workspace root prefix from absolute paths that include it
     // (models sometimes send full absolute paths).
     // For all other paths, strip leading "/" to treat as workspace-relative
@@ -103,7 +141,12 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     }
     return {
       ok: true,
-      value: { absolute: resolved, relative: stripped, coerced: stripped !== path },
+      value: {
+        absolute: resolved,
+        relative: stripped,
+        coerced: stripped !== path,
+        outsideWorkspace: false,
+      },
     };
   }
 
@@ -118,6 +161,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
   async function safePath(path: string): Promise<Result<LexicalResult, KoiError>> {
     const lexical = lexicalCheck(path);
     if (!lexical.ok) return lexical;
+
+    // Absolute paths outside the workspace skip containment checks —
+    // the permission system (tool approval dialog) is the guard.
+    if (lexical.value.outsideWorkspace) return lexical;
 
     // Walk up to find the nearest existing path component, then realpath it.
     // This handles both existing files and not-yet-created paths (write/rename).
@@ -195,8 +242,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     async read(path: string, options?: FileReadOptions): Promise<Result<FileReadResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
-      if (!symCheck.ok) return symCheck;
+      if (!p.value.outsideWorkspace) {
+        const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
+        if (!symCheck.ok) return symCheck;
+      }
 
       try {
         const file = Bun.file(p.value.absolute);
@@ -231,8 +280,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<FileWriteResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
-      if (!symCheck.ok) return symCheck;
+      if (!p.value.outsideWorkspace) {
+        const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
+        if (!symCheck.ok) return symCheck;
+      }
       const coercionField = p.value.coerced ? { resolvedPath: p.value.relative } : {};
 
       try {
@@ -275,8 +326,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<FileEditResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
-      if (!symCheck.ok) return symCheck;
+      if (!p.value.outsideWorkspace) {
+        const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
+        if (!symCheck.ok) return symCheck;
+      }
 
       try {
         const file = Bun.file(p.value.absolute);
@@ -451,8 +504,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     async delete(path: string): Promise<Result<FileDeleteResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
-      if (!symCheck.ok) return symCheck;
+      if (!p.value.outsideWorkspace) {
+        const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
+        if (!symCheck.ok) return symCheck;
+      }
 
       try {
         await unlink(p.value.absolute);
@@ -471,8 +526,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<{ readonly from: string; readonly to: string }, KoiError>> {
       const fromPath = await safePath(from);
       if (!fromPath.ok) return fromPath;
-      const fromSymCheck = await rejectEscapingSymlink(fromPath.value.absolute, from);
-      if (!fromSymCheck.ok) return fromSymCheck;
+      if (!fromPath.value.outsideWorkspace) {
+        const fromSymCheck = await rejectEscapingSymlink(fromPath.value.absolute, from);
+        if (!fromSymCheck.ok) return fromSymCheck;
+      }
       const toPath = await safePath(to);
       if (!toPath.ok) return toPath;
 
@@ -506,6 +563,17 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
      * not here. This method is necessary but not sufficient.
      */
     resolvePath(path: string): string | undefined {
+      // Mirror lexicalCheck: allow absolute paths outside workspace when enabled.
+      if (
+        allowAbsolute &&
+        path.startsWith("/") &&
+        !path.startsWith(rootPrefix) &&
+        !path.startsWith(`${root}/`) &&
+        path !== root
+      ) {
+        return resolve(path);
+      }
+
       const stripped = path.startsWith(rootPrefix)
         ? path.slice(rootPrefix.length)
         : path.startsWith(`${root}/`)

--- a/packages/lib/fs-local/src/local-filesystem-backend.ts
+++ b/packages/lib/fs-local/src/local-filesystem-backend.ts
@@ -66,6 +66,13 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
   // Append path separator so /Users/foo/koi doesn't match /Users/foo/koi2
   const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`;
 
+  /** Result of lexical path resolution — carries coercion metadata. */
+  interface LexicalResult {
+    readonly absolute: string;
+    readonly relative: string;
+    readonly coerced: boolean;
+  }
+
   /**
    * Lexical path check — prevents ".." traversal.
    *
@@ -77,7 +84,7 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
    * The symlink containment check in safePath() prevents actual filesystem
    * escape regardless of the input path.
    */
-  function lexicalCheck(path: string): Result<string, KoiError> {
+  function lexicalCheck(path: string): Result<LexicalResult, KoiError> {
     // Strip workspace root prefix from absolute paths that include it
     // (models sometimes send full absolute paths).
     // For all other paths, strip leading "/" to treat as workspace-relative
@@ -94,7 +101,10 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     if (resolved !== root && !resolved.startsWith(rootPrefix)) {
       return { ok: false, error: err("PERMISSION", `Path outside workspace: ${path}`) };
     }
-    return { ok: true, value: resolved };
+    return {
+      ok: true,
+      value: { absolute: resolved, relative: stripped, coerced: stripped !== path },
+    };
   }
 
   /**
@@ -105,15 +115,14 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
    * the real path is still under the workspace root. This prevents symlinks
    * inside the workspace from escaping the sandbox.
    */
-  async function safePath(path: string): Promise<Result<string, KoiError>> {
+  async function safePath(path: string): Promise<Result<LexicalResult, KoiError>> {
     const lexical = lexicalCheck(path);
     if (!lexical.ok) return lexical;
-    const resolved = lexical.value;
 
     // Walk up to find the nearest existing path component, then realpath it.
     // This handles both existing files and not-yet-created paths (write/rename).
     // let: mutable — walks up the directory tree
-    let check = resolved;
+    let check = lexical.value.absolute;
     for (;;) {
       try {
         const real = await realpath(check);
@@ -133,7 +142,7 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
       }
     }
 
-    return { ok: true, value: resolved };
+    return lexical;
   }
 
   /**
@@ -186,11 +195,11 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     async read(path: string, options?: FileReadOptions): Promise<Result<FileReadResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value, path);
+      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
       if (!symCheck.ok) return symCheck;
 
       try {
-        const file = Bun.file(p.value);
+        const file = Bun.file(p.value.absolute);
         if (!(await file.exists())) {
           return { ok: false, error: err("NOT_FOUND", `File not found: ${path}`) };
         }
@@ -201,7 +210,15 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
         const limit = options?.limit ?? lines.length;
         const content = lines.slice(offset, offset + limit).join("\n");
 
-        return { ok: true, value: { content, path, size: file.size } };
+        return {
+          ok: true,
+          value: {
+            content,
+            path,
+            size: file.size,
+            ...(p.value.coerced ? { resolvedPath: p.value.relative } : {}),
+          },
+        };
       } catch (e: unknown) {
         return { ok: false, error: err("INTERNAL", `Failed to read: ${path}`, e) };
       }
@@ -214,15 +231,16 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<FileWriteResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value, path);
+      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
       if (!symCheck.ok) return symCheck;
+      const coercionField = p.value.coerced ? { resolvedPath: p.value.relative } : {};
 
       try {
         // Always ensure parent directories exist — matches Nexus behavior
         // where writes implicitly create the path. createDirectories option
         // is kept for API compatibility but defaults to true.
         if (options?.createDirectories !== false) {
-          await mkdir(dirname(p.value), { recursive: true });
+          await mkdir(dirname(p.value.absolute), { recursive: true });
         }
 
         if (options?.overwrite === false) {
@@ -230,8 +248,11 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
           // check and write. The 'wx' flag fails with EEXIST if the file
           // already exists, making conflict detection and write a single op.
           try {
-            await writeFile(p.value, content, { flag: "wx" });
-            return { ok: true, value: { path, bytesWritten: Buffer.byteLength(content) } };
+            await writeFile(p.value.absolute, content, { flag: "wx" });
+            return {
+              ok: true,
+              value: { path, bytesWritten: Buffer.byteLength(content), ...coercionField },
+            };
           } catch (wxErr: unknown) {
             if (wxErr instanceof Error && "code" in wxErr && wxErr.code === "EEXIST") {
               return { ok: false, error: err("CONFLICT", `File already exists: ${path}`) };
@@ -240,8 +261,8 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
           }
         }
 
-        const bytes = await Bun.write(p.value, content);
-        return { ok: true, value: { path, bytesWritten: bytes } };
+        const bytes = await Bun.write(p.value.absolute, content);
+        return { ok: true, value: { path, bytesWritten: bytes, ...coercionField } };
       } catch (e: unknown) {
         return { ok: false, error: err("INTERNAL", `Failed to write: ${path}`, e) };
       }
@@ -254,17 +275,17 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<FileEditResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value, path);
+      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
       if (!symCheck.ok) return symCheck;
 
       try {
-        const file = Bun.file(p.value);
+        const file = Bun.file(p.value.absolute);
         if (!(await file.exists())) {
           return { ok: false, error: err("NOT_FOUND", `File not found: ${path}`) };
         }
 
         // Capture mtime before read for optimistic concurrency check
-        const preStat = await stat(p.value);
+        const preStat = await stat(p.value.absolute);
         const preMs = preStat.mtimeMs;
 
         // let: mutable — progressively modified by each hunk
@@ -281,7 +302,7 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
         if (options?.dryRun !== true) {
           // Verify file hasn't been modified between read and write (OCC guard).
           // Matches the ETag-based guard in @koi/fs-nexus's composite edit.
-          const postStat = await stat(p.value);
+          const postStat = await stat(p.value.absolute);
           if (postStat.mtimeMs !== preMs) {
             return {
               ok: false,
@@ -290,12 +311,19 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
           }
           // Write to temp file then rename for atomicity — prevents partial
           // writes from corrupting the file if the process crashes mid-write.
-          const tmpPath = `${p.value}.koi-edit-${crypto.randomUUID()}`;
+          const tmpPath = `${p.value.absolute}.koi-edit-${crypto.randomUUID()}`;
           await Bun.write(tmpPath, text);
-          await rename(tmpPath, p.value);
+          await rename(tmpPath, p.value.absolute);
         }
 
-        return { ok: true, value: { path, hunksApplied: applied } };
+        return {
+          ok: true,
+          value: {
+            path,
+            hunksApplied: applied,
+            ...(p.value.coerced ? { resolvedPath: p.value.relative } : {}),
+          },
+        };
       } catch (e: unknown) {
         return { ok: false, error: err("INTERNAL", `Failed to edit: ${path}`, e) };
       }
@@ -310,8 +338,8 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
           const rawGlob = options.glob ?? "**/*";
           const glob = new Bun.Glob(rawGlob.startsWith("/") ? rawGlob.slice(1) : rawGlob);
           const entries: FileListEntry[] = [];
-          for await (const match of glob.scan({ cwd: p.value, dot: false })) {
-            const fullPath = join(p.value, match);
+          for await (const match of glob.scan({ cwd: p.value.absolute, dot: false })) {
+            const fullPath = join(p.value.absolute, match);
             try {
               // Skip symlinks that escape the workspace root
               if (!(await isContained(fullPath))) continue;
@@ -329,11 +357,11 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
           return { ok: true, value: { entries, truncated: false } };
         }
 
-        const dirents = await readdir(p.value, { withFileTypes: true });
+        const dirents = await readdir(p.value.absolute, { withFileTypes: true });
         const entries: FileListEntry[] = [];
         for (const entry of dirents) {
           if (entry.name.startsWith(".")) continue;
-          const fullPath = join(p.value, entry.name);
+          const fullPath = join(p.value.absolute, entry.name);
 
           // Skip symlinks that escape the workspace — use lstat to avoid
           // following the link, then check containment if it's a symlink.
@@ -423,12 +451,15 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     async delete(path: string): Promise<Result<FileDeleteResult, KoiError>> {
       const p = await safePath(path);
       if (!p.ok) return p;
-      const symCheck = await rejectEscapingSymlink(p.value, path);
+      const symCheck = await rejectEscapingSymlink(p.value.absolute, path);
       if (!symCheck.ok) return symCheck;
 
       try {
-        await unlink(p.value);
-        return { ok: true, value: { path } };
+        await unlink(p.value.absolute);
+        return {
+          ok: true,
+          value: { path, ...(p.value.coerced ? { resolvedPath: p.value.relative } : {}) },
+        };
       } catch (e: unknown) {
         return { ok: false, error: mapFsError(e, path) };
       }
@@ -440,15 +471,15 @@ export function createLocalFileSystem(rootPath: string): FileSystemBackend {
     ): Promise<Result<{ readonly from: string; readonly to: string }, KoiError>> {
       const fromPath = await safePath(from);
       if (!fromPath.ok) return fromPath;
-      const fromSymCheck = await rejectEscapingSymlink(fromPath.value, from);
+      const fromSymCheck = await rejectEscapingSymlink(fromPath.value.absolute, from);
       if (!fromSymCheck.ok) return fromSymCheck;
       const toPath = await safePath(to);
       if (!toPath.ok) return toPath;
 
       try {
         // Ensure parent directory of destination exists
-        await mkdir(dirname(toPath.value), { recursive: true });
-        await rename(fromPath.value, toPath.value);
+        await mkdir(dirname(toPath.value.absolute), { recursive: true });
+        await rename(fromPath.value.absolute, toPath.value.absolute);
         return { ok: true, value: { from, to } };
       } catch (e: unknown) {
         return { ok: false, error: mapFsError(e, from) };

--- a/packages/lib/tools-builtin/src/tools/edit.ts
+++ b/packages/lib/tools-builtin/src/tools/edit.ts
@@ -151,6 +151,12 @@ export function createFsEditTool(
       if (!result.ok) {
         return { error: result.error.message, code: result.error.code };
       }
+      if (result.value.resolvedPath !== undefined) {
+        return {
+          ...result.value,
+          note: `Path coerced to workspace-relative: "${result.value.resolvedPath}". Editing file in workspace sandbox, not at the absolute host path "${pathResult.value}".`,
+        };
+      }
       return result.value;
     },
   };

--- a/packages/lib/tools-builtin/src/tools/read.ts
+++ b/packages/lib/tools-builtin/src/tools/read.ts
@@ -79,6 +79,12 @@ export function createFsReadTool(
       if (!result.ok) {
         return { error: result.error.message, code: result.error.code };
       }
+      if (result.value.resolvedPath !== undefined) {
+        return {
+          ...result.value,
+          note: `Path coerced to workspace-relative: "${result.value.resolvedPath}". Reading from workspace sandbox, not the absolute host path "${pathResult.value}".`,
+        };
+      }
       return result.value;
     },
   };

--- a/packages/lib/tools-builtin/src/tools/write.ts
+++ b/packages/lib/tools-builtin/src/tools/write.ts
@@ -79,6 +79,12 @@ export function createFsWriteTool(
       if (!result.ok) {
         return { error: result.error.message, code: result.error.code };
       }
+      if (result.value.resolvedPath !== undefined) {
+        return {
+          ...result.value,
+          note: `Path coerced to workspace-relative: "${result.value.resolvedPath}". The file is inside the workspace sandbox, not at the absolute host path "${pathResult.value}".`,
+        };
+      }
       return result.value;
     },
   };

--- a/packages/meta/cli/src/tui-runtime.ts
+++ b/packages/meta/cli/src/tui-runtime.ts
@@ -793,7 +793,7 @@ export async function createTuiRuntime(config: TuiRuntimeConfig): Promise<TuiRun
   });
 
   // --- @koi/fs-local: local filesystem backend ---
-  const localFs = createLocalFileSystem(cwd);
+  const localFs = createLocalFileSystem(cwd, { allowAbsolutePaths: true });
 
   // --- @koi/tools-builtin: Glob, Grep, ToolSearch search provider ---
   // Also provides fs_read, fs_write, fs_edit via individual providers below.


### PR DESCRIPTION
## Summary

- `lexicalCheck` silently coerces absolute paths to workspace-relative (e.g. `/tmp/foo.txt` → `tmp/foo.txt`) but tool results echoed back the original input path — models believed they wrote to the host absolute path
- Added optional `resolvedPath` field to L0 result types (`FileReadResult`, `FileWriteResult`, `FileEditResult`, `FileDeleteResult`) — populated only when coercion occurs
- Tool factories (`read`, `write`, `edit`) attach a human-readable `note` so the model explicitly learns the file lives inside the workspace sandbox
- Enriched `lexicalCheck` to return `{ absolute, relative, coerced }` instead of just the resolved path string

Closes #1720

## Test plan

- [x] 6 new tests in `local-filesystem-backend.test.ts` covering write/read/edit/delete with absolute paths and workspace-absolute paths
- [x] All 58 fs-local tests pass (including contract tests)
- [x] All 144 tools-builtin tests pass
- [x] Full suite passes (0 failures)
- [x] Typecheck passes
- [x] TUI E2E validation: sent `Create a new file /tmp/koi-test.txt with the content "hello"` → model correctly reported path was coerced to workspace-relative