### PR TITLE
docs(testing): #1787 seed CLAUDE.md in bug-bash fixture so rules-loader Q3 is testable

### DIFF
--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -67,6 +67,17 @@ cat > README.md <<'EOF'
 # Fixture Project
 A small TypeScript project used by the Phase 2 bug bash.
 EOF
+cat > CLAUDE.md <<'EOF'
+# Fixture Project Rules
+
+These rules MUST be surfaced by the rules-loader middleware. Q3 of S1
+verifies injection by asking the agent to name them.
+
+- Always use **Bun**, never npm or yarn.
+- Test runner is **bun:test**.
+- Magic phrase: `pineapple-rhubarb-42` (an unambiguous token so Q3 can
+  assert the rules block was injected, not hallucinated).
+EOF
 mkdir -p src test
 cat > src/math.ts <<'EOF'
 export function add(a: number, b: number): number { return a + b; }
@@ -123,7 +134,7 @@ Each query (Q) is a prompt sent via `tmux send-keys -t "$KOI_SESSION" '<prompt>'
 |---|--------|---------------|-------|---------------|
 | Q1 | `Hello, what can you do?` | none | reset | Text streams incrementally, no tool calls |
 | Q2 | `What runtime are you running on?` | none | same session as Q1 | Mentions Bun/TypeScript from system prompt |
-| Q3 | `What project rules apply to this repo?` | none | same session | Mentions rules from CLAUDE.md (verifies rules-loader MW injection) |
+| Q3 | `What project rules apply to this repo?` | none | same session | Mentions rules from CLAUDE.md — must include the magic phrase `pineapple-rhubarb-42` verbatim to prove rules-loader MW injection (not hallucination) |
 | Q4 | `What did we just talk about?` | none | kill TUI, `start --resume <id> --prompt "..."` | Resumes prior context; same JSONL file grows |
 | Q5 | `What did we just talk about?` | none | kill TUI, relaunch, use TUI session picker | Session picker shows prior session; context coherent |
 


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` creation to the §1.4 fixture setup in `docs/testing/phase-2-bug-bash.md` so the rules-loader middleware has something to discover when S1/Q3 runs.
- Tightens S1/Q3's pass criterion to require the literal marker phrase `pineapple-rhubarb-42` verbatim — converts the query from a hallucination-tolerant check into an unambiguous injection assertion.

## Why

In the latest bug bash run, S1/Q3 (`What project rules apply to this repo?`) was reported as a failure because the agent made 7 fs_read calls and concluded *"No explicit rule files were found"*. The root cause was a fixture gap, not a MW bug: the fixture had no `CLAUDE.md` for rules-loader to surface. See #1787.

With this change, Q3 becomes a true smoke test for rules-loader injection: if the phrase appears in the agent's answer, the MW successfully loaded the file from the project root and injected it into the system prompt.

## Test plan

- [ ] Re-run S1 with an updated fixture containing `CLAUDE.md`
- [ ] Verify agent mentions `pineapple-rhubarb-42` in Q3 response (blocked on current main CLI build failure — `@koi/decision-ledger` unresolved in `@koi-agent/cli#build`; verified by inspection + rules-loader's existing unit tests cover CLAUDE.md discovery at repo root)
- [ ] `bun test --filter=@koi/rules-loader` still green (unchanged by this PR)

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
