### PR TITLE
docs(bug-bash): add package.json to fixture setup (#1739)

### DIFF
--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -125,6 +125,13 @@ import { add, multiply } from "../src/math.js";
 test("add", () => expect(add(2, 3)).toBe(5));
 test("multiply", () => expect(multiply(2, 3)).toBe(6));
 EOF
+cat > package.json <<'EOF'
+{
+  "name": "koi-bugbash-fixture",
+  "type": "module",
+  "private": true
+}
+EOF
 git add -A && git commit -q -m "init"
 cd - >/dev/null
 # For Q7e (out-of-workspace read):


### PR DESCRIPTION
## Summary
- Adds a minimal ESM `package.json` to the §1.4 fixture setup script so `bun test` in §S2 Q9 has the package context to run.

## Why
Per #1739, the fixture setup creates `src/math.ts` + `test/math.test.ts` but never writes `package.json`, making Q9 (`Run the tests to make sure nothing broke.`) unrunnable as written. This is a doc-only defect — no Koi code changes.

## Test plan
- [x] Diff review: +7 lines, adds a HEREDOC for `package.json` right before `git add -A`
- [ ] Reviewer walks §1.4 as written end-to-end in a clean `$FIXTURE`; `bun test` exits 0

Closes #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
