### PR TITLE
docs(bug-bash): rewrite S6/Q19 + Q22 setup for TUI env/CLI-only design (#1780)

### DIFF
--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -194,13 +194,13 @@ EOF
 
 ### S6 — Permissions & Hooks
 
-**Setup for Q19**: config with `tools.bash.allow: ["bun test", "bun run build"]`
+**Setup for Q19**: none (in-session grant exercises the same code path). The TUI has no user config file for pre-allowing tools — by design, it is configured via environment variables and CLI flags only. The `[a] Always allow <tool> this session` keystroke on the first approval modal is the mechanism for tool-granularity pre-approval within a session. See #1780 for the architectural rationale.
 **Setup for Q21**: `$KOI_HOME/.koi/hooks.json` with pre-tool-use command hook writing to `$HOOK_LOG`
-**Setup for Q22**: Bun stub server on per-tester `$HOOK_PORT`, hooks.json POSTing to it
+**Setup for Q22**: Bun stub server on per-tester `$HOOK_PORT`, hooks.json POSTing to it. Requires `KOI_DEV=1` or `NODE_ENV=development` in the TUI environment so the HTTP hook URL validator accepts loopback (`http://127.0.0.1:...`); see `packages/lib/hooks/src/hook-validation.ts`.
 
 | Q | Prompt | Tools Expected | Pass Criteria |
 |---|--------|---------------|---------------|
-| Q19 | `Run the tests.` | Bash | No approval prompt (allow-list match) |
+| Q19 | Turn 1: `Run the tests.` → approve modal with `[a] Always allow Bash this session`. Turn 2: `Run the tests again.` | Bash | First turn renders the Bash approval modal; after pressing `a`, the second turn's Bash call runs with **no re-prompt** (session-wide grant holds for subsequent identical-tool calls). |
 | Q20 | `Fix the typo in README.md (change 'Fixture' to 'Fixtures').` | fs_edit | TUI permission prompt renders; edit completes after approval |
 | Q21 | `Read src/math.ts and write a summary to summary.txt.` | fs_read, fs_write | `$HOOK_LOG` shows 2+ entries with tool names |
 | Q22 | `Read README.md` | fs_read | `$HOOK_LOG` shows POST with JSON event body |


### PR DESCRIPTION
## Summary
- Rewrites §S6 Q19 setup to use the in-session `[a] Always allow` keystroke instead of a `tools.bash.allow` config file that doesn't exist.
- Documents the `KOI_DEV=1` requirement for Q22 loopback HTTP hooks.

## Why
The §S6/Q19 setup called for `config with tools.bash.allow: ["bun test", "bun run build"]`, but the TUI has no such config surface — per CLAUDE.md, the TUI is configured via environment variables and CLI flags only. The permission allow-list is hardcoded in the preset-stacks permissions stack and has no file loader.

Rather than wire a config loader (breaks the architectural rule), rewrite Q19 to exercise the same pre-approval code path via the `[a] Always allow <tool> this session` keystroke. This is already the user-facing mechanism for tool-granularity session grants and was verified working in the #1732 repro (cross-turn persistence of `a` grants holds).

The Q22 `KOI_DEV=1` requirement was surfaced during the bug bash (tester tried loopback HTTP hooks and they silently didn't fire until the env var was set) — `packages/lib/hooks/src/hook-validation.ts:30-34` gates `http://127.0.0.1:...` on `NODE_ENV=development` or `KOI_DEV=1`.

## Test plan
- [x] Diff review: +3 / -3, doc only, no code changes
- [ ] Reviewer walks §S6 Q19 with a fresh TUI, presses `a` on turn 1, verifies turn 2 issues the same Bash call with no re-prompt
- [ ] Reviewer walks §S6 Q22 with `KOI_DEV=1`, verifies HTTP hook fires against the loopback stub

Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
