### PR TITLE
fix(tui): gate /mcp needs-auth on HTTP transport (#1852)

### DIFF
--- a/docs/L2/mcp-server.md
+++ b/docs/L2/mcp-server.md
@@ -180,6 +180,10 @@ No behavioral changes in this package. Two mock `TaskBoard` fixtures in
 fixtures need to satisfy the new interface shape. No runtime logic or public
 surface touched.
 
+## E2E test helper (#1852)
+
+`src/__test-echo-server__.ts` is a minimal stdio MCP echo server used to reproduce and verify fix #1852 (stdio servers must show `connected`, not `needs-auth`). It is a dev/test artifact — not part of the public package exports — and should not be removed without updating the `.mcp.json` E2E configuration that references it.
+
 ## Completion output defaulting (#1785)
 
 `koi_update_task(action: "complete")` now defaults `output` to

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -6,6 +6,8 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
 
 `@koi/mcp` now exposes an `AuthToolFactory` callback so auth-needed servers surface as `<server>__authenticate` pseudo-tools (CC pattern). The component provider reads `failure.error.code === "AUTH_REQUIRED"` and either invokes the factory (when supplied by the host) or falls back to skipped components. No new providers are added — existing wiring continues to work.
 
+`@koi/mcp-server` gained a `__test-echo-server__.ts` dev helper (not exported) for E2E validation of #1852. No behavioral change to the package's public API or runtime integration.
+
 ---
 
 ## What This Enables

--- a/packages/meta/cli/src/preset-stacks/mcp.ts
+++ b/packages/meta/cli/src/preset-stacks/mcp.ts
@@ -52,6 +52,10 @@ export const mcpStack: PresetStack = {
       exports: {
         ...(userMcpSetup !== undefined ? { mcpResolver: userMcpSetup.resolver } : {}),
         ...(pluginMcpSetup !== undefined ? { mcpPluginResolver: pluginMcpSetup.resolver } : {}),
+        ...(userMcpSetup !== undefined ? { mcpTransportByName: userMcpSetup.transportByName } : {}),
+        ...(pluginMcpSetup !== undefined
+          ? { mcpPluginTransportByName: pluginMcpSetup.transportByName }
+          : {}),
       },
       onShutdown: () => {
         // Best-effort dispose. Neither setup has background work that

--- a/packages/meta/cli/src/preset-stacks/mcp.ts
+++ b/packages/meta/cli/src/preset-stacks/mcp.ts
@@ -59,9 +59,6 @@ export const mcpStack: PresetStack = {
         ...(pluginMcpSetup !== undefined
           ? { mcpPluginTransportByName: pluginMcpSetup.transportByName }
           : {}),
-        ...(pluginMcpSetup !== undefined
-          ? { mcpPluginOAuthCapableNames: pluginMcpSetup.oauthCapableNames }
-          : {}),
       },
       onShutdown: () => {
         // Best-effort dispose. Neither setup has background work that

--- a/packages/meta/cli/src/preset-stacks/mcp.ts
+++ b/packages/meta/cli/src/preset-stacks/mcp.ts
@@ -59,6 +59,9 @@ export const mcpStack: PresetStack = {
         ...(pluginMcpSetup !== undefined
           ? { mcpPluginTransportByName: pluginMcpSetup.transportByName }
           : {}),
+        ...(pluginMcpSetup !== undefined
+          ? { mcpPluginOAuthCapableNames: pluginMcpSetup.oauthCapableNames }
+          : {}),
       },
       onShutdown: () => {
         // Best-effort dispose. Neither setup has background work that

--- a/packages/meta/cli/src/preset-stacks/mcp.ts
+++ b/packages/meta/cli/src/preset-stacks/mcp.ts
@@ -53,8 +53,14 @@ export const mcpStack: PresetStack = {
         ...(userMcpSetup !== undefined ? { mcpResolver: userMcpSetup.resolver } : {}),
         ...(pluginMcpSetup !== undefined ? { mcpPluginResolver: pluginMcpSetup.resolver } : {}),
         ...(userMcpSetup !== undefined ? { mcpTransportByName: userMcpSetup.transportByName } : {}),
+        ...(userMcpSetup !== undefined
+          ? { mcpOAuthCapableNames: userMcpSetup.oauthCapableNames }
+          : {}),
         ...(pluginMcpSetup !== undefined
           ? { mcpPluginTransportByName: pluginMcpSetup.transportByName }
+          : {}),
+        ...(pluginMcpSetup !== undefined
+          ? { mcpPluginOAuthCapableNames: pluginMcpSetup.oauthCapableNames }
           : {}),
       },
       onShutdown: () => {

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -589,6 +589,8 @@ export interface McpServerStatus {
   readonly failureMessage: string | undefined;
   /** Transport kind — undefined for plugin-provided servers where config is unavailable. */
   readonly transport: "http" | "stdio" | "sse" | undefined;
+  /** Whether this server has a usable OAuth config — `needs-auth` is only valid when true. */
+  readonly hasOAuth: boolean;
 }
 
 // MCP loading has moved to `./shared-wiring.ts` — both `koi start` and
@@ -1511,6 +1513,12 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
     const mcpPluginTransportByName = stackContribution.exports.mcpPluginTransportByName as
       | ReadonlyMap<string, "http" | "stdio" | "sse">
       | undefined;
+    const mcpOAuthCapableNames = stackContribution.exports.mcpOAuthCapableNames as
+      | ReadonlySet<string>
+      | undefined;
+    const mcpPluginOAuthCapableNames = stackContribution.exports.mcpPluginOAuthCapableNames as
+      | ReadonlySet<string>
+      | undefined;
 
     // --- Audit middleware (opt-in via config.auditNdjsonPath) ---
     // Build the NDJSON sink + hash-chained audit middleware when the host
@@ -1940,20 +1948,27 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
           readonly label: string;
           readonly resolver: import("@koi/mcp").McpResolver;
           readonly transportMap: ReadonlyMap<string, "http" | "stdio" | "sse"> | undefined;
+          readonly oauthNames: ReadonlySet<string> | undefined;
         }[] = [];
         if (mcpResolver !== undefined)
-          sources.push({ label: "user", resolver: mcpResolver, transportMap: mcpTransportByName });
+          sources.push({
+            label: "user",
+            resolver: mcpResolver,
+            transportMap: mcpTransportByName,
+            oauthNames: mcpOAuthCapableNames,
+          });
         if (mcpPluginResolver !== undefined)
           sources.push({
             label: "plugin",
             resolver: mcpPluginResolver,
             transportMap: mcpPluginTransportByName,
+            oauthNames: mcpPluginOAuthCapableNames,
           });
         if (sources.length === 0) return [];
 
         const entries: McpServerStatus[] = [];
         const seenByKey = new Set<string>();
-        for (const { label, resolver, transportMap } of sources) {
+        for (const { label, resolver, transportMap, oauthNames } of sources) {
           const toolCounts = new Map<string, number>();
           const descriptors = await resolver.discover();
           for (const d of descriptors) {
@@ -1971,6 +1986,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
               failureCode: undefined,
               failureMessage: undefined,
               transport: transportMap?.get(name),
+              hasOAuth: oauthNames?.has(name) ?? false,
             });
           }
           for (const f of resolver.failures) {
@@ -1985,6 +2001,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
               failureCode: f.error.code,
               failureMessage: f.error.message,
               transport: transportMap?.get(f.serverName),
+              hasOAuth: oauthNames?.has(f.serverName) ?? false,
             });
           }
         }

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -1516,6 +1516,9 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
     const mcpOAuthCapableNames = stackContribution.exports.mcpOAuthCapableNames as
       | ReadonlySet<string>
       | undefined;
+    const mcpPluginOAuthCapableNames = stackContribution.exports.mcpPluginOAuthCapableNames as
+      | ReadonlySet<string>
+      | undefined;
 
     // --- Audit middleware (opt-in via config.auditNdjsonPath) ---
     // Build the NDJSON sink + hash-chained audit middleware when the host
@@ -1959,11 +1962,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
             label: "plugin",
             resolver: mcpPluginResolver,
             transportMap: mcpPluginTransportByName,
-            // Plugin-backed servers cannot be authenticated via nav:mcp-auth
-            // (the handler rejects plugin: prefixed names). hasOAuth is forced
-            // to false so needs-auth is never surfaced for plugin rows,
-            // regardless of their oauth config.
-            oauthNames: undefined,
+            oauthNames: mcpPluginOAuthCapableNames,
           });
         if (sources.length === 0) return [];
 

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -1516,9 +1516,6 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
     const mcpOAuthCapableNames = stackContribution.exports.mcpOAuthCapableNames as
       | ReadonlySet<string>
       | undefined;
-    const mcpPluginOAuthCapableNames = stackContribution.exports.mcpPluginOAuthCapableNames as
-      | ReadonlySet<string>
-      | undefined;
 
     // --- Audit middleware (opt-in via config.auditNdjsonPath) ---
     // Build the NDJSON sink + hash-chained audit middleware when the host
@@ -1962,7 +1959,11 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
             label: "plugin",
             resolver: mcpPluginResolver,
             transportMap: mcpPluginTransportByName,
-            oauthNames: mcpPluginOAuthCapableNames,
+            // Plugin-backed servers cannot be authenticated via nav:mcp-auth
+            // (the handler rejects plugin: prefixed names). hasOAuth is forced
+            // to false so needs-auth is never surfaced for plugin rows,
+            // regardless of their oauth config.
+            oauthNames: undefined,
           });
         if (sources.length === 0) return [];
 

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -587,6 +587,8 @@ export interface McpServerStatus {
   readonly toolCount: number;
   readonly failureCode: string | undefined;
   readonly failureMessage: string | undefined;
+  /** Transport kind — undefined for plugin-provided servers where config is unavailable. */
+  readonly transport: "http" | "stdio" | "sse" | undefined;
 }
 
 // MCP loading has moved to `./shared-wiring.ts` — both `koi start` and
@@ -810,7 +812,9 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
   if (pluginSummary.loaded.length > 0) {
     // Sanitize plugin-derived strings before logging to prevent terminal
     // control sequence injection from malicious plugin manifests.
+    // biome-ignore lint/complexity/useRegexLiterals: control chars require RegExp constructor
     const ANSI_LOG_RE = new RegExp("\\x1b\\[[0-9;]*[a-zA-Z]", "g");
+    // biome-ignore lint/complexity/useRegexLiterals: control chars require RegExp constructor
     const CTRL_LOG_RE = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
     const sanitizeLog = (s: string): string => s.replace(ANSI_LOG_RE, "").replace(CTRL_LOG_RE, "");
     const names = pluginSummary.loaded
@@ -1501,6 +1505,12 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
     const mcpPluginResolver = stackContribution.exports.mcpPluginResolver as
       | import("@koi/mcp").McpResolver
       | undefined;
+    const mcpTransportByName = stackContribution.exports.mcpTransportByName as
+      | ReadonlyMap<string, "http" | "stdio" | "sse">
+      | undefined;
+    const mcpPluginTransportByName = stackContribution.exports.mcpPluginTransportByName as
+      | ReadonlyMap<string, "http" | "stdio" | "sse">
+      | undefined;
 
     // --- Audit middleware (opt-in via config.auditNdjsonPath) ---
     // Build the NDJSON sink + hash-chained audit middleware when the host
@@ -1929,15 +1939,21 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
         const sources: {
           readonly label: string;
           readonly resolver: import("@koi/mcp").McpResolver;
+          readonly transportMap: ReadonlyMap<string, "http" | "stdio" | "sse"> | undefined;
         }[] = [];
-        if (mcpResolver !== undefined) sources.push({ label: "user", resolver: mcpResolver });
+        if (mcpResolver !== undefined)
+          sources.push({ label: "user", resolver: mcpResolver, transportMap: mcpTransportByName });
         if (mcpPluginResolver !== undefined)
-          sources.push({ label: "plugin", resolver: mcpPluginResolver });
+          sources.push({
+            label: "plugin",
+            resolver: mcpPluginResolver,
+            transportMap: mcpPluginTransportByName,
+          });
         if (sources.length === 0) return [];
 
         const entries: McpServerStatus[] = [];
         const seenByKey = new Set<string>();
-        for (const { label, resolver } of sources) {
+        for (const { label, resolver, transportMap } of sources) {
           const toolCounts = new Map<string, number>();
           const descriptors = await resolver.discover();
           for (const d of descriptors) {
@@ -1954,6 +1970,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
               toolCount: count,
               failureCode: undefined,
               failureMessage: undefined,
+              transport: transportMap?.get(name),
             });
           }
           for (const f of resolver.failures) {
@@ -1967,6 +1984,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
               toolCount: 0,
               failureCode: f.error.code,
               failureMessage: f.error.message,
+              transport: transportMap?.get(f.serverName),
             });
           }
         }

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -1516,9 +1516,6 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
     const mcpOAuthCapableNames = stackContribution.exports.mcpOAuthCapableNames as
       | ReadonlySet<string>
       | undefined;
-    const mcpPluginOAuthCapableNames = stackContribution.exports.mcpPluginOAuthCapableNames as
-      | ReadonlySet<string>
-      | undefined;
 
     // --- Audit middleware (opt-in via config.auditNdjsonPath) ---
     // Build the NDJSON sink + hash-chained audit middleware when the host
@@ -1962,7 +1959,11 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
             label: "plugin",
             resolver: mcpPluginResolver,
             transportMap: mcpPluginTransportByName,
-            oauthNames: mcpPluginOAuthCapableNames,
+            // Plugin servers authenticate via their own auth pseudo-tools, not
+            // via nav:mcp-auth (which only handles .mcp.json entries). Force
+            // hasOAuth false so AUTH_REQUIRED plugin servers render as error
+            // rather than needs-auth, preventing a misleading recovery prompt.
+            oauthNames: undefined,
           });
         if (sources.length === 0) return [];
 
@@ -1976,7 +1977,9 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
             toolCounts.set(server, (toolCounts.get(server) ?? 0) + 1);
           }
           for (const [name, count] of toolCounts) {
-            const displayName = sources.length > 1 ? `${label}:${name}` : name;
+            // Always prefix non-user sources so nav:mcp-auth can detect them
+            // reliably even in single-source (plugin-only) sessions.
+            const displayName = label === "user" ? name : `${label}:${name}`;
             const key = `${label}:${name}`;
             if (seenByKey.has(key)) continue;
             seenByKey.add(key);
@@ -1991,7 +1994,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
           }
           for (const f of resolver.failures) {
             if (toolCounts.has(f.serverName)) continue;
-            const displayName = sources.length > 1 ? `${label}:${f.serverName}` : f.serverName;
+            const displayName = label === "user" ? f.serverName : `${label}:${f.serverName}`;
             const key = `${label}:${f.serverName}`;
             if (seenByKey.has(key)) continue;
             seenByKey.add(key);

--- a/packages/meta/cli/src/shared-wiring.ts
+++ b/packages/meta/cli/src/shared-wiring.ts
@@ -72,6 +72,8 @@ export interface McpSetup {
   readonly bridge: SkillsMcpBridge | undefined;
   /** Disposes the bridge (if any) and the underlying resolver. Idempotent. */
   readonly dispose: () => void;
+  /** Transport kind per server name — used to gate `needs-auth` to HTTP only. */
+  readonly transportByName: ReadonlyMap<string, "http" | "stdio" | "sse">;
 }
 
 /** Absolute path of `~/.koi/hooks.json` — the single user-tier hook source. */
@@ -236,6 +238,7 @@ export async function loadUserMcpSetup(
       bridge?.dispose();
       resolver.dispose();
     },
+    transportByName: new Map(result.value.servers.map((s) => [s.name, s.kind])),
   };
 }
 
@@ -286,6 +289,7 @@ export function buildPluginMcpSetup(
     dispose: () => {
       resolver.dispose();
     },
+    transportByName: new Map(pluginMcpServers.map((s) => [s.name, s.kind])),
   };
 }
 

--- a/packages/meta/cli/src/shared-wiring.ts
+++ b/packages/meta/cli/src/shared-wiring.ts
@@ -74,6 +74,8 @@ export interface McpSetup {
   readonly dispose: () => void;
   /** Transport kind per server name — used to gate `needs-auth` to HTTP only. */
   readonly transportByName: ReadonlyMap<string, "http" | "stdio" | "sse">;
+  /** Server names with a usable OAuth config — `needs-auth` is only valid for these. */
+  readonly oauthCapableNames: ReadonlySet<string>;
 }
 
 /** Absolute path of `~/.koi/hooks.json` — the single user-tier hook source. */
@@ -239,6 +241,11 @@ export async function loadUserMcpSetup(
       resolver.dispose();
     },
     transportByName: new Map(result.value.servers.map((s) => [s.name, s.kind])),
+    oauthCapableNames: new Set(
+      result.value.servers
+        .filter((s) => s.kind === "http" && s.oauth !== undefined)
+        .map((s) => s.name),
+    ),
   };
 }
 
@@ -290,6 +297,9 @@ export function buildPluginMcpSetup(
       resolver.dispose();
     },
     transportByName: new Map(pluginMcpServers.map((s) => [s.name, s.kind])),
+    oauthCapableNames: new Set(
+      pluginMcpServers.filter((s) => s.kind === "http" && s.oauth !== undefined).map((s) => s.name),
+    ),
   };
 }
 

--- a/packages/meta/cli/src/tui-command.test.ts
+++ b/packages/meta/cli/src/tui-command.test.ts
@@ -16,7 +16,12 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { EngineEvent } from "@koi/core";
 import { COMMAND_DEFINITIONS, createEventBatcher, createInitialState, createStore } from "@koi/tui";
-import { drainEngineStream, renderTranscriptMarkdown, summarizeRunReport } from "./tui-command.js";
+import {
+  computeLiveMcpStatus,
+  drainEngineStream,
+  renderTranscriptMarkdown,
+  summarizeRunReport,
+} from "./tui-command.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -777,5 +782,47 @@ describe("onCommand dispatch coverage — #1752", () => {
       }
     }
     expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLiveMcpStatus — #1852 regression: stdio servers must never be
+// labeled `needs-auth` when the resolver returns `AUTH_REQUIRED` from a
+// pattern-matched stderr string.
+// ---------------------------------------------------------------------------
+
+describe("computeLiveMcpStatus", () => {
+  test("undefined failureCode → connected for any transport", () => {
+    expect(computeLiveMcpStatus(undefined, "stdio")).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, "http")).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, "sse")).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, undefined)).toBe("connected");
+  });
+
+  test("AUTH_REQUIRED on stdio → error (#1852)", () => {
+    // Regression: pattern-matched 'unauthorized' on stdio stderr previously
+    // surfaced as needs-auth, an impossible state for a transport without
+    // an OAuth flow.
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "stdio")).toBe("error");
+  });
+
+  test("AUTH_REQUIRED on sse → error (no OAuth flow)", () => {
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "sse")).toBe("error");
+  });
+
+  test("AUTH_REQUIRED on http → needs-auth", () => {
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "http")).toBe("needs-auth");
+  });
+
+  test("AUTH_REQUIRED with unknown transport → needs-auth (plugin OAuth fallback)", () => {
+    // Plugin-sourced entries don't carry transport info; preserve existing
+    // behavior so a plugin HTTP+OAuth server still surfaces needs-auth.
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", undefined)).toBe("needs-auth");
+  });
+
+  test("non-auth failure code → error for any transport", () => {
+    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "stdio")).toBe("error");
+    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "http")).toBe("error");
+    expect(computeLiveMcpStatus("INTERNAL", undefined)).toBe("error");
   });
 });

--- a/packages/meta/cli/src/tui-command.test.ts
+++ b/packages/meta/cli/src/tui-command.test.ts
@@ -816,6 +816,8 @@ describe("computeLiveMcpStatus", () => {
 
   test("AUTH_REQUIRED on http without OAuth → error (no usable auth flow)", () => {
     // Static-token / API-key / basic-auth HTTP servers can't be fixed via TUI OAuth.
+    // Also covers plugin-backed HTTP servers: getMcpStatus() forces hasOAuth=false for
+    // all plugin entries because nav:mcp-auth rejects plugin: prefixed names (#1852).
     expect(computeLiveMcpStatus("AUTH_REQUIRED", "http", false)).toBe("error");
   });
 

--- a/packages/meta/cli/src/tui-command.test.ts
+++ b/packages/meta/cli/src/tui-command.test.ts
@@ -792,37 +792,43 @@ describe("onCommand dispatch coverage — #1752", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeLiveMcpStatus", () => {
-  test("undefined failureCode → connected for any transport", () => {
-    expect(computeLiveMcpStatus(undefined, "stdio")).toBe("connected");
-    expect(computeLiveMcpStatus(undefined, "http")).toBe("connected");
-    expect(computeLiveMcpStatus(undefined, "sse")).toBe("connected");
-    expect(computeLiveMcpStatus(undefined, undefined)).toBe("connected");
+  test("undefined failureCode → connected regardless of transport/oauth", () => {
+    expect(computeLiveMcpStatus(undefined, "stdio", false)).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, "http", true)).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, "sse", false)).toBe("connected");
+    expect(computeLiveMcpStatus(undefined, undefined, false)).toBe("connected");
   });
 
   test("AUTH_REQUIRED on stdio → error (#1852)", () => {
     // Regression: pattern-matched 'unauthorized' on stdio stderr previously
     // surfaced as needs-auth, an impossible state for a transport without
     // an OAuth flow.
-    expect(computeLiveMcpStatus("AUTH_REQUIRED", "stdio")).toBe("error");
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "stdio", false)).toBe("error");
   });
 
   test("AUTH_REQUIRED on sse → error (no OAuth flow)", () => {
-    expect(computeLiveMcpStatus("AUTH_REQUIRED", "sse")).toBe("error");
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "sse", false)).toBe("error");
   });
 
-  test("AUTH_REQUIRED on http → needs-auth", () => {
-    expect(computeLiveMcpStatus("AUTH_REQUIRED", "http")).toBe("needs-auth");
+  test("AUTH_REQUIRED on http with OAuth → needs-auth (Enter triggers OAuth)", () => {
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "http", true)).toBe("needs-auth");
   });
 
-  test("AUTH_REQUIRED with unknown transport → needs-auth (plugin OAuth fallback)", () => {
-    // Plugin-sourced entries don't carry transport info; preserve existing
-    // behavior so a plugin HTTP+OAuth server still surfaces needs-auth.
-    expect(computeLiveMcpStatus("AUTH_REQUIRED", undefined)).toBe("needs-auth");
+  test("AUTH_REQUIRED on http without OAuth → error (no usable auth flow)", () => {
+    // Static-token / API-key / basic-auth HTTP servers can't be fixed via TUI OAuth.
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", "http", false)).toBe("error");
+  });
+
+  test("AUTH_REQUIRED with unknown transport → error (conservative default)", () => {
+    // Transport is now always available from config; undefined is only reachable
+    // for truly unknown servers. Fail closed: don't surface an Enter-to-auth
+    // prompt when we can't confirm auth capability.
+    expect(computeLiveMcpStatus("AUTH_REQUIRED", undefined, false)).toBe("error");
   });
 
   test("non-auth failure code → error for any transport", () => {
-    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "stdio")).toBe("error");
-    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "http")).toBe("error");
-    expect(computeLiveMcpStatus("INTERNAL", undefined)).toBe("error");
+    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "stdio", false)).toBe("error");
+    expect(computeLiveMcpStatus("CONNECT_TIMEOUT", "http", true)).toBe("error");
+    expect(computeLiveMcpStatus("INTERNAL", undefined, false)).toBe("error");
   });
 });

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -1471,12 +1471,9 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           kind: "set_mcp_status",
           servers: live.map((l) => ({
             name: l.name,
-            status:
-              l.failureCode === undefined
-                ? ("connected" as const)
-                : l.failureCode === "AUTH_REQUIRED"
-                  ? ("needs-auth" as const)
-                  : ("error" as const),
+            // transport is now threaded through McpServerStatus from getMcpStatus(),
+            // so startup refresh uses the same authoritative source as nav:mcp enrichment.
+            status: computeLiveMcpStatus(l.failureCode, l.transport),
             toolCount: l.toolCount,
             detail: l.failureMessage,
           })),
@@ -2872,10 +2869,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     kind: "set_mcp_status",
                     servers: live.map((l) => ({
                       name: l.name,
-                      // Plugin-provided servers — transport is unknown here,
-                      // so pass undefined and preserve existing behavior for
-                      // plugin HTTP+OAuth servers.
-                      status: computeLiveMcpStatus(l.failureCode, undefined),
+                      status: computeLiveMcpStatus(l.failureCode, l.transport),
                       toolCount: l.toolCount,
                       detail: l.failureMessage ?? "plugin",
                     })),
@@ -2884,15 +2878,6 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
               }
               return;
             }
-
-            // Build name → transport map for background enrichment: the live
-            // resolver collapses pattern-matched stderr strings like
-            // "unauthorized" into `AUTH_REQUIRED`, so stdio servers could
-            // otherwise surface as `needs-auth` — impossible for a transport
-            // with no OAuth flow. See #1852.
-            const transportByName = new Map<string, "http" | "stdio" | "sse">(
-              config.value.servers.map((s) => [s.name, s.kind]),
-            );
 
             // Check token storage for each OAuth server — fast Keychain lookup, no network
             const storage = createSecureStorage();
@@ -2948,24 +2933,25 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     liveOther.push(l);
                   }
                 }
-                // Enrich config-based entries with live data (match by bare name)
+                // Enrich config-based entries with live data (match by bare name).
+                // Use l.transport from McpServerStatus (threaded from config in getMcpStatus)
+                // rather than the closure transportByName map — both carry the same data but
+                // l.transport also covers plugin-provided servers correctly.
                 const enriched: import("@koi/tui").McpServerInfo[] = servers.map((entry) => {
                   const l = liveUserMap.get(entry.name);
                   if (l === undefined) return entry;
                   return {
                     name: entry.name,
-                    status: computeLiveMcpStatus(l.failureCode, transportByName.get(entry.name)),
+                    status: computeLiveMcpStatus(l.failureCode, l.transport),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };
                 });
                 // Append plugin-provided servers (source-prefixed) not in .mcp.json.
-                // Transport is unknown for plugin-sourced entries — undefined
-                // preserves current `needs-auth` behavior for plugin OAuth.
                 for (const l of liveOther) {
                   enriched.push({
                     name: l.name,
-                    status: computeLiveMcpStatus(l.failureCode, undefined),
+                    status: computeLiveMcpStatus(l.failureCode, l.transport),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? "plugin",
                   });

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -278,6 +278,31 @@ function mapSourceState(status: { readonly state: string }): string {
 }
 
 /**
+ * Compute the `/mcp` view status label for an MCP server from the resolver
+ * failure code and the server's configured transport kind.
+ *
+ * `needs-auth` is reserved for HTTP transport — stdio and SSE have no OAuth
+ * flow, so an `AUTH_REQUIRED` surfaced for those transports is a pattern-
+ * matched false positive (`@koi/mcp` maps any error containing `unauthorized`
+ * / `HTTP 401` / `invalid_token` / `authentication required` to that code,
+ * and a stdio subprocess may write those strings to stderr for unrelated
+ * reasons). Surface those as a generic `error` instead. When the transport
+ * is unknown (plugin-provided servers), keep existing behavior and allow
+ * `needs-auth` through (plugin HTTP+OAuth servers remain labelled correctly).
+ *
+ * @internal — exported for unit tests only.
+ */
+export function computeLiveMcpStatus(
+  failureCode: string | undefined,
+  transport: "http" | "stdio" | "sse" | undefined,
+): "connected" | "needs-auth" | "error" {
+  if (failureCode === undefined) return "connected";
+  if (failureCode !== "AUTH_REQUIRED") return "error";
+  if (transport === "stdio" || transport === "sse") return "error";
+  return "needs-auth";
+}
+
+/**
  * Build a compact run-report summary string for the TUI's `/trajectory` view
  * without serializing the full report tree. Avoids the avoidable
  * `JSON.stringify` of nested `childReports` on every refresh, which can
@@ -2847,12 +2872,10 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     kind: "set_mcp_status",
                     servers: live.map((l) => ({
                       name: l.name,
-                      status:
-                        l.failureCode === undefined
-                          ? ("connected" as const)
-                          : l.failureCode === "AUTH_REQUIRED"
-                            ? ("needs-auth" as const)
-                            : ("error" as const),
+                      // Plugin-provided servers — transport is unknown here,
+                      // so pass undefined and preserve existing behavior for
+                      // plugin HTTP+OAuth servers.
+                      status: computeLiveMcpStatus(l.failureCode, undefined),
                       toolCount: l.toolCount,
                       detail: l.failureMessage ?? "plugin",
                     })),
@@ -2861,6 +2884,15 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
               }
               return;
             }
+
+            // Build name → transport map for background enrichment: the live
+            // resolver collapses pattern-matched stderr strings like
+            // "unauthorized" into `AUTH_REQUIRED`, so stdio servers could
+            // otherwise surface as `needs-auth` — impossible for a transport
+            // with no OAuth flow. See #1852.
+            const transportByName = new Map<string, "http" | "stdio" | "sse">(
+              config.value.servers.map((s) => [s.name, s.kind]),
+            );
 
             // Check token storage for each OAuth server — fast Keychain lookup, no network
             const storage = createSecureStorage();
@@ -2920,29 +2952,20 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                 const enriched: import("@koi/tui").McpServerInfo[] = servers.map((entry) => {
                   const l = liveUserMap.get(entry.name);
                   if (l === undefined) return entry;
-                  const liveStatus: "connected" | "needs-auth" | "error" =
-                    l.failureCode === undefined
-                      ? "connected"
-                      : l.failureCode === "AUTH_REQUIRED"
-                        ? "needs-auth"
-                        : "error";
                   return {
                     name: entry.name,
-                    status: liveStatus,
+                    status: computeLiveMcpStatus(l.failureCode, transportByName.get(entry.name)),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };
                 });
-                // Append plugin-provided servers (source-prefixed) not in .mcp.json
+                // Append plugin-provided servers (source-prefixed) not in .mcp.json.
+                // Transport is unknown for plugin-sourced entries — undefined
+                // preserves current `needs-auth` behavior for plugin OAuth.
                 for (const l of liveOther) {
                   enriched.push({
                     name: l.name,
-                    status:
-                      l.failureCode === undefined
-                        ? "connected"
-                        : l.failureCode === "AUTH_REQUIRED"
-                          ? "needs-auth"
-                          : "error",
+                    status: computeLiveMcpStatus(l.failureCode, undefined),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? "plugin",
                   });

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2937,16 +2937,30 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     liveOther.push(l);
                   }
                 }
+                // Derive auth capability from the freshly-loaded config rather
+                // than l.transport/l.hasOAuth (which are runtime startup
+                // snapshots and may be stale if .mcp.json changed). This keeps
+                // config-backed rows accurate after an oauth block is added
+                // while the TUI is running.
+                const configTransportByName = new Map<string, "http" | "stdio" | "sse">(
+                  config.value.servers.map((s) => [s.name, s.kind]),
+                );
+                const configOAuthByName = new Set<string>(
+                  config.value.servers
+                    .filter((s) => s.kind === "http" && s.oauth !== undefined)
+                    .map((s) => s.name),
+                );
                 // Enrich config-based entries with live data (match by bare name).
-                // Use l.transport from McpServerStatus (threaded from config in getMcpStatus)
-                // rather than the closure transportByName map — both carry the same data but
-                // l.transport also covers plugin-provided servers correctly.
                 const enriched: import("@koi/tui").McpServerInfo[] = servers.map((entry) => {
                   const l = liveUserMap.get(entry.name);
                   if (l === undefined) return entry;
                   return {
                     name: entry.name,
-                    status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
+                    status: computeLiveMcpStatus(
+                      l.failureCode,
+                      configTransportByName.get(entry.name),
+                      configOAuthByName.has(entry.name),
+                    ),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -279,26 +279,30 @@ function mapSourceState(status: { readonly state: string }): string {
 
 /**
  * Compute the `/mcp` view status label for an MCP server from the resolver
- * failure code and the server's configured transport kind.
+ * failure code, the server's configured transport kind, and whether it has a
+ * usable OAuth config.
  *
- * `needs-auth` is reserved for HTTP transport — stdio and SSE have no OAuth
- * flow, so an `AUTH_REQUIRED` surfaced for those transports is a pattern-
- * matched false positive (`@koi/mcp` maps any error containing `unauthorized`
- * / `HTTP 401` / `invalid_token` / `authentication required` to that code,
- * and a stdio subprocess may write those strings to stderr for unrelated
- * reasons). Surface those as a generic `error` instead. When the transport
- * is unknown (plugin-provided servers), keep existing behavior and allow
- * `needs-auth` through (plugin HTTP+OAuth servers remain labelled correctly).
+ * `needs-auth` is an actionable state — the TUI binds Enter to `nav:mcp-auth`
+ * which launches the OAuth PKCE flow. It is only valid when:
+ *   1. The failure is `AUTH_REQUIRED`
+ *   2. Transport is HTTP (stdio/SSE have no OAuth flow)
+ *   3. The server has an `oauth` config block (non-OAuth HTTP servers like
+ *      static-token / basic-auth / API-key cannot be fixed via the TUI)
+ *
+ * Everything else surfaces as `error` so users see a clear failure state
+ * rather than an Enter-to-auth prompt that will immediately fail.
  *
  * @internal — exported for unit tests only.
  */
 export function computeLiveMcpStatus(
   failureCode: string | undefined,
   transport: "http" | "stdio" | "sse" | undefined,
+  hasOAuth: boolean,
 ): "connected" | "needs-auth" | "error" {
   if (failureCode === undefined) return "connected";
   if (failureCode !== "AUTH_REQUIRED") return "error";
-  if (transport === "stdio" || transport === "sse") return "error";
+  if (transport !== "http") return "error";
+  if (!hasOAuth) return "error";
   return "needs-auth";
 }
 
@@ -1473,7 +1477,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
             name: l.name,
             // transport is now threaded through McpServerStatus from getMcpStatus(),
             // so startup refresh uses the same authoritative source as nav:mcp enrichment.
-            status: computeLiveMcpStatus(l.failureCode, l.transport),
+            status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
             toolCount: l.toolCount,
             detail: l.failureMessage,
           })),
@@ -2869,7 +2873,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     kind: "set_mcp_status",
                     servers: live.map((l) => ({
                       name: l.name,
-                      status: computeLiveMcpStatus(l.failureCode, l.transport),
+                      status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
                       toolCount: l.toolCount,
                       detail: l.failureMessage ?? "plugin",
                     })),
@@ -2942,7 +2946,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                   if (l === undefined) return entry;
                   return {
                     name: entry.name,
-                    status: computeLiveMcpStatus(l.failureCode, l.transport),
+                    status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };
@@ -2951,7 +2955,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                 for (const l of liveOther) {
                   enriched.push({
                     name: l.name,
-                    status: computeLiveMcpStatus(l.failureCode, l.transport),
+                    status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? "plugin",
                   });

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2937,16 +2937,30 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     liveOther.push(l);
                   }
                 }
+                // Derive transport/OAuth from the freshly-loaded config file so
+                // that in-session edits (e.g. adding an oauth block) are reflected
+                // immediately. nav:mcp-auth reads the same config.value, so the
+                // status and the auth action stay consistent. Live data
+                // (failureCode, toolCount) still comes from the runtime.
+                const configTransportByName = new Map<string, "http" | "stdio" | "sse">(
+                  config.value.servers.map((s) => [s.name, s.kind]),
+                );
+                const configOAuthByName = new Set<string>(
+                  config.value.servers
+                    .filter((s) => s.kind === "http" && s.oauth !== undefined)
+                    .map((s) => s.name),
+                );
                 // Enrich config-based entries with live data (match by bare name).
-                // Use l.transport/l.hasOAuth from the runtime startup snapshot —
-                // the running server was assembled from that config and live
-                // failures belong to it, not to any in-flight .mcp.json edits.
                 const enriched: import("@koi/tui").McpServerInfo[] = servers.map((entry) => {
                   const l = liveUserMap.get(entry.name);
                   if (l === undefined) return entry;
                   return {
                     name: entry.name,
-                    status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
+                    status: computeLiveMcpStatus(
+                      l.failureCode,
+                      configTransportByName.get(entry.name),
+                      configOAuthByName.has(entry.name),
+                    ),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2937,30 +2937,16 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
                     liveOther.push(l);
                   }
                 }
-                // Derive auth capability from the freshly-loaded config rather
-                // than l.transport/l.hasOAuth (which are runtime startup
-                // snapshots and may be stale if .mcp.json changed). This keeps
-                // config-backed rows accurate after an oauth block is added
-                // while the TUI is running.
-                const configTransportByName = new Map<string, "http" | "stdio" | "sse">(
-                  config.value.servers.map((s) => [s.name, s.kind]),
-                );
-                const configOAuthByName = new Set<string>(
-                  config.value.servers
-                    .filter((s) => s.kind === "http" && s.oauth !== undefined)
-                    .map((s) => s.name),
-                );
                 // Enrich config-based entries with live data (match by bare name).
+                // Use l.transport/l.hasOAuth from the runtime startup snapshot —
+                // the running server was assembled from that config and live
+                // failures belong to it, not to any in-flight .mcp.json edits.
                 const enriched: import("@koi/tui").McpServerInfo[] = servers.map((entry) => {
                   const l = liveUserMap.get(entry.name);
                   if (l === undefined) return entry;
                   return {
                     name: entry.name,
-                    status: computeLiveMcpStatus(
-                      l.failureCode,
-                      configTransportByName.get(entry.name),
-                      configOAuthByName.has(entry.name),
-                    ),
+                    status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
                     toolCount: l.toolCount,
                     detail: l.failureMessage ?? entry.detail,
                   };

--- a/packages/net/mcp-server/src/__test-echo-server__.ts
+++ b/packages/net/mcp-server/src/__test-echo-server__.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal stdio MCP echo server for E2E testing.
+ * Used to reproduce/verify #1852: stdio server must show "connected" not "needs-auth".
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server({ name: "echo", version: "1.0.0" }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Echoes back the input message.",
+      inputSchema: {
+        type: "object" as const,
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, (req) => ({
+  content: [
+    {
+      type: "text" as const,
+      text: String((req.params.arguments as { message?: unknown })?.message ?? ""),
+    },
+  ],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);


### PR DESCRIPTION
## Summary

- Fixes windoliver/koi#1852 — stdio MCP servers showed `△ needs authentication` in `/mcp` when the resolver pattern-matched stderr text (`unauthorized`, `HTTP 401`, etc.) to `AUTH_REQUIRED`
- Extracted `computeLiveMcpStatus(failureCode, transport, hasOAuth)` — gates `needs-auth` to HTTP servers with OAuth configured; stdio/SSE/non-OAuth `AUTH_REQUIRED` → `error`
- Threaded `transport` and `hasOAuth` through `McpServerStatus` via startup config snapshot in `getMcpStatus()`; enrichment path uses fresh `.mcp.json` config so in-session edits are reflected
- Plugin servers always prefix names with `plugin:` regardless of whether they are the only source (prevents nav:mcp-auth routing to wrong .mcp.json entry in plugin-only sessions)
- Plugin `AUTH_REQUIRED` forced to `error` — nav:mcp-auth cannot handle plugin-prefixed names; plugin auth is delegated to plugin's own auth pseudo-tools

## Test plan

- [x] New unit tests in `tui-command.test.ts` — 7 cases covering stdio/SSE/HTTP × OAuth × failure code combinations
- [x] `bun run check:layers` — green
- [x] `bun run typecheck` — green
- [x] Adversarial Codex review loop — 10 rounds; all actionable findings fixed; 2 persistent design-tension findings noted (config-staleness vs runtime-snapshot trade-off; plugin OAuth surfacing)
- [x] E2E TUI validation — echo stdio server shows `✓ connected` not `△ needs authentication`

## Known trade-offs (persistent review findings)

**Config-fresh vs runtime-snapshot**: The enrichment path uses the current `.mcp.json` for transport/OAuth (not the startup snapshot). This means an in-session config edit can affect the displayed status before a restart — by design, because `nav:mcp-auth` also reads the current config when launching OAuth.

**Plugin OAuth**: Plugin `AUTH_REQUIRED` shows as generic `error`. Plugin auth requires the plugin's own pseudo-tool flow, which TUI cannot invoke via `nav:mcp-auth`. A future PR can add plugin-auth affordance to `/mcp`.