### PR TITLE
fix(tui): enable Ed25519 signing on audit middleware

### DIFF
--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -1531,7 +1531,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
         }
       }
       const auditSink = createNdjsonAuditSink({ filePath: config.auditNdjsonPath });
-      const auditMw = createAuditMiddleware({ sink: auditSink });
+      const auditMw = createAuditMiddleware({ sink: auditSink, signing: true });
       auditPresetExtras.push(auditMw);
       auditMwForShutdown = {
         flush: () => auditMw.flush(),
@@ -1587,7 +1587,7 @@ export async function createKoiRuntime(config: KoiRuntimeConfig): Promise<KoiRun
         }
       }
       const sqliteSink = createSqliteAuditSink({ dbPath: config.auditSqlitePath });
-      const sqliteAuditMw = createAuditMiddleware({ sink: sqliteSink });
+      const sqliteAuditMw = createAuditMiddleware({ sink: sqliteSink, signing: true });
       auditPresetExtras.push(sqliteAuditMw);
       auditSqliteMwForShutdown = {
         flush: () => sqliteAuditMw.flush(),


### PR DESCRIPTION
## Summary
- Enable signing: true on both NDJSON and SQLite audit middleware wiring
- Both prev_hash (SHA-256 chain) and signature (Ed25519) fields were NULL

## Context
Discovered during Phase 2 bug bash Q133 (S20 Audit Stack). Audit entries were written correctly but without cryptographic signatures or hash chains.

## Test plan
- [x] bun run typecheck passes
- [x] Verified via TUI: all 114 entries have non-NULL signature and prev_hash
- [x] bun run test --filter=@koi/middleware-audit (28/28 pass)