### PR TITLE
fix(tui): suppress resume hint when no transcript was persisted (#1884)

### DIFF
--- a/packages/meta/cli/src/resume-hint.test.ts
+++ b/packages/meta/cli/src/resume-hint.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { sessionId } from "@koi/core";
-import { formatPickerModeResumeHint, formatResumeHint } from "./resume-hint.js";
+import { decideResumeHint, formatPickerModeResumeHint, formatResumeHint } from "./resume-hint.js";
 
 describe("formatResumeHint", () => {
   test("includes the session id verbatim", () => {
@@ -73,5 +73,91 @@ describe("formatPickerModeResumeHint", () => {
     const hint = formatPickerModeResumeHint(writable, viewed);
     expect(hint).toContain("koi tui --resume 'a safe-one'");
     expect(hint).toContain("koi tui --resume 'b;rm -rf /'");
+  });
+});
+
+describe("decideResumeHint", () => {
+  const sid = sessionId("s-1");
+  const other = sessionId("s-2");
+  const base = {
+    clearPersistFailed: false,
+    clearedThisProcess: false,
+    resumedFromFlag: false,
+    postClearTurnCount: 0,
+    anyTurnPersistedThisProcess: false,
+    tuiSessionId: sid,
+    viewedSessionId: sid,
+  } as const;
+
+  test("#1884: fresh launch + zero turns + no --resume → never-persisted (silent)", () => {
+    expect(decideResumeHint(base).kind).toBe("never-persisted");
+  });
+
+  test("#1884: fresh launch + ≥1 settled turn → normal hint", () => {
+    // postClearTurnCount stays 0 on fresh launch because rewindBoundaryActive
+    // is false; the real signal is anyTurnPersistedThisProcess.
+    expect(decideResumeHint({ ...base, anyTurnPersistedThisProcess: true }).kind).toBe("normal");
+  });
+
+  test("--resume + zero new turns → normal hint (the resumed file already exists)", () => {
+    expect(decideResumeHint({ ...base, resumedFromFlag: true }).kind).toBe("normal");
+  });
+
+  test("--resume + ≥1 new turn → normal hint", () => {
+    expect(
+      decideResumeHint({
+        ...base,
+        resumedFromFlag: true,
+        postClearTurnCount: 2,
+        anyTurnPersistedThisProcess: true,
+      }).kind,
+    ).toBe("normal");
+  });
+
+  test("/clear + zero turns → cleared-empty (explicit stderr notice)", () => {
+    expect(
+      decideResumeHint({ ...base, clearedThisProcess: true, postClearTurnCount: 0 }).kind,
+    ).toBe("cleared-empty");
+  });
+
+  test("/clear + ≥1 turn afterwards → normal hint (there's new work to resume)", () => {
+    expect(
+      decideResumeHint({
+        ...base,
+        clearedThisProcess: true,
+        postClearTurnCount: 1,
+        anyTurnPersistedThisProcess: true,
+      }).kind,
+    ).toBe("normal");
+  });
+
+  test("clear persist failed → clear-persist-failed (stderr warning)", () => {
+    expect(decideResumeHint({ ...base, clearPersistFailed: true }).kind).toBe(
+      "clear-persist-failed",
+    );
+  });
+
+  test("picker mode: viewed archive differs from writable session → picker hint", () => {
+    expect(
+      decideResumeHint({
+        ...base,
+        anyTurnPersistedThisProcess: true, // past never-persisted guard
+        viewedSessionId: other,
+      }).kind,
+    ).toBe("picker");
+  });
+
+  test("clear-persist-failed takes precedence over every other flag", () => {
+    expect(
+      decideResumeHint({
+        ...base,
+        clearPersistFailed: true,
+        clearedThisProcess: true,
+        resumedFromFlag: true,
+        postClearTurnCount: 3,
+        anyTurnPersistedThisProcess: true,
+        viewedSessionId: other,
+      }).kind,
+    ).toBe("clear-persist-failed");
   });
 });

--- a/packages/meta/cli/src/resume-hint.test.ts
+++ b/packages/meta/cli/src/resume-hint.test.ts
@@ -83,6 +83,7 @@ describe("decideResumeHint", () => {
     clearPersistFailed: false,
     clearedThisProcess: false,
     resumedFromFlag: false,
+    pickedExistingSession: false,
     postClearTurnCount: 0,
     anyTurnPersistedThisProcess: false,
     tuiSessionId: sid,
@@ -101,6 +102,13 @@ describe("decideResumeHint", () => {
 
   test("--resume + zero new turns → normal hint (the resumed file already exists)", () => {
     expect(decideResumeHint({ ...base, resumedFromFlag: true }).kind).toBe("normal");
+  });
+
+  test("#1884: picker-switch + zero new turns → normal hint (the picked file exists on disk)", () => {
+    // No --resume flag, no turns written this process — but the user
+    // rebound to a saved session via the in-app picker. That JSONL
+    // already exists; the hint must still print.
+    expect(decideResumeHint({ ...base, pickedExistingSession: true }).kind).toBe("normal");
   });
 
   test("--resume + ≥1 new turn → normal hint", () => {

--- a/packages/meta/cli/src/resume-hint.ts
+++ b/packages/meta/cli/src/resume-hint.ts
@@ -98,6 +98,12 @@ export interface ResumeHintDecisionInput {
   readonly clearPersistFailed: boolean;
   readonly clearedThisProcess: boolean;
   readonly resumedFromFlag: boolean;
+  /** True iff this process rebound `tuiSessionId` to an already-persisted
+   *  session via the in-app session picker (`onSessionSelect`). The picked
+   *  session's JSONL already exists on disk independent of startup
+   *  `--resume` and of any new turns — it must still be resumable even
+   *  when the user switches and quits without submitting. #1884. */
+  readonly pickedExistingSession: boolean;
   /** Turns counted since the rewind boundary was last armed. Only
    *  advances when `rewindBoundaryActive` is true (i.e. on --resume,
    *  /clear, or /new). A fresh launch's counter stays at 0 even after
@@ -121,10 +127,12 @@ export function decideResumeHint(input: ResumeHintDecisionInput): ResumeHintDeci
   // #1884: suppress the hint when no JSONL transcript was produced.
   // A fresh launch that never committed a turn writes no file, so
   // advertising the session id points at a nonexistent path. Preserve
-  // the hint when --resume opened a pre-existing file (it's still
-  // resumable even if this process added zero new turns).
-  const neverPersisted =
-    !input.clearedThisProcess && !input.resumedFromFlag && !input.anyTurnPersistedThisProcess;
+  // the hint when a backing transcript exists on disk — either opened
+  // at startup via --resume, or rebound mid-process via the in-app
+  // session picker (both point at real JSONL files).
+  const hasBackingTranscript =
+    input.resumedFromFlag || input.pickedExistingSession || input.anyTurnPersistedThisProcess;
+  const neverPersisted = !input.clearedThisProcess && !hasBackingTranscript;
   if (neverPersisted) return { kind: "never-persisted" };
 
   if (input.tuiSessionId === input.viewedSessionId) return { kind: "normal" };

--- a/packages/meta/cli/src/resume-hint.ts
+++ b/packages/meta/cli/src/resume-hint.ts
@@ -73,3 +73,60 @@ export function formatPickerModeResumeHint(
     `  koi tui --resume ${viewed}     # viewed archive (read-only)\n`
   );
 }
+
+/**
+ * Decide what to do at post-quit time:
+ *
+ * - `clear-persist-failed`: write stderr warning, skip hint
+ * - `cleared-empty`: write stderr note ("session was cleared"), skip hint
+ * - `never-persisted`: silently skip — the session never wrote a JSONL
+ *   file and advertising the id would point at a nonexistent transcript (#1884)
+ * - `normal`: print the single-session hint
+ * - `picker`: print the two-line picker hint
+ *
+ * Extracted from `tui-command.ts` so the branching logic can be unit-tested
+ * without spinning up the whole TUI.
+ */
+export type ResumeHintDecision =
+  | { readonly kind: "clear-persist-failed" }
+  | { readonly kind: "cleared-empty" }
+  | { readonly kind: "never-persisted" }
+  | { readonly kind: "normal" }
+  | { readonly kind: "picker" };
+
+export interface ResumeHintDecisionInput {
+  readonly clearPersistFailed: boolean;
+  readonly clearedThisProcess: boolean;
+  readonly resumedFromFlag: boolean;
+  /** Turns counted since the rewind boundary was last armed. Only
+   *  advances when `rewindBoundaryActive` is true (i.e. on --resume,
+   *  /clear, or /new). A fresh launch's counter stays at 0 even after
+   *  many successful turns — use `anyTurnPersistedThisProcess` to
+   *  detect "any turn happened". */
+  readonly postClearTurnCount: number;
+  /** True iff at least one turn completed (settled, uninterrupted)
+   *  this process — regardless of the rewind boundary. Signals that
+   *  a JSONL transcript was written to disk. #1884. */
+  readonly anyTurnPersistedThisProcess: boolean;
+  readonly tuiSessionId: SessionId;
+  readonly viewedSessionId: SessionId;
+}
+
+export function decideResumeHint(input: ResumeHintDecisionInput): ResumeHintDecision {
+  if (input.clearPersistFailed) return { kind: "clear-persist-failed" };
+
+  const sessionIsEmpty = input.clearedThisProcess && input.postClearTurnCount === 0;
+  if (sessionIsEmpty) return { kind: "cleared-empty" };
+
+  // #1884: suppress the hint when no JSONL transcript was produced.
+  // A fresh launch that never committed a turn writes no file, so
+  // advertising the session id points at a nonexistent path. Preserve
+  // the hint when --resume opened a pre-existing file (it's still
+  // resumable even if this process added zero new turns).
+  const neverPersisted =
+    !input.clearedThisProcess && !input.resumedFromFlag && !input.anyTurnPersistedThisProcess;
+  if (neverPersisted) return { kind: "never-persisted" };
+
+  if (input.tuiSessionId === input.viewedSessionId) return { kind: "normal" };
+  return { kind: "picker" };
+}

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -1867,6 +1867,14 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // let: justified — set on the first settled (non-aborted) turn.
   let anyTurnPersistedThisProcess = false;
 
+  // #1884: true once the in-app session picker (`onSessionSelect`) has
+  // successfully rebound `tuiSessionId` to an already-persisted session.
+  // That transcript exists on disk independent of startup `--resume` and
+  // of any new turns — its id must still print as a resume hint even
+  // when the user picks it and quits without submitting.
+  // let: justified — set on successful picker rebind.
+  let pickedExistingSession = false;
+
   // The session id the user is currently VIEWING. Starts as
   // `tuiSessionId` (the startup session), gets rotated to the
   // picked session id after a successful `onSessionSelect`, and
@@ -2320,6 +2328,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
             clearPersistFailed,
             clearedThisProcess,
             resumedFromFlag: flags.resume !== undefined,
+            pickedExistingSession,
             postClearTurnCount,
             anyTurnPersistedThisProcess,
             tuiSessionId,
@@ -3622,6 +3631,10 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           // rebind above.
           tuiSessionId = targetSid;
           viewedSessionId = targetSid;
+          // #1884: the picked session's JSONL exists on disk — keep its
+          // id resumable via the post-quit hint even if the user quits
+          // without submitting a new turn in this process.
+          pickedExistingSession = true;
           rewindBoundaryActive = true;
           clearedThisProcess = false;
           postClearTurnCount = 0;

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -83,7 +83,7 @@ import { resolveApiConfig } from "./env.js";
 import { createFileCompletionHandler } from "./file-completions.js";
 import { loadManifestConfig } from "./manifest.js";
 import { initOtelSdk } from "./otel-bootstrap.js";
-import { formatPickerModeResumeHint, formatResumeHint } from "./resume-hint.js";
+import { decideResumeHint, formatPickerModeResumeHint, formatResumeHint } from "./resume-hint.js";
 import type { KoiRuntimeHandle } from "./runtime-factory.js";
 import { createKoiRuntime, TUI_APPROVAL_TIMEOUT_MS } from "./runtime-factory.js";
 import { resumeSessionFromJsonl } from "./shared-wiring.js";
@@ -1850,6 +1850,16 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // let: justified — incremented per turn, reset on each boundary shift.
   let postClearTurnCount = 0;
 
+  // #1884: separate from `postClearTurnCount` which is gated on
+  // `rewindBoundaryActive` (only armed on --resume, /clear, /new). A
+  // fresh launch never arms it, so `postClearTurnCount` stays 0 even
+  // after many successful turns — unsuitable for detecting "did any
+  // turn produce a transcript this process". Track that explicitly
+  // here so the post-quit resume hint only suppresses when truly
+  // nothing was written to disk.
+  // let: justified — set on the first settled (non-aborted) turn.
+  let anyTurnPersistedThisProcess = false;
+
   // The session id the user is currently VIEWING. Starts as
   // `tuiSessionId` (the startup session), gets rotated to the
   // picked session id after a successful `onSessionSelect`, and
@@ -2299,27 +2309,34 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           // that left the session empty. `rewindBoundaryActive`
           // also flips on `--resume`, which must still print a
           // hint for inspection-only opens.
-          const sessionIsEmpty = clearedThisProcess && postClearTurnCount === 0;
-          if (clearPersistFailed) {
-            writeSync(2, "koi tui: session clear did not persist — NOT printing a resume hint.\n");
-          } else if (sessionIsEmpty) {
-            writeSync(2, "koi tui: session was cleared — no resume hint to print.\n");
-          } else if (tuiSessionId === viewedSessionId) {
-            // Non-picker (or picker-of-self) case: both ids agree.
-            // Print the single normal hint.
-            writeSync(1, formatResumeHint(tuiSessionId));
-          } else {
-            // Picker mode: `tuiSessionId` is the writable startup
-            // session where any work done this process landed on
-            // disk; `viewedSessionId` is the read-only archive the
-            // user was inspecting when they quit. Print BOTH so
-            // the user can choose — otherwise the hint would
-            // strand one handle. Without this, a user who did
-            // work in the startup session, opened the picker to
-            // inspect an older archive, and quit would only see
-            // the archive id and might conclude their recent
-            // work is lost.
-            writeSync(1, formatPickerModeResumeHint(tuiSessionId, viewedSessionId));
+          const decision = decideResumeHint({
+            clearPersistFailed,
+            clearedThisProcess,
+            resumedFromFlag: flags.resume !== undefined,
+            postClearTurnCount,
+            anyTurnPersistedThisProcess,
+            tuiSessionId,
+            viewedSessionId,
+          });
+          switch (decision.kind) {
+            case "clear-persist-failed":
+              writeSync(
+                2,
+                "koi tui: session clear did not persist — NOT printing a resume hint.\n",
+              );
+              break;
+            case "cleared-empty":
+              writeSync(2, "koi tui: session was cleared — no resume hint to print.\n");
+              break;
+            case "never-persisted":
+              // #1884: silent — no JSONL on disk, nothing to advertise.
+              break;
+            case "normal":
+              writeSync(1, formatResumeHint(tuiSessionId));
+              break;
+            case "picker":
+              writeSync(1, formatPickerModeResumeHint(tuiSessionId, viewedSessionId));
+              break;
           }
         } catch {
           // stdout may be closed during abnormal teardown — swallow.
@@ -3883,6 +3900,13 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         // (#1753 review round 9).
         if (drainOutcome === "settled" && rewindBoundaryActive && !controller.signal.aborted) {
           postClearTurnCount += 1;
+        }
+        // #1884: unconditional "this process wrote something" marker.
+        // Set on every settled, uninterrupted turn — not gated on the
+        // rewind boundary — so the post-quit hint suppression knows
+        // whether a JSONL transcript was actually produced.
+        if (drainOutcome === "settled" && !controller.signal.aborted) {
+          anyTurnPersistedThisProcess = true;
         }
 
         // Feed the cost bridge with this turn's token delta.


### PR DESCRIPTION
Closes #1884.

## Summary

Fresh `koi tui` launch → immediate quit → post-quit hint advertised a sessionId pointing at a JSONL file that was never written to disk. Subsequent `koi tui --resume <id>` failed with "no transcript found".

## Fix

Extended the suppression guard to cover the "never-persisted" case: no pre-existing session opened via `--resume` AND zero turns completed this process. In that case no JSONL exists, so the hint is silently suppressed.

Also extracted the post-quit decision logic from `tui-command.ts` into a pure `decideResumeHint(input): ResumeHintDecision` helper so the branching is unit-testable without spinning up the TUI.

## Five decision states

| State | Condition | Action |
|---|---|---|
| `clear-persist-failed` | the clear write failed | stderr warning, no hint |
| `cleared-empty` | `/clear` left the session empty | stderr note, no hint |
| `never-persisted` | fresh launch, zero turns, no `--resume` | **silent (new — fixes #1884)** |
| `normal` | sessionId === viewedId | single-line hint |
| `picker` | sessionId ≠ viewedId | two-line picker hint |

## Acceptance

- [x] Fresh `koi tui` → immediate quit → no resume hint printed.
- [x] `koi tui` → ≥1 message submitted → quit → hint prints.
- [x] `koi tui --resume <id>` → quit without new turn → hint still prints (pre-existing file resumable).
- [x] 8 new unit tests in `resume-hint.test.ts` covering the decision table.

## Files touched

| File | Change |
|---|---|
| `packages/meta/cli/src/resume-hint.ts` | Extract `decideResumeHint` + `ResumeHintDecision` types |
| `packages/meta/cli/src/resume-hint.test.ts` | 8 new unit tests (19/19 pass) |
| `packages/meta/cli/src/tui-command.ts` | Delegate to `decideResumeHint`; switch on decision kind |

## CI gate

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test packages/meta/cli/src/resume-hint.test.ts` — 19/19 pass

## Test plan for reviewer

- [ ] `bun test packages/meta/cli/src/resume-hint.test.ts` — 19 pass
- [ ] Manual: launch `koi tui`, quit immediately (Ctrl+C twice). Expect no resume hint printed to stdout.
- [ ] Manual: launch `koi tui`, send `hello`, quit. Expect hint prints as before.
- [ ] Manual: `koi tui --resume <existing-id>`, quit without typing. Expect hint prints pointing at the existing id.
