### PR TITLE
[codex] fix memory index escaping and tool payload validation

### DIFF
--- a/packages/kernel/core/src/capability-registry.test.ts
+++ b/packages/kernel/core/src/capability-registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { isToolCallPayload } from "./capability-registry.js";
+
+describe("isToolCallPayload", () => {
+  test("accepts valid payload shape", () => {
+    expect(
+      isToolCallPayload({
+        toolName: "read_file",
+        args: { path: "README.md" },
+        callerAgentId: "agent-1",
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects payload missing args", () => {
+    expect(
+      isToolCallPayload({
+        toolName: "read_file",
+        callerAgentId: "agent-1",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects payload with non-object args", () => {
+    expect(
+      isToolCallPayload({
+        toolName: "read_file",
+        args: "path=README.md",
+        callerAgentId: "agent-1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/kernel/core/src/capability-registry.ts
+++ b/packages/kernel/core/src/capability-registry.ts
@@ -86,6 +86,9 @@ export function isToolCallPayload(value: unknown): value is ToolCallPayload {
   return (
     typeof obj.toolName === "string" &&
     obj.toolName.length > 0 &&
-    typeof obj.callerAgentId === "string"
+    typeof obj.callerAgentId === "string" &&
+    obj.args !== null &&
+    typeof obj.args === "object" &&
+    !Array.isArray(obj.args)
   );
 }

--- a/packages/kernel/core/src/memory.test.ts
+++ b/packages/kernel/core/src/memory.test.ts
@@ -531,6 +531,28 @@ describe("formatMemoryIndexEntry / parseMemoryIndexEntry (adversarial)", () => {
     const formatted = formatMemoryIndexEntry(entry);
     expect(defined(formatted).split("\n")).toHaveLength(1);
   });
+
+  test("roundtrips title ending with backslash", () => {
+    const entry: MemoryIndexEntry = {
+      title: "path slash\\",
+      filePath: "safe.md",
+      hook: "keeps trailing slash in title",
+    };
+    const formatted = formatMemoryIndexEntry(entry);
+    const parsed = parseMemoryIndexEntry(defined(formatted));
+    expect(parsed).toEqual(entry);
+  });
+
+  test("roundtrips title containing backslash before closing bracket", () => {
+    const entry: MemoryIndexEntry = {
+      title: "literal \\] sequence",
+      filePath: "safe.md",
+      hook: "keeps escaped-bracket-like text",
+    };
+    const formatted = formatMemoryIndexEntry(entry);
+    const parsed = parseMemoryIndexEntry(defined(formatted));
+    expect(parsed).toEqual(entry);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/kernel/core/src/memory.ts
+++ b/packages/kernel/core/src/memory.ts
@@ -413,14 +413,14 @@ function sanitizeIndexValue(value: string): string {
     .trim();
 }
 
-/** Escapes Markdown link metacharacters in a title (brackets). */
+/** Escapes Markdown link metacharacters in a title (backslash + brackets). */
 function escapeTitle(value: string): string {
-  return value.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+  return value.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
 }
 
-/** Unescapes Markdown link metacharacters in a title. */
+/** Unescapes Markdown link metacharacters in a title (backslash + brackets). */
 function unescapeTitle(value: string): string {
-  return value.replace(/\\\[/g, "[").replace(/\\\]/g, "]");
+  return value.replace(/\\([\[\]\\])/g, "$1");
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix `formatMemoryIndexEntry`/`parseMemoryIndexEntry` title escaping to roundtrip backslashes safely (including trailing `\\` and `\\]` cases)
- tighten `isToolCallPayload` runtime validation to require `args` as a non-null object (and reject arrays)
- add targeted regression tests for both fixes

## Root Cause
- memory index formatting escaped `[` and `]` but not backslashes, while parsing treated backslash as an escape prefix, causing parse failures for some valid titles
- `isToolCallPayload` only checked `toolName` and `callerAgentId`, so malformed payloads without valid `args` passed type-guard validation

## User Impact
- MEMORY.md entries with backslash-heavy titles no longer become unreadable or silently dropped during parse
- malformed tool-call payloads are rejected earlier at boundaries, reducing downstream runtime failures

## Validation
- `cd packages/kernel/core && bun test src/memory.test.ts src/capability-registry.test.ts`
- `bun x biome check packages/kernel/core/src/memory.ts packages/kernel/core/src/memory.test.ts packages/kernel/core/src/capability-registry.ts packages/kernel/core/src/capability-registry.test.ts`
