### PR TITLE
feat(browser-a11y): extract L0u package (P1 of #1609)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,14 @@
       "name": "@koi/bash-security",
       "version": "0.0.0",
     },
+    "packages/lib/browser-a11y": {
+      "name": "@koi/browser-a11y",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/token-estimator": "workspace:*",
+      },
+    },
     "packages/lib/channel-base": {
       "name": "@koi/channel-base",
       "version": "0.0.0",
@@ -1217,6 +1225,8 @@
     "@koi/bash-classifier": ["@koi/bash-classifier@workspace:packages/lib/bash-classifier"],
 
     "@koi/bash-security": ["@koi/bash-security@workspace:packages/lib/bash-security"],
+
+    "@koi/browser-a11y": ["@koi/browser-a11y@workspace:packages/lib/browser-a11y"],
 
     "@koi/channel-base": ["@koi/channel-base@workspace:packages/lib/channel-base"],
 

--- a/docs/L2/browser-a11y.md
+++ b/docs/L2/browser-a11y.md
@@ -1,0 +1,80 @@
+# @koi/browser-a11y — Accessibility-tree serializer + Playwright error translator
+
+L0u utility package. Pure functions. Depends only on `@koi/core` and `@koi/token-estimator`. Imported by `@koi/browser-playwright` (CDP-over-Playwright driver) and `@koi/browser-ext` (extension-injected session driver) to produce compact text tree snapshots from accessibility data and to translate Playwright exceptions into typed `KoiError`s.
+
+---
+
+## Why It Exists
+
+LLM agents can't see pixels. Browser automation has to expose the page as text with stable per-element references. Two different browser drivers (Playwright-over-CDP, extension-over-native-messaging) need exactly the same text format and the same error-translation semantics so agent prompts and error-handling code work identically against either. Duplicating 500 LOC of serialization across both drivers would be a Rule-of-Three violation waiting to happen. Lifting those files into an L0u package gives a single source of truth.
+
+---
+
+## Public API
+
+```typescript
+import {
+  serializeA11yTree,
+  parseAriaYaml,
+  isAriaRole,
+  VALID_ROLES,
+  translatePlaywrightError,
+  type A11yNode,
+  type SerializeResult,
+} from "@koi/browser-a11y";
+```
+
+### `serializeA11yTree(root: A11yNode, options?: BrowserSnapshotOptions): SerializeResult`
+
+Walks an accessibility tree and produces compact text output with `[ref=eN]` markers on interactive elements. Tracks occurrence counts for `nthIndex` so drivers can disambiguate duplicate `role+name` pairs via `getByRole().nth(N)`.
+
+### `parseAriaYaml(yaml: string, options?: BrowserSnapshotOptions): SerializeResult`
+
+Parses Playwright 1.44+ `locator.ariaSnapshot()` YAML output. Captures Playwright's native `aria-ref=eN` attributes into `BrowserRefInfo.ariaRef` so drivers can use the O(1) `[aria-ref=eN]` CSS selector path when available, falling back to `getByRole() + nth` otherwise.
+
+### `isAriaRole(role: string): boolean`
+
+Type guard: returns true for the 22 interactive ARIA roles listed in `VALID_ROLES`.
+
+### `translatePlaywrightError(operation: string, err: unknown): KoiError`
+
+Maps Playwright exceptions to typed `KoiError`s via duck-typed `.name` and `.message` probing — no Playwright runtime dependency. Covers 9 failure patterns (timeout, stale ref, CORS, DNS failure, page-closed, WebSocket disconnect, JS eval error, invalid selector, unknown). See the table in `src/error-translator.ts`.
+
+---
+
+## Layer Compliance
+
+```
+L0  @koi/core ──────────────────────────────────────────┐
+    BrowserRefInfo, BrowserSnapshotOptions, KoiError,    │
+    external(), internal(), permission(), staleRef(),    │
+    timeout(), validation() — types + factory functions   │
+                                                         │
+L0u @koi/token-estimator                                 │
+    CHARS_PER_TOKEN                                      │
+                                                         │
+L0u @koi/browser-a11y ◄──────────────────────────────────┘
+    imports only from @koi/core and @koi/token-estimator.
+    No Playwright. No filesystem. No network.
+    Imported by:
+      @koi/browser-playwright (L2, P2)
+      @koi/browser-ext       (L2, P5)
+```
+
+---
+
+## Testing
+
+- `src/__tests__/a11y-serializer.test.ts` — golden-file assertions for tree→text conversion and parseAriaYaml, ported verbatim from v1.
+- `src/__tests__/error-translator.test.ts` — table-driven mapping from Playwright exception patterns to `KoiError`, ported from v1.
+- `src/__tests__/api-surface.test.ts` — guards the public export list so accidental internal leaks are caught in CI.
+
+Run: `bun test --cwd packages/lib/browser-a11y`
+
+---
+
+## Non-Goals
+
+- **No Playwright runtime coupling.** All functions take plain JS values or implement duck-typed probes. This package can be imported into environments that don't have Playwright installed (e.g., the MV3 extension build output).
+- **No ref resolution.** The `BrowserRefInfo.nthIndex` and `.ariaRef` fields are emitted here; actually using them against a live `Page` is the driver's job (see `@koi/browser-playwright.playwright-browser-driver.ts`).
+- **No serialization for input trees beyond accessibility.** Full-DOM or visual-regression serializers would be separate packages.

--- a/packages/lib/browser-a11y/package.json
+++ b/packages/lib/browser-a11y/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/browser-a11y",
+  "description": "Accessibility-tree serializer + Playwright error translator — pure L0u helpers shared by browser-playwright and browser-ext",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/token-estimator": "workspace:*"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  }
+}

--- a/packages/lib/browser-a11y/src/__tests__/a11y-serializer.test.ts
+++ b/packages/lib/browser-a11y/src/__tests__/a11y-serializer.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it } from "bun:test";
+import { type A11yNode, parseAriaYaml, serializeA11yTree } from "../a11y-serializer.js";
+
+describe("serializeA11yTree", () => {
+  describe("basic structure", () => {
+    it("serializes a simple root with no children", () => {
+      const node: A11yNode = { role: "WebArea", name: "My Page" };
+      const result = serializeA11yTree(node);
+      expect(result.text).toBe('WebArea "My Page"');
+      expect(result.refs).toEqual({});
+      expect(result.truncated).toBe(false);
+    });
+
+    it("omits quotes when name is empty string", () => {
+      const node: A11yNode = { role: "WebArea", name: "" };
+      const result = serializeA11yTree(node);
+      expect(result.text).toBe("WebArea");
+      expect(result.text).not.toContain('""');
+    });
+
+    it("indents children by 2 spaces per depth level", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Root",
+        children: [
+          {
+            role: "group",
+            name: "Nav",
+            children: [{ role: "link", name: "Home" }],
+          },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      const lines = result.text.split("\n");
+      expect(lines[0]).toMatch(/^WebArea/);
+      expect(lines[1]).toMatch(/^ {2}group/);
+      expect(lines[2]).toMatch(/^ {4}link/);
+    });
+  });
+
+  describe("interactive element refs", () => {
+    it("marks interactive elements with [ref=eN]", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Test",
+        children: [
+          { role: "button", name: "Submit" },
+          { role: "link", name: "Home" },
+          { role: "textbox", name: "Email" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain("[ref=e1]");
+      expect(result.text).toContain("[ref=e2]");
+      expect(result.text).toContain("[ref=e3]");
+    });
+
+    it("populates refs map with role and name", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Test",
+        children: [
+          { role: "button", name: "Submit" },
+          { role: "link", name: "Home" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.refs).toEqual({
+        e1: { role: "button", name: "Submit", nthIndex: 0 },
+        e2: { role: "link", name: "Home", nthIndex: 0 },
+      });
+    });
+
+    it("omits name from refs entry when node name is empty", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Test",
+        children: [{ role: "button", name: "" }],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.refs.e1).toEqual({ role: "button", nthIndex: 0 });
+      expect(result.refs.e1).not.toHaveProperty("name");
+    });
+
+    it("does not mark non-interactive elements", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Test",
+        children: [
+          { role: "heading", name: "Title", level: 1 },
+          { role: "paragraph", name: "Some text" },
+          { role: "img", name: "Logo" },
+          { role: "text", name: "Body" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).not.toContain("[ref=");
+      expect(result.refs).toEqual({});
+    });
+
+    it("assigns refs sequentially across the full tree", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Root",
+        children: [
+          { role: "button", name: "First" },
+          {
+            role: "group",
+            name: "Nav",
+            children: [{ role: "link", name: "Second" }],
+          },
+          { role: "textbox", name: "Third" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(Object.keys(result.refs)).toEqual(["e1", "e2", "e3"]);
+      expect(result.refs.e1).toEqual({ role: "button", name: "First", nthIndex: 0 });
+      expect(result.refs.e2).toEqual({ role: "link", name: "Second", nthIndex: 0 });
+      expect(result.refs.e3).toEqual({ role: "textbox", name: "Third", nthIndex: 0 });
+    });
+  });
+
+  describe("state attributes", () => {
+    it("includes level for headings", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Root",
+        children: [{ role: "heading", name: "Title", level: 2 }],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain("level=2");
+    });
+
+    it("includes checked state for checkboxes", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Form",
+        children: [
+          { role: "checkbox", name: "Subscribe", checked: true },
+          { role: "checkbox", name: "Terms", checked: false },
+          { role: "checkbox", name: "Optional", checked: "mixed" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain("checked");
+      expect(result.text).toContain("indeterminate");
+      // unchecked: no extra attribute
+      const lines = result.text.split("\n");
+      const termsLine = lines.find((l) => l.includes('"Terms"'));
+      expect(termsLine).toBeDefined();
+      expect(termsLine).not.toContain("checked");
+    });
+
+    it("includes required, disabled, selected states", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Form",
+        children: [
+          { role: "textbox", name: "Name", required: true },
+          { role: "textbox", name: "Bio", disabled: true },
+          { role: "option", name: "Item", selected: true },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain("required");
+      expect(result.text).toContain("disabled");
+      expect(result.text).toContain("selected");
+    });
+
+    it("includes expanded/collapsed state", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Root",
+        children: [
+          { role: "combobox", name: "Open", expanded: true },
+          { role: "combobox", name: "Closed", expanded: false },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain("expanded");
+      expect(result.text).toContain("collapsed");
+    });
+
+    it("includes value attribute", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Form",
+        children: [{ role: "textbox", name: "Search", value: "hello world" }],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.text).toContain('value="hello world"');
+    });
+  });
+
+  describe("truncation", () => {
+    it("respects maxDepth and sets truncated=true", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Root",
+        children: [
+          {
+            role: "group",
+            name: "A",
+            children: [
+              {
+                role: "group",
+                name: "B",
+                children: [{ role: "button", name: "Deep" }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = serializeA11yTree(node, { maxDepth: 1 });
+      expect(result.truncated).toBe(true);
+      expect(result.text).not.toContain("Deep");
+      expect(result.text).toContain("Root");
+    });
+
+    it("respects maxTokens and sets truncated=true", () => {
+      const children: A11yNode[] = Array.from({ length: 100 }, (_, i) => ({
+        role: "button",
+        name: `Button number ${i} with a longish name`,
+      }));
+      const node: A11yNode = { role: "WebArea", name: "Test", children };
+      const result = serializeA11yTree(node, { maxTokens: 30 });
+      expect(result.truncated).toBe(true);
+      expect(Object.keys(result.refs).length).toBeGreaterThan(0);
+      expect(Object.keys(result.refs).length).toBeLessThan(100);
+    });
+
+    it("does not truncate within the default limits", () => {
+      const node: A11yNode = {
+        role: "WebArea",
+        name: "Simple Page",
+        children: [
+          { role: "heading", name: "Welcome", level: 1 },
+          { role: "button", name: "Go" },
+          { role: "link", name: "Back" },
+        ],
+      };
+      const result = serializeA11yTree(node);
+      expect(result.truncated).toBe(false);
+    });
+
+    it("uses default maxTokens=4000 and maxDepth=8", () => {
+      const node: A11yNode = { role: "WebArea", name: "Test" };
+      const result = serializeA11yTree(node);
+      expect(result.truncated).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAriaYaml
+// ---------------------------------------------------------------------------
+
+describe("parseAriaYaml", () => {
+  describe("basic parsing", () => {
+    it("parses a single non-interactive element", () => {
+      const yaml = '- heading "Example Domain" [level=1]';
+      const result = parseAriaYaml(yaml);
+      expect(result.text).toContain('heading "Example Domain"');
+      expect(result.text).toContain("level=1");
+      expect(result.refs).toEqual({});
+      expect(result.truncated).toBe(false);
+    });
+
+    it("parses a link and assigns a ref", () => {
+      const yaml = '- link "Learn more"';
+      const result = parseAriaYaml(yaml);
+      expect(result.text).toContain('link "Learn more"');
+      expect(result.text).toContain("[ref=e1]");
+      expect(result.refs).toEqual({ e1: { role: "link", name: "Learn more", nthIndex: 0 } });
+    });
+
+    it("parses multiple interactive elements with sequential refs", () => {
+      const yaml = ['- button "Submit"', '- link "Home"', '- textbox "Email"'].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(Object.keys(result.refs)).toEqual(["e1", "e2", "e3"]);
+      expect(result.refs.e1).toEqual({ role: "button", name: "Submit", nthIndex: 0 });
+      expect(result.refs.e2).toEqual({ role: "link", name: "Home", nthIndex: 0 });
+      expect(result.refs.e3).toEqual({ role: "textbox", name: "Email", nthIndex: 0 });
+    });
+
+    it("non-interactive elements get no ref", () => {
+      const yaml = [
+        '- heading "Title" [level=1]',
+        "- paragraph: some text",
+        '- link "Click me"',
+      ].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(Object.keys(result.refs)).toEqual(["e1"]);
+      expect(result.refs.e1).toEqual({ role: "link", name: "Click me", nthIndex: 0 });
+    });
+
+    it("skips metadata lines starting with - /", () => {
+      const yaml = [
+        '- link "Learn more":',
+        "  - /url: https://iana.org/domains/example",
+        '- button "Submit"',
+      ].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(result.text).not.toContain("/url");
+      expect(Object.keys(result.refs)).toHaveLength(2);
+    });
+
+    it("skips blank lines", () => {
+      const yaml = ['- button "A"', "", "  ", '- button "B"'].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(Object.keys(result.refs)).toHaveLength(2);
+    });
+
+    it("handles elements without a name", () => {
+      const yaml = "- button";
+      const result = parseAriaYaml(yaml);
+      expect(result.text).toBe("button [ref=e1]");
+      expect(result.refs.e1).toEqual({ role: "button", nthIndex: 0 });
+      expect(result.refs.e1).not.toHaveProperty("name");
+    });
+  });
+
+  describe("indentation / depth", () => {
+    it("preserves indentation as depth in output", () => {
+      const yaml = ["- document:", '  - heading "Title"', '    - link "Nested"'].join("\n");
+      const result = parseAriaYaml(yaml);
+      const lines = result.text.split("\n");
+      expect(lines[0]).toMatch(/^document/);
+      expect(lines[1]).toMatch(/^ {2}heading/);
+      expect(lines[2]).toMatch(/^ {4}link/);
+    });
+
+    it("real example.com ariaSnapshot YAML produces refs for links", () => {
+      const yaml = [
+        '- heading "Example Domain" [level=1]',
+        "- paragraph: This domain is for use in examples.",
+        "- paragraph:",
+        '  - link "Learn more":',
+        "    - /url: https://iana.org/domains/example",
+      ].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(result.refs).toEqual({ e1: { role: "link", name: "Learn more", nthIndex: 0 } });
+      expect(result.text).toContain('link "Learn more"');
+      expect(result.text).toContain("[ref=e1]");
+      expect(result.text).not.toContain("/url");
+    });
+  });
+
+  describe("attribute parsing", () => {
+    it("preserves bracket attributes in output", () => {
+      const yaml = '- heading "Title" [level=2]';
+      const result = parseAriaYaml(yaml);
+      expect(result.text).toContain("level=2");
+    });
+
+    it("preserves multiple bracket attributes", () => {
+      const yaml = '- textbox "Name" [required, disabled]';
+      const result = parseAriaYaml(yaml);
+      expect(result.text).toContain("required");
+      expect(result.text).toContain("disabled");
+    });
+
+    it("appends ref after other attributes for interactive elements", () => {
+      const yaml = '- checkbox "Subscribe" [checked]';
+      const result = parseAriaYaml(yaml);
+      const line = result.text;
+      const checkIdx = line.indexOf("checked");
+      const refIdx = line.indexOf("ref=e1");
+      expect(checkIdx).toBeGreaterThan(-1);
+      expect(refIdx).toBeGreaterThan(checkIdx);
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates at maxDepth and sets truncated=true", () => {
+      const yaml = ["- document:", "  - main:", "    - section:", '      - button "Deep"'].join(
+        "\n",
+      );
+      // maxDepth=1 means only depth 0 and 1 visible
+      const result = parseAriaYaml(yaml, { maxDepth: 1 });
+      expect(result.truncated).toBe(true);
+      expect(result.text).not.toContain("button");
+      expect(result.text).toContain("main");
+    });
+
+    it("truncates at maxTokens and sets truncated=true", () => {
+      const lines = Array.from(
+        { length: 50 },
+        (_, i) => `- button "Button number ${i} with a longer name"`,
+      );
+      const result = parseAriaYaml(lines.join("\n"), { maxTokens: 20 });
+      expect(result.truncated).toBe(true);
+      expect(Object.keys(result.refs).length).toBeGreaterThan(0);
+      expect(Object.keys(result.refs).length).toBeLessThan(50);
+    });
+
+    it("does not truncate within default limits", () => {
+      const yaml = ['- heading "Welcome" [level=1]', '- button "Go"', '- link "Back"'].join("\n");
+      const result = parseAriaYaml(yaml);
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe("empty input", () => {
+    it("returns empty result for empty string", () => {
+      const result = parseAriaYaml("");
+      expect(result.text).toBe("");
+      expect(result.refs).toEqual({});
+      expect(result.truncated).toBe(false);
+    });
+
+    it("returns empty result for whitespace-only string", () => {
+      const result = parseAriaYaml("   \n  \n");
+      expect(result.text).toBe("");
+      expect(result.refs).toEqual({});
+    });
+  });
+});

--- a/packages/lib/browser-a11y/src/__tests__/api-surface.test.ts
+++ b/packages/lib/browser-a11y/src/__tests__/api-surface.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import * as publicApi from "../index.js";
+
+describe("@koi/browser-a11y public API surface", () => {
+  test("exports serializeA11yTree function", () => {
+    expect(typeof publicApi.serializeA11yTree).toBe("function");
+  });
+
+  test("exports parseAriaYaml function", () => {
+    expect(typeof publicApi.parseAriaYaml).toBe("function");
+  });
+
+  test("exports isAriaRole type guard", () => {
+    expect(typeof publicApi.isAriaRole).toBe("function");
+    expect(publicApi.isAriaRole("button")).toBe(true);
+    expect(publicApi.isAriaRole("not-a-role")).toBe(false);
+  });
+
+  test("exports VALID_ROLES ReadonlySet", () => {
+    expect(publicApi.VALID_ROLES).toBeInstanceOf(Set);
+    expect(publicApi.VALID_ROLES.has("button")).toBe(true);
+  });
+
+  test("exports translatePlaywrightError function", () => {
+    expect(typeof publicApi.translatePlaywrightError).toBe("function");
+  });
+
+  test("exported names do not leak internal helpers", () => {
+    // Internal helpers like extractMsg/hasName/msgIncludes must NOT be exported.
+    expect(Object.keys(publicApi).sort()).toEqual([
+      "VALID_ROLES",
+      "isAriaRole",
+      "parseAriaYaml",
+      "serializeA11yTree",
+      "translatePlaywrightError",
+    ]);
+  });
+});

--- a/packages/lib/browser-a11y/src/__tests__/error-translator.test.ts
+++ b/packages/lib/browser-a11y/src/__tests__/error-translator.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { translatePlaywrightError } from "../error-translator.js";
+
+// ---------------------------------------------------------------------------
+// Helper: construct a Playwright-style Error with a given name + message
+// ---------------------------------------------------------------------------
+
+function playwrightError(message: string, name = "Error"): Error {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+describe("translatePlaywrightError", () => {
+  // Pattern 1: TimeoutError
+  test("maps TimeoutError (by name) to TIMEOUT code", () => {
+    const err = playwrightError(
+      "Timeout 3000ms exceeded while waiting for element",
+      "TimeoutError",
+    );
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("TIMEOUT");
+    expect(result.message).toContain("browser_click");
+    expect(result.message).toContain("browser_snapshot");
+    expect(result.retryable).toBe(true);
+  });
+
+  test("maps message containing 'Timeout ' to TIMEOUT code", () => {
+    const err = playwrightError("Timeout 5000ms exceeded");
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("TIMEOUT");
+  });
+
+  // Pattern 2: Element detached from DOM
+  test("maps 'element is detached' to STALE_REF code", () => {
+    const err = playwrightError("locator.click: element is detached from document");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+    expect(result.message).toContain("browser_snapshot");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps 'element is not stable' to STALE_REF code", () => {
+    const err = playwrightError("locator.click: element is not stable");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+  });
+
+  test("maps 'not attached to a Document' to STALE_REF code", () => {
+    const err = playwrightError("locator.fill: element is not attached to a Document");
+    const result = translatePlaywrightError("browser_type", err);
+    expect(result.code).toBe("STALE_REF");
+  });
+
+  // Pattern 3: Execution context destroyed
+  test("maps 'Execution context was destroyed' to STALE_REF code", () => {
+    const err = playwrightError(
+      "Execution context was destroyed, most likely because of a navigation.",
+    );
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("STALE_REF");
+    expect(result.message).toContain("navigated");
+    expect(result.message).toContain("browser_snapshot");
+  });
+
+  // Pattern 4: Network navigation failures
+  test("maps net::ERR_NAME_NOT_RESOLVED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_NAME_NOT_RESOLVED at https://nonexistent.example");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("reachable");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps net::ERR_CONNECTION_REFUSED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_CONNECTION_REFUSED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  test("maps net::ERR_ABORTED to EXTERNAL code", () => {
+    const err = playwrightError("net::ERR_ABORTED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  // Pattern 5: Page/target closed
+  test("maps 'Target closed' to INTERNAL code", () => {
+    const err = playwrightError("Target closed.");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("closed unexpectedly");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps 'page has been closed' to INTERNAL code", () => {
+    const err = playwrightError("locator.click: page has been closed");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+  });
+
+  // Pattern 6: WebSocket / connection lost
+  test("maps 'WebSocket error' to INTERNAL code", () => {
+    const err = playwrightError("WebSocket error: connection refused");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("connection was lost");
+  });
+
+  // Pattern 7: JavaScript eval error
+  test("maps 'Evaluation failed:' to EXTERNAL code", () => {
+    const err = playwrightError("Evaluation failed: ReferenceError: window.myFn is not defined");
+    const result = translatePlaywrightError("browser_evaluate", err);
+    expect(result.code).toBe("EXTERNAL");
+    expect(result.message).toContain("JavaScript");
+    expect(result.cause).toBe(err);
+  });
+
+  test("maps 'is not a function' to EXTERNAL code", () => {
+    const err = playwrightError("document.querySelectorAll is not a function");
+    const result = translatePlaywrightError("browser_evaluate", err);
+    expect(result.code).toBe("EXTERNAL");
+  });
+
+  // Pattern 8: Invalid CSS selector
+  test("maps 'is not a valid selector' to VALIDATION code", () => {
+    const err = playwrightError(".foo[[bar] is not a valid selector");
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("VALIDATION");
+    expect(result.retryable).toBe(false);
+  });
+
+  test("maps 'Failed to execute querySelector' to VALIDATION code", () => {
+    const err = playwrightError(
+      "Failed to execute 'querySelector' on 'Document': '#bad>>' is not a valid selector.",
+    );
+    const result = translatePlaywrightError("browser_wait", err);
+    expect(result.code).toBe("VALIDATION");
+  });
+
+  // Pattern 9: CORS / security policy
+  test("maps CORS error to PERMISSION code", () => {
+    const err = playwrightError("Blocked by CORS policy: No 'Access-Control-Allow-Origin' header");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("PERMISSION");
+    expect(result.message).toContain("security policy");
+  });
+
+  test("maps ERR_BLOCKED_BY_CLIENT to PERMISSION code", () => {
+    const err = playwrightError("net::ERR_BLOCKED_BY_CLIENT");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.code).toBe("PERMISSION");
+  });
+
+  // Default fallback
+  test("defaults unknown errors to INTERNAL with cause preserved", () => {
+    const err = playwrightError("Something completely unexpected happened");
+    const result = translatePlaywrightError("browser_click", err);
+    expect(result.code).toBe("INTERNAL");
+    expect(result.message).toContain("browser_click");
+    expect(result.cause).toBe(err);
+  });
+
+  test("handles non-Error thrown values", () => {
+    const result = translatePlaywrightError("browser_click", "raw string error");
+    expect(result.code).toBe("INTERNAL");
+  });
+
+  // Operation name appears in error messages for traceability
+  test("includes operation name in TIMEOUT messages", () => {
+    const err = playwrightError("Timeout 3000ms exceeded", "TimeoutError");
+    const result = translatePlaywrightError("browser_fill_form", err);
+    expect(result.message).toContain("browser_fill_form");
+  });
+
+  test("includes operation name in EXTERNAL messages", () => {
+    const err = playwrightError("net::ERR_CONNECTION_REFUSED");
+    const result = translatePlaywrightError("browser_navigate", err);
+    expect(result.message).toContain("browser_navigate");
+  });
+});

--- a/packages/lib/browser-a11y/src/a11y-serializer.ts
+++ b/packages/lib/browser-a11y/src/a11y-serializer.ts
@@ -1,0 +1,309 @@
+/**
+ * Accessibility-tree serializer for Playwright accessibility snapshots.
+ *
+ * Two entry-points:
+ *  - parseAriaYaml()   — parses Playwright 1.44+ locator.ariaSnapshot() YAML output
+ *  - serializeA11yTree() — converts the legacy AccessibilityNode tree format
+ *
+ * Both produce the same SerializeResult: compact text + refs map with [ref=eN] markers.
+ * ~800 tokens per typical page vs 5000+ for screenshots.
+ * Compatible with any LLM — plain text, zero vision required.
+ */
+
+import type { BrowserRefInfo, BrowserSnapshotOptions } from "@koi/core";
+import { CHARS_PER_TOKEN } from "@koi/token-estimator";
+
+/**
+ * Minimal subset of Playwright's AccessibilityNode that we use.
+ * Defined locally to keep the serializer testable with zero Playwright dep.
+ */
+export interface A11yNode {
+  readonly role: string;
+  readonly name: string;
+  readonly value?: string | number;
+  readonly description?: string;
+  readonly level?: number;
+  readonly checked?: boolean | "mixed";
+  readonly pressed?: boolean | "mixed";
+  readonly selected?: boolean;
+  readonly expanded?: boolean;
+  readonly disabled?: boolean;
+  readonly required?: boolean;
+  readonly children?: readonly A11yNode[];
+}
+
+/**
+ * Roles that receive [ref=eN] markers and can be targeted by interaction tools.
+ * Also used as the valid AriaRole set for type-safe getByRole() calls.
+ */
+export const VALID_ROLES: ReadonlySet<string> = new Set<string>([
+  "button",
+  "link",
+  "textbox",
+  "searchbox",
+  "combobox",
+  "listbox",
+  "radiogroup",
+  "radio",
+  "checkbox",
+  "switch",
+  "spinbutton",
+  "slider",
+  "menuitem",
+  "menuitemradio",
+  "menuitemcheckbox",
+  "tab",
+  "treeitem",
+  "option",
+  "cell",
+  "gridcell",
+  "columnheader",
+  "rowheader",
+]);
+
+/** Type guard: narrows a string to a valid ARIA role for getByRole(). */
+export function isAriaRole(role: string): role is string & { readonly __ariaRole: true } {
+  return VALID_ROLES.has(role);
+}
+
+export interface SerializeResult {
+  readonly text: string;
+  readonly refs: Readonly<Record<string, BrowserRefInfo>>;
+  readonly truncated: boolean;
+  /** Page title extracted from the first document/WebArea node, if present. */
+  readonly title?: string;
+}
+
+/**
+ * Serialize an accessibility node tree to compact text with [ref=eN] markers.
+ *
+ * Output format (example):
+ *   WebArea "Page Title"
+ *     heading "Section" [level=1]
+ *     button "Submit" [ref=e1]
+ *     link "Home" [ref=e2]
+ *     textbox "Search" [required, ref=e3]
+ */
+export function serializeA11yTree(
+  root: A11yNode,
+  options?: BrowserSnapshotOptions,
+): SerializeResult {
+  const maxTokens = options?.maxTokens ?? 4000;
+  const maxDepth = options?.maxDepth ?? 8;
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+  let refCounter = 0;
+  const refs: Record<string, BrowserRefInfo> = {};
+  const lines: string[] = [];
+  let charCount = 0;
+  let truncated = false;
+  let title: string | undefined;
+
+  // Track occurrence counts for nthIndex: key = "role\0name"
+  const occurrenceCount = new Map<string, number>();
+
+  function visit(node: A11yNode, depth: number): boolean {
+    if (truncated) return false;
+    if (depth > maxDepth) {
+      truncated = true;
+      return false;
+    }
+    if (charCount >= maxChars) {
+      truncated = true;
+      return false;
+    }
+
+    // Extract title from root WebArea/document node
+    if (depth === 0 && (node.role === "WebArea" || node.role === "document") && node.name) {
+      title = node.name;
+    }
+
+    const indent = "  ".repeat(depth);
+    const isInteractive = VALID_ROLES.has(node.role);
+
+    let line = `${indent}${node.role}`;
+    if (node.name) {
+      line += ` "${node.name}"`;
+    }
+
+    // Collect state attributes
+    const attrs: string[] = [];
+    if (node.level !== undefined) attrs.push(`level=${node.level}`);
+    if (node.value !== undefined) attrs.push(`value="${node.value}"`);
+    if (node.checked === true) attrs.push("checked");
+    if (node.checked === "mixed") attrs.push("indeterminate");
+    if (node.pressed === true) attrs.push("pressed");
+    if (node.selected === true) attrs.push("selected");
+    if (node.expanded === true) attrs.push("expanded");
+    if (node.expanded === false) attrs.push("collapsed");
+    if (node.disabled === true) attrs.push("disabled");
+    if (node.required === true) attrs.push("required");
+    if (node.description) attrs.push(`desc="${node.description}"`);
+
+    if (isInteractive) {
+      const occKey = `${node.role}\0${node.name ?? ""}`;
+      const nthIndex = occurrenceCount.get(occKey) ?? 0;
+      occurrenceCount.set(occKey, nthIndex + 1);
+
+      const refKey = `e${++refCounter}`;
+      refs[refKey] = {
+        role: node.role,
+        ...(node.name ? { name: node.name } : {}),
+        nthIndex,
+      };
+      attrs.push(`ref=${refKey}`);
+    }
+
+    if (attrs.length > 0) {
+      line += ` [${attrs.join(", ")}]`;
+    }
+
+    // Check if adding this line would exceed the limit
+    const lineLen = line.length + 1; // +1 for newline
+    if (charCount + lineLen > maxChars) {
+      truncated = true;
+      return false;
+    }
+
+    charCount += lineLen;
+    lines.push(line);
+
+    if (node.children) {
+      for (const child of node.children) {
+        if (!visit(child, depth + 1)) break;
+      }
+    }
+
+    return true;
+  }
+
+  visit(root, 0);
+
+  return {
+    text: lines.join("\n"),
+    refs,
+    truncated,
+    ...(title !== undefined ? { title } : {}),
+  };
+}
+
+/**
+ * Parse Playwright 1.44+ ARIA snapshot YAML (from `locator.ariaSnapshot()`) into compact
+ * text with [ref=eN] markers — the same format as serializeA11yTree().
+ *
+ * Input example:
+ *   - document "Page Title"
+ *   - heading "Example Domain" [level=1]
+ *   - paragraph: This domain is for use in examples.
+ *   - paragraph:
+ *     - link "Learn more" [aria-ref=e12]:
+ *       - /url: https://iana.org/domains/example
+ *
+ * Lines starting with `- /key:` are metadata properties (e.g. /url) and are skipped.
+ * Native `aria-ref` attributes from Playwright are captured in BrowserRefInfo.ariaRef.
+ */
+export function parseAriaYaml(yaml: string, options?: BrowserSnapshotOptions): SerializeResult {
+  const maxTokens = options?.maxTokens ?? 4000;
+  const maxDepth = options?.maxDepth ?? 8;
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+  let refCounter = 0;
+  const refs: Record<string, BrowserRefInfo> = {};
+  const lines: string[] = [];
+  let charCount = 0;
+  let truncated = false;
+  let title: string | undefined;
+
+  // Track occurrence counts for nthIndex: key = "role\0name"
+  const occurrenceCount = new Map<string, number>();
+
+  // Matches: `  - role "name" [attrs]: inline-text`
+  // Groups: [1]=indent, [2]=role, [3]=name (opt), [4]=attrs (opt), [5]=inline (opt)
+  const LINE_RE = /^( *)- ([a-z][\w-]*)(?:\s+"([^"]*)")?(?:\s+\[([^\]]*)\])?(?::\s*(.*))?$/;
+
+  for (const rawLine of yaml.split("\n")) {
+    const trimmed = rawLine.trimEnd();
+    if (!trimmed.trim()) continue;
+    // Skip metadata properties emitted by Playwright like `- /url: ...`
+    if (/^ *- \//.test(trimmed)) continue;
+
+    const m = LINE_RE.exec(trimmed);
+    if (!m) continue;
+
+    const depth = (m[1]?.length ?? 0) / 2;
+    if (depth > maxDepth) {
+      truncated = true;
+      continue;
+    }
+    if (charCount >= maxChars) {
+      truncated = true;
+      break;
+    }
+
+    const role = m[2] ?? "";
+    const name = m[3] ?? "";
+    const rawAttrs = m[4] ?? "";
+    const isInteractive = VALID_ROLES.has(role);
+
+    // Extract page title from root document/WebArea node
+    if (depth === 0 && (role === "document" || role === "WebArea") && name) {
+      title = name;
+    }
+
+    let outLine = `${"  ".repeat(depth)}${role}`;
+    if (name) outLine += ` "${name}"`;
+
+    // Parse raw attrs — look for native aria-ref from Playwright
+    const attrParts: string[] = rawAttrs
+      ? rawAttrs
+          .split(",")
+          .map((a) => a.trim())
+          .filter(Boolean)
+      : [];
+
+    // Extract native aria-ref if present (e.g. "aria-ref=e12")
+    let nativeAriaRef: string | undefined;
+    const outAttrs: string[] = [];
+    for (const part of attrParts) {
+      const ariaRefMatch = /^aria-ref=(.+)$/.exec(part);
+      if (ariaRefMatch) {
+        nativeAriaRef = ariaRefMatch[1];
+        // Don't pass the native aria-ref through to output — we'll re-emit as ref=eN
+      } else {
+        outAttrs.push(part);
+      }
+    }
+
+    if (isInteractive) {
+      const occKey = `${role}\0${name}`;
+      const nthIndex = occurrenceCount.get(occKey) ?? 0;
+      occurrenceCount.set(occKey, nthIndex + 1);
+
+      const refKey = `e${++refCounter}`;
+      refs[refKey] = {
+        role,
+        ...(name ? { name } : {}),
+        ...(nativeAriaRef !== undefined ? { ariaRef: nativeAriaRef } : {}),
+        nthIndex,
+      };
+      outAttrs.push(`ref=${refKey}`);
+    }
+
+    if (outAttrs.length > 0) outLine += ` [${outAttrs.join(", ")}]`;
+
+    const lineLen = outLine.length + 1;
+    if (charCount + lineLen > maxChars) {
+      truncated = true;
+      break;
+    }
+    charCount += lineLen;
+    lines.push(outLine);
+  }
+
+  return {
+    text: lines.join("\n"),
+    refs,
+    truncated,
+    ...(title !== undefined ? { title } : {}),
+  };
+}

--- a/packages/lib/browser-a11y/src/error-translator.ts
+++ b/packages/lib/browser-a11y/src/error-translator.ts
@@ -1,0 +1,183 @@
+/**
+ * Playwright → KoiError translator.
+ *
+ * Maps raw Playwright exceptions to typed KoiError objects with
+ * actionable guidance for LLM agents. Uses name/message checks
+ * since Playwright's TypeScript types don't export error classes.
+ *
+ * ## 9-pattern taxonomy
+ *
+ * | Pattern                        | Code        | Guidance                                    |
+ * |-------------------------------|-------------|---------------------------------------------|
+ * | TimeoutError (name check)     | TIMEOUT     | Try browser_wait or re-snapshot first        |
+ * | Element detached from DOM     | STALE_REF   | Call browser_snapshot to refresh refs        |
+ * | Execution context destroyed   | STALE_REF   | Page navigated — call browser_snapshot       |
+ * | Blocked by policy (CORS etc.) | PERMISSION  | Blocked by browser security policy           |
+ * | net::ERR_* navigation failure | EXTERNAL    | Check the URL is reachable                  |
+ * | Page/target closed            | INTERNAL    | Browser page closed unexpectedly             |
+ * | WebSocket disconnected        | INTERNAL    | Browser connection lost                      |
+ * | JavaScript eval error         | EXTERNAL    | Page JS threw an error                       |
+ * | Invalid CSS selector syntax   | VALIDATION  | Fix the CSS selector string                  |
+ */
+
+import type { KoiError } from "@koi/core";
+import { external, internal, permission, staleRef, timeout, validation } from "@koi/core";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Extract a message string safely from an unknown caught value. */
+function extractMsg(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** True when the error's `.name` property equals the given value. */
+function hasName(err: unknown, name: string): boolean {
+  return err instanceof Error && err.name === name;
+}
+
+/** True when the message includes any of the given fragments. */
+function msgIncludes(msg: string, ...fragments: readonly string[]): boolean {
+  return fragments.some((f) => msg.includes(f));
+}
+
+// ---------------------------------------------------------------------------
+// Main translator
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a caught Playwright exception to a typed KoiError with actionable
+ * guidance for LLM agents.
+ *
+ * @param operation - The browser operation that failed (e.g., "browser_click").
+ *                    Used in fallback INTERNAL messages for traceability.
+ * @param err       - The caught value from a catch block (`e: unknown`).
+ */
+export function translatePlaywrightError(operation: string, err: unknown): KoiError {
+  const msg = extractMsg(err);
+
+  // Pattern 1: TimeoutError — check .name since Playwright doesn't export the class
+  if (hasName(err, "TimeoutError") || msgIncludes(msg, "Timeout ", "timeout exceeded")) {
+    return timeout(
+      `${operation} timed out — try browser_wait first, increase the timeout, ` +
+        "or call browser_snapshot to verify the element is visible",
+      2_000,
+    );
+  }
+
+  // Pattern 2 & 3: Stale element / execution context destroyed
+  // These both indicate the DOM or page changed after the last snapshot.
+  if (
+    msgIncludes(
+      msg,
+      "element is detached",
+      "Element is detached",
+      "element was detached",
+      "is detached from document",
+      "not attached to a Document",
+      "element is not stable",
+      "not stable",
+    )
+  ) {
+    return staleRef(
+      "element",
+      "call browser_snapshot to get fresh refs — the DOM changed since your last snapshot",
+    );
+  }
+
+  if (msgIncludes(msg, "Execution context was destroyed", "execution context was destroyed")) {
+    return staleRef(
+      "page",
+      "the page navigated and all refs are now stale — call browser_snapshot to continue",
+    );
+  }
+
+  // Pattern 4: CORS / policy / security blocks
+  // Checked BEFORE generic net::ERR_* to avoid ERR_BLOCKED_BY_CLIENT being misclassified.
+  if (
+    msgIncludes(
+      msg,
+      "Access-Control-Allow-Origin",
+      "CORS",
+      "Cross-Origin",
+      "Blocked by CORS policy",
+      "ERR_BLOCKED_BY_CLIENT",
+      "ERR_BLOCKED_BY_RESPONSE",
+    )
+  ) {
+    return permission(
+      `${operation} blocked by browser security policy (CORS or content policy) — ${msg}`,
+    );
+  }
+
+  // Pattern 5: Network navigation failures
+  if (
+    msgIncludes(
+      msg,
+      "net::ERR_NAME_NOT_RESOLVED",
+      "net::ERR_CONNECTION_REFUSED",
+      "net::ERR_CONNECTION_TIMED_OUT",
+      "net::ERR_ABORTED",
+      "net::ERR_CERT_",
+      "net::ERR_",
+      "ERR_NAME_NOT_RESOLVED",
+      "ERR_CONNECTION",
+    )
+  ) {
+    return external(
+      `${operation} failed: navigation error — check the URL is reachable (${msg})`,
+      err,
+    );
+  }
+
+  // Pattern 6: Page or browser target closed unexpectedly
+  if (
+    msgIncludes(
+      msg,
+      "Target closed",
+      "Target page, context or browser has been closed",
+      "Page closed",
+      "page has been closed",
+      "browser has disconnected",
+    )
+  ) {
+    return internal(`${operation} failed: browser page was closed unexpectedly`, err);
+  }
+
+  // Pattern 7: WebSocket / CDP connection lost
+  if (msgIncludes(msg, "WebSocket error", "socket hang up", "Connection closed")) {
+    return internal(`${operation} failed: browser connection was lost`, err);
+  }
+
+  // Pattern 8: JavaScript evaluation errors (thrown inside the page)
+  if (
+    msgIncludes(
+      msg,
+      "Evaluation failed:",
+      "evaluation failed",
+      "Cannot read properties of",
+      "is not defined",
+      "is not a function",
+    )
+  ) {
+    return external(`${operation} failed: JavaScript in the page threw an error — ${msg}`, err);
+  }
+
+  // Pattern 9: Invalid CSS selector syntax
+  if (
+    msgIncludes(
+      msg,
+      "is not a valid selector",
+      "Failed to execute 'querySelector'",
+      "Invalid selector",
+      "SyntaxError: ",
+    )
+  ) {
+    return validation(`${operation} failed: invalid CSS selector syntax — ${msg}`);
+  }
+
+  // Default: unexpected error, preserve cause for debugging
+  return internal(`${operation} failed`, err);
+}

--- a/packages/lib/browser-a11y/src/index.ts
+++ b/packages/lib/browser-a11y/src/index.ts
@@ -1,16 +1,12 @@
 /**
- * @koi/browser-a11y — Accessibility-tree serializer and Playwright error translator (L0u).
+ * @koi/browser-a11y — accessibility-tree serializer + Playwright error translator.
  *
- * Provides browser-tooling utilities that are decoupled from any specific driver:
- *  - `a11y-serializer`: parse Playwright ariaSnapshot YAML into compact text + ref maps
- *    (~800 tokens per page vs 5000+ for screenshots; LLM-vision-free).
- *  - `error-translator`: map raw Playwright exceptions to typed `KoiError` objects with
- *    actionable LLM guidance.
- *
- * Depends on `@koi/core` (types/factories) and `@koi/token-estimator` (CHARS_PER_TOKEN).
- *
- * Public API is wired in P1-T4 once `a11y-serializer` (P1-T2) and `error-translator`
- * (P1-T3) are ported from `archive/v1/packages/drivers/browser-playwright`.
+ * Pure L0u utilities shared by `@koi/browser-playwright` (CDP-over-Playwright
+ * driver) and `@koi/browser-ext` (extension-injected session driver). Depends
+ * only on L0 (`@koi/core` for types) and peer L0u (`@koi/token-estimator` for
+ * CHARS_PER_TOKEN). No Playwright runtime import.
  */
 
-export {};
+export type { A11yNode, SerializeResult } from "./a11y-serializer.js";
+export { isAriaRole, parseAriaYaml, serializeA11yTree, VALID_ROLES } from "./a11y-serializer.js";
+export { translatePlaywrightError } from "./error-translator.js";

--- a/packages/lib/browser-a11y/src/index.ts
+++ b/packages/lib/browser-a11y/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @koi/browser-a11y — Accessibility-tree serializer and Playwright error translator (L0u).
+ *
+ * Provides browser-tooling utilities that are decoupled from any specific driver:
+ *  - `a11y-serializer`: parse Playwright ariaSnapshot YAML into compact text + ref maps
+ *    (~800 tokens per page vs 5000+ for screenshots; LLM-vision-free).
+ *  - `error-translator`: map raw Playwright exceptions to typed `KoiError` objects with
+ *    actionable LLM guidance.
+ *
+ * Depends on `@koi/core` (types/factories) and `@koi/token-estimator` (CHARS_PER_TOKEN).
+ *
+ * Public API is wired in P1-T4 once `a11y-serializer` (P1-T2) and `error-translator`
+ * (P1-T3) are ported from `archive/v1/packages/drivers/browser-playwright`.
+ */
+
+export {};

--- a/packages/lib/browser-a11y/tsconfig.json
+++ b/packages/lib/browser-a11y/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../../kernel/core" }, { "path": "../../mm/token-estimator" }]
+}

--- a/packages/lib/browser-a11y/tsup.config.ts
+++ b/packages/lib/browser-a11y/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -19,6 +19,7 @@ export const L0U_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/bash-ast",
   "@koi/bash-classifier",
   "@koi/bash-security",
+  "@koi/browser-a11y",
   "@koi/channel-base",
   "@koi/config",
   "@koi/context-manager",


### PR DESCRIPTION
## Summary

First of seven stacked PRs that close #1609 (extension-injected browser sessions). This PR extracts the v1 accessibility-tree serializer and Playwright error translator from `archive/v1/packages/drivers/browser-playwright/` into a new **L0u** package `@koi/browser-a11y`, so they can be shared by:

- **P2** — ported `@koi/browser-playwright` (CDP-over-Playwright driver).
- **P5** — new `@koi/browser-ext` driver (extension-over-native-messaging).

No functional change yet — this is a pure extraction. Downstream packages that will consume it land in follow-up PRs.

## Why extract, not duplicate

Two drivers need the same text-tree format and the same error-translation semantics. Duplicating ~500 LOC across both would be a Rule-of-Three violation waiting to happen. Lifting to L0u gives one source of truth.

## What's in this PR (6 commits)

| Commit | Scope |
|--------|-------|
| `f3c140d0f` | Scaffold L0u package (package.json, tsconfig, tsup) |
| `f4fa58810` | Port `a11y-serializer.ts` + its 34 tests from v1 (verbatim) |
| `7461efcf3` | Port `error-translator.ts` + its 22 tests from v1 (verbatim) |
| `c5a12b8a5` | Wire public API via `src/index.ts` + 6 api-surface guard tests |
| `4fcadbaaa` | Add `docs/L2/browser-a11y.md` |
| `805d7385c` | Register `@koi/browser-a11y` in `scripts/layers.ts` L0U_PACKAGES |

## Layer compliance

- Imports from `@koi/core` (L0) and `@koi/token-estimator` (peer L0u) only.
- No Playwright runtime import — `translatePlaywrightError` uses duck-typed `.name` / `.message` probing.
- `bun run check:layers` passes.

## Test plan

- [x] `bun run typecheck` — clean, 183 tasks pass.
- [x] `bun run lint` — clean, 94 tasks pass.
- [x] `bun run check:layers` — `@koi/browser-a11y` classified as L0u, no violations.
- [x] `bun test --cwd packages/lib/browser-a11y` — **62 tests pass** (34 serializer + 22 translator + 6 api-surface).
- [x] `bun run check:duplicates` — passes (pre-existing internal clone in the v1 port is noted; archive/v1 is excluded from the scanner).
- [x] `bun run check:unused` — passes (no `@koi/browser-a11y` exports flagged).
- [x] `bun run --cwd packages/lib/browser-a11y build` — produces `dist/index.{js,d.ts}` with all five public runtime exports.

## Deviations from the original plan

- The design spec listed three files (`a11y-serializer.ts`, `error-translator.ts`, `ref-resolution.ts`) inside `@koi/browser-a11y`. `ref-resolution.ts` is **not** extracted in this PR because the v1 logic uses Playwright's `page.locator` and lives embedded in `playwright-browser-driver.ts`. Keeping the extracted package purely Playwright-free is higher value than forcing a third file; ref-resolution stays with the Playwright driver port in P2.

## Next (for reviewers)

- P2 (`@koi/browser-playwright` port) depends on this PR.
- P3/P4 (native host + MV3 extension) do not depend on P1; they can develop in parallel.
- P5 (`@koi/browser-ext` driver) depends on P1 + P2 + P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
