### PR TITLE
feat(watch-patterns): @koi/watch-patterns L0u + L0 types (#1769 1/4)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,7 @@
       - "packages/**/tools-core/**"
       - "packages/**/url-safety/**"
       - "packages/**/validation/**"
+      - "packages/**/watch-patterns/**"
 
 "layer:L3":
   - changed-files:
@@ -99,3 +100,4 @@
       - "!packages/**/tools-core/**"
       - "!packages/**/url-safety/**"
       - "!packages/**/validation/**"
+      - "!packages/**/watch-patterns/**"

--- a/bun.lock
+++ b/bun.lock
@@ -564,6 +564,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+        "re2-wasm": "1.0.2",
       },
     },
     "packages/meta/cli": {
@@ -2167,6 +2168,8 @@
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "re2-wasm": ["re2-wasm@1.0.2", "", {}, "sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA=="],
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -559,6 +559,13 @@
         "zod": "4.3.6",
       },
     },
+    "packages/lib/watch-patterns": {
+      "name": "@koi/watch-patterns",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/meta/cli": {
       "name": "@koi-agent/cli",
       "version": "0.1.0",
@@ -1388,6 +1395,8 @@
     "@koi/url-safety": ["@koi/url-safety@workspace:packages/lib/url-safety"],
 
     "@koi/validation": ["@koi/validation@workspace:packages/lib/validation"],
+
+    "@koi/watch-patterns": ["@koi/watch-patterns@workspace:packages/lib/watch-patterns"],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 

--- a/docs/L2/watch-patterns.md
+++ b/docs/L2/watch-patterns.md
@@ -1,0 +1,27 @@
+# `@koi/watch-patterns` (L0u)
+
+Linear-time regex matcher, line buffer, and pending-match store.
+
+## What it does
+
+- Compile a small list of regex `watch_patterns` via `re2-wasm` (linear-time; no catastrophic backtracking).
+- Feed bytes through `createLineBufferedMatcher(...).writeStdout(taskId, chunk)` / `writeStderr(...)`. Each stream has its own decoder, line buffer, and `lineNumber` counter.
+- Matches land in a `PendingMatchStore` keyed by `(taskId, event, stream)` with explicit `peek`/`ack` semantics — non-destructive peek + success-gated ack makes delivery survive `@koi/middleware-semantic-retry`'s separate-request retry model.
+
+## Not in scope
+
+- Networking, persistence, or any subprocess/shell management — this package is pure string→events transformation.
+- Binary / non-UTF-8 subprocess output. Invalid UTF-8 decodes to U+FFFD; use raw `task_output` for binary-aware retrieval.
+- Patterns larger than 256 chars. Events not matching `/^(?!__)[a-z0-9_-]{1,64}$/`. More than 16 patterns per spawn.
+
+## Contracts
+
+See `src/index.ts` re-exports — `compilePatterns`, `createLineBufferedMatcher`, `createPendingMatchStore` and their accompanying types.
+
+## Reserved events
+
+- `__watch_overflow__` — emitted once per stream when the matcher hits a 16 KB newline-free line.
+- `__watch_dropped__` — emitted for each `(taskId, event, stream)` bucket evicted when the store exceeds 256 live buckets.
+- `__watch_dropped_older__` — emitted once when the tombstone list itself overflows at 4096 entries.
+
+All reserved events are rejected from user-supplied `event` names at compile time.

--- a/docs/architecture/Koi.md
+++ b/docs/architecture/Koi.md
@@ -226,8 +226,8 @@ Infrastructure backends      L3      Pluggable (Nexus, SQLite, custom)
 
 Engine *adapters* (Claude, Pi, Loop, custom) are swappable L2 packages. The engine *runtime* (guards, governance) is not — it IS the kernel runtime.
 
-**L0-utility packages** (31 total — canonical list lives in `scripts/layers.ts` → `L0U_PACKAGES`):
-`@koi/bash-ast`, `@koi/bash-classifier`, `@koi/bash-security`, `@koi/channel-base`, `@koi/config`, `@koi/context-manager`, `@koi/edit-match`, `@koi/errors`, `@koi/event-delivery`, `@koi/execution-context`, `@koi/file-resolution`, `@koi/fs-scoped`, `@koi/git-utils`, `@koi/hash`, `@koi/hook-prompt`, `@koi/memory`, `@koi/model-registry`, `@koi/query-engine`, `@koi/redaction`, `@koi/replay`, `@koi/rules-loader`, `@koi/secure-storage`, `@koi/session-repair`, `@koi/shutdown`, `@koi/skill-scanner`, `@koi/task-board`, `@koi/test`, `@koi/token-estimator`, `@koi/tools-core`, `@koi/url-safety`, `@koi/validation`.
+**L0-utility packages** (32 total — canonical list lives in `scripts/layers.ts` → `L0U_PACKAGES`):
+`@koi/bash-ast`, `@koi/bash-classifier`, `@koi/bash-security`, `@koi/channel-base`, `@koi/config`, `@koi/context-manager`, `@koi/edit-match`, `@koi/errors`, `@koi/event-delivery`, `@koi/execution-context`, `@koi/file-resolution`, `@koi/fs-scoped`, `@koi/git-utils`, `@koi/hash`, `@koi/hook-prompt`, `@koi/memory`, `@koi/model-registry`, `@koi/query-engine`, `@koi/redaction`, `@koi/replay`, `@koi/rules-loader`, `@koi/secure-storage`, `@koi/session-repair`, `@koi/shutdown`, `@koi/skill-scanner`, `@koi/task-board`, `@koi/test`, `@koi/token-estimator`, `@koi/tools-core`, `@koi/url-safety`, `@koi/validation`, `@koi/watch-patterns`.
 These contain pure utility functions with zero business logic. They depend on `@koi/core` + peer
 L0u packages only, and are importable by both L1 and L2 packages. They do NOT define core
 contracts — they provide shared implementations of common operations (error creation, schema

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -1207,6 +1207,14 @@ export type {
   VersionedBrickRef,
 } from "./version-types.js";
 export { publisherId } from "./version-types.js";
+// watch-patterns — L0 types for pattern-based stdout/stderr matching
+export type {
+  CoalescedMatch,
+  MatchEntry,
+  PatternMatch,
+  PendingMatchStore,
+  WatchPattern,
+} from "./watch-patterns/index.js";
 // webhook — outbound webhook delivery contract
 export type {
   OutboundWebhookConfig,

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -1213,6 +1213,7 @@ export type {
   MatchEntry,
   PatternMatch,
   PendingMatchStore,
+  TurnRequestKey,
   WatchPattern,
 } from "./watch-patterns/index.js";
 // webhook — outbound webhook delivery contract

--- a/packages/kernel/core/src/watch-patterns/index.ts
+++ b/packages/kernel/core/src/watch-patterns/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CoalescedMatch,
+  MatchEntry,
+  PatternMatch,
+  PendingMatchStore,
+  WatchPattern,
+} from "./types.js";

--- a/packages/kernel/core/src/watch-patterns/index.ts
+++ b/packages/kernel/core/src/watch-patterns/index.ts
@@ -3,5 +3,6 @@ export type {
   MatchEntry,
   PatternMatch,
   PendingMatchStore,
+  TurnRequestKey,
   WatchPattern,
 } from "./types.js";

--- a/packages/kernel/core/src/watch-patterns/types.ts
+++ b/packages/kernel/core/src/watch-patterns/types.ts
@@ -1,13 +1,20 @@
 import type { TaskItemId } from "../task-board.js";
 
+/** Key type for `WeakMap`-based per-request match stores (a `WeakKey` alias). */
+export type TurnRequestKey = WeakKey;
+
+/** A regex watcher attached to a background process's stdout/stderr. */
 export interface WatchPattern {
   readonly pattern: string;
   readonly event: string;
+  /** RE2 flag string (default `'i'`). `'g'` and `'y'` are rejected at compile time. */
   readonly flags?: string;
 }
 
+/** A single regex-to-line match emitted by the line-buffered matcher. */
 export interface PatternMatch {
   readonly taskId: TaskItemId;
+  /** Subprocess pid — optional, absent after process exit. */
   readonly pid?: number;
   readonly event: string;
   readonly stream: "stdout" | "stderr";
@@ -15,6 +22,7 @@ export interface PatternMatch {
   readonly timestamp: number;
 }
 
+/** A deduplicated, coalesced view of multiple `PatternMatch` events for the same pattern. */
 export interface CoalescedMatch {
   readonly taskId: TaskItemId;
   readonly event: string;
@@ -24,25 +32,30 @@ export interface CoalescedMatch {
   readonly lastTimestamp: number;
 }
 
+/** Raw match record stored in the ring buffer, including byte-level window metadata. */
 export interface MatchEntry {
   readonly event: string;
   readonly stream: "stdout" | "stderr";
   readonly lineNumber: number;
   readonly timestamp: number;
   readonly line: string;
-  readonly line_byte_length: number;
-  readonly line_clipped_prefix_bytes: number;
-  readonly line_clipped_suffix_bytes: number;
-  readonly line_original_byte_length: number;
-  readonly match_span_units: { readonly start: number; readonly end: number };
+  readonly lineByteLength: number;
+  /** Bytes trimmed from the original line when the stored window does not contain the full line. */
+  readonly lineClippedPrefixBytes: number;
+  /** Bytes trimmed from the original line when the stored window does not contain the full line. */
+  readonly lineClippedSuffixBytes: number;
+  readonly lineOriginalByteLength: number;
+  /** Regex-match span in UTF-16 code-unit offsets into `line`. Always valid within the stored window even after truncation. */
+  readonly matchSpanUnits: { readonly start: number; readonly end: number };
 }
 
+/** In-memory store that buffers and coalesces `PatternMatch` events until a turn acknowledges them. */
 export interface PendingMatchStore {
   readonly record: (match: PatternMatch) => void;
-  readonly peek: (request: object) => readonly CoalescedMatch[];
-  readonly ack: (request: object) => void;
+  readonly peek: (request: TurnRequestKey) => readonly CoalescedMatch[];
+  readonly ack: (request: TurnRequestKey) => void;
   readonly pending: () => number;
   readonly registerMatcher: (matcher: { readonly cancel: () => void }) => void;
   readonly unregisterMatcher: (matcher: { readonly cancel: () => void }) => void;
-  readonly dispose: () => void;
+  readonly dispose?: () => void | Promise<void>;
 }

--- a/packages/kernel/core/src/watch-patterns/types.ts
+++ b/packages/kernel/core/src/watch-patterns/types.ts
@@ -1,0 +1,48 @@
+import type { TaskItemId } from "../task-board.js";
+
+export interface WatchPattern {
+  readonly pattern: string;
+  readonly event: string;
+  readonly flags?: string;
+}
+
+export interface PatternMatch {
+  readonly taskId: TaskItemId;
+  readonly pid?: number;
+  readonly event: string;
+  readonly stream: "stdout" | "stderr";
+  readonly lineNumber: number;
+  readonly timestamp: number;
+}
+
+export interface CoalescedMatch {
+  readonly taskId: TaskItemId;
+  readonly event: string;
+  readonly stream: "stdout" | "stderr";
+  readonly firstMatch: PatternMatch;
+  readonly count: number;
+  readonly lastTimestamp: number;
+}
+
+export interface MatchEntry {
+  readonly event: string;
+  readonly stream: "stdout" | "stderr";
+  readonly lineNumber: number;
+  readonly timestamp: number;
+  readonly line: string;
+  readonly line_byte_length: number;
+  readonly line_clipped_prefix_bytes: number;
+  readonly line_clipped_suffix_bytes: number;
+  readonly line_original_byte_length: number;
+  readonly match_span_units: { readonly start: number; readonly end: number };
+}
+
+export interface PendingMatchStore {
+  readonly record: (match: PatternMatch) => void;
+  readonly peek: (request: object) => readonly CoalescedMatch[];
+  readonly ack: (request: object) => void;
+  readonly pending: () => number;
+  readonly registerMatcher: (matcher: { readonly cancel: () => void }) => void;
+  readonly unregisterMatcher: (matcher: { readonly cancel: () => void }) => void;
+  readonly dispose: () => void;
+}

--- a/packages/lib/watch-patterns/package.json
+++ b/packages/lib/watch-patterns/package.json
@@ -18,6 +18,7 @@
     "test:api": "bun test src/__tests__/api-surface.test.ts"
   },
   "dependencies": {
-    "@koi/core": "workspace:*"
+    "@koi/core": "workspace:*",
+    "re2-wasm": "1.0.2"
   }
 }

--- a/packages/lib/watch-patterns/package.json
+++ b/packages/lib/watch-patterns/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@koi/watch-patterns",
+  "description": "Linear-time regex matcher, line buffer, and pending-match store for reactive shell notifications",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  }
+}

--- a/packages/lib/watch-patterns/src/__tests__/api-surface.test.ts
+++ b/packages/lib/watch-patterns/src/__tests__/api-surface.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import * as api from "../index.js";
+
+describe("@koi/watch-patterns API surface", () => {
+  test("exported functions are stable", () => {
+    const names = Object.keys(api).sort();
+    expect(names).toEqual([
+      "compilePatterns",
+      "createLineBufferedMatcher",
+      "createPendingMatchStore",
+    ]);
+  });
+});

--- a/packages/lib/watch-patterns/src/compile.test.ts
+++ b/packages/lib/watch-patterns/src/compile.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { WatchPattern } from "@koi/core";
+import { compilePatterns } from "./compile.js";
+
+describe("compilePatterns", () => {
+  test("compiles a simple valid pattern", () => {
+    const res = compilePatterns([{ pattern: "ready", event: "ready" }]);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toHaveLength(1);
+      expect(res.value[0]?.event).toBe("ready");
+    }
+  });
+
+  test("respects empty flags", () => {
+    const res = compilePatterns([{ pattern: "Error", event: "err", flags: "" }]);
+    expect(res.ok).toBe(true);
+  });
+
+  test("defaults flags to 'i' (case-insensitive)", () => {
+    const res = compilePatterns([{ pattern: "Ready", event: "ready" }]);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value[0]?.re.test("READY")).toBe(true);
+  });
+
+  test("rejects pattern >256 chars", () => {
+    const res = compilePatterns([{ pattern: "a".repeat(257), event: "ok" }]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("VALIDATION");
+  });
+
+  test("rejects pattern of length 0", () => {
+    const res = compilePatterns([{ pattern: "", event: "ok" }]);
+    expect(res.ok).toBe(false);
+  });
+
+  test("rejects >16 patterns", () => {
+    const patterns: WatchPattern[] = [];
+    for (let i = 0; i < 17; i++) patterns.push({ pattern: `p${i}`, event: `e${i}` });
+    const res = compilePatterns(patterns);
+    expect(res.ok).toBe(false);
+  });
+
+  test.each([
+    ["", "empty event"],
+    ["UPPER", "uppercase"],
+    ["has space", "space"],
+    ['has"quote', "double quote"],
+    ["has\nnewline", "newline"],
+    ["has\u0000null", "null byte"],
+    ["a".repeat(65), "65 chars"],
+    ["__reserved", "__ prefix"],
+  ])("rejects invalid event %p (%s)", (event, _why) => {
+    const res = compilePatterns([{ pattern: "x", event }]);
+    expect(res.ok).toBe(false);
+  });
+
+  test.each([["g"], ["y"], ["gy"]])("rejects flag %p", (flags) => {
+    const res = compilePatterns([{ pattern: "x", event: "ok", flags }]);
+    expect(res.ok).toBe(false);
+  });
+
+  test("rejects RE2-unsupported construct (lookahead)", () => {
+    const res = compilePatterns([{ pattern: "(?=x)x", event: "ok" }]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.message).toMatch(/RE2|lookahead|unsupported/i);
+  });
+});

--- a/packages/lib/watch-patterns/src/compile.ts
+++ b/packages/lib/watch-patterns/src/compile.ts
@@ -1,17 +1,15 @@
-import type { WatchPattern } from "@koi/core";
+import type { KoiError, WatchPattern } from "@koi/core";
+import { validation } from "@koi/core";
 import { RE2 } from "re2-wasm";
 
 export interface CompiledPattern {
   readonly event: string;
-  readonly re: RE2;
+  readonly re: { readonly test: (input: string) => boolean };
 }
 
 export type CompileResult =
   | { readonly ok: true; readonly value: readonly CompiledPattern[] }
-  | {
-      readonly ok: false;
-      readonly error: { readonly code: "VALIDATION"; readonly message: string };
-    };
+  | { readonly ok: false; readonly error: KoiError };
 
 const MAX_PATTERN_CHARS = 256;
 const MAX_PATTERNS = 16;
@@ -65,5 +63,5 @@ export function compilePatterns(input: readonly WatchPattern[]): CompileResult {
 }
 
 function fail(message: string): CompileResult {
-  return { ok: false, error: { code: "VALIDATION", message } };
+  return { ok: false, error: validation(message) };
 }

--- a/packages/lib/watch-patterns/src/compile.ts
+++ b/packages/lib/watch-patterns/src/compile.ts
@@ -1,0 +1,69 @@
+import type { WatchPattern } from "@koi/core";
+import { RE2 } from "re2-wasm";
+
+export interface CompiledPattern {
+  readonly event: string;
+  readonly re: RE2;
+}
+
+export type CompileResult =
+  | { readonly ok: true; readonly value: readonly CompiledPattern[] }
+  | {
+      readonly ok: false;
+      readonly error: { readonly code: "VALIDATION"; readonly message: string };
+    };
+
+const MAX_PATTERN_CHARS = 256;
+const MAX_PATTERNS = 16;
+const EVENT_RE = /^(?!__)[a-z0-9_-]{1,64}$/;
+const DISALLOWED_FLAGS = /[gy]/;
+
+/**
+ * Compile user-supplied watch patterns.
+ *
+ * - Validates event names against strict identifier regex (excludes `__`-prefixed reserved names).
+ * - Validates pattern length (≤256 chars).
+ * - Validates max pattern count (≤16).
+ * - Rejects `g` and `y` flags.
+ * - Always injects the `u` (Unicode) flag required by re2-wasm.
+ * - Catches RE2 compile errors (backreferences, lookahead/lookbehind) and returns typed VALIDATION.
+ */
+export function compilePatterns(input: readonly WatchPattern[]): CompileResult {
+  if (input.length > MAX_PATTERNS) {
+    return fail(`Too many watch patterns (got ${input.length}, max ${MAX_PATTERNS})`);
+  }
+
+  const compiled: CompiledPattern[] = [];
+  for (const [i, w] of input.entries()) {
+    if (w.pattern.length === 0 || w.pattern.length > MAX_PATTERN_CHARS) {
+      return fail(`watch_patterns[${i}].pattern length must be 1..${MAX_PATTERN_CHARS}`);
+    }
+    if (!EVENT_RE.test(w.event)) {
+      return fail(
+        `watch_patterns[${i}].event must match /^(?!__)[a-z0-9_-]{1,64}$/ (got ${JSON.stringify(w.event)})`,
+      );
+    }
+    const userFlags = w.flags ?? "i";
+    if (DISALLOWED_FLAGS.test(userFlags)) {
+      return fail(
+        `watch_patterns[${i}].flags rejected: 'g' and 'y' are disallowed (got '${userFlags}')`,
+      );
+    }
+    // Always add the mandatory 'u' flag for re2-wasm. Deduplicate if user already passed 'u'.
+    const flags = userFlags.includes("u") ? userFlags : `${userFlags}u`;
+    try {
+      const re = new RE2(w.pattern, flags);
+      compiled.push({ event: w.event, re });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return fail(
+        `watch_patterns[${i}] rejected by RE2 (unsupported construct? backreferences/lookahead/lookbehind not supported): ${msg}`,
+      );
+    }
+  }
+  return { ok: true, value: compiled };
+}
+
+function fail(message: string): CompileResult {
+  return { ok: false, error: { code: "VALIDATION", message } };
+}

--- a/packages/lib/watch-patterns/src/index.ts
+++ b/packages/lib/watch-patterns/src/index.ts
@@ -1,0 +1,2 @@
+// Package exports populated as Tasks 1.4–1.9 land.
+export {};

--- a/packages/lib/watch-patterns/src/index.ts
+++ b/packages/lib/watch-patterns/src/index.ts
@@ -1,2 +1,7 @@
-// Package exports populated as Tasks 1.4–1.9 land.
-export {};
+export type { CompiledPattern, CompileResult } from "./compile.js";
+export { compilePatterns } from "./compile.js";
+
+export type { LineBufferedMatcher } from "./matcher.js";
+export { createLineBufferedMatcher } from "./matcher.js";
+
+export { createPendingMatchStore } from "./store.js";

--- a/packages/lib/watch-patterns/src/matcher.test.ts
+++ b/packages/lib/watch-patterns/src/matcher.test.ts
@@ -121,3 +121,72 @@ describe("createLineBufferedMatcher", () => {
     expect(seen).toHaveLength(1);
   });
 });
+
+describe("createLineBufferedMatcher — long lines", () => {
+  test("16 KB sliding window: match in last 8 KB is still detected", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "NEEDLE", event: "needle" }], (x) => {
+      seen.push(x);
+    });
+    const filler = " ".repeat(32 * 1024);
+    m.writeStdout(TASK, filler);
+    m.writeStdout(TASK, "NEEDLE\n");
+    const needle = seen.find((s) => s.event === "needle");
+    expect(needle).toBeDefined();
+  });
+
+  test("first trim emits __watch_overflow__ exactly once per task", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "x", event: "x" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "y".repeat(32 * 1024));
+    m.writeStdout(TASK, "y".repeat(32 * 1024));
+    const overflows = seen.filter((s) => s.event === "__watch_overflow__");
+    expect(overflows).toHaveLength(1);
+  });
+
+  test("overflow emitted independently per stream", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "x", event: "x" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "y".repeat(32 * 1024));
+    m.writeStderr(TASK, "y".repeat(32 * 1024));
+    const stdoutOverflows = seen.filter(
+      (s) => s.event === "__watch_overflow__" && s.stream === "stdout",
+    );
+    const stderrOverflows = seen.filter(
+      (s) => s.event === "__watch_overflow__" && s.stream === "stderr",
+    );
+    expect(stdoutOverflows).toHaveLength(1);
+    expect(stderrOverflows).toHaveLength(1);
+  });
+});
+
+describe("createLineBufferedMatcher — scanner-error isolation", () => {
+  test("one pattern's scanner throwing does not block other patterns on the same line", () => {
+    // Construct CompiledPattern directly — bypass compilePatterns so we can use a mock regex that throws.
+    // This mirrors the matcher's internal contract and exercises the scanner-error catch path.
+    const throwingRegex = {
+      test: (): boolean => {
+        throw new Error("regex engine bug");
+      },
+    };
+    const workingRegex = { test: (line: string): boolean => line.includes("good") };
+    const compiled = [
+      { event: "broken", re: throwingRegex },
+      { event: "good", re: workingRegex },
+    ];
+
+    const seen: PatternMatch[] = [];
+    const m = createLineBufferedMatcher(compiled, (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "the good line\n");
+    const goodMatch = seen.find((s) => s.event === "good");
+    expect(goodMatch).toBeDefined();
+    const brokenMatch = seen.find((s) => s.event === "broken");
+    expect(brokenMatch).toBeUndefined();
+  });
+});

--- a/packages/lib/watch-patterns/src/matcher.test.ts
+++ b/packages/lib/watch-patterns/src/matcher.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import type { PatternMatch, TaskItemId } from "@koi/core";
+import { compilePatterns } from "./compile.js";
+import { createLineBufferedMatcher } from "./matcher.js";
+
+function buildMatcher(
+  patterns: Array<{ pattern: string; event: string }>,
+  onMatch: (m: PatternMatch) => void,
+) {
+  const c = compilePatterns(patterns);
+  if (!c.ok) throw new Error(c.error.message);
+  return createLineBufferedMatcher(c.value, onMatch);
+}
+
+const TASK = "task_1" as unknown as TaskItemId;
+
+describe("createLineBufferedMatcher", () => {
+  test("matches a complete line on stdout", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "ready", event: "ready" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "server ready\n");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.stream).toBe("stdout");
+    expect(seen[0]?.event).toBe("ready");
+    expect(seen[0]?.lineNumber).toBe(1);
+  });
+
+  test("holds partial lines across chunks", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "ready", event: "ready" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "server ");
+    expect(seen).toHaveLength(0);
+    m.writeStdout(TASK, "ready\n");
+    expect(seen).toHaveLength(1);
+  });
+
+  test("stdout and stderr have independent line buffers", () => {
+    const seen: PatternMatch[] = [];
+    // Use anchored "^A$" so it matches only the literal "A" line on stderr,
+    // not "a" inside "part B" on stdout (default "i" flag would match "a" in "part").
+    const m = buildMatcher(
+      [
+        { pattern: "^A$", event: "a" },
+        { pattern: "B", event: "b" },
+      ],
+      (x) => {
+        seen.push(x);
+      },
+    );
+    m.writeStdout(TASK, "part ");
+    m.writeStderr(TASK, "A\n");
+    m.writeStdout(TASK, "B\n");
+    expect(seen).toHaveLength(2);
+    const stdoutMatch = seen.find((s) => s.stream === "stdout");
+    const stderrMatch = seen.find((s) => s.stream === "stderr");
+    expect(stdoutMatch?.event).toBe("b");
+    expect(stderrMatch?.event).toBe("a");
+  });
+
+  test("per-stream lineNumber increments independently", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "x", event: "e" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "x\nx\n");
+    m.writeStderr(TASK, "x\n");
+    const stdoutNums = seen.filter((s) => s.stream === "stdout").map((s) => s.lineNumber);
+    const stderrNums = seen.filter((s) => s.stream === "stderr").map((s) => s.lineNumber);
+    expect(stdoutNums).toEqual([1, 2]);
+    expect(stderrNums).toEqual([1]);
+  });
+
+  test("flush() scans trailing partial line on natural end", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "ready", event: "ready" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "almost ready");
+    expect(seen).toHaveLength(0);
+    m.flush(TASK);
+    expect(seen).toHaveLength(1);
+  });
+
+  test("cancel() ignores subsequent writes", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "ready", event: "ready" }], (x) => {
+      seen.push(x);
+    });
+    m.cancel();
+    m.writeStdout(TASK, "ready\n");
+    expect(seen).toHaveLength(0);
+  });
+
+  test("pattern throwing isolates other patterns (consumer error)", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher(
+      [
+        { pattern: "good", event: "good" },
+        { pattern: "bad", event: "bad" },
+      ],
+      (x) => {
+        if (x.event === "bad") throw new Error("consumer throws");
+        seen.push(x);
+      },
+    );
+    m.writeStdout(TASK, "good and bad on one line\n");
+    const goodSeen = seen.filter((s) => s.event === "good");
+    expect(goodSeen).toHaveLength(1);
+  });
+
+  test("handles \\r\\n line endings (strips trailing CR)", () => {
+    const seen: PatternMatch[] = [];
+    const m = buildMatcher([{ pattern: "^ready$", event: "ready" }], (x) => {
+      seen.push(x);
+    });
+    m.writeStdout(TASK, "ready\r\n");
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/packages/lib/watch-patterns/src/matcher.ts
+++ b/packages/lib/watch-patterns/src/matcher.ts
@@ -1,0 +1,128 @@
+import type { PatternMatch, TaskItemId } from "@koi/core";
+import type { CompiledPattern } from "./compile.js";
+
+const LINE_CAP_BYTES = 16 * 1024;
+const TRIM_KEEP_BYTES = 8 * 1024;
+
+/** Per-stream line-buffered matcher. Stdout and stderr have independent buffers. */
+export interface LineBufferedMatcher {
+  readonly writeStdout: (taskId: TaskItemId, chunk: string) => void;
+  readonly writeStderr: (taskId: TaskItemId, chunk: string) => void;
+  /** Scan any trailing partial line on natural process exit. */
+  readonly flush: (taskId: TaskItemId) => void;
+  /** Dispose; subsequent writes are ignored. */
+  readonly cancel: () => void;
+}
+
+interface StreamState {
+  buffer: string;
+  lineNumber: number;
+  overflowEmitted: boolean;
+}
+
+export function createLineBufferedMatcher(
+  compiled: readonly CompiledPattern[],
+  onMatch: (match: PatternMatch) => void,
+): LineBufferedMatcher {
+  let cancelled = false;
+  const stdout: StreamState = { buffer: "", lineNumber: 0, overflowEmitted: false };
+  const stderr: StreamState = { buffer: "", lineNumber: 0, overflowEmitted: false };
+
+  function scanLine(
+    taskId: TaskItemId,
+    stream: "stdout" | "stderr",
+    line: string,
+    lineNumber: number,
+  ): void {
+    for (const cp of compiled) {
+      let matched = false;
+      try {
+        matched = cp.re.test(line);
+      } catch {
+        // Scanner errors on this pattern: skip this pattern on this line.
+        continue;
+      }
+      if (!matched) continue;
+      const match: PatternMatch = {
+        taskId,
+        event: cp.event,
+        stream,
+        lineNumber,
+        timestamp: Date.now(),
+      };
+      try {
+        onMatch(match);
+      } catch {
+        // Consumer errors must not break other patterns or the decode loop.
+      }
+    }
+  }
+
+  function emitOverflow(taskId: TaskItemId, stream: "stdout" | "stderr", state: StreamState): void {
+    if (state.overflowEmitted) return;
+    state.overflowEmitted = true;
+    try {
+      onMatch({
+        taskId,
+        event: "__watch_overflow__",
+        stream,
+        lineNumber: state.lineNumber + 1,
+        timestamp: Date.now(),
+      });
+    } catch {
+      // Swallow — overflow is a best-effort signal.
+    }
+  }
+
+  function processStream(
+    taskId: TaskItemId,
+    stream: "stdout" | "stderr",
+    state: StreamState,
+    chunk: string,
+  ): void {
+    if (cancelled) return;
+    state.buffer += chunk;
+    let newlineIdx = state.buffer.indexOf("\n");
+    while (newlineIdx !== -1) {
+      const rawLine = state.buffer.slice(0, newlineIdx);
+      state.buffer = state.buffer.slice(newlineIdx + 1);
+      state.lineNumber += 1;
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+      scanLine(taskId, stream, line, state.lineNumber);
+      newlineIdx = state.buffer.indexOf("\n");
+    }
+    if (state.buffer.length > LINE_CAP_BYTES) {
+      emitOverflow(taskId, stream, state);
+      state.lineNumber += 1;
+      scanLine(taskId, stream, state.buffer, state.lineNumber);
+      state.buffer = state.buffer.slice(-TRIM_KEEP_BYTES);
+    }
+  }
+
+  return {
+    writeStdout: (taskId, chunk) => {
+      processStream(taskId, "stdout", stdout, chunk);
+    },
+    writeStderr: (taskId, chunk) => {
+      processStream(taskId, "stderr", stderr, chunk);
+    },
+    flush: (taskId) => {
+      if (cancelled) return;
+      for (const [stream, state] of [
+        ["stdout", stdout],
+        ["stderr", stderr],
+      ] as const) {
+        if (state.buffer.length > 0) {
+          state.lineNumber += 1;
+          scanLine(taskId, stream, state.buffer, state.lineNumber);
+          state.buffer = "";
+        }
+      }
+    },
+    cancel: () => {
+      cancelled = true;
+      stdout.buffer = "";
+      stderr.buffer = "";
+    },
+  };
+}

--- a/packages/lib/watch-patterns/src/re2-smoke.test.ts
+++ b/packages/lib/watch-patterns/src/re2-smoke.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { RE2 } from "re2-wasm";
+
+// NOTE: re2-wasm@1.0.2 enforces Unicode mode — the "u" flag is always required.
+// Every RE2 constructor call must include "u" in its flags string.
+
+describe("re2-wasm smoke gate", () => {
+  test("compiles and matches a simple pattern", () => {
+    // "ui" — unicode (required) + case-insensitive
+    const re = new RE2("ready", "ui");
+    expect(re.test("server listening — READY")).toBe(true);
+    expect(re.test("still warming up")).toBe(false);
+  });
+
+  test("4 KB input matches within budget", () => {
+    const re = new RE2("\\bneedle\\b", "u");
+    // Use spaces (non-word chars) as filler so the word boundary fires correctly.
+    const filler = " ".repeat(4096 - 8);
+    const line = `${filler}needle`;
+    const start = Bun.nanoseconds();
+    expect(re.test(line)).toBe(true);
+    const durationMs = (Bun.nanoseconds() - start) / 1e6;
+    if (durationMs > 5) {
+      console.warn(`[re2-smoke] slow match: ${durationMs.toFixed(2)} ms (expected <2 ms)`);
+    }
+  });
+
+  test("rejects unsupported construct (lookahead)", () => {
+    expect(() => new RE2("(?=ready)ready", "u")).toThrow();
+  });
+});

--- a/packages/lib/watch-patterns/src/store.test.ts
+++ b/packages/lib/watch-patterns/src/store.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import type { PatternMatch, TaskItemId } from "@koi/core";
+import { createPendingMatchStore } from "./store.js";
+
+const TASK = "task_1" as unknown as TaskItemId;
+
+function mk(
+  opts: Partial<PatternMatch> & { event: string; stream: "stdout" | "stderr" },
+): PatternMatch {
+  return {
+    taskId: opts.taskId ?? TASK,
+    event: opts.event,
+    stream: opts.stream,
+    lineNumber: opts.lineNumber ?? 1,
+    timestamp: opts.timestamp ?? 0,
+  };
+}
+
+describe("createPendingMatchStore", () => {
+  test("peek returns coalesced snapshot; ack clears those records", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 1 }));
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 2 }));
+    const reqA = {};
+    const snap1 = s.peek(reqA);
+    expect(snap1).toHaveLength(1);
+    expect(snap1[0]?.count).toBe(2);
+    s.ack(reqA);
+    const snap2 = s.peek({});
+    expect(snap2).toHaveLength(0);
+  });
+
+  test("peek is non-destructive; retry with same request returns same snapshot", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout" }));
+    const req = {};
+    const a = s.peek(req);
+    const b = s.peek(req);
+    expect(b).toEqual(a);
+  });
+
+  test("without ack, matches survive — simulates failed attempt + retry", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 1 }));
+    const reqA = {};
+    s.peek(reqA);
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 2 }));
+    // No ack(reqA) — attempt failed.
+    const reqB = {};
+    const snap = s.peek(reqB);
+    expect(snap).toHaveLength(1);
+    expect(snap[0]?.count).toBe(2);
+  });
+
+  test("ack only clears records in the peeked snapshot", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 1 }));
+    const req = {};
+    s.peek(req);
+    s.record(mk({ event: "e", stream: "stdout", lineNumber: 2 })); // after peek
+    s.ack(req);
+    const after = s.peek({});
+    expect(after).toHaveLength(1);
+    expect(after[0]?.count).toBe(1);
+    expect(after[0]?.firstMatch.lineNumber).toBe(2);
+  });
+
+  test("coalesce key includes stream: stdout and stderr are separate buckets", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout" }));
+    s.record(mk({ event: "e", stream: "stderr" }));
+    const snap = s.peek({});
+    expect(snap).toHaveLength(2);
+    expect(snap.map((c) => c.stream).sort()).toEqual(["stderr", "stdout"]);
+  });
+
+  test("ack on unseen request is a no-op", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout" }));
+    s.ack({}); // never peeked
+    expect(s.pending()).toBe(1);
+  });
+
+  test("dispose clears state and rejects further use", () => {
+    const s = createPendingMatchStore();
+    s.record(mk({ event: "e", stream: "stdout" }));
+    s.dispose?.();
+    expect(s.pending()).toBe(0);
+    s.record(mk({ event: "e", stream: "stdout" })); // no-op
+    expect(s.peek({})).toHaveLength(0);
+  });
+
+  test("registered matchers are cancelled on dispose", () => {
+    const s = createPendingMatchStore();
+    let cancelled = false;
+    const matcher = {
+      cancel: () => {
+        cancelled = true;
+      },
+    };
+    s.registerMatcher(matcher);
+    s.dispose?.();
+    expect(cancelled).toBe(true);
+  });
+
+  test("unregisterMatcher removes matcher before dispose", () => {
+    const s = createPendingMatchStore();
+    let cancelled = false;
+    const matcher = {
+      cancel: () => {
+        cancelled = true;
+      },
+    };
+    s.registerMatcher(matcher);
+    s.unregisterMatcher(matcher);
+    s.dispose?.();
+    expect(cancelled).toBe(false);
+  });
+
+  test("pending() returns current bucket count", () => {
+    const s = createPendingMatchStore();
+    expect(s.pending()).toBe(0);
+    s.record(mk({ event: "a", stream: "stdout" }));
+    s.record(mk({ event: "a", stream: "stdout" }));
+    expect(s.pending()).toBe(1); // 1 bucket, 2 matches
+    s.record(mk({ event: "b", stream: "stdout" }));
+    expect(s.pending()).toBe(2);
+  });
+});

--- a/packages/lib/watch-patterns/src/store.test.ts
+++ b/packages/lib/watch-patterns/src/store.test.ts
@@ -127,3 +127,94 @@ describe("createPendingMatchStore", () => {
     expect(s.pending()).toBe(2);
   });
 });
+
+describe("store eviction — tombstones", () => {
+  test("evicts oldest bucket at 257th distinct key and emits __watch_dropped__ tombstone", () => {
+    const s = createPendingMatchStore();
+    for (let i = 0; i < 257; i++) {
+      const taskId = `t${i}` as unknown as TaskItemId;
+      s.record({
+        taskId,
+        event: "e",
+        stream: "stdout",
+        lineNumber: 1,
+        timestamp: i,
+      });
+    }
+    const snap = s.peek({});
+    const live = snap.filter(
+      (c) => c.event !== "__watch_dropped__" && c.event !== "__watch_dropped_older__",
+    );
+    const tombstones = snap.filter((c) => c.event === "__watch_dropped__");
+    expect(live).toHaveLength(256);
+    expect(tombstones).toHaveLength(1);
+    expect(String(tombstones[0]?.taskId)).toBe("t0");
+  });
+
+  test("tombstones cleared after successful ack", () => {
+    const s = createPendingMatchStore();
+    for (let i = 0; i < 260; i++) {
+      s.record({
+        taskId: `t${i}` as unknown as TaskItemId,
+        event: "e",
+        stream: "stdout",
+        lineNumber: 1,
+        timestamp: i,
+      });
+    }
+    const req = {};
+    s.peek(req);
+    s.ack(req);
+    const next = s.peek({});
+    const tombstones = next.filter(
+      (c) => c.event === "__watch_dropped__" || c.event === "__watch_dropped_older__",
+    );
+    expect(tombstones).toHaveLength(0);
+  });
+
+  test("tombstone preserves original (taskId, event, stream) identity for targeted recovery", () => {
+    const s = createPendingMatchStore();
+    s.record({
+      taskId: "oldest_task" as unknown as TaskItemId,
+      event: "ready",
+      stream: "stderr",
+      lineNumber: 1,
+      timestamp: 0,
+    });
+    for (let i = 1; i < 257; i++) {
+      s.record({
+        taskId: `t${i}` as unknown as TaskItemId,
+        event: "e",
+        stream: "stdout",
+        lineNumber: 1,
+        timestamp: i,
+      });
+    }
+    const snap = s.peek({});
+    const tombstone = snap.find((c) => c.event === "__watch_dropped__");
+    expect(tombstone).toBeDefined();
+    expect(String(tombstone?.firstMatch.taskId)).toBe("oldest_task");
+    expect(tombstone?.firstMatch.event).toBe("ready");
+    expect(tombstone?.firstMatch.stream).toBe("stderr");
+  });
+
+  test("tombstone list bounded at 4096; __watch_dropped_older__ summarizes further drops", () => {
+    const s = createPendingMatchStore();
+    // Produce 256 + 4097 distinct buckets → 4097 evictions → 4096 tombstones + 1 older-marker.
+    for (let i = 0; i < 256 + 4097; i++) {
+      s.record({
+        taskId: `t${i}` as unknown as TaskItemId,
+        event: "e",
+        stream: "stdout",
+        lineNumber: 1,
+        timestamp: i,
+      });
+    }
+    const snap = s.peek({});
+    const tombstones = snap.filter((c) => c.event === "__watch_dropped__");
+    const older = snap.filter((c) => c.event === "__watch_dropped_older__");
+    expect(tombstones).toHaveLength(4096);
+    expect(older).toHaveLength(1);
+    expect(older[0]?.count).toBe(1);
+  });
+});

--- a/packages/lib/watch-patterns/src/store.ts
+++ b/packages/lib/watch-patterns/src/store.ts
@@ -27,7 +27,10 @@ export function createPendingMatchStore(): PendingMatchStore {
     const view: CoalescedMatch[] = [];
     const idsByKey = new Map<string, readonly number[]>();
     for (const [key, s] of currentWindow) {
-      const firstId = Math.min(...s.records.keys());
+      let firstId = Number.POSITIVE_INFINITY;
+      for (const id of s.records.keys()) {
+        if (id < firstId) firstId = id;
+      }
       const firstMatch = s.records.get(firstId);
       if (firstMatch === undefined) continue;
       view.push({

--- a/packages/lib/watch-patterns/src/store.ts
+++ b/packages/lib/watch-patterns/src/store.ts
@@ -1,0 +1,118 @@
+import type { CoalescedMatch, PatternMatch, PendingMatchStore, TurnRequestKey } from "@koi/core";
+
+interface WindowState {
+  count: number;
+  lastTimestamp: number;
+  /** Per-record payloads keyed by monotonic recordId. */
+  records: Map<number, PatternMatch>;
+}
+
+interface Snapshot {
+  readonly view: readonly CoalescedMatch[];
+  readonly idsByKey: Map<string, readonly number[]>;
+}
+
+function keyOf(taskId: string, event: string, stream: "stdout" | "stderr"): string {
+  return `${taskId}\u241F${event}\u241F${stream}`;
+}
+
+export function createPendingMatchStore(): PendingMatchStore {
+  const currentWindow = new Map<string, WindowState>();
+  const snapshotCache = new WeakMap<TurnRequestKey, Snapshot>();
+  const matchers = new Set<{ readonly cancel: () => void }>();
+  let nextRecordId = 0;
+  let disposed = false;
+
+  function snapshotWindow(): Snapshot {
+    const view: CoalescedMatch[] = [];
+    const idsByKey = new Map<string, readonly number[]>();
+    for (const [key, s] of currentWindow) {
+      const firstId = Math.min(...s.records.keys());
+      const firstMatch = s.records.get(firstId);
+      if (firstMatch === undefined) continue;
+      view.push({
+        taskId: firstMatch.taskId,
+        event: firstMatch.event,
+        stream: firstMatch.stream,
+        firstMatch,
+        count: s.count,
+        lastTimestamp: s.lastTimestamp,
+      });
+      idsByKey.set(key, Array.from(s.records.keys()));
+    }
+    return { view, idsByKey };
+  }
+
+  return {
+    record(match) {
+      if (disposed) return;
+      const key = keyOf(String(match.taskId), match.event, match.stream);
+      const id = nextRecordId++;
+      const existing = currentWindow.get(key);
+      if (existing) {
+        existing.count += 1;
+        existing.lastTimestamp = match.timestamp;
+        existing.records.set(id, match);
+      } else {
+        currentWindow.set(key, {
+          count: 1,
+          lastTimestamp: match.timestamp,
+          records: new Map([[id, match]]),
+        });
+      }
+    },
+    peek(request) {
+      if (disposed) return [];
+      const cached = snapshotCache.get(request);
+      if (cached) return cached.view;
+      const snap = snapshotWindow();
+      snapshotCache.set(request, snap);
+      return snap.view;
+    },
+    ack(request) {
+      if (disposed) return;
+      const snap = snapshotCache.get(request);
+      if (!snap) return;
+      for (const [key, ids] of snap.idsByKey) {
+        const state = currentWindow.get(key);
+        if (!state) continue;
+        for (const id of ids) state.records.delete(id);
+        if (state.records.size === 0) {
+          currentWindow.delete(key);
+        } else {
+          state.count = state.records.size;
+          let latest = 0;
+          for (const m of state.records.values()) {
+            if (m.timestamp > latest) latest = m.timestamp;
+          }
+          state.lastTimestamp = latest;
+        }
+      }
+      snapshotCache.delete(request);
+    },
+    pending() {
+      if (disposed) return 0;
+      return currentWindow.size;
+    },
+    registerMatcher(matcher) {
+      if (disposed) return;
+      matchers.add(matcher);
+    },
+    unregisterMatcher(matcher) {
+      matchers.delete(matcher);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const m of matchers) {
+        try {
+          m.cancel();
+        } catch {
+          /* swallow */
+        }
+      }
+      matchers.clear();
+      currentWindow.clear();
+    },
+  };
+}

--- a/packages/lib/watch-patterns/src/store.ts
+++ b/packages/lib/watch-patterns/src/store.ts
@@ -1,5 +1,8 @@
 import type { CoalescedMatch, PatternMatch, PendingMatchStore, TurnRequestKey } from "@koi/core";
 
+const MAX_BUCKETS = 256;
+const MAX_TOMBSTONES = 4096;
+
 interface WindowState {
   count: number;
   lastTimestamp: number;
@@ -12,6 +15,11 @@ interface Snapshot {
   readonly idsByKey: Map<string, readonly number[]>;
 }
 
+interface TombstoneEntry {
+  readonly firstMatch: PatternMatch;
+  readonly lastTimestamp: number;
+}
+
 function keyOf(taskId: string, event: string, stream: "stdout" | "stderr"): string {
   return `${taskId}\u241F${event}\u241F${stream}`;
 }
@@ -20,8 +28,21 @@ export function createPendingMatchStore(): PendingMatchStore {
   const currentWindow = new Map<string, WindowState>();
   const snapshotCache = new WeakMap<TurnRequestKey, Snapshot>();
   const matchers = new Set<{ readonly cancel: () => void }>();
+  // let is justified: monotonically incremented counter (mutable by design)
   let nextRecordId = 0;
   let disposed = false;
+
+  const tombstones: TombstoneEntry[] = [];
+  // let is justified: overflow counter that accumulates evictions beyond MAX_TOMBSTONES
+  let tombstoneOverflowCount = 0;
+
+  function pushTombstone(entry: TombstoneEntry): void {
+    if (tombstones.length >= MAX_TOMBSTONES) {
+      tombstones.shift();
+      tombstoneOverflowCount += 1;
+    }
+    tombstones.push(entry);
+  }
 
   function snapshotWindow(): Snapshot {
     const view: CoalescedMatch[] = [];
@@ -43,6 +64,32 @@ export function createPendingMatchStore(): PendingMatchStore {
       });
       idsByKey.set(key, Array.from(s.records.keys()));
     }
+
+    for (const t of tombstones) {
+      view.push({
+        taskId: t.firstMatch.taskId,
+        event: "__watch_dropped__",
+        stream: t.firstMatch.stream,
+        firstMatch: t.firstMatch,
+        count: 0,
+        lastTimestamp: t.lastTimestamp,
+      });
+    }
+
+    if (tombstoneOverflowCount > 0 && tombstones.length > 0) {
+      const sample = tombstones[0];
+      if (sample !== undefined) {
+        view.push({
+          taskId: sample.firstMatch.taskId,
+          event: "__watch_dropped_older__",
+          stream: sample.firstMatch.stream,
+          firstMatch: sample.firstMatch,
+          count: tombstoneOverflowCount,
+          lastTimestamp: Date.now(),
+        });
+      }
+    }
+
     return { view, idsByKey };
   }
 
@@ -56,13 +103,29 @@ export function createPendingMatchStore(): PendingMatchStore {
         existing.count += 1;
         existing.lastTimestamp = match.timestamp;
         existing.records.set(id, match);
-      } else {
-        currentWindow.set(key, {
-          count: 1,
-          lastTimestamp: match.timestamp,
-          records: new Map([[id, match]]),
-        });
+        return;
       }
+      // New bucket — evict oldest if at cap.
+      if (currentWindow.size >= MAX_BUCKETS) {
+        const oldestIter = currentWindow.entries().next();
+        if (!oldestIter.done && oldestIter.value !== undefined) {
+          const [oldestKey, oldest] = oldestIter.value;
+          let firstId = Number.POSITIVE_INFINITY;
+          for (const rid of oldest.records.keys()) {
+            if (rid < firstId) firstId = rid;
+          }
+          const oldestFirstMatch = oldest.records.get(firstId);
+          if (oldestFirstMatch !== undefined) {
+            pushTombstone({ firstMatch: oldestFirstMatch, lastTimestamp: oldest.lastTimestamp });
+          }
+          currentWindow.delete(oldestKey);
+        }
+      }
+      currentWindow.set(key, {
+        count: 1,
+        lastTimestamp: match.timestamp,
+        records: new Map([[id, match]]),
+      });
     },
     peek(request) {
       if (disposed) return [];
@@ -76,6 +139,9 @@ export function createPendingMatchStore(): PendingMatchStore {
       if (disposed) return;
       const snap = snapshotCache.get(request);
       if (!snap) return;
+      // Tombstones were delivered in the snapshot — clear them all on ack.
+      tombstones.length = 0;
+      tombstoneOverflowCount = 0;
       for (const [key, ids] of snap.idsByKey) {
         const state = currentWindow.get(key);
         if (!state) continue;
@@ -107,6 +173,8 @@ export function createPendingMatchStore(): PendingMatchStore {
     dispose() {
       if (disposed) return;
       disposed = true;
+      tombstones.length = 0;
+      tombstoneOverflowCount = 0;
       for (const m of matchers) {
         try {
           m.cancel();

--- a/packages/lib/watch-patterns/tsconfig.json
+++ b/packages/lib/watch-patterns/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../kernel/core"
+    }
+  ]
+}

--- a/packages/lib/watch-patterns/tsup.config.ts
+++ b/packages/lib/watch-patterns/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -47,6 +47,7 @@ export const L0U_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/tools-core",
   "@koi/url-safety",
   "@koi/validation",
+  "@koi/watch-patterns",
 ]);
 
 export const L1_PACKAGES: ReadonlySet<string> = new Set([


### PR DESCRIPTION
## Summary

First of 4 stacked PRs for #1769. Adds `@koi/watch-patterns` (L0u) + L0 types in `@koi/core`.

- RE2 linear-time regex compile with strict validation (event: `/^(?!__)[a-z0-9_-]{1,64}$/`, 256-char pattern cap, 16-pattern max, `g`/`y` flags rejected, lookahead/lookbehind/backreferences rejected by RE2).
- Per-stream line-buffered matcher: independent stdout/stderr buffers, 16 KB sliding-suffix with `__watch_overflow__` signal, scanner-error isolation.
- Pending-match store with **non-destructive peek / success-gated ack** — survives the fresh-request retry pattern in `@koi/middleware-semantic-retry`.
- Coalesce key is `(taskId, event, stream)` — stdout and stderr matches kept distinct.
- Bucket eviction at 256 live keys emits identity-preserving `__watch_dropped__` tombstones.

**Stack:** this PR → PR 2 (turn-prelude middleware) → PR 3a (exec callbacks) → PR 3b (bash_background wiring).

## Test plan
- [x] `bun test --filter @koi/watch-patterns` — 48 pass incl. re2-wasm smoke gate
- [x] `bun run check:layers` green (registered in L0U_PACKAGES)
- [x] API surface snapshot locked
- [x] re2-wasm verified under Bun 1.3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)
