### PR TITLE
docs(claude): raise PR logic-change limit from 300 to 1,500 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,6 @@ curl -s http://localhost:3100/admin/api/health
 ## Git
 
 - Commit format: `<type>: <description>` (feat, fix, refactor, docs, test, chore, perf, ci)
-- PRs: < 300 lines of logic changes. Larger PRs get rubber-stamped — split them
+- PRs: < 1,500 lines of logic changes. Larger PRs get rubber-stamped — split them
 - `bun.lock` always committed (text JSONC, git-friendly)
 - Never force-push to main


### PR DESCRIPTION
## Summary
- Raise the PR size guideline in `CLAUDE.md` from `< 300` to `< 1,500` lines of logic changes.

## Test plan
- [x] Doc-only change; no code or tests affected.