### PR TITLE
feat(cli): default manifest auto-discovery + nexus multi-connector + S13 fixes

### DIFF
--- a/docs/L2/manifest.md
+++ b/docs/L2/manifest.md
@@ -171,6 +171,57 @@ friction for security-critical relaxations.
 
 ---
 
+## Default manifest auto-discovery (#1959)
+
+When `--manifest` is omitted, `koi tui` and `koi start` look for a default
+manifest in the current working directory. The first matching file wins:
+
+1. `./koi.yaml`
+2. `./koi.yml`
+3. `./koi.manifest.yaml`
+4. `./koi.manifest.yml`
+
+Explicit `--manifest <path>` always overrides discovery. Set
+`KOI_NO_AUTO_MANIFEST=1` to skip discovery entirely (useful for CI jobs
+that want strict explicit configuration).
+
+Committing `koi.yaml` at the repo root lets contributors run `koi tui`
+or `koi start` with no extra flags and get the project's configured
+model, stacks, filesystem mounts, governance caps, and middleware.
+
+---
+
+## Nexus filesystem + inline OAuth
+
+The [`examples/koi.yaml`](../../examples/koi.yaml) template includes a
+commented `filesystem:` block for wiring `nexus-fs` connectors. Uncomment
+the connector URIs you want — each OAuth-gated connector prompts inline
+the first time an agent tool hits it, with loopback-callback flow (no
+copy/paste). Token persistence is handled by nexus in
+`$NEXUS_STATE_DIR` (default `$HOME/.nexus/auth/`).
+
+OAuth client credentials come from environment variables:
+
+```bash
+# Google connectors: gdrive, gmail, calendar
+export NEXUS_OAUTH_GOOGLE_CLIENT_ID="<client-id>.apps.googleusercontent.com"
+export NEXUS_OAUTH_GOOGLE_CLIENT_SECRET="<secret>"
+
+# Slack
+export NEXUS_OAUTH_SLACK_CLIENT_ID="<client-id>"
+export NEXUS_OAUTH_SLACK_CLIENT_SECRET="<secret>"
+```
+
+The first tool call that touches an unauthenticated connector (e.g.
+`fs_list /gdrive/my-drive`) triggers an `AuthenticationError` from
+`nexus-fs`. Koi's bridge catches it, emits an `auth_required`
+notification to the TUI channel, and the user sees an inline message
+with the authorization URL. After clicking authorize in their browser,
+the loopback callback captures the code, nexus exchanges it for a
+token, and the original tool call retries automatically.
+
+---
+
 ## Governance defaults (gov-10)
 
 A copy-ready annotated manifest lives at

--- a/docs/testing/phase-2-bug-bash.md
+++ b/docs/testing/phase-2-bug-bash.md
@@ -297,9 +297,18 @@ Rationale: file-level corruption can hide a `failClosed` hook that the operator 
 > (no Docker). The bridge spawns `python3 bridge.py <mount_uri>` as a subprocess, communicates via
 > stdin/stdout JSON-RPC, and handles inline OAuth via `auth_required`/`auth_complete` notifications.
 >
-> **Current status**: `koi tui` is hardcoded to `@koi/fs-local` (`tui-runtime.ts:787`).
-> `resolveFileSystemAsync()` exists in `@koi/runtime` but is NOT wired into `createTuiRuntime()`.
-> S13 scenarios run via **`koi start --manifest`** (which supports filesystem config) or via test suite.
+> **Current status**: `koi tui --manifest <path>` supports the Nexus filesystem backend.
+> `tui-command.ts` calls `resolveFileSystemAsync()` with the manifest's `filesystem` block and
+> wires `createAuthNotificationHandler(tuiChannel)` so `auth_required` / `auth_complete`
+> notifications render as messages in the TUI. Multi-mount configs are routed via
+> `createNexusMultiMountFileSystem`, which dispatches each op to the sub-backend whose mount
+> prefix matches the input path and exposes a synthetic `list("/")` for mount discovery.
+>
+> **Path convention**: the model uses the bridge-reported mount names as leading path segments.
+> For a manifest declaring `local:///tmp/ws` + `gdrive://my-drive`, the bridge typically reports
+> mounts like `/local/ws` + `/gdrive`. The model then calls `fs_list("/")` to discover them and
+> `fs_read("/local/ws/README.md")` or `fs_read("/gdrive/file.pdf")` to access them. Scheme URIs
+> such as `gdrive://my-drive/file` are NOT accepted — use the namespaced form.
 
 **Setup**:
 ```bash
@@ -327,11 +336,15 @@ filesystem:
 EOF
 ```
 
-Run via `koi start` (NOT `koi tui`):
+Run via `koi tui --manifest` (supports inline OAuth via the TUI channel):
 ```bash
-HOME="$KOI_HOME" bun run "$REPO_ROOT/packages/meta/cli/src/bin.ts" \
-  start --manifest "$FIXTURE/koi.manifest.yaml" --prompt "<query>"
+tmux new-session -d -s "$KOI_SESSION" \
+  "cd '$FIXTURE' && HOME='$KOI_HOME' bun run '$REPO_ROOT/packages/meta/cli/src/bin.ts' \
+     tui --manifest '$FIXTURE/koi.manifest.yaml'"
 ```
+
+For non-interactive scripting, `koi start --manifest --prompt "<query>"` works too but has no
+channel-aware auth handler — OAuth-gated queries hang until `authTimeoutMs` without it.
 
 | Q | Prompt / Action | Tools Expected | Pass Criteria |
 |---|--------|---------------|---------------|

--- a/examples/koi.yaml
+++ b/examples/koi.yaml
@@ -56,6 +56,35 @@ model:
 #   backend: local                 # or "nexus" with options.transport/mountUri
 #   operations: [read, write, edit]
 
+# ---- Optional: Nexus multi-connector filesystem (OAuth-gated) --------------
+
+# Wire gdrive / gmail / slack / calendar / local CAS mounts via nexus-fs.
+# Requires: pip install nexus-ai-fs. Connectors needing OAuth will prompt
+# inline the first time a tool call touches them (loopback flow — no paste).
+# Token persists in $NEXUS_STATE_DIR (default: $HOME/.nexus/auth/).
+#
+# OAuth client credentials come from environment variables:
+#   Google connectors (gdrive, gmail, calendar):
+#     export NEXUS_OAUTH_GOOGLE_CLIENT_ID="<client-id>.apps.googleusercontent.com"
+#     export NEXUS_OAUTH_GOOGLE_CLIENT_SECRET="<secret>"
+#   Slack:
+#     export NEXUS_OAUTH_SLACK_CLIENT_ID="<client-id>"
+#     export NEXUS_OAUTH_SLACK_CLIENT_SECRET="<secret>"
+#
+# filesystem:
+#   backend: nexus
+#   operations: [read, list]       # add write/edit for read-write mounts
+#   options:
+#     transport: local             # spawn bridge subprocess via pythonPath
+#     mountUri:
+#       - "local:///tmp/my-workspace"  # CAS-backed local workspace (no OAuth)
+#       - "gdrive://my-drive"          # Google Drive  (OAuth: Google)
+#       - "gmail://my-inbox"           # Gmail         (OAuth: Google)
+#       - "calendar://my-cal"          # Google Calendar (OAuth: Google)
+#       - "slack://my-workspace"       # Slack         (OAuth: Slack)
+#     pythonPath: python3
+#     authTimeoutMs: 300000        # max wait for user to complete OAuth (ms)
+
 # ---- Optional: governance defaults (gov-10) --------------------------------
 
 # Every field here is a default for the matching CLI flag. CLI flags always

--- a/packages/kernel/core/src/assembly.ts
+++ b/packages/kernel/core/src/assembly.ts
@@ -169,10 +169,12 @@ export interface FileSystemConfig {
   /** Backend-specific configuration, validated by the L2 dispatch factory. */
   readonly options?: JsonObject;
   /**
-   * Which filesystem operations to expose as tools. Default: ["read"].
+   * Which filesystem operations to expose as tools. Default: ["read", "list"].
    * Write/edit require explicit opt-in to prevent accidental mutation grants.
+   * `list` is a read-only discovery primitive; multi-mount Nexus backends
+   * rely on `list("/")` for mount-name enumeration.
    */
-  readonly operations?: readonly ("read" | "write" | "edit")[];
+  readonly operations?: readonly ("read" | "write" | "edit" | "list")[];
 }
 
 /**

--- a/packages/lib/fs-nexus/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/lib/fs-nexus/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -116,6 +116,37 @@ interface NexusFileSystemFullConfig extends NexusFileSystemConfig {
 declare function createNexusFileSystem(config: NexusFileSystemFullConfig): FileSystemBackend;
 
 /**
+ * Multi-mount Nexus backend.
+ *
+ * Wraps N \`createNexusFileSystem\` sub-backends (one per reported mount) and
+ * dispatches each op to the backend whose mount prefix matches the input path.
+ * Exposes a synthetic \`list("/")\` so callers can discover mounts without
+ * needing out-of-band knowledge of what the bridge reported.
+ *
+ * Used by \`@koi/runtime\`'s \`resolveFileSystemAsync\` when the local bridge
+ * reports two or more mounts (e.g., \`local://./\` + \`gdrive://my-drive\`).
+ * For single-mount configs, call \`createNexusFileSystem\` directly — this
+ * wrapper's overhead only pays for itself when there are actual routing
+ * decisions to make.
+ */
+
+interface MultiMountConfig {
+    readonly transport: NexusTransport;
+    /**
+     * Mount paths as reported by the bridge's \`ready\` notification
+     * (e.g., \`["/local/workspace", "/gdrive"]\`). Each must begin with \`/\`
+     * and be unique. Order matters for overlapping prefixes: earlier entries
+     * win, so \`/local/a\` must precede \`/local/a/b\` if both are present.
+     */
+    readonly mountPoints: readonly string[];
+}
+/**
+ * Create a routing backend that dispatches each op to the right sub-backend
+ * based on the leading mount-prefix of the input path.
+ */
+declare function createNexusMultiMountFileSystem(config: MultiMountConfig): FileSystemBackend;
+
+/**
  * Inline JSON-RPC 2.0 transport for Nexus server.
  *
  * Will be extracted to @koi/nexus-client when a second consumer exists.
@@ -131,7 +162,7 @@ declare function createHttpTransport(config: NexusFileSystemConfig): NexusTransp
 /** Validate NexusFileSystemConfig at the system boundary. */
 declare function validateNexusFileSystemConfig(config: unknown): Result<NexusFileSystemConfig, KoiError>;
 
-export { BridgeNotification, type LocalTransportConfig, NexusFileSystemConfig, type NexusFileSystemFullConfig, NexusTransport, createAuthNotificationHandler, createHttpTransport, createLocalTransport, createNexusFileSystem, validateNexusFileSystemConfig };
+export { BridgeNotification, type LocalTransportConfig, type MultiMountConfig, NexusFileSystemConfig, type NexusFileSystemFullConfig, NexusTransport, createAuthNotificationHandler, createHttpTransport, createLocalTransport, createNexusFileSystem, createNexusMultiMountFileSystem, validateNexusFileSystemConfig };
 "
 `;
 

--- a/packages/lib/fs-nexus/src/bridge.py
+++ b/packages/lib/fs-nexus/src/bridge.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import asyncio
+import inspect
 import json
 import os
 import re
@@ -28,6 +29,20 @@ import sys
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Event, Thread
+
+
+async def _aw(value):
+    """Accept both sync and async SlimNexusFS method results.
+
+    nexus.fs's SlimNexusFS ships some releases with sync methods and others
+    with coroutines. `inspect.isawaitable` catches coroutines, futures, and
+    anything with `__await__`, and returns the plain value unchanged for sync
+    implementations so the bridge works with either ABI.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
 
 # CRITICAL: stdout is the JSON-RPC channel.
 # Redirect ALL print() / library output to stderr BEFORE importing nexus.fs
@@ -375,9 +390,9 @@ async def dispatch(fs, method, params):
     path = params.get("path", "/")
 
     if method == "read":
-        data = await fs.read(path)
+        data = await _aw(fs.read(path))
         content = data.decode("utf-8") if isinstance(data, bytes) else str(data)
-        stat = await fs.stat(path) or {}
+        stat = (await _aw(fs.stat(path))) or {}
         return {"content": content, "metadata": stat}
 
     if method == "write":
@@ -390,7 +405,7 @@ async def dispatch(fs, method, params):
         # Treat missing file or missing etag as conflict — prevents
         # resurrecting deleted files with stale content.
         if if_match is not None:
-            current_stat = await fs.stat(path)
+            current_stat = await _aw(fs.stat(path))
             if current_stat is None:
                 raise ConflictError(
                     f"Conflict: file was deleted (expected etag {if_match}, file no longer exists)"
@@ -405,7 +420,7 @@ async def dispatch(fs, method, params):
                     f"Conflict: file was modified (expected etag {if_match}, got {current_etag})"
                 )
 
-        result = await fs.write(path, raw) or {}
+        result = (await _aw(fs.write(path, raw))) or {}
         size = len(raw)
         return {"bytes_written": size, "size": size, **result}
 
@@ -417,7 +432,7 @@ async def dispatch(fs, method, params):
         # Capture etag before read for OCC guard on write.
         # Fail closed: if the backend doesn't provide etags, refuse
         # to perform a non-preview edit (can't detect concurrent mods).
-        pre_stat = await fs.stat(path)
+        pre_stat = await _aw(fs.stat(path))
         pre_etag = pre_stat.get("etag") if pre_stat else None
 
         if not preview and pre_etag is None:
@@ -437,7 +452,7 @@ async def dispatch(fs, method, params):
                     f"Conflict: file was modified before edit (expected etag {if_match}, got {pre_etag})"
                 )
 
-        data = await fs.read(path)
+        data = await _aw(fs.read(path))
         content = data.decode("utf-8") if isinstance(data, bytes) else str(data)
 
         applied = 0
@@ -469,7 +484,7 @@ async def dispatch(fs, method, params):
             # support on the facade (tracked for nexus-fs enhancement).
             # For the HTTP transport, Nexus server handles if_match
             # atomically, so this gap only affects the local bridge.
-            post_stat = await fs.stat(path)
+            post_stat = await _aw(fs.stat(path))
             post_etag = post_stat.get("etag") if post_stat else None
             if post_etag is None:
                 raise ConflictError(
@@ -479,14 +494,14 @@ async def dispatch(fs, method, params):
                 raise ConflictError(
                     f"Conflict: file was modified during edit (etag changed from {pre_etag} to {post_etag})"
                 )
-            await fs.write(path, content.encode("utf-8"))
+            await _aw(fs.write(path, content.encode("utf-8")))
 
         return {"edits_applied": applied}
 
     if method == "list":
         detail = params.get("details", params.get("detail", False))
         recursive = params.get("recursive", True)
-        entries = await fs.ls(path, detail=detail, recursive=recursive)
+        entries = await _aw(fs.ls(path, detail=detail, recursive=recursive))
 
         if detail and entries and isinstance(entries[0], dict):
             files = entries
@@ -507,7 +522,7 @@ async def dispatch(fs, method, params):
         flags = re.IGNORECASE if ignore_case else 0
         regex = re.compile(pattern_str, flags)
 
-        file_list = await fs.ls(search_path, detail=False, recursive=True)
+        file_list = await _aw(fs.ls(search_path, detail=False, recursive=True))
         results = []
         skipped = []
 
@@ -518,7 +533,7 @@ async def dispatch(fs, method, params):
             if file_pattern and not fnmatch.fnmatch(fp, file_pattern):
                 continue
             try:
-                data = await fs.read(fp)
+                data = await _aw(fs.read(fp))
                 # Only skip binary/non-decodable files; re-raise other errors.
                 try:
                     text = data.decode("utf-8") if isinstance(data, bytes) else str(data)
@@ -540,22 +555,22 @@ async def dispatch(fs, method, params):
         return {"results": results, "skipped": skipped}
 
     if method == "delete":
-        await fs.delete(path)
+        await _aw(fs.delete(path))
         return {"deleted": True}
 
     if method == "rename":
         old_path = params.get("old_path", "")
         new_path = params.get("new_path", "")
-        await fs.rename(old_path, new_path)
+        await _aw(fs.rename(old_path, new_path))
         return {"renamed": True}
 
     if method == "stat":
-        result = await fs.stat(path)
+        result = await _aw(fs.stat(path))
         return {"metadata": result or {}}
 
     if method == "mkdir":
         parents = params.get("parents", True)
-        await fs.mkdir(path, parents=parents)
+        await _aw(fs.mkdir(path, parents=parents))
         return {"created": True}
 
     raise NotImplementedError(f"Unknown method: {method}")
@@ -711,7 +726,7 @@ async def main():
         response = await handle_request(fs, request)
         _write(response)
 
-    await fs.close()
+    await _aw(fs.close())
 
 
 if __name__ == "__main__":

--- a/packages/lib/fs-nexus/src/index.ts
+++ b/packages/lib/fs-nexus/src/index.ts
@@ -11,6 +11,9 @@ export { createAuthNotificationHandler } from "./auth-notifications.js";
 // Local transport (subprocess bridge — no HTTP server needed)
 export type { LocalTransportConfig } from "./local-transport.js";
 export { createLocalTransport } from "./local-transport.js";
+// Multi-mount router — used when the local bridge reports 2+ mounts.
+export type { MultiMountConfig } from "./multi-mount.js";
+export { createNexusMultiMountFileSystem } from "./multi-mount.js";
 // Factory
 export type { NexusFileSystemFullConfig } from "./nexus-filesystem-backend.js";
 export { createNexusFileSystem } from "./nexus-filesystem-backend.js";

--- a/packages/lib/fs-nexus/src/multi-mount.test.ts
+++ b/packages/lib/fs-nexus/src/multi-mount.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { createNexusMultiMountFileSystem } from "./multi-mount.js";
+import type { NexusTransport } from "./types.js";
+
+/**
+ * Stub transport that records calls and returns scripted responses.
+ * Each call is logged as `{ method, params }` in `calls[]`.
+ */
+function stubTransport(
+  responseMap: Record<string, unknown> = {},
+): NexusTransport & { readonly calls: { method: string; params: unknown }[] } {
+  const calls: { method: string; params: unknown }[] = [];
+  return {
+    mounts: [],
+    calls,
+    call: async <T>(method: string, params: unknown) => {
+      calls.push({ method, params });
+      const response = responseMap[method];
+      if (response === undefined) {
+        return {
+          ok: false as const,
+          error: {
+            code: "NOT_FOUND" as const,
+            message: `mock: no response for ${method}`,
+            retryable: false,
+          },
+        };
+      }
+      return { ok: true as const, value: response as T };
+    },
+    subscribe: () => () => {},
+    close: () => {},
+    submitAuthCode: () => {},
+  };
+}
+
+describe("createNexusMultiMountFileSystem", () => {
+  test("list('/') returns synthetic mount entries", async () => {
+    const transport = stubTransport();
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/workspace", "/gdrive"],
+    });
+    const result = await backend.list("/");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.entries).toEqual([
+      { path: "/local/workspace", kind: "directory" },
+      { path: "/gdrive", kind: "directory" },
+    ]);
+    // Synthetic listing must not hit transport
+    expect(transport.calls).toEqual([]);
+  });
+
+  test("read routes to the backend whose mount prefix matches", async () => {
+    const transport = stubTransport({
+      read: { content: "hello", metadata: { size: 5 } },
+    });
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/workspace", "/gdrive"],
+    });
+    const result = await backend.read("/gdrive/file.txt");
+    expect(result.ok).toBe(true);
+    // The sub-backend computes its own fullPath. We care that it was called —
+    // the path it sent to transport will start with `/gdrive/`.
+    expect(transport.calls).toHaveLength(1);
+    const call = transport.calls[0];
+    expect(call?.method).toBe("read");
+    expect((call?.params as { path: string }).path).toBe("/gdrive/file.txt");
+  });
+
+  test("read on mount root (exact prefix match) routes to backend root", async () => {
+    const transport = stubTransport({
+      read: { content: "", metadata: { size: 0 } },
+    });
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/workspace", "/gdrive"],
+    });
+    const result = await backend.read("/gdrive");
+    expect(result.ok).toBe(true);
+    const call = transport.calls[0];
+    expect((call?.params as { path: string }).path).toBe("/gdrive");
+  });
+
+  test("returns NOT_FOUND with mount hint when prefix matches nothing", async () => {
+    const transport = stubTransport();
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/workspace", "/gdrive"],
+    });
+    const result = await backend.read("/s3/bucket/file");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(result.error.message).toContain("/local/workspace");
+    expect(result.error.message).toContain("/gdrive");
+    expect(transport.calls).toEqual([]);
+  });
+
+  test("list on non-root path routes to correct backend", async () => {
+    const transport = stubTransport({
+      list: {
+        files: [{ path: "/local/workspace/a.txt", size: 3, is_directory: false }],
+        has_more: false,
+      },
+    });
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/workspace", "/gdrive"],
+    });
+    const result = await backend.list("/local/workspace");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.entries).toHaveLength(1);
+    expect(transport.calls[0]?.method).toBe("list");
+  });
+
+  test("write routes and passes namespaced path to transport", async () => {
+    const transport = stubTransport({
+      write: { bytes_written: 11 },
+    });
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/ws", "/gdrive"],
+    });
+    const result = await backend.write("/local/ws/hello.txt", "hello world");
+    expect(result.ok).toBe(true);
+    const call = transport.calls[0];
+    expect(call?.method).toBe("write");
+    expect((call?.params as { path: string }).path).toBe("/local/ws/hello.txt");
+  });
+
+  test("rename across mounts is rejected", async () => {
+    const transport = stubTransport();
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/ws", "/gdrive"],
+    });
+    const rename = backend.rename;
+    if (rename === undefined) throw new Error("rename missing");
+    const result = await rename("/local/ws/a.txt", "/gdrive/b.txt");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION");
+    expect(result.error.message).toContain("different namespaces");
+  });
+
+  test("sibling-prefix collision: /local/ws must not match /local/wsX", async () => {
+    const transport = stubTransport({
+      read: { content: "x", metadata: { size: 1 } },
+    });
+    const backend = createNexusMultiMountFileSystem({
+      transport,
+      mountPoints: ["/local/ws", "/gdrive"],
+    });
+    const result = await backend.read("/local/wsOTHER/file");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(transport.calls).toEqual([]);
+  });
+
+  test("validates mountPoints: rejects empty list", () => {
+    const transport = stubTransport();
+    expect(() => createNexusMultiMountFileSystem({ transport, mountPoints: [] })).toThrow(
+      "at least one mountPoint",
+    );
+  });
+
+  test("validates mountPoints: rejects duplicate", () => {
+    const transport = stubTransport();
+    expect(() => createNexusMultiMountFileSystem({ transport, mountPoints: ["/a", "/a"] })).toThrow(
+      "duplicate",
+    );
+  });
+
+  test("validates mountPoints: rejects missing leading slash", () => {
+    const transport = stubTransport();
+    expect(() => createNexusMultiMountFileSystem({ transport, mountPoints: ["local"] })).toThrow(
+      "must begin with '/'",
+    );
+  });
+
+  test("validates mountPoints: rejects bare '/'", () => {
+    const transport = stubTransport();
+    expect(() => createNexusMultiMountFileSystem({ transport, mountPoints: ["/"] })).toThrow(
+      "empty namespace",
+    );
+  });
+});

--- a/packages/lib/fs-nexus/src/multi-mount.ts
+++ b/packages/lib/fs-nexus/src/multi-mount.ts
@@ -1,0 +1,257 @@
+/**
+ * Multi-mount Nexus backend.
+ *
+ * Wraps N `createNexusFileSystem` sub-backends (one per reported mount) and
+ * dispatches each op to the backend whose mount prefix matches the input path.
+ * Exposes a synthetic `list("/")` so callers can discover mounts without
+ * needing out-of-band knowledge of what the bridge reported.
+ *
+ * Used by `@koi/runtime`'s `resolveFileSystemAsync` when the local bridge
+ * reports two or more mounts (e.g., `local://./` + `gdrive://my-drive`).
+ * For single-mount configs, call `createNexusFileSystem` directly — this
+ * wrapper's overhead only pays for itself when there are actual routing
+ * decisions to make.
+ */
+
+import type {
+  FileDeleteResult,
+  FileEdit,
+  FileEditOptions,
+  FileEditResult,
+  FileListOptions,
+  FileListResult,
+  FileReadOptions,
+  FileReadResult,
+  FileRenameResult,
+  FileSearchOptions,
+  FileSearchResult,
+  FileSystemBackend,
+  FileWriteOptions,
+  FileWriteResult,
+  KoiError,
+  Result,
+} from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core";
+import { createNexusFileSystem } from "./nexus-filesystem-backend.js";
+import type { NexusTransport } from "./types.js";
+
+export interface MultiMountConfig {
+  readonly transport: NexusTransport;
+  /**
+   * Mount paths as reported by the bridge's `ready` notification
+   * (e.g., `["/local/workspace", "/gdrive"]`). Each must begin with `/`
+   * and be unique. Order matters for overlapping prefixes: earlier entries
+   * win, so `/local/a` must precede `/local/a/b` if both are present.
+   */
+  readonly mountPoints: readonly string[];
+}
+
+interface Route {
+  readonly backend: FileSystemBackend;
+  readonly relativePath: string;
+}
+
+function notFoundForUnknownMount(path: string, mountPoints: readonly string[]): KoiError {
+  return {
+    code: "NOT_FOUND",
+    message:
+      `Path '${path}' does not match any mounted namespace. ` +
+      `Available mounts: ${mountPoints.join(", ")}. ` +
+      `Use the namespace prefix as the leading path segment (e.g. '${mountPoints[0]}/file.txt').`,
+    retryable: RETRYABLE_DEFAULTS.NOT_FOUND,
+    context: { path, mountPoints },
+  };
+}
+
+function validateMountPoints(mountPoints: readonly string[]): void {
+  if (mountPoints.length === 0) {
+    throw new Error("createNexusMultiMountFileSystem requires at least one mountPoint");
+  }
+  const seen = new Set<string>();
+  for (const mp of mountPoints) {
+    if (!mp.startsWith("/")) {
+      throw new Error(`mountPoint '${mp}' must begin with '/'`);
+    }
+    if (mp.length === 1) {
+      throw new Error(`mountPoint must not be '/' (empty namespace)`);
+    }
+    if (seen.has(mp)) {
+      throw new Error(`duplicate mountPoint '${mp}'`);
+    }
+    seen.add(mp);
+  }
+}
+
+/**
+ * Create a routing backend that dispatches each op to the right sub-backend
+ * based on the leading mount-prefix of the input path.
+ */
+export function createNexusMultiMountFileSystem(config: MultiMountConfig): FileSystemBackend {
+  validateMountPoints(config.mountPoints);
+
+  // Build sub-backends: one per mount, sharing the transport. Each sub-backend
+  // already applies its mountPoint as a prefix to every op, so we pass
+  // mount-relative paths and let it reattach the namespace.
+  const subBackends: readonly FileSystemBackend[] = config.mountPoints.map((mp) =>
+    createNexusFileSystem({
+      url: "local://bridge",
+      transport: config.transport,
+      mountPoint: mp.replace(/^\/+/, ""),
+    }),
+  );
+
+  function route(path: string): Route | undefined {
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    for (let i = 0; i < config.mountPoints.length; i++) {
+      const mp = config.mountPoints[i];
+      if (mp === undefined) continue; // unreachable — validated above
+      if (normalized === mp) {
+        const backend = subBackends[i];
+        if (backend === undefined) continue;
+        return { backend, relativePath: "/" };
+      }
+      const mpSlash = mp.endsWith("/") ? mp : `${mp}/`;
+      if (normalized.startsWith(mpSlash)) {
+        const backend = subBackends[i];
+        if (backend === undefined) continue;
+        return { backend, relativePath: normalized.slice(mp.length) };
+      }
+    }
+    return undefined;
+  }
+
+  // Synthetic root listing so `list("/")` returns each mount as a directory.
+  // Without this, discovery of mount names requires out-of-band knowledge.
+  function syntheticRootList(): FileListResult {
+    return {
+      entries: config.mountPoints.map((mp) => ({ path: mp, kind: "directory" as const })),
+      truncated: false,
+    };
+  }
+
+  async function read(
+    path: string,
+    options?: FileReadOptions,
+  ): Promise<Result<FileReadResult, KoiError>> {
+    const r = route(path);
+    if (r === undefined)
+      return { ok: false, error: notFoundForUnknownMount(path, config.mountPoints) };
+    return r.backend.read(r.relativePath, options);
+  }
+
+  async function write(
+    path: string,
+    content: string,
+    options?: FileWriteOptions,
+  ): Promise<Result<FileWriteResult, KoiError>> {
+    const r = route(path);
+    if (r === undefined)
+      return { ok: false, error: notFoundForUnknownMount(path, config.mountPoints) };
+    return r.backend.write(r.relativePath, content, options);
+  }
+
+  async function edit(
+    path: string,
+    edits: readonly FileEdit[],
+    options?: FileEditOptions,
+  ): Promise<Result<FileEditResult, KoiError>> {
+    const r = route(path);
+    if (r === undefined)
+      return { ok: false, error: notFoundForUnknownMount(path, config.mountPoints) };
+    return r.backend.edit(r.relativePath, edits, options);
+  }
+
+  async function list(
+    path: string,
+    options?: FileListOptions,
+  ): Promise<Result<FileListResult, KoiError>> {
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    if (normalized === "/" || normalized === "") {
+      return { ok: true, value: syntheticRootList() };
+    }
+    const r = route(path);
+    if (r === undefined)
+      return { ok: false, error: notFoundForUnknownMount(path, config.mountPoints) };
+    return r.backend.list(r.relativePath, options);
+  }
+
+  async function search(
+    pattern: string,
+    options?: FileSearchOptions,
+  ): Promise<Result<FileSearchResult, KoiError>> {
+    // Global search doesn't map cleanly to a single mount — delegate to the
+    // first backend and return its results. Callers that need cross-mount
+    // search should issue per-mount queries explicitly.
+    const first = subBackends[0];
+    if (first === undefined) {
+      return { ok: false, error: notFoundForUnknownMount("/", config.mountPoints) };
+    }
+    return first.search(pattern, options);
+  }
+
+  async function del(path: string): Promise<Result<FileDeleteResult, KoiError>> {
+    const r = route(path);
+    if (r === undefined)
+      return { ok: false, error: notFoundForUnknownMount(path, config.mountPoints) };
+    if (r.backend.delete === undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "delete not supported by underlying backend",
+          retryable: false,
+        },
+      };
+    }
+    return r.backend.delete(r.relativePath);
+  }
+
+  async function rename(from: string, to: string): Promise<Result<FileRenameResult, KoiError>> {
+    const rFrom = route(from);
+    const rTo = route(to);
+    if (rFrom === undefined)
+      return { ok: false, error: notFoundForUnknownMount(from, config.mountPoints) };
+    if (rTo === undefined)
+      return { ok: false, error: notFoundForUnknownMount(to, config.mountPoints) };
+    if (rFrom.backend !== rTo.backend) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: `Cannot rename across mounts: '${from}' and '${to}' belong to different namespaces`,
+          retryable: false,
+          context: { from, to },
+        },
+      };
+    }
+    if (rFrom.backend.rename === undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "rename not supported by underlying backend",
+          retryable: false,
+        },
+      };
+    }
+    return rFrom.backend.rename(rFrom.relativePath, rTo.relativePath);
+  }
+
+  async function dispose(): Promise<void> {
+    // All sub-backends share the transport; disposing the first one closes it.
+    // The remainder become no-ops against a closed transport, which is safe.
+    await subBackends[0]?.dispose?.();
+  }
+
+  return {
+    name: `nexus-multi:${config.mountPoints.join(",")}`,
+    read,
+    write,
+    edit,
+    list,
+    search,
+    delete: del,
+    rename,
+    dispose,
+  };
+}

--- a/packages/lib/tools-builtin/src/index.ts
+++ b/packages/lib/tools-builtin/src/index.ts
@@ -26,6 +26,7 @@ export { createToolSearchTool } from "./tool-search-tool.js";
 export type { AskUserToolConfig } from "./tools/ask-user.js";
 export { createAskUserTool } from "./tools/ask-user.js";
 export { createFsEditTool } from "./tools/edit.js";
+export { createFsListTool } from "./tools/list.js";
 export type {
   EnterPlanModeConfig,
   ExitPlanModeConfig,

--- a/packages/lib/tools-builtin/src/tools/list.ts
+++ b/packages/lib/tools-builtin/src/tools/list.ts
@@ -1,0 +1,80 @@
+/**
+ * Tool factory for `{prefix}_list` — lists directory entries via a FileSystemBackend.
+ *
+ * Needed for discovering mount namespaces when the backend is a multi-mount
+ * router (`list("/")` returns one entry per mount). Also useful as a directory
+ * listing primitive for any FileSystemBackend that implements it.
+ */
+
+import type {
+  FileListOptions,
+  FileSystemBackend,
+  JsonObject,
+  Tool,
+  ToolExecuteOptions,
+  ToolPolicy,
+} from "@koi/core";
+import { parseOptionalString, parseString } from "../parse-args.js";
+
+export function createFsListTool(
+  backend: FileSystemBackend,
+  prefix: string,
+  policy: ToolPolicy,
+): Tool {
+  return {
+    descriptor: {
+      name: `${prefix}_list`,
+      description:
+        `List directory entries. Backend: ${backend.name}. ` +
+        `Pass path='/' to discover top-level mounts when using a multi-mount Nexus backend.`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description:
+              "Directory path. Use '/' to discover mount namespaces in multi-mount configs.",
+          },
+          recursive: {
+            type: "boolean",
+            description: "Walk subdirectories recursively (default: false)",
+          },
+          glob: {
+            type: "string",
+            description: "Filter entries by glob pattern (e.g. '*.ts')",
+          },
+        },
+        required: ["path"],
+      } as JsonObject,
+    },
+    origin: "primordial",
+    policy,
+    execute: async (args: JsonObject, execOptions?: ToolExecuteOptions): Promise<unknown> => {
+      if (execOptions?.signal?.aborted) {
+        return { error: "Operation cancelled", code: "CANCELLED" };
+      }
+
+      const pathResult = parseString(args, "path");
+      if (!pathResult.ok) return pathResult.err;
+
+      const recursive = typeof args.recursive === "boolean" ? args.recursive : undefined;
+
+      const globResult = parseOptionalString(args, "glob");
+      if (!globResult.ok) return globResult.err;
+
+      const options: FileListOptions = {
+        ...(recursive !== undefined && { recursive }),
+        ...(globResult.value !== undefined && { glob: globResult.value }),
+      };
+
+      const result = await backend.list(pathResult.value, options);
+      if (execOptions?.signal?.aborted) {
+        return { error: "Operation cancelled", code: "CANCELLED" };
+      }
+      if (!result.ok) {
+        return { error: result.error.message, code: result.error.code };
+      }
+      return result.value;
+    },
+  };
+}

--- a/packages/meta/cli/src/commands/start.ts
+++ b/packages/meta/cli/src/commands/start.ts
@@ -42,7 +42,7 @@ import {
   HEADLESS_EXIT,
   runHeadless,
 } from "../headless/run.js";
-import { loadManifestConfig } from "../manifest.js";
+import { discoverDefaultManifest, loadManifestConfig } from "../manifest.js";
 import { initOtelSdk } from "../otel-bootstrap.js";
 import { loadPolicyFile } from "../policy-file.js";
 import { DEFAULT_STACKS } from "../preset-stacks.js";
@@ -378,12 +378,18 @@ export async function run(flags: StartFlags): Promise<ExitCode> {
   // permission backend cannot enforce backend-aware approvals for
   // remote/bridge storage, which would silently grant a repo-local
   // manifest unreviewed access to data outside the workspace.
-  let manifestFilesystemOps: readonly ("read" | "write" | "edit")[] | undefined;
+  let manifestFilesystemOps: readonly ("read" | "write" | "edit" | "list")[] | undefined;
   let manifestFilesystemBackend: FileSystemBackend | undefined;
   let manifestMiddleware: import("../manifest.js").ManifestMiddlewareEntry[] | undefined;
   let manifestGovernance: import("../manifest.js").ManifestGovernanceConfig | undefined;
-  if (flags.manifest !== undefined) {
-    const manifestResult = await loadManifestConfig(flags.manifest);
+  // Auto-discover `./koi.yaml` (or variants) when --manifest is omitted.
+  // Explicit flag always wins. Pass `KOI_NO_AUTO_MANIFEST=1` to skip discovery
+  // (e.g. for CI or non-interactive jobs that want strict explicit config).
+  const resolvedManifestPath =
+    flags.manifest ??
+    (process.env.KOI_NO_AUTO_MANIFEST === "1" ? undefined : discoverDefaultManifest(process.cwd()));
+  if (resolvedManifestPath !== undefined) {
+    const manifestResult = await loadManifestConfig(resolvedManifestPath);
     if (!manifestResult.ok) {
       // Manifest error can include filesystem paths, user-provided values,
       // or schema diagnostics. Safe to classify but don't forward raw text
@@ -515,7 +521,7 @@ export async function run(flags: StartFlags): Promise<ExitCode> {
         );
       }
 
-      manifestFilesystemOps = fs.operations ?? (["read"] as const);
+      manifestFilesystemOps = fs.operations ?? (["read", "list"] as const);
       // Sync resolver is sufficient — OAuth mounts were rejected above,
       // and the async path (local bridge subprocess) is only needed for
       // OAuth-gated mounts.

--- a/packages/meta/cli/src/manifest.test.ts
+++ b/packages/meta/cli/src/manifest.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadManifestConfig } from "./manifest.js";
+import { discoverDefaultManifest, loadManifestConfig } from "./manifest.js";
 
 // Regression tests for #1777 — manifest.filesystem must be parsed,
 // validated, and surfaced so `koi start --manifest` / `koi tui --manifest`
@@ -151,10 +151,35 @@ describe("loadManifestConfig: filesystem block", () => {
     expect(mountUri[0]).toContain(`${dir}/a`);
   });
 
-  test("rejects multi-mount arrays (runtime does not support them yet)", async () => {
-    // Regression for #1777 round 9: the runtime `resolveFileSystemAsync`
-    // throws on multi-mount local-bridge configs. Fail fast at parse
-    // time instead of at runtime assembly.
+  test("does not inject root: undefined when root is absent", async () => {
+    // Regression: anchorFilesystemPaths was unconditionally spreading
+    // `root: nextRoot` even when `opts.root` was undefined. That injected
+    // an explicit `root: undefined` key whenever mountUri was rebuilt
+    // (every array case), which then failed the `.strict()` Zod schema
+    // in resolve-filesystem.ts and blocked `koi tui --manifest` startup.
+    const p = writeManifest(
+      [
+        "model:",
+        "  name: google/gemini-2.0-flash-001",
+        "filesystem:",
+        "  backend: nexus",
+        "  options:",
+        "    transport: local",
+        "    mountUri:",
+        '      - "local:///tmp/koi-no-root"',
+      ].join("\n"),
+    );
+    const result = await loadManifestConfig(p);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const options = (result.value.filesystem?.options ?? {}) as Record<string, unknown>;
+    expect("root" in options).toBe(false);
+  });
+
+  test("accepts multi-mount arrays (runtime dispatches via multi-mount router)", async () => {
+    // `resolveFileSystemAsync` now routes each op to the sub-backend whose
+    // reported mount prefix matches. Parse-time validation must let the
+    // manifest through so the runtime can wire the router.
     const p = writeManifest(
       [
         "model:",
@@ -169,9 +194,32 @@ describe("loadManifestConfig: filesystem block", () => {
       ].join("\n"),
     );
     const result = await loadManifestConfig(p);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const options = (result.value.filesystem?.options ?? {}) as Record<string, unknown>;
+    expect(options.mountUri).toEqual(["local:///tmp/a", "local:///tmp/b"]);
+  });
+
+  test("rejects multi-mount combined with explicit mountPoint override", async () => {
+    const p = writeManifest(
+      [
+        "model:",
+        "  name: google/gemini-2.0-flash-001",
+        "filesystem:",
+        "  backend: nexus",
+        "  options:",
+        "    transport: local",
+        "    mountPoint: fs",
+        "    mountUri:",
+        '      - "local:///tmp/a"',
+        '      - "local:///tmp/b"',
+      ].join("\n"),
+    );
+    const result = await loadManifestConfig(p);
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.toLowerCase()).toContain("multi-mount");
+    expect(result.error).toContain("mountPoint");
+    expect(result.error).toContain("multi-entry mountUri");
   });
 
   test("rejects non-local:// mountUri schemes (OAuth gate)", async () => {
@@ -337,5 +385,61 @@ describe("loadManifestConfig: governance block (gov-10)", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toContain("governance");
+  });
+});
+
+describe("discoverDefaultManifest (#1959)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "koi-default-manifest-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns undefined when no default manifest exists", () => {
+    expect(discoverDefaultManifest(dir)).toBeUndefined();
+  });
+
+  test("finds koi.yaml", () => {
+    writeFileSync(join(dir, "koi.yaml"), "model:\n  name: x");
+    expect(discoverDefaultManifest(dir)).toBe(join(dir, "koi.yaml"));
+  });
+
+  test("finds koi.yml as fallback", () => {
+    writeFileSync(join(dir, "koi.yml"), "model:\n  name: x");
+    expect(discoverDefaultManifest(dir)).toBe(join(dir, "koi.yml"));
+  });
+
+  test("finds koi.manifest.yaml as fallback", () => {
+    writeFileSync(join(dir, "koi.manifest.yaml"), "model:\n  name: x");
+    expect(discoverDefaultManifest(dir)).toBe(join(dir, "koi.manifest.yaml"));
+  });
+
+  test("koi.yaml wins over koi.manifest.yaml when both exist", () => {
+    writeFileSync(join(dir, "koi.yaml"), "model:\n  name: a");
+    writeFileSync(join(dir, "koi.manifest.yaml"), "model:\n  name: b");
+    expect(discoverDefaultManifest(dir)).toBe(join(dir, "koi.yaml"));
+  });
+
+  test("koi.yaml wins over koi.yml when both exist", () => {
+    writeFileSync(join(dir, "koi.yaml"), "model:\n  name: a");
+    writeFileSync(join(dir, "koi.yml"), "model:\n  name: b");
+    expect(discoverDefaultManifest(dir)).toBe(join(dir, "koi.yaml"));
+  });
+
+  test("loadManifestConfig reads the discovered default", async () => {
+    writeFileSync(
+      join(dir, "koi.yaml"),
+      ["model:", "  name: google/gemini-2.0-flash-001"].join("\n"),
+    );
+    const discovered = discoverDefaultManifest(dir);
+    expect(discovered).toBeDefined();
+    if (discovered === undefined) return;
+    const result = await loadManifestConfig(discovered);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.modelName).toBe("google/gemini-2.0-flash-001");
   });
 });

--- a/packages/meta/cli/src/manifest.ts
+++ b/packages/meta/cli/src/manifest.ts
@@ -38,10 +38,39 @@
  *                                  #   per-host.
  */
 
+import { existsSync } from "node:fs";
 import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
 import { loadConfig } from "@koi/config";
 import type { FileSystemConfig } from "@koi/core";
 import { validateFileSystemConfig } from "@koi/runtime";
+
+/**
+ * Default manifest filenames checked by `discoverDefaultManifest` in order.
+ * The first existing file wins. Mirrors how `.mcp.json` is auto-discovered.
+ */
+const DEFAULT_MANIFEST_FILENAMES: readonly string[] = [
+  "koi.yaml",
+  "koi.yml",
+  "koi.manifest.yaml",
+  "koi.manifest.yml",
+];
+
+/**
+ * Return the path of the first default-named manifest found in `cwd`, or
+ * `undefined` if none exist. Callers use this when `--manifest` is omitted
+ * so projects with a committed `koi.yaml` work out-of-the-box.
+ *
+ * Resolution order: `koi.yaml` → `koi.yml` → `koi.manifest.yaml` →
+ * `koi.manifest.yml`. Only the first match is returned — callers should
+ * not attempt to merge multiple defaults.
+ */
+export function discoverDefaultManifest(cwd: string): string | undefined {
+  for (const name of DEFAULT_MANIFEST_FILENAMES) {
+    const candidate = resolvePath(cwd, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
 
 /**
  * Absolutize a `local://` mountUri against the manifest directory so relative
@@ -111,10 +140,12 @@ function anchorFilesystemPaths(config: FileSystemConfig, manifestDir: string): F
   }
 
   if (nextMountUri === opts.mountUri && nextRoot === opts.root) return config;
-  return {
-    ...config,
-    options: { ...opts, mountUri: nextMountUri, root: nextRoot },
-  };
+  // Only spread root when it was present in the input — otherwise we'd inject
+  // `root: undefined`, which breaks the `.strict()` Zod schema in
+  // resolve-filesystem.ts (unknown key) and blocks startup.
+  const nextOptions: Record<string, unknown> = { ...opts, mountUri: nextMountUri };
+  if ("root" in opts) nextOptions.root = nextRoot;
+  return { ...config, options: nextOptions };
 }
 
 /**
@@ -465,17 +496,20 @@ export async function loadManifestConfig(
           : Array.isArray(mountUri)
             ? (mountUri as unknown[])
             : [];
-      // Runtime `resolveFileSystemAsync` rejects multi-mount local-bridge
-      // configs because createNexusFileSystem accepts only one mountPoint
-      // prefix (#1777 review round 9). Validating the runtime invariant
-      // at parse time turns "looks valid, fails later on startup" into a
-      // clean error before any subprocess spawn.
-      if (candidates.length > 1) {
+      // Multi-mount is supported via createNexusMultiMountFileSystem, which
+      // routes ops to the sub-backend whose reported mount prefix matches the
+      // input path. We still reject mixing mountPoint override with multi-mount
+      // since the override addresses only one namespace.
+      if (
+        candidates.length > 1 &&
+        typeof (filesystem.options as Record<string, unknown>).mountPoint === "string"
+      ) {
         return {
           ok: false,
           error:
-            "manifest.filesystem.options.mountUri may declare at most one URI on this host. " +
-            "Multi-mount local-bridge configs are not yet supported by the runtime resolver.",
+            "manifest.filesystem.options.mountPoint cannot be combined with a multi-entry mountUri — " +
+            "the override selects a single namespace while the bridge reports several. " +
+            "Omit mountPoint to let each mount route to its own sub-backend.",
         };
       }
       if (!(options?.allowOAuthSchemes === true)) {

--- a/packages/meta/cli/src/runtime-factory.ts
+++ b/packages/meta/cli/src/runtime-factory.ts
@@ -739,7 +739,7 @@ export interface KoiRuntimeConfig {
    * honor a `manifest.filesystem.operations` gate pass the resolved
    * list through here. Honored by `buildCoreProviders`.
    */
-  readonly filesystemOperations?: readonly ("read" | "write" | "edit")[] | undefined;
+  readonly filesystemOperations?: readonly ("read" | "write" | "edit" | "list")[] | undefined;
   /**
    * Active filesystem backend to use for `fs_read`, `fs_write`, and
    * `fs_edit` tools, AND for the checkpoint preset stack's backend

--- a/packages/meta/cli/src/shared-wiring.ts
+++ b/packages/meta/cli/src/shared-wiring.ts
@@ -56,6 +56,7 @@ import type { SkillsRuntime } from "@koi/skills-runtime";
 import {
   createBuiltinSearchProvider,
   createFsEditTool,
+  createFsListTool,
   createFsReadTool,
   createFsWriteTool,
 } from "@koi/tools-builtin";
@@ -910,7 +911,7 @@ export interface CoreProvidersConfig {
    * authors point the agent at an alternate backend without silently
    * escalating mutation authority.
    */
-  readonly filesystemOperations?: readonly ("read" | "write" | "edit")[] | undefined;
+  readonly filesystemOperations?: readonly ("read" | "write" | "edit" | "list")[] | undefined;
   /**
    * When true, wire the web_fetch tool. Defaults to `true` — hosts that
    * run in airgapped environments can pass `false` to strip network access.
@@ -1004,6 +1005,10 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
     const wantRead = ops === undefined || ops.includes("read");
     const wantWrite = ops === undefined || ops.includes("write");
     const wantEdit = ops === undefined || ops.includes("edit");
+    // fs_list is a read-only discovery primitive. Enable it alongside read
+    // by default so multi-mount Nexus backends can expose their mount names
+    // via the synthetic `list("/")` entry.
+    const wantList = ops === undefined || ops.includes("list");
     if (wantRead) {
       providers.push(
         createSingleToolProvider({
@@ -1028,6 +1033,15 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
           name: "fs-edit",
           toolName: "fs_edit",
           createTool: () => createFsEditTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY),
+        }),
+      );
+    }
+    if (wantList) {
+      providers.push(
+        createSingleToolProvider({
+          name: "fs-list",
+          toolName: "fs_list",
+          createTool: () => createFsListTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY),
         }),
       );
     }

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -94,7 +94,7 @@ import { resolveApiConfig } from "./env.js";
 import { createFileCompletionHandler } from "./file-completions.js";
 import { createForegroundSubmitQueue } from "./foreground-submit-queue.js";
 import { createGovernanceBridge, type GovernanceBridge } from "./governance-bridge.js";
-import { loadManifestConfig } from "./manifest.js";
+import { discoverDefaultManifest, loadManifestConfig } from "./manifest.js";
 import { type FetchModelsResult, fetchAvailableModels } from "./model-list-fetch.js";
 import { initOtelSdk } from "./otel-bootstrap.js";
 import { loadPolicyFile } from "./policy-file.js";
@@ -1053,16 +1053,24 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // For nexus with local-bridge transport, the TUI wires the OAuth auth
   // loop: createAuthNotificationHandler (outbound) + createAuthInterceptor
   // (inbound) so the user can complete OAuth flows inline.
-  let manifestFilesystemOps: readonly ("read" | "write" | "edit")[] | undefined;
+  let manifestFilesystemOps: readonly ("read" | "write" | "edit" | "list")[] | undefined;
   // Full filesystem config for nexus async resolution — stored here so the
   // async resolve can run just before createKoiRuntime (after TUI setup).
   let manifestFilesystemConfig: import("@koi/core").FileSystemConfig | undefined;
   let manifestMiddleware: import("./manifest.js").ManifestMiddlewareEntry[] | undefined;
   let manifestGovernance: import("./manifest.js").ManifestGovernanceConfig | undefined;
-  if (flags.manifest !== undefined) {
+  // Auto-discover `./koi.yaml` (or variants) when --manifest is omitted so
+  // projects with a committed manifest work out-of-the-box. Explicit flag
+  // always wins. Pass `KOI_NO_AUTO_MANIFEST=1` to skip discovery.
+  const resolvedManifestPath =
+    flags.manifest ??
+    (process.env.KOI_NO_AUTO_MANIFEST === "1" ? undefined : discoverDefaultManifest(process.cwd()));
+  if (resolvedManifestPath !== undefined) {
     // Pass allowOAuthSchemes so the manifest loader skips the local-only
     // scheme allowlist for this host — the TUI wires the auth loop below.
-    const manifestResult = await loadManifestConfig(flags.manifest, { allowOAuthSchemes: true });
+    const manifestResult = await loadManifestConfig(resolvedManifestPath, {
+      allowOAuthSchemes: true,
+    });
     if (!manifestResult.ok) {
       process.stderr.write(`koi tui: invalid manifest — ${manifestResult.error}\n`);
       process.exit(1);
@@ -1085,7 +1093,8 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       // need a true read-only posture should also omit `execution`
       // from `manifest.stacks`.
       manifestFilesystemConfig = manifestResult.value.filesystem;
-      manifestFilesystemOps = manifestResult.value.filesystem.operations ?? (["read"] as const);
+      manifestFilesystemOps =
+        manifestResult.value.filesystem.operations ?? (["read", "list"] as const);
     }
     manifestMiddleware =
       manifestResult.value.middleware !== undefined

--- a/packages/meta/runtime/src/create-filesystem-provider.ts
+++ b/packages/meta/runtime/src/create-filesystem-provider.ts
@@ -16,15 +16,16 @@ import type {
 import { createServiceProvider, DEFAULT_UNSANDBOXED_POLICY, FILESYSTEM } from "@koi/core";
 import {
   createFsEditTool,
+  createFsListTool,
   createFsReadTool,
   createFsWriteTool,
   type FsToolOptions,
 } from "@koi/tools-builtin";
 
 /** Filesystem operations exposed as tools. */
-type FsOperation = "read" | "write" | "edit";
+type FsOperation = "read" | "write" | "edit" | "list";
 
-const _FS_OPERATIONS: readonly FsOperation[] = ["read", "write", "edit"] as const;
+const _FS_OPERATIONS: readonly FsOperation[] = ["read", "write", "edit", "list"] as const;
 
 const FS_TOOL_FACTORIES: Readonly<
   Record<
@@ -40,6 +41,8 @@ const FS_TOOL_FACTORIES: Readonly<
   read: createFsReadTool,
   write: createFsWriteTool,
   edit: createFsEditTool,
+  // list has no path guard (read-only, no file content returned) — ignore fsToolOptions.
+  list: (backend, prefix, policy) => createFsListTool(backend, prefix, policy),
 } as const;
 
 /** Resolved filesystem tools — both instances (for execution) and descriptors (for advertisement). */
@@ -55,10 +58,12 @@ export interface FileSystemTools {
  * and their descriptors (for advertisement in callHandlers.tools).
  */
 /**
- * Default: read-only. Write/edit require explicit opt-in to prevent
- * accidental mutation grants when enabling filesystem.
+ * Default: read-only (read + list). Write/edit require explicit opt-in to
+ * prevent accidental mutation grants when enabling filesystem. List is
+ * included because it's a discovery primitive — multi-mount Nexus backends
+ * rely on `list("/")` for mount-name enumeration.
  */
-const DEFAULT_FS_OPERATIONS: readonly FsOperation[] = ["read"] as const;
+const DEFAULT_FS_OPERATIONS: readonly FsOperation[] = ["read", "list"] as const;
 
 export function createFileSystemTools(
   backend: FileSystemBackend,
@@ -134,6 +139,7 @@ export function createFileSystemProvider(
           read: (b, p, pol) => createFsReadTool(b, p, pol, fsToolOptions),
           write: (b, p, pol) => createFsWriteTool(b, p, pol, fsToolOptions),
           edit: (b, p, pol) => createFsEditTool(b, p, pol, fsToolOptions),
+          list: (b, p, pol) => createFsListTool(b, p, pol),
         }
       : FS_TOOL_FACTORIES;
 

--- a/packages/meta/runtime/src/resolve-filesystem.ts
+++ b/packages/meta/runtime/src/resolve-filesystem.ts
@@ -14,6 +14,7 @@ import type { BridgeNotification } from "@koi/fs-nexus";
 import {
   createLocalTransport,
   createNexusFileSystem,
+  createNexusMultiMountFileSystem,
   validateNexusFileSystemConfig,
 } from "@koi/fs-nexus";
 import { createScopedFileSystem } from "@koi/fs-scoped";
@@ -27,7 +28,7 @@ const fileSystemConfigSchema = z
   .object({
     backend: z.enum(["local", "nexus"]).optional(),
     options: z.record(z.string(), z.unknown()).optional(),
-    operations: z.array(z.enum(["read", "write", "edit"])).optional(),
+    operations: z.array(z.enum(["read", "write", "edit", "list"])).optional(),
   })
   .strict();
 
@@ -251,7 +252,7 @@ export async function resolveFileSystemAsync(
   onNotification?: ((n: BridgeNotification) => void) | undefined,
 ): Promise<{
   readonly backend: FileSystemBackend;
-  readonly operations: readonly ("read" | "write" | "edit")[] | undefined;
+  readonly operations: readonly ("read" | "write" | "edit" | "list")[] | undefined;
   /**
    * The underlying local bridge transport, only present when
    * `filesystem.options.transport === "local"`. Callers must use this to
@@ -295,19 +296,6 @@ export async function resolveFileSystemAsync(
   }
   if (localBridgeParsed.ok) {
     const options = localBridgeParsed.value; // validated — overrides outer `options`
-    // Multi-mount is not supported in this path: the bridge reports multiple mounts
-    // but createNexusFileSystem() accepts only one mountPoint prefix. Until per-mount
-    // transport routing exists, mixing OAuth-gated mounts (gdrive://) with local mounts
-    // in one resolveFileSystemAsync() call would silently route all paths under the
-    // first mount, breaking the others. Reject early with an actionable message.
-    const mountUris = Array.isArray(options.mountUri) ? options.mountUri : [options.mountUri];
-    if (mountUris.length > 1) {
-      throw new Error(
-        `resolveFileSystemAsync() does not support multi-mount local bridge configs yet. ` +
-          `Split mounts into separate transports or use a single mountUri. ` +
-          `Provided: ${mountUris.join(", ")}`,
-      );
-    }
 
     const transport = await createLocalTransport({
       mountUri: options.mountUri,
@@ -321,22 +309,30 @@ export async function resolveFileSystemAsync(
     // If backend construction fails, close the already-started subprocess to
     // avoid leaking it. Without this try/catch, any error below this point
     // (e.g. invalid mountPoint validation) would orphan the bridge process.
-    let nexusBackend: ReturnType<typeof createNexusFileSystem>;
+    let nexusBackend: FileSystemBackend;
     let unsubscribe: () => void;
     try {
       unsubscribe = onNotification !== undefined ? transport.subscribe(onNotification) : () => {};
 
-      // Derive mount point: explicit config wins, then fall back to the bridge's
-      // actual mount (transport.mounts[0] without leading slash). Without this,
-      // local and gdrive paths resolve against the HTTP default ("fs"), not the
-      // bridge's real namespace, and every I/O call will fail.
-      const derivedMountPoint = options.mountPoint ?? transport.mounts?.[0]?.slice(1);
-
-      nexusBackend = createNexusFileSystem({
-        url: "local://bridge",
-        transport,
-        ...(derivedMountPoint !== undefined ? { mountPoint: derivedMountPoint } : {}),
-      });
+      const bridgeMounts = transport.mounts ?? [];
+      if (bridgeMounts.length > 1 && options.mountPoint === undefined) {
+        // Multi-mount dispatcher: route each op to the sub-backend whose
+        // mount prefix matches the input path. Synthetic `list("/")` returns
+        // mount names so callers can discover them without out-of-band info.
+        nexusBackend = createNexusMultiMountFileSystem({
+          transport,
+          mountPoints: bridgeMounts,
+        });
+      } else {
+        // Single-mount path (either bridge reported one, or caller overrode
+        // with an explicit mountPoint).
+        const derivedMountPoint = options.mountPoint ?? bridgeMounts[0]?.slice(1);
+        nexusBackend = createNexusFileSystem({
+          url: "local://bridge",
+          transport,
+          ...(derivedMountPoint !== undefined ? { mountPoint: derivedMountPoint } : {}),
+        });
+      }
     } catch (e: unknown) {
       transport.close();
       throw e;

--- a/packages/meta/runtime/src/types.ts
+++ b/packages/meta/runtime/src/types.ts
@@ -225,10 +225,10 @@ export interface RuntimeConfig {
    * pre-created `FileSystemBackend` (e.g., from `resolveFileSystemAsync()`).
    * Ignored when `filesystem` is a `FileSystemConfig` — operations come from the config.
    *
-   * Default: `["read"]` (the `createFileSystemProvider` default).
-   * Set explicitly to `["read", "write", "edit"]` to restore mutation tools.
+   * Default: `["read", "list"]` (the `createFileSystemProvider` default).
+   * Set explicitly to `["read", "write", "edit", "list"]` to restore mutation tools.
    */
-  readonly filesystemOperations?: readonly ("read" | "write" | "edit")[] | undefined;
+  readonly filesystemOperations?: readonly ("read" | "write" | "edit" | "list")[] | undefined;
 
   /**
    * Session transcript configuration. When provided, wires a JSONL-backed


### PR DESCRIPTION
## Summary

Closes #1959 (default manifest auto-discovery) and ships the pending S13 (Nexus GWS Connectors & OAuth) fixes validated in the phase-2 bug bash.

### What ships

- **Default manifest auto-discovery.** When \`--manifest\` is omitted, \`koi tui\` and \`koi start\` look for \`./koi.yaml\` → \`./koi.yml\` → \`./koi.manifest.yaml\` → \`./koi.manifest.yml\`. First match wins. Explicit \`--manifest\` always overrides. \`KOI_NO_AUTO_MANIFEST=1\` opts out.
- **\`examples/koi.yaml\` extended** with a commented \`filesystem:\` block showing nexus-fs multi-connector wiring (local + gdrive + gmail + calendar + slack) and inline OAuth env-var guidance. Inline loopback auth flow validated end-to-end through the TUI against [nexus release/v0.9.32](https://github.com/nexi-lab/nexus/pull/3825).
- **Multi-mount router** (\`packages/lib/fs-nexus/src/multi-mount.ts\`). Dispatches each op to the sub-backend whose mount prefix matches the input path. Synthetic \`list("/")\` returns mount entries for discovery.
- **\`fs_list\` tool** (\`packages/lib/tools-builtin/src/tools/list.ts\`). Surfaces mount namespaces to the agent. Wired into the default read-only filesystem operation set alongside \`fs_read\`.
- **Manifest root-inject fix.** Stop injecting \`root: undefined\` into the filesystem options when a scope root is not declared — the strict Zod schema rejects extra keys and this inject would break every nexus config that doesn't set a scope. Also drops the multi-mount rejection path; the new router handles routing deterministically.
- **bridge.py sync/async tolerance.** Add \`inspect\`-based \`_aw\` helper so SlimNexusFS's mixed sync/async return shapes are tolerated without type errors.
- **Docs.** New sections in \`docs/L2/manifest.md\` for auto-discovery and nexus filesystem + inline OAuth. S13 test plan updates in \`docs/testing/phase-2-bug-bash.md\` reflect the namespaced mount-path convention (\`/local/...\`, \`/gdrive/...\`) instead of scheme URIs.

### End-to-end validation

Live through the TUI against nexus release/v0.9.32 with real Google OAuth client credentials:

1. \`koi tui\` (with committed \`koi.yaml\` + nexus block uncommented) starts and auto-discovers the manifest.
2. Agent issues \`fs_list /gdrive/my-drive\` → nexus raises \`AuthenticationError(auth_url)\` → bridge emits \`auth_required\` → TUI renders inline prompt with PKCE-ready URL.
3. User clicks authorize in browser → loopback callback at \`127.0.0.1:<ephemeral>/callback\` captures code → nexus exchanges for token → \`auth_complete\` fires.
4. Original tool call retries, returns real Drive files (\`koi-test.txt\`, \`.readme/\`, schemas).
5. Subsequent \`fs_list /gdrive/my-drive\` reuses cached token, no re-prompt.

### Test plan

- [x] \`bun test packages/meta/cli/src/manifest.test.ts\` — 27 tests pass (+ 7 new \`discoverDefaultManifest\` cases, + 4 root-inject / multi-mount regressions).
- [x] \`bun test packages/lib/fs-nexus/src/multi-mount.test.ts\` — 12/12 pass.
- [x] \`bun test packages/meta/cli/src/args/governance-flags.test.ts\` — 31/31 pass (unaffected, sanity).
- [x] \`bun run build --filter='@koi/runtime' --filter='@koi-agent/cli'\` — clean.
- [x] \`bunx @biomejs/biome check\` — no errors.
- [x] TUI E2E validation per section above.

Pre-existing failures in \`packages/meta/cli/src/commands/start.test.ts\` (\`createHookObserver\` missing export from \`@koi/runtime\` dist) predate this branch and are not touched here.

### Follow-ups (separate PRs)

- #1982 — unify OAuth UX between nexus connectors and MCP servers via shared \`OAuthChannel\` protocol (today nexus uses inline auth, MCP uses \`/mcp\` view).