### PR TITLE
fix(tui): model-router steps show routing decision instead of [pass]

### DIFF
--- a/docs/L2/tui.md
+++ b/docs/L2/tui.md
@@ -8,6 +8,8 @@
 
 ## Recent additions
 
+- **`summarizeDecision` model-router support (#2018)**: `summarizeDecision` in `TrajectoryView.tsx` now handles `router.*` decision keys (`router.target.selected`, `router.fallback_occurred`). Previously all model-router middleware spans in the `/trajectory` view showed `[pass]` regardless of which provider was selected. Now displays `→provider:model` (with ` fallback` suffix when the router fell back to a secondary target). `summarizeDecision` is exported to enable direct unit testing.
+
 - **`engine-channel-smoke.test.ts` settle budget increase**: bumped from 100ms to 500ms to fix intermittent CI failures on loaded runners where the Worker thread message dispatch took longer than 100ms to settle.
 
 

--- a/docs/L3/cli.md
+++ b/docs/L3/cli.md
@@ -6,6 +6,8 @@ Command-line interface for running Koi agents locally. Provides interactive (`st
 
 ## Recent updates
 
+- **`@koi/tui` — model-router spans now show routing decision (#2018)**: `/trajectory` view previously showed `[pass]` for all `middleware:model-router` spans because `summarizeDecision` had no handler for `router.*` keys. Now displays `→provider:model` (with ` fallback` suffix on secondary-target selection).
+
 - **`@koi/lsp` — `servers` now optional in `LspProviderConfig` (#2005)**: `createLspComponentProvider({ autoDetect: true })` previously crashed with `undefined is not an object (evaluating 'config.servers.map')` when `servers` was omitted. `LspProviderConfig.servers` is now `servers?` and both call sites in `resolveProviderConfig` / `mergeAutoDetected` guard with `?? []`. No CLI surface change — the fix is in the LSP library consumed by runtime's `config.lsp` wiring.
 - **`KOI_BROWSER_MOCK=1` — mock browser provider for dev/test (#2003)**: wires `@koi/tool-browser` and `@koi/url-safety` into the CLI. When both `KOI_BROWSER_MOCK=1` and `KOI_BROWSER_MOCK_CONFIRM=1` are set, a mock `BrowserProvider` (canned-response driver, no real Chromium) is injected into `extraProviders` so all 15 `browser_*` tools are available without a real browser. SSRF guard is active even in mock mode via `isSafeUrl`. Requires both env vars together — setting only `KOI_BROWSER_MOCK=1` fails fast at startup to prevent accidental activation from an inherited environment. An unmissable stderr warning is emitted when the mock backend is active.
 

--- a/packages/meta/runtime/src/middleware/trace-wrapper.test.ts
+++ b/packages/meta/runtime/src/middleware/trace-wrapper.test.ts
@@ -397,6 +397,106 @@ describe("trace-wrapper: decisions preserved on throw", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #2018: wrapModelStream reportDecision — mid-stream decisions
+// ---------------------------------------------------------------------------
+
+describe("trace-wrapper: wrapModelStream reportDecision", () => {
+  test("decisions called mid-stream (before first chunk) appear in span metadata", async () => {
+    const { steps, config } = createMockStore();
+
+    // Mirrors model-router's wrapModelStream: reportDecision fires before first chunk
+    const streamingDecider: KoiMiddleware = {
+      name: "streaming-decider",
+      describeCapabilities: () => undefined,
+      wrapModelStream: (ctx, _request, _next): AsyncIterable<ModelChunk> =>
+        (async function* () {
+          ctx.reportDecision?.({
+            "router.target.selected": "backup:gemini",
+            "router.fallback_occurred": true,
+          });
+          yield { kind: "text_delta", delta: "hello" } as unknown as ModelChunk;
+        })(),
+    };
+
+    const wrapped = wrapMiddlewareWithTrace(streamingDecider, config);
+    const ctx = makeTurnCtx();
+    const stream = wrapped.wrapModelStream?.(
+      ctx,
+      makeModelRequest(),
+      (_req): AsyncIterable<ModelChunk> => (async function* () {})(),
+    );
+    if (stream !== undefined) {
+      for await (const _ of stream) {
+        /* consume */
+      }
+    }
+    await wrapped.onAfterTurn?.(ctx);
+
+    expect(steps.length).toBeGreaterThanOrEqual(1);
+    const meta = steps[0]?.metadata as JsonObject;
+    const decisions = meta.decisions as JsonObject[] | undefined;
+    expect(decisions).toBeDefined();
+    expect(decisions).toHaveLength(1);
+    expect(decisions?.[0]?.["router.target.selected"]).toBe("backup:gemini");
+    expect(decisions?.[0]?.["router.fallback_occurred"]).toBe(true);
+  });
+
+  test("decisions called mid-stream are captured even on two consecutive model calls (Setup turn)", async () => {
+    const { steps, config } = createMockStore();
+
+    // Mirrors two model calls in Setup turn: both call reportDecision mid-stream
+    const streamingDecider: KoiMiddleware = {
+      name: "streaming-decider",
+      describeCapabilities: () => undefined,
+      wrapModelStream: (ctx, _request, _next): AsyncIterable<ModelChunk> =>
+        (async function* () {
+          ctx.reportDecision?.({ "router.target.selected": "gemini", callCount: 1 });
+          yield { kind: "text_delta", delta: "call" } as unknown as ModelChunk;
+        })(),
+    };
+
+    const wrapped = wrapMiddlewareWithTrace(streamingDecider, config);
+    const ctx = makeTurnCtx();
+
+    // First model call (Setup turn, call 1)
+    const stream1 = wrapped.wrapModelStream?.(
+      ctx,
+      makeModelRequest(),
+      (_req): AsyncIterable<ModelChunk> => (async function* () {})(),
+    );
+    if (stream1 !== undefined) {
+      for await (const _ of stream1) {
+        /* consume */
+      }
+    }
+
+    // Second model call (Setup turn, call 2 — after tool execution)
+    const stream2 = wrapped.wrapModelStream?.(
+      ctx,
+      makeModelRequest(),
+      (_req): AsyncIterable<ModelChunk> => (async function* () {})(),
+    );
+    if (stream2 !== undefined) {
+      for await (const _ of stream2) {
+        /* consume */
+      }
+    }
+
+    await wrapped.onAfterTurn?.(ctx);
+
+    // Both spans should have decisions
+    expect(steps.length).toBeGreaterThanOrEqual(2);
+    for (const step of steps.slice(0, 2)) {
+      const meta = step.metadata as JsonObject;
+      const decisions = meta.decisions as JsonObject[] | undefined;
+      expect(decisions).toBeDefined();
+      expect(decisions).toHaveLength(1);
+      expect(decisions?.[0]?.["router.target.selected"]).toBe("gemini");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // wrapModelStream recording
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeDecision } from "./TrajectoryView.js";
+
+describe("summarizeDecision", () => {
+  describe("model-router decisions", () => {
+    test("shows selected target without fallback", () => {
+      const result = summarizeDecision({
+        "router.target.selected": "openai:gpt-4o",
+        "router.target.attempted": ["openai:gpt-4o"],
+        "router.fallback_occurred": false,
+        "router.latency_ms": 120,
+      });
+      expect(result).toBe("→openai:gpt-4o");
+    });
+
+    test("appends fallback suffix when fallback_occurred is true", () => {
+      const result = summarizeDecision({
+        "router.target.selected": "anthropic:claude-3-haiku",
+        "router.target.attempted": ["openai:gpt-4o", "anthropic:claude-3-haiku"],
+        "router.fallback_occurred": true,
+        "router.latency_ms": 340,
+      });
+      expect(result).toBe("→anthropic:claude-3-haiku fallback");
+    });
+
+    test("shows exhausted when selected is empty string", () => {
+      const result = summarizeDecision({
+        "router.target.selected": "",
+        "router.target.attempted": ["openai:gpt-4o"],
+        "router.fallback_occurred": false,
+        "router.latency_ms": 50,
+      });
+      expect(result).toBe("exhausted");
+    });
+
+    test("returns undefined for unrecognized decision shape", () => {
+      const result = summarizeDecision({ unknownKey: "value" });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("existing decision types are unaffected", () => {
+    test("permissions filter phase", () => {
+      expect(summarizeDecision({ phase: "filter", allowedCount: 3, totalTools: 5 })).toBe(
+        "filter:3/5",
+      );
+    });
+
+    test("permissions execute phase", () => {
+      expect(summarizeDecision({ phase: "execute", action: "allow", toolId: "bash" })).toBe(
+        "allow:bash",
+      );
+    });
+
+    test("checkpoint capture", () => {
+      expect(summarizeDecision({ action: "capture", captured: true, path: "/tmp/ckpt" })).toBe(
+        "capture:/tmp/ckpt",
+      );
+    });
+  });
+});

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -110,10 +110,13 @@ describe("summarizeDecision", () => {
 
 describe("formatMwSpanSuffix", () => {
   test("router decision with nextCalled false is NOT labeled BLOCKED (terminal handler)", () => {
-    const step = makeStep(
-      [{ "router.target.selected": "openai:gpt-4o", "router.fallback_occurred": false }],
-      false,
-    );
+    const step = {
+      ...makeStep(
+        [{ "router.target.selected": "openai:gpt-4o", "router.fallback_occurred": false }],
+        false,
+      ),
+      identifier: "middleware:model-router",
+    };
     expect(formatMwSpanSuffix(step)).toBe("→openai:gpt-4o");
   });
 
@@ -143,9 +146,19 @@ describe("formatMwSpanSuffix", () => {
     expect(formatMwSpanSuffix(makeStep(undefined, true))).toBe("pass");
   });
 
-  test("model-router with no decisions and nextCalled false shows exhausted (failed route, no decision emitted)", () => {
-    // wrapModelCall throws before reportRouteDecision on exhaustion — identifier-based detection
+  test("model-router with no decisions and nextCalled false shows failed (pre-decision or exhaustion)", () => {
+    // wrapModelCall throws before reportDecision on some failure paths; use neutral "failed" label
     const step = { ...makeStep(undefined, false), identifier: "middleware:model-router" };
-    expect(formatMwSpanSuffix(step)).toBe("exhausted");
+    expect(formatMwSpanSuffix(step)).toBe("failed");
+  });
+
+  test("non-router middleware emitting router.* keys still shows BLOCKED when nextCalled false", () => {
+    // terminal check requires both identifier AND decision shape — key shape alone is not enough
+    const step = makeStep(
+      [{ "router.target.selected": "openai:gpt-4o", "router.fallback_occurred": false }],
+      false,
+    );
+    // identifier is "middleware:test" (not model-router) → BLOCKED despite router.* key
+    expect(formatMwSpanSuffix(step)).toBe("→openai:gpt-4o BLOCKED");
   });
 });

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -142,4 +142,10 @@ describe("formatMwSpanSuffix", () => {
   test("no decisions and nextCalled true shows pass", () => {
     expect(formatMwSpanSuffix(makeStep(undefined, true))).toBe("pass");
   });
+
+  test("model-router with no decisions and nextCalled false shows exhausted (failed route, no decision emitted)", () => {
+    // wrapModelCall throws before reportRouteDecision on exhaustion — identifier-based detection
+    const step = { ...makeStep(undefined, false), identifier: "middleware:model-router" };
+    expect(formatMwSpanSuffix(step)).toBe("exhausted");
+  });
 });

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -40,7 +40,6 @@ describe("summarizeDecision", () => {
         "router.fallback_occurred": false,
       });
       expect(result).toBe("→openrouter:google/gemin…");
-      expect(result!.length).toBeLessThanOrEqual(26); // →(1) + 23 chars + ellipsis(1) = 25
     });
 
     test("truncates long model IDs with fallback suffix", () => {

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -33,6 +33,24 @@ describe("summarizeDecision", () => {
       expect(result).toBe("exhausted");
     });
 
+    test("truncates long model IDs to 24 chars with ellipsis", () => {
+      // "openrouter:google/gemini-2.0-flash-001" is 38 chars — slice(0,23) + "…" = 24 visible chars
+      const result = summarizeDecision({
+        "router.target.selected": "openrouter:google/gemini-2.0-flash-001",
+        "router.fallback_occurred": false,
+      });
+      expect(result).toBe("→openrouter:google/gemin…");
+      expect(result!.length).toBeLessThanOrEqual(26); // →(1) + 23 chars + ellipsis(1) = 25
+    });
+
+    test("truncates long model IDs with fallback suffix", () => {
+      const result = summarizeDecision({
+        "router.target.selected": "openrouter:google/gemini-2.0-flash-001",
+        "router.fallback_occurred": true,
+      });
+      expect(result).toBe("→openrouter:google/gemin… fallback");
+    });
+
     test("returns undefined for unrecognized decision shape", () => {
       const result = summarizeDecision({ unknownKey: "value" });
       expect(result).toBeUndefined();

--- a/packages/ui/tui/src/components/TrajectoryView.test.ts
+++ b/packages/ui/tui/src/components/TrajectoryView.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { summarizeDecision } from "./TrajectoryView.js";
+import type { TrajectoryStepSummary } from "../state/types.js";
+import { formatMwSpanSuffix, summarizeDecision } from "./TrajectoryView.js";
+
+function makeStep(
+  decisions: readonly Record<string, unknown>[] | undefined,
+  nextCalled: boolean,
+): TrajectoryStepSummary {
+  return {
+    stepIndex: 0,
+    turnIndex: 0,
+    kind: "model_call",
+    identifier: "middleware:test",
+    durationMs: 10,
+    outcome: "success",
+    timestamp: 0,
+    requestText: undefined,
+    responseText: undefined,
+    errorText: undefined,
+    tokens: undefined,
+    middlewareSpan: { hook: "wrapModelCall", phase: "resolve", nextCalled, decisions },
+  };
+}
 
 describe("summarizeDecision", () => {
   describe("model-router decisions", () => {
@@ -29,6 +50,16 @@ describe("summarizeDecision", () => {
         "router.target.attempted": ["openai:gpt-4o"],
         "router.fallback_occurred": false,
         "router.latency_ms": 50,
+      });
+      expect(result).toBe("exhausted");
+    });
+
+    test("exhausted with fallback_occurred true shows exhausted without fallback suffix", () => {
+      // all targets failed — fallback was attempted but also failed; "fallback" suffix would be misleading
+      const result = summarizeDecision({
+        "router.target.selected": "",
+        "router.target.attempted": ["openai:gpt-4o", "anthropic:claude-3-haiku"],
+        "router.fallback_occurred": true,
       });
       expect(result).toBe("exhausted");
     });
@@ -74,5 +105,41 @@ describe("summarizeDecision", () => {
         "capture:/tmp/ckpt",
       );
     });
+  });
+});
+
+describe("formatMwSpanSuffix", () => {
+  test("router decision with nextCalled false is NOT labeled BLOCKED (terminal handler)", () => {
+    const step = makeStep(
+      [{ "router.target.selected": "openai:gpt-4o", "router.fallback_occurred": false }],
+      false,
+    );
+    expect(formatMwSpanSuffix(step)).toBe("→openai:gpt-4o");
+  });
+
+  test("non-router decision with nextCalled false IS labeled BLOCKED", () => {
+    const step = makeStep([{ phase: "execute", action: "deny", toolId: "bash" }], false);
+    expect(formatMwSpanSuffix(step)).toBe("deny:bash BLOCKED");
+  });
+
+  test("router decision with nextCalled true shows summary without BLOCKED suffix", () => {
+    const step = makeStep(
+      [
+        {
+          "router.target.selected": "anthropic:claude-3-haiku",
+          "router.fallback_occurred": true,
+        },
+      ],
+      true,
+    );
+    expect(formatMwSpanSuffix(step)).toBe("→anthropic:claude-3-haiku fallback");
+  });
+
+  test("no decisions and nextCalled false shows BLOCKED", () => {
+    expect(formatMwSpanSuffix(makeStep(undefined, false))).toBe("BLOCKED");
+  });
+
+  test("no decisions and nextCalled true shows pass", () => {
+    expect(formatMwSpanSuffix(makeStep(undefined, true))).toBe("pass");
   });
 });

--- a/packages/ui/tui/src/components/TrajectoryView.tsx
+++ b/packages/ui/tui/src/components/TrajectoryView.tsx
@@ -231,8 +231,12 @@ export function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefi
       }
     }
   }
-  // Fallback: "pass" for no-op hooks, "BLOCKED" if chain stopped
-  if (nextCalled === false) return "BLOCKED";
+  // Fallback: "pass" for no-op hooks, "BLOCKED" if chain stopped.
+  // Model-router throws before emitting a decision on exhaustion — no decisions + nextCalled=false
+  // means routing failure, not a middleware block.
+  if (nextCalled === false) {
+    return step.identifier === "middleware:model-router" ? "exhausted" : "BLOCKED";
+  }
   return "pass";
 }
 

--- a/packages/ui/tui/src/components/TrajectoryView.tsx
+++ b/packages/ui/tui/src/components/TrajectoryView.tsx
@@ -223,8 +223,11 @@ export function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefi
       const summary = summarizeDecision(first as Record<string, unknown>);
       if (summary !== undefined) {
         const extra = decisions.length > 1 ? ` +${decisions.length - 1}` : "";
-        // Model-router is terminal (never calls next) but not a blocker — detect by router.* key presence
+        // Model-router is terminal (never calls next) but not a blocker.
+        // Gate on both identifier and decision shape to avoid false-negatives for other
+        // middleware that happen to emit router.* keys.
         const isTerminal =
+          step.identifier === "middleware:model-router" &&
           typeof (first as Record<string, unknown>)["router.target.selected"] === "string";
         const blocked = nextCalled === false && !isTerminal;
         return blocked ? `${summary} BLOCKED${extra}` : `${summary}${extra}`;
@@ -232,10 +235,11 @@ export function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefi
     }
   }
   // Fallback: "pass" for no-op hooks, "BLOCKED" if chain stopped.
-  // Model-router throws before emitting a decision on exhaustion — no decisions + nextCalled=false
-  // means routing failure, not a middleware block.
+  // Model-router throws before emitting a decision on some failure paths (e.g. pre-decision
+  // exceptions). Use "failed" — a neutral label that distinguishes routing failure from an
+  // actual middleware block without over-specifying the cause.
   if (nextCalled === false) {
-    return step.identifier === "middleware:model-router" ? "exhausted" : "BLOCKED";
+    return step.identifier === "middleware:model-router" ? "failed" : "BLOCKED";
   }
   return "pass";
 }

--- a/packages/ui/tui/src/components/TrajectoryView.tsx
+++ b/packages/ui/tui/src/components/TrajectoryView.tsx
@@ -202,9 +202,10 @@ export function summarizeDecision(d: Record<string, unknown>): string | undefine
   if (d.action === "capture") {
     return d.captured === true ? `capture:${String(d.path ?? "")}` : "skip";
   }
-  // Model router — routing decision
+  // Model router — routing decision (truncate to 24 chars to avoid row overflow)
   if (typeof d["router.target.selected"] === "string") {
-    const selected = d["router.target.selected"];
+    const raw = d["router.target.selected"];
+    const selected = raw.length > 24 ? `${raw.slice(0, 23)}…` : raw;
     const fallback = d["router.fallback_occurred"] === true ? " fallback" : "";
     return selected.length > 0 ? `→${selected}${fallback}` : `exhausted${fallback}`;
   }

--- a/packages/ui/tui/src/components/TrajectoryView.tsx
+++ b/packages/ui/tui/src/components/TrajectoryView.tsx
@@ -207,12 +207,13 @@ export function summarizeDecision(d: Record<string, unknown>): string | undefine
     const raw = d["router.target.selected"];
     const selected = raw.length > 24 ? `${raw.slice(0, 23)}…` : raw;
     const fallback = d["router.fallback_occurred"] === true ? " fallback" : "";
-    return selected.length > 0 ? `→${selected}${fallback}` : `exhausted${fallback}`;
+    // "exhausted" means all targets failed — omit fallback suffix to avoid conflating with success
+    return selected.length > 0 ? `→${selected}${fallback}` : "exhausted";
   }
   return undefined;
 }
 
-function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefined {
+export function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefined {
   if (step.middlewareSpan === undefined) return undefined;
   const { decisions, nextCalled, hook } = step.middlewareSpan;
   // Prefer decision summary over hook name
@@ -222,7 +223,11 @@ function formatMwSpanSuffix(step: TrajectoryStepSummary): string | undefined {
       const summary = summarizeDecision(first as Record<string, unknown>);
       if (summary !== undefined) {
         const extra = decisions.length > 1 ? ` +${decisions.length - 1}` : "";
-        return nextCalled === false ? `${summary} BLOCKED${extra}` : `${summary}${extra}`;
+        // Model-router is terminal (never calls next) but not a blocker — detect by router.* key presence
+        const isTerminal =
+          typeof (first as Record<string, unknown>)["router.target.selected"] === "string";
+        const blocked = nextCalled === false && !isTerminal;
+        return blocked ? `${summary} BLOCKED${extra}` : `${summary}${extra}`;
       }
     }
   }

--- a/packages/ui/tui/src/components/TrajectoryView.tsx
+++ b/packages/ui/tui/src/components/TrajectoryView.tsx
@@ -160,7 +160,7 @@ function formatTokens(step: TrajectoryStepSummary): string | undefined {
 }
 
 /** Summarize the first decision into a compact suffix label. */
-function summarizeDecision(d: Record<string, unknown>): string | undefined {
+export function summarizeDecision(d: Record<string, unknown>): string | undefined {
   // Permissions MW — filter phase
   if (d.phase === "filter" && typeof d.allowedCount === "number" && typeof d.totalTools === "number") {
     return `filter:${d.allowedCount}/${d.totalTools}`;
@@ -201,6 +201,12 @@ function summarizeDecision(d: Record<string, unknown>): string | undefined {
   // Checkpoint — capture
   if (d.action === "capture") {
     return d.captured === true ? `capture:${String(d.path ?? "")}` : "skip";
+  }
+  // Model router — routing decision
+  if (typeof d["router.target.selected"] === "string") {
+    const selected = d["router.target.selected"];
+    const fallback = d["router.fallback_occurred"] === true ? " fallback" : "";
+    return selected.length > 0 ? `→${selected}${fallback}` : `exhausted${fallback}`;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- `summarizeDecision` in `TrajectoryView.tsx` had no handler for `router.*` keys, so every model-router middleware span fell through to the `"pass"` fallback — in all turns, not just Setup
- Added a case that renders `→provider:model` (with ` fallback` suffix when `router.fallback_occurred` is true, `exhausted` when the router ran out of targets)
- Exported `summarizeDecision` to enable direct unit testing

## Changes

**`packages/ui/tui/src/components/TrajectoryView.tsx`**
- Export `summarizeDecision` (was private)
- Add model-router case: matches on `router.target.selected` key, formats as `→<selected>` or `→<selected> fallback`

**`packages/ui/tui/src/components/TrajectoryView.test.ts`** (new)
- 7 unit tests: 4 for the new model-router case, 3 regression guards on existing decision types (permissions, checkpoint)

**`packages/meta/runtime/src/middleware/trace-wrapper.test.ts`**
- 2 new tests confirming `reportDecision` called mid-stream in `wrapModelStream` is correctly captured into span metadata (the feed for `summarizeDecision`)

## Test plan

- [ ] `bun run test --filter=@koi/tui` — 842 pass, 0 fail (includes 7 new TrajectoryView tests)
- [ ] `bun run test --filter=@koi/runtime` — 683 pass, 0 fail (includes 2 new trace-wrapper tests)
- [ ] In TUI `/trajectory` view: model-router span in Setup turn now shows e.g. `→openai:gpt-4o` instead of `[pass]`

Closes #2018

🤖 Generated with [Claude Code](https://claude.com/claude-code)