### PR TITLE
fix(tui): route bg-exit hint through store to prevent row duplication on Ctrl+C (#1912)

### DIFF
--- a/packages/meta/cli/src/sigint-handler.ts
+++ b/packages/meta/cli/src/sigint-handler.ts
@@ -24,6 +24,12 @@ export interface SigintHandlerDeps {
   readonly onForce: () => void;
   /** Used to print the "Interrupting…" hint. Typically `process.stderr.write`. */
   readonly write: (msg: string) => void;
+  /**
+   * Optional override for the "Interrupting…" hint. When provided, called
+   * instead of `write` so TUI hosts can route the message through the store
+   * rather than raw stderr (#1912). Falls back to `write` when absent.
+   */
+  readonly onInterruptHint?: (msg: string) => void;
   /** How long the user has to tap Ctrl+C a second time. */
   readonly doubleTapWindowMs: number;
   /**
@@ -231,7 +237,7 @@ export function createSigintHandler(deps: SigintHandlerDeps): SigintHandler {
     const thisArmGen = ++armGen; // monotonic; unique even for same-millisecond re-arms
     const doubleTapTimer = armDoubleTapTimer(thisArmGen);
     state = { kind: "armed", failsafeTimer, doubleTapTimer, armGen: thisArmGen, armedAt: t };
-    deps.write("\nInterrupting… (Ctrl+C again to force)\n");
+    (deps.onInterruptHint ?? deps.write)("\nInterrupting… (Ctrl+C again to force)\n");
     deps.onGraceful();
   };
 

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2236,14 +2236,37 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     write: (msg: string) => {
       process.stderr.write(msg);
     },
-    // #1912: route both SIGINT hints through the TUI store so OpenTUI owns
-    // the layout. Raw process.stderr.write during an active OpenTUI frame
-    // causes row duplication and character-level overlay.
-    onInterruptHint: (msg: string) => {
-      dispatchNotice(store, "interrupt-hint", msg.trim());
+    // #1912: route SIGINT hints through the toast surface (transient, keyed,
+    // auto-dismiss) instead of raw stderr or add_info. Raw stderr writes during
+    // an active OpenTUI frame cause row duplication and character-level overlay;
+    // add_info would pollute conversation history with stale control-flow banners.
+    onInterruptHint: (_msg: string) => {
+      store.dispatch({
+        kind: "add_toast",
+        toast: {
+          id: `sigint-interrupt-${Date.now()}`,
+          kind: "info",
+          key: "sigint:interrupt",
+          title: "Interrupting…",
+          body: "Ctrl+C again to force",
+          ts: Date.now(),
+          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS + 1000,
+        },
+      });
     },
-    onBgExitHint: (msg: string) => {
-      dispatchNotice(store, "bg-exit-hint", msg.trim());
+    onBgExitHint: (_msg: string) => {
+      store.dispatch({
+        kind: "add_toast",
+        toast: {
+          id: `sigint-bg-exit-${Date.now()}`,
+          kind: "warn",
+          key: "sigint:bg-exit",
+          title: "Background tasks still running",
+          body: "Press Ctrl+C again to exit (background tasks will be terminated).",
+          ts: Date.now(),
+          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS + 1000,
+        },
+      });
     },
     doubleTapWindowMs: TUI_DOUBLE_TAP_WINDOW_MS,
     coalesceWindowMs: TUI_COALESCE_WINDOW_MS,

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2236,9 +2236,12 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     write: (msg: string) => {
       process.stderr.write(msg);
     },
-    // #1912: route the bg-exit hint through the TUI store so OpenTUI owns
+    // #1912: route both SIGINT hints through the TUI store so OpenTUI owns
     // the layout. Raw process.stderr.write during an active OpenTUI frame
     // causes row duplication and character-level overlay.
+    onInterruptHint: (msg: string) => {
+      dispatchNotice(store, "interrupt-hint", msg.trim());
+    },
     onBgExitHint: (msg: string) => {
       dispatchNotice(store, "bg-exit-hint", msg.trim());
     },

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2250,7 +2250,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           title: "Interrupting…",
           body: "Ctrl+C again to force",
           ts: Date.now(),
-          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS + 1000,
+          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS,
         },
       });
     },
@@ -2264,7 +2264,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           title: "Background tasks still running",
           body: "Press Ctrl+C again to exit (background tasks will be terminated).",
           ts: Date.now(),
-          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS + 1000,
+          autoDismissMs: TUI_DOUBLE_TAP_WINDOW_MS,
         },
       });
     },

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -2236,6 +2236,12 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     write: (msg: string) => {
       process.stderr.write(msg);
     },
+    // #1912: route the bg-exit hint through the TUI store so OpenTUI owns
+    // the layout. Raw process.stderr.write during an active OpenTUI frame
+    // causes row duplication and character-level overlay.
+    onBgExitHint: (msg: string) => {
+      dispatchNotice(store, "bg-exit-hint", msg.trim());
+    },
     doubleTapWindowMs: TUI_DOUBLE_TAP_WINDOW_MS,
     coalesceWindowMs: TUI_COALESCE_WINDOW_MS,
     setTimer: createUnrefTimer,

--- a/packages/meta/cli/src/tui-graceful-sigint.test.ts
+++ b/packages/meta/cli/src/tui-graceful-sigint.test.ts
@@ -501,7 +501,40 @@ describe("createTuiSigintHandler — dynamic onWindowElapse (#1999 spawn regress
   });
 });
 
-describe("createTuiSigintHandler — onBgExitHint routing (#1912)", () => {
+describe("createTuiSigintHandler — onInterruptHint + onBgExitHint routing (#1912)", () => {
+  test("bg-only first Ctrl+C: no raw write() when both hint overrides are provided", () => {
+    const timers = createFakeTimers();
+    const writes: string[] = [];
+    const interruptHints: string[] = [];
+    const bgHints: string[] = [];
+    const handler = createTuiSigintHandler({
+      hasActiveForegroundStream: () => false,
+      hasActiveBackgroundTasks: () => true,
+      abortActiveStream: () => {},
+      onShutdown: () => {},
+      onForce: () => {},
+      write: (msg) => {
+        writes.push(msg);
+      },
+      onInterruptHint: (msg) => {
+        interruptHints.push(msg);
+      },
+      onBgExitHint: (msg) => {
+        bgHints.push(msg);
+      },
+      setTimer: timers.setTimer,
+      doubleTapWindowMs: 2000,
+      coalesceWindowMs: 0,
+    });
+
+    handler.handleSignal();
+
+    // Both hints routed through store callbacks, not raw write (#1912)
+    expect(interruptHints.join("")).toContain("Interrupting");
+    expect(bgHints.join("")).toContain("Background tasks still running");
+    expect(writes).toHaveLength(0);
+  });
+
   test("onBgExitHint is called instead of write for the bg banner when provided", () => {
     const timers = createFakeTimers();
     const writes: string[] = [];
@@ -531,7 +564,7 @@ describe("createTuiSigintHandler — onBgExitHint routing (#1912)", () => {
     expect(writes.join("")).not.toContain("Background tasks still running");
   });
 
-  test("falls back to write when onBgExitHint is absent", () => {
+  test("falls back to write when hint overrides are absent", () => {
     const timers = createFakeTimers();
     const writes: string[] = [];
     const handler = createTuiSigintHandler({
@@ -550,6 +583,7 @@ describe("createTuiSigintHandler — onBgExitHint routing (#1912)", () => {
 
     handler.handleSignal();
 
+    expect(writes.join("")).toContain("Interrupting");
     expect(writes.join("")).toContain("Background tasks still running");
   });
 });

--- a/packages/meta/cli/src/tui-graceful-sigint.test.ts
+++ b/packages/meta/cli/src/tui-graceful-sigint.test.ts
@@ -500,3 +500,56 @@ describe("createTuiSigintHandler — dynamic onWindowElapse (#1999 spawn regress
     expect(forceCount.n).toBe(1);
   });
 });
+
+describe("createTuiSigintHandler — onBgExitHint routing (#1912)", () => {
+  test("onBgExitHint is called instead of write for the bg banner when provided", () => {
+    const timers = createFakeTimers();
+    const writes: string[] = [];
+    const bgHints: string[] = [];
+    const handler = createTuiSigintHandler({
+      hasActiveForegroundStream: () => false,
+      hasActiveBackgroundTasks: () => true,
+      abortActiveStream: () => {},
+      onShutdown: () => {},
+      onForce: () => {},
+      write: (msg) => {
+        writes.push(msg);
+      },
+      onBgExitHint: (msg) => {
+        bgHints.push(msg);
+      },
+      setTimer: timers.setTimer,
+      doubleTapWindowMs: 2000,
+      coalesceWindowMs: 0,
+    });
+
+    handler.handleSignal();
+
+    expect(bgHints.length).toBe(1);
+    expect(bgHints[0]).toContain("Background tasks still running");
+    // write must not receive the bg banner — raw stderr is bypassed (#1912)
+    expect(writes.join("")).not.toContain("Background tasks still running");
+  });
+
+  test("falls back to write when onBgExitHint is absent", () => {
+    const timers = createFakeTimers();
+    const writes: string[] = [];
+    const handler = createTuiSigintHandler({
+      hasActiveForegroundStream: () => false,
+      hasActiveBackgroundTasks: () => true,
+      abortActiveStream: () => {},
+      onShutdown: () => {},
+      onForce: () => {},
+      write: (msg) => {
+        writes.push(msg);
+      },
+      setTimer: timers.setTimer,
+      doubleTapWindowMs: 2000,
+      coalesceWindowMs: 0,
+    });
+
+    handler.handleSignal();
+
+    expect(writes.join("")).toContain("Background tasks still running");
+  });
+});

--- a/packages/meta/cli/src/tui-graceful-sigint.ts
+++ b/packages/meta/cli/src/tui-graceful-sigint.ts
@@ -88,6 +88,13 @@ export interface TuiSigintDeps {
    */
   readonly onForce: () => void;
   readonly write: (msg: string) => void;
+  /**
+   * Optional: route the bg-exit hint through the TUI store instead of raw
+   * stdout so OpenTUI owns the layout. When provided, this is called instead
+   * of `write` for the "Background tasks still running" banner (#1912).
+   * Falls back to `write` when absent (e.g. in tests that predate this dep).
+   */
+  readonly onBgExitHint?: (hint: string) => void;
   readonly setTimer: (fn: () => void, ms: number) => Timer;
   readonly doubleTapWindowMs: number;
   readonly coalesceWindowMs?: number;
@@ -148,7 +155,7 @@ export function createTuiSigintHandler(deps: TuiSigintDeps): SigintHandler {
           // bg-wait arm too — any other branch would have taken the
           // invalidation path above).
           invalidateCurrentBgWait?.();
-          deps.write(action.hint);
+          (deps.onBgExitHint ?? deps.write)(action.hint);
           // Generation-scoped self-disarm. Only THIS arm's timer is
           // allowed to complete THIS arm; a stale timer from an earlier
           // arm whose `valid` flag was flipped to false is a no-op.

--- a/packages/meta/cli/src/tui-graceful-sigint.ts
+++ b/packages/meta/cli/src/tui-graceful-sigint.ts
@@ -89,6 +89,12 @@ export interface TuiSigintDeps {
   readonly onForce: () => void;
   readonly write: (msg: string) => void;
   /**
+   * Optional: route the "Interrupting…" hint through the TUI store instead
+   * of raw stderr so OpenTUI owns the layout on first tap (#1912).
+   * Falls back to `write` when absent.
+   */
+  readonly onInterruptHint?: (msg: string) => void;
+  /**
    * Optional: route the bg-exit hint through the TUI store instead of raw
    * stdout so OpenTUI owns the layout. When provided, this is called instead
    * of `write` for the "Background tasks still running" banner (#1912).
@@ -189,6 +195,7 @@ export function createTuiSigintHandler(deps: TuiSigintDeps): SigintHandler {
       deps.onForce();
     },
     write: deps.write,
+    ...(deps.onInterruptHint !== undefined ? { onInterruptHint: deps.onInterruptHint } : {}),
     doubleTapWindowMs: deps.doubleTapWindowMs,
     setTimer: deps.setTimer,
     ...(deps.coalesceWindowMs !== undefined ? { coalesceWindowMs: deps.coalesceWindowMs } : {}),


### PR DESCRIPTION
## Summary

Fixes row duplication and character overlay when Ctrl+C fires during `bash_background` streaming.

**Root cause:** `sigint-handler.ts` called `process.stderr.write` unconditionally on every first Ctrl+C, and the bg-exit banner also went through raw stderr. Raw writes during an active OpenTUI frame force a re-flow that collides with the in-flight paint.

**Fix (3-part):**
- Add `onInterruptHint?` to `SigintHandlerDeps` — lets callers override the "Interrupting…" line
- Add `onBgExitHint?` and thread `onInterruptHint?` through `TuiSigintDeps`
- Wire both in `tui-command.ts` to dispatch `add_toast` (keyed, auto-dismiss at exactly `doubleTapWindowMs`) instead of raw stderr — no raw writes during active OpenTUI frames, no stale banners in conversation history

**Toast approach vs add_info:**
`add_info` would have appended permanent rows to conversation history. `add_toast` is keyed (repeated Ctrl+C replaces one toast), auto-dismisses when the armed window expires, and is transient.

## Test plan

- [ ] 19-test suite passes (`tui-graceful-sigint.test.ts`)
- [ ] New: bg-only first Ctrl+C produces zero raw `write()` calls when both hint overrides are provided
- [ ] New: fallback to `write` when hint overrides are absent (backwards compat)
- [ ] Manual: `koi tui` → `run sleep 60 with bash_background` → Ctrl+C mid-stream → banner renders as toast, no row duplication

Closes #1912

🤖 Generated with [Claude Code](https://claude.com/claude-code)