### PR TITLE
feat(skill-distiller): wire @koi/runtime + golden tests (PR 4/4 for #1649)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1246,6 +1246,7 @@
         "@koi/scratchpad-local": "workspace:*",
         "@koi/session": "workspace:*",
         "@koi/settings": "workspace:*",
+        "@koi/skill-distiller": "workspace:*",
         "@koi/skill-scanner": "workspace:*",
         "@koi/skill-tool": "workspace:*",
         "@koi/skills-runtime": "workspace:*",

--- a/packages/lib/skill-distiller/package.json
+++ b/packages/lib/skill-distiller/package.json
@@ -19,8 +19,5 @@
   "dependencies": {
     "@koi/core": "workspace:*",
     "@koi/hash": "workspace:*"
-  },
-  "koi": {
-    "optional": true
   }
 }

--- a/packages/meta/runtime/package.json
+++ b/packages/meta/runtime/package.json
@@ -121,6 +121,7 @@
     "@koi/scheduler-provider": "workspace:*",
     "@koi/session": "workspace:*",
     "@koi/settings": "workspace:*",
+    "@koi/skill-distiller": "workspace:*",
     "@koi/skill-scanner": "workspace:*",
     "@koi/skill-tool": "workspace:*",
     "@koi/playbook-store-sqlite": "workspace:*",

--- a/packages/meta/runtime/src/__tests__/golden-replay.test.ts
+++ b/packages/meta/runtime/src/__tests__/golden-replay.test.ts
@@ -16267,3 +16267,95 @@ describe("Golden: @koi/middleware-intent-capsule", () => {
     });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Golden: @koi/skill-distiller (no LLM, no cassette — pure pipeline)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Issue #1649 promises auto-distillation of reusable skills from successful
+// task traces, with content-hash dedupe, LRU eviction, and relevance ranking.
+// Exercise the full in-process pipeline with an injected stub LLM:
+//   policy gate → distiller (stub LLM JSON) → store (LRU) → relevance.rank.
+
+describe("Golden: @koi/skill-distiller", () => {
+  test("end-to-end: policy → distill → store → rank surfaces the skill", async () => {
+    const { createDistillationPolicy, createDistiller, createSkillStore, createRelevanceScorer } =
+      await import("@koi/skill-distiller");
+
+    const policy = createDistillationPolicy();
+    const outcome = {
+      traceId: "t-golden-1",
+      verdict: "verified" as const,
+      turnCount: 4,
+      toolCallCount: 2,
+    };
+    expect(policy.shouldDistill(outcome)).toBe(true);
+
+    const llmJson = JSON.stringify({
+      name: "format-pr",
+      description: "Format a PR title and body for review.",
+      triggers: ["format pr", "tidy pr"],
+      parameters: [{ name: "prNumber", description: "PR id", required: true }],
+      toolSequence: ["read_file", "write_file"],
+      expectedInputs: ["pr number"],
+      expectedOutputs: ["formatted markdown"],
+    });
+
+    const distiller = createDistiller({
+      llm: async () => ({ ok: true, value: llmJson }),
+      now: () => 1700000000000,
+    });
+    const trace = {
+      traceId: outcome.traceId,
+      sessionId: "s-golden-1",
+      turns: [
+        { role: "user" as const, text: "format pr 42" },
+        { role: "assistant" as const, toolCalls: [{ name: "read_file", argsJson: "{}" }] },
+        { role: "tool" as const, text: "ok" },
+        { role: "assistant" as const, text: "done" },
+      ],
+    };
+    const distilled = await distiller.distill(trace);
+    expect(distilled.ok).toBe(true);
+    if (!distilled.ok) return;
+
+    const store = createSkillStore({ maxSize: 8 });
+    expect(store.add(distilled.value)).toBe("added");
+
+    const scorer = createRelevanceScorer();
+    const ranked = scorer.rank("please format pr now", store.list());
+    expect(ranked.length).toBe(1);
+    expect(ranked[0]?.record.draft.name).toBe("format-pr");
+    expect(ranked[0]?.score).toBeGreaterThan(0);
+  });
+
+  test("dedupe + LRU eviction: re-add is duplicate; overflow evicts oldest", async () => {
+    const { createSkillStore } = await import("@koi/skill-distiller");
+    const draft = (name: string) => ({
+      draft: {
+        name,
+        description: name,
+        triggers: [],
+        parameters: [],
+        toolSequence: [name],
+        expectedInputs: [],
+        expectedOutputs: [],
+      },
+      source: { traceId: name, timestamp: 0, sourceHash: `src-${name}` },
+      draftHash: `hash-${name}`,
+    });
+
+    const evicted: string[] = [];
+    const store = createSkillStore({
+      maxSize: 2,
+      onEvicted: (r) => evicted.push(r.draft.name),
+    });
+    expect(store.add(draft("alpha"))).toBe("added");
+    expect(store.add(draft("alpha"))).toBe("duplicate");
+    expect(store.add(draft("beta"))).toBe("added");
+    expect(store.add(draft("gamma"))).toBe("added");
+    expect(evicted).toEqual(["alpha"]);
+    expect(store.size()).toBe(2);
+    expect(store.has("alpha")).toBe(false);
+  });
+});

--- a/packages/meta/runtime/tsconfig.json
+++ b/packages/meta/runtime/tsconfig.json
@@ -118,6 +118,7 @@
     { "path": "../../security/permissions" },
     { "path": "../../security/permissions-nexus" },
     { "path": "../../security/redaction" },
+    { "path": "../../lib/skill-distiller" },
     { "path": "../../security/skill-scanner" },
     { "path": "../../lib/skill-tool" },
     { "path": "../../lib/playbook-store-sqlite" },


### PR DESCRIPTION
## Summary

PR 4 of 4 toward [#1649](https://github.com/windoliver/koi/issues/1649). Stacked on top of #2108 (PR 3). Wires `@koi/skill-distiller` into `@koi/runtime` and adds two standalone golden tests.

- **Runtime wiring** — added `@koi/skill-distiller` to `packages/meta/runtime/package.json` dependencies and `tsconfig.json` references. Drops `koi.optional` now that the package has a real consumer.
- **Golden test 1 — end-to-end pipeline:** policy gate (`shouldDistill`) → `createDistiller` (with a stub LLM returning canned JSON) → `createSkillStore` (LRU) → `createRelevanceScorer.rank()` surfaces the distilled skill against the user query. Validates that all five new factories compose without runtime glue.
- **Golden test 2 — dedupe + LRU eviction:** re-adding the same `(name, hash)` returns `"duplicate"`; overflowing `maxSize=2` evicts the least-recently-used entry and fires `onEvicted("alpha")`.

No real-LLM cassette is recorded — this PR runs offline. The two standalone tests satisfy the per-L2 golden coverage rule (matches the pattern used by `@koi/playbook-store-sqlite`, `@koi/scratchpad-local`, etc.).

## Test plan

- [x] `bun test src/__tests__/golden-replay.test.ts -t "Golden: @koi/skill-distiller"` — 2 pass
- [x] `bun run check:orphans` — passes (104 L2 deps, including skill-distiller)
- [x] `bun run check:golden-queries` — passes (104 L2 deps with golden coverage)
- [x] `bun run check:layers` — passes
- [x] `bun run check:doc-gate`, `check:descriptions`, `check:doc-sync` — pass
- [x] `cd packages/lib/skill-distiller && bun test` — 67 pass / 0 fail (unchanged)
- [x] `cd packages/lib/skill-distiller && bun run typecheck` — clean

## Closes

Closes #1649 once the four-PR stack lands (#2104 → #2107 → #2108 → this).

## Base branch

Targets `feat/1649-skill-distillation-p3` (PR #2108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
