### PR TITLE
feat(sandbox): capability declarations + conformance hookups for sandbox-os and sandbox-docker (PR 2/4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1406,6 +1406,9 @@
       "dependencies": {
         "@koi/core": "workspace:*",
       },
+      "devDependencies": {
+        "@koi/sandbox-conformance": "workspace:*",
+      },
     },
     "packages/sandbox/sandbox-executor": {
       "name": "@koi/sandbox-executor",
@@ -1419,6 +1422,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@koi/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/sandbox-conformance": "workspace:*",
       },
     },
     "packages/sandbox/sandbox-router": {

--- a/docs/L2/sandbox-docker.md
+++ b/docs/L2/sandbox-docker.md
@@ -26,6 +26,73 @@ L2  @koi/sandbox-docker
 Docker is optional — `koi` field `optional: true`. Missing Docker yields a typed
 `SANDBOX_UNAVAILABLE` error from `createDockerAdapter`; nothing throws.
 
+## Capabilities
+
+Declared on the returned adapter (see `@koi/sandbox-router` for selection semantics):
+
+```
+supports: { exec, copy-files, network, filesystem-rw }
+priority: 10
+```
+
+`spawn` and `persistence` are intentionally NOT declared — the instance has no
+`spawn()` (use `exec()`) and the adapter has no `findOrCreate` (no cross-session
+container reuse).
+
+## Threat model
+
+### Trust boundary
+
+- Inside: code executed via `instance.exec(cmd, args)` — runs as the image's
+  default user inside an isolated container with the configured network and
+  filesystem policy applied.
+- Outside: the host kernel, the Docker daemon socket (`/var/run/docker.sock` or
+  configured path), all other host processes and files not bind-mounted in.
+
+### Privileged surfaces
+
+- **Docker daemon socket.** The default client connects to `dockerd` over a
+  Unix socket. Anyone who can talk to that socket can run arbitrary containers
+  on the host; treat it as root-equivalent. Limit access via Unix permissions.
+- **Image trust.** The `image` field controls which container starts. Untrusted
+  images can include backdoors or supply-chain implants. Pin to digests
+  (`@sha256:...`) in production.
+- **Bind mounts.** When the profile's `filesystem.allowRead`/`allowWrite` lists
+  host paths, those become readable/writable from inside the container.
+
+### Escape vectors
+
+- **Daemon-socket abuse:** code that gains the daemon socket inside a container
+  can spawn a privileged sibling container with the host filesystem mounted.
+  Mitigated by: never bind-mount the daemon socket into a sandboxed container.
+- **Kernel exploits:** containers share the host kernel; a kernel CVE can break
+  isolation. Mitigated by: keep the host kernel patched; configure
+  `--security-opt` profiles where available.
+- **Resource exhaustion:** without `--memory`/`--pids-limit`, a busy container
+  can starve the host. Mitigated by: `profile.resources` translates to
+  container limits; defaults are conservative.
+- **Filesystem leak:** bind-mounted paths grant read/write outside the
+  container. Mitigated by: profile `denyRead`/`denyWrite` are honored when
+  computing mount options; callers should declare the smallest path set needed.
+
+### Mitigations
+
+- Network defaults to `--network none` unless `profile.network.allow=true`.
+- Resources are clamped to the profile's `maxMemoryMb` / `maxPids` when set.
+- `instance.destroy()` removes the container; failures surface as typed errors.
+
+### Residual risk
+
+- Docker daemon socket compromise — out-of-scope for adapter; treat the daemon
+  as a trust-boundary above the adapter.
+- Kernel-level isolation gaps — adapter cannot defend against them.
+
+### Out-of-scope
+
+- Hardware side-channels (Spectre/Meltdown class).
+- Image supply-chain integrity (use Sigstore/cosign at a higher layer).
+- Multi-tenant host isolation (use a hypervisor-based sandbox for that tier).
+
 ## Public API
 
 ```typescript

--- a/docs/L2/sandbox-local.md
+++ b/docs/L2/sandbox-local.md
@@ -1,0 +1,125 @@
+# @koi/sandbox-os — OS-level Subprocess SandboxAdapter
+
+OS-level isolation via macOS `sandbox-exec` (Seatbelt) or Linux `bwrap`
+(Bubblewrap). Each call to `instance.exec(cmd, args)` spawns a child process
+with profile-derived isolation flags applied; long-lived state lives on the
+host filesystem (no container).
+
+## Why it exists
+
+For local-host workflows where Docker is overkill (no daemon, no image pull,
+no per-call cold-start). Pairs with `@koi/sandbox-docker` (containerized) and
+the future `@koi/sandbox-ssh` (remote).
+
+## Layer
+
+```
+L2  @koi/sandbox-os
+    depends on: @koi/core (L0)
+    does NOT import: @koi/engine (L1), peer L2
+```
+
+`@koi/sandbox-os` is `optional: true` — `createOsAdapter()` returns a typed
+`UNAVAILABLE` error when neither `sandbox-exec` (macOS) nor `bwrap` (Linux) is
+on `PATH`.
+
+## Capabilities
+
+Declared on the returned adapter (read by `@koi/sandbox-router`):
+
+```
+supports: { exec, network, filesystem-rw }
+priority: 0
+```
+
+`spawn`, `copy-files`, and `persistence` are intentionally NOT declared:
+
+- `spawn` — `instance.spawn` is not implemented in this adapter (callers should
+  use `instance.exec` and read the buffered result).
+- `copy-files` — `instance.readFile`/`writeFile` throw "use `@koi/nexus-fuse-mount`
+  for virtual FS." Direct host-FS reads/writes within profile-allowed paths are
+  the responsibility of the caller's code, not the adapter.
+- `persistence` — there is no per-instance state to detach/reattach; each `exec`
+  is run-to-completion against the host filesystem.
+
+## Public API
+
+```typescript
+import { createOsAdapter, type SandboxOsAdapter } from "@koi/sandbox-os";
+
+const result = createOsAdapter();
+if (!result.ok) {
+  // result.error.code === "UNAVAILABLE" or platform-specific error
+  return;
+}
+const adapter: SandboxOsAdapter = result.value;
+// adapter.platform.platform === "seatbelt" | "bwrap"
+// adapter.capabilities, adapter.version available for the router
+```
+
+`adapter.create(profile)` validates the profile against the detected platform
+(seatbelt has different rules than bwrap) and returns a `SandboxInstance`.
+`instance.exec(cmd, args, opts)` spawns a child with the seatbelt/bwrap prefix
+applied; output is buffered up to `opts.maxOutputBytes` (default 1 MB).
+
+## Threat model
+
+### Trust boundary
+
+- Inside: code executed via `instance.exec(cmd, args)` — runs as the calling
+  user, inside a Seatbelt or bwrap profile that restricts filesystem and
+  network access per `SandboxProfile`.
+- Outside: anything not allowed by the profile — host PATH binaries not
+  explicitly permitted, network destinations not allowed, filesystem paths
+  outside `allowRead`/`allowWrite`.
+
+### Privileged surfaces
+
+- **Parent process.** The sandboxed child is a descendant of the calling Bun
+  process; signals propagate up the process tree. A misuse of `process.kill`
+  in the parent could affect siblings.
+- **Profile policy authoring.** A profile that mistakenly grants `network.allow=true`
+  or wide `allowWrite` paths weakens isolation. Profile validation runs at
+  `create(profile)` time.
+- **Environment variables.** `profile.env` overlays caller-supplied env onto the
+  child process. Secrets in env are visible to the child.
+
+### Escape vectors
+
+- **Seatbelt allow-rule loopholes:** Seatbelt profiles can be fooled by
+  symlink races or escaped path patterns. Mitigated by: profile generator
+  uses canonical paths, no glob expansion at runtime.
+- **bwrap setuid issues:** unprivileged bubblewrap on certain kernels (AppArmor
+  user-namespace restriction) cannot create the namespace. Mitigated by:
+  `isAppArmorUserNsRestricted()` detects the condition; `createOsAdapter()`
+  returns `UNAVAILABLE` rather than silently falling back to no isolation.
+- **Resource limits not enforced when systemd-run unavailable:** cgroup v2
+  memory/pids enforcement requires `systemd-run --user`. When absent on Linux,
+  resource limits are best-effort. Mitigated by: detection probe
+  (`probeSystemdRunUser`) — when absent, callers must accept reduced enforcement.
+- **Path-traversal in deny lists:** `denyRead`/`denyWrite` are checked by the
+  underlying sandbox, not the adapter — mistakes in profile authorship leak.
+
+### Mitigations
+
+- Profile validation rejects malformed paths and conflicting allow/deny rules.
+- Network defaults to `allow: false` and is enforced by the kernel-level
+  sandbox.
+- Output is bounded (`maxOutputBytes`) to prevent host memory exhaustion.
+- `AbortSignal` integration kills the child process group (and the systemd
+  scope, if used) on cancel.
+
+### Residual risk
+
+- A kernel-level vulnerability in Seatbelt/bwrap defeats this layer entirely.
+- A caller that mounts the host FS via `allowWrite: ["/"]` has effectively
+  disabled isolation. Adapter does not refuse such profiles — that is policy.
+- `readFile`/`writeFile` not implemented: callers needing virtual FS must
+  compose with `@koi/nexus-fuse-mount` or another L2 package.
+
+### Out-of-scope
+
+- Hardware side-channel attacks.
+- Mitigations against parent-process compromise (the parent is trusted).
+- Multi-user host isolation (single-user assumption — Seatbelt and unprivileged
+  bwrap are user-scoped).

--- a/packages/sandbox/sandbox-docker/package.json
+++ b/packages/sandbox/sandbox-docker/package.json
@@ -22,5 +22,7 @@
   "dependencies": {
     "@koi/core": "workspace:*"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@koi/sandbox-conformance": "workspace:*"
+  }
 }

--- a/packages/sandbox/sandbox-docker/src/__tests__/conformance.test.ts
+++ b/packages/sandbox/sandbox-docker/src/__tests__/conformance.test.ts
@@ -1,0 +1,51 @@
+import type { SandboxAdapter, SandboxProfile } from "@koi/core";
+import { describeSandboxConformance } from "@koi/sandbox-conformance";
+import { createDockerAdapter } from "../adapter.js";
+import type { DockerClient } from "../types.js";
+
+// Stubbed Docker client — conformance verifies adapter contract shape, not
+// real Docker daemon behavior. The DOCKER_E2E=1 integration suite covers
+// real-daemon paths.
+const stubClient: DockerClient = {
+  createContainer: async () => ({
+    id: "c1",
+    exec: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+    readFile: async () => new Uint8Array(),
+    writeFile: async () => {},
+    stop: async () => {},
+    remove: async () => {},
+  }),
+};
+
+const profile: SandboxProfile = {
+  filesystem: { defaultReadAccess: "open" },
+  network: { allow: false },
+  resources: {},
+};
+
+async function makeAdapter(): Promise<SandboxAdapter> {
+  const result = await createDockerAdapter({ client: stubClient });
+  if (!result.ok) throw new Error(`createDockerAdapter failed: ${result.error.message}`);
+  return result.value;
+}
+
+// `describeSandboxConformance` expects a synchronous factory. We pre-build a
+// shared adapter; each test that needs a fresh one re-uses this reference
+// (the conformance suite tolerates this — it does not mutate the adapter).
+let cached: SandboxAdapter | undefined;
+async function getAdapter(): Promise<SandboxAdapter> {
+  if (cached === undefined) cached = await makeAdapter();
+  return cached;
+}
+
+// Eagerly resolve before describe() runs so the synchronous factory works.
+await getAdapter();
+
+describeSandboxConformance(
+  "@koi/sandbox-docker",
+  () => {
+    if (cached === undefined) throw new Error("adapter not initialized");
+    return cached;
+  },
+  () => profile,
+);

--- a/packages/sandbox/sandbox-docker/src/adapter.ts
+++ b/packages/sandbox/sandbox-docker/src/adapter.ts
@@ -1,10 +1,32 @@
-import type { KoiError, Result, SandboxAdapter, SandboxProfile } from "@koi/core";
+import type {
+  AdapterCapabilities,
+  AdapterCapability,
+  KoiError,
+  Result,
+  SandboxAdapter,
+  SandboxProfile,
+} from "@koi/core";
 import { createDefaultDockerClient } from "./default-client.js";
 import { detectDocker } from "./detect.js";
 import { createDockerInstance } from "./instance.js";
 import { mapProfileToDockerOpts } from "./profile-to-opts.js";
 import type { DockerAdapterConfig } from "./types.js";
 import { validateDockerConfig } from "./validate.js";
+
+// Honest declaration: sandbox-docker instance has no spawn (use exec()),
+// adapter has no findOrCreate (no persistence). Profile-controlled network
+// and filesystem-rw are supported.
+const SANDBOX_DOCKER_SUPPORTED: ReadonlySet<AdapterCapability> = new Set<AdapterCapability>([
+  "exec",
+  "copy-files",
+  "network",
+  "filesystem-rw",
+]);
+
+const SANDBOX_DOCKER_CAPABILITIES: AdapterCapabilities = {
+  supports: SANDBOX_DOCKER_SUPPORTED,
+  priority: 10,
+};
 
 /**
  * Create a Docker sandbox adapter.
@@ -63,6 +85,8 @@ function buildAdapter(
     ok: true,
     value: {
       name: "docker",
+      version: "0.1.0",
+      capabilities: SANDBOX_DOCKER_CAPABILITIES,
       create: async (profile: SandboxProfile) => {
         const mapping = mapProfileToDockerOpts(profile, image);
         if (!mapping.ok) {

--- a/packages/sandbox/sandbox-os/package.json
+++ b/packages/sandbox/sandbox-os/package.json
@@ -22,5 +22,7 @@
   "dependencies": {
     "@koi/core": "workspace:*"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@koi/sandbox-conformance": "workspace:*"
+  }
 }

--- a/packages/sandbox/sandbox-os/src/__tests__/conformance.test.ts
+++ b/packages/sandbox/sandbox-os/src/__tests__/conformance.test.ts
@@ -1,0 +1,22 @@
+import type { SandboxProfile } from "@koi/core";
+import { describeSandboxConformance } from "@koi/sandbox-conformance";
+import { createOsAdapterForTest } from "../adapter.js";
+
+// Use the test factory so the suite runs without requiring sandbox-exec/bwrap
+// to be installed in the test environment. The conformance suite checks
+// adapter contract shape, not real subprocess isolation.
+const profile: SandboxProfile = {
+  filesystem: { defaultReadAccess: "open" },
+  network: { allow: false },
+  resources: {},
+};
+
+describeSandboxConformance(
+  "@koi/sandbox-os",
+  () =>
+    createOsAdapterForTest({
+      platform: "seatbelt",
+      available: true,
+    }),
+  () => profile,
+);

--- a/packages/sandbox/sandbox-os/src/adapter.ts
+++ b/packages/sandbox/sandbox-os/src/adapter.ts
@@ -1,4 +1,6 @@
 import type {
+  AdapterCapabilities,
+  AdapterCapability,
   KoiError,
   Result,
   SandboxAdapter,
@@ -24,6 +26,20 @@ import { buildSeatbeltPrefix, generateSeatbeltProfile } from "./platform/seatbel
 import { validateProfile } from "./validate.js";
 
 const DEFAULT_MAX_OUTPUT_BYTES = 1_048_576; // 1 MB — matches @koi/middleware-sandbox default
+
+// Honest declaration: sandbox-os instance.spawn is NOT implemented; readFile/writeFile
+// throw "not implemented — use @koi/nexus-fuse-mount for virtual FS". Only `exec`,
+// `network`, and `filesystem-rw` (host FS access permitted by profile) are real.
+const SANDBOX_OS_SUPPORTED: ReadonlySet<AdapterCapability> = new Set<AdapterCapability>([
+  "exec",
+  "network",
+  "filesystem-rw",
+]);
+
+const SANDBOX_OS_CAPABILITIES: AdapterCapabilities = {
+  supports: SANDBOX_OS_SUPPORTED,
+  priority: 0,
+};
 
 // Module-level cache — systemd-run --user requires an active D-Bus user session.
 // Bun.which() only checks PATH; this probe verifies the user session is reachable.
@@ -380,6 +396,8 @@ export function createOsAdapterForTest(opts: {
 }): SandboxOsAdapter {
   return {
     name: "@koi/sandbox-os",
+    version: "0.1.0",
+    capabilities: SANDBOX_OS_CAPABILITIES,
     platform: {
       platform: opts.platform,
       available: opts.available,


### PR DESCRIPTION
## Summary

PR 2 of issue #1641 (multi-backend executor). **Stacks on top of PR #2109** — `base` is the PR 1 branch. Will rebase to `main` after PR 1 merges.

Discovered during planning that `@koi/sandbox-os` is **already** a `SandboxAdapter` (`createOsAdapter()` returns one). Original PR 2 plan to "wrap sandbox-os primitives into an adapter" was redundant. This revised PR 2 instead declares capabilities on both existing adapters and wires the conformance suite from PR 1.

- **`@koi/sandbox-os`:** declares `{exec, network, filesystem-rw}`, priority 0. `spawn`/`copy-files` intentionally NOT declared (`spawn` not implemented; `readFile`/`writeFile` throw "use `@koi/nexus-fuse-mount`"). The `capability-honesty` conformance group catches lying.
- **`@koi/sandbox-docker`:** declares `{exec, copy-files, network, filesystem-rw}`, priority 10. `spawn`/`persistence` NOT declared (instance has no `spawn`; adapter has no `findOrCreate`).
- **Conformance hookups:** both packages add `__tests__/conformance.test.ts` calling `describeSandboxConformance` with an in-process fake (`createOsAdapterForTest` for sandbox-os; `stubClient` for sandbox-docker). 7 conformance tests pass per package.
- **Docs:** new `docs/L2/sandbox-local.md` with threat model; updated `docs/L2/sandbox-docker.md` with capabilities + threat-model section using the template from PR 1.

## Scope reduction

The original 5-PR plan compressed to **3 remaining PRs**:
- ~~PR 2 (original): `@koi/sandbox-local` wrapping sandbox-os~~ → **collapsed: sandbox-os already an adapter**
- ~~PR 3 (original): `@koi/sandbox-docker` capability declaration~~ → **collapsed into this PR**
- This PR: capability declarations + conformance for both existing adapters
- Future PR 3 (was 4): `@koi/sandbox-ssh` new package
- Future PR 4 (was 5): `@koi/runtime` wiring + golden queries

## Test plan

- [ ] `bun run typecheck` — PASS
- [ ] `bun run check:layers` — PASS
- [ ] `bun test packages/sandbox/sandbox-os/` — existing 154 + new 7 conformance pass
- [ ] `bun test packages/sandbox/sandbox-docker/` — existing tests + new 7 conformance pass
- [ ] DOCKER_E2E=1 conformance still gated and unaffected
- [ ] No regressions in `@koi/sandbox-router` (40 router+conformance tests still pass)