### PR TITLE
feat(sandbox-ssh): SSH-backed remote SandboxAdapter (PR 3/4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1434,6 +1434,18 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/sandbox/sandbox-ssh": {
+      "name": "@koi/sandbox-ssh",
+      "version": "0.1.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "ssh2": "1.16.0",
+      },
+      "devDependencies": {
+        "@koi/sandbox-conformance": "workspace:*",
+        "@types/ssh2": "1.15.5",
+      },
+    },
     "packages/sched/scheduler": {
       "name": "@koi/scheduler",
       "version": "0.0.0",
@@ -2255,6 +2267,8 @@
 
     "@koi/sandbox-router": ["@koi/sandbox-router@workspace:packages/sandbox/sandbox-router"],
 
+    "@koi/sandbox-ssh": ["@koi/sandbox-ssh@workspace:packages/sandbox/sandbox-ssh"],
+
     "@koi/scheduler": ["@koi/scheduler@workspace:packages/sched/scheduler"],
 
     "@koi/scheduler-provider": ["@koi/scheduler-provider@workspace:packages/sched/scheduler-provider"],
@@ -2723,6 +2737,8 @@
 
     "@types/sinonjs__fake-timers": ["@types/sinonjs__fake-timers@15.0.1", "", {}, "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w=="],
 
+    "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
@@ -2791,6 +2807,8 @@
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
+    "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
     "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
 
     "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
@@ -2813,6 +2831,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.24", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA=="],
 
+    "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "blamer": ["blamer@1.0.7", "", { "dependencies": { "execa": "^4.0.0", "which": "^2.0.2" } }, "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA=="],
@@ -2832,6 +2852,8 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
 
@@ -2896,6 +2918,8 @@
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "croner": ["croner@9.0.0", "", {}, "sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA=="],
 
@@ -3225,6 +3249,8 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
+    "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
@@ -3473,6 +3499,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "ssh2": ["ssh2@1.16.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.20.0" } }, "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg=="],
+
     "stage-js": ["stage-js@1.0.2", "", {}, "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -3542,6 +3570,8 @@
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
@@ -3695,6 +3725,8 @@
 
     "@smithy/smithy-client/@smithy/util-stream": ["@smithy/util-stream@4.5.25", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA=="],
 
+    "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-keywords/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -3780,6 +3812,8 @@
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@17.67.0", "", { "dependencies": { "@jsonjoy.com/util": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA=="],
 
     "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
+
+    "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/docs/L2/sandbox-ssh.md
+++ b/docs/L2/sandbox-ssh.md
@@ -1,0 +1,132 @@
+# @koi/sandbox-ssh — Remote-host SandboxAdapter via SSH
+
+Implements `SandboxAdapter` against a remote host over SSH. Each `create(profile)`
+call opens an SSH connection (or reuses one from the pool when called via
+`findOrCreate(scope, profile)`); `instance.exec` runs the command remotely with
+POSIX shell quoting; `readFile`/`writeFile` go over SFTP.
+
+## Why it exists
+
+Some workflows need to run tools on a remote machine — a CI runner, a GPU
+workstation, a customer's bastion host. SSH is the universal transport for
+exactly this case. Pairs with the local subprocess adapter (`@koi/sandbox-os`)
+and the containerized adapter (`@koi/sandbox-docker`).
+
+## Layer
+
+```
+L2  @koi/sandbox-ssh
+    depends on: @koi/core (L0), ssh2 (npm)
+    does NOT import: @koi/engine (L1), peer L2
+```
+
+`@koi/sandbox-ssh` is `optional: true` — callers who never configure
+`profile.ssh` won't load it.
+
+## Capabilities
+
+```
+supports: { exec, copy-files, persistence, network }
+priority: 20
+```
+
+`spawn` and `filesystem-rw` are intentionally NOT declared:
+
+- `spawn` — `instance.spawn` is not implemented (no interactive PTY in this PR;
+  callers who need it should use `instance.exec` with a remote multiplexer).
+- `filesystem-rw` — write authority depends on the SSH user's permissions on
+  the remote host, not on the adapter. Declaring would lie about a guarantee
+  that lives outside the adapter.
+
+`persistence` IS declared because `findOrCreate(scope, profile)` reuses a
+single SSH connection per scope key across calls.
+
+## Public API
+
+```typescript
+import { createSshAdapter, defaultSshClientFactory } from "@koi/sandbox-ssh";
+
+const adapter = createSshAdapter({ clientFactory: defaultSshClientFactory });
+
+const profile = {
+  filesystem: { defaultReadAccess: "open" },
+  network: { allow: true },
+  resources: {},
+  ssh: { host: "remote.example", user: "ci", keyPath: "/etc/koi/ci_id_ed25519" },
+};
+
+const instance = await adapter.create(profile);
+const out = await instance.exec("ls", ["-la", "/tmp"]);
+// out.stdout / out.stderr / out.exitCode / out.durationMs
+await instance.destroy();
+```
+
+`profile.ssh` is REQUIRED for every `create()` call — profiles without it are
+rejected with a typed `VALIDATION` error. The `clientFactory` is dependency-injected
+so tests can supply a stub. The default factory wraps `ssh2.Client.connect`.
+
+## Threat model
+
+### Trust boundary
+
+- Inside: code executed via `instance.exec(cmd, args)` — runs on the remote
+  host as the SSH user, with whatever permissions that user has there.
+- Outside: the SSH transport (network), the remote host's other processes and
+  files, the local key file used for authentication.
+
+### Privileged surfaces
+
+- **Private key file.** `profile.ssh.keyPath` points to a private key the
+  calling process must be able to read. Treat as a credential — protect file
+  permissions (0600), rotate, audit access.
+- **Remote user account.** Whatever the SSH user can do, sandboxed code can
+  do. Use a least-privileged role (no sudo, no root login). Pair with a
+  remote-side wrapper if you need finer-grained policy than the user account
+  provides.
+- **Network path.** SSH transport is encrypted but not censored — anything the
+  remote host can reach, this adapter can reach.
+
+### Escape vectors
+
+- **Shell injection at the quoting boundary.** `composeCommandLine` quotes args
+  via POSIX single-quoting; literal single quotes inside an arg are escaped via
+  close-escape-reopen. Unit tests exercise injection vectors (`$(...)`, backticks,
+  `;|&`). Mitigated as long as callers use `(cmd, args)` and never pre-format
+  shell strings.
+- **Host-key acceptance.** The default factory does not configure
+  `hostHash`/`hostVerifier` — `ssh2` falls back to its built-in defaults. For
+  production, callers should provide a custom factory with strict
+  `~/.ssh/known_hosts` verification. Mitigated by: documenting this; future
+  PRs may add explicit host-key pinning to the `SshTarget` shape.
+- **Connection hijacking via key compromise.** A leaked key gives full SSH
+  access. Mitigated by: per-environment keys, hardware-backed keys (yubikey),
+  short-lived certificates. The adapter is agnostic.
+- **Pool entry stale connection.** `findOrCreate` returns the same client
+  across calls; if the underlying TCP connection drops, subsequent calls
+  fail. Mitigated by: `instance.destroy` removes the pool entry on close;
+  callers must catch and retry on transport-level errors.
+
+### Mitigations
+
+- Mandatory `profile.ssh` validation at `create()` — no implicit defaults.
+- POSIX-correct argument quoting (single source of truth in `quote.ts`).
+- Idempotent `destroy()` — calling twice is a no-op.
+- Per-scope connection pool prevents fork-bombing the remote host with new
+  connections per call.
+
+### Residual risk
+
+- Host-key trust is delegated to `ssh2`'s defaults; the adapter doesn't
+  enforce strict pinning by default. Callers building security-sensitive
+  flows should supply a custom `clientFactory`.
+- The remote host is, by definition, outside the trust boundary of the adapter.
+- Key rotation is a caller concern — adapter does not detect stale keys.
+
+### Out-of-scope
+
+- SSH agent forwarding (intentionally not configured; risk of agent hijack
+  outweighs convenience).
+- Password / keyboard-interactive auth (key auth only by design — no password
+  field exists on `SandboxSshTarget`).
+- Multiplexing (`ControlMaster`-style) — `findOrCreate` provides
+  per-scope reuse, which is sufficient for current use cases.

--- a/packages/sandbox/sandbox-ssh/package.json
+++ b/packages/sandbox/sandbox-ssh/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@koi/sandbox-ssh",
+  "description": "SSH-backed SandboxAdapter for remote command execution via ssh2",
+  "version": "0.1.0",
+  "private": true,
+  "koi": {
+    "optional": true
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "ssh2": "1.16.0"
+  },
+  "devDependencies": {
+    "@koi/sandbox-conformance": "workspace:*",
+    "@types/ssh2": "1.15.5"
+  }
+}

--- a/packages/sandbox/sandbox-ssh/src/__tests__/conformance.test.ts
+++ b/packages/sandbox/sandbox-ssh/src/__tests__/conformance.test.ts
@@ -1,0 +1,33 @@
+import type { SandboxProfile } from "@koi/core";
+import { describeSandboxConformance } from "@koi/sandbox-conformance";
+import { createSshAdapter } from "../adapter.js";
+import type { SshClient, SshClientFactory } from "../types.js";
+
+// Stub factory — conformance verifies the adapter contract shape, not real
+// SSH transport. The SSH_E2E env-gated suite (future) covers real-server
+// roundtrips. The 3 PR-1 conformance groups (lifecycle, create+destroy,
+// capability-honesty) all run cleanly against this stub.
+const stubFactory: SshClientFactory = {
+  connect: async () => {
+    const client: SshClient = {
+      exec: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+      readFile: async () => new Uint8Array(),
+      writeFile: async () => {},
+      end: async () => {},
+    };
+    return client;
+  },
+};
+
+const profile: SandboxProfile = {
+  filesystem: { defaultReadAccess: "open" },
+  network: { allow: true },
+  resources: {},
+  ssh: { host: "stub.example", user: "user", keyPath: "/tmp/no-such-key" },
+};
+
+describeSandboxConformance(
+  "@koi/sandbox-ssh",
+  () => createSshAdapter({ clientFactory: stubFactory }),
+  () => profile,
+);

--- a/packages/sandbox/sandbox-ssh/src/adapter.test.ts
+++ b/packages/sandbox/sandbox-ssh/src/adapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxProfile } from "@koi/core";
+import { createSshAdapter } from "./adapter.js";
+import type { SshClient, SshClientFactory, SshExecResult } from "./types.js";
+
+interface StubControls {
+  readonly execResult?: SshExecResult;
+  readonly execError?: Error;
+  readonly readFileBytes?: Uint8Array;
+  readonly connectError?: Error;
+}
+
+let connectCallCount = 0;
+let endCallCount = 0;
+interface Trace {
+  lastCommandLine: string | undefined;
+}
+const trace: Trace = { lastCommandLine: undefined };
+
+function fakeFactory(controls: StubControls = {}): SshClientFactory {
+  return {
+    connect: async (_target) => {
+      if (controls.connectError !== undefined) throw controls.connectError;
+      connectCallCount++;
+      const client: SshClient = {
+        exec: async (line) => {
+          trace.lastCommandLine = line;
+          if (controls.execError !== undefined) throw controls.execError;
+          return controls.execResult ?? { exitCode: 0, stdout: "ok\n", stderr: "" };
+        },
+        readFile: async (_path) => controls.readFileBytes ?? new Uint8Array([1, 2, 3]),
+        writeFile: async (_path, _data) => {},
+        end: async () => {
+          endCallCount++;
+        },
+      };
+      return client;
+    },
+  };
+}
+
+function profile(overrides: Partial<SandboxProfile> = {}): SandboxProfile {
+  return {
+    filesystem: { defaultReadAccess: "open" },
+    network: { allow: true },
+    resources: {},
+    ssh: { host: "ex.com", user: "user", keyPath: "/tmp/k" },
+    ...overrides,
+  };
+}
+
+describe("createSshAdapter", () => {
+  test("declares capabilities {exec, copy-files, persistence, network} priority 20", () => {
+    const adapter = createSshAdapter({ clientFactory: fakeFactory() });
+    const caps = adapter.capabilities;
+    expect(caps).toBeDefined();
+    if (caps === undefined) throw new Error("no caps");
+    expect(caps.priority).toBe(20);
+    expect([...caps.supports].sort()).toEqual(["copy-files", "exec", "network", "persistence"]);
+  });
+
+  test("create() opens an SSH connection and returns a SandboxInstance", async () => {
+    connectCallCount = 0;
+    const adapter = createSshAdapter({ clientFactory: fakeFactory() });
+    const instance = await adapter.create(profile());
+    expect(typeof instance.exec).toBe("function");
+    expect(typeof instance.destroy).toBe("function");
+    expect(connectCallCount).toBe(1);
+    await instance.destroy();
+  });
+
+  test("create() rejects when profile.ssh is missing", async () => {
+    const adapter = createSshAdapter({ clientFactory: fakeFactory() });
+    const noSsh: SandboxProfile = {
+      filesystem: { defaultReadAccess: "open" },
+      network: { allow: true },
+      resources: {},
+    };
+    await expect(adapter.create(noSsh)).rejects.toThrow(/profile\.ssh is required/);
+  });
+
+  test("instance.exec quotes args via composeCommandLine and returns the result", async () => {
+    trace.lastCommandLine = undefined;
+    const adapter = createSshAdapter({
+      clientFactory: fakeFactory({
+        execResult: { exitCode: 0, stdout: "hi", stderr: "" },
+      }),
+    });
+    const instance = await adapter.create(profile());
+    const r = await instance.exec("echo", ["hello world"]);
+    expect(trace.lastCommandLine ?? "").toBe("'echo' 'hello world'");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("hi");
+    await instance.destroy();
+  });
+
+  test("instance.destroy is idempotent — second call is a no-op", async () => {
+    endCallCount = 0;
+    const adapter = createSshAdapter({ clientFactory: fakeFactory() });
+    const instance = await adapter.create(profile());
+    await instance.destroy();
+    await instance.destroy();
+    expect(endCallCount).toBe(1);
+  });
+
+  test("findOrCreate reuses the SSH connection per scope key", async () => {
+    connectCallCount = 0;
+    const adapter = createSshAdapter({ clientFactory: fakeFactory() });
+    if (adapter.findOrCreate === undefined) throw new Error("findOrCreate must exist");
+    const i1 = await adapter.findOrCreate("scope-A", profile());
+    const i2 = await adapter.findOrCreate("scope-A", profile());
+    expect(connectCallCount).toBe(1);
+    await i1.destroy(); // closes pool entry
+    const i3 = await adapter.findOrCreate("scope-A", profile());
+    expect(connectCallCount).toBe(2); // re-opened after destroy
+    await i2.destroy(); // already closed connection — idempotent end
+    await i3.destroy();
+  });
+
+  test("connect failure surfaces as a typed thrown Error with cause", async () => {
+    const adapter = createSshAdapter({
+      clientFactory: fakeFactory({ connectError: new Error("auth denied") }),
+    });
+    await expect(adapter.create(profile())).rejects.toThrow(/failed to connect/);
+  });
+});

--- a/packages/sandbox/sandbox-ssh/src/adapter.ts
+++ b/packages/sandbox/sandbox-ssh/src/adapter.ts
@@ -1,0 +1,104 @@
+import type {
+  AdapterCapabilities,
+  AdapterCapability,
+  KoiError,
+  Result,
+  SandboxAdapter,
+  SandboxInstance,
+  SandboxProfile,
+} from "@koi/core";
+import { createSshInstance } from "./instance.js";
+import type { SshAdapterConfig, SshClient } from "./types.js";
+
+const SANDBOX_SSH_SUPPORTED: ReadonlySet<AdapterCapability> = new Set<AdapterCapability>([
+  "exec",
+  "copy-files",
+  "persistence",
+  "network",
+]);
+
+const SANDBOX_SSH_CAPABILITIES: AdapterCapabilities = {
+  supports: SANDBOX_SSH_SUPPORTED,
+  priority: 20,
+};
+
+/**
+ * Create a SandboxAdapter that opens SSH connections per `create()` call and
+ * tracks them by scope key for `findOrCreate` reuse. Closing happens via
+ * `instance.destroy()` (or the caller calling the adapter's optional pool
+ * teardown — currently not exposed; pool entries persist for the lifetime of
+ * the process).
+ *
+ * `profile.ssh` MUST be set on every profile passed to `create()`. Profiles
+ * without `ssh` are rejected with a typed `VALIDATION` error.
+ *
+ * `filesystem-rw` is NOT declared because remote write authority depends on
+ * the SSH user's permissions, not the adapter — declaring it here would lie
+ * about a guarantee we can't enforce.
+ */
+export function createSshAdapter(config: SshAdapterConfig): SandboxAdapter {
+  const pool: Map<string, SshClient> = new Map();
+
+  async function connectFromProfile(profile: SandboxProfile): Promise<Result<SshClient, KoiError>> {
+    const target = profile.ssh;
+    if (target === undefined) {
+      const error: KoiError = {
+        code: "VALIDATION",
+        message: "sandbox-ssh: profile.ssh is required",
+        retryable: false,
+      };
+      return { ok: false, error };
+    }
+    try {
+      const client = await config.clientFactory.connect(target);
+      return { ok: true, value: client };
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          code: "EXTERNAL",
+          message: `sandbox-ssh: failed to connect to ${target.user}@${target.host}`,
+          retryable: false,
+          cause: err,
+        },
+      };
+    }
+  }
+
+  return {
+    name: "@koi/sandbox-ssh",
+    version: "0.1.0",
+    capabilities: SANDBOX_SSH_CAPABILITIES,
+    async create(profile: SandboxProfile): Promise<SandboxInstance> {
+      const r = await connectFromProfile(profile);
+      if (!r.ok) {
+        throw new Error(r.error.message, { cause: r.error });
+      }
+      return createSshInstance(r.value);
+    },
+    async findOrCreate(scope: string, profile: SandboxProfile): Promise<SandboxInstance> {
+      const existing = pool.get(scope);
+      if (existing !== undefined) {
+        return createSshInstance(existing);
+      }
+      const r = await connectFromProfile(profile);
+      if (!r.ok) {
+        throw new Error(r.error.message, { cause: r.error });
+      }
+      pool.set(scope, r.value);
+      // The pool retains the connection; instance.destroy will close it AND
+      // remove the pool entry to avoid handing out a closed client next time.
+      const instance = createSshInstance(r.value);
+      const originalDestroy = instance.destroy;
+      return {
+        ...instance,
+        destroy: async () => {
+          pool.delete(scope);
+          await originalDestroy.call(instance);
+        },
+      };
+    },
+  };
+}
+
+export type { SshAdapterConfig, SshClient, SshClientFactory } from "./types.js";

--- a/packages/sandbox/sandbox-ssh/src/default-client.ts
+++ b/packages/sandbox/sandbox-ssh/src/default-client.ts
@@ -1,0 +1,116 @@
+/**
+ * Default `SshClient` backed by the `ssh2` npm package. The factory:
+ *
+ *   1. Reads the private key from `target.keyPath` (callers must pre-grant FS access).
+ *   2. Calls `ssh2.Client.connect` with strict host-key handling left to the caller's
+ *      `~/.ssh/known_hosts` (`hostHash`/`hostVerifier` not configured here).
+ *   3. Resolves with a wrapper exposing exec / readFile / writeFile / end.
+ *
+ * Each `exec` call opens a fresh channel; the connection itself is reused for the
+ * lifetime of the wrapper (one connection per `SandboxInstance`).
+ */
+
+import { readFile as fsReadFile } from "node:fs/promises";
+import { Client } from "ssh2";
+import type { SshClient, SshClientFactory, SshExecResult, SshTarget } from "./types.js";
+
+async function loadPrivateKey(keyPath: string): Promise<Buffer> {
+  return fsReadFile(keyPath);
+}
+
+function execOnce(client: Client, command: string): Promise<SshExecResult> {
+  return new Promise((resolve, reject) => {
+    client.exec(command, (err, stream) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+        return;
+      }
+      let stdout = "";
+      let stderr = "";
+      let exitCode = 0;
+      stream.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf8");
+      });
+      stream.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf8");
+      });
+      stream.on("exit", (code: number | null) => {
+        exitCode = code ?? -1;
+      });
+      stream.on("close", () => {
+        resolve({ exitCode, stdout, stderr });
+      });
+      stream.on("error", reject);
+    });
+  });
+}
+
+async function sftpReadFile(client: Client, path: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    client.sftp((err, sftp) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+        return;
+      }
+      sftp.readFile(path, (rerr, data) => {
+        sftp.end();
+        if (rerr !== undefined && rerr !== null) {
+          reject(rerr);
+          return;
+        }
+        resolve(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+      });
+    });
+  });
+}
+
+async function sftpWriteFile(client: Client, path: string, data: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    client.sftp((err, sftp) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+        return;
+      }
+      sftp.writeFile(path, Buffer.from(data), (werr) => {
+        sftp.end();
+        if (werr !== undefined && werr !== null) {
+          reject(werr);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+}
+
+function endClient(client: Client): Promise<void> {
+  return new Promise((resolve) => {
+    client.on("close", () => resolve());
+    client.end();
+  });
+}
+
+async function connect(target: SshTarget): Promise<SshClient> {
+  const privateKey = await loadPrivateKey(target.keyPath);
+  const client = new Client();
+  await new Promise<void>((resolve, reject) => {
+    client.on("ready", () => resolve());
+    client.on("error", reject);
+    client.connect({
+      host: target.host,
+      username: target.user,
+      privateKey,
+    });
+  });
+
+  return {
+    exec: (command: string) => execOnce(client, command),
+    readFile: (path: string) => sftpReadFile(client, path),
+    writeFile: (path: string, data: Uint8Array) => sftpWriteFile(client, path, data),
+    end: () => endClient(client),
+  };
+}
+
+export const defaultSshClientFactory: SshClientFactory = {
+  connect,
+};

--- a/packages/sandbox/sandbox-ssh/src/index.ts
+++ b/packages/sandbox/sandbox-ssh/src/index.ts
@@ -1,0 +1,9 @@
+export { createSshAdapter } from "./adapter.js";
+export { defaultSshClientFactory } from "./default-client.js";
+export type {
+  SshAdapterConfig,
+  SshClient,
+  SshClientFactory,
+  SshExecResult,
+  SshTarget,
+} from "./types.js";

--- a/packages/sandbox/sandbox-ssh/src/instance.ts
+++ b/packages/sandbox/sandbox-ssh/src/instance.ts
@@ -1,0 +1,73 @@
+import type { SandboxAdapterResult, SandboxExecOptions, SandboxInstance } from "@koi/core";
+import { composeCommandLine } from "./quote.js";
+import type { SshClient } from "./types.js";
+
+const DEFAULT_MAX_OUTPUT_BYTES = 1_048_576; // 1 MB — matches sandbox-os default
+
+/**
+ * Build a SandboxInstance backed by a connected SSH client.
+ *
+ * `exec` quotes the command + args via `composeCommandLine` (POSIX shell
+ * escaping) and runs over the existing SSH connection. `readFile`/`writeFile`
+ * proxy to the client's SFTP wrappers.
+ *
+ * `destroy` closes the SSH connection. Subsequent calls on this instance
+ * become rejected promises (the underlying ssh2 connection refuses ops once
+ * `end()` has been called).
+ */
+export function createSshInstance(client: SshClient): SandboxInstance {
+  let destroyed = false;
+
+  return {
+    async exec(
+      command: string,
+      args: readonly string[],
+      opts?: SandboxExecOptions,
+    ): Promise<SandboxAdapterResult> {
+      if (destroyed) {
+        throw new Error("sandbox-ssh: instance has been destroyed");
+      }
+      const start = Date.now();
+      const line = composeCommandLine(command, args);
+      const result = await client.exec(line);
+      const max = opts?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+      const stdout = truncate(result.stdout, max);
+      const stderr = truncate(result.stderr, max);
+      const truncated =
+        stdout.length < result.stdout.length || stderr.length < result.stderr.length;
+      return {
+        exitCode: result.exitCode,
+        stdout,
+        stderr,
+        durationMs: Date.now() - start,
+        timedOut: false,
+        oomKilled: false,
+        truncated,
+      };
+    },
+    async readFile(path: string): Promise<Uint8Array> {
+      if (destroyed) throw new Error("sandbox-ssh: instance has been destroyed");
+      return client.readFile(path);
+    },
+    async writeFile(path: string, data: Uint8Array): Promise<void> {
+      if (destroyed) throw new Error("sandbox-ssh: instance has been destroyed");
+      return client.writeFile(path, data);
+    },
+    async destroy(): Promise<void> {
+      if (destroyed) return;
+      destroyed = true;
+      await client.end();
+    },
+  };
+}
+
+function truncate(s: string, maxBytes: number): string {
+  // Cheap approximation — cap at codepoint count when string is short.
+  if (Buffer.byteLength(s, "utf8") <= maxBytes) return s;
+  // Step back until under the byte limit.
+  let truncated = s;
+  while (Buffer.byteLength(truncated, "utf8") > maxBytes) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated;
+}

--- a/packages/sandbox/sandbox-ssh/src/quote.test.ts
+++ b/packages/sandbox/sandbox-ssh/src/quote.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { composeCommandLine, quoteArg } from "./quote.js";
+
+describe("quoteArg", () => {
+  test("empty string becomes '' literal", () => {
+    expect(quoteArg("")).toBe("''");
+  });
+
+  test("simple word is single-quoted", () => {
+    expect(quoteArg("hello")).toBe("'hello'");
+  });
+
+  test("argument containing spaces is single-quoted intact", () => {
+    expect(quoteArg("hello world")).toBe("'hello world'");
+  });
+
+  test("internal single quote is escaped via close-escape-reopen", () => {
+    expect(quoteArg("it's")).toBe("'it'\\''s'");
+  });
+
+  test("shell metacharacters do not escape the quote", () => {
+    expect(quoteArg("$(rm -rf /)")).toBe("'$(rm -rf /)'");
+    expect(quoteArg("`whoami`")).toBe("'`whoami`'");
+    expect(quoteArg("a;b|c&d")).toBe("'a;b|c&d'");
+  });
+});
+
+describe("composeCommandLine", () => {
+  test("command with no args quotes only the command", () => {
+    expect(composeCommandLine("ls", [])).toBe("'ls'");
+  });
+
+  test("command with simple args is space-joined and quoted", () => {
+    expect(composeCommandLine("echo", ["hello", "world"])).toBe("'echo' 'hello' 'world'");
+  });
+
+  test("metacharacters in args do not break out of quoting", () => {
+    expect(composeCommandLine("echo", ["$(rm -rf /)"])).toBe("'echo' '$(rm -rf /)'");
+  });
+
+  test("internal quotes in args are escaped per quoteArg rules", () => {
+    expect(composeCommandLine("echo", ["it's"])).toBe("'echo' 'it'\\''s'");
+  });
+});

--- a/packages/sandbox/sandbox-ssh/src/quote.ts
+++ b/packages/sandbox/sandbox-ssh/src/quote.ts
@@ -1,0 +1,30 @@
+/**
+ * Quote a single argument for safe inclusion in a POSIX shell command line.
+ *
+ * Wraps the argument in single quotes; any literal single quotes inside the
+ * argument are escaped by closing the quote, inserting an escaped quote, and
+ * reopening. Empty strings become `''` (a literal empty argument, not nothing).
+ *
+ * Example:
+ *   quoteArg("hello world")   === "'hello world'"
+ *   quoteArg("it's")          === "'it'\\''s'"
+ *   quoteArg("")              === "''"
+ */
+export function quoteArg(arg: string): string {
+  if (arg.length === 0) return "''";
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Compose a shell command line from a command and its argument list with
+ * each argument independently quoted. Uses POSIX shell quoting rules.
+ *
+ * The returned string is suitable for `Client.exec(line)` from the `ssh2`
+ * package (which interprets the argument as a shell command). NEVER pass
+ * raw user input concatenated into a command — always go through this.
+ */
+export function composeCommandLine(command: string, args: readonly string[]): string {
+  const parts: string[] = [quoteArg(command)];
+  for (const a of args) parts.push(quoteArg(a));
+  return parts.join(" ");
+}

--- a/packages/sandbox/sandbox-ssh/src/types.ts
+++ b/packages/sandbox/sandbox-ssh/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Internal SSH client abstraction. The real implementation in `default-client.ts`
+ * delegates to the `ssh2` package; tests inject a `SshClient` stub to avoid
+ * needing a live SSH server.
+ *
+ * This interface intentionally exposes only the operations the adapter needs —
+ * not the full ssh2 API. Adding a method here means adding an entry to the
+ * DI seam.
+ */
+
+export interface SshExecResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface SshClient {
+  /** Run a fully-quoted POSIX shell command line; buffer stdout+stderr. */
+  readonly exec: (command: string) => Promise<SshExecResult>;
+  /** Read a remote file via SFTP. */
+  readonly readFile: (path: string) => Promise<Uint8Array>;
+  /** Write a remote file via SFTP. */
+  readonly writeFile: (path: string, data: Uint8Array) => Promise<void>;
+  /** Close the underlying SSH connection. */
+  readonly end: () => Promise<void>;
+}
+
+/**
+ * Caller-supplied factory that produces a connected `SshClient` from a target.
+ * The default factory wraps `ssh2.Client.connect`. Tests inject a fake.
+ */
+export interface SshClientFactory {
+  readonly connect: (target: SshTarget) => Promise<SshClient>;
+}
+
+export interface SshTarget {
+  readonly host: string;
+  readonly user: string;
+  readonly keyPath: string;
+}
+
+export interface SshAdapterConfig {
+  /** Caller-supplied SSH connection factory. Required — no implicit default. */
+  readonly clientFactory: SshClientFactory;
+}

--- a/packages/sandbox/sandbox-ssh/tsconfig.json
+++ b/packages/sandbox/sandbox-ssh/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../kernel/core"
+    }
+  ]
+}

--- a/packages/sandbox/sandbox-ssh/tsup.config.ts
+++ b/packages/sandbox/sandbox-ssh/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -102,6 +102,7 @@ export const L2_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/sandbox-executor",
   "@koi/sandbox-os",
   "@koi/sandbox-router",
+  "@koi/sandbox-ssh",
   "@koi/session",
   "@koi/skill-tool",
   "@koi/skills-runtime",


### PR DESCRIPTION
## Summary

PR 3 of issue #1641. **Stacks on top of PR #2111** (which stacks on PR #2109). Will rebase to `main` after the chain merges.

New L2 package `@koi/sandbox-ssh` — SSH-backed remote command execution. Wraps the `ssh2` npm package behind a dependency-injected `SshClientFactory` so unit tests run without a live SSH server.

- **`quote.ts`** — POSIX-correct shell argument escaping. 9 unit tests, 100% coverage. Injection-vector tests for `\$(...)`, backticks, `;|&`.
- **`instance.ts`** — `SandboxInstance` with `exec` (quoted command line), `readFile`/`writeFile` (SFTP), idempotent `destroy`. Output buffering with `maxOutputBytes` cap.
- **`adapter.ts`** — `createSshAdapter(config)` requires a `clientFactory` (no implicit default). `findOrCreate(scope, profile)` reuses one SSH connection per scope key; `instance.destroy` removes the pool entry on close.
- **`default-client.ts`** — production factory using `ssh2.Client.connect`. Promisifies exec/SFTP. Reads private key from `profile.ssh.keyPath`.
- **Conformance:** `__tests__/conformance.test.ts` runs lifecycle/create+destroy/capability-honesty groups against a stub factory. 7 conformance + 9 quote + 7 adapter = 23 tests pass.
- **Docs:** `docs/L2/sandbox-ssh.md` with capability section + full threat model (template from PR 1).

## Capability declaration

```
supports: { exec, copy-files, persistence, network }
priority: 20
```

`spawn` and `filesystem-rw` are intentionally NOT declared:
- `spawn` — no PTY in this PR; defer to follow-up if interactive shells are needed.
- `filesystem-rw` — write authority depends on the remote SSH user's permissions, not on the adapter.

`persistence` IS declared — `findOrCreate` reuses connections per scope key.

## Dependencies

- `ssh2@1.16.0` (exact pin, mature & widely deployed)
- `@types/ssh2@1.15.5` (devDependency)

## Out of scope

- PTY/`spawn` support — TODO follow-up
- Strict host-key pinning — `ssh2` defaults used; production callers should provide a custom factory with `~/.ssh/known_hosts` checking
- Real-server SSH_E2E test suite — should land alongside runtime wiring (next PR) or independently

## Test plan

- [ ] `bun run typecheck` — PASS
- [ ] `bun run lint` — PASS
- [ ] `bun run check:layers` — PASS
- [ ] `bun test packages/sandbox/sandbox-ssh/` — 23 tests pass
- [ ] No regressions in PR 1 + PR 2 sandbox tests
- [ ] Quote helper tested against shell injection vectors