### PR TITLE
[codex] fix review findings

### DIFF
--- a/docs/L2/tools-builtin.md
+++ b/docs/L2/tools-builtin.md
@@ -10,7 +10,7 @@ Provides the core tools that every Koi agent needs:
 
 - **read** — Read file content with optional line offset/limit
 - **edit** — Search-and-replace with uniqueness preflight (oldText must exist exactly once)
-- **write** — Create or overwrite files with optional directory creation
+- **write** — Create or overwrite files with optional directory creation. Parent directory creation defaults to `false`; callers must opt in with `createDirectories: true`.
 
 These are "primordial" tools — bundled at build time, highest trust level. They delegate all I/O to a `FileSystemBackend` (L0 contract), keeping the tools themselves pure argument validation + dispatch.
 
@@ -53,7 +53,9 @@ L2  @koi/tools-builtin  ← this package
 
 ## Filesystem Tool API
 
-Each factory takes `(backend: FileSystemBackend, prefix: string, policy: ToolPolicy)` and returns a `Tool`.
+Each factory takes `(backend: FileSystemBackend, prefix: string, policy: ToolPolicy, fsToolOptions?)` and returns a `Tool`.
+
+`fsToolOptions.pathGuard` is an optional host-supplied guard that runs before backend I/O for `read`, `write`, and `edit`. Hosts use it to reject sensitive credential paths before permission policy or backend access can allow them.
 
 #### `createFsReadTool`
 
@@ -78,7 +80,7 @@ Each factory takes `(backend: FileSystemBackend, prefix: string, policy: ToolPol
 |-----------|------|----------|-------------|
 | `path` | `string` | yes | Absolute path to the file |
 | `content` | `string` | yes | Content to write |
-| `createDirectories` | `boolean` | no | Create parent dirs if missing |
+| `createDirectories` | `boolean` | no | Create parent dirs if missing (default: false) |
 | `overwrite` | `boolean` | no | Overwrite existing file (default: false — fails closed) |
 
 ### Argument Parsing
@@ -169,4 +171,5 @@ Omit from the tool set entirely (don't call the factory) when `elicit` is not av
 
 ## Changelog
 
+- **Filesystem guard/default hardening** — fs read/write/edit factories accept `FsToolOptions.pathGuard` so hosts can block credential paths before backend I/O. The write tool now passes `createDirectories: false` when the argument is omitted, matching the public schema instead of inheriting a backend default.
 - **Path-aware filesystem permissions** — fs_read for out-of-workspace paths triggers permission prompt instead of silent NOT_FOUND.

--- a/docs/L2/tools-web.md
+++ b/docs/L2/tools-web.md
@@ -6,6 +6,12 @@ Wraps HTTP fetching and web search as 2 Koi Tool components: `web_fetch` and `we
 
 ## Recent updates
 
+Review-finding cancellation sync: `web_fetch` and `web_search` now receive the
+tool execution options object and forward `ToolExecuteOptions.signal` to
+`WebExecutor.fetch()` / `WebExecutor.search()`. Cancelled turns can therefore
+abort slow fetch/search providers instead of waiting for the provider timeout or
+leaking in-flight work.
+
 gov-15 scope integration: `preflightBlockReason(url: string): string | undefined`
 is now exported as a public API. It performs the DNS-free SSRF preflight check
 inline — returns a human-readable reason string if the URL is definitively blocked
@@ -125,7 +131,8 @@ LLM decides: "call web_fetch
   ┌────────────────────────────────────┐
   │ executor.fetch(url, {              │
   │   method: "GET",                   │
-  │   timeoutMs: 15000                 │
+  │   timeoutMs: 15000,                │
+  │   signal: execution signal         │
   │ })                                 │
   └───────┬────────────────────────────┘
           │

--- a/docs/L3/cli.md
+++ b/docs/L3/cli.md
@@ -27,6 +27,15 @@ Command-line interface for running Koi agents locally. Provides interactive (`st
   hardening: per-port advisory lock with reclaim sentinel, lsof+ps
   process-tree listener-ownership verification (handles the uvx
   wrapper around nexusd), and stopSandbox descendant-PID sweep.
+- **Review-finding wiring sync (#2121)**: no CLI command, flag, or dependency
+  changes. Shared CLI tool wiring now passes the default credential path guard
+  into local filesystem read/write/edit tools, so credential locations are
+  denied before backend I/O even when a local permission mode allows filesystem
+  access. The same integrated `@koi/tools-builtin` surface now makes
+  `fs_write.createDirectories` fail closed by default (`false` when omitted),
+  and integrated `@koi/tools-web` forwards the turn cancellation signal into
+  `web_fetch` and `web_search` providers so cancelled turns do not wait on slow
+  network calls.
 - **Review-finding wiring sync**: no CLI command, flag, or dependency changes.
   The existing runtime/TUI wiring inherits two L2 behavior fixes: scheduled task
   dispatch now waits for async stores to persist `running` before the dispatcher

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -6,6 +6,14 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
 
 `@koi/rlm-stack` wired (#1359, PR #2126): added as a dependency of `@koi/runtime`. The L3 meta-package composes `@koi/middleware-rlm` with thresholds coordinated against `@koi/context-manager` so RLM segments fire only when a single user input exceeds the entire context window (above the 75% hard-compact threshold). Default priority is `RLM_STACK_PRIORITY_FLOOR = 801` — strictly above `@koi/middleware-tool-disclosure` (800) so the engine sorter cannot place RLM ahead of tool-disclosure under equal-priority ambiguity. Two standalone golden queries cover the factory's threshold computation and `policyFor` classifier (passthrough/compact/virtualize). No cassette trajectory: the middleware fires only on oversized inputs that aren't representative of the goldens' fixture sizes; RLM behavior under load is covered by `@koi/middleware-rlm`'s own 100-test unit suite. See `docs/L2/rlm-stack.md` for the API and `Caveats` (resolveThresholds prefix-canonicalization limitations).
 
+Review-finding wiring sync (#2121): no runtime dependency set changes. The
+existing `@koi/tools-builtin` integration now has an explicit filesystem
+`pathGuard` hook on read/write/edit factories and `fs_write` defaults
+`createDirectories` to `false` when omitted, matching its schema instead of
+inheriting backend auto-create behavior. The existing `@koi/tools-web`
+integration now forwards `ToolExecuteOptions.signal` into fetch/search executor
+calls so cancelled turns can abort slow providers promptly.
+
 `@koi/middleware-user-model` wired (#1389): added as a dependency of `@koi/runtime`. The package fuses three observation channels — pre-action ambiguity detection, post-action correction (incl. optional drift detection sub-channel), and pluggable sensor enrichment via the L0 `SignalSource` contract — into a single `[User Context]` block injected at the head of `ModelRequest.messages`. Default priority `415` (`intercept` phase) places it outside permissions/audit but inside the model adapter. Each channel is independently optional and degrades gracefully: failing `SignalSource.read()` is skipped, memory recall throwing yields empty preferences, classifier failures fall through to fail-closed-on-drift / fail-open-on-salience per the doc. Two standalone golden queries cover the factory wiring (priority 415, all hooks present) and the `formatUserContext` rendering invariant ([User Context] open/close, preferences + sensor state lines). No cassette trajectory recorded — the middleware has no LLM-callable tool surface; the optional drift-detection LLM classifier is a caller-supplied function, mocked in unit tests via `createKeywordDriftDetector`. See `docs/L2/middleware-user-model.md` for the full contract.
 
 `@koi/handoff` + `@koi/task-spawn` wiring (#1371, PR #2117): both L2 packages

--- a/packages/lib/edit-match/src/levenshtein.test.ts
+++ b/packages/lib/edit-match/src/levenshtein.test.ts
@@ -63,4 +63,22 @@ describe("computeSlidingWindowMatch", () => {
     expect(result).toBeDefined();
     expect(source.slice(result?.startIndex, result?.endIndex)).toBe("bbb");
   });
+
+  test("does not allocate candidate windows with Array.prototype.slice", () => {
+    const source = Array.from({ length: 250 }, (_, i) => `line ${i}`).join("\n");
+    const search = "line 249";
+    const originalSlice = Array.prototype.slice;
+    let sliceCalls = 0;
+    Array.prototype.slice = function patchedSlice<T>(this: T[], ...args: [number?, number?]): T[] {
+      sliceCalls++;
+      return originalSlice.apply(this, args) as T[];
+    };
+    try {
+      const result = computeSlidingWindowMatch(source, search, FUZZY_THRESHOLD);
+      expect(result).toBeDefined();
+    } finally {
+      Array.prototype.slice = originalSlice;
+    }
+    expect(sliceCalls).toBe(0);
+  });
 });

--- a/packages/lib/edit-match/src/levenshtein.ts
+++ b/packages/lib/edit-match/src/levenshtein.ts
@@ -86,6 +86,7 @@ export function computeSlidingWindowMatch(
   const sourceLines = source.split("\n");
   const searchLines = search.split("\n");
   const searchLineCount = searchLines.length;
+  const lineStartOffsets = computeLineStartOffsets(sourceLines);
 
   if (searchLineCount === 0 || sourceLines.length === 0) {
     return undefined;
@@ -102,8 +103,9 @@ export function computeSlidingWindowMatch(
 
   for (let windowSize = minWindowSize; windowSize <= maxWindowSize; windowSize++) {
     for (let i = 0; i <= sourceLines.length - windowSize; i++) {
-      const windowLines = sourceLines.slice(i, i + windowSize);
-      const windowText = windowLines.join("\n");
+      const startIndex = lineStartOffsets[i] ?? 0;
+      const endIndex = computeLineEndOffset(sourceLines, lineStartOffsets, i + windowSize);
+      const windowText = source.slice(startIndex, endIndex);
       const dist = computeLevenshtein(windowText, search, maxDist);
       const maxLen = Math.max(windowText.length, search.length);
 
@@ -113,15 +115,10 @@ export function computeSlidingWindowMatch(
 
       const similarity = 1 - dist / maxLen;
       if (similarity > bestSimilarity) {
-        // Compute character offsets from line positions
-        const startIndex = sourceLines.slice(0, i).join("\n").length + (i > 0 ? 1 : 0);
-        const endText = sourceLines.slice(0, i + windowSize).join("\n");
-        const _endIndex = endText.length + (i + windowSize > 0 && i === 0 ? 0 : 0);
-
         bestSimilarity = similarity;
         best = {
           startIndex,
-          endIndex: startIndex + windowText.length,
+          endIndex,
           similarity,
         };
       }
@@ -129,4 +126,25 @@ export function computeSlidingWindowMatch(
   }
 
   return best;
+}
+
+function computeLineStartOffsets(lines: readonly string[]): readonly number[] {
+  const offsets: number[] = [];
+  let offset = 0;
+  for (let i = 0; i < lines.length; i++) {
+    offsets.push(offset);
+    offset += (lines[i] ?? "").length;
+    if (i < lines.length - 1) offset++;
+  }
+  return offsets;
+}
+
+function computeLineEndOffset(
+  lines: readonly string[],
+  lineStartOffsets: readonly number[],
+  endLineExclusive: number,
+): number {
+  const lastLineIndex = endLineExclusive - 1;
+  if (lastLineIndex < 0) return lineStartOffsets[0] ?? 0;
+  return (lineStartOffsets[lastLineIndex] ?? 0) + (lines[lastLineIndex] ?? "").length;
 }

--- a/packages/lib/tools-builtin/src/tools/filesystem.test.ts
+++ b/packages/lib/tools-builtin/src/tools/filesystem.test.ts
@@ -418,7 +418,7 @@ describe("createFsWriteTool", () => {
     expect(receivedOptions).toEqual({ createDirectories: true, overwrite: false });
   });
 
-  test("defaults overwrite to false when omitted", async () => {
+  test("defaults overwrite and createDirectories to false when omitted", async () => {
     let receivedOptions: FileWriteOptions | undefined;
     const backend = {
       ...createMockBackend(),
@@ -429,7 +429,7 @@ describe("createFsWriteTool", () => {
     };
     const tool = createFsWriteTool(backend, "fs", DEFAULT_UNSANDBOXED_POLICY);
     await tool.execute({ path: "/test", content: "x" });
-    expect(receivedOptions).toEqual({ overwrite: false });
+    expect(receivedOptions).toEqual({ createDirectories: false, overwrite: false });
   });
 
   test("returns error on backend failure", async () => {

--- a/packages/lib/tools-builtin/src/tools/write.ts
+++ b/packages/lib/tools-builtin/src/tools/write.ts
@@ -70,8 +70,8 @@ export function createFsWriteTool(
       }
 
       const options: FileWriteOptions = {
+        createDirectories: createDirsResult.value ?? false,
         overwrite: overwriteResult.value ?? false,
-        ...(createDirsResult.value !== undefined && { createDirectories: createDirsResult.value }),
       };
       const result = await backend.write(pathResult.value, contentResult.value, options);
       // No post-write cancellation check: if the backend committed, report

--- a/packages/lib/tools-web/src/web-fetch-tool.test.ts
+++ b/packages/lib/tools-web/src/web-fetch-tool.test.ts
@@ -147,6 +147,24 @@ describe("createWebFetchTool", () => {
   });
 
   describe("noCache flag", () => {
+    test("forwards caller abort signal to the executor", async () => {
+      const controller = new AbortController();
+      let capturedSignal: AbortSignal | undefined;
+      const executor: WebExecutor = {
+        fetch: async (_url, options) => {
+          capturedSignal = options?.signal;
+          return successResponse("ok", "text/plain");
+        },
+        search: async () => ({
+          ok: false,
+          error: { code: "VALIDATION", message: "n/a", retryable: false },
+        }),
+      };
+      const tool = createWebFetchTool(executor, "web", POLICY);
+      await tool.execute({ url: "https://example.com" }, { signal: controller.signal });
+      expect(capturedSignal).toBe(controller.signal);
+    });
+
     test("forwards noCache=true to the executor", async () => {
       let captured: { readonly noCache: boolean | undefined } | undefined;
       const executor: WebExecutor = {

--- a/packages/lib/tools-web/src/web-fetch-tool.ts
+++ b/packages/lib/tools-web/src/web-fetch-tool.ts
@@ -2,7 +2,7 @@
  * Tool factory for `web_fetch` — fetch a URL and return the response content.
  */
 
-import type { JsonObject, Tool, ToolPolicy } from "@koi/core";
+import type { JsonObject, Tool, ToolExecuteOptions, ToolPolicy } from "@koi/core";
 import { BLOCKED_HOST_SUFFIXES, BLOCKED_HOSTS, isBlockedIp } from "@koi/url-safety";
 import { MAX_TIMEOUT_MS } from "./constants.js";
 import { htmlToMarkdown } from "./html-to-markdown.js";
@@ -90,7 +90,7 @@ export function createWebFetchTool(
     },
     origin: "primordial",
     policy,
-    execute: async (args: JsonObject): Promise<unknown> => {
+    execute: async (args: JsonObject, options?: ToolExecuteOptions): Promise<unknown> => {
       if (typeof args.url !== "string" || args.url.trim() === "") {
         return { error: "url must be a non-empty string", code: "VALIDATION" };
       }
@@ -134,7 +134,13 @@ export function createWebFetchTool(
       }
       const noCache = args.noCache === true;
 
-      const result = await executor.fetch(url, { method, headers, timeoutMs: timeout, noCache });
+      const result = await executor.fetch(url, {
+        method,
+        headers,
+        timeoutMs: timeout,
+        noCache,
+        signal: options?.signal,
+      });
       if (!result.ok) {
         return { error: result.error.message, code: result.error.code };
       }

--- a/packages/lib/tools-web/src/web-search-tool.test.ts
+++ b/packages/lib/tools-web/src/web-search-tool.test.ts
@@ -77,6 +77,24 @@ describe("createWebSearchTool", () => {
   });
 
   describe("results", () => {
+    test("forwards caller abort signal to the executor", async () => {
+      const controller = new AbortController();
+      let capturedSignal: AbortSignal | undefined;
+      const executor: WebExecutor = {
+        fetch: async () => ({
+          ok: false,
+          error: { code: "VALIDATION", message: "Not implemented", retryable: false },
+        }),
+        search: async (_query, options) => {
+          capturedSignal = options?.signal;
+          return { ok: true, value: SAMPLE_RESULTS };
+        },
+      };
+      const tool = createWebSearchTool(executor, "web", DEFAULT_UNSANDBOXED_POLICY);
+      await tool.execute({ query: "test" }, { signal: controller.signal });
+      expect(capturedSignal).toBe(controller.signal);
+    });
+
     test("returns search results", async () => {
       const tool = createWebSearchTool(
         mockExecutor({ ok: true, value: SAMPLE_RESULTS }),

--- a/packages/lib/tools-web/src/web-search-tool.ts
+++ b/packages/lib/tools-web/src/web-search-tool.ts
@@ -2,7 +2,7 @@
  * Tool factory for `web_search` — search the web via injectable backend.
  */
 
-import type { JsonObject, Tool, ToolPolicy } from "@koi/core";
+import type { JsonObject, Tool, ToolExecuteOptions, ToolPolicy } from "@koi/core";
 import type { WebExecutor } from "./web-executor.js";
 
 const DEFAULT_MAX_RESULTS = 5;
@@ -35,7 +35,7 @@ export function createWebSearchTool(
     },
     origin: "primordial",
     policy,
-    execute: async (args: JsonObject): Promise<unknown> => {
+    execute: async (args: JsonObject, options?: ToolExecuteOptions): Promise<unknown> => {
       if (typeof args.query !== "string" || args.query.trim() === "") {
         return { error: "query must be a non-empty string", code: "VALIDATION" };
       }
@@ -44,7 +44,10 @@ export function createWebSearchTool(
           ? Math.min(Math.max(1, Math.floor(args.max_results)), MAX_MAX_RESULTS)
           : DEFAULT_MAX_RESULTS;
 
-      const result = await executor.search(args.query.trim(), { maxResults });
+      const result = await executor.search(args.query.trim(), {
+        maxResults,
+        signal: options?.signal,
+      });
       if (!result.ok) {
         return { error: result.error.message, code: result.error.code };
       }

--- a/packages/meta/cli/src/shared-wiring.test.ts
+++ b/packages/meta/cli/src/shared-wiring.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import type { HookConfig } from "@koi/core";
+import { type ComponentProvider, type HookConfig, isAttachResult, type Tool } from "@koi/core";
 import type { McpServerConfig } from "@koi/mcp";
 import {
   __setUserHooksConfigPathForTests,
@@ -30,6 +30,22 @@ function commandHook(name: string): HookConfig {
 
 function agentHook(name: string): HookConfig {
   return { kind: "agent", name, prompt: "verify" };
+}
+
+async function getToolFromProvider(
+  providers: readonly ComponentProvider[],
+  providerName: string,
+  toolName: string,
+): Promise<Tool> {
+  const provider = providers.find((p) => p.name === providerName);
+  if (provider === undefined) throw new Error(`provider ${providerName} missing`);
+  const attachResult = await provider.attach({} as Parameters<typeof provider.attach>[0]);
+  const components = isAttachResult(attachResult) ? attachResult.components : attachResult;
+  const tool = components.get(`tool:${toolName}`);
+  if (tool === undefined || tool === null || typeof tool !== "object" || !("execute" in tool)) {
+    throw new Error(`tool ${toolName} missing`);
+  }
+  return tool as Tool;
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +260,15 @@ describe("buildCoreProviders: filesystem operation gating", () => {
     expect(names).toContain("fs-read");
     expect(names).toContain("fs-write");
     expect(names).toContain("fs-edit");
+  });
+
+  test("default filesystem tools block credential paths", async () => {
+    const providers = buildCoreProviders({ cwd: mkTempCwd(), includeWebFetch: false });
+    const readTool = await getToolFromProvider(providers, "fs-read", "fs_read");
+    const result = (await readTool.execute({
+      path: join(homedir(), ".ssh", "id_rsa"),
+    })) as { readonly code?: string };
+    expect(result.code).toBe("CREDENTIAL_PATH_DENIED");
   });
 });
 

--- a/packages/meta/cli/src/shared-wiring.ts
+++ b/packages/meta/cli/src/shared-wiring.ts
@@ -69,9 +69,11 @@ import {
 import type { SkillsRuntime } from "@koi/skills-runtime";
 import {
   createBuiltinSearchProvider,
+  createCredentialPathGuard,
   createFsEditTool,
   createFsReadTool,
   createFsWriteTool,
+  type FsToolOptions,
 } from "@koi/tools-builtin";
 import { createWebExecutor, createWebProvider } from "@koi/tools-web";
 import { createSafeFetcher } from "@koi/url-safety";
@@ -1254,6 +1256,11 @@ export interface CoreProvidersConfig {
    */
   readonly filesystemOperations?: readonly ("read" | "write" | "edit")[] | undefined;
   /**
+   * Filesystem tool safety options. Defaults to the credential path guard so
+   * CLI/TUI wiring matches @koi/runtime's security default.
+   */
+  readonly fsToolOptions?: FsToolOptions | undefined;
+  /**
    * When true, wire the web_fetch tool. Defaults to `true` — hosts that
    * run in airgapped environments can pass `false` to strip network access.
    */
@@ -1377,6 +1384,7 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
     // Use the caller-supplied backend when provided (e.g. a Nexus backend
     // from resolveFileSystemAsync); otherwise create the default local one.
     const fs = config.filesystemBackend ?? createLocalFileSystem(cwd, { allowExternalPaths: true });
+    const fsToolOptions = config.fsToolOptions ?? { pathGuard: createCredentialPathGuard() };
     // Operation gating: `undefined` means "wire all three" (the default
     // for host-default filesystems). Manifest-driven filesystems apply
     // the `FileSystemConfig` contract's `["read"]` default at the host
@@ -1391,7 +1399,7 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
         createSingleToolProvider({
           name: "fs-read",
           toolName: "fs_read",
-          createTool: () => createFsReadTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY),
+          createTool: () => createFsReadTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY, fsToolOptions),
         }),
       );
     }
@@ -1400,7 +1408,7 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
         createSingleToolProvider({
           name: "fs-write",
           toolName: "fs_write",
-          createTool: () => createFsWriteTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY),
+          createTool: () => createFsWriteTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY, fsToolOptions),
         }),
       );
     }
@@ -1409,7 +1417,7 @@ export function buildCoreProviders(config: CoreProvidersConfig): ComponentProvid
         createSingleToolProvider({
           name: "fs-edit",
           toolName: "fs_edit",
-          createTool: () => createFsEditTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY),
+          createTool: () => createFsEditTool(fs, "fs", DEFAULT_UNSANDBOXED_POLICY, fsToolOptions),
         }),
       );
     }


### PR DESCRIPTION
## Summary

Fixes the five review findings from the package-by-package code review:

- Enable the credential path guard for CLI/TUI filesystem providers wired through `buildCoreProviders`.
- Forward tool execution abort signals through `web_fetch` and `web_search`.
- Await scheduler `running` status persistence before invoking task dispatch.
- Align `fs_write` createDirectories default with its schema by passing `false` when omitted.
- Reduce fuzzy edit-match allocation work by using precomputed line offsets instead of repeated `slice().join()` windows.

## Validation

- `bun test src/shared-wiring.test.ts`
- `bun test src/web-fetch-tool.test.ts src/web-search-tool.test.ts`
- `bun test src/scheduler.test.ts`
- `bun test src/tools/filesystem.test.ts`
- `bun test src/levenshtein.test.ts`
- `bun run typecheck` in affected packages: `@koi-agent/cli`, `@koi/tools-web`, `@koi/tools-builtin`, `@koi/scheduler`, `@koi/edit-match`
- `bunx biome check` on touched files
- `bun scripts/check-layers.ts` (passed layer boundaries; reported existing unrelated session-state warning for `@koi/middleware-tool-selector`)
- Pre-push hook ran targeted Turbo `typecheck` and `build` successfully before pushing.