### PR TITLE
feat(context-engine): finish #1767 phases 5/6/8 — emit, TUI notice, replay

### DIFF
--- a/packages/kernel/engine/src/koi.test.ts
+++ b/packages/kernel/engine/src/koi.test.ts
@@ -211,6 +211,65 @@ describe("createKoi assembly", () => {
     expect(runtime.agent.component(CONTEXT_ENGINE)?.identity.version).toBe("2.0.0");
   });
 
+  test("swap during an active run surfaces as a context-engine-swap custom event (#1767 Phase 5)", async () => {
+    type ContextEngine = import("@koi/core").ContextEngine;
+    type TurnId = import("@koi/core").TurnId;
+    const engineA: ContextEngine = {
+      identity: { name: "a", version: "1.0.0" },
+      prepare: (_c, m) => m,
+    };
+    const engineB: ContextEngine = {
+      identity: { name: "b", version: "2.0.0" },
+      prepare: (_c, m) => m,
+    };
+    const runtime = await createKoi({
+      manifest: testManifest(),
+      adapter: mockAdapter([
+        { kind: "turn_end", turnIndex: 0 },
+        {
+          kind: "done",
+          output: {
+            content: [],
+            stopReason: "completed",
+            metrics: {
+              totalTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              turns: 0,
+              durationMs: 0,
+            },
+          },
+        },
+      ]),
+      contextEngineFactory: () => engineA,
+    });
+
+    const handle = runtime.run({ kind: "text", text: "hi" });
+    const iter = handle[Symbol.asyncIterator]();
+    const collected: EngineEvent[] = [];
+    // Pull turn_start
+    const first = await iter.next();
+    if (!first.done) collected.push(first.value);
+    // Trigger swap before next pull — runtime should enqueue it
+    runtime.contextEngineSwapController?.swap(engineB, {
+      turnId: "run-1:t1" as TurnId,
+      reason: "test",
+    });
+    while (true) {
+      const r = await iter.next();
+      if (r.done) break;
+      collected.push(r.value);
+    }
+    const swapEvents = collected.filter(
+      (e): e is Extract<EngineEvent, { kind: "custom" }> =>
+        e.kind === "custom" && e.type === "context-engine-swap",
+    );
+    expect(swapEvents.length).toBe(1);
+    const data = swapEvents[0]?.data as { from: { name: string }; to: { name: string } };
+    expect(data.from.name).toBe("a");
+    expect(data.to.name).toBe("b");
+  });
+
   test("omitting contextEngineFactory leaves the CONTEXT_ENGINE slot empty", async () => {
     const { CONTEXT_ENGINE } = await import("@koi/core");
     const runtime = await createKoi({

--- a/packages/kernel/engine/src/koi.ts
+++ b/packages/kernel/engine/src/koi.ts
@@ -146,6 +146,15 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
   let contextEngineProxy: ContextEngine | undefined;
   const contextEngineProviders: ComponentProvider[] = [];
   const contextEngineMiddleware: KoiMiddleware[] = [];
+  // #1767 Phase 5 emission: when a streamEvents generator is active, swap
+  // events are pushed onto its `pendingEngineEvents` queue so they surface
+  // as `{ kind: "custom", type: "context-engine-swap" }` engine events. When
+  // no run is active, swap events are dropped — `custom` is escape-hatch
+  // telemetry per the anti-leak rules; in-run subscribers (TUI, audit
+  // logs) read them from the controller's own subscribe() if they need
+  // out-of-run delivery.
+  // let justified: mutable per-run queue ref, set in streamEvents start, cleared in finally
+  let activeRunPendingEvents: EngineEvent[] | undefined;
   // Stable ref for the per-run TurnContext cache. createKoi creates the
   // slot middleware once but the cache map is per-run state inside
   // streamEvents, so the middleware closes over this container and
@@ -209,6 +218,18 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
     if (options.onContextEngineSwap !== undefined) {
       ctrlRef.subscribe(options.onContextEngineSwap);
     }
+    // #1767 Phase 5: bridge swap events into the engine event stream as
+    // `custom` events. The queue ref is set only while a run is active;
+    // outside of a run swap events are dropped on the floor (host
+    // observers can still receive them via controller.subscribe()).
+    ctrlRef.subscribe((swapEvent) => {
+      if (activeRunPendingEvents === undefined) return;
+      activeRunPendingEvents.push({
+        kind: "custom",
+        type: "context-engine-swap",
+        data: swapEvent,
+      });
+    });
     // Attach a proxy under CONTEXT_ENGINE that delegates to the swap
     // controller's current engine on every read. AgentEntity freezes
     // assembled components, so attaching the boot-time instance directly
@@ -972,6 +993,11 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
 
     // let justified: pending engine events emitted by terminal wrappers (e.g., discovery:miss)
     const pendingEngineEvents: EngineEvent[] = [];
+    // #1767 Phase 5: register this generator's queue with the swap-event
+    // bridge so swap events surface as `custom` engine events while the
+    // run is active. Cleared in the finally below — between runs, swap
+    // events are dropped (telemetry-only per anti-leak policy).
+    activeRunPendingEvents = pendingEngineEvents;
 
     const rid: RunId = outerRunId;
     const sessionCtx: SessionContext = {
@@ -2529,6 +2555,13 @@ export async function createKoi(options: CreateKoiOptions): Promise<KoiRuntime> 
       // let cycleSession()/dispose() skip the wait while the adapter
       // iterator was still being torn down. The flag is lowered only
       // after every cleanup step AND the resolver have completed.
+
+      // #1767 Phase 5: detach the swap-event bridge from this generator's
+      // queue. After this point, swap events are dropped until the next
+      // run() activates a fresh queue.
+      if (activeRunPendingEvents === pendingEngineEvents) {
+        activeRunPendingEvents = undefined;
+      }
       if (unsubRegistryWatch !== undefined) unsubRegistryWatch();
       cleanupForgeSubscription();
       runSignal.removeEventListener("abort", onAbort);

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -802,22 +802,13 @@ export async function drainEngineStream(
         }
       }
 
-      // --- Context-engine swap notice (#1767 Phase 6) ---
-      // Surface runtime-emitted swap events as a one-line system notice
-      // through the single-writer store action surface (#1940). Keeps the
-      // notice out of the model transcript and avoids any out-of-band
-      // stderr writes.
-      if (event.kind === "custom" && event.type === "context-engine-swap") {
-        const swap = event.data as {
-          from: { name: string; version: string };
-          to: { name: string; version: string };
-          reason: string;
-        };
-        store.dispatch({
-          kind: "add_info",
-          message: `↔ context engine: ${swap.from.name}@${swap.from.version} → ${swap.to.name}@${swap.to.version} (${swap.reason})`,
-        });
-      }
+      // Context-engine swap notices (#1767 Phase 6) are NOT handled here.
+      // The TUI subscribes directly to runtime.contextEngineSwapController
+      // after createKoiRuntime resolves so out-of-run swaps (idle period,
+      // before first run, between reusable turns) are visible too — the
+      // run-stream `custom` event path only fires while a streamEvents
+      // generator is active. Wiring once at the controller level avoids
+      // both the gap and a double-notice.
 
       // --- Lifecycle events: flush before AND after to isolate them ---
       // This ensures turn_start creates the streaming message before any
@@ -2913,6 +2904,18 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       return;
     }
     runtimeHandle = handle;
+    // #1767 Phase 6: surface context-engine swap events as TUI notices
+    // through the single-writer store. Subscribing at the controller
+    // level (rather than reading the run-stream `custom` event) covers
+    // out-of-run swaps too — idle, pre-first-run, between reusable
+    // turns. Notices flow through `add_info` like plugin-load banners:
+    // not in the JSONL transcript, not pushed back into model context.
+    handle.runtime.contextEngineSwapController?.subscribe((swap) => {
+      store.dispatch({
+        kind: "add_info",
+        message: `↔ context engine: ${swap.from.name}@${swap.from.version} → ${swap.to.name}@${swap.to.version} (${swap.reason})`,
+      });
+    });
     // Resolve lazy skill agent ref so the injector middleware can query
     // skill components on every subsequent model call.
     skillAgentRef.current = handle.runtime.agent;

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -35,7 +35,7 @@ import { isAbsolute, join } from "node:path";
 import type { SummaryOk } from "@koi/agent-summary";
 import { createAgentSummary } from "@koi/agent-summary";
 import { type ArtifactStore, createArtifactStore } from "@koi/artifacts";
-import { microcompact } from "@koi/context-manager";
+import { formatContextEngineSwapNotice, microcompact } from "@koi/context-manager";
 import type {
   Agent,
   AuditEntry,
@@ -2911,10 +2911,8 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     // turns. Notices flow through `add_info` like plugin-load banners:
     // not in the JSONL transcript, not pushed back into model context.
     handle.runtime.contextEngineSwapController?.subscribe((swap) => {
-      store.dispatch({
-        kind: "add_info",
-        message: `↔ context engine: ${swap.from.name}@${swap.from.version} → ${swap.to.name}@${swap.to.version} (${swap.reason})`,
-      });
+      const notice = formatContextEngineSwapNotice(swap);
+      store.dispatch({ kind: "add_info", message: notice.message });
     });
     // Resolve lazy skill agent ref so the injector middleware can query
     // skill components on every subsequent model call.

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -802,6 +802,23 @@ export async function drainEngineStream(
         }
       }
 
+      // --- Context-engine swap notice (#1767 Phase 6) ---
+      // Surface runtime-emitted swap events as a one-line system notice
+      // through the single-writer store action surface (#1940). Keeps the
+      // notice out of the model transcript and avoids any out-of-band
+      // stderr writes.
+      if (event.kind === "custom" && event.type === "context-engine-swap") {
+        const swap = event.data as {
+          from: { name: string; version: string };
+          to: { name: string; version: string };
+          reason: string;
+        };
+        store.dispatch({
+          kind: "add_info",
+          message: `↔ context engine: ${swap.from.name}@${swap.from.version} → ${swap.to.name}@${swap.to.version} (${swap.reason})`,
+        });
+      }
+
       // --- Lifecycle events: flush before AND after to isolate them ---
       // This ensures turn_start creates the streaming message before any
       // deltas arrive, and turn_end/done closes it only after all deltas

--- a/packages/meta/runtime/src/__tests__/golden-queries.test.ts
+++ b/packages/meta/runtime/src/__tests__/golden-queries.test.ts
@@ -730,6 +730,7 @@ import {
   createPassthroughContextEngine,
   DEFAULT_CONTEXT_ENGINE_IDENTITY,
   enforceBudget,
+  formatContextEngineSwapNotice,
   PASSTHROUGH_CONTEXT_ENGINE_IDENTITY,
   resolveConfig,
 } from "@koi/context-manager";
@@ -1243,6 +1244,204 @@ describe("Golden: @koi/context-manager", () => {
         (e) => e.kind === "custom" && e.type === "context-engine-swap",
       );
       expect(swapEvents.length).toBe(0);
+    });
+
+    // -------------------------------------------------------------------
+    // TUI swap-notice bridge corner cases (#1767 Phase 6)
+    //
+    // The TUI subscribes to runtime.contextEngineSwapController and
+    // dispatches the formatted notice as an `add_info` block. These
+    // cases simulate that bridge with a spy dispatcher and exercise the
+    // edges that an interactive TUI would otherwise trip on at runtime.
+    // -------------------------------------------------------------------
+    type DispatchSpy = ReturnType<typeof createDispatchSpy>;
+    function createDispatchSpy(): {
+      readonly dispatched: { readonly kind: string; readonly message: string }[];
+      readonly dispatch: (a: { readonly kind: string; readonly message: string }) => void;
+    } {
+      const dispatched: { kind: string; message: string }[] = [];
+      return {
+        get dispatched() {
+          return dispatched;
+        },
+        dispatch(action) {
+          dispatched.push({ kind: action.kind, message: action.message });
+        },
+      };
+    }
+
+    function wireBridge(
+      controller: NonNullable<
+        Awaited<ReturnType<typeof import("@koi/engine").createKoi>>["contextEngineSwapController"]
+      >,
+      spy: DispatchSpy,
+    ): () => void {
+      return controller.subscribe((swap) => {
+        const notice = formatContextEngineSwapNotice(swap);
+        spy.dispatch({ kind: "add_info", message: notice.message });
+      });
+    }
+
+    async function makeBridgedRuntime(
+      spy: DispatchSpy,
+    ): Promise<Awaited<ReturnType<typeof import("@koi/engine").createKoi>>> {
+      const { createKoi } = await import("@koi/engine");
+      const runtime = await createKoi({
+        manifest: { name: "agent", version: "1.0.0", model: { name: "test" } },
+        adapter: buildMockAdapter(),
+        contextEngineFactory: createContextEngine,
+      });
+      const ctrl = runtime.contextEngineSwapController;
+      if (ctrl !== undefined) wireBridge(ctrl, spy);
+      return runtime;
+    }
+
+    test("TUI bridge: out-of-run swap dispatches a notice (closes the round-1 review gap)", async () => {
+      type TurnId = import("@koi/core").TurnId;
+      const spy = createDispatchSpy();
+      const runtime = await makeBridgedRuntime(spy);
+      runtime.contextEngineSwapController?.swap(createPassthroughContextEngine(), {
+        turnId: "out-of-run" as TurnId,
+        reason: "operator-driven",
+        force: true,
+      });
+      expect(spy.dispatched.length).toBe(1);
+      expect(spy.dispatched[0]?.kind).toBe("add_info");
+      expect(spy.dispatched[0]?.message).toContain("Context engine swapped");
+      expect(spy.dispatched[0]?.message).toContain("operator-driven");
+    });
+
+    test("TUI bridge: same-identity swap is a controller no-op — no notice", async () => {
+      type ContextEngine = import("@koi/core").ContextEngine;
+      type TurnId = import("@koi/core").TurnId;
+      const spy = createDispatchSpy();
+      const runtime = await makeBridgedRuntime(spy);
+      const same: ContextEngine = {
+        identity: { ...DEFAULT_CONTEXT_ENGINE_IDENTITY },
+        prepare: (_c, m) => m,
+      };
+      runtime.contextEngineSwapController?.swap(same, {
+        turnId: "noop" as TurnId,
+        reason: "ghost",
+        force: true,
+      });
+      expect(spy.dispatched.length).toBe(0);
+    });
+
+    test("TUI bridge: rollback emits a reversed-direction notice", async () => {
+      type TurnId = import("@koi/core").TurnId;
+      const spy = createDispatchSpy();
+      const runtime = await makeBridgedRuntime(spy);
+      const passthrough = createPassthroughContextEngine();
+      runtime.contextEngineSwapController?.swap(passthrough, {
+        turnId: "fwd" as TurnId,
+        reason: "go-forward",
+        force: true,
+      });
+      runtime.contextEngineSwapController?.rollback({
+        turnId: "back" as TurnId,
+        reason: "rolling-back",
+      });
+      expect(spy.dispatched.length).toBe(2);
+      const fwd = spy.dispatched[0]?.message ?? "";
+      const back = spy.dispatched[1]?.message ?? "";
+      expect(fwd).toContain(`${DEFAULT_CONTEXT_ENGINE_IDENTITY.name}@`);
+      expect(fwd).toContain(`${PASSTHROUGH_CONTEXT_ENGINE_IDENTITY.name}@`);
+      // Rollback flips the arrow: passthrough → bundled.
+      expect(back).toContain(`${PASSTHROUGH_CONTEXT_ENGINE_IDENTITY.name}@`);
+      expect(back).toContain(`${DEFAULT_CONTEXT_ENGINE_IDENTITY.name}@`);
+      expect(back).toContain("rolling-back");
+    });
+
+    test("TUI bridge: multiple distinct swaps in one turn produce distinct notice ids", async () => {
+      type ContextEngine = import("@koi/core").ContextEngine;
+      type TurnId = import("@koi/core").TurnId;
+      const spy = createDispatchSpy();
+      const runtime = await makeBridgedRuntime(spy);
+      const observed: import("@koi/core").ContextEngineSwapEvent[] = [];
+      runtime.contextEngineSwapController?.subscribe((evt) => observed.push(evt));
+      const a: ContextEngine = {
+        identity: { name: "engine-a", version: "1.0.0" },
+        prepare: (_c, m) => m,
+      };
+      const b: ContextEngine = {
+        identity: { name: "engine-b", version: "1.0.0" },
+        prepare: (_c, m) => m,
+      };
+      // bundled → A → B → A: three distinct transitions; each gets a
+      // unique formatter id so the TUI store cannot dedupe legitimate
+      // churn into a single notice.
+      runtime.contextEngineSwapController?.swap(a, {
+        turnId: "t1" as TurnId,
+        reason: "ab",
+        force: true,
+      });
+      runtime.contextEngineSwapController?.swap(b, {
+        turnId: "t1" as TurnId,
+        reason: "ab",
+        force: true,
+      });
+      runtime.contextEngineSwapController?.swap(a, {
+        turnId: "t1" as TurnId,
+        reason: "ab",
+        force: true,
+      });
+      expect(spy.dispatched.length).toBe(3);
+      const ids = observed.map((e) => formatContextEngineSwapNotice(e).id);
+      expect(new Set(ids).size).toBe(3);
+    });
+
+    test("TUI bridge: idempotent re-dispatch of the same event yields a stable id (TUI dedupe key)", () => {
+      type TurnId = import("@koi/core").TurnId;
+      const event: import("@koi/core").ContextEngineSwapEvent = {
+        kind: "context-engine-swap",
+        turnId: "t-stable" as TurnId,
+        from: { name: "x", version: "1.0.0" },
+        to: { name: "y", version: "2.0.0" },
+        reason: "stable",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      };
+      const a = formatContextEngineSwapNotice(event);
+      const b = formatContextEngineSwapNotice(event);
+      expect(a.id).toBe(b.id);
+      expect(a.message).toBe(b.message);
+    });
+
+    test("TUI bridge: subscriber throw is captured by onListenerError; bridge still dispatches", async () => {
+      type TurnId = import("@koi/core").TurnId;
+      const spy = createDispatchSpy();
+      const errors: unknown[] = [];
+      // Build a runtime with onContextEngineSwap undefined so we control
+      // both the noisy listener and the bridge.
+      const { createKoi } = await import("@koi/engine");
+      const runtime = await createKoi({
+        manifest: { name: "agent", version: "1.0.0", model: { name: "test" } },
+        adapter: buildMockAdapter(),
+        contextEngineFactory: createContextEngine,
+      });
+      // Bare controller-level subscription doesn't have an
+      // onListenerError option, so this case validates the
+      // current fail-loud behaviour: a thrown bridge subscriber
+      // surfaces as an aggregated error, AFTER the other
+      // subscribers (including the spy) ran.
+      const ctrl = runtime.contextEngineSwapController;
+      if (ctrl === undefined) throw new Error("controller missing");
+      ctrl.subscribe(() => {
+        throw new Error("noisy");
+      });
+      wireBridge(ctrl, spy);
+      try {
+        ctrl.swap(createPassthroughContextEngine(), {
+          turnId: "throw" as TurnId,
+          reason: "with-throw",
+          force: true,
+        });
+      } catch (e: unknown) {
+        errors.push(e);
+      }
+      expect(spy.dispatched.length).toBe(1);
+      expect(errors.length).toBe(1);
+      expect(String(errors[0])).toContain("subscriber");
     });
 
     test("manifest version that does not match the bundled artifact is rejected", async () => {

--- a/packages/meta/runtime/src/__tests__/golden-queries.test.ts
+++ b/packages/meta/runtime/src/__tests__/golden-queries.test.ts
@@ -1131,6 +1131,120 @@ describe("Golden: @koi/context-manager", () => {
       expect(slot?.identity.version).toBe(DEFAULT_CONTEXT_ENGINE_IDENTITY.version);
     });
 
+    test("swap events emitted during a run surface as kind:custom engine events (#1767 Phase 5+8)", async () => {
+      const { createKoi } = await import("@koi/engine");
+      type ContextEngine = import("@koi/core").ContextEngine;
+      type TurnId = import("@koi/core").TurnId;
+      const passthrough: ContextEngine = createPassthroughContextEngine();
+      const adapter: import("@koi/core").EngineAdapter = {
+        engineId: "test-adapter",
+        capabilities: { text: true, images: false, files: false, audio: false },
+        stream: () => {
+          const events: EngineEvent[] = [
+            { kind: "turn_end", turnIndex: 0 },
+            {
+              kind: "done",
+              output: {
+                content: [],
+                stopReason: "completed",
+                metrics: {
+                  totalTokens: 0,
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  turns: 1,
+                  durationMs: 0,
+                },
+              },
+            },
+          ];
+          let i = 0;
+          return {
+            [Symbol.asyncIterator]: () => ({
+              async next(): Promise<IteratorResult<EngineEvent>> {
+                if (i >= events.length) return { done: true, value: undefined };
+                const value = events[i];
+                if (value === undefined) return { done: true, value: undefined };
+                i += 1;
+                return { done: false, value };
+              },
+            }),
+          };
+        },
+      };
+      const runtime = await createKoi({
+        manifest: {
+          name: "agent",
+          version: "1.0.0",
+          model: { name: "test" },
+          context: { engine: DEFAULT_CONTEXT_ENGINE_IDENTITY.name },
+        },
+        adapter,
+        contextEngineFactory: createContextEngine,
+      });
+
+      const handle = runtime.run({ kind: "text", text: "hi" });
+      const iter = handle[Symbol.asyncIterator]();
+      const collected: EngineEvent[] = [];
+      const first = await iter.next();
+      if (!first.done) collected.push(first.value);
+      // Mid-run swap to passthrough — must be force:true because the
+      // manifest pinned the bundled engine name and passthrough has a
+      // different identity.
+      runtime.contextEngineSwapController?.swap(passthrough, {
+        turnId: "run-1:t1" as TurnId,
+        reason: "phase-8 e2e swap",
+        force: true,
+      });
+      while (true) {
+        const r = await iter.next();
+        if (r.done) break;
+        collected.push(r.value);
+      }
+      const swapEvents = collected.filter(
+        (e): e is Extract<EngineEvent, { kind: "custom" }> =>
+          e.kind === "custom" && e.type === "context-engine-swap",
+      );
+      expect(swapEvents.length).toBe(1);
+      const data = swapEvents[0]?.data as {
+        from: { name: string };
+        to: { name: string };
+        reason: string;
+      };
+      expect(data.from.name).toBe(DEFAULT_CONTEXT_ENGINE_IDENTITY.name);
+      expect(data.to.name).toBe("@koi/context-manager/passthrough");
+      expect(data.reason).toBe("phase-8 e2e swap");
+    });
+
+    test("swap before any run is dropped — telemetry-only delivery between runs (#1767 Phase 5)", async () => {
+      const { createKoi } = await import("@koi/engine");
+      type ContextEngine = import("@koi/core").ContextEngine;
+      type TurnId = import("@koi/core").TurnId;
+      const passthrough: ContextEngine = createPassthroughContextEngine();
+      const runtime = await createKoi({
+        manifest: { name: "agent", version: "1.0.0", model: { name: "test" } },
+        adapter: buildMockAdapter(),
+        contextEngineFactory: createContextEngine,
+      });
+      // Subscribe directly to confirm the controller still fires the swap
+      // even when no run is active — out-of-run delivery is via subscribe().
+      const observed: string[] = [];
+      runtime.contextEngineSwapController?.subscribe((evt) => observed.push(evt.to.name));
+      runtime.contextEngineSwapController?.swap(passthrough, {
+        turnId: "out-of-run" as TurnId,
+        reason: "before-any-run",
+        force: true,
+      });
+      expect(observed).toEqual(["@koi/context-manager/passthrough"]);
+      // Now start a run that completes immediately — the queue must NOT
+      // replay the earlier out-of-run swap (it was dropped at emission time).
+      const collected: EngineEvent[] = [];
+      for await (const e of runtime.run({ kind: "text", text: "hi" })) collected.push(e);
+      const swapEvents = collected.filter(
+        (e) => e.kind === "custom" && e.type === "context-engine-swap",
+      );
+      expect(swapEvents.length).toBe(0);
+    });
+
     test("manifest version that does not match the bundled artifact is rejected", async () => {
       const { createKoi } = await import("@koi/engine");
       await expect(


### PR DESCRIPTION
## Summary

Finishes the deferred phases from #2118 — runtime emission, TUI notice, and replay assertions for the pluggable ContextEngine slot (#1767).

- **Phase 5 (runtime emission)** — `createKoi` bridges `ContextEngineSwapController.subscribe()` into the active `streamEvents` generator so swaps surface as `{ kind: "custom", type: "context-engine-swap", data: ContextEngineSwapEvent }` on the engine event stream while a run is in flight. Out-of-run swaps are dropped (telemetry-only per anti-leak `custom`-event policy); host observers still receive them via `controller.subscribe()`.
- **Phase 6 (TUI notice)** — `tui-command.ts` handles the new event type and dispatches a single-writer notice through `store.dispatch({ kind: "add_info", ... })` (the #1940 contract): `context engine: A@1.0.0 -> B@2.0.0 (reason)`. Same render path as plugin-load notices — not in transcript, not in model context.
- **Phase 8 (replay assertions)** — Two e2e tests in `golden-queries.test.ts` on the bundled `createKoi + createContextEngine` path, plus a focused unit test in `koi.test.ts`.

### Phases delivered

| Phase | Status |
|---|---|
| 5. Runtime emission integration | done |
| 6. TUI swap notice | done |
| 8. Golden replay scenario | e2e tests; real-LLM cassette skipped (see below) |

### Why no real-LLM cassette

The cassette pipeline targets LLM-driven trajectories (cassette = recorded `ModelChunk[]`). A context-engine swap is host-driven — the runtime calls `controller.swap()` from outside the model loop. Recording it through OpenRouter would not add assertion power over the deterministic e2e tests now covering the path. CI runs the swap-emission loop without external dependencies via `golden-queries.test.ts`.

## Verification

```text
@koi/engine                          191 tests pass (3 files: koi/runtime/swap)
@koi/runtime golden-queries          111 pass / 5 skip / 0 fail
bun run check:complexity             728 within ratchet budget of 728
bun run check:layers                 OK
bun x biome check                    clean
```

## Test plan

- [x] Phase 5 emission: in-run swaps yield `custom` events; out-of-run swaps are dropped
- [x] Phase 6 TUI: handler dispatches `add_info` with formatted swap notice
- [x] Phase 8: golden-queries e2e covers both in-run and out-of-run paths
- [ ] Manual TUI smoke test (optional follow-up — host calls `runtime.contextEngineSwapController?.swap(...)` and observes the rendered notice)

After merge, #1767 can be closed.