### PR TITLE
feat(tui): remote gateway runtime + reconnect/resume — closes #2122

### DIFF
--- a/docs/L3/cli.md
+++ b/docs/L3/cli.md
@@ -6,6 +6,17 @@ Command-line interface for running Koi agents locally. Provides interactive (`st
 
 ## Recent updates
 
+- **Remote TUI gateway client (#2122)**: `koi tui --gateway-url ws://…`
+  connects to a running `koi gateway-up` instead of executing the engine
+  in-process. New modules `tui-gateway-client.ts` + `tui-request-stream.ts`
+  bridge per-request gateway response/error frames into `EngineEvent`
+  deltas + terminal `done`. Authentication uses `KOI_GATEWAY_TOKEN`
+  (set on both the gateway and the TUI). Each `run()` installs a
+  ref-correlated WebSocket listener; mismatched refs are ignored, terminal
+  frames detach the listener via the iterator's try/finally. Tests cover
+  matching/mismatching ref, error frames, and pre-terminal socket close.
+  No new dependencies.
+
 - **`koi gateway-up` command (#1213 follow-up)**: new direct dependency on
   `@koi/gateway-stack`. Adds the `gateway-up` subcommand, which spins up a
   loopback gateway via the new `createLocalGatewayLauncher` (gateway WS +

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -17,7 +17,7 @@ Current snapshot:
 | exec | 2 | 12 | 2 |
 | kernel | 4 | 126 | 0 |
 | lib | 139 | 718 | 121 |
-| meta | 3 | 107 | 3 |
+| meta | 3 | 109 | 3 |
 | mm | 12 | 54 | 12 |
 | net | 10 | 90 | 10 |
 | sandbox | 11 | 58 | 11 |
@@ -190,7 +190,7 @@ Each line shows package name, package directory, package description, test-file 
 
 ## meta (3)
 
-- `@koi-agent/cli` (packages/meta/cli) - Interactive command-line interface for agent initialization and local execution. Tests: 66. Docs: docs/L3/cli.md.
+- `@koi-agent/cli` (packages/meta/cli) - Interactive command-line interface for agent initialization and local execution. Tests: 68. Docs: docs/L3/cli.md.
 - `@koi/rlm-stack` (packages/meta/rlm-stack) - L3 composition wiring @koi/middleware-rlm with @koi/context-manager threshold coordination. Tests: 3. Docs: docs/L2/rlm-stack.md, docs/L3/rlm-stack.md.
 - `@koi/runtime` (packages/meta/runtime) - L3 meta-package: wires Phase 1 kernel + L2 packages into a bootable runtime with progressive stub replacement. Tests: 38. Docs: docs/L3/runtime.md.
 

--- a/packages/meta/cli/src/__tests__/tui-gateway-ha.e2e.test.ts
+++ b/packages/meta/cli/src/__tests__/tui-gateway-ha.e2e.test.ts
@@ -1,0 +1,591 @@
+import { expect, test } from "bun:test";
+
+const RUN_TMUX_E2E =
+  process.env.KOI_RUN_TMUX_E2E === "1" || process.env.KOI_RUN_TMUX_E2E === "true";
+
+const HOSTNAME = "127.0.0.1";
+const GW_A_WS = "ws://127.0.0.1:19500";
+const GW_B_WS = "ws://127.0.0.1:19510";
+const NEXUS_API_KEY = "tmux-ha-test-key";
+const CLIENT_ID = "failover-client";
+const GW_A_CMD_ENV = "KOI_TMUX_E2E_GWA_CMD";
+const GW_B_CMD_ENV = "KOI_TMUX_E2E_GWB_CMD";
+const TUI_CMD_ENV = "KOI_TMUX_E2E_TUI_CMD";
+
+type JsonRpcRequest = {
+  readonly id?: string | number | null;
+  readonly method?: string;
+  readonly params?: Record<string, unknown>;
+};
+
+type GatewaySessionRecord = {
+  readonly ownerInstance: string;
+  readonly session: {
+    readonly id: string;
+    readonly seq: number;
+    readonly remoteSeq: number;
+  };
+};
+
+interface TextBuffer {
+  readonly read: () => string;
+  readonly done: Promise<void>;
+}
+
+interface ManagedProcess {
+  readonly proc: Bun.Subprocess<"inherit", "pipe", "pipe">;
+  readonly stdout: TextBuffer;
+  readonly stderr: TextBuffer;
+}
+
+interface MockNexus {
+  readonly url: string;
+  readonly store: Map<string, string>;
+  readonly stop: () => void;
+}
+
+test.skipIf(!RUN_TMUX_E2E)(
+  "real tui resumes through gateway failover",
+  async () => {
+    const sessionName = `koi-gw-ha-${Date.now()}`;
+    const mockNexus = await startMockNexus();
+    const gatewayEnv = {
+      ...process.env,
+      NEXUS_URL: mockNexus.url,
+      NEXUS_API_KEY,
+    };
+    const gwA = spawnManagedShell(gatewayLauncherCommand("gwA", mockNexus.url), gatewayEnv);
+    const gwB = spawnManagedShell(gatewayLauncherCommand("gwB", mockNexus.url), gatewayEnv);
+
+    try {
+      await waitForJsonEvent(gwA, "gateway_up_started", "gwA startup");
+      await waitForJsonEvent(gwB, "gateway_up_started", "gwB startup");
+
+      await runTmux([
+        "new-session",
+        "-d",
+        "-s",
+        sessionName,
+        "-c",
+        process.cwd(),
+        tuiLauncherCommand(),
+      ]);
+
+      await waitForPaneText(
+        sessionName,
+        `Connected to remote gateway ${GW_A_WS}`,
+        "tui remote connect",
+      );
+
+      await runTmux(["send-keys", "-t", sessionName, "hello before failover", "Enter"]);
+      await waitFor(
+        () => {
+          const record = readGatewaySessionRecord(mockNexus.store, CLIENT_ID);
+          return record?.ownerInstance === "gwA";
+        },
+        10_000,
+        "initial session persisted via gwA",
+        async () =>
+          `gwA stdout:\n${gwA.stdout.read()}\n\ngwA stderr:\n${gwA.stderr.read()}\n\npane:\n${await capturePane(
+            sessionName,
+          )}`,
+      );
+
+      gwA.proc.kill("SIGKILL");
+      await gwA.proc.exited;
+
+      await runTmux(["send-keys", "-t", sessionName, "hello after failover", "Enter"]);
+      await waitForPaneText(
+        sessionName,
+        "Gateway disconnected - reconnecting...",
+        "reconnect notice",
+      );
+      await waitForPaneText(sessionName, "Gateway resumed existing session.", "resume notice");
+
+      await waitFor(
+        () => {
+          const record = readGatewaySessionRecord(mockNexus.store, CLIENT_ID);
+          return record?.ownerInstance === "gwB";
+        },
+        10_000,
+        "session ownership moved to gwB",
+        async () =>
+          `gwB stdout:\n${gwB.stdout.read()}\n\ngwB stderr:\n${gwB.stderr.read()}\n\npane:\n${await capturePane(
+            sessionName,
+          )}`,
+      );
+
+      const finalPane = await capturePane(sessionName);
+      expect(finalPane).toContain("Gateway disconnected - reconnecting...");
+      expect(finalPane).toContain("Gateway resumed existing session.");
+
+      const finalRecord = readGatewaySessionRecord(mockNexus.store, CLIENT_ID);
+      expect(finalRecord?.ownerInstance).toBe("gwB");
+    } finally {
+      await Promise.all([
+        cleanupTmuxSession(sessionName),
+        stopManagedProcess(gwA, "SIGTERM"),
+        stopManagedProcess(gwB, "SIGTERM"),
+      ]);
+      mockNexus.stop();
+    }
+  },
+  60_000,
+);
+
+test("tui gateway ha e2e: $KOI_RUN_TMUX_E2E gating wired", () => {
+  expect(typeof RUN_TMUX_E2E).toBe("boolean");
+});
+
+test("gateway launcher env overrides win over defaults", () => {
+  const previousGwA = process.env[GW_A_CMD_ENV];
+  const previousGwB = process.env[GW_B_CMD_ENV];
+  const previousTui = process.env[TUI_CMD_ENV];
+  process.env[GW_A_CMD_ENV] = "custom-gwa";
+  process.env[GW_B_CMD_ENV] = "custom-gwb";
+  process.env[TUI_CMD_ENV] = "custom-tui";
+  try {
+    expect(gatewayLauncherCommand("gwA", "http://nexus.local")).toBe("custom-gwa");
+    expect(gatewayLauncherCommand("gwB", "http://nexus.local")).toBe("custom-gwb");
+    expect(tuiLauncherCommand()).toBe("custom-tui");
+  } finally {
+    restoreEnv(GW_A_CMD_ENV, previousGwA);
+    restoreEnv(GW_B_CMD_ENV, previousGwB);
+    restoreEnv(TUI_CMD_ENV, previousTui);
+  }
+});
+
+test("default launcher commands include the HA-specific arguments", () => {
+  const previousGwA = process.env[GW_A_CMD_ENV];
+  const previousGwB = process.env[GW_B_CMD_ENV];
+  const previousTui = process.env[TUI_CMD_ENV];
+  delete process.env[GW_A_CMD_ENV];
+  delete process.env[GW_B_CMD_ENV];
+  delete process.env[TUI_CMD_ENV];
+  try {
+    const gwA = gatewayLauncherCommand("gwA", "http://nexus.local");
+    const gwB = gatewayLauncherCommand("gwB", "http://nexus.local");
+    const tui = tuiLauncherCommand();
+    expect(gwA).toContain("gateway-up");
+    expect(gwA).toContain("--port 19500");
+    expect(gwA).toContain("--instance-id gwA");
+    expect(gwA).toContain("--nexus-url http://nexus.local");
+    expect(gwA).toContain(`--nexus-api-key ${NEXUS_API_KEY}`);
+    expect(gwA).toContain("--log-format json");
+    expect(gwB).toContain("--port 19510");
+    expect(gwB).toContain("--instance-id gwB");
+    expect(tui).toContain("tui");
+    expect(tui).toContain(`--gateway-url ${GW_A_WS}`);
+    expect(tui).toContain(`--session ${CLIENT_ID}`);
+  } finally {
+    restoreEnv(GW_A_CMD_ENV, previousGwA);
+    restoreEnv(GW_B_CMD_ENV, previousGwB);
+    restoreEnv(TUI_CMD_ENV, previousTui);
+  }
+});
+
+test("waitForJsonEvent ignores non-json lines and finds the requested event", async () => {
+  const proc = createFakeManagedProcess(
+    ["starting up...", '{"kind":"other"}', '{"kind":"gateway_up_started","instanceId":"gwA"}'].join(
+      "\n",
+    ),
+    "",
+  );
+
+  const event = await waitForJsonEvent(proc, "gateway_up_started", "fake startup");
+  expect(event.instanceId).toBe("gwA");
+});
+
+test("waitForJsonEvent timeout includes stdout and stderr context", async () => {
+  const proc = createFakeManagedProcess('{"kind":"other"}', "boom on stderr");
+
+  await expect(waitForJsonEvent(proc, "gateway_up_started", "missing startup", 25)).rejects.toThrow(
+    "stderr:\nboom on stderr",
+  );
+});
+
+test("decodeNexusContent accepts bytes payloads and rejects invalid shapes", () => {
+  expect(decodeNexusContent("plain")).toBe("plain");
+  expect(
+    decodeNexusContent({
+      __type__: "bytes",
+      data: Buffer.from("payload", "utf-8").toString("base64"),
+    }),
+  ).toBe("payload");
+  expect(decodeNexusContent({ __type__: "bytes", data: 123 })).toBeUndefined();
+  expect(decodeNexusContent({ nope: true })).toBeUndefined();
+});
+
+test("readGatewaySessionRecord uses the encoded session path and returns undefined when absent", () => {
+  const store = new Map<string, string>();
+  expect(readGatewaySessionRecord(store, "missing-client")).toBeUndefined();
+
+  const record = {
+    ownerInstance: "gwB",
+    session: { id: "sess-6661696c6f7665722d636c69656e74", seq: 7, remoteSeq: 3 },
+  } satisfies GatewaySessionRecord;
+  store.set(nexusSessionPath(CLIENT_ID), JSON.stringify(record));
+
+  expect(readGatewaySessionRecord(store, CLIENT_ID)).toEqual(record);
+  expect(nexusSessionPath(CLIENT_ID)).toBe(
+    "global/gateway/sessions/c2Vzcy02NjYxNjk2YzZmNzY2NTcyMmQ2MzZjNjk2NTZlNzQ.json",
+  );
+});
+
+function gatewayLauncherCommand(instanceId: "gwA" | "gwB", nexusUrl: string): string {
+  const override = process.env[instanceId === "gwA" ? GW_A_CMD_ENV : GW_B_CMD_ENV];
+  if (override !== undefined && override.length > 0) return override;
+  const port = instanceId === "gwA" ? 19500 : 19510;
+  return (
+    `${process.execPath} packages/meta/cli/src/bin.ts gateway-up ` +
+    `--port ${String(port)} --instance-id ${instanceId} ` +
+    `--nexus-url ${nexusUrl} --nexus-api-key ${NEXUS_API_KEY} --log-format json`
+  );
+}
+
+function tuiLauncherCommand(): string {
+  const override = process.env[TUI_CMD_ENV];
+  if (override !== undefined && override.length > 0) return override;
+  const command = `${process.execPath} packages/meta/cli/src/bin.ts tui --gateway-url ${GW_A_WS} --session ${CLIENT_ID}`;
+  return wrapCommandForTmuxPane(command);
+}
+
+function createFakeManagedProcess(stdout: string, stderr: string): ManagedProcess {
+  return {
+    proc: {
+      exited: Promise.resolve(0),
+      kill: () => undefined,
+    } as unknown as ManagedProcess["proc"],
+    stdout: { read: () => stdout, done: Promise.resolve() },
+    stderr: { read: () => stderr, done: Promise.resolve() },
+  };
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function wrapCommandForTmuxPane(command: string): string {
+  return (
+    "bash -lc " +
+    singleQuoteForShell(`${command}; code=$?; printf "\\n[TUI EXIT %s]\\n" "$code"; sleep 30`)
+  );
+}
+
+function singleQuoteForShell(text: string): string {
+  return `'${text.replaceAll("'", `'"'"'`)}'`;
+}
+
+function spawnManagedShell(command: string, env: NodeJS.ProcessEnv): ManagedProcess {
+  const proc = Bun.spawn(["/bin/bash", "-lc", command], {
+    cwd: process.cwd(),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "inherit",
+  });
+  return {
+    proc,
+    stdout: collectText(proc.stdout),
+    stderr: collectText(proc.stderr),
+  };
+}
+
+function collectText(stream: ReadableStream<Uint8Array> | null): TextBuffer {
+  let text = "";
+  const decoder = new TextDecoder();
+  const done = (async () => {
+    if (stream === null) return;
+    for await (const chunk of stream) {
+      text += decoder.decode(chunk, { stream: true });
+    }
+    text += decoder.decode();
+  })();
+  return {
+    read: () => text,
+    done,
+  };
+}
+
+async function waitForJsonEvent(
+  proc: ManagedProcess,
+  kind: string,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<Record<string, unknown>> {
+  return await waitFor(
+    () => {
+      const lines = proc.stdout
+        .read()
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line) as Record<string, unknown>;
+          if (parsed.kind === kind) return parsed;
+        } catch {
+          // Ignore non-JSON output during startup.
+        }
+      }
+      return undefined;
+    },
+    timeoutMs,
+    label,
+    async () => `stdout:\n${proc.stdout.read()}\n\nstderr:\n${proc.stderr.read()}`,
+  );
+}
+
+async function runTmux(args: readonly string[]): Promise<void> {
+  const proc = Bun.spawn(["tmux", ...args], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await readStream(proc.stdout);
+  const stderr = await readStream(proc.stderr);
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(
+      `tmux ${args.join(" ")} failed with exit ${String(exitCode)}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    );
+  }
+}
+
+async function capturePane(sessionName: string): Promise<string> {
+  const proc = Bun.spawn(["tmux", "capture-pane", "-pt", sessionName, "-S", "-"], {
+    cwd: process.cwd(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await readStream(proc.stdout);
+  const stderr = await readStream(proc.stderr);
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(
+      `tmux capture-pane failed for ${sessionName} with exit ${String(exitCode)}\nstderr:\n${stderr}`,
+    );
+  }
+  return stdout;
+}
+
+async function waitForPaneText(sessionName: string, text: string, label: string): Promise<void> {
+  await waitFor(
+    async () => {
+      const pane = await tryCapturePane(sessionName);
+      return pane !== undefined && pane.includes(text);
+    },
+    15_000,
+    label,
+    async () => {
+      const pane = await tryCapturePane(sessionName);
+      return pane ?? `<pane unavailable for session ${sessionName}>`;
+    },
+  );
+}
+
+async function tryCapturePane(sessionName: string): Promise<string | undefined> {
+  try {
+    return await capturePane(sessionName);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("can't find pane")) return undefined;
+    throw error;
+  }
+}
+
+async function waitFor<T>(
+  predicate: () => T | Promise<T>,
+  timeoutMs: number,
+  label: string,
+  debugText?: (() => Promise<string>) | undefined,
+): Promise<NonNullable<T>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value) {
+      return value as NonNullable<T>;
+    }
+    await Bun.sleep(100);
+  }
+  const detail = debugText ? await debugText() : "";
+  throw new Error(`Timed out waiting for ${label}${detail.length > 0 ? `\n${detail}` : ""}`);
+}
+
+async function readStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (stream === null) return "";
+  const decoder = new TextDecoder();
+  let text = "";
+  for await (const chunk of stream) {
+    text += decoder.decode(chunk, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+async function startMockNexus(): Promise<MockNexus> {
+  const store = new Map<string, string>();
+  const server = startMockNexusServer(store);
+
+  return {
+    url: `http://${HOSTNAME}:${server.port}`,
+    store,
+    stop: () => server.stop(true),
+  };
+}
+
+function startMockNexusServer(store: Map<string, string>): Bun.Server<undefined> {
+  const basePort = 26000 + Math.floor(Math.random() * 1000);
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const port = basePort + attempt;
+    try {
+      return Bun.serve({
+        port,
+        hostname: HOSTNAME,
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === "/health") {
+            return Response.json({ status: "ok", entries: store.size });
+          }
+          if (!url.pathname.startsWith("/api/nfs/")) {
+            return new Response("not found", { status: 404 });
+          }
+          const rpc = (await request.json()) as JsonRpcRequest;
+          const method = decodeURIComponent(url.pathname.slice("/api/nfs/".length));
+          const params = rpc.params ?? {};
+          const ok = (result: unknown): Response =>
+            Response.json({ jsonrpc: "2.0", id: rpc.id ?? null, result });
+          const fail = (code: number, message: string): Response =>
+            Response.json({ jsonrpc: "2.0", id: rpc.id ?? null, error: { code, message } });
+
+          switch (method) {
+            case "version":
+              return ok("mock-nexus");
+            case "read_bulk": {
+              const paths = Array.isArray(params.paths) ? params.paths : [];
+              const result = Object.fromEntries(
+                paths.map((path) => {
+                  if (typeof path !== "string") return ["", null];
+                  const value = store.get(path);
+                  return [
+                    path,
+                    value === undefined
+                      ? null
+                      : {
+                          __type__: "bytes",
+                          data: Buffer.from(value, "utf-8").toString("base64"),
+                        },
+                  ];
+                }),
+              );
+              return ok(result);
+            }
+            case "write_batch": {
+              const files = Array.isArray(params.files) ? params.files : [];
+              for (const file of files) {
+                if (!Array.isArray(file) || typeof file[0] !== "string") {
+                  return fail(-32602, "bad write_batch payload");
+                }
+                const text = decodeNexusContent(file[1]);
+                if (text === undefined) {
+                  return fail(-32602, "bad content");
+                }
+                store.set(file[0], text);
+              }
+              return ok(
+                Object.fromEntries(
+                  files
+                    .filter((file): file is readonly [string, unknown] => Array.isArray(file))
+                    .map((file) => [file[0], { success: true }]),
+                ),
+              );
+            }
+            case "delete_batch": {
+              const paths = Array.isArray(params.paths) ? params.paths : [];
+              return ok(
+                Object.fromEntries(
+                  paths.map((path) => {
+                    if (typeof path !== "string") {
+                      return ["", { success: false, error: "bad path" }];
+                    }
+                    const existed = store.delete(path);
+                    return [
+                      path,
+                      existed ? { success: true } : { success: false, error: "File not found" },
+                    ];
+                  }),
+                ),
+              );
+            }
+            default:
+              return fail(-32601, `unknown method: ${method}`);
+          }
+        },
+      });
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+      if (code !== "EADDRINUSE" && !String(error).includes("EADDRINUSE")) {
+        throw error;
+      }
+    }
+  }
+  throw new Error(
+    `failed to bind mock nexus on ports ${String(basePort)}-${String(basePort + 199)}`,
+  );
+}
+
+function decodeNexusContent(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    (content as { __type__?: string }).__type__ === "bytes" &&
+    typeof (content as { data?: unknown }).data === "string"
+  ) {
+    return Buffer.from((content as { data: string }).data, "base64").toString("utf-8");
+  }
+  return undefined;
+}
+
+function readGatewaySessionRecord(
+  store: ReadonlyMap<string, string>,
+  clientId: string,
+): GatewaySessionRecord | undefined {
+  const text = store.get(nexusSessionPath(clientId));
+  if (text === undefined) return undefined;
+  return JSON.parse(text) as GatewaySessionRecord;
+}
+
+function nexusSessionPath(clientId: string): string {
+  const sessionId = `sess-${Buffer.from(clientId).toString("hex")}`;
+  const encoded = Buffer.from(sessionId, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `global/gateway/sessions/${encoded}.json`;
+}
+
+async function stopManagedProcess(proc: ManagedProcess, signal: NodeJS.Signals): Promise<void> {
+  proc.proc.kill(signal);
+  await Promise.race([proc.proc.exited, Bun.sleep(5_000)]);
+  await Promise.all([proc.stdout.done, proc.stderr.done]);
+}
+
+async function cleanupTmuxSession(sessionName: string): Promise<void> {
+  const proc = Bun.spawn(["tmux", "kill-session", "-t", sessionName], {
+    cwd: process.cwd(),
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+}

--- a/packages/meta/cli/src/args/tui.ts
+++ b/packages/meta/cli/src/args/tui.ts
@@ -72,6 +72,12 @@ export interface TuiFlags extends BaseFlags {
    * `mode: sandbox` (or `auto` with no URL) auto-spawns @koi/nexus-sandbox.
    */
   readonly nexusUrl: string | undefined;
+  /**
+   * Optional remote gateway URL (issue #2122). When set, the TUI connects
+   * to a running `koi gateway-up` over WebSocket instead of executing the
+   * engine in-process. Requires KOI_GATEWAY_TOKEN to authenticate.
+   */
+  readonly gatewayUrl: string | undefined;
 }
 
 export function parseTuiFlags(rest: readonly string[]): TuiFlags {
@@ -80,6 +86,7 @@ export function parseTuiFlags(rest: readonly string[]): TuiFlags {
     readonly session: string | undefined;
     readonly resume: string | undefined;
     readonly manifest: string | undefined;
+    readonly "gateway-url": string | undefined;
     readonly "no-manifest": boolean | undefined;
     readonly "until-pass": string[] | undefined;
     readonly "max-iter": string | undefined;
@@ -106,6 +113,7 @@ export function parseTuiFlags(rest: readonly string[]): TuiFlags {
         session: { type: "string" },
         resume: { type: "string" },
         manifest: { type: "string" },
+        "gateway-url": { type: "string" },
         "no-manifest": { type: "boolean", default: false },
         "until-pass": { type: "string", multiple: true },
         "max-iter": { type: "string" },
@@ -202,6 +210,7 @@ export function parseTuiFlags(rest: readonly string[]): TuiFlags {
     yolo: (values.yolo ?? false) || (values["dangerously-skip-permissions"] ?? false),
     governance,
     nexusUrl: values["nexus-url"],
+    gatewayUrl: values["gateway-url"],
   };
 }
 

--- a/packages/meta/cli/src/tui-command.ts
+++ b/packages/meta/cli/src/tui-command.ts
@@ -138,6 +138,7 @@ import {
   writeSessionMeta,
 } from "./shared-wiring.js";
 import { createUnrefTimer } from "./sigint-handler.js";
+import { createTuiGatewayClient, type TuiGatewayClient } from "./tui-gateway-client.js";
 import { createTuiSigintHandler } from "./tui-graceful-sigint.js";
 import {
   createSigusr1Handler,
@@ -236,6 +237,10 @@ export function clampContextLength(raw: number | undefined): number | undefined 
   if (!Number.isFinite(raw) || !Number.isInteger(raw)) return undefined;
   if (raw < 2048 || raw > 4_000_000) return undefined;
   return raw;
+}
+
+export function selectTuiRuntimeMode(flags: Pick<TuiFlags, "gatewayUrl">): "local" | "remote" {
+  return flags.gatewayUrl === undefined ? "local" : "remote";
 }
 
 // ---------------------------------------------------------------------------
@@ -2122,6 +2127,9 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
   // The runtimeReady promise resolves before the first submit.
   // let: set once when the promise resolves
   let runtimeHandle: KoiRuntimeHandle | null = null;
+  const runtimeMode = selectTuiRuntimeMode(flags);
+  let gatewayClient: TuiGatewayClient | null = null;
+  let activeRemoteRequestId: string | null = null;
   // Manifest-declared supervision (#1866). Populated only when the loaded
   // koi.yaml carries a `supervision:` block. Disposed in reverse-construction
   // order in the teardown chain below.
@@ -2249,6 +2257,11 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         try {
           if (runtimeHandle !== null) {
             await runtimeHandle.runtime.dispose();
+          }
+        } catch {}
+        try {
+          if (runtimeHandle === null) {
+            await gatewayClient?.dispose();
           }
         } catch {}
         // Dispose the auth notification handler synchronously first: the
@@ -2563,687 +2576,737 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     }
   }
 
-  const runtimeReady = createKoiRuntime({
-    modelAdapter,
-    modelName,
-    approvalHandler: labeledApprovalHandler,
-    approvalTimeoutMs: TUI_APPROVAL_TIMEOUT_MS,
-    cwd: process.cwd(),
-    systemPrompt,
-    ...(yoloPermissionBackend !== undefined
-      ? {
-          permissionBackend: yoloPermissionBackend,
-          permissionsDescription: "koi tui --yolo (auto-allow all tools)",
-          bashElicitAutoApprove: true,
-        }
-      : {}),
-    currentModelMiddleware,
-    // Resolve budgetConfig per turn so a mid-session model switch picks up
-    // the new model's context window immediately.
-    getCurrentModel: () => ({
-      model: currentModelBox.current,
-      ...(currentModelBox.contextLength !== undefined
-        ? { contextLength: currentModelBox.contextLength }
-        : {}),
-    }),
-    ...(modelRouterMiddleware !== undefined ? { modelRouterMiddleware } : {}),
-    // TUI opts out of engine loop detection explicitly: the
-    // per-submit iteration budget reset + governance caps below
-    // already bound spirals, and false-positive trips during an
-    // interactive session are expensive (they abort mid-turn with a
-    // confusing error). `koi start`'s auto-allow backend leaves
-    // this at the engine default (enabled) — see `runtime-factory.ts`.
-    loopDetection: false,
-    // In loop mode, session persistence is intentionally omitted so
-    // failed iterations don't pollute the resumable JSONL transcript.
-    // Loop mode is a self-correcting execution, not a conversation.
-    ...(isLoopMode ? {} : { session: { transcript: jsonlTranscript, sessionId: tuiSessionId } }),
-    // Issue #1683: cancel-resume checkpoint wiring. Activates only when
-    // `KOI_SESSION_STATE_DB` was set (and the SQLite open succeeded) and
-    // we're not in loop mode. Loop mode skips both session and checkpoint
-    // by design — failed iterations must not pollute resumable state.
-    // initialEngineState/initialEngineStateVersion are forwarded from the
-    // resume so the wrapped adapter restores the cancel cursor and the
-    // CAS check protects against a parallel runtime overwriting our row.
-    ...(stateSessionPersistence !== undefined && !isLoopMode
-      ? {
-          sessionPersistence: {
-            persistence: stateSessionPersistence,
-            agentId: (await import("@koi/core")).agentId(`koi-tui:${tuiSessionId}`),
-            manifestSnapshot: {
-              name: "koi-tui",
-              version: "0",
-              model: { name: modelName },
-            } satisfies import("@koi/core").AgentManifest,
-            onPersistError: (err: import("@koi/core").KoiError | Error): void => {
-              const msg = "message" in err ? err.message : String(err);
-              process.stderr.write(
-                `koi tui: cancel checkpoint write failed (${msg}); next resume will fall back to transcript-only\n`,
-              );
-            },
-            ...(resumedEngineState !== undefined ? { initialEngineState: resumedEngineState } : {}),
-            ...(resumedStateVersion !== undefined
-              ? { initialEngineStateVersion: resumedStateVersion }
-              : {}),
-          },
-        }
-      : {}),
-    skillsRuntime: skillRuntime,
-    skillsProgressive: true,
-    mcpOAuthChannel: tuiOAuthChannel,
-    ...(approvalStore !== undefined ? { persistentApprovals: approvalStore } : {}),
-    ...(governance.enabled && (governance.maxSpendUsd ?? 0) > 0
-      ? { maxSpendUsd: governance.maxSpendUsd }
-      : {}),
-    ...(governance.enabled && governance.maxTurns !== undefined
-      ? { maxTurns: governance.maxTurns }
-      : {}),
-    ...(governance.enabled && governance.maxSpawnDepth !== undefined
-      ? { maxSpawnDepth: governance.maxSpawnDepth }
-      : {}),
-    ...(governance.enabled && governance.alertThresholds !== undefined
-      ? { governanceAlertThresholds: governance.alertThresholds }
-      : {}),
-    ...(governance.enabled && governanceRules !== undefined ? { governanceRules } : {}),
-    ...(governance.enabled ? {} : { governanceDisabled: true }),
-    // Fallback model chain validation only runs when the router actually
-    // wired up. If router config validation failed above (modelRouterMiddleware
-    // === undefined), fallback models are unreachable — passing them to
-    // resolveCostConfig would refuse startup over models the runtime can't
-    // ever call.
-    ...(fallbackModels.length > 0 && modelRouterMiddleware !== undefined
-      ? { fallbackModelNames: fallbackModels }
-      : {}),
-    // Manifest-driven opt-in for preset stacks + plugins. Omitted
-    // when the user didn't pass --manifest, in which case the
-    // factory defaults to activating every stack / every discovered
-    // plugin (v1's "wire everything" posture).
-    ...(manifestStacks !== undefined ? { stacks: manifestStacks } : {}),
-    ...(manifestPlugins !== undefined ? { plugins: manifestPlugins } : {}),
-    ...(manifestFilesystemOps !== undefined ? { filesystemOperations: manifestFilesystemOps } : {}),
-    // gov-15: outbound-network scope from manifest.network → web-tools fetch wrap.
-    ...(manifestNetwork !== undefined ? { networkScope: { allow: manifestNetwork.allow } } : {}),
-    // gov-15: shared scoped CredentialComponent — same instance is registered
-    // on the CREDENTIALS subsystem token AND used by the progressive skill
-    // provider to gate skill `requires.credentials` at attach time.
-    ...(scopedCredentials !== undefined ? { credentials: scopedCredentials } : {}),
-    // #2088: ACE activation. resolvedAceConfig is built above under the
-    // spawn-gate; on resume without --manifest, manifestResult is never
-    // loaded so resolvedAceConfig stays undefined (resume-provenance gate
-    // by construction). Passes undefined → no middleware installed.
-    ...(resolvedAceConfig !== undefined ? { ace: resolvedAceConfig } : {}),
-    // Nexus backend (when resolved above) is passed through so the checkpoint
-    // stack stamps the correct backend name and the restore protocol dispatches
-    // compensating ops through the right backend. Omitted when undefined —
-    // factory falls back to the default local backend rooted at cwd.
-    ...(resolvedFilesystemBackend !== undefined ? { filesystem: resolvedFilesystemBackend } : {}),
-    // Nexus transport (when a local-bridge resolved above) enables permission
-    // policy sync and nexus audit trail alongside NDJSON/SQLite sinks.
-    ...(nexusFilesystemTransport !== undefined ? { nexusTransport: nexusFilesystemTransport } : {}),
-    // @koi/artifacts tools — wired when the advisory lock was acquired at
-    // boot. When construction failed (concurrent TUI, FS issue) the array
-    // is empty and the artifact_* tools are simply absent from the agent.
-    //
-    // The mock browser provider (KOI_BROWSER_MOCK) is single-agent by
-    // design: createBrowserProvider throws if a second distinct agent
-    // tries to attach. This is safe here because extraProviders are only
-    // assembled onto the root TUI agent — create-agent-spawn-fn.ts does
-    // NOT propagate extraProviders into childProviders for spawned agents.
-    // Limitation: browser_* tools are therefore NOT available in spawned
-    // sub-agents. Workflows that delegate browser work to a child agent
-    // will lose those tools after the spawn. This is a known scope
-    // restriction of the mock dev/test path, not a bug in production.
-    // Post-permissions slot: runs inside the security layers so request.tools
-    // is permissions-filtered when the injector checks for the Skill tool.
-    skillInjector: skillInjectorMw,
-    // Propagate skill injection into spawned children so they receive the
-    // <available_skills> XML block in progressive mode. Uses a filtered injector
-    // that only includes runtimeBacked skills — body-backed skills (browser,
-    // memory) belong to root-only providers not available in children.
-    childSkillInjector: childSkillInjectorMw,
-    extraProviders: [
-      skillProvider,
-      ...(nexusDelegationProvider !== undefined ? [nexusDelegationProvider] : []),
-      ...artifactExtraProviders,
-      ...(process.env.KOI_BROWSER_MOCK === "1"
-        ? [
-            createBrowserProvider({
-              backend: createMockDriver(),
-              // Mock driver never opens a real connection, so SSRF
-              // protection only needs to block IP literals and known
-              // metadata hostnames — no DNS resolution required.
-              // Note: BLOCKED_HOST_SUFFIXES includes .local/.internal,
-              // so mDNS/RFC6762 names are still rejected by design.
-              isUrlAllowed: (url) => {
-                try {
-                  const { protocol, hostname } = new URL(url);
-                  if (protocol !== "http:" && protocol !== "https:") return false;
-                  // Strip IPv6 brackets then lower-case + strip trailing DNS root
-                  // dot so `localhost.` / `metadata.google.internal.` can't
-                  // bypass suffix/host checks (same canonicalization as isSafeUrl).
-                  const h = hostname
-                    .replace(/^\[|\]$/g, "")
-                    .toLowerCase()
-                    .replace(/\.$/, "");
-                  if (isBlockedIp(h)) return false;
-                  if (BLOCKED_HOSTS.includes(h)) return false;
-                  // h === s.slice(1) blocks bare apex hosts: "internal" matches ".internal",
-                  // "local" matches ".local" — endsWith alone misses these.
-                  if (BLOCKED_HOST_SUFFIXES.some((s) => h.endsWith(s) || h === s.slice(1)))
-                    return false;
-                  return true;
-                } catch {
-                  return false;
-                }
-              },
-            }),
-          ]
-        : []),
-    ],
-    // Zone B — manifest-declared middleware. Resolved inside the
-    // factory via the default built-in registry. Runs INSIDE the
-    // security guard so repo-authored content cannot observe raw
-    // traffic before `exfiltration-guard` redacts secrets.
-    //
-    // `allowManifestFileSinks` gates the built-in audit entry
-    // (which opens a file at resolution time). Controlled by the
-    // KOI_ALLOW_MANIFEST_FILE_SINKS env var rather than the
-    // manifest so repo content cannot flip it.
-    ...(manifestMiddleware !== undefined ? { manifestMiddleware } : {}),
-    ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" ? { allowManifestFileSinks: true } : {}),
-    // TUI defaults `backgroundSubprocesses` to `true` (the factory
-    // default) because its interactive surface makes long-running
-    // jobs observable. A manifest setting wins if provided.
-    ...(manifestBackgroundSubprocesses !== undefined
-      ? { backgroundSubprocesses: manifestBackgroundSubprocesses }
-      : {}),
-    // KOI_OTEL_ENABLED=true opts into OTel span emission for the TUI session.
-    // initOtelSdk() registers a global TracerProvider so middleware-otel's
-    // trace.getTracer() returns a real tracer. Must be called before createKoiRuntime.
-    ...(otelEnabled ? { otel: true as const } : {}),
-    // KOI_AUDIT_NDJSON=<path> opts into security-grade audit logging.
-    // Manifest audit.ndjson is the fallback when the env var is absent.
-    // Gated behind KOI_ALLOW_MANIFEST_FILE_SINKS=1 (repo-authored path).
-    // Precedence: env var (present, even "") → manifest (gate required) → off.
-    // Setting the env var to "" is an explicit disable that wins over manifest.
-    ...(process.env.KOI_AUDIT_NDJSON !== undefined
-      ? process.env.KOI_AUDIT_NDJSON !== ""
-        ? { auditNdjsonPath: process.env.KOI_AUDIT_NDJSON }
-        : {}
-      : manifestAudit?.ndjson !== undefined && process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
-        ? { auditNdjsonPath: manifestAudit.ndjson }
-        : {}),
-    // KOI_AUDIT_SQLITE=<path> opts into SQLite-backed audit logging.
-    // Same precedence/disable semantics as KOI_AUDIT_NDJSON above.
-    ...(process.env.KOI_AUDIT_SQLITE !== undefined
-      ? process.env.KOI_AUDIT_SQLITE !== ""
-        ? { auditSqlitePath: process.env.KOI_AUDIT_SQLITE }
-        : {}
-      : manifestAudit?.sqlite !== undefined && process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
-        ? { auditSqlitePath: manifestAudit.sqlite }
-        : {}),
-    // KOI_AUDIT_VIOLATIONS=<path> overrides the violations DB path.
-    // Manifest audit.violations is the fallback when the env var is absent.
-    // Gated behind KOI_ALLOW_MANIFEST_FILE_SINKS=1 for manifest paths.
-    // Precedence: env var (present, even "") → manifest (gate required) → default (~/.koi/violations.db).
-    // Setting the env var to "" passes the empty string through — runtime-factory treats
-    // length===0 as an explicit disable (no violations DB), preventing the default fallback.
-    ...(process.env.KOI_AUDIT_VIOLATIONS !== undefined
-      ? { violationSqlitePath: process.env.KOI_AUDIT_VIOLATIONS }
-      : manifestAudit?.violations !== undefined && process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
-        ? { violationSqlitePath: manifestAudit.violations }
-        : {}),
-    // KOI_AUDIT_NDJSON_MAX_BYTES=<n> enables size-based NDJSON log rotation.
-    // KOI_AUDIT_NDJSON_DAILY=1 enables daily UTC rotation.
-    ...(() => {
-      const rawBytes = process.env.KOI_AUDIT_NDJSON_MAX_BYTES;
-      const maxBytes = rawBytes !== undefined ? Number(rawBytes) : undefined;
-      if (
-        rawBytes !== undefined &&
-        (maxBytes === undefined || !Number.isFinite(maxBytes) || maxBytes <= 0)
-      ) {
-        console.warn(
-          `[koi] KOI_AUDIT_NDJSON_MAX_BYTES="${rawBytes}" is not a positive number — NDJSON size rotation disabled`,
-        );
-      }
-      const daily = process.env.KOI_AUDIT_NDJSON_DAILY === "1";
-      const validMaxBytes = maxBytes !== undefined && Number.isFinite(maxBytes) && maxBytes > 0;
-      if (validMaxBytes || daily) {
-        return {
-          auditNdjsonRotation: {
-            ...(validMaxBytes ? { maxSizeBytes: maxBytes } : {}),
-            ...(daily ? { daily: true as const } : {}),
-          },
-        };
-      }
-      return {};
-    })(),
-    // KOI_AUDIT_SQLITE_RETENTION_DAYS is not supported in the CLI audit path because
-    // the CLI always writes signed (hash-chained) audit entries, which are incompatible
-    // with session-granular pruning. Warn and ignore instead of aborting at boot.
-    ...(() => {
-      const rawDays = process.env.KOI_AUDIT_SQLITE_RETENTION_DAYS;
-      if (rawDays !== undefined) {
-        console.warn(
-          "[koi] KOI_AUDIT_SQLITE_RETENTION_DAYS is not supported in the CLI audit path " +
-            "(signed/hash-chained logs cannot be pruned). The setting is ignored.",
-        );
-      }
-      return {};
-    })(),
-    // Per-sink manifest provenance: only pass the source path for sinks that
-    // actually came from the manifest (not from operator env vars). This lets
-    // createKoiRuntime run a final containment check immediately before each
-    // manifest-derived sink open, without incorrectly revalidating env-var
-    // sourced paths against the manifest directory.
-    ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
-    process.env.KOI_AUDIT_NDJSON === undefined &&
-    manifestAudit?.ndjson !== undefined &&
-    manifestLoadPath !== undefined
-      ? { manifestNdjsonSourcePath: manifestLoadPath }
-      : {}),
-    ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
-    process.env.KOI_AUDIT_SQLITE === undefined &&
-    manifestAudit?.sqlite !== undefined &&
-    manifestLoadPath !== undefined
-      ? { manifestSqliteSourcePath: manifestLoadPath }
-      : {}),
-    ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
-    process.env.KOI_AUDIT_VIOLATIONS === undefined &&
-    manifestAudit?.violations !== undefined &&
-    manifestLoadPath !== undefined
-      ? { manifestViolationsSourcePath: manifestLoadPath }
-      : {}),
-    // KOI_REPORT_ENABLED=true opts into run-report middleware.
-    // Wires @koi/middleware-report so a RunReport is printed at session end.
-    ...(process.env.KOI_REPORT_ENABLED === "true" ? { reportEnabled: true } : {}),
-    // KOI_PLANNING_ENABLED=true opts into @koi/middleware-planning.
-    // Default off because plan state is ephemeral across resume until
-    // durable persistence (#1842) lands. Hosts that accept the
-    // limitation can opt in today.
-    ...(process.env.KOI_PLANNING_ENABLED === "true" ? { planningEnabled: true } : {}),
-    // KOI_FEEDBACK_LOOP_ENABLED=true opts into @koi/middleware-feedback-loop.
-    // Activates model-response validation + tool-health tracking with an
-    // empty config (observe-only, no validators, no quarantine thresholds).
-    ...(process.env.KOI_FEEDBACK_LOOP_ENABLED === "true" ? { feedbackLoop: {} } : {}),
-    // KOI_INTENT_CAPSULE=<systemPrompt> opts into @koi/middleware-intent-capsule.
-    // Cryptographically binds the agent's mandate at session start with Ed25519;
-    // verifies hash on every model call. Throws PERMISSION on tamper. (gov-16 #1883)
-    ...(process.env.KOI_INTENT_CAPSULE !== undefined && process.env.KOI_INTENT_CAPSULE !== ""
-      ? { intentCapsule: { systemPrompt: process.env.KOI_INTENT_CAPSULE } }
-      : {}),
-    extraMiddleware:
-      aceMiddleware !== undefined
-        ? [securityBridge.middleware, aceMiddleware]
-        : [securityBridge.middleware],
-    // Bridge spawn lifecycle events into the TUI store so /agents view and
-    // inline spawn_call blocks reflect real spawn state. Each spawn call
-    // produces one spawn_requested + one agent_status_changed event.
-    onSpawnEvent: (event): void => {
-      // Delegate to the current drain's spawn tracker for SIGINT grace.
-      // Null between drains so cross-drain survivors from earlier turns cannot
-      // influence the grace policy of a later, unrelated turn (#1999 r14).
-      currentDrainSpawnHandler?.(event);
-      // Defense-in-depth: store.dispatch can throw if the reducer or
-      // SolidJS reactivity hits an edge case. A throwing callback must
-      // not crash the spawn flow — the engine wraps this in safeSpawnEvent
-      // too, but belt-and-braces keeps the TUI safe even if the engine
-      // guard is ever removed.
-      try {
-        if (event.kind === "spawn_requested") {
-          store.dispatch({
-            kind: "engine_event",
-            event: {
-              kind: "spawn_requested",
-              childAgentId: event.agentId as unknown as import("@koi/core").AgentId,
-              request: {
-                agentName: event.agentName,
-                description: event.description,
-                signal: new AbortController().signal,
-              },
-            },
+  const runtimeReady =
+    runtimeMode === "remote"
+      ? (async (): Promise<void> => {
+          const remoteToken = process.env["KOI_GATEWAY_TOKEN"];
+          if (remoteToken === undefined || remoteToken.length === 0) {
+            store.dispatch({
+              kind: "add_info",
+              message:
+                "Remote gateway requires KOI_GATEWAY_TOKEN environment variable. Aborting connect.",
+            });
+            return;
+          }
+          const client = createTuiGatewayClient({
+            gatewayUrl: flags.gatewayUrl as string,
+            clientId: flags.session ?? `tui-${process.pid}`,
+            authToken: remoteToken,
           });
-        } else {
-          // agent_status_changed: use the dedicated set_spawn_terminal action so the
-          // outcome (complete vs failed) is preserved. The engine's ProcessState only
-          // has a single "terminated" value — routing through that path would collapse
-          // failures into successes.
-          const outcome: "complete" | "failed" = event.status === "failed" ? "failed" : "complete";
+          await client.connect();
+          if (shutdownStarted) {
+            await client.dispose();
+            return;
+          }
+          gatewayClient = client;
           store.dispatch({
-            kind: "set_spawn_terminal",
-            agentId: event.agentId,
-            outcome,
-            // Pass metadata so the reducer can synthesize a record when
-            // spawn_requested dispatch was lost (#1855).
-            agentName: event.agentName,
-            description: event.description,
+            kind: "add_info",
+            message: `Connected to remote gateway ${flags.gatewayUrl}`,
           });
-        }
-      } catch (e: unknown) {
-        console.warn("[koi:tui] onSpawnEvent dispatch failed — spawn UI may be stale", e);
-      }
-    },
-  }).then(async (handle) => {
-    // If an interim SIGUSR1 teardown started while createKoiRuntime was
-    // in flight (#1906 R10), the teardown couldn't dispose `handle`
-    // because it wasn't assigned yet. Dispose it here directly and do
-    // NOT assign `runtimeHandle` — otherwise the rest of bootstrap
-    // (transcript priming, /mcp refresh) would run against an
-    // already-disposed runtime.
-    if (shutdownStarted) {
-      handle.shutdownBackgroundTasks();
-      void handle.runtime.dispose().catch(() => {
-        /* best effort — hard-exit failsafe will still fire */
-      });
-      return;
-    }
-    runtimeHandle = handle;
-    // #1767 Phase 6: surface context-engine swap events as TUI notices
-    // through the single-writer store. Subscribing at the controller
-    // level (rather than reading the run-stream `custom` event) covers
-    // out-of-run swaps too — idle, pre-first-run, between reusable
-    // turns. Notices flow through `add_info` like plugin-load banners:
-    // not in the JSONL transcript, not pushed back into model context.
-    handle.runtime.contextEngineSwapController?.subscribe((swap) => {
-      const notice = formatContextEngineSwapNotice(swap);
-      store.dispatch({ kind: "add_info", message: notice.message });
-    });
-    // Resolve lazy skill agent ref so the injector middleware can query
-    // skill components on every subsequent model call.
-    skillAgentRef.current = handle.runtime.agent;
-    // Seed the mutable live skill map from the ECS components attached during
-    // createKoiRuntime. Subsequent session resets update liveSkillComponents via
-    // reloadSkillComponents() without touching the static ECS.
-    liveSkillComponents = handle.runtime.agent.query<SkillComponent>("skill:");
-    // Wire governance bridge when the agent has a GovernanceController
-    // component attached. In default sessions (no --max-spend or equivalent
-    // future flag), component() returns undefined and the bridge stays unset,
-    // leaving all governanceBridge?.xxx() call sites as no-ops.
-    try {
-      const governanceController = handle.runtime.agent.component<GovernanceController>(GOVERNANCE);
-      // `--no-governance` / manifest disable wins here: even though the
-      // engine's bundled GOVERNANCE component is still attached for
-      // guard-level safety, the host-level observer surface (bridge, alerts
-      // JSONL, toast reducer) must stay inert so operator intent is
-      // honored end-to-end. Without this gate, disabling governance would
-      // still fire toasts, persist alerts, and poll snapshots — a
-      // fail-open.
-      if (governanceController !== undefined && handle.governanceEnabled) {
-        governanceBridge = createGovernanceBridge({
-          store,
-          controller: governanceController,
-          sessionId: tuiSessionId as string,
-          alertsPath: join(homedir(), ".koi", "governance-alerts.jsonl"),
-          // Static rule snapshot resolved by runtime-factory via
-          // backend.describeRules() — falls back to a synthetic default-allow
-          // entry until the manifest YAML loader (#1877) wires real rules.
-          rules: handle.governanceRules,
-          // Resolved `--alert-threshold` / manifest thresholds. When both are
-          // unset the bridge falls back to its observational default
-          // ([0.5, 0.8, 0.95]); passing the resolved set here is what makes
-          // CLI/manifest precedence authoritative for TUI toast firing.
-          ...(handle.governanceAlertThresholds !== undefined
-            ? { alertThresholds: handle.governanceAlertThresholds }
+        })()
+      : createKoiRuntime({
+          modelAdapter,
+          modelName,
+          approvalHandler: labeledApprovalHandler,
+          approvalTimeoutMs: TUI_APPROVAL_TIMEOUT_MS,
+          cwd: process.cwd(),
+          systemPrompt,
+          ...(yoloPermissionBackend !== undefined
+            ? {
+                permissionBackend: yoloPermissionBackend,
+                permissionsDescription: "koi tui --yolo (auto-allow all tools)",
+                bashElicitAutoApprove: true,
+              }
             : {}),
-          ...(handle.violationStore !== undefined ? { violationStore: handle.violationStore } : {}),
-          // Static capability mirror — matches the createGovernanceMiddleware's
-          // describeCapabilities() output. Hardcoded here to avoid plumbing the
-          // middleware instance back from runtime-factory just for one string.
-          capabilities: [
-            { label: "governance", description: "Policy gate + setpoint enforcement active" },
-          ],
-        });
-        // Seed up to 10 most-recent alerts from JSONL so /governance
-        // shows context across sessions instead of starting empty.
-        // TODO(gov-9): replace per-alert dispatch with a `replay_persisted_alerts`
-        // bulk action once seed counts grow past ~10 to avoid N reducer runs.
-        const recent = governanceBridge.loadRecentAlerts(10);
-        for (const alert of recent) {
-          store.dispatch({ kind: "add_governance_alert", alert });
-        }
-        // Seed up to 10 most-recent persisted violations for the current
-        // session so /governance's "Recent violations" panel is populated
-        // on restart / resume. Load is async (SQLite) — fire-and-forget
-        // so startup isn't blocked on history backfill.
-        void governanceBridge
-          .loadRecentViolations(10)
-          .then((violations) => {
-            // Synthesize UI-shape fields: id is per-entry counter, ts
-            // is load-time (the ViolationStore row timestamp is not
-            // exposed in the Violation shape — it would need an L0
-            // widening to surface). Order is preserved from the DB.
-            for (const v of violations) {
-              store.dispatch({
-                kind: "add_governance_violation",
-                violation: {
-                  id: `backfill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-                  ts: Date.now(),
-                  variable: v.rule,
-                  reason: v.message,
+          currentModelMiddleware,
+          // Resolve budgetConfig per turn so a mid-session model switch picks up
+          // the new model's context window immediately.
+          getCurrentModel: () => ({
+            model: currentModelBox.current,
+            ...(currentModelBox.contextLength !== undefined
+              ? { contextLength: currentModelBox.contextLength }
+              : {}),
+          }),
+          ...(modelRouterMiddleware !== undefined ? { modelRouterMiddleware } : {}),
+          // TUI opts out of engine loop detection explicitly: the
+          // per-submit iteration budget reset + governance caps below
+          // already bound spirals, and false-positive trips during an
+          // interactive session are expensive (they abort mid-turn with a
+          // confusing error). `koi start`'s auto-allow backend leaves
+          // this at the engine default (enabled) — see `runtime-factory.ts`.
+          loopDetection: false,
+          // In loop mode, session persistence is intentionally omitted so
+          // failed iterations don't pollute the resumable JSONL transcript.
+          // Loop mode is a self-correcting execution, not a conversation.
+          ...(isLoopMode
+            ? {}
+            : { session: { transcript: jsonlTranscript, sessionId: tuiSessionId } }),
+          // Issue #1683: cancel-resume checkpoint wiring. Activates only when
+          // `KOI_SESSION_STATE_DB` was set (and the SQLite open succeeded) and
+          // we're not in loop mode. Loop mode skips both session and checkpoint
+          // by design — failed iterations must not pollute resumable state.
+          // initialEngineState/initialEngineStateVersion are forwarded from the
+          // resume so the wrapped adapter restores the cancel cursor and the
+          // CAS check protects against a parallel runtime overwriting our row.
+          ...(stateSessionPersistence !== undefined && !isLoopMode
+            ? {
+                sessionPersistence: {
+                  persistence: stateSessionPersistence,
+                  agentId: (await import("@koi/core")).agentId(`koi-tui:${tuiSessionId}`),
+                  manifestSnapshot: {
+                    name: "koi-tui",
+                    version: "0",
+                    model: { name: modelName },
+                  } satisfies import("@koi/core").AgentManifest,
+                  onPersistError: (err: import("@koi/core").KoiError | Error): void => {
+                    const msg = "message" in err ? err.message : String(err);
+                    process.stderr.write(
+                      `koi tui: cancel checkpoint write failed (${msg}); next resume will fall back to transcript-only\n`,
+                    );
+                  },
+                  ...(resumedEngineState !== undefined
+                    ? { initialEngineState: resumedEngineState }
+                    : {}),
+                  ...(resumedStateVersion !== undefined
+                    ? { initialEngineStateVersion: resumedStateVersion }
+                    : {}),
                 },
-              });
+              }
+            : {}),
+          skillsRuntime: skillRuntime,
+          skillsProgressive: true,
+          mcpOAuthChannel: tuiOAuthChannel,
+          ...(approvalStore !== undefined ? { persistentApprovals: approvalStore } : {}),
+          ...(governance.enabled && (governance.maxSpendUsd ?? 0) > 0
+            ? { maxSpendUsd: governance.maxSpendUsd }
+            : {}),
+          ...(governance.enabled && governance.maxTurns !== undefined
+            ? { maxTurns: governance.maxTurns }
+            : {}),
+          ...(governance.enabled && governance.maxSpawnDepth !== undefined
+            ? { maxSpawnDepth: governance.maxSpawnDepth }
+            : {}),
+          ...(governance.enabled && governance.alertThresholds !== undefined
+            ? { governanceAlertThresholds: governance.alertThresholds }
+            : {}),
+          ...(governance.enabled && governanceRules !== undefined ? { governanceRules } : {}),
+          ...(governance.enabled ? {} : { governanceDisabled: true }),
+          // Fallback model chain validation only runs when the router actually
+          // wired up. If router config validation failed above (modelRouterMiddleware
+          // === undefined), fallback models are unreachable — passing them to
+          // resolveCostConfig would refuse startup over models the runtime can't
+          // ever call.
+          ...(fallbackModels.length > 0 && modelRouterMiddleware !== undefined
+            ? { fallbackModelNames: fallbackModels }
+            : {}),
+          // Manifest-driven opt-in for preset stacks + plugins. Omitted
+          // when the user didn't pass --manifest, in which case the
+          // factory defaults to activating every stack / every discovered
+          // plugin (v1's "wire everything" posture).
+          ...(manifestStacks !== undefined ? { stacks: manifestStacks } : {}),
+          ...(manifestPlugins !== undefined ? { plugins: manifestPlugins } : {}),
+          ...(manifestFilesystemOps !== undefined
+            ? { filesystemOperations: manifestFilesystemOps }
+            : {}),
+          // gov-15: outbound-network scope from manifest.network → web-tools fetch wrap.
+          ...(manifestNetwork !== undefined
+            ? { networkScope: { allow: manifestNetwork.allow } }
+            : {}),
+          // gov-15: shared scoped CredentialComponent — same instance is registered
+          // on the CREDENTIALS subsystem token AND used by the progressive skill
+          // provider to gate skill `requires.credentials` at attach time.
+          ...(scopedCredentials !== undefined ? { credentials: scopedCredentials } : {}),
+          // #2088: ACE activation. resolvedAceConfig is built above under the
+          // spawn-gate; on resume without --manifest, manifestResult is never
+          // loaded so resolvedAceConfig stays undefined (resume-provenance gate
+          // by construction). Passes undefined → no middleware installed.
+          ...(resolvedAceConfig !== undefined ? { ace: resolvedAceConfig } : {}),
+          // Nexus backend (when resolved above) is passed through so the checkpoint
+          // stack stamps the correct backend name and the restore protocol dispatches
+          // compensating ops through the right backend. Omitted when undefined —
+          // factory falls back to the default local backend rooted at cwd.
+          ...(resolvedFilesystemBackend !== undefined
+            ? { filesystem: resolvedFilesystemBackend }
+            : {}),
+          // Nexus transport (when a local-bridge resolved above) enables permission
+          // policy sync and nexus audit trail alongside NDJSON/SQLite sinks.
+          ...(nexusFilesystemTransport !== undefined
+            ? { nexusTransport: nexusFilesystemTransport }
+            : {}),
+          // @koi/artifacts tools — wired when the advisory lock was acquired at
+          // boot. When construction failed (concurrent TUI, FS issue) the array
+          // is empty and the artifact_* tools are simply absent from the agent.
+          //
+          // The mock browser provider (KOI_BROWSER_MOCK) is single-agent by
+          // design: createBrowserProvider throws if a second distinct agent
+          // tries to attach. This is safe here because extraProviders are only
+          // assembled onto the root TUI agent — create-agent-spawn-fn.ts does
+          // NOT propagate extraProviders into childProviders for spawned agents.
+          // Limitation: browser_* tools are therefore NOT available in spawned
+          // sub-agents. Workflows that delegate browser work to a child agent
+          // will lose those tools after the spawn. This is a known scope
+          // restriction of the mock dev/test path, not a bug in production.
+          // Post-permissions slot: runs inside the security layers so request.tools
+          // is permissions-filtered when the injector checks for the Skill tool.
+          skillInjector: skillInjectorMw,
+          // Propagate skill injection into spawned children so they receive the
+          // <available_skills> XML block in progressive mode. Uses a filtered injector
+          // that only includes runtimeBacked skills — body-backed skills (browser,
+          // memory) belong to root-only providers not available in children.
+          childSkillInjector: childSkillInjectorMw,
+          extraProviders: [
+            skillProvider,
+            ...(nexusDelegationProvider !== undefined ? [nexusDelegationProvider] : []),
+            ...artifactExtraProviders,
+            ...(process.env.KOI_BROWSER_MOCK === "1"
+              ? [
+                  createBrowserProvider({
+                    backend: createMockDriver(),
+                    // Mock driver never opens a real connection, so SSRF
+                    // protection only needs to block IP literals and known
+                    // metadata hostnames — no DNS resolution required.
+                    // Note: BLOCKED_HOST_SUFFIXES includes .local/.internal,
+                    // so mDNS/RFC6762 names are still rejected by design.
+                    isUrlAllowed: (url) => {
+                      try {
+                        const { protocol, hostname } = new URL(url);
+                        if (protocol !== "http:" && protocol !== "https:") return false;
+                        // Strip IPv6 brackets then lower-case + strip trailing DNS root
+                        // dot so `localhost.` / `metadata.google.internal.` can't
+                        // bypass suffix/host checks (same canonicalization as isSafeUrl).
+                        const h = hostname
+                          .replace(/^\[|\]$/g, "")
+                          .toLowerCase()
+                          .replace(/\.$/, "");
+                        if (isBlockedIp(h)) return false;
+                        if (BLOCKED_HOSTS.includes(h)) return false;
+                        // h === s.slice(1) blocks bare apex hosts: "internal" matches ".internal",
+                        // "local" matches ".local" — endsWith alone misses these.
+                        if (BLOCKED_HOST_SUFFIXES.some((s) => h.endsWith(s) || h === s.slice(1)))
+                          return false;
+                        return true;
+                      } catch {
+                        return false;
+                      }
+                    },
+                  }),
+                ]
+              : []),
+          ],
+          // Zone B — manifest-declared middleware. Resolved inside the
+          // factory via the default built-in registry. Runs INSIDE the
+          // security guard so repo-authored content cannot observe raw
+          // traffic before `exfiltration-guard` redacts secrets.
+          //
+          // `allowManifestFileSinks` gates the built-in audit entry
+          // (which opens a file at resolution time). Controlled by the
+          // KOI_ALLOW_MANIFEST_FILE_SINKS env var rather than the
+          // manifest so repo content cannot flip it.
+          ...(manifestMiddleware !== undefined ? { manifestMiddleware } : {}),
+          ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
+            ? { allowManifestFileSinks: true }
+            : {}),
+          // TUI defaults `backgroundSubprocesses` to `true` (the factory
+          // default) because its interactive surface makes long-running
+          // jobs observable. A manifest setting wins if provided.
+          ...(manifestBackgroundSubprocesses !== undefined
+            ? { backgroundSubprocesses: manifestBackgroundSubprocesses }
+            : {}),
+          // KOI_OTEL_ENABLED=true opts into OTel span emission for the TUI session.
+          // initOtelSdk() registers a global TracerProvider so middleware-otel's
+          // trace.getTracer() returns a real tracer. Must be called before createKoiRuntime.
+          ...(otelEnabled ? { otel: true as const } : {}),
+          // KOI_AUDIT_NDJSON=<path> opts into security-grade audit logging.
+          // Manifest audit.ndjson is the fallback when the env var is absent.
+          // Gated behind KOI_ALLOW_MANIFEST_FILE_SINKS=1 (repo-authored path).
+          // Precedence: env var (present, even "") → manifest (gate required) → off.
+          // Setting the env var to "" is an explicit disable that wins over manifest.
+          ...(process.env.KOI_AUDIT_NDJSON !== undefined
+            ? process.env.KOI_AUDIT_NDJSON !== ""
+              ? { auditNdjsonPath: process.env.KOI_AUDIT_NDJSON }
+              : {}
+            : manifestAudit?.ndjson !== undefined &&
+                process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
+              ? { auditNdjsonPath: manifestAudit.ndjson }
+              : {}),
+          // KOI_AUDIT_SQLITE=<path> opts into SQLite-backed audit logging.
+          // Same precedence/disable semantics as KOI_AUDIT_NDJSON above.
+          ...(process.env.KOI_AUDIT_SQLITE !== undefined
+            ? process.env.KOI_AUDIT_SQLITE !== ""
+              ? { auditSqlitePath: process.env.KOI_AUDIT_SQLITE }
+              : {}
+            : manifestAudit?.sqlite !== undefined &&
+                process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
+              ? { auditSqlitePath: manifestAudit.sqlite }
+              : {}),
+          // KOI_AUDIT_VIOLATIONS=<path> overrides the violations DB path.
+          // Manifest audit.violations is the fallback when the env var is absent.
+          // Gated behind KOI_ALLOW_MANIFEST_FILE_SINKS=1 for manifest paths.
+          // Precedence: env var (present, even "") → manifest (gate required) → default (~/.koi/violations.db).
+          // Setting the env var to "" passes the empty string through — runtime-factory treats
+          // length===0 as an explicit disable (no violations DB), preventing the default fallback.
+          ...(process.env.KOI_AUDIT_VIOLATIONS !== undefined
+            ? { violationSqlitePath: process.env.KOI_AUDIT_VIOLATIONS }
+            : manifestAudit?.violations !== undefined &&
+                process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1"
+              ? { violationSqlitePath: manifestAudit.violations }
+              : {}),
+          // KOI_AUDIT_NDJSON_MAX_BYTES=<n> enables size-based NDJSON log rotation.
+          // KOI_AUDIT_NDJSON_DAILY=1 enables daily UTC rotation.
+          ...(() => {
+            const rawBytes = process.env.KOI_AUDIT_NDJSON_MAX_BYTES;
+            const maxBytes = rawBytes !== undefined ? Number(rawBytes) : undefined;
+            if (
+              rawBytes !== undefined &&
+              (maxBytes === undefined || !Number.isFinite(maxBytes) || maxBytes <= 0)
+            ) {
+              console.warn(
+                `[koi] KOI_AUDIT_NDJSON_MAX_BYTES="${rawBytes}" is not a positive number — NDJSON size rotation disabled`,
+              );
             }
-          })
-          .catch((err: unknown) => {
-            console.warn("[tui-command] violation backfill failed:", err);
-          });
-        // Initial snapshot push so the view has data before the first turn.
-        governanceBridge.pollSnapshot();
-      }
-    } catch (err: unknown) {
-      console.warn("[tui-command] governance bridge init failed:", err);
-    }
-    // Registry-only daemon bridge (#1944). The registry path follows the
-    // `koi bg` convention — `KOI_STATE_DIR/daemon/sessions` when set, else
-    // `~/.koi/daemon/sessions`. Per-workspace isolation: set KOI_STATE_DIR
-    // per shell. Opened only when the directory already exists so that
-    // simply launching the TUI does not create or mutate shared state on
-    // hosts where no daemon has ever run. Replaced by the live bridge
-    // below when the manifest declares subprocess children.
-    const registryDir = defaultRegistryDir();
-    const registryDirExists = await stat(registryDir)
-      .then((s) => s.isDirectory())
-      .catch(() => false);
-    // Inline helper: maps a DaemonBridgeToast to the TUI Toast shape.
-    // body is empty — daemon toasts carry their message in title only.
-    const pushDaemonToast = (
-      toast: import("./daemon-bridge.js").DaemonBridgeToast,
-      key: string,
-    ): void => {
-      store.dispatch({
-        kind: "add_toast",
-        toast: {
-          id: crypto.randomUUID(),
-          kind: toast.kind,
-          key,
-          title: toast.message,
-          body: "",
-          ts: Date.now(),
-        },
-      });
-    };
-    if (registryDirExists) {
-      try {
-        // The registry-only bridge only calls describeList() + watch() —
-        // it never invokes register/update/unregister, so even though
-        // FileSessionRegistry exposes write methods we never use them.
-        const roRegistry = createFileSessionRegistry({ dir: registryDir });
-        registryOnlyBridge = createDaemonBridge({
-          mode: { kind: "registry-only", registry: roRegistry },
-          dispatch: store.dispatch,
-          pushToast: (toast) => {
-            pushDaemonToast(toast, "daemon-bridge");
-          },
-        });
-      } catch (err: unknown) {
-        console.warn("[tui-command] registry-only bridge init failed:", err);
-      }
-    }
-    // Daemon supervisor wiring (#1944). Constructed BEFORE
-    // wireManifestSupervision so its supervisor + sessionRegistry can back
-    // a daemon-aware SpawnChildFn for subprocess children with `command`.
-    // Skipped when the manifest has no subprocess children.
-    const hasSubprocessChild =
-      manifestSupervision?.children.some((c) => c.isolation === "subprocess") === true;
-    if (hasSubprocessChild) {
-      // Tear down the registry-only bridge first; live mode owns the registry.
-      try {
-        await registryOnlyBridge?.close();
-        registryOnlyBridge = null;
-      } catch (err: unknown) {
-        console.warn("[tui-command] registry-only bridge close failed:", err);
-      }
-      try {
-        const supervisorManifest: import("@koi/core").AgentManifest = {
-          name: flags.manifest ?? "supervisor",
-          version: "0",
-          model: { name: modelName },
-          ...(manifestSupervision !== undefined && { supervision: manifestSupervision }),
-        };
-        daemonSupervisorHandle = await wireDaemonSupervisor({
-          stateDir: registryDir,
-          manifest: supervisorManifest,
-          dispatch: store.dispatch,
-          pushToast: (toast) => {
-            pushDaemonToast(toast, "daemon-supervisor");
-          },
-          backends: { subprocess: createSubprocessBackend() },
-        });
-        store.dispatch({ kind: "set_supervisor_attached", attached: true });
-      } catch (err: unknown) {
-        console.warn("[tui-command] daemon supervisor wiring failed:", err);
-      }
-    }
-    // Manifest-driven supervision wiring (#1866 + #1944). When the loaded
-    // manifest declares `supervision:`, activate the subsystem here so the
-    // declared children appear in the runtime's AgentRegistry and in the
-    // /agents view. When the daemon supervisor is also active and a child
-    // declares `command`, route that child through the daemon adapter so
-    // /supervisor, /bg, ownership checks, and on-path kills observe and
-    // control the same worker. Children without `command` continue to
-    // use the in-process stub for backwards compatibility.
-    if (manifestSupervision !== undefined) {
-      try {
-        const daemonHandle = daemonSupervisorHandle;
-        const subprocessSpawnFactory =
-          daemonHandle !== undefined
-            ? (agentRegistry: import("@koi/core").AgentRegistry) => {
-                agentRegistryBridge = attachAgentRegistry({
-                  supervisor: daemonHandle.supervisor,
-                  agentRegistry,
+            const daily = process.env.KOI_AUDIT_NDJSON_DAILY === "1";
+            const validMaxBytes =
+              maxBytes !== undefined && Number.isFinite(maxBytes) && maxBytes > 0;
+            if (validMaxBytes || daily) {
+              return {
+                auditNdjsonRotation: {
+                  ...(validMaxBytes ? { maxSizeBytes: maxBytes } : {}),
+                  ...(daily ? { daily: true as const } : {}),
+                },
+              };
+            }
+            return {};
+          })(),
+          // KOI_AUDIT_SQLITE_RETENTION_DAYS is not supported in the CLI audit path because
+          // the CLI always writes signed (hash-chained) audit entries, which are incompatible
+          // with session-granular pruning. Warn and ignore instead of aborting at boot.
+          ...(() => {
+            const rawDays = process.env.KOI_AUDIT_SQLITE_RETENTION_DAYS;
+            if (rawDays !== undefined) {
+              console.warn(
+                "[koi] KOI_AUDIT_SQLITE_RETENTION_DAYS is not supported in the CLI audit path " +
+                  "(signed/hash-chained logs cannot be pruned). The setting is ignored.",
+              );
+            }
+            return {};
+          })(),
+          // Per-sink manifest provenance: only pass the source path for sinks that
+          // actually came from the manifest (not from operator env vars). This lets
+          // createKoiRuntime run a final containment check immediately before each
+          // manifest-derived sink open, without incorrectly revalidating env-var
+          // sourced paths against the manifest directory.
+          ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
+          process.env.KOI_AUDIT_NDJSON === undefined &&
+          manifestAudit?.ndjson !== undefined &&
+          manifestLoadPath !== undefined
+            ? { manifestNdjsonSourcePath: manifestLoadPath }
+            : {}),
+          ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
+          process.env.KOI_AUDIT_SQLITE === undefined &&
+          manifestAudit?.sqlite !== undefined &&
+          manifestLoadPath !== undefined
+            ? { manifestSqliteSourcePath: manifestLoadPath }
+            : {}),
+          ...(process.env.KOI_ALLOW_MANIFEST_FILE_SINKS === "1" &&
+          process.env.KOI_AUDIT_VIOLATIONS === undefined &&
+          manifestAudit?.violations !== undefined &&
+          manifestLoadPath !== undefined
+            ? { manifestViolationsSourcePath: manifestLoadPath }
+            : {}),
+          // KOI_REPORT_ENABLED=true opts into run-report middleware.
+          // Wires @koi/middleware-report so a RunReport is printed at session end.
+          ...(process.env.KOI_REPORT_ENABLED === "true" ? { reportEnabled: true } : {}),
+          // KOI_PLANNING_ENABLED=true opts into @koi/middleware-planning.
+          // Default off because plan state is ephemeral across resume until
+          // durable persistence (#1842) lands. Hosts that accept the
+          // limitation can opt in today.
+          ...(process.env.KOI_PLANNING_ENABLED === "true" ? { planningEnabled: true } : {}),
+          // KOI_FEEDBACK_LOOP_ENABLED=true opts into @koi/middleware-feedback-loop.
+          // Activates model-response validation + tool-health tracking with an
+          // empty config (observe-only, no validators, no quarantine thresholds).
+          ...(process.env.KOI_FEEDBACK_LOOP_ENABLED === "true" ? { feedbackLoop: {} } : {}),
+          // KOI_INTENT_CAPSULE=<systemPrompt> opts into @koi/middleware-intent-capsule.
+          // Cryptographically binds the agent's mandate at session start with Ed25519;
+          // verifies hash on every model call. Throws PERMISSION on tamper. (gov-16 #1883)
+          ...(process.env.KOI_INTENT_CAPSULE !== undefined && process.env.KOI_INTENT_CAPSULE !== ""
+            ? { intentCapsule: { systemPrompt: process.env.KOI_INTENT_CAPSULE } }
+            : {}),
+          extraMiddleware:
+            aceMiddleware !== undefined
+              ? [securityBridge.middleware, aceMiddleware]
+              : [securityBridge.middleware],
+          // Bridge spawn lifecycle events into the TUI store so /agents view and
+          // inline spawn_call blocks reflect real spawn state. Each spawn call
+          // produces one spawn_requested + one agent_status_changed event.
+          onSpawnEvent: (event): void => {
+            // Delegate to the current drain's spawn tracker for SIGINT grace.
+            // Null between drains so cross-drain survivors from earlier turns cannot
+            // influence the grace policy of a later, unrelated turn (#1999 r14).
+            currentDrainSpawnHandler?.(event);
+            // Defense-in-depth: store.dispatch can throw if the reducer or
+            // SolidJS reactivity hits an edge case. A throwing callback must
+            // not crash the spawn flow — the engine wraps this in safeSpawnEvent
+            // too, but belt-and-braces keeps the TUI safe even if the engine
+            // guard is ever removed.
+            try {
+              if (event.kind === "spawn_requested") {
+                store.dispatch({
+                  kind: "engine_event",
+                  event: {
+                    kind: "spawn_requested",
+                    childAgentId: event.agentId as unknown as import("@koi/core").AgentId,
+                    request: {
+                      agentName: event.agentName,
+                      description: event.description,
+                      signal: new AbortController().signal,
+                    },
+                  },
                 });
-                return createDaemonSpawnChildFn({
-                  supervisor: daemonHandle.supervisor,
-                  sessionRegistry: daemonHandle.registry,
-                  agentRegistry,
-                  bridge: agentRegistryBridge,
-                  // Subprocess children must declare a `command` to reach
-                  // this branch (the dispatcher in wireManifestSupervision
-                  // only routes here when childSpec.command is set), so
-                  // the builder is always invoked with a defined command.
-                  commandBuilder: (_parent, childSpec) => childSpec.command ?? [],
+              } else {
+                // agent_status_changed: use the dedicated set_spawn_terminal action so the
+                // outcome (complete vs failed) is preserved. The engine's ProcessState only
+                // has a single "terminated" value — routing through that path would collapse
+                // failures into successes.
+                const outcome: "complete" | "failed" =
+                  event.status === "failed" ? "failed" : "complete";
+                store.dispatch({
+                  kind: "set_spawn_terminal",
+                  agentId: event.agentId,
+                  outcome,
+                  // Pass metadata so the reducer can synthesize a record when
+                  // spawn_requested dispatch was lost (#1855).
+                  agentName: event.agentName,
+                  description: event.description,
                 });
               }
-            : undefined;
-        const supHandle = await wireManifestSupervision({
-          runtime: handle.runtime,
-          supervisorManifestName: flags.manifest ?? "supervisor",
-          supervision: manifestSupervision,
-          onChange: (children) => {
-            store.dispatch({ kind: "set_supervised_children", children });
+            } catch (e: unknown) {
+              console.warn("[koi:tui] onSpawnEvent dispatch failed — spawn UI may be stale", e);
+            }
           },
-          ...(subprocessSpawnFactory !== undefined && { subprocessSpawnFactory }),
+        }).then(async (handle) => {
+          // If an interim SIGUSR1 teardown started while createKoiRuntime was
+          // in flight (#1906 R10), the teardown couldn't dispose `handle`
+          // because it wasn't assigned yet. Dispose it here directly and do
+          // NOT assign `runtimeHandle` — otherwise the rest of bootstrap
+          // (transcript priming, /mcp refresh) would run against an
+          // already-disposed runtime.
+          if (shutdownStarted) {
+            handle.shutdownBackgroundTasks();
+            void handle.runtime.dispose().catch(() => {
+              /* best effort — hard-exit failsafe will still fire */
+            });
+            return;
+          }
+          runtimeHandle = handle;
+          // #1767 Phase 6: surface context-engine swap events as TUI notices
+          // through the single-writer store. Subscribing at the controller
+          // level (rather than reading the run-stream `custom` event) covers
+          // out-of-run swaps too — idle, pre-first-run, between reusable
+          // turns. Notices flow through `add_info` like plugin-load banners:
+          // not in the JSONL transcript, not pushed back into model context.
+          handle.runtime.contextEngineSwapController?.subscribe((swap) => {
+            const notice = formatContextEngineSwapNotice(swap);
+            store.dispatch({ kind: "add_info", message: notice.message });
+          });
+          // Resolve lazy skill agent ref so the injector middleware can query
+          // skill components on every subsequent model call.
+          skillAgentRef.current = handle.runtime.agent;
+          // Seed the mutable live skill map from the ECS components attached during
+          // createKoiRuntime. Subsequent session resets update liveSkillComponents via
+          // reloadSkillComponents() without touching the static ECS.
+          liveSkillComponents = handle.runtime.agent.query<SkillComponent>("skill:");
+          // Wire governance bridge when the agent has a GovernanceController
+          // component attached. In default sessions (no --max-spend or equivalent
+          // future flag), component() returns undefined and the bridge stays unset,
+          // leaving all governanceBridge?.xxx() call sites as no-ops.
+          try {
+            const governanceController =
+              handle.runtime.agent.component<GovernanceController>(GOVERNANCE);
+            // `--no-governance` / manifest disable wins here: even though the
+            // engine's bundled GOVERNANCE component is still attached for
+            // guard-level safety, the host-level observer surface (bridge, alerts
+            // JSONL, toast reducer) must stay inert so operator intent is
+            // honored end-to-end. Without this gate, disabling governance would
+            // still fire toasts, persist alerts, and poll snapshots — a
+            // fail-open.
+            if (governanceController !== undefined && handle.governanceEnabled) {
+              governanceBridge = createGovernanceBridge({
+                store,
+                controller: governanceController,
+                sessionId: tuiSessionId as string,
+                alertsPath: join(homedir(), ".koi", "governance-alerts.jsonl"),
+                // Static rule snapshot resolved by runtime-factory via
+                // backend.describeRules() — falls back to a synthetic default-allow
+                // entry until the manifest YAML loader (#1877) wires real rules.
+                rules: handle.governanceRules,
+                // Resolved `--alert-threshold` / manifest thresholds. When both are
+                // unset the bridge falls back to its observational default
+                // ([0.5, 0.8, 0.95]); passing the resolved set here is what makes
+                // CLI/manifest precedence authoritative for TUI toast firing.
+                ...(handle.governanceAlertThresholds !== undefined
+                  ? { alertThresholds: handle.governanceAlertThresholds }
+                  : {}),
+                ...(handle.violationStore !== undefined
+                  ? { violationStore: handle.violationStore }
+                  : {}),
+                // Static capability mirror — matches the createGovernanceMiddleware's
+                // describeCapabilities() output. Hardcoded here to avoid plumbing the
+                // middleware instance back from runtime-factory just for one string.
+                capabilities: [
+                  { label: "governance", description: "Policy gate + setpoint enforcement active" },
+                ],
+              });
+              // Seed up to 10 most-recent alerts from JSONL so /governance
+              // shows context across sessions instead of starting empty.
+              // TODO(gov-9): replace per-alert dispatch with a `replay_persisted_alerts`
+              // bulk action once seed counts grow past ~10 to avoid N reducer runs.
+              const recent = governanceBridge.loadRecentAlerts(10);
+              for (const alert of recent) {
+                store.dispatch({ kind: "add_governance_alert", alert });
+              }
+              // Seed up to 10 most-recent persisted violations for the current
+              // session so /governance's "Recent violations" panel is populated
+              // on restart / resume. Load is async (SQLite) — fire-and-forget
+              // so startup isn't blocked on history backfill.
+              void governanceBridge
+                .loadRecentViolations(10)
+                .then((violations) => {
+                  // Synthesize UI-shape fields: id is per-entry counter, ts
+                  // is load-time (the ViolationStore row timestamp is not
+                  // exposed in the Violation shape — it would need an L0
+                  // widening to surface). Order is preserved from the DB.
+                  for (const v of violations) {
+                    store.dispatch({
+                      kind: "add_governance_violation",
+                      violation: {
+                        id: `backfill-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+                        ts: Date.now(),
+                        variable: v.rule,
+                        reason: v.message,
+                      },
+                    });
+                  }
+                })
+                .catch((err: unknown) => {
+                  console.warn("[tui-command] violation backfill failed:", err);
+                });
+              // Initial snapshot push so the view has data before the first turn.
+              governanceBridge.pollSnapshot();
+            }
+          } catch (err: unknown) {
+            console.warn("[tui-command] governance bridge init failed:", err);
+          }
+          // Registry-only daemon bridge (#1944). The registry path follows the
+          // `koi bg` convention — `KOI_STATE_DIR/daemon/sessions` when set, else
+          // `~/.koi/daemon/sessions`. Per-workspace isolation: set KOI_STATE_DIR
+          // per shell. Opened only when the directory already exists so that
+          // simply launching the TUI does not create or mutate shared state on
+          // hosts where no daemon has ever run. Replaced by the live bridge
+          // below when the manifest declares subprocess children.
+          const registryDir = defaultRegistryDir();
+          const registryDirExists = await stat(registryDir)
+            .then((s) => s.isDirectory())
+            .catch(() => false);
+          // Inline helper: maps a DaemonBridgeToast to the TUI Toast shape.
+          // body is empty — daemon toasts carry their message in title only.
+          const pushDaemonToast = (
+            toast: import("./daemon-bridge.js").DaemonBridgeToast,
+            key: string,
+          ): void => {
+            store.dispatch({
+              kind: "add_toast",
+              toast: {
+                id: crypto.randomUUID(),
+                kind: toast.kind,
+                key,
+                title: toast.message,
+                body: "",
+                ts: Date.now(),
+              },
+            });
+          };
+          if (registryDirExists) {
+            try {
+              // The registry-only bridge only calls describeList() + watch() —
+              // it never invokes register/update/unregister, so even though
+              // FileSessionRegistry exposes write methods we never use them.
+              const roRegistry = createFileSessionRegistry({ dir: registryDir });
+              registryOnlyBridge = createDaemonBridge({
+                mode: { kind: "registry-only", registry: roRegistry },
+                dispatch: store.dispatch,
+                pushToast: (toast) => {
+                  pushDaemonToast(toast, "daemon-bridge");
+                },
+              });
+            } catch (err: unknown) {
+              console.warn("[tui-command] registry-only bridge init failed:", err);
+            }
+          }
+          // Daemon supervisor wiring (#1944). Constructed BEFORE
+          // wireManifestSupervision so its supervisor + sessionRegistry can back
+          // a daemon-aware SpawnChildFn for subprocess children with `command`.
+          // Skipped when the manifest has no subprocess children.
+          const hasSubprocessChild =
+            manifestSupervision?.children.some((c) => c.isolation === "subprocess") === true;
+          if (hasSubprocessChild) {
+            // Tear down the registry-only bridge first; live mode owns the registry.
+            try {
+              await registryOnlyBridge?.close();
+              registryOnlyBridge = null;
+            } catch (err: unknown) {
+              console.warn("[tui-command] registry-only bridge close failed:", err);
+            }
+            try {
+              const supervisorManifest: import("@koi/core").AgentManifest = {
+                name: flags.manifest ?? "supervisor",
+                version: "0",
+                model: { name: modelName },
+                ...(manifestSupervision !== undefined && { supervision: manifestSupervision }),
+              };
+              daemonSupervisorHandle = await wireDaemonSupervisor({
+                stateDir: registryDir,
+                manifest: supervisorManifest,
+                dispatch: store.dispatch,
+                pushToast: (toast) => {
+                  pushDaemonToast(toast, "daemon-supervisor");
+                },
+                backends: { subprocess: createSubprocessBackend() },
+              });
+              store.dispatch({ kind: "set_supervisor_attached", attached: true });
+            } catch (err: unknown) {
+              console.warn("[tui-command] daemon supervisor wiring failed:", err);
+            }
+          }
+          // Manifest-driven supervision wiring (#1866 + #1944). When the loaded
+          // manifest declares `supervision:`, activate the subsystem here so the
+          // declared children appear in the runtime's AgentRegistry and in the
+          // /agents view. When the daemon supervisor is also active and a child
+          // declares `command`, route that child through the daemon adapter so
+          // /supervisor, /bg, ownership checks, and on-path kills observe and
+          // control the same worker. Children without `command` continue to
+          // use the in-process stub for backwards compatibility.
+          if (manifestSupervision !== undefined) {
+            try {
+              const daemonHandle = daemonSupervisorHandle;
+              const subprocessSpawnFactory =
+                daemonHandle !== undefined
+                  ? (agentRegistry: import("@koi/core").AgentRegistry) => {
+                      agentRegistryBridge = attachAgentRegistry({
+                        supervisor: daemonHandle.supervisor,
+                        agentRegistry,
+                      });
+                      return createDaemonSpawnChildFn({
+                        supervisor: daemonHandle.supervisor,
+                        sessionRegistry: daemonHandle.registry,
+                        agentRegistry,
+                        bridge: agentRegistryBridge,
+                        // Subprocess children must declare a `command` to reach
+                        // this branch (the dispatcher in wireManifestSupervision
+                        // only routes here when childSpec.command is set), so
+                        // the builder is always invoked with a defined command.
+                        commandBuilder: (_parent, childSpec) => childSpec.command ?? [],
+                      });
+                    }
+                  : undefined;
+              const supHandle = await wireManifestSupervision({
+                runtime: handle.runtime,
+                supervisorManifestName: flags.manifest ?? "supervisor",
+                supervision: manifestSupervision,
+                onChange: (children) => {
+                  store.dispatch({ kind: "set_supervised_children", children });
+                },
+                ...(subprocessSpawnFactory !== undefined && { subprocessSpawnFactory }),
+              });
+              supervisionHandle = supHandle;
+            } catch (err: unknown) {
+              console.warn("[tui-command] supervision wiring failed:", err);
+            }
+          }
+          // Prime the runtime's in-memory transcript with the resumed
+          // messages. The runtime's context-window builder reads from this
+          // array on every turn, so without this push the model would see
+          // an empty history and treat the first post-resume turn as a
+          // fresh conversation. Dispatching `rehydrate_messages` only
+          // updates the UI; this line makes the agent remember.
+          if (resumedMessagesToPrime.length > 0) {
+            handle.transcript.push(...resumedMessagesToPrime);
+            resumedMessagesToPrime = [];
+          }
+          // If /mcp was opened during startup, refresh its live status now
+          // that the runtime is ready.
+          if (store.getState().activeView === "mcp") {
+            void (async () => {
+              mcpViewGeneration += 1;
+              const refreshGen = mcpViewGeneration;
+              const live = await handle.getMcpStatus();
+              if (mcpViewGeneration !== refreshGen) return;
+              store.dispatch({
+                kind: "set_mcp_status",
+                servers: live.map((l) => ({
+                  name: l.name,
+                  // transport is now threaded through McpServerStatus from getMcpStatus(),
+                  // so startup refresh uses the same authoritative source as nav:mcp enrichment.
+                  status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
+                  toolCount: l.toolCount,
+                  detail: l.failureMessage,
+                })),
+              });
+            })();
+          }
+
+          // Dispatch plugin summary to TUI store (#1728)
+          store.dispatch({
+            kind: "set_plugin_summary",
+            summary: handle.pluginSummary,
+          });
+
+          // Surface plugin status as inline TUI notice (#1728, #1887).
+          // UI-only — not injected into the model transcript to avoid a trust
+          // boundary issue (plugin descriptions are untrusted metadata).
+          // Agent awareness comes through the /plugins view and startup log.
+          //
+          // #1887: suppress the banner on the happy path (plugins loaded cleanly,
+          // no errors) — users who configured those plugins already know they
+          // loaded, and `/plugins` is the canonical way to inspect them. Only
+          // render when there are errors to surface, so failures are never
+          // silent. Include the loaded list alongside errors for context.
+          //
+          // Plugin-derived strings are sanitized to strip ANSI escape sequences
+          // and control characters before display.
+          if (handle.pluginSummary.errors.length > 0) {
+            // Strip ANSI escapes and control characters from untrusted plugin text.
+            // Constructor form avoids `noControlCharactersInRegex` (hex escapes in
+            // literal regex still trip the rule). The `useRegexLiterals` warning on
+            // the next two lines is a false positive in that case.
+            // biome-ignore lint/complexity/useRegexLiterals: constructor avoids noControlCharactersInRegex
+            const ANSI_RE = new RegExp("\\x1b\\[[0-9;]*[a-zA-Z]", "g");
+            // biome-ignore lint/complexity/useRegexLiterals: constructor avoids noControlCharactersInRegex
+            const CTRL_RE = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
+            const sanitize = (s: string): string => s.replace(ANSI_RE, "").replace(CTRL_RE, "");
+
+            const parts: string[] = [];
+            if (handle.pluginSummary.loaded.length > 0) {
+              const pluginLines = handle.pluginSummary.loaded
+                .map((p) => `- ${sanitize(p.name)} v${sanitize(p.version)}`)
+                .join("\n");
+              parts.push(`[Loaded Plugins]\n${pluginLines}`);
+            }
+            const errorLines = handle.pluginSummary.errors
+              .map((e) => `- ${sanitize(e.plugin)}: ${sanitize(e.error)}`)
+              .join("\n");
+            parts.push(`[Plugin Load Errors]\n${errorLines}`);
+
+            // Route through `add_info` so the notice renders as a system block
+            // rather than being attributed to "You:", and stays out of the
+            // JSONL transcript + next-submit model context.
+            store.dispatch({
+              kind: "add_info",
+              message: parts.join("\n\n"),
+            });
+          }
+
+          return handle;
         });
-        supervisionHandle = supHandle;
-      } catch (err: unknown) {
-        console.warn("[tui-command] supervision wiring failed:", err);
-      }
-    }
-    // Prime the runtime's in-memory transcript with the resumed
-    // messages. The runtime's context-window builder reads from this
-    // array on every turn, so without this push the model would see
-    // an empty history and treat the first post-resume turn as a
-    // fresh conversation. Dispatching `rehydrate_messages` only
-    // updates the UI; this line makes the agent remember.
-    if (resumedMessagesToPrime.length > 0) {
-      handle.transcript.push(...resumedMessagesToPrime);
-      resumedMessagesToPrime = [];
-    }
-    // If /mcp was opened during startup, refresh its live status now
-    // that the runtime is ready.
-    if (store.getState().activeView === "mcp") {
-      void (async () => {
-        mcpViewGeneration += 1;
-        const refreshGen = mcpViewGeneration;
-        const live = await handle.getMcpStatus();
-        if (mcpViewGeneration !== refreshGen) return;
-        store.dispatch({
-          kind: "set_mcp_status",
-          servers: live.map((l) => ({
-            name: l.name,
-            // transport is now threaded through McpServerStatus from getMcpStatus(),
-            // so startup refresh uses the same authoritative source as nav:mcp enrichment.
-            status: computeLiveMcpStatus(l.failureCode, l.transport, l.hasOAuth),
-            toolCount: l.toolCount,
-            detail: l.failureMessage,
-          })),
-        });
-      })();
-    }
-
-    // Dispatch plugin summary to TUI store (#1728)
-    store.dispatch({
-      kind: "set_plugin_summary",
-      summary: handle.pluginSummary,
-    });
-
-    // Surface plugin status as inline TUI notice (#1728, #1887).
-    // UI-only — not injected into the model transcript to avoid a trust
-    // boundary issue (plugin descriptions are untrusted metadata).
-    // Agent awareness comes through the /plugins view and startup log.
-    //
-    // #1887: suppress the banner on the happy path (plugins loaded cleanly,
-    // no errors) — users who configured those plugins already know they
-    // loaded, and `/plugins` is the canonical way to inspect them. Only
-    // render when there are errors to surface, so failures are never
-    // silent. Include the loaded list alongside errors for context.
-    //
-    // Plugin-derived strings are sanitized to strip ANSI escape sequences
-    // and control characters before display.
-    if (handle.pluginSummary.errors.length > 0) {
-      // Strip ANSI escapes and control characters from untrusted plugin text.
-      // Constructor form avoids `noControlCharactersInRegex` (hex escapes in
-      // literal regex still trip the rule). The `useRegexLiterals` warning on
-      // the next two lines is a false positive in that case.
-      // biome-ignore lint/complexity/useRegexLiterals: constructor avoids noControlCharactersInRegex
-      const ANSI_RE = new RegExp("\\x1b\\[[0-9;]*[a-zA-Z]", "g");
-      // biome-ignore lint/complexity/useRegexLiterals: constructor avoids noControlCharactersInRegex
-      const CTRL_RE = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
-      const sanitize = (s: string): string => s.replace(ANSI_RE, "").replace(CTRL_RE, "");
-
-      const parts: string[] = [];
-      if (handle.pluginSummary.loaded.length > 0) {
-        const pluginLines = handle.pluginSummary.loaded
-          .map((p) => `- ${sanitize(p.name)} v${sanitize(p.version)}`)
-          .join("\n");
-        parts.push(`[Loaded Plugins]\n${pluginLines}`);
-      }
-      const errorLines = handle.pluginSummary.errors
-        .map((e) => `- ${sanitize(e.plugin)}: ${sanitize(e.error)}`)
-        .join("\n");
-      parts.push(`[Plugin Load Errors]\n${errorLines}`);
-
-      // Route through `add_info` so the notice renders as a system block
-      // rather than being attributed to "You:", and stays out of the
-      // JSONL transcript + next-submit model context.
-      store.dispatch({
-        kind: "add_info",
-        message: parts.join("\n\n"),
-      });
-    }
-
-    return handle;
-  });
 
   // let: set once after createTuiApp resolves, read in shutdown.
   let appHandle: { readonly stop: () => Promise<void> } | null = null;
@@ -3337,6 +3400,11 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     // dismiss the modal and keep the bridge usable for the next turn.
     // (#1759 review round 5)
     activeController?.abort();
+    if (activeRemoteRequestId !== null) {
+      void gatewayClient?.cancel(activeRemoteRequestId).catch(() => {
+        /* best effort while remote cancel is a safe no-op placeholder */
+      });
+    }
     permissionBridge.cancelPending("Turn cancelled by user");
   };
 
@@ -3464,6 +3532,11 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
           } catch {
             /* stderr unwritable — best effort */
           }
+        }
+        try {
+          await gatewayClient?.dispose();
+        } catch {
+          // Best-effort — force-quit must always terminate.
         }
         if (liveTasks) {
           // Wait long enough for the runtime's SIGKILL escalation window
@@ -4203,6 +4276,17 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         );
       }
     }
+    if (runtimeHandle === null) {
+      try {
+        await gatewayClient?.dispose();
+      } catch (disposeErr) {
+        process.stderr.write(
+          `[koi tui] gateway client dispose failed during shutdown: ${
+            disposeErr instanceof Error ? disposeErr.message : String(disposeErr)
+          }\n`,
+        );
+      }
+    }
     // Governance bridge dispose is a no-op (sync, no open handles), but
     // calling it here keeps the pattern symmetric with future bridges that
     // may hold timers or open file handles.
@@ -4567,6 +4651,47 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
     store.dispatch({ kind: "set_at_results", results }),
   );
 
+  async function createRemoteStreamWithReconnect(
+    remoteClient: TuiGatewayClient,
+    text: string,
+  ): Promise<AsyncIterable<EngineEvent>> {
+    const startRemoteRun = (): AsyncIterable<EngineEvent> => {
+      const requestId = crypto.randomUUID();
+      activeRemoteRequestId = requestId;
+      return remoteClient.run({
+        requestId,
+        text,
+      });
+    };
+
+    try {
+      return startRemoteRun();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message !== "gateway socket is not connected") {
+        throw err;
+      }
+      store.dispatch({
+        kind: "add_info",
+        message: "Gateway disconnected - reconnecting...",
+      });
+      try {
+        await remoteClient.reconnect();
+      } catch (reconnectErr) {
+        throw new Error(
+          `Remote gateway resume failed: ${
+            reconnectErr instanceof Error ? reconnectErr.message : String(reconnectErr)
+          }`,
+        );
+      }
+      store.dispatch({
+        kind: "add_info",
+        message: "Gateway resumed existing session.",
+      });
+      return startRemoteRun();
+    }
+  }
+
   const processSubmit = async (text: string): Promise<void> => {
     // Fail closed after a durable clear failure. If the last
     // `/clear` or `/new` could not truncate the JSONL, the
@@ -4643,7 +4768,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       // P2-A: block on runtime assembly if not yet ready.
       // First submit waits for createKoiRuntime to complete; subsequent
       // submits use the cached runtimeHandle (already resolved).
-      if (runtimeHandle === null) {
+      if (runtimeHandle === null && gatewayClient === null) {
         try {
           await runtimeReady;
         } catch (e: unknown) {
@@ -4656,13 +4781,12 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         }
       }
 
-      // runtimeHandle is guaranteed non-null after runtimeReady resolves.
-      // The await above sets runtimeHandle; if it threw, we returned early.
-      if (runtimeHandle === null) return;
+      if (runtimeHandle === null && gatewayClient === null) return;
       // Bail if a reset (e.g. `/clear`, `/new`) landed during runtime
       // initialization. The submit was implicitly invalidated.
       if (resetGeneration !== submitResetGen) return;
       const handle = runtimeHandle;
+      const remoteClient = gatewayClient;
 
       // Wait for any pending session reset to complete before submitting.
       // Prevents hitting stale task board or trajectory state.
@@ -4738,20 +4862,22 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
       // Inject a synthetic turn-boundary step so /trajectory can group steps
       // by user turn. The engine resets ctx.turnIndex to 0 on each run() call,
       // so we maintain our own counter here at the TUI session level.
-      const thisTurnIndex = tuiTurnCounter++;
-      await runtimeHandle.appendTrajectoryStep({
-        stepIndex: 0,
-        timestamp: Date.now(),
-        source: "system",
-        kind: "tool_call",
-        identifier: "koi:tui_turn_start",
-        outcome: "success",
-        durationMs: 0,
-        metadata: {
-          type: "tui_turn_start",
-          tuiTurnIndex: thisTurnIndex,
-        } as import("@koi/core").JsonObject,
-      });
+      if (handle !== null) {
+        const thisTurnIndex = tuiTurnCounter++;
+        await handle.appendTrajectoryStep({
+          stepIndex: 0,
+          timestamp: Date.now(),
+          source: "system",
+          kind: "tool_call",
+          identifier: "koi:tui_turn_start",
+          outcome: "success",
+          durationMs: 0,
+          metadata: {
+            type: "tui_turn_start",
+            tuiTurnIndex: thisTurnIndex,
+          } as import("@koi/core").JsonObject,
+        });
+      }
 
       try {
         // A2-A: drive conversation via runtime.run() — the KoiRuntime handles
@@ -4825,13 +4951,19 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
 
         let stream: AsyncIterable<EngineEvent>;
         try {
-          stream = isLoopMode
-            ? runTuiLoopTurn(handle.runtime, modelText, controller.signal, flags, store)
-            : handle.runtime.run({
-                kind: "text",
-                text: modelText,
-                signal: controller.signal,
-              });
+          if (remoteClient !== null) {
+            stream = await createRemoteStreamWithReconnect(remoteClient, modelText);
+          } else if (handle !== null) {
+            stream = isLoopMode
+              ? runTuiLoopTurn(handle.runtime, modelText, controller.signal, flags, store)
+              : handle.runtime.run({
+                  kind: "text",
+                  text: modelText,
+                  signal: controller.signal,
+                });
+          } else {
+            throw new Error("Runtime failed to initialize");
+          }
         } catch (err) {
           store.dispatch({
             kind: "add_error",
@@ -4960,15 +5092,17 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         // reset that runs in the 500 ms window invalidates this refresh
         // before it dispatches. Otherwise the post-reset store would be
         // repopulated with this turn's stale trajectory. (#1764)
-        const submitGen = trajectoryRefreshGen;
-        void new Promise<void>((resolve) => setTimeout(resolve, 500)).then(() =>
-          refreshTrajectoryData(
-            handle,
-            store,
-            handle.runtime.sessionId,
-            () => trajectoryRefreshGen === submitGen,
-          ),
-        );
+        if (handle !== null) {
+          const submitGen = trajectoryRefreshGen;
+          void new Promise<void>((resolve) => setTimeout(resolve, 500)).then(() =>
+            refreshTrajectoryData(
+              handle,
+              store,
+              handle.runtime.sessionId,
+              () => trajectoryRefreshGen === submitGen,
+            ),
+          );
+        }
       } finally {
         // Guard against cross-run races: only clear activeController and
         // reset the SIGINT handler if THIS run is still the active one.
@@ -4978,6 +5112,7 @@ export async function runTuiCommand(flags: TuiFlags): Promise<void> {
         const isStillActive = activeController === controller;
         if (isStillActive) {
           activeController = null;
+          activeRemoteRequestId = null;
           activeRunPromise = null;
         }
         // The active run has settled. Clear the interrupt-time spawn snapshot

--- a/packages/meta/cli/src/tui-gateway-client.test.ts
+++ b/packages/meta/cli/src/tui-gateway-client.test.ts
@@ -1,0 +1,524 @@
+import { describe, expect, test } from "bun:test";
+import { createTuiGatewayClient } from "./tui-gateway-client.js";
+
+type WebSocketEventName = "open" | "message" | "close" | "error";
+
+interface FakeWebSocketController {
+  readonly socket: WebSocket;
+  readonly sent: string[];
+  readonly open: () => void;
+  readonly message: (data: string) => void;
+  readonly close: () => void;
+  readonly error: () => void;
+}
+
+function createFakeWebSocket(initialReadyState = 0): FakeWebSocketController {
+  const sent: string[] = [];
+  const listeners = new Map<WebSocketEventName, Set<(event?: unknown) => void>>();
+  let readyState = initialReadyState;
+
+  function emit(type: WebSocketEventName, event?: unknown): void {
+    for (const listener of listeners.get(type) ?? []) listener(event);
+  }
+
+  const socket = {
+    get readyState(): number {
+      return readyState;
+    },
+    send: (data: string) => {
+      sent.push(data);
+    },
+    close: () => {
+      readyState = 3;
+    },
+    addEventListener: (type: WebSocketEventName, listener: (event?: unknown) => void) => {
+      let bucket = listeners.get(type);
+      if (bucket === undefined) {
+        bucket = new Set();
+        listeners.set(type, bucket);
+      }
+      bucket.add(listener);
+    },
+    removeEventListener: (type: WebSocketEventName, listener: (event?: unknown) => void) => {
+      listeners.get(type)?.delete(listener);
+    },
+  } as unknown as WebSocket;
+
+  return {
+    socket,
+    sent,
+    open: () => {
+      readyState = 1;
+      emit("open");
+    },
+    message: (data: string) => {
+      emit("message", { data });
+    },
+    close: () => {
+      readyState = 3;
+      emit("close");
+    },
+    error: () => {
+      emit("error");
+    },
+  };
+}
+
+describe("createTuiGatewayClient", () => {
+  test("reconnect preserves session identity and resume watermark expectations", async () => {
+    const first = createFakeWebSocket();
+    const second = createFakeWebSocket();
+    const sockets = [first, second];
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "resume-client",
+      authToken: "test-token",
+      webSocketFactory: () => {
+        const next = sockets.shift();
+        if (next === undefined) {
+          throw new Error("no websocket available");
+        }
+        return next.socket;
+      },
+    });
+
+    const connectPromise = client.connect();
+    first.open();
+    first.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", remoteSeq: 5, protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    await client.noteRemoteSeq(5);
+
+    const reconnectPromise = client.reconnect();
+    second.open();
+    second.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-2",
+        seq: 1,
+        timestamp: 2,
+        payload: { sessionId: "sess-123", remoteSeq: 5, protocol: 1 },
+      }),
+    );
+    await reconnectPromise;
+
+    expect(client.sessionId()).toBe("sess-123");
+    expect(first.socket.readyState).toBe(3);
+    expect(second.sent[0]).toContain('"kind":"connect"');
+  });
+
+  test("reconnect rejects when the gateway resumes a different session", async () => {
+    const first = createFakeWebSocket();
+    const second = createFakeWebSocket();
+    const sockets = [first, second];
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "resume-client",
+      authToken: "test-token",
+      webSocketFactory: () => {
+        const next = sockets.shift();
+        if (next === undefined) {
+          throw new Error("no websocket available");
+        }
+        return next.socket;
+      },
+    });
+
+    const connectPromise = client.connect();
+    first.open();
+    first.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", remoteSeq: 5, protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    await client.noteRemoteSeq(5);
+
+    const reconnectPromise = client.reconnect();
+    second.open();
+    second.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-2",
+        seq: 1,
+        timestamp: 2,
+        payload: { sessionId: "sess-999", remoteSeq: 5, protocol: 1 },
+      }),
+    );
+
+    await expect(reconnectPromise).rejects.toThrow("gateway resume failed");
+  });
+
+  test("reconnect rejects when the gateway ack regresses the resume watermark", async () => {
+    const first = createFakeWebSocket();
+    const second = createFakeWebSocket();
+    const sockets = [first, second];
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "resume-client",
+      authToken: "test-token",
+      webSocketFactory: () => {
+        const next = sockets.shift();
+        if (next === undefined) {
+          throw new Error("no websocket available");
+        }
+        return next.socket;
+      },
+    });
+
+    const connectPromise = client.connect();
+    first.open();
+    first.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", remoteSeq: 5, protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    await client.noteRemoteSeq(5);
+
+    const reconnectPromise = client.reconnect();
+    second.open();
+    second.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-2",
+        seq: 1,
+        timestamp: 2,
+        payload: { sessionId: "sess-123", remoteSeq: 4, protocol: 1 },
+      }),
+    );
+
+    await expect(reconnectPromise).rejects.toThrow("gateway resume failed");
+  });
+
+  test("remote-mode boot on an already-open socket still waits for ack", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]).toContain('"kind":"connect"');
+
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+    expect(client.sessionId()).toBe("sess-123");
+  });
+
+  test("waits for handshake ack before resolving and captures session id", async () => {
+    const ws = createFakeWebSocket();
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    expect(client.sessionId()).toBeUndefined();
+    let resolved = false;
+    const connectPromise = client.connect().then(() => {
+      resolved = true;
+    });
+
+    expect(ws.sent).toEqual([]);
+    ws.open();
+    expect(ws.sent[0]).toContain('"kind":"connect"');
+    expect(ws.sent[0]).toContain('"id":"cli-test"');
+    expect(resolved).toBe(false);
+    expect(client.sessionId()).toBeUndefined();
+
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+    expect(resolved).toBe(true);
+    expect(client.sessionId()).toBe("sess-123");
+  });
+
+  test("rejects handshake on close before ack", async () => {
+    const ws = createFakeWebSocket();
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    ws.open();
+    ws.close();
+
+    await expect(connectPromise).rejects.toThrow("gateway connect failed");
+  });
+
+  test("rejects handshake on error before ack", async () => {
+    const ws = createFakeWebSocket();
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    ws.open();
+    ws.error();
+
+    await expect(connectPromise).rejects.toThrow("gateway connect failed");
+  });
+
+  test("cancel sends a control request for the active request", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    expect(ws.sent).toHaveLength(1);
+    await client.cancel("req-1");
+    expect(ws.sent).toHaveLength(2);
+    expect(ws.sent[1]).toContain('"kind":"request"');
+    expect(ws.sent[1]).toContain('"kind":"cancel"');
+    expect(ws.sent[1]).toContain('"requestId":"req-1"');
+  });
+
+  test("run sends a request frame keyed by the provided request id", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    const stream = client.run({ requestId: "req-1", text: "hello gateway" });
+    // Server replies with a terminal response frame keyed by ref=req-1.
+    ws.message(
+      JSON.stringify({
+        kind: "response",
+        id: "resp-1",
+        seq: 1,
+        ref: "req-1",
+        timestamp: 2,
+        payload: { text: "hi back" },
+      }),
+    );
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    expect(ws.sent).toHaveLength(2);
+    expect(ws.sent[1]).toContain('"kind":"request"');
+    expect(ws.sent[1]).toContain('"id":"req-1"');
+    expect(ws.sent[1]).toContain('"text":"hello gateway"');
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ kind: "text_delta", delta: "hi back" });
+    expect(events[1]).toMatchObject({ kind: "done" });
+  });
+
+  test("dispose closes the websocket", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    await client.dispose();
+    expect(ws.socket.readyState).toBe(3);
+  });
+
+  test("run yields done with stopReason error when an error frame arrives for the request", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    const stream = client.run({ requestId: "req-err", text: "boom" });
+    ws.message(
+      JSON.stringify({
+        kind: "error",
+        id: "err-1",
+        seq: 1,
+        ref: "req-err",
+        timestamp: 2,
+        payload: { code: "NO_RUNTIME", message: "no handler" },
+      }),
+    );
+
+    const events: unknown[] = [];
+    for await (const e of stream) events.push(e);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "done", output: { stopReason: "error" } });
+  });
+
+  test("run ignores frames with mismatched ref so concurrent requests don't cross-talk", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    const stream = client.run({ requestId: "req-A", text: "for A" });
+    // Response for a different request — must not terminate stream A.
+    ws.message(
+      JSON.stringify({
+        kind: "response",
+        id: "resp-other",
+        seq: 1,
+        ref: "req-OTHER",
+        timestamp: 2,
+        payload: { text: "wrong stream" },
+      }),
+    );
+    // Now the right one.
+    ws.message(
+      JSON.stringify({
+        kind: "response",
+        id: "resp-A",
+        seq: 2,
+        ref: "req-A",
+        timestamp: 3,
+        payload: { text: "right stream" },
+      }),
+    );
+
+    const events: unknown[] = [];
+    for await (const e of stream) events.push(e);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ kind: "text_delta", delta: "right stream" });
+    expect(events[1]).toMatchObject({ kind: "done", output: { stopReason: "completed" } });
+  });
+
+  test("run yields done with stopReason error if the websocket closes before a terminal frame", async () => {
+    const ws = createFakeWebSocket(1);
+    const client = createTuiGatewayClient({
+      gatewayUrl: "ws://127.0.0.1:19500",
+      clientId: "cli-test",
+      authToken: "test-token",
+      webSocketFactory: () => ws.socket,
+    });
+    const connectPromise = client.connect();
+    ws.message(
+      JSON.stringify({
+        kind: "ack",
+        id: "gw-1",
+        seq: 0,
+        timestamp: 1,
+        payload: { sessionId: "sess-123", protocol: 1 },
+      }),
+    );
+    await connectPromise;
+
+    const stream = client.run({ requestId: "req-disco", text: "will disconnect" });
+    ws.close();
+
+    const events: unknown[] = [];
+    for await (const e of stream) events.push(e);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "done", output: { stopReason: "error" } });
+  });
+});

--- a/packages/meta/cli/src/tui-gateway-client.ts
+++ b/packages/meta/cli/src/tui-gateway-client.ts
@@ -1,0 +1,164 @@
+import type { EngineEvent } from "@koi/core";
+import { createRequestStream } from "./tui-request-stream.js";
+
+export interface TuiGatewayClient {
+  readonly connect: () => Promise<void>;
+  readonly reconnect: () => Promise<void>;
+  readonly noteRemoteSeq: (seq: number) => Promise<void>;
+  readonly run: (input: {
+    readonly text: string;
+    readonly requestId: string;
+  }) => AsyncIterable<EngineEvent>;
+  readonly cancel: (requestId: string) => Promise<void>;
+  readonly dispose: () => Promise<void>;
+  readonly sessionId: () => string | undefined;
+}
+
+export interface TuiGatewayClientDeps {
+  readonly gatewayUrl: string;
+  readonly clientId: string;
+  readonly authToken: string;
+  readonly webSocketFactory?: ((url: string) => WebSocket) | undefined;
+}
+
+type GatewaySessionFrame = {
+  readonly kind?: string;
+  readonly payload?: {
+    readonly sessionId?: string;
+    readonly remoteSeq?: number;
+  };
+};
+
+interface ClientState {
+  ws: WebSocket | undefined;
+  sessionId: string | undefined;
+  lastRemoteSeq: number;
+  nextSeq: number;
+}
+
+function sendConnectFrame(socket: WebSocket, deps: TuiGatewayClientDeps): void {
+  socket.send(
+    JSON.stringify({
+      kind: "connect",
+      minProtocol: 1,
+      maxProtocol: 1,
+      auth: { token: deps.authToken },
+      client: { id: deps.clientId, version: "0.0.0", platform: "koi-tui" },
+    }),
+  );
+}
+
+function awaitAck(
+  socket: WebSocket,
+  state: ClientState,
+  mode: "initial" | "resume",
+  expectedSessionId: string | undefined,
+  minimumRemoteSeq: number,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const failMsg = mode === "resume" ? "gateway resume failed" : "gateway connect failed";
+    const settle = (err?: string): void => {
+      if (settled) return;
+      settled = true;
+      err === undefined ? resolve() : reject(new Error(err));
+    };
+
+    socket.addEventListener("message", (event) => {
+      const frame = parseSessionFrame(event.data);
+      if (frame === undefined) return;
+      const ackSessionId = frame.payload?.sessionId;
+      if (ackSessionId === undefined) return;
+      const ackRemoteSeq = frame.payload?.remoteSeq ?? 0;
+      if (expectedSessionId !== undefined && ackSessionId !== expectedSessionId) {
+        return settle("gateway resume failed: session identity changed");
+      }
+      if (expectedSessionId !== undefined && ackRemoteSeq < minimumRemoteSeq) {
+        return settle("gateway resume failed: remote seq regressed");
+      }
+      state.sessionId = ackSessionId;
+      if (ackRemoteSeq > state.lastRemoteSeq) state.lastRemoteSeq = ackRemoteSeq;
+      settle();
+    });
+    socket.addEventListener("error", () => settle(failMsg));
+    socket.addEventListener("close", () => settle(failMsg));
+  });
+}
+
+function parseSessionFrame(data: unknown): GatewaySessionFrame | undefined {
+  try {
+    const frame = JSON.parse(String(data)) as GatewaySessionFrame;
+    return frame.kind === "ack" ? frame : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function connectSocket(
+  state: ClientState,
+  deps: TuiGatewayClientDeps,
+  mode: "initial" | "resume",
+): Promise<void> {
+  const expectedSessionId = mode === "resume" ? state.sessionId : undefined;
+  const minimumRemoteSeq = mode === "resume" ? state.lastRemoteSeq : 0;
+
+  state.ws?.close();
+  state.ws = (deps.webSocketFactory ?? ((url) => new WebSocket(url)))(deps.gatewayUrl);
+  const socket = state.ws;
+
+  const ackPromise = awaitAck(socket, state, mode, expectedSessionId, minimumRemoteSeq);
+  if (socket.readyState === 1) {
+    sendConnectFrame(socket, deps);
+  } else {
+    socket.addEventListener("open", () => sendConnectFrame(socket, deps));
+  }
+  await ackPromise;
+}
+
+function sendRequestFrame(state: ClientState, payload: unknown, id: string): void {
+  if (state.ws === undefined || state.ws.readyState !== 1) {
+    throw new Error("gateway socket is not connected");
+  }
+  state.ws.send(
+    JSON.stringify({
+      kind: "request",
+      id,
+      seq: state.nextSeq++,
+      payload,
+      timestamp: Date.now(),
+    }),
+  );
+}
+
+export function createTuiGatewayClient(deps: TuiGatewayClientDeps): TuiGatewayClient {
+  const state: ClientState = {
+    ws: undefined,
+    sessionId: undefined,
+    lastRemoteSeq: 0,
+    nextSeq: 0,
+  };
+
+  return {
+    connect: () => connectSocket(state, deps, "initial"),
+    reconnect: () => connectSocket(state, deps, "resume"),
+    noteRemoteSeq: async (seq) => {
+      if (seq > state.lastRemoteSeq) state.lastRemoteSeq = seq;
+    },
+    run: (input) => {
+      if (state.ws === undefined || state.ws.readyState !== 1) {
+        throw new Error("gateway socket is not connected");
+      }
+      const stream = createRequestStream(state.ws, input.requestId);
+      sendRequestFrame(state, { text: input.text }, input.requestId);
+      return stream.iterator;
+    },
+    cancel: async (requestId) => {
+      sendRequestFrame(state, { kind: "cancel", requestId }, crypto.randomUUID());
+    },
+    dispose: async () => {
+      state.ws?.close();
+      state.ws = undefined;
+    },
+    sessionId: () => state.sessionId,
+  };
+}

--- a/packages/meta/cli/src/tui-request-stream.ts
+++ b/packages/meta/cli/src/tui-request-stream.ts
@@ -1,0 +1,109 @@
+import type { EngineEvent } from "@koi/core";
+
+interface ResponseFrameLike {
+  readonly kind?: string;
+  readonly ref?: string;
+  readonly payload?: unknown;
+}
+
+export interface RequestStream {
+  readonly iterator: AsyncIterable<EngineEvent>;
+}
+
+const EMPTY_METRICS = {
+  totalTokens: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  turns: 0,
+  durationMs: 0,
+} as const;
+
+function makeTerminator(
+  push: (event: EngineEvent) => void,
+  state: { terminated: boolean },
+): (reason: "completed" | "error", text?: string) => void {
+  return (reason, text) => {
+    if (state.terminated) return;
+    state.terminated = true;
+    push({
+      kind: "done",
+      output: {
+        stopReason: reason,
+        content: text !== undefined && text.length > 0 ? [{ kind: "text", text }] : [],
+        metrics: EMPTY_METRICS,
+      },
+    } satisfies EngineEvent);
+  };
+}
+
+function makeMessageHandler(
+  requestId: string,
+  push: (event: EngineEvent) => void,
+  terminate: (reason: "completed" | "error", text?: string) => void,
+): (ev: MessageEvent) => void {
+  return (ev) => {
+    let frame: ResponseFrameLike;
+    try {
+      frame = JSON.parse(String(ev.data)) as ResponseFrameLike;
+    } catch {
+      return;
+    }
+    if (frame.ref !== requestId) return;
+    if (frame.kind === "response") {
+      const payload = frame.payload as { readonly text?: unknown } | undefined;
+      const text = typeof payload?.text === "string" ? payload.text : undefined;
+      if (text !== undefined && text.length > 0) {
+        push({ kind: "text_delta", delta: text } satisfies EngineEvent);
+      }
+      terminate("completed", text);
+    } else if (frame.kind === "error") {
+      terminate("error");
+    }
+  };
+}
+
+async function* drain(
+  queue: EngineEvent[],
+  waiters: Array<() => void>,
+  detach: () => void,
+): AsyncIterable<EngineEvent> {
+  try {
+    while (true) {
+      if (queue.length === 0) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+      const next = queue.shift();
+      if (next === undefined) continue;
+      yield next;
+      if (next.kind === "done") return;
+    }
+  } finally {
+    detach();
+  }
+}
+
+export function createRequestStream(socket: WebSocket, requestId: string): RequestStream {
+  const queue: EngineEvent[] = [];
+  const waiters: Array<() => void> = [];
+  const state = { terminated: false };
+  const push = (event: EngineEvent): void => {
+    queue.push(event);
+    waiters.shift()?.();
+  };
+  const terminate = makeTerminator(push, state);
+  const onMessage = makeMessageHandler(requestId, push, terminate);
+  const onClose = (): void => terminate("error");
+  const onError = (): void => terminate("error");
+
+  socket.addEventListener("message", onMessage);
+  socket.addEventListener("close", onClose);
+  socket.addEventListener("error", onError);
+
+  const detach = (): void => {
+    socket.removeEventListener("message", onMessage);
+    socket.removeEventListener("close", onClose);
+    socket.removeEventListener("error", onError);
+  };
+
+  return { iterator: drain(queue, waiters, detach) };
+}


### PR DESCRIPTION
## Summary
- New `koi gateway-up` command that runs the gateway runtime stack (transport + auth + optional Nexus link) with a sibling health server
- TUI gains a remote gateway runtime mode with handshake-gated connect, request/response framing, reconnect, and session-resume semantics
- HA e2e test (tmux + dual gateway processes + mock Nexus) covering failover and session ownership transfer

## Changes
- `packages/meta/cli/src/args/gateway-up.{ts,test.ts}`, `commands/gateway-up.{ts,test.ts}` — new command surface and runtime
- `packages/meta/cli/src/tui-command.ts`, `tui-gateway-client.{ts,test.ts}` — wire remote gateway client into TUI
- `packages/meta/cli/src/__tests__/tui-gateway-ha.e2e.test.ts` — e2e reconnect/resume coverage
- `docs/L2/2026-05-06-issue-2122-remote-tui-gateway.md` + design doc — implementation plan and design
- workspace deps: `@koi/gateway` and `@koi/gateway-stack` added across cli/kernel/lib/net packages where required

## Test plan
- [ ] `bun run typecheck` (passes locally)
- [ ] `bun run test --filter=@koi-agent/cli`
- [ ] `bun run check:layers`
- [ ] Manual: `koi gateway-up --instance-id gw-1` then connect TUI and verify reconnect after gateway restart

Closes #2122

🤖 Generated with [Claude Code](https://claude.com/claude-code)