### PR TITLE
feat(ipc-nexus): Nexus-backed mailbox adapter (closes #1373)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -665,6 +665,14 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/lib/ipc-nexus": {
+      "name": "@koi/ipc-nexus",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+        "@koi/nexus-client": "workspace:*",
+      },
+    },
     "packages/lib/long-running": {
       "name": "@koi/long-running",
       "version": "0.0.0",
@@ -2632,6 +2640,8 @@
     "@koi/hooks": ["@koi/hooks@workspace:packages/lib/hooks"],
 
     "@koi/ipc-local": ["@koi/ipc-local@workspace:packages/lib/ipc-local"],
+
+    "@koi/ipc-nexus": ["@koi/ipc-nexus@workspace:packages/lib/ipc-nexus"],
 
     "@koi/long-running": ["@koi/long-running@workspace:packages/lib/long-running"],
 

--- a/docs/L2/ipc-nexus.md
+++ b/docs/L2/ipc-nexus.md
@@ -1,595 +1,66 @@
-# @koi/ipc-nexus — Agent-to-Agent Messaging via Nexus IPC
+# @koi/ipc-nexus
 
-Agent-to-agent messaging through a central REST mailbox. Any Koi agent can send messages to any other agent — the LLM decides when to communicate using `ipc_send`, `ipc_list`, and `ipc_discover` tools.
+**Layer:** L2  
+**Package:** `packages/lib/ipc-nexus`
 
-## Why
+`@koi/ipc-nexus` provides a Nexus-backed `MailboxComponent` for cross-node agent messaging.
 
-Agents working in a swarm need to coordinate — request code reviews, broadcast build results, delegate subtasks. Without IPC, agents are isolated:
+This v2 implementation is intentionally small and transport-centered:
 
-```
-Agent A ──(works alone)──► done
-Agent B ──(works alone)──► done     ← no coordination, duplicated effort
-Agent C ──(works alone)──► done
-```
+- it builds on `NexusTransport` from `@koi/nexus-client`
+- it implements the `MailboxComponent` contract from `@koi/core`
+- it uses polling for inbox delivery in the first pass
+- it supports explicit fallback to another `MailboxComponent` when Nexus is unavailable
 
-With `@koi/ipc-nexus`, agents talk to each other through a shared mailbox:
-
-```
-Agent A ──ipc_send("review this")──► Nexus ──► Agent B (reviewer)
-Agent B ──ipc_send("approved")─────► Nexus ──► Agent A
-Agent A ──ipc_send("deploy")───────► Nexus ──► Agent C (deployer)
-```
-
-## Use Cases
-
-### Autonomous CI Pipeline
-
-An orchestrator delegates tasks to specialist agents, aggregates results, and ships — zero human coordination:
-
-```
-  Human: "Ship feature X"
-         │
-         ▼
-  ┌──────────────┐
-  │ Orchestrator  │  "I'll coordinate the team"
-  └──────┬───────┘
-         │  Fan-out: 3 ipc_send(kind:"request") calls
-         │
-    ┌────┴────────────────┬──────────────────────┐
-    ▼                     ▼                      ▼
-┌──────────┐       ┌────────────┐         ┌────────────┐
-│  Coder   │       │ Test Runner│         │ Typechecker │
-│  Agent   │       │   Agent    │         │   Agent     │
-└────┬─────┘       └─────┬──────┘         └──────┬─────┘
-     │                   │                       │
-     │ "code ready"      │                       │
-     ├──────────────────▶│                       │
-     ├───────────────────┼──────────────────────▶│
-     │                   │                       │
-     │             runs tests               checks types
-     │                   │                       │
-     │  kind:"response"  │   kind:"response"     │
-     │  correlationId=X  │   correlationId=Y     │
-     │◀──────────────────┤                       │
-     │◀──────────────────┼───────────────────────┤
-     │
-     │  Orchestrator: ipc_list(kind:"response")
-     │  All 3 passed → ipc_send("deploy") to deployer
-     ▼
-┌──────────┐
-│ Deployer │
-│  Agent   │──── kind:"response" ────▶ Orchestrator
-└──────────┘
-
-  Orchestrator: "Feature X shipped. All checks passed."
-```
-
-### Peer Code Review
-
-Two agents collaborate: one writes code, the other reviews it:
-
-```
-┌─────────────┐                                     ┌─────────────┐
-│  Coder      │                                     │  Reviewer   │
-│  Agent      │                                     │  Agent      │
-│             │                                     │             │
-│ writes code │                                     │  idle...    │
-│ ...done     │                                     │             │
-│             │── kind:"request"  ──────────────────▶│             │
-│             │   type:"code-review"                │  reviews    │
-│             │   payload:{ file, diff }            │  the diff   │
-│             │                                     │  ...done    │
-│             │◀── kind:"response" ─────────────────│             │
-│             │    correlationId: <original-id>     │             │
-│             │    payload:{ approved: true }        │             │
-│  continues  │                                     │             │
-└─────────────┘                                     └─────────────┘
-```
-
-### Event-Driven Monitoring
-
-Agents broadcast status updates without expecting replies:
-
-```
-┌──────────┐   kind:"event"         ┌──────────────┐
-│ CI Agent │──type:"build-complete"─▶│ Deploy Agent │
-│          │  payload:{ success }    │  (listens)   │
-└──────────┘                        └──────┬───────┘
-                                           │
-     kind:"event"                          │  deploys if success
-     type:"deploy-complete"                │
-┌──────────────┐◀──────────────────────────┘
-│ Notification │
-│    Agent     │──── notifies Slack/email
-└──────────────┘
-
-  No responses. No correlation IDs. Fire-and-forget.
-```
-
-### Multi-Agent Debug Session
-
-An agent hits a bug it can't solve alone — it asks a specialist for help:
-
-```
-┌──────────────┐                              ┌──────────────┐
-│  Feature     │                              │  Debug       │
-│  Agent       │                              │  Specialist  │
-│              │                              │              │
-│ hits error   │                              │              │
-│ ...stuck     │                              │              │
-│              │── kind:"request" ───────────▶│              │
-│              │   type:"debug-help"          │ analyzes     │
-│              │   payload:{ error, stack,    │ the error    │
-│              │     file, context }          │ ...found fix │
-│              │                              │              │
-│              │◀── kind:"response" ──────────│              │
-│              │    payload:{ fix, patch }    │              │
-│ applies fix  │                              │              │
-│ continues    │                              │              │
-└──────────────┘                              └──────────────┘
-```
-
-## Architecture
-
-```
-L0  @koi/core          MailboxComponent + MAILBOX token + AgentMessage types
-L2  @koi/ipc-nexus     NexusClient + MailboxAdapter + ComponentProvider + tools
-```
-
-The mailbox is an **ECS component** attached to agents via a `ComponentProvider`. The provider registers `ipc_send` and `ipc_list` as agent-facing tools — the LLM calls them autonomously. When an `AgentRegistry` is provided, `ipc_discover` is also attached, enabling agents to find each other without hardcoded IDs.
-
-```
-┌───────────────────────────────────────────────────────────────┐
-│                     createKoi()                               │
-│   providers: [createIpcNexusProvider({ agentId, registry })]  │
-└────────────────────────┬──────────────────────────────────────┘
-                         │ attach()
-                         ▼
-                  ┌─────────────────────┐
-                  │   Agent             │
-                  │                     │
-                  │  MAILBOX            │◄── MailboxComponent (send/onMessage/list)
-                  │  tool:ipc_send      │◄── LLM-callable tool
-                  │  tool:ipc_list      │◄── LLM-callable tool
-                  │  tool:ipc_discover  │◄── LLM-callable tool (when registry provided)
-                  └──────┬──────────────┘
-                         │ HTTP
-                         ▼
-                  ┌──────────────┐
-                  │  Nexus IPC   │  Inbox per agent
-                  │  Server      │  REST API v2
-                  └──────────────┘
-```
-
-## Quick Start
+## API
 
 ```typescript
-import { createKoi } from "@koi/engine";
-import { createLoopAdapter } from "@koi/engine-loop";
-import { createIpcNexusProvider } from "@koi/ipc-nexus";
 import { agentId } from "@koi/core";
-import type { AgentRegistry } from "@koi/core";
-
-// 1. Create provider — attaches MAILBOX + tools
-//    Pass registry to also enable ipc_discover
-const provider = createIpcNexusProvider({
-  agentId: agentId("my-agent"),
-  nexusBaseUrl: "http://localhost:2026",
-  registry,  // optional — enables ipc_discover tool
-});
-
-// 2. Wire into runtime
-const runtime = await createKoi({
-  manifest: { name: "my-agent", version: "1.0.0", model: { name: "claude-haiku-4-5-20251001" } },
-  adapter: createLoopAdapter({ modelCall: handler, maxTurns: 10 }),
-  providers: [provider],
-});
-
-// 3. Agent can now send/receive messages via tools
-//    LLM sees ipc_send and ipc_list in its tool list
-const events = await collectEvents(
-  runtime.run({ kind: "text", text: "Send a code review request to reviewer-agent" }),
-);
-```
-
-The LLM will autonomously call `ipc_send` when it decides to communicate.
-
-## Message Flow
-
-```
-  Agent A calls ipc_send tool
-         │
-         ▼
-  ┌─────────────────┐
-  │ mapKoiToNexus() │  Koi "request" → Nexus "task"
-  │                 │  Koi "response" → Nexus "response"
-  │                 │  Koi "event"   → Nexus "event"
-  │                 │  Koi "cancel"  → Nexus "cancel"
-  └────────┬────────┘
-           │
-           ▼  POST /api/v2/ipc/send
-  ┌─────────────────┐     { from, to, kind, type, payload,
-  │  Nexus Server   │       correlationId?, ttlSeconds?,
-  │                 │       metadata? }
-  │  generates:     │
-  │  • UUID id      │     Response: NexusMessageEnvelope
-  │  • ISO timestamp│     { id, createdAt, ...request }
-  └────────┬────────┘
-           │  stored in recipient's inbox
-           ▼
-  Agent B notified via SSE push (or polls in fallback mode)
-           │  GET /api/v2/ipc/inbox/agent-b
-  ┌────────┴────────┐
-  │ mapNexusToKoi() │  Nexus "task" → Koi "request"
-  │ + deduplication │  seen-buffer ring (10K capacity)
-  └────────┬────────┘
-           │
-           ▼
-  handler(AgentMessage) ← Agent B's onMessage() fires
-```
-
-## Message Kinds
-
-| Kind | Purpose | Example |
-|------|---------|---------|
-| `"request"` | Ask another agent to do something | Code review, deploy, run tests |
-| `"response"` | Reply to a request (linked by `correlationId`) | Review approved, deploy succeeded |
-| `"event"` | Fire-and-forget notification | Build complete, status update |
-| `"cancel"` | Cancel a pending request | Abort deployment |
-
-## Patterns
-
-### Request-Response (Correlated)
-
-```typescript
-// Agent A sends a request
-const result = await mailbox.send({
-  from: agentId("agent-a"),
-  to: agentId("agent-b"),
-  kind: "request",
-  type: "code-review",
-  payload: { file: "auth.ts", diff: "..." },
-});
-
-// Agent B receives and responds with correlationId
-mailbox.onMessage(async (msg) => {
-  if (msg.kind === "request") {
-    await mailbox.send({
-      from: agentId("agent-b"),
-      to: msg.from,
-      kind: "response",
-      type: msg.type,
-      correlationId: msg.id,  // ← links response to request
-      payload: { approved: true },
-    });
-  }
-});
-```
-
-### Fan-Out (Orchestrator → Workers)
-
-```
-  ┌──────────────┐
-  │ Orchestrator  │
-  └──────┬───────┘
-         │  ipc_send × 3
-    ┌────┼────┐
-    ▼    ▼    ▼
-  ┌───┐┌───┐┌───┐
-  │ T ││ L ││ C │   T = test-runner, L = linter, C = typechecker
-  └─┬─┘└─┬─┘└─┬─┘
-    │    │    │  kind:"response", correlationId
-    └────┼────┘
-         ▼
-  ┌──────────────┐
-  │ Orchestrator  │  ipc_list(kind:"response")
-  │ aggregates    │  → all 3 passed → ship it
-  └──────────────┘
-```
-
-### Event Bus (Fire-and-Forget)
-
-```typescript
-// CI agent broadcasts build result
-await mailbox.send({
-  from: agentId("ci-agent"),
-  to: agentId("deploy-agent"),
-  kind: "event",
-  type: "build-complete",
-  payload: { success: true, buildId: "abc123" },
-  metadata: { source: "ci" },
-});
-// No response expected — fire and forget
-```
-
-## Direct Mailbox Usage
-
-For programmatic use outside the LLM tool loop:
-
-```typescript
+import { createHttpTransport } from "@koi/nexus-client";
 import { createNexusMailbox } from "@koi/ipc-nexus";
-import { agentId } from "@koi/core";
 
-const mailbox = createNexusMailbox({
-  agentId: agentId("my-agent"),
-  baseUrl: "http://localhost:2026",
-  delivery: "sse",        // "sse" (default) or "polling"
-  seenCapacity: 10_000,   // dedup ring buffer capacity (default: 10K)
-  pollMinMs: 1_000,       // min poll interval (fallback / polling mode)
-  pollMaxMs: 30_000,      // max poll interval (backoff ceiling)
-  pollMultiplier: 2,      // exponential backoff multiplier
-  pageLimit: 50,          // messages per poll page
+const transport = createHttpTransport({
+  url: "http://localhost:2026",
 });
 
-// Send
-const result = await mailbox.send({
-  from: agentId("my-agent"),
-  to: agentId("other-agent"),
-  kind: "request",
-  type: "task",
-  payload: { action: "review" },
+const mailbox = await createNexusMailbox({
+  agentId: agentId("agent-a"),
+  transport,
+  pollIntervalMs: 1_000,
+  pageSize: 50,
 });
-if (!result.ok) console.error(result.error.message);
-
-// Subscribe to incoming messages
-const unsubscribe = mailbox.onMessage((msg) => {
-  console.log(`Got ${msg.kind} from ${msg.from}: ${msg.type}`);
-});
-
-// Query inbox with filters
-const requests = await mailbox.list({ kind: "request", from: agentId("boss") });
-
-// Cleanup
-unsubscribe();
-mailbox[Symbol.dispose]();
 ```
 
-## Provider Configuration
+### `NexusMailboxConfig`
 
 ```typescript
-import { createIpcNexusProvider } from "@koi/ipc-nexus";
-
-const provider = createIpcNexusProvider({
-  agentId: agentId("my-agent"),        // required — agent's identity
-  nexusBaseUrl: "http://localhost:2026", // Nexus server URL
-  authToken: "Bearer ...",              // optional auth token
-  trustTier: "verified",               // tool trust tier (default: "verified")
-  prefix: "ipc",                       // tool name prefix (default: "ipc")
-  delivery: "sse",                     // "sse" (default) or "polling"
-  seenCapacity: 10_000,                // dedup ring buffer capacity
-  pollMinMs: 1_000,                    // min poll interval (fallback/polling)
-  pollMaxMs: 30_000,                   // max poll interval
-  pageLimit: 50,                       // messages per page
-  timeoutMs: 10_000,                   // HTTP timeout
-  operations: ["send", "list"],        // which tools to register (default: both)
-  registry,                            // optional — enables ipc_discover tool
-});
-```
-
-| Option | Default | Purpose |
-|--------|---------|---------|
-| `agentId` | — | Agent identity for inbox routing |
-| `nexusBaseUrl` | `http://localhost:2026` | Nexus IPC server URL |
-| `authToken` | `undefined` | Bearer token for authenticated Nexus |
-| `trustTier` | `"verified"` | Tool trust level |
-| `prefix` | `"ipc"` | Tool name prefix → `ipc_send`, `ipc_list` |
-| `delivery` | `"sse"` | Delivery mode: `"sse"` (push) or `"polling"` (pull) |
-| `seenCapacity` | `10000` | Deduplication ring buffer capacity |
-| `pollMinMs` | `1000` | Minimum polling interval (ms) |
-| `pollMaxMs` | `30000` | Maximum polling interval after backoff |
-| `pageLimit` | `50` | Messages fetched per poll cycle |
-| `timeoutMs` | `10000` | HTTP request timeout |
-| `operations` | `["send", "list"]` | Which tools to expose |
-| `registry` | `undefined` | `AgentRegistry` instance — enables `ipc_discover` tool |
-
-## Nexus REST API
-
-The client targets these 4 endpoints:
-
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/api/v2/ipc/send` | POST | Send a message to another agent's inbox |
-| `/api/v2/ipc/inbox/{agentId}` | GET | List messages in an agent's inbox |
-| `/api/v2/ipc/inbox/{agentId}/count` | GET | Count messages in inbox |
-| `/api/v2/ipc/provision/{agentId}` | POST | Create an empty inbox (204) |
-
-Query parameters for inbox listing: `limit` (page size), `offset` (pagination).
-
-## Message Delivery
-
-The mailbox supports two delivery modes: **SSE** (default) and **polling fallback**.
-
-### SSE Mode (Default)
-
-Server-Sent Events provide near-instant message delivery (~10ms latency vs 1-30s polling):
-
-```
-                    SSE Mode
-                    ────────
-Nexus Server ──SSE push──► sse-transport ──notification──► mailbox-adapter
-                                                                │
-                           nexus-client ◄──HTTP GET inbox───────┘
-                                │
-                          process-inbox → seen-buffer → handlers
-```
-
-1. When the first `onMessage` handler is registered, the adapter opens an SSE connection to `GET /api/v2/events/stream`
-2. The Nexus server pushes `ipc.inbox.*` events over the stream
-3. On each event, the adapter fetches the inbox via REST and dispatches new messages
-4. If SSE fails to connect within 2 seconds, it falls back to polling automatically
-5. The SSE transport handles reconnection with exponential backoff internally
-
-### Polling Mode (Fallback)
-
-```
-                    Polling Mode
-                    ────────────
-                           nexus-client ◄──HTTP GET inbox (on timer)──┐
-                                │                                      │
-                          process-inbox → seen-buffer → handlers      │
-                                                                       │
-                           mailbox-adapter ──setTimeout backoff────────┘
-```
-
-```
-  onMessage() registered
-       │
-       ▼
-  Start polling at pollMinMs (1s)
-       │
-       ├── messages found → reset to pollMinMs
-       │
-       └── no messages → interval × pollMultiplier
-                          │
-                          ▼
-                   capped at pollMaxMs (30s)
-```
-
-### Shared Behavior (Both Modes)
-
-- Delivery starts when the first handler is registered
-- Delivery stops when the last handler is unsubscribed
-- Each message is delivered exactly once (deduplication via bounded ring buffer)
-- Handler errors are swallowed — one broken handler cannot crash the delivery loop
-- The ring buffer caps memory at ~400KB (default 10K message IDs)
-
-## Error Handling
-
-`send()` returns `Result<AgentMessage, KoiError>` — never throws:
-
-| HTTP Status | Error Code | Retryable |
-|-------------|-----------|-----------|
-| 404 | `NOT_FOUND` | No |
-| 429 | `RATE_LIMIT` | Yes |
-| 408, 504 | `TIMEOUT` | Yes |
-| 500+ | `EXTERNAL` | Yes |
-| Network error | `EXTERNAL` | Depends |
-
-```typescript
-const result = await mailbox.send(message);
-if (!result.ok) {
-  if (result.error.retryable) {
-    // safe to retry
-  }
-  console.error(result.error.message);
+interface NexusMailboxConfig {
+  readonly agentId: AgentId;
+  readonly transport: NexusTransport;
+  readonly fallback?: MailboxComponent | undefined;
+  readonly inboxMethodPrefix?: string | undefined;
+  readonly pollIntervalMs?: number | undefined;
+  readonly pageSize?: number | undefined;
 }
 ```
 
-## Tools
+## Behavior
 
-### `ipc_send`
+- `send(message)` sends an `AgentMessageInput` through Nexus RPC and returns a fully populated `AgentMessage`
+- `list(filter)` lists inbox messages for the configured agent and applies the standard `MessageFilter`
+- `onMessage(handler)` starts polling and dispatches unseen messages to subscribers
+- `drain()` returns the locally seen message buffer and clears it
 
-Sends a message to another agent's mailbox.
+## Fallback
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `from` | string | yes | Sender agent ID |
-| `to` | string | yes | Recipient agent ID |
-| `kind` | string | yes | `request`, `response`, `event`, or `cancel` |
-| `type` | string | yes | Application-level message type |
-| `payload` | object | yes | Message payload |
-| `correlationId` | string | no | Links response to originating request |
-| `ttlSeconds` | number | no | Time-to-live in seconds |
-| `metadata` | object | no | Routing hints, tracing context |
+Fallback is explicit and injected through `config.fallback`.
 
-### `ipc_list`
+- if `transport.health()` fails during creation and a fallback exists, `createNexusMailbox()` returns the fallback mailbox
+- if startup health passes but a later `send()` or `list()` call fails, the mailbox degrades to the fallback for subsequent operations
+- if no fallback is configured, Nexus errors surface through the normal `MailboxComponent` return path
 
-Lists messages in the agent's inbox with optional filtering.
+## Design Notes
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `kind` | string | no | Filter by message kind |
-| `type` | string | no | Filter by message type |
-| `from` | string | no | Filter by sender |
-| `limit` | number | no | Maximum messages to return |
-
-### `ipc_discover`
-
-Lists live agents available for messaging. Only attached when `registry` is provided in the provider config. Enables agents to discover each other dynamically instead of relying on hardcoded agent IDs.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `agentType` | string | no | Filter by agent type: `"copilot"` or `"worker"` |
-| `phase` | string | no | Filter by process state: `"created"`, `"running"`, `"waiting"`, `"suspended"`, or `"terminated"`. Defaults to `"running"` |
-
-Returns `{ agents: [{ agentId, agentType, phase, registeredAt }] }`.
-
-```
-  Agent: "Who can I send a code review to?"
-         │
-         ▼  ipc_discover({ agentType: "worker" })
-  ┌──────────────┐
-  │ AgentRegistry│  list({ phase: "running", agentType: "worker" })
-  │              │  → [{ agentId: "reviewer-1", ... }]
-  └──────────────┘
-         │
-         ▼
-  Agent: "Found reviewer-1. Sending review request."
-         │
-         ▼  ipc_send({ to: "reviewer-1", kind: "request", ... })
-```
-
-## L0 Types (in @koi/core)
-
-```typescript
-// Branded message ID
-type MessageId = string & { readonly [__messageBrand]: "MessageId" };
-
-// Message kinds
-type MessageKind = "request" | "response" | "event" | "cancel";
-
-// Full message envelope (received)
-interface AgentMessage {
-  readonly id: MessageId;
-  readonly from: AgentId;
-  readonly to: AgentId;
-  readonly kind: MessageKind;
-  readonly correlationId?: MessageId;
-  readonly createdAt: string;
-  readonly ttlSeconds?: number;
-  readonly type: string;
-  readonly payload: JsonObject;
-  readonly metadata?: JsonObject;
-}
-
-// Message input (id + createdAt generated by backend)
-type AgentMessageInput = Omit<AgentMessage, "id" | "createdAt">;
-
-// ECS component
-interface MailboxComponent {
-  readonly send: (message: AgentMessageInput) => Promise<Result<AgentMessage, KoiError>>;
-  readonly onMessage: (handler: (message: AgentMessage) => void | Promise<void>) => () => void;
-  readonly list: (filter?: MessageFilter) => readonly AgentMessage[] | Promise<readonly AgentMessage[]>;
-}
-
-// Well-known token
-const MAILBOX: SubsystemToken<MailboxComponent>;
-```
-
-## Public API
-
-| Export | Type | Purpose |
-|--------|------|---------|
-| `createNexusMailbox` | Factory | Creates a `MailboxComponent` backed by Nexus REST |
-| `createIpcNexusProvider` | Factory | Creates a `ComponentProvider` (MAILBOX + tools) |
-| `createDiscoverTool` | Factory | Creates `ipc_discover` tool (advanced usage) |
-| `createSendTool` | Factory | Creates `ipc_send` tool (advanced usage) |
-| `createListTool` | Factory | Creates `ipc_list` tool (advanced usage) |
-| `NexusMailboxConfig` | Interface | Config for `createNexusMailbox` |
-| `IpcNexusProviderConfig` | Interface | Config for `createIpcNexusProvider` |
-| `DeliveryMode` | Type | `"sse" \| "polling"` |
-| `SseEvent` | Interface | Parsed SSE event (id, event, data, retry) |
-| `IpcOperation` | Type | `"send" \| "list"` |
-| `DEFAULT_DELIVERY_MODE` | Const | `"sse"` |
-| `DEFAULT_PREFIX` | Const | `"ipc"` |
-| `OPERATIONS` | Const | `["send", "list"]` |
-
-## Related
-
-- Issue #192 — Original implementation issue
-- Issue #608 — `ipc_discover` tool for agent discovery
-- Issue #618 — SSE push delivery upgrade
-- Issue #193 — `@koi/registry-nexus` (agent discovery)
-- Issue #397 — `@koi/events-nexus` (event sourcing)
-- `@koi/core` `mailbox.ts` — L0 types
-- `docs/service-provider.md` — `createServiceProvider` pattern used internally
+- This first v2 slice does **not** restore the archive-era SSE delivery path
+- The RPC method names are isolated behind a small client module so transport mapping can evolve without changing callers
+- The package focuses on contract parity with `MailboxComponent`, not on full v1 feature parity

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -185,7 +185,7 @@ Each line shows package name, package description, test-file count, and any exis
 - `@koi/federation` (packages/ipc/federation) - Coordinate multi-zone agents with vector clock sync and conflict resolution. Tests: 14. Docs: docs/L2/federation.md.
 - `@koi/handoff` (packages/ipc/handoff) - Relay typed context between agents via structured handoff tools and middleware. Tests: 12. Docs: docs/L2/handoff.md.
 - `@koi/ipc-local` (packages/ipc/ipc-local) - Route messages between in-process agents using in-memory mailbox dispatch. Tests: 3.
-- `@koi/ipc-nexus` (packages/ipc/ipc-nexus) - Enable agent messaging via Nexus REST API with subscriptions and inbox listing. Tests: 13. Docs: docs/L2/ipc-nexus.md.
+- `@koi/ipc-nexus` (packages/lib/ipc-nexus) - Route agent messages through Nexus transport with polling-based inbox delivery and optional fallback to another MailboxComponent. Tests: 5. Docs: docs/L2/ipc-nexus.md.
 - `@koi/scratchpad-local` (packages/ipc/scratchpad-local) - Store versioned files with CAS and TTL in in-memory scratchpad. Tests: 2.
 - `@koi/scratchpad-nexus` (packages/ipc/scratchpad-nexus) - Persist agent scratchpad state across zones via Nexus group-scoped storage. Tests: 4. Docs: docs/L2/scratchpad-nexus.md.
 - `@koi/task-spawn` (packages/ipc/task-spawn) - Inject task tool for zero-friction delegation to pre-registered subagent types. Tests: 16. Docs: docs/L2/task-spawn.md.

--- a/docs/superpowers/plans/2026-05-06-issue-1373-ipc-nexus.md
+++ b/docs/superpowers/plans/2026-05-06-issue-1373-ipc-nexus.md
@@ -1,0 +1,701 @@
+# Issue #1373 `@koi/ipc-nexus` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first slice of issue `#1373` by adding `@koi/ipc-nexus`, a Nexus-backed `MailboxComponent` with explicit optional fallback to a local mailbox.
+
+**Architecture:** Build a thin adapter over `NexusTransport` from `@koi/nexus-client`. Keep Nexus RPC knowledge inside a tiny client module, use polling rather than SSE in the first pass, and degrade to an injected fallback mailbox when Nexus health is unavailable at creation time or Nexus operations fail later.
+
+**Tech Stack:** Bun 1.3.x, TypeScript 6, `bun:test`, tsup ESM-only builds, injected fake `NexusTransport` for tests.
+
+---
+
+## Spec Reference
+
+Read [`docs/superpowers/specs/2026-05-06-issue-1373-nexus-variants-design.md`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/docs/superpowers/specs/2026-05-06-issue-1373-nexus-variants-design.md) before starting. This plan implements **Phase 1 only**.
+
+---
+
+## File Map
+
+```text
+Create:
+  packages/lib/ipc-nexus/package.json
+  packages/lib/ipc-nexus/tsconfig.json
+  packages/lib/ipc-nexus/tsup.config.ts
+  packages/lib/ipc-nexus/src/index.ts
+  packages/lib/ipc-nexus/src/types.ts
+  packages/lib/ipc-nexus/src/client.ts
+  packages/lib/ipc-nexus/src/map-message.ts
+  packages/lib/ipc-nexus/src/seen-set.ts
+  packages/lib/ipc-nexus/src/mailbox.ts
+  packages/lib/ipc-nexus/src/mailbox.test.ts
+  packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
+  docs/L2/ipc-nexus.md
+
+Modify:
+  package.json
+  tsconfig.json
+  docs/package-coverage-map.md
+```
+
+---
+
+### Task 1: Scaffold `@koi/ipc-nexus`
+
+**Files:**
+- Create: `packages/lib/ipc-nexus/package.json`
+- Create: `packages/lib/ipc-nexus/tsconfig.json`
+- Create: `packages/lib/ipc-nexus/tsup.config.ts`
+- Create: `packages/lib/ipc-nexus/src/index.ts`
+
+- [ ] **Step 1: Write the failing API-surface test**
+
+Create `packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+
+describe("@koi/ipc-nexus API surface", () => {
+  test("exports createNexusMailbox", async () => {
+    const mod = await import("../index.js");
+    expect(typeof mod.createNexusMailbox).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
+```
+
+Expected: module resolution failure because the package does not exist yet.
+
+- [ ] **Step 3: Add the package scaffold**
+
+Create `packages/lib/ipc-nexus/package.json`:
+
+```json
+{
+  "name": "@koi/ipc-nexus",
+  "description": "Nexus-backed MailboxComponent with optional local fallback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/nexus-client": "workspace:*"
+  }
+}
+```
+
+Create `packages/lib/ipc-nexus/tsconfig.json`:
+
+```json
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../kernel/core" },
+    { "path": "../nexus-client" }
+  ]
+}
+```
+
+Create `packages/lib/ipc-nexus/tsup.config.ts`:
+
+```typescript
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});
+```
+
+Create `packages/lib/ipc-nexus/src/index.ts`:
+
+```typescript
+export type { NexusMailboxConfig } from "./mailbox.js";
+export { createNexusMailbox } from "./mailbox.js";
+```
+
+- [ ] **Step 4: Run the API-surface test again**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
+```
+
+Expected: still failing because `mailbox.ts` is not implemented yet, but the package path now exists.
+
+---
+
+### Task 2: Define the package types and RPC client
+
+**Files:**
+- Create: `packages/lib/ipc-nexus/src/types.ts`
+- Create: `packages/lib/ipc-nexus/src/client.ts`
+
+- [ ] **Step 1: Write the failing client test**
+
+Create `packages/lib/ipc-nexus/src/mailbox.test.ts` with:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import { agentId } from "@koi/core";
+
+describe("createNexusMailbox", () => {
+  test("sends a message through Nexus transport", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const transport = {
+      kind: "http" as const,
+      call: async () => ({
+        ok: true as const,
+        value: {
+          id: "msg-1",
+          from: "agent-a",
+          to: "agent-b",
+          kind: "request",
+          type: "review",
+          payload: { text: "check this" },
+          createdAt: "2026-05-06T00:00:00.000Z",
+        },
+      }),
+      health: async () => ({
+        ok: true as const,
+        value: {
+          status: "ok" as const,
+          version: "1",
+          latencyMs: 1,
+          probed: ["version"],
+        },
+      }),
+      close: () => {},
+    };
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport,
+    });
+
+    const result = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-b"),
+      kind: "request",
+      type: "review",
+      payload: { text: "check this" },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.id).toBe("msg-1");
+      expect(result.value.to).toBe(agentId("agent-b"));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the mailbox test to verify it fails**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/mailbox.test.ts
+```
+
+Expected: import failure because `mailbox.ts` and supporting types do not exist.
+
+- [ ] **Step 3: Add `types.ts`**
+
+Create `packages/lib/ipc-nexus/src/types.ts`:
+
+```typescript
+import type { AgentId, AgentMessage, MailboxComponent } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+
+export interface NexusMailboxConfig {
+  readonly agentId: AgentId;
+  readonly transport: NexusTransport;
+  readonly fallback?: MailboxComponent | undefined;
+  readonly inboxMethodPrefix?: string | undefined;
+  readonly pollIntervalMs?: number | undefined;
+  readonly pageSize?: number | undefined;
+}
+
+export interface NexusEnvelope {
+  readonly id: string;
+  readonly from: string;
+  readonly to: string;
+  readonly kind: "request" | "response" | "event" | "cancel";
+  readonly correlationId?: string | undefined;
+  readonly createdAt: string;
+  readonly ttlSeconds?: number | undefined;
+  readonly type: string;
+  readonly payload: Record<string, unknown>;
+  readonly metadata?: Record<string, unknown> | undefined;
+}
+
+export interface NexusInboxResponse {
+  readonly messages: readonly NexusEnvelope[];
+}
+
+export interface SeenMessage extends AgentMessage {
+  readonly deliveredAt: string;
+}
+```
+
+- [ ] **Step 4: Add `client.ts`**
+
+Create `packages/lib/ipc-nexus/src/client.ts`:
+
+```typescript
+import type { AgentMessageInput, KoiError, Result } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+import type { NexusEnvelope, NexusInboxResponse } from "./types.js";
+
+export interface NexusMailboxClient {
+  readonly send: (message: AgentMessageInput) => Promise<Result<NexusEnvelope, KoiError>>;
+  readonly list: (
+    agentId: string,
+    limit: number,
+  ) => Promise<Result<readonly NexusEnvelope[], KoiError>>;
+}
+
+export function createNexusMailboxClient(
+  transport: NexusTransport,
+  prefix: string,
+): NexusMailboxClient {
+  return {
+    send: async (message) =>
+      transport.call<NexusEnvelope>(`${prefix}.send`, {
+        from: message.from,
+        to: message.to,
+        kind: message.kind,
+        correlationId: message.correlationId,
+        ttlSeconds: message.ttlSeconds,
+        type: message.type,
+        payload: message.payload,
+        metadata: message.metadata,
+      }),
+    list: async (agentId, limit) => {
+      const result = await transport.call<NexusInboxResponse>(`${prefix}.list`, { agentId, limit });
+      return result.ok ? { ok: true, value: result.value.messages } : result;
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run the mailbox test again**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/mailbox.test.ts
+```
+
+Expected: still failing because message mapping and mailbox behavior are not implemented yet.
+
+---
+
+### Task 3: Implement message mapping and local seen tracking
+
+**Files:**
+- Create: `packages/lib/ipc-nexus/src/map-message.ts`
+- Create: `packages/lib/ipc-nexus/src/seen-set.ts`
+
+- [ ] **Step 1: Add mapping helpers**
+
+Create `packages/lib/ipc-nexus/src/map-message.ts`:
+
+```typescript
+import { agentId, messageId } from "@koi/core";
+import type { AgentMessage, AgentMessageInput } from "@koi/core";
+import type { NexusEnvelope } from "./types.js";
+
+export function mapAgentMessageToRpc(message: AgentMessageInput): Record<string, unknown> {
+  return {
+    from: message.from,
+    to: message.to,
+    kind: message.kind,
+    correlationId: message.correlationId,
+    ttlSeconds: message.ttlSeconds,
+    type: message.type,
+    payload: message.payload,
+    metadata: message.metadata,
+  };
+}
+
+export function mapNexusEnvelopeToAgentMessage(envelope: NexusEnvelope): AgentMessage {
+  return {
+    id: messageId(envelope.id),
+    from: agentId(envelope.from),
+    to: agentId(envelope.to),
+    kind: envelope.kind,
+    correlationId:
+      envelope.correlationId !== undefined ? messageId(envelope.correlationId) : undefined,
+    createdAt: envelope.createdAt,
+    ttlSeconds: envelope.ttlSeconds,
+    type: envelope.type,
+    payload: envelope.payload,
+    metadata: envelope.metadata,
+  };
+}
+```
+
+- [ ] **Step 2: Add the seen-message tracker**
+
+Create `packages/lib/ipc-nexus/src/seen-set.ts`:
+
+```typescript
+import type { AgentMessage } from "@koi/core";
+
+export interface SeenSet {
+  readonly has: (id: string) => boolean;
+  readonly add: (message: AgentMessage) => void;
+  readonly drain: () => readonly AgentMessage[];
+}
+
+export function createSeenSet(): SeenSet {
+  const ids = new Set<string>();
+  let buffered: readonly AgentMessage[] = [];
+
+  return {
+    has: (id) => ids.has(id),
+    add: (message) => {
+      ids.add(message.id as string);
+      buffered = [...buffered, message];
+    },
+    drain: () => {
+      const snapshot = buffered;
+      buffered = [];
+      return snapshot;
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Run the test suite**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/mailbox.test.ts
+```
+
+Expected: still failing because the mailbox itself is not wired yet.
+
+---
+
+### Task 4: Implement the mailbox with fallback and polling
+
+**Files:**
+- Create: `packages/lib/ipc-nexus/src/mailbox.ts`
+- Modify: `packages/lib/ipc-nexus/src/index.ts`
+
+- [ ] **Step 1: Implement `mailbox.ts`**
+
+Create `packages/lib/ipc-nexus/src/mailbox.ts`:
+
+```typescript
+import type { AgentMessage, MailboxComponent } from "@koi/core";
+import type { NexusMailboxConfig } from "./types.js";
+import { createNexusMailboxClient } from "./client.js";
+import { mapNexusEnvelopeToAgentMessage } from "./map-message.js";
+import { createSeenSet } from "./seen-set.js";
+
+const DEFAULT_PREFIX = "ipc";
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+export async function createNexusMailbox(config: NexusMailboxConfig): Promise<MailboxComponent> {
+  const prefix = config.inboxMethodPrefix ?? DEFAULT_PREFIX;
+  const pageSize = config.pageSize ?? DEFAULT_PAGE_SIZE;
+  const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  if (config.transport.health !== undefined) {
+    const health = await config.transport.health();
+    if (!health.ok && config.fallback !== undefined) {
+      return config.fallback;
+    }
+  }
+
+  const client = createNexusMailboxClient(config.transport, prefix);
+  const seen = createSeenSet();
+  const handlers = new Set<(message: AgentMessage) => void | Promise<void>>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let degraded = false;
+
+  async function pollOnce(): Promise<void> {
+    if (degraded && config.fallback !== undefined) return;
+    const listed = await client.list(config.agentId as string, pageSize);
+    if (!listed.ok) {
+      if (config.fallback !== undefined) degraded = true;
+      return;
+    }
+    for (const envelope of listed.value) {
+      if (seen.has(envelope.id)) continue;
+      const message = mapNexusEnvelopeToAgentMessage(envelope);
+      seen.add(message);
+      for (const handler of handlers) {
+        await handler(message);
+      }
+    }
+  }
+
+  function ensurePolling(): void {
+    if (timer !== null || degraded || handlers.size === 0) return;
+    timer = setInterval(() => {
+      void pollOnce();
+    }, pollIntervalMs);
+  }
+
+  function stopPolling(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return {
+    send: async (message) => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.send(message);
+      }
+      const result = await client.send(message);
+      if (!result.ok) {
+        if (config.fallback !== undefined) {
+          degraded = true;
+          return config.fallback.send(message);
+        }
+        return result;
+      }
+      return { ok: true, value: mapNexusEnvelopeToAgentMessage(result.value) };
+    },
+    onMessage: (handler) => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.onMessage(handler);
+      }
+      handlers.add(handler);
+      ensurePolling();
+      void pollOnce();
+      return () => {
+        handlers.delete(handler);
+        if (handlers.size === 0) stopPolling();
+      };
+    },
+    list: async (filter) => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.list(filter);
+      }
+      const listed = await client.list(config.agentId as string, filter?.limit ?? pageSize);
+      if (!listed.ok) {
+        if (config.fallback !== undefined) {
+          degraded = true;
+          return config.fallback.list(filter);
+        }
+        return [];
+      }
+      return listed.value.map(mapNexusEnvelopeToAgentMessage);
+    },
+    drain: () => seen.drain(),
+  };
+}
+```
+
+- [ ] **Step 2: Update `index.ts` exports**
+
+Replace `packages/lib/ipc-nexus/src/index.ts` with:
+
+```typescript
+export type { NexusMailboxClient } from "./client.js";
+export type { NexusMailboxConfig, NexusEnvelope, NexusInboxResponse } from "./types.js";
+export { createNexusMailbox } from "./mailbox.js";
+```
+
+- [ ] **Step 3: Run the mailbox tests**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src/mailbox.test.ts packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
+```
+
+Expected: basic send test passes; additional behavior tests are still missing.
+
+---
+
+### Task 5: Add fallback, polling, and drain behavior tests
+
+**Files:**
+- Modify: `packages/lib/ipc-nexus/src/mailbox.test.ts`
+
+- [ ] **Step 1: Extend the mailbox test file**
+
+Add these tests to `packages/lib/ipc-nexus/src/mailbox.test.ts`:
+
+```typescript
+test("uses fallback mailbox when health check fails", async () => {
+  const { createLocalMailbox } = await import("@koi/ipc-local");
+  const { createNexusMailbox } = await import("./index.js");
+
+  const fallback = createLocalMailbox({ agentId: agentId("agent-a") });
+  const mailbox = await createNexusMailbox({
+    agentId: agentId("agent-a"),
+    transport: {
+      kind: "http",
+      call: async () => ({
+        ok: false as const,
+        error: { code: "EXTERNAL", message: "down", retryable: false },
+      }),
+      health: async () => ({
+        ok: false as const,
+        error: { code: "EXTERNAL", message: "down", retryable: false },
+      }),
+      close: () => {},
+    },
+    fallback,
+  });
+
+  const result = await mailbox.send({
+    from: agentId("agent-a"),
+    to: agentId("agent-a"),
+    kind: "event",
+    type: "noop",
+    payload: {},
+  });
+
+  expect(result.ok).toBe(true);
+});
+
+test("drain returns seen messages once", async () => {
+  const { createNexusMailbox } = await import("./index.js");
+
+  const transport = {
+    kind: "http" as const,
+    call: async (method: string) => {
+      if (method === "ipc.list") {
+        return {
+          ok: true as const,
+          value: {
+            messages: [
+              {
+                id: "msg-2",
+                from: "agent-b",
+                to: "agent-a",
+                kind: "event",
+                type: "status",
+                payload: { ok: true },
+                createdAt: "2026-05-06T00:00:00.000Z",
+              },
+            ],
+          },
+        };
+      }
+      return {
+        ok: false as const,
+        error: { code: "EXTERNAL", message: "unexpected", retryable: false },
+      };
+    },
+    health: async () => ({
+      ok: true as const,
+      value: { status: "ok" as const, version: "1", latencyMs: 1, probed: ["version"] },
+    }),
+    close: () => {},
+  };
+
+  const mailbox = await createNexusMailbox({ agentId: agentId("agent-a"), transport });
+  const unsubscribe = mailbox.onMessage(() => {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  unsubscribe();
+
+  expect(mailbox.drain()).toHaveLength(1);
+  expect(mailbox.drain()).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run the package tests**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src
+```
+
+Expected: all `ipc-nexus` tests pass.
+
+---
+
+### Task 6: Wire docs and workspace metadata
+
+**Files:**
+- Create: `docs/L2/ipc-nexus.md`
+- Modify: `docs/package-coverage-map.md`
+- Modify: `package.json`
+- Modify: `tsconfig.json`
+
+- [ ] **Step 1: Write the package doc**
+
+Create `docs/L2/ipc-nexus.md` describing:
+
+- the contract implemented
+- the config shape
+- polling-first design
+- explicit fallback behavior
+- examples using an injected `NexusTransport`
+
+- [ ] **Step 2: Register workspace metadata**
+
+Update the root `package.json` and `tsconfig.json` so the new package participates in the workspace and project references the same way `packages/lib/ipc-local` does.
+
+- [ ] **Step 3: Update package coverage map**
+
+Edit `docs/package-coverage-map.md` so `@koi/ipc-nexus` points at `packages/lib/ipc-nexus` and describes the implemented polling-based scope rather than the broader archive-era package.
+
+- [ ] **Step 4: Run lint, typecheck, and tests**
+
+Run:
+
+```bash
+bun test packages/lib/ipc-nexus/src
+bun run typecheck
+bun run build
+```
+
+Expected:
+
+- `ipc-nexus` tests pass
+- repository typecheck passes
+- build completes with the new package included
+
+---
+
+## Self-Review Notes
+
+- This plan intentionally limits Phase 1 to polling-only IPC.
+- The fallback design is explicit and injected; no hidden local mailbox creation.
+- `scratchpad-nexus` and `workspace-nexus` are deliberately left for follow-up plans after this slice lands.

--- a/docs/superpowers/specs/2026-05-06-issue-1373-nexus-variants-design.md
+++ b/docs/superpowers/specs/2026-05-06-issue-1373-nexus-variants-design.md
@@ -1,0 +1,392 @@
+# Design: Issue #1373 Nexus-Backed IPC, Workspace, and Scratchpad Variants
+
+**Date:** 2026-05-06
+**Issue:** [#1373](https://github.com/windoliver/koi/issues/1373)
+**Approach:** B - thin v2 adapters over `@koi/nexus-client`, delivered incrementally
+
+---
+
+## Overview
+
+Issue `#1373` adds three optional Nexus-backed variants that implement existing v2 contracts:
+
+- `@koi/ipc-nexus` for `MailboxComponent`
+- `@koi/workspace-nexus` for `WorkspaceBackend`
+- `@koi/scratchpad-nexus` for `ScratchpadComponent`
+
+The v1 archive already contains working versions of all three packages, but v2 now has:
+
+- a shared transport package at [`packages/lib/nexus-client`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/lib/nexus-client)
+- different package locations and naming conventions under `packages/lib`
+- stronger contract emphasis in `@koi/core`
+- an explicit requirement that Nexus variants remain optional and support fallback to local behavior when Nexus is unavailable
+
+The design here keeps the v1 behavioral intent while avoiding a line-for-line port.
+
+---
+
+## Project Context
+
+### Existing v2 contracts
+
+- [`packages/kernel/core/src/mailbox.ts`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/kernel/core/src/mailbox.ts)
+- [`packages/kernel/core/src/workspace.ts`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/kernel/core/src/workspace.ts)
+- [`packages/kernel/core/src/scratchpad.ts`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/kernel/core/src/scratchpad.ts)
+
+### Existing local references
+
+- [`packages/lib/ipc-local`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/lib/ipc-local)
+- [`packages/lib/workspace`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/lib/workspace)
+- [`packages/lib/scratchpad-local`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/lib/scratchpad-local)
+
+### Archive reference implementations
+
+- [`archive/v1/packages/ipc/ipc-nexus`](/Users/sophiawj/private/koi/archive/v1/packages/ipc/ipc-nexus)
+- [`archive/v1/packages/ipc/workspace-nexus`](/Users/sophiawj/private/koi/archive/v1/packages/ipc/workspace-nexus)
+- [`archive/v1/packages/ipc/scratchpad-nexus`](/Users/sophiawj/private/koi/archive/v1/packages/ipc/scratchpad-nexus)
+
+### Supporting v2 transport
+
+- [`packages/lib/nexus-client`](/Users/sophiawj/private/koi/.worktrees/issue-1373-nexus-variants/packages/lib/nexus-client)
+
+---
+
+## Approaches Considered
+
+### Approach A: direct v1 port
+
+Copy each archive package into `packages/lib`, fix imports, and patch tests until green.
+
+Pros:
+- fastest path to something runnable
+- preserves proven behavior from the archive
+
+Cons:
+- drags forward bespoke v1 client wrappers that duplicate `@koi/nexus-client`
+- likely carries v1 assumptions about package layout and runtime wiring
+- makes fallback behavior harder to express cleanly in v2
+
+### Approach B: thin adapters over `@koi/nexus-client`
+
+Rebuild each package around the current v2 contracts, using v1 for behavior and test shape only.
+
+Pros:
+- matches the direction v2 is already taking
+- avoids duplicating transport logic
+- keeps the new packages focused on contract mapping, fallback, and state semantics
+
+Cons:
+- more design work up front
+- slightly slower than a direct port
+
+### Approach C: wrap local implementations with sync layers
+
+Keep local implementations authoritative and add Nexus write-through or mirror sync around them.
+
+Pros:
+- strong fallback story
+- maximum reuse of local behavior
+
+Cons:
+- unnatural fit for mailbox delivery
+- risks hiding network failures behind local state in ways that blur contract semantics
+- likely different per subsystem anyway
+
+### Recommendation
+
+Use **Approach B** and deliver the work in three slices:
+
+1. `@koi/ipc-nexus`
+2. `@koi/scratchpad-nexus`
+3. `@koi/workspace-nexus`
+
+This keeps the first implementation small, validates the transport boundary early, and lets the more stateful packages learn from the first slice.
+
+---
+
+## Non-Goals
+
+- restoring every v1 tool, provider, or UI integration in the first pass
+- introducing new Nexus server capabilities
+- changing the L0 contracts in `@koi/core`
+- making Nexus variants the default runtime path
+
+---
+
+## Package Layout
+
+Three new packages will be added under `packages/lib`:
+
+```text
+packages/lib/ipc-nexus/
+packages/lib/scratchpad-nexus/
+packages/lib/workspace-nexus/
+```
+
+This matches the current v2 package layout used by `ipc-local`, `scratchpad-local`, and `workspace`.
+
+---
+
+## Cross-Cutting Design Rules
+
+### 1. Transport ownership
+
+Each package uses `NexusTransport` from `@koi/nexus-client` as the low-level RPC surface.
+
+Packages may optionally expose an HTTP convenience factory that builds a transport internally, but the core factories should accept a `NexusTransport` so tests can inject fakes.
+
+### 2. Local fallback is explicit
+
+The issue requires fallback to local when Nexus is unavailable. To keep this deterministic and testable, each package accepts an explicit local fallback implementation rather than silently inventing one.
+
+Examples:
+
+- `ipc-nexus` accepts a fallback `MailboxComponent`
+- `scratchpad-nexus` accepts a fallback `ScratchpadComponent`
+- `workspace-nexus` accepts a fallback `WorkspaceBackend`
+
+If no fallback is provided, Nexus failures surface normally through the package contract.
+
+### 3. Health checks are creation-time gates, not hot-path network calls
+
+When a package is configured with a fallback, it should decide whether to start in Nexus mode or fallback mode using `transport.health()` where available. It should not probe health before every operation.
+
+After creation:
+
+- normal calls go to the selected backend
+- transient operation failures may trigger a one-way degradation into fallback mode
+- the first pass does not require automatic recovery back into Nexus mode
+
+This keeps behavior predictable and easy to test.
+
+### 4. Contract parity beats feature parity
+
+The requirement is “same contracts as local variants,” not “same internal architecture as v1.” The new packages should preserve:
+
+- method names
+- return types
+- failure surface
+- ordering semantics that callers depend on
+
+But internal helpers, module names, and buffering details may change.
+
+---
+
+## Slice 1: `@koi/ipc-nexus`
+
+### Goal
+
+Provide a `MailboxComponent` implementation backed by Nexus JSON-RPC, with optional fallback to a local mailbox.
+
+### Public API
+
+```typescript
+export interface NexusMailboxConfig {
+  readonly agentId: AgentId;
+  readonly transport: NexusTransport;
+  readonly fallback?: MailboxComponent | undefined;
+  readonly inboxMethodPrefix?: string | undefined;
+  readonly pollIntervalMs?: number | undefined;
+  readonly pageSize?: number | undefined;
+}
+
+export function createNexusMailbox(
+  config: NexusMailboxConfig,
+): MailboxComponent | Promise<MailboxComponent>;
+```
+
+The first pass should prefer polling over SSE. v1 used SSE plus polling fallback, but v2 already has a generic transport and the issue scope does not require real-time push specifically. Polling is enough to satisfy persisted delivery and cross-node visibility while keeping the initial implementation smaller.
+
+### Behavior
+
+- `send(message)` maps `AgentMessageInput` to Nexus RPC and returns a fully populated `AgentMessage`
+- `list(filter)` returns inbox messages for the configured agent, newest first
+- `onMessage(handler)` starts polling for new messages and dispatches unseen entries
+- `drain()` returns buffered inbox messages already observed by the component and clears the local buffer
+
+### Nexus mode vs fallback mode
+
+- If `transport.health()` succeeds, create a Nexus-backed mailbox
+- If health fails and `fallback` is present, use the fallback mailbox instead
+- If health fails and no fallback exists, create the Nexus mailbox anyway and let normal call failures surface
+
+### RPC shape
+
+The exact Nexus methods should be isolated behind a small client module in this package. The client becomes the only place that knows method names and payload mapping.
+
+Candidate methods:
+
+- `ipc.send`
+- `ipc.list`
+- `ipc.ack` if the server supports it
+
+If the current server surface differs, that difference should remain inside the client module.
+
+### File layout
+
+```text
+packages/lib/ipc-nexus/src/
+  index.ts
+  types.ts
+  client.ts
+  map-message.ts
+  seen-set.ts
+  mailbox.ts
+  mailbox.test.ts
+  __tests__/api-surface.test.ts
+```
+
+---
+
+## Slice 2: `@koi/scratchpad-nexus`
+
+### Goal
+
+Provide a `ScratchpadComponent` backed by Nexus storage with CAS semantics and optional local fallback.
+
+### Public API
+
+```typescript
+export interface NexusScratchpadConfig {
+  readonly groupId: AgentGroupId;
+  readonly authorId: AgentId;
+  readonly transport: NexusTransport;
+  readonly fallback?: ScratchpadComponent | undefined;
+  readonly basePath?: string | undefined;
+}
+
+export function createNexusScratchpad(
+  config: NexusScratchpadConfig,
+): ScratchpadComponent | Promise<ScratchpadComponent>;
+```
+
+### Behavior
+
+- preserve `ScratchpadComponent` method signatures from `@koi/core`
+- preserve per-path CAS semantics from the local contract
+- prefer direct read/write/delete/list calls first
+- defer write buffering and generation-cache optimization until after basic contract parity exists
+
+This is an intentional simplification from v1. The first v2 version should start with correctness and contract parity, then add buffering or cache layers only if profiling or test coverage shows a real need.
+
+### Fallback rule
+
+Fallback is selected at creation-time health check or on first unrecoverable Nexus operation error when `fallback` exists.
+
+---
+
+## Slice 3: `@koi/workspace-nexus`
+
+### Goal
+
+Provide a `WorkspaceBackend` backed by Nexus metadata persistence with optional local fallback backend.
+
+### Public API
+
+```typescript
+export interface NexusWorkspaceBackendConfig {
+  readonly transport: NexusTransport;
+  readonly fallback?: WorkspaceBackend | undefined;
+  readonly basePath?: string | undefined;
+  readonly localBaseDir?: string | undefined;
+}
+
+export function createNexusWorkspaceBackend(
+  config: NexusWorkspaceBackendConfig,
+): WorkspaceBackend | Promise<WorkspaceBackend>;
+```
+
+### Behavior
+
+- create local workspace directories on the current host
+- persist metadata to Nexus for cross-node discovery
+- keep `WorkspaceInfo` and lifecycle semantics consistent with the current `WorkspaceBackend` contract
+- preserve Nexus-first artifact ordering only if the selected server methods and failure semantics still justify it in v2
+
+This package is the least urgent slice because it is less central to agent-to-agent coordination than IPC and scratchpad.
+
+---
+
+## Testing Strategy
+
+### Shared strategy
+
+- use `bun:test`
+- inject fake `NexusTransport` objects directly
+- avoid network servers in unit tests
+- verify contract parity against the current local packages where practical
+
+### `ipc-nexus`
+
+Required tests:
+
+- sends a message through the transport and reconstructs `AgentMessage`
+- lists inbox messages using `MessageFilter.limit`
+- polls and emits unseen messages via `onMessage`
+- `drain()` returns buffered seen messages and clears them
+- falls back to local mailbox when health check fails and fallback exists
+- surfaces Nexus errors when no fallback exists
+
+### `scratchpad-nexus`
+
+Required tests:
+
+- write/read/list/delete round-trip
+- create-only and CAS update conflict semantics
+- fallback to local scratchpad when health check fails
+- same method return shapes as local scratchpad
+
+### `workspace-nexus`
+
+Required tests:
+
+- create persists metadata and returns `WorkspaceInfo`
+- dispose removes persisted metadata
+- `isHealthy()` reflects Nexus metadata availability plus local directory existence
+- fallback to local backend when health check fails
+
+---
+
+## Documentation Impact
+
+The current docs and package coverage map mention packages that do not exist yet. As each slice lands, the package docs must be updated to match the implemented scope rather than the broader archive-era feature set.
+
+Specifically:
+
+- `docs/L2/ipc-nexus.md`
+- `docs/L2/scratchpad-nexus.md`
+- `docs/L2/workspace-nexus.md`
+- `docs/package-coverage-map.md`
+
+---
+
+## Rollout Plan
+
+### Phase 1
+
+Implement `@koi/ipc-nexus` only.
+
+### Phase 2
+
+Implement `@koi/scratchpad-nexus` after `ipc-nexus` proves the RPC mapping and fallback shape.
+
+### Phase 3
+
+Implement `@koi/workspace-nexus` last.
+
+This keeps each phase reviewable and ensures we do not block the whole issue on the most stateful subsystem.
+
+---
+
+## Open Questions Resolved For This Spec
+
+- **Should we port SSE from v1 immediately?** No. Start with polling in `ipc-nexus`.
+- **Should fallback be automatic and invisible?** No. It is explicit in config and one-way after degradation.
+- **Should scratchpad start with buffer/cache layers?** No. Start with direct correctness-first calls.
+- **Should workspace land before IPC?** No. `ipc-nexus` is the first slice.
+
+---
+
+## Recommendation
+
+Start implementation with `@koi/ipc-nexus` in this branch. It is the smallest slice, validates the `NexusTransport` integration pattern, and gives the next two packages a cleaner template for fallback and contract parity.

--- a/packages/lib/ipc-nexus/package.json
+++ b/packages/lib/ipc-nexus/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@koi/ipc-nexus",
+  "description": "Nexus-backed MailboxComponent with optional local fallback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test",
+    "test:api": "bun test src/__tests__/api-surface.test.ts"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*",
+    "@koi/nexus-client": "workspace:*"
+  }
+}

--- a/packages/lib/ipc-nexus/package.json
+++ b/packages/lib/ipc-nexus/package.json
@@ -20,5 +20,8 @@
   "dependencies": {
     "@koi/core": "workspace:*",
     "@koi/nexus-client": "workspace:*"
+  },
+  "koi": {
+    "optional": true
   }
 }

--- a/packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
+++ b/packages/lib/ipc-nexus/src/__tests__/api-surface.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+
+describe("@koi/ipc-nexus API surface", () => {
+  test("exports createNexusMailbox", async () => {
+    const mod = await import("../index.js");
+    expect(typeof mod.createNexusMailbox).toBe("function");
+  });
+});

--- a/packages/lib/ipc-nexus/src/client.ts
+++ b/packages/lib/ipc-nexus/src/client.ts
@@ -1,0 +1,34 @@
+import type { AgentMessageInput, KoiError, Result } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+import type { NexusEnvelope, NexusInboxResponse } from "./types.js";
+
+export interface NexusMailboxClient {
+  readonly send: (message: AgentMessageInput) => Promise<Result<NexusEnvelope, KoiError>>;
+  readonly list: (
+    agentId: string,
+    limit: number,
+  ) => Promise<Result<readonly NexusEnvelope[], KoiError>>;
+}
+
+export function createNexusMailboxClient(
+  transport: NexusTransport,
+  prefix: string,
+): NexusMailboxClient {
+  return {
+    send: async (message) =>
+      transport.call<NexusEnvelope>(`${prefix}.send`, {
+        from: message.from,
+        to: message.to,
+        kind: message.kind,
+        correlationId: message.correlationId,
+        ttlSeconds: message.ttlSeconds,
+        type: message.type,
+        payload: message.payload,
+        metadata: message.metadata,
+      }),
+    list: async (agentId, limit) => {
+      const result = await transport.call<NexusInboxResponse>(`${prefix}.list`, { agentId, limit });
+      return result.ok ? { ok: true, value: result.value.messages } : result;
+    },
+  };
+}

--- a/packages/lib/ipc-nexus/src/index.ts
+++ b/packages/lib/ipc-nexus/src/index.ts
@@ -1,0 +1,3 @@
+export type { NexusMailboxClient } from "./client.js";
+export { createNexusMailbox } from "./mailbox.js";
+export type { NexusEnvelope, NexusInboxResponse, NexusMailboxConfig } from "./types.js";

--- a/packages/lib/ipc-nexus/src/mailbox.test.ts
+++ b/packages/lib/ipc-nexus/src/mailbox.test.ts
@@ -13,8 +13,8 @@ function createFallbackMailbox(owner = agentId("agent-a")): MailboxComponent {
     readonly createdAt: string;
     readonly ttlSeconds?: number | undefined;
     readonly type: string;
-    readonly payload: Record<string, never>;
-    readonly metadata?: Record<string, never> | undefined;
+    readonly payload: Readonly<Record<string, unknown>>;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
   }[] = [];
 
   return {
@@ -195,6 +195,177 @@ describe("createNexusMailbox", () => {
     const filtered = await mailbox.list({ kind: "request", from: agentId("agent-b") });
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.type).toBe("review");
+  });
+
+  test("handler that throws does not kill subsequent dispatch", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    let listCalls = 0;
+    const transport = createHealthyTransport(async <T>(method: string) => {
+      if (method === "ipc.list") {
+        listCalls += 1;
+        const id = `msg-throw-${listCalls}`;
+        return {
+          ok: true,
+          value: {
+            messages: [
+              {
+                id,
+                from: "agent-b",
+                to: "agent-a",
+                kind: "event",
+                type: "status",
+                payload: {},
+                createdAt: "2026-05-06T00:00:00.000Z",
+              },
+            ],
+          } as T,
+        };
+      }
+      return { ok: false, error: { code: "EXTERNAL", message: "x", retryable: false } };
+    });
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport,
+      pollIntervalMs: 5,
+    });
+
+    const seen: string[] = [];
+    let firstCall = true;
+    const unsubscribe = mailbox.onMessage((m) => {
+      seen.push(m.id as string);
+      if (firstCall) {
+        firstCall = false;
+        throw new Error("handler boom");
+      }
+    });
+
+    await Bun.sleep(40);
+    unsubscribe();
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    expect(seen[0]).toBe("msg-throw-1");
+  });
+
+  test("degraded mode is sticky — does not recover on transport recovery", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    let sendShouldFail = true;
+    const fallback = createFallbackMailbox();
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport: createHealthyTransport(async <T>(method: string) => {
+        if (method === "ipc.send" && sendShouldFail) {
+          return { ok: false, error: { code: "EXTERNAL", message: "down", retryable: false } };
+        }
+        if (method === "ipc.send") {
+          return {
+            ok: true,
+            value: {
+              id: "nexus-recovered",
+              from: "agent-a",
+              to: "agent-a",
+              kind: "event",
+              type: "noop",
+              payload: {},
+              createdAt: "2026-05-06T00:00:00.000Z",
+            } as T,
+          };
+        }
+        return { ok: true, value: { messages: [] } as T };
+      }),
+      fallback,
+    });
+
+    const first = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-a"),
+      kind: "event",
+      type: "noop",
+      payload: {},
+    });
+    expect(first.ok).toBe(true);
+
+    sendShouldFail = false;
+    const second = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-a"),
+      kind: "event",
+      type: "noop",
+      payload: {},
+    });
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect((second.value.id as string).startsWith("fallback-")).toBe(true);
+    }
+  });
+
+  test("dedupes a message even when multiple polls observe it concurrently", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const transport = createHealthyTransport(async <T>(method: string) => {
+      if (method === "ipc.list") {
+        return {
+          ok: true,
+          value: {
+            messages: [
+              {
+                id: "msg-dup",
+                from: "agent-b",
+                to: "agent-a",
+                kind: "event",
+                type: "status",
+                payload: {},
+                createdAt: "2026-05-06T00:00:00.000Z",
+              },
+            ],
+          } as T,
+        };
+      }
+      return { ok: false, error: { code: "EXTERNAL", message: "x", retryable: false } };
+    });
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport,
+      pollIntervalMs: 5,
+    });
+
+    const seen: string[] = [];
+    const unsubscribe = mailbox.onMessage((m) => {
+      seen.push(m.id as string);
+    });
+
+    await Bun.sleep(40);
+    unsubscribe();
+
+    const dupCount = seen.filter((id) => id === "msg-dup").length;
+    expect(dupCount).toBe(1);
+  });
+
+  test("send failure surfaces error when no fallback is configured", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport: createHealthyTransport(async (method) => {
+        if (method === "ipc.send") {
+          return { ok: false, error: { code: "EXTERNAL", message: "down", retryable: false } };
+        }
+        return { ok: false, error: { code: "EXTERNAL", message: "x", retryable: false } };
+      }),
+    });
+
+    const result = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-a"),
+      kind: "event",
+      type: "noop",
+      payload: {},
+    });
+
+    expect(result.ok).toBe(false);
   });
 
   test("falls back on send failure after startup health passes", async () => {

--- a/packages/lib/ipc-nexus/src/mailbox.test.ts
+++ b/packages/lib/ipc-nexus/src/mailbox.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiError, MailboxComponent, Result } from "@koi/core";
+import { agentId, messageId } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+
+function createFallbackMailbox(owner = agentId("agent-a")): MailboxComponent {
+  let messages: readonly {
+    readonly id: ReturnType<typeof messageId>;
+    readonly from: ReturnType<typeof agentId>;
+    readonly to: ReturnType<typeof agentId>;
+    readonly kind: "request" | "response" | "event" | "cancel";
+    readonly correlationId?: ReturnType<typeof messageId> | undefined;
+    readonly createdAt: string;
+    readonly ttlSeconds?: number | undefined;
+    readonly type: string;
+    readonly payload: Record<string, never>;
+    readonly metadata?: Record<string, never> | undefined;
+  }[] = [];
+
+  return {
+    send: async (message) => {
+      const mapped = {
+        ...message,
+        id: messageId(`fallback-${messages.length + 1}`),
+        createdAt: "2026-05-06T00:00:00.000Z",
+      };
+      messages = [...messages, mapped];
+      return { ok: true, value: mapped };
+    },
+    onMessage: () => () => {},
+    list: async () => messages.filter((message) => message.to === owner),
+    drain: () => {
+      const snapshot = messages;
+      messages = [];
+      return snapshot;
+    },
+  };
+}
+
+function createHealthyTransport(call: NexusTransport["call"]): NexusTransport {
+  return {
+    kind: "http",
+    call,
+    health: async () => ({
+      ok: true,
+      value: {
+        status: "ok",
+        version: "1",
+        latencyMs: 1,
+        probed: ["version"],
+      },
+    }),
+    close: () => {},
+  };
+}
+
+describe("createNexusMailbox", () => {
+  test("sends a message through Nexus transport", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const transport = createHealthyTransport(async <T>() => ({
+      ok: true,
+      value: {
+        id: "msg-1",
+        from: "agent-a",
+        to: "agent-b",
+        kind: "request",
+        type: "review",
+        payload: { text: "check this" },
+        createdAt: "2026-05-06T00:00:00.000Z",
+      } as T,
+    }));
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport,
+    });
+
+    const result = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-b"),
+      kind: "request",
+      type: "review",
+      payload: { text: "check this" },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.id).toBe(messageId("msg-1"));
+      expect(result.value.to).toBe(agentId("agent-b"));
+    }
+  });
+
+  test("uses fallback mailbox when health check fails", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const fallback = createFallbackMailbox();
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport: {
+        kind: "http",
+        call: async <T>(): Promise<Result<T, KoiError>> => ({
+          ok: false,
+          error: { code: "EXTERNAL", message: "down", retryable: false },
+        }),
+        health: async () => ({
+          ok: false,
+          error: { code: "EXTERNAL", message: "down", retryable: false },
+        }),
+        close: () => {},
+      },
+      fallback,
+    });
+
+    const result = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-a"),
+      kind: "event",
+      type: "noop",
+      payload: {},
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("drain returns seen messages once", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const transport = createHealthyTransport(async <T>(method: string) => {
+      if (method === "ipc.list") {
+        return {
+          ok: true,
+          value: {
+            messages: [
+              {
+                id: "msg-2",
+                from: "agent-b",
+                to: "agent-a",
+                kind: "event",
+                type: "status",
+                payload: { ok: true },
+                createdAt: "2026-05-06T00:00:00.000Z",
+              },
+            ],
+          } as T,
+        };
+      }
+      return {
+        ok: false,
+        error: { code: "EXTERNAL", message: "unexpected", retryable: false },
+      };
+    });
+
+    const mailbox = await createNexusMailbox({ agentId: agentId("agent-a"), transport });
+    const unsubscribe = mailbox.onMessage(() => {});
+    await Bun.sleep(10);
+    unsubscribe();
+
+    expect(mailbox.drain()).toHaveLength(1);
+    expect(mailbox.drain()).toHaveLength(0);
+  });
+
+  test("list filters messages returned from Nexus", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport: createHealthyTransport(async <T>() => ({
+        ok: true,
+        value: {
+          messages: [
+            {
+              id: "msg-3",
+              from: "agent-b",
+              to: "agent-a",
+              kind: "request",
+              type: "review",
+              payload: {},
+              createdAt: "2026-05-06T00:00:00.000Z",
+            },
+            {
+              id: "msg-4",
+              from: "agent-c",
+              to: "agent-a",
+              kind: "event",
+              type: "status",
+              payload: {},
+              createdAt: "2026-05-06T00:00:01.000Z",
+            },
+          ],
+        } as T,
+      })),
+    });
+
+    const filtered = await mailbox.list({ kind: "request", from: agentId("agent-b") });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.type).toBe("review");
+  });
+
+  test("falls back on send failure after startup health passes", async () => {
+    const { createNexusMailbox } = await import("./index.js");
+
+    const fallback = createFallbackMailbox();
+    const mailbox = await createNexusMailbox({
+      agentId: agentId("agent-a"),
+      transport: createHealthyTransport(async <T>(method: string) => {
+        if (method === "ipc.send") {
+          return {
+            ok: false,
+            error: { code: "EXTERNAL", message: "down", retryable: false },
+          };
+        }
+        return {
+          ok: true,
+          value: { messages: [] } as T,
+        };
+      }),
+      fallback,
+    });
+
+    const result = await mailbox.send({
+      from: agentId("agent-a"),
+      to: agentId("agent-a"),
+      kind: "event",
+      type: "local",
+      payload: {},
+    });
+
+    expect(result.ok).toBe(true);
+    const listed = await mailbox.list();
+    expect(listed).toHaveLength(1);
+  });
+});

--- a/packages/lib/ipc-nexus/src/mailbox.ts
+++ b/packages/lib/ipc-nexus/src/mailbox.ts
@@ -1,0 +1,122 @@
+import type { AgentMessage, MailboxComponent, MessageFilter } from "@koi/core";
+import { createNexusMailboxClient } from "./client.js";
+import { mapNexusEnvelopeToAgentMessage } from "./map-message.js";
+import { createSeenSet } from "./seen-set.js";
+import type { NexusMailboxConfig } from "./types.js";
+
+const DEFAULT_PREFIX = "ipc";
+const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+export async function createNexusMailbox(config: NexusMailboxConfig): Promise<MailboxComponent> {
+  const prefix = config.inboxMethodPrefix ?? DEFAULT_PREFIX;
+  const pageSize = config.pageSize ?? DEFAULT_PAGE_SIZE;
+  const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  if (config.transport.health !== undefined) {
+    const health = await config.transport.health();
+    if (!health.ok && config.fallback !== undefined) {
+      return config.fallback;
+    }
+  }
+
+  const client = createNexusMailboxClient(config.transport, prefix);
+  const seen = createSeenSet();
+  const handlers = new Set<(message: AgentMessage) => void | Promise<void>>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let degraded = false;
+
+  async function dispatchMessages(messages: readonly AgentMessage[]): Promise<void> {
+    for (const message of messages) {
+      for (const handler of handlers) {
+        await handler(message);
+      }
+    }
+  }
+
+  async function listFromNexus(limit: number): Promise<readonly AgentMessage[]> {
+    const listed = await client.list(config.agentId as string, limit);
+    if (!listed.ok) {
+      if (config.fallback !== undefined) {
+        degraded = true;
+        return [];
+      }
+      return [];
+    }
+    return listed.value.map(mapNexusEnvelopeToAgentMessage);
+  }
+
+  async function pollOnce(): Promise<void> {
+    if (degraded && config.fallback !== undefined) return;
+    const messages = await listFromNexus(pageSize);
+    const unseen = messages.filter((message) => {
+      if (seen.has(message.id as string)) return false;
+      seen.add(message);
+      return true;
+    });
+    await dispatchMessages(unseen);
+  }
+
+  function ensurePolling(): void {
+    if (timer !== null || degraded || handlers.size === 0) return;
+    timer = setInterval(() => {
+      void pollOnce();
+    }, pollIntervalMs);
+  }
+
+  function stopPolling(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  async function list(filter?: MessageFilter): Promise<readonly AgentMessage[]> {
+    if (degraded && config.fallback !== undefined) {
+      return config.fallback.list(filter);
+    }
+    const messages = await listFromNexus(filter?.limit ?? pageSize);
+    return messages.filter((message) => {
+      if (filter?.kind !== undefined && message.kind !== filter.kind) return false;
+      if (filter?.type !== undefined && message.type !== filter.type) return false;
+      if (filter?.from !== undefined && message.from !== filter.from) return false;
+      return true;
+    });
+  }
+
+  return {
+    send: async (message) => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.send(message);
+      }
+      const result = await client.send(message);
+      if (!result.ok) {
+        if (config.fallback !== undefined) {
+          degraded = true;
+          return config.fallback.send(message);
+        }
+        return result;
+      }
+      return { ok: true, value: mapNexusEnvelopeToAgentMessage(result.value) };
+    },
+    onMessage: (handler) => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.onMessage(handler);
+      }
+      handlers.add(handler);
+      ensurePolling();
+      void pollOnce();
+      return () => {
+        handlers.delete(handler);
+        if (handlers.size === 0) stopPolling();
+      };
+    },
+    list,
+    drain: () => {
+      if (degraded && config.fallback !== undefined) {
+        return config.fallback.drain();
+      }
+      return seen.drain();
+    },
+  };
+}

--- a/packages/lib/ipc-nexus/src/mailbox.ts
+++ b/packages/lib/ipc-nexus/src/mailbox.ts
@@ -1,127 +1,144 @@
-import type { AgentMessage, MailboxComponent, MessageFilter } from "@koi/core";
+import type {
+  AgentMessage,
+  AgentMessageInput,
+  KoiError,
+  MailboxComponent,
+  MessageFilter,
+  Result,
+} from "@koi/core";
+import type { NexusMailboxClient } from "./client.js";
 import { createNexusMailboxClient } from "./client.js";
 import { mapNexusEnvelopeToAgentMessage } from "./map-message.js";
-import { createSeenSet } from "./seen-set.js";
+import { createSeenSet, type SeenSet } from "./seen-set.js";
 import type { NexusMailboxConfig } from "./types.js";
 
 const DEFAULT_PREFIX = "ipc";
 const DEFAULT_PAGE_SIZE = 50;
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
 
+type Handler = (message: AgentMessage) => void | Promise<void>;
+
+interface State {
+  readonly client: NexusMailboxClient;
+  readonly seen: SeenSet;
+  readonly handlers: Set<Handler>;
+  readonly timer: { value: ReturnType<typeof setInterval> | null };
+  readonly degraded: { value: boolean };
+  readonly agentId: string;
+  readonly pageSize: number;
+  readonly pollIntervalMs: number;
+  readonly fallback: MailboxComponent | undefined;
+}
+
 export async function createNexusMailbox(config: NexusMailboxConfig): Promise<MailboxComponent> {
   const prefix = config.inboxMethodPrefix ?? DEFAULT_PREFIX;
-  const pageSize = config.pageSize ?? DEFAULT_PAGE_SIZE;
-  const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-
   if (config.transport.health !== undefined) {
     const health = await config.transport.health();
-    if (!health.ok && config.fallback !== undefined) {
-      return config.fallback;
-    }
+    if (!health.ok && config.fallback !== undefined) return config.fallback;
   }
-
-  const client = createNexusMailboxClient(config.transport, prefix);
-  const seen = createSeenSet();
-  const handlers = new Set<(message: AgentMessage) => void | Promise<void>>();
-  let timer: ReturnType<typeof setInterval> | null = null;
-  let degraded = false;
-
-  async function dispatchMessages(messages: readonly AgentMessage[]): Promise<void> {
-    for (const message of messages) {
-      for (const handler of handlers) {
-        try {
-          await handler(message);
-        } catch {
-          // Handler errors must not kill the polling loop; the next message
-          // and the next handler still need to be delivered.
-        }
-      }
-    }
-  }
-
-  async function listFromNexus(limit: number): Promise<readonly AgentMessage[]> {
-    const listed = await client.list(config.agentId as string, limit);
-    if (!listed.ok) {
-      if (config.fallback !== undefined) {
-        degraded = true;
-        return [];
-      }
-      return [];
-    }
-    return listed.value.map(mapNexusEnvelopeToAgentMessage);
-  }
-
-  async function pollOnce(): Promise<void> {
-    if (degraded && config.fallback !== undefined) return;
-    const messages = await listFromNexus(pageSize);
-    const unseen = messages.filter((message) => {
-      if (seen.has(message.id as string)) return false;
-      seen.add(message);
-      return true;
-    });
-    await dispatchMessages(unseen);
-  }
-
-  function ensurePolling(): void {
-    if (timer !== null || degraded || handlers.size === 0) return;
-    timer = setInterval(() => {
-      void pollOnce();
-    }, pollIntervalMs);
-  }
-
-  function stopPolling(): void {
-    if (timer !== null) {
-      clearInterval(timer);
-      timer = null;
-    }
-  }
-
-  async function list(filter?: MessageFilter): Promise<readonly AgentMessage[]> {
-    if (degraded && config.fallback !== undefined) {
-      return config.fallback.list(filter);
-    }
-    const messages = await listFromNexus(filter?.limit ?? pageSize);
-    return messages.filter((message) => {
-      if (filter?.kind !== undefined && message.kind !== filter.kind) return false;
-      if (filter?.type !== undefined && message.type !== filter.type) return false;
-      if (filter?.from !== undefined && message.from !== filter.from) return false;
-      return true;
-    });
-  }
-
-  return {
-    send: async (message) => {
-      if (degraded && config.fallback !== undefined) {
-        return config.fallback.send(message);
-      }
-      const result = await client.send(message);
-      if (!result.ok) {
-        if (config.fallback !== undefined) {
-          degraded = true;
-          return config.fallback.send(message);
-        }
-        return result;
-      }
-      return { ok: true, value: mapNexusEnvelopeToAgentMessage(result.value) };
-    },
-    onMessage: (handler) => {
-      if (degraded && config.fallback !== undefined) {
-        return config.fallback.onMessage(handler);
-      }
-      handlers.add(handler);
-      ensurePolling();
-      void pollOnce();
-      return () => {
-        handlers.delete(handler);
-        if (handlers.size === 0) stopPolling();
-      };
-    },
-    list,
-    drain: () => {
-      if (degraded && config.fallback !== undefined) {
-        return config.fallback.drain();
-      }
-      return seen.drain();
-    },
+  const state: State = {
+    client: createNexusMailboxClient(config.transport, prefix),
+    seen: createSeenSet(),
+    handlers: new Set(),
+    timer: { value: null },
+    degraded: { value: false },
+    agentId: config.agentId as string,
+    pageSize: config.pageSize ?? DEFAULT_PAGE_SIZE,
+    pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    fallback: config.fallback,
   };
+  return {
+    send: (m) => sendMessage(state, m),
+    onMessage: (h) => subscribeHandler(state, h),
+    list: (f) => listMessages(state, f),
+    drain: () => drainMessages(state),
+  };
+}
+
+async function dispatchMessages(s: State, messages: readonly AgentMessage[]): Promise<void> {
+  // Handler errors are isolated so the polling loop survives a thrown handler.
+  for (const message of messages) {
+    for (const handler of s.handlers) {
+      await Promise.resolve()
+        .then(() => handler(message))
+        .catch(() => {});
+    }
+  }
+}
+
+async function listFromNexus(s: State, limit: number): Promise<readonly AgentMessage[]> {
+  const listed = await s.client.list(s.agentId, limit);
+  if (!listed.ok) {
+    if (s.fallback !== undefined) s.degraded.value = true;
+    return [];
+  }
+  return listed.value.map(mapNexusEnvelopeToAgentMessage);
+}
+
+async function pollOnce(s: State): Promise<void> {
+  if (s.degraded.value && s.fallback !== undefined) return;
+  const messages = await listFromNexus(s, s.pageSize);
+  const unseen = messages.filter((message) => {
+    if (s.seen.has(message.id as string)) return false;
+    s.seen.add(message);
+    return true;
+  });
+  await dispatchMessages(s, unseen);
+}
+
+function ensurePolling(s: State): void {
+  if (s.timer.value !== null || s.degraded.value || s.handlers.size === 0) return;
+  s.timer.value = setInterval(() => {
+    void pollOnce(s);
+  }, s.pollIntervalMs);
+}
+
+function stopPolling(s: State): void {
+  if (s.timer.value !== null) {
+    clearInterval(s.timer.value);
+    s.timer.value = null;
+  }
+}
+
+async function sendMessage(
+  s: State,
+  message: AgentMessageInput,
+): Promise<Result<AgentMessage, KoiError>> {
+  if (s.degraded.value && s.fallback !== undefined) return s.fallback.send(message);
+  const result = await s.client.send(message);
+  if (!result.ok) {
+    if (s.fallback !== undefined) {
+      s.degraded.value = true;
+      return s.fallback.send(message);
+    }
+    return result;
+  }
+  return { ok: true, value: mapNexusEnvelopeToAgentMessage(result.value) };
+}
+
+function subscribeHandler(s: State, handler: Handler): () => void {
+  if (s.degraded.value && s.fallback !== undefined) return s.fallback.onMessage(handler);
+  s.handlers.add(handler);
+  ensurePolling(s);
+  void pollOnce(s);
+  return () => {
+    s.handlers.delete(handler);
+    if (s.handlers.size === 0) stopPolling(s);
+  };
+}
+
+async function listMessages(s: State, filter?: MessageFilter): Promise<readonly AgentMessage[]> {
+  if (s.degraded.value && s.fallback !== undefined) return s.fallback.list(filter);
+  const messages = await listFromNexus(s, filter?.limit ?? s.pageSize);
+  return messages.filter((message) => {
+    if (filter?.kind !== undefined && message.kind !== filter.kind) return false;
+    if (filter?.type !== undefined && message.type !== filter.type) return false;
+    if (filter?.from !== undefined && message.from !== filter.from) return false;
+    return true;
+  });
+}
+
+function drainMessages(s: State): readonly AgentMessage[] | Promise<readonly AgentMessage[]> {
+  if (s.degraded.value && s.fallback !== undefined) return s.fallback.drain();
+  return s.seen.drain();
 }

--- a/packages/lib/ipc-nexus/src/mailbox.ts
+++ b/packages/lib/ipc-nexus/src/mailbox.ts
@@ -29,7 +29,12 @@ export async function createNexusMailbox(config: NexusMailboxConfig): Promise<Ma
   async function dispatchMessages(messages: readonly AgentMessage[]): Promise<void> {
     for (const message of messages) {
       for (const handler of handlers) {
-        await handler(message);
+        try {
+          await handler(message);
+        } catch {
+          // Handler errors must not kill the polling loop; the next message
+          // and the next handler still need to be delivered.
+        }
       }
     }
   }

--- a/packages/lib/ipc-nexus/src/map-message.ts
+++ b/packages/lib/ipc-nexus/src/map-message.ts
@@ -1,0 +1,19 @@
+import type { AgentMessage } from "@koi/core";
+import { agentId, messageId } from "@koi/core";
+import type { NexusEnvelope } from "./types.js";
+
+export function mapNexusEnvelopeToAgentMessage(envelope: NexusEnvelope): AgentMessage {
+  return {
+    id: messageId(envelope.id),
+    from: agentId(envelope.from),
+    to: agentId(envelope.to),
+    kind: envelope.kind,
+    correlationId:
+      envelope.correlationId !== undefined ? messageId(envelope.correlationId) : undefined,
+    createdAt: envelope.createdAt,
+    ttlSeconds: envelope.ttlSeconds,
+    type: envelope.type,
+    payload: envelope.payload,
+    metadata: envelope.metadata,
+  };
+}

--- a/packages/lib/ipc-nexus/src/seen-set.ts
+++ b/packages/lib/ipc-nexus/src/seen-set.ts
@@ -1,0 +1,25 @@
+import type { AgentMessage } from "@koi/core";
+
+export interface SeenSet {
+  readonly has: (id: string) => boolean;
+  readonly add: (message: AgentMessage) => void;
+  readonly drain: () => readonly AgentMessage[];
+}
+
+export function createSeenSet(): SeenSet {
+  const ids = new Set<string>();
+  let buffered: readonly AgentMessage[] = [];
+
+  return {
+    has: (id) => ids.has(id),
+    add: (message) => {
+      ids.add(message.id as string);
+      buffered = [...buffered, message];
+    },
+    drain: () => {
+      const snapshot = buffered;
+      buffered = [];
+      return snapshot;
+    },
+  };
+}

--- a/packages/lib/ipc-nexus/src/types.ts
+++ b/packages/lib/ipc-nexus/src/types.ts
@@ -1,0 +1,32 @@
+import type { AgentId, AgentMessage, JsonObject, MailboxComponent } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+
+export interface NexusMailboxConfig {
+  readonly agentId: AgentId;
+  readonly transport: NexusTransport;
+  readonly fallback?: MailboxComponent | undefined;
+  readonly inboxMethodPrefix?: string | undefined;
+  readonly pollIntervalMs?: number | undefined;
+  readonly pageSize?: number | undefined;
+}
+
+export interface NexusEnvelope {
+  readonly id: string;
+  readonly from: string;
+  readonly to: string;
+  readonly kind: "request" | "response" | "event" | "cancel";
+  readonly correlationId?: string | undefined;
+  readonly createdAt: string;
+  readonly ttlSeconds?: number | undefined;
+  readonly type: string;
+  readonly payload: JsonObject;
+  readonly metadata?: JsonObject | undefined;
+}
+
+export interface NexusInboxResponse {
+  readonly messages: readonly NexusEnvelope[];
+}
+
+export interface SeenMessage extends AgentMessage {
+  readonly deliveredAt: string;
+}

--- a/packages/lib/ipc-nexus/tsconfig.json
+++ b/packages/lib/ipc-nexus/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../kernel/core"
+    },
+    {
+      "path": "../nexus-client"
+    }
+  ]
+}

--- a/packages/lib/ipc-nexus/tsup.config.ts
+++ b/packages/lib/ipc-nexus/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});


### PR DESCRIPTION
## Summary

- Adds `@koi/ipc-nexus`: a `MailboxComponent` factory backed by a `NexusTransport` with optional local fallback. Closes #1373.
- Marked `koi.optional: true` to match sibling Nexus backends (`playbook-store-nexus`, `snapshot-store-nexus`) — swappable backend, not part of the default agent loop closure.
- Hardens `dispatchMessages`: handler exceptions are now isolated so a thrown handler cannot propagate up through `pollOnce` and kill the polling loop.

## Corner cases tested

Added 4 tests on top of the original 5:

- handler-throws → next handler + next poll tick still fire
- degraded mode is sticky (documents intentional behavior)
- concurrent poll observers dedupe via seen-set
- send failure with no fallback surfaces the error verbatim

## Test plan

- [x] `bun test` (ipc-nexus) — 10/10 pass
- [x] `bun run typecheck` (ipc-nexus) — clean
- [x] `bun run check:layers` — pass
- [x] `bun run check:orphans` — pass (now optional)
- [x] `bun run check:golden-queries` — pass
- [ ] CI green on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)
