### PR TITLE
feat(proactive): composition planner (closes #1299)

### DIFF
--- a/docs/L2/proactive.md
+++ b/docs/L2/proactive.md
@@ -244,6 +244,100 @@ Tests use a stub `SchedulerComponent` whose `submit`, `schedule`, `unschedule`, 
 Per project convention, tests are colocated (`*.test.ts` next to `*.ts`).
 Coverage target: 80 % lines/functions/statements (project default).
 
+## Composition planner (issue #1299)
+
+The package additionally exposes a planning layer that turns observed
+`SystemSignal`s into `CompositionPlan` values. Execution stays out of scope
+— this layer ends at plan generation + approval classification. The
+composition tools (`sleep` / `schedule_cron` / etc.) and the planner are
+independent surfaces that share `@koi/proactive` only because both are
+"proactive" autonomy primitives.
+
+### Public API
+
+```typescript
+mapSystemSignalToCompositionTrigger(signal: SystemSignal): CompositionTrigger | undefined
+
+createRuleBasedCompositionPlanner(config?: RuleBasedCompositionPlannerConfig): CompositionPlanner
+createLlmCompositionPlanner(config: LlmCompositionPlannerConfig): CompositionPlanner
+
+computeCompositionApproval(
+  trigger: CompositionTrigger,
+  estimatedCost: number,
+  policy: CompositionApprovalPolicy,
+  context: CompositionApprovalContext,
+): boolean
+```
+
+All `Composition*` types live in `@koi/core` (L0). This package contributes
+only behavior — there are no new L0 types here.
+
+### Signal → trigger mapping
+
+`mapSystemSignalToCompositionTrigger` is exhaustive over `SystemSignal.kind`:
+
+| Signal kind | Resulting `CompositionMoment` | Notes |
+|---|---|---|
+| `governance` | `threshold_crossed` | `error_rate` adds `spawn_agent` + `notify_user` capability hints |
+| `forge_demand` | `capability_gap` | `missing` derived from inner `ForgeTrigger`; signal preserved in `context.forgeDemand` |
+| `schedule` | `task_terminal` | outcome ∈ `completed`/`failed`/`dead_letter`/`cancelled`; only `failed`/`dead_letter` carry follow-up capability hints |
+| `anomaly` (metric-shift kinds) | `frontier_changed` | `error_spike`, `model_latency_anomaly`, `token_spike`, positive `goal_drift`, `tool_rate_exceeded` |
+| `anomaly` (other), `vfs`, `agent_lifecycle`, `compaction` | `undefined` | not yet mapped — kept silent rather than emitting noisy triggers |
+
+### Rule-based planner
+
+Deterministic planner driven by `trigger.moment.kind`. Capability gating
+is mandatory — the planner reads `CompositionCapabilities.agents` and
+**never emits a `spawn_agent` step for an agent type that is not
+present**. The fallback when an agent type is missing is either a
+non-spawn step (`notify_user` for `error_rate`) or an empty plan
+(`requiresApproval = true` because zero-step plans always require
+human review).
+
+| Moment | Step(s) emitted (when capable) | Behavior when capability missing |
+|---|---|---|
+| `capability_gap` w/ `forge_demand{ suggestedBrickKind: "skill" }` | `forge_skill` | empty plan → approval required |
+| `threshold_crossed` (`error_rate`, `direction: "above"`) | `spawn_agent("diagnostic")` + `notify_user` (high) | `notify_user` only |
+| `task_terminal` (`failed` / `dead_letter`) | `spawn_agent("recovery")` | empty plan → approval required |
+| `task_terminal` (`completed` / `cancelled`) | none | `cancelled` is an explicit no-op — queue cancellation never began work |
+| `frontier_changed` | `spawn_agent("researcher", deferred)` | empty plan → approval required |
+| `pattern_matched`, `external_event` | none | requires explicit human-driven plan |
+
+`forge_skill` only fires for `suggestedBrickKind === "skill"`. Other forge
+demand kinds (tool / agent / middleware / channel / composite) yield an
+empty plan rather than a misleading `forge_skill` step.
+
+### LLM planner
+
+Wraps a `CompositionPlannerAdapter` (anything that maps
+`{ trigger, capabilities }` → JSON string). The output is parsed against a
+strict Zod schema covering every `CompositionStep` variant — `tool_call`,
+`spawn_agent`, `submit_task`, `create_schedule`, `forge_skill`,
+`notify_user`. Schema mismatch, malformed JSON, trigger-id mismatch, and
+non-finite / negative `estimatedCost` all raise `AdapterPlanParseError`.
+
+If `fallbackToRulePlanner` is configured, parse errors fall through to
+the rule planner and the resulting plan is then **reclassified** under
+the LLM planner's own `approvalPolicy` (so a rule-planner fallback
+inherits the LLM-side novelty / confidence gates). Local errors raised
+inside `classifyNovelty` are not silenced — they surface to the caller.
+
+### Approval policy
+
+`computeCompositionApproval` returns `true` (approval required) when **any**
+of these hold:
+
+- `trigger.confidence < policy.confidenceThreshold` — strict less-than:
+  equal-to-threshold does **not** require approval.
+- `estimatedCost > policy.maxEstimatedCost` — strict greater-than:
+  equal-to-budget does **not** require approval.
+- `policy.requireApprovalOnNovelty && context.isNovel`.
+
+Default policy: `{ confidenceThreshold: 0.5, maxEstimatedCost: 10,
+requireApprovalOnNovelty: true }`. The rule planner additionally
+short-circuits to `requiresApproval: true` whenever it produces a
+zero-step plan, so the runtime never executes an empty plan silently.
+
 ## Future Phases (out of scope here)
 
 Phase 3a tracker (this issue): sleep / wake / cron tools.
@@ -253,7 +347,7 @@ Phase 3a tracker (this issue): sleep / wake / cron tools.
 | 3a (now) | #1195 | This package — sleep + cron |
 | 3a | #1297 | `SystemSignal` L0 contract |
 | 3a | #1298 | System signal adapters |
-| 3a | #1299 | `CompositionTrigger` + `CompositionPlanner` |
+| 3a (now) | #1299 | `CompositionTrigger` + `CompositionPlanner` (rule + LLM) — landed in this package |
 | 3a | #1300 | `CompositionExecutor` + governance gate |
 | 3-4 | #1301 | Proactive delivery + temporal durability |
 

--- a/docs/superpowers/plans/2026-05-06-composition-planner.md
+++ b/docs/superpowers/plans/2026-05-06-composition-planner.md
@@ -1,0 +1,1183 @@
+# Composition Planner Implementation Plan
+
+> **STATUS: HISTORICAL / OBSOLETE.** This plan was the pre-implementation design for issue #1299. The shipped implementation diverges from this document in several ways — most notably the public contract in `packages/kernel/core/src/composition-planner.ts` (`AgentDefinition[]` not `RegistryEntry[]`; `mode`/`taskOptions` on `submit_task`/`create_schedule`), capability gating on `spawn_agent` steps, `cancelled`-as-no-op semantics in the rule planner, and full step-kind validation (`tool_call`, `spawn_agent`, `submit_task`, `create_schedule`, `forge_skill`, `notify_user`) in the LLM planner. **Do not use this file as an implementation source of truth.** Read the code in `@koi/core` and `@koi/proactive`, and the spec at `docs/superpowers/specs/2026-05-06-composition-planner-design.md`, instead.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the L0 composition-planning contracts plus proactive signal normalization, deterministic planning, and optional LLM-backed planning for issue `#1299`.
+
+**Architecture:** Define the shared planning vocabulary in `@koi/core`, then implement a thin `@koi/proactive` layer that maps `SystemSignal` into `CompositionTrigger` and produces `CompositionPlan` values using either deterministic rules or a validated LLM adapter. Execution stays out of scope; this work stops at plan generation and approval classification.
+
+**Tech Stack:** TypeScript 6, Bun test runner, tsup type exports, `@koi/core`, `@koi/proactive`
+
+---
+
+## File Structure
+
+### `@koi/core`
+
+- Create: `packages/kernel/core/src/composition-planner.ts`
+- Modify: `packages/kernel/core/src/index.ts`
+- Modify: `packages/kernel/core/src/system-signal.test.ts`
+- Verify: `packages/kernel/core/src/__tests__/api-surface.test.ts`
+
+### `@koi/proactive`
+
+- Create: `packages/lib/proactive/src/composition-trigger.ts`
+- Create: `packages/lib/proactive/src/composition-trigger.test.ts`
+- Create: `packages/lib/proactive/src/composition-approval.ts`
+- Create: `packages/lib/proactive/src/composition-approval.test.ts`
+- Create: `packages/lib/proactive/src/rule-based-composition-planner.ts`
+- Create: `packages/lib/proactive/src/rule-based-composition-planner.test.ts`
+- Create: `packages/lib/proactive/src/llm-composition-planner.ts`
+- Create: `packages/lib/proactive/src/llm-composition-planner.test.ts`
+- Modify: `packages/lib/proactive/src/index.ts`
+- Optionally modify: `packages/lib/proactive/src/test-helpers.ts` if shared trigger/planner fixtures reduce duplication without bloating tests
+
+### Docs
+
+- Reference only: `docs/superpowers/specs/2026-05-06-composition-planner-design.md`
+
+---
+
+### Task 1: Add L0 Composition Planning Contracts
+
+**Files:**
+- Create: `packages/kernel/core/src/composition-planner.ts`
+- Modify: `packages/kernel/core/src/index.ts`
+- Modify: `packages/kernel/core/src/system-signal.test.ts`
+- Test: `packages/kernel/core/src/system-signal.test.ts`
+- Verify: `packages/kernel/core/src/__tests__/api-surface.test.ts`
+
+- [ ] **Step 1: Write the failing type-level test coverage for the new contract**
+
+Add assertions to `packages/kernel/core/src/system-signal.test.ts` that prove the new types are wired correctly before the file exists:
+
+```ts
+import type {
+  CompositionCapabilities,
+  CompositionMoment,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "./composition-planner.js";
+
+type _MomentKindCheck = CompositionMoment["kind"];
+const _momentKindCheck: _MomentKindCheck = "capability_gap";
+void _momentKindCheck;
+
+const _triggerConformance: CompositionTrigger = {
+  id: "trigger-1",
+  source: "governance",
+  confidence: 0.8,
+  moment: { kind: "capability_gap", missing: "diagnostic-agent" },
+  suggestedCapabilities: ["spawn_agent"],
+  context: {},
+  emittedAt: 1,
+};
+void _triggerConformance;
+
+const _plannerConformance: CompositionPlanner = {
+  async plan(
+    trigger: CompositionTrigger,
+    _capabilities: CompositionCapabilities,
+  ): Promise<CompositionPlan> {
+    const step: CompositionStep = {
+      kind: "notify_user",
+      channel: "inbox",
+      message: trigger.id,
+      priority: "normal",
+    };
+    return {
+      triggerId: trigger.id,
+      steps: [step],
+      estimatedCost: 0,
+      requiresApproval: false,
+    };
+  },
+};
+void _plannerConformance;
+```
+
+- [ ] **Step 2: Run the core contract test to verify it fails**
+
+Run:
+
+```bash
+bun test packages/kernel/core/src/system-signal.test.ts
+```
+
+Expected: FAIL with a module resolution or missing export error for `./composition-planner.js`.
+
+- [ ] **Step 3: Implement the L0 contract file**
+
+Create `packages/kernel/core/src/composition-planner.ts` with the shared types only:
+
+```ts
+import type { DeliveryPolicy } from "./delivery.js";
+import type { AgentId, ToolDescriptor } from "./ecs.js";
+import type { EngineInput } from "./engine.js";
+import type { ForgeStore } from "./brick-store.js";
+import type { ForgeDemandSignal } from "./forge-demand.js";
+import type { RegistryEntry } from "./lifecycle.js";
+import type { CronSchedule, TaskId } from "./scheduler.js";
+
+export interface CompositionTrigger {
+  readonly id: string;
+  readonly source: string;
+  readonly confidence: number;
+  readonly moment: CompositionMoment;
+  readonly suggestedCapabilities: readonly string[];
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly emittedAt: number;
+}
+
+export type CompositionMoment =
+  | { readonly kind: "capability_gap"; readonly missing: string }
+  | {
+      readonly kind: "threshold_crossed";
+      readonly sensor: string;
+      readonly value: number;
+      readonly limit: number;
+      readonly direction: "above" | "below";
+    }
+  | { readonly kind: "pattern_matched"; readonly patternId: string; readonly description: string }
+  | {
+      readonly kind: "task_terminal";
+      readonly taskId: TaskId;
+      readonly outcome: "completed" | "failed" | "dead_letter" | "cancelled";
+    }
+  | { readonly kind: "external_event"; readonly source: string; readonly eventType: string }
+  | { readonly kind: "frontier_changed"; readonly metric: string; readonly improvement: number };
+
+export interface CompositionCapabilities {
+  readonly tools: readonly ToolDescriptor[];
+  readonly agents: readonly RegistryEntry[];
+  readonly schedules: readonly CronSchedule[];
+  readonly forgeStore?: ForgeStore | undefined;
+}
+
+export interface CompositionPlan {
+  readonly triggerId: string;
+  readonly steps: readonly CompositionStep[];
+  readonly estimatedCost: number;
+  readonly requiresApproval: boolean;
+}
+
+export type CompositionStep =
+  | { readonly kind: "tool_call"; readonly toolName: string; readonly input: unknown }
+  | {
+      readonly kind: "spawn_agent";
+      readonly agentType: string;
+      readonly input: EngineInput;
+      readonly delivery: DeliveryPolicy;
+    }
+  | {
+      readonly kind: "submit_task";
+      readonly agentId: AgentId;
+      readonly input: EngineInput;
+      readonly delayMs: number;
+    }
+  | {
+      readonly kind: "create_schedule";
+      readonly expression: string;
+      readonly agentId: AgentId;
+      readonly input: EngineInput;
+      readonly timezone?: string | undefined;
+    }
+  | { readonly kind: "forge_skill"; readonly demand: ForgeDemandSignal }
+  | {
+      readonly kind: "notify_user";
+      readonly channel: string;
+      readonly message: string;
+      readonly priority: "low" | "normal" | "high";
+    };
+
+export interface CompositionPlanner {
+  readonly plan: (
+    trigger: CompositionTrigger,
+    capabilities: CompositionCapabilities,
+  ) => Promise<CompositionPlan>;
+}
+
+export interface CompositionApprovalPolicy {
+  readonly confidenceThreshold: number;
+  readonly maxEstimatedCost: number;
+  readonly requireApprovalOnNovelty: boolean;
+}
+
+export interface CompositionApprovalContext {
+  readonly isNovel: boolean;
+}
+```
+
+- [ ] **Step 4: Export the new core contract**
+
+Update `packages/kernel/core/src/index.ts` near the forge/scheduler/system-signal exports:
+
+```ts
+// composition planner — trigger and planning contracts
+export type {
+  CompositionApprovalContext,
+  CompositionApprovalPolicy,
+  CompositionCapabilities,
+  CompositionMoment,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "./composition-planner.js";
+```
+
+- [ ] **Step 5: Run the focused core tests to verify they pass**
+
+Run:
+
+```bash
+bun test packages/kernel/core/src/system-signal.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Build `@koi/core` and run API-surface verification**
+
+Run:
+
+```bash
+bun run --cwd packages/kernel/core build
+bun test packages/kernel/core/src/__tests__/api-surface.test.ts
+```
+
+Expected: PASS with snapshot updates only if the new root export changes the generated `.d.ts`.
+
+- [ ] **Step 7: Commit the L0 contract work**
+
+```bash
+git add packages/kernel/core/src/composition-planner.ts \
+  packages/kernel/core/src/index.ts \
+  packages/kernel/core/src/system-signal.test.ts
+git commit -m "feat(core): add composition planning contracts"
+```
+
+---
+
+### Task 2: Add SystemSignal to CompositionTrigger Mapping
+
+**Files:**
+- Create: `packages/lib/proactive/src/composition-trigger.ts`
+- Create: `packages/lib/proactive/src/composition-trigger.test.ts`
+- Modify: `packages/lib/proactive/src/index.ts`
+
+- [ ] **Step 1: Write failing mapper tests**
+
+Create `packages/lib/proactive/src/composition-trigger.test.ts` with focused normalization cases:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
+
+describe("mapSystemSignalToCompositionTrigger", () => {
+  test("maps governance threshold crossings", () => {
+    const trigger = mapSystemSignalToCompositionTrigger({
+      kind: "governance",
+      sensor: "error_rate",
+      value: 0.4,
+      limit: 0.2,
+      direction: "above",
+      emittedAt: 123,
+    });
+
+    expect(trigger).toEqual({
+      id: "governance:error_rate:123",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.4,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 123,
+    });
+  });
+
+  test("maps forge demand to capability_gap", () => {
+    const trigger = mapSystemSignalToCompositionTrigger({
+      id: "fd-1",
+      kind: "forge_demand",
+      confidence: 0.7,
+      suggestedBrickKind: "skill",
+      trigger: { kind: "capability_gap", requiredCapability: "diagnostics" },
+      context: { failureCount: 2, failedToolCalls: [] },
+      emittedAt: 50,
+    });
+
+    expect(trigger?.moment).toEqual({ kind: "capability_gap", missing: "diagnostics" });
+    expect(trigger?.context).toMatchObject({ forgeDemand: { id: "fd-1" } });
+  });
+
+  test("maps schedule terminal failure to task_terminal", () => {
+    const trigger = mapSystemSignalToCompositionTrigger({
+      kind: "schedule",
+      event: { kind: "task:failed", taskId: "task-1" as never, error: { message: "boom" } as never },
+      emittedAt: 77,
+    });
+
+    expect(trigger?.moment).toEqual({
+      kind: "task_terminal",
+      taskId: "task-1",
+      outcome: "failed",
+    });
+  });
+
+  test("ignores agent lifecycle in the first pass", () => {
+    const trigger = mapSystemSignalToCompositionTrigger({
+      kind: "agent_lifecycle",
+      agentId: "a-1" as never,
+      from: "created",
+      to: "running",
+      reason: "started" as never,
+      generation: 1,
+      emittedAt: 10,
+    });
+
+    expect(trigger).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the mapper test to verify it fails**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/composition-trigger.test.ts
+```
+
+Expected: FAIL with missing module/export errors for `./composition-trigger.js`.
+
+- [ ] **Step 3: Implement the mapper**
+
+Create `packages/lib/proactive/src/composition-trigger.ts`:
+
+```ts
+import type { CompositionTrigger, ForgeTrigger, SystemSignal } from "@koi/core";
+
+function capabilityFromForgeTrigger(trigger: ForgeTrigger): string | undefined {
+  switch (trigger.kind) {
+    case "capability_gap":
+    case "composition_gap":
+      return trigger.requiredCapability;
+    case "agent_capability_gap":
+      return trigger.agentType;
+    case "data_source_gap":
+      return trigger.missingCapability;
+    case "no_matching_tool":
+      return trigger.query;
+    default:
+      return undefined;
+  }
+}
+
+export function mapSystemSignalToCompositionTrigger(
+  signal: SystemSignal,
+): CompositionTrigger | undefined {
+  switch (signal.kind) {
+    case "governance":
+      return {
+        id: `governance:${signal.sensor}:${String(signal.emittedAt)}`,
+        source: "governance",
+        confidence: 1,
+        moment: {
+          kind: "threshold_crossed",
+          sensor: signal.sensor,
+          value: signal.value,
+          limit: signal.limit,
+          direction: signal.direction,
+        },
+        suggestedCapabilities:
+          signal.sensor === "error_rate" ? ["spawn_agent", "notify_user"] : [],
+        context: {},
+        emittedAt: signal.emittedAt,
+      };
+    case "forge_demand": {
+      const missing = capabilityFromForgeTrigger(signal.trigger) ?? "unknown-capability";
+      return {
+        id: signal.id,
+        source: "forge_demand",
+        confidence: signal.confidence,
+        moment: { kind: "capability_gap", missing },
+        suggestedCapabilities: ["forge_skill"],
+        context: { forgeDemand: signal },
+        emittedAt: signal.emittedAt,
+      };
+    }
+    case "schedule":
+      return {
+        id: `schedule:${String(signal.event.taskId)}:${String(signal.emittedAt)}`,
+        source: "schedule",
+        confidence: 1,
+        moment: {
+          kind: "task_terminal",
+          taskId: signal.event.taskId,
+          outcome: signal.event.kind === "task:completed"
+            ? "completed"
+            : signal.event.kind === "task:failed"
+              ? "failed"
+              : signal.event.kind === "task:dead_letter"
+                ? "dead_letter"
+                : "cancelled",
+        },
+        suggestedCapabilities:
+          signal.event.kind === "task:completed" ? [] : ["spawn_agent", "notify_user"],
+        context: { schedulerEvent: signal.event },
+        emittedAt: signal.emittedAt,
+      };
+    case "vfs":
+    case "agent_lifecycle":
+    case "compaction":
+      return undefined;
+    case "anomaly":
+      return undefined;
+  }
+}
+```
+
+- [ ] **Step 4: Export the mapper from proactive**
+
+Update `packages/lib/proactive/src/index.ts`:
+
+```ts
+export { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
+```
+
+- [ ] **Step 5: Run the mapper test and package smoke tests**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/composition-trigger.test.ts \
+  packages/lib/proactive/src/create-proactive-tools.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the mapper work**
+
+```bash
+git add packages/lib/proactive/src/composition-trigger.ts \
+  packages/lib/proactive/src/composition-trigger.test.ts \
+  packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): map system signals to composition triggers"
+```
+
+---
+
+### Task 3: Add Approval Helper and Rule-Based Planner
+
+**Files:**
+- Create: `packages/lib/proactive/src/composition-approval.ts`
+- Create: `packages/lib/proactive/src/composition-approval.test.ts`
+- Create: `packages/lib/proactive/src/rule-based-composition-planner.ts`
+- Create: `packages/lib/proactive/src/rule-based-composition-planner.test.ts`
+- Modify: `packages/lib/proactive/src/index.ts`
+
+- [ ] **Step 1: Write failing approval helper tests**
+
+Create `packages/lib/proactive/src/composition-approval.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { computeCompositionApproval } from "./composition-approval.js";
+
+const trigger = {
+  id: "t-1",
+  source: "governance",
+  confidence: 0.9,
+  moment: { kind: "capability_gap", missing: "diagnostics" },
+  suggestedCapabilities: [],
+  context: {},
+  emittedAt: 1,
+} as const;
+
+describe("computeCompositionApproval", () => {
+  test("requires approval below confidence threshold", () => {
+    expect(
+      computeCompositionApproval({ ...trigger, confidence: 0.2 }, 1, {
+        confidenceThreshold: 0.5,
+        maxEstimatedCost: 10,
+        requireApprovalOnNovelty: false,
+      }, { isNovel: false }),
+    ).toBe(true);
+  });
+
+  test("requires approval above cost budget", () => {
+    expect(
+      computeCompositionApproval(trigger, 100, {
+        confidenceThreshold: 0.5,
+        maxEstimatedCost: 10,
+        requireApprovalOnNovelty: false,
+      }, { isNovel: false }),
+    ).toBe(true);
+  });
+
+  test("requires approval on novelty when configured", () => {
+    expect(
+      computeCompositionApproval(trigger, 1, {
+        confidenceThreshold: 0.5,
+        maxEstimatedCost: 10,
+        requireApprovalOnNovelty: true,
+      }, { isNovel: true }),
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Write failing rule-planner tests**
+
+Create `packages/lib/proactive/src/rule-based-composition-planner.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_DELIVERY_POLICY } from "@koi/core";
+import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
+
+describe("createRuleBasedCompositionPlanner", () => {
+  test("plans forge for capability gaps", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const plan = await planner.plan(
+      {
+        id: "gap-1",
+        source: "forge_demand",
+        confidence: 0.9,
+        moment: { kind: "capability_gap", missing: "diagnostics" },
+        suggestedCapabilities: ["forge_skill"],
+        context: {
+          forgeDemand: {
+            id: "fd-1",
+            kind: "forge_demand",
+            confidence: 0.9,
+            suggestedBrickKind: "skill",
+            trigger: { kind: "capability_gap", requiredCapability: "diagnostics" },
+            context: { failureCount: 1, failedToolCalls: [] },
+            emittedAt: 1,
+          },
+        },
+        emittedAt: 1,
+      },
+      { tools: [], agents: [], schedules: [] },
+    );
+
+    expect(plan.steps[0]).toMatchObject({ kind: "forge_skill" });
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("plans diagnostic spawn for error-rate thresholds", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const plan = await planner.plan(
+      {
+        id: "gov-1",
+        source: "governance",
+        confidence: 1,
+        moment: {
+          kind: "threshold_crossed",
+          sensor: "error_rate",
+          value: 0.6,
+          limit: 0.2,
+          direction: "above",
+        },
+        suggestedCapabilities: ["spawn_agent", "notify_user"],
+        context: {},
+        emittedAt: 1,
+      },
+      { tools: [], agents: [], schedules: [] },
+    );
+
+    expect(plan.steps).toContainEqual({
+      kind: "spawn_agent",
+      agentType: "diagnostic",
+      input: { kind: "text", text: "Investigate elevated error_rate and summarize root causes." },
+      delivery: DEFAULT_DELIVERY_POLICY,
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/composition-approval.test.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.test.ts
+```
+
+Expected: FAIL with missing module/export errors.
+
+- [ ] **Step 4: Implement the shared approval helper**
+
+Create `packages/lib/proactive/src/composition-approval.ts`:
+
+```ts
+import type {
+  CompositionApprovalContext,
+  CompositionApprovalPolicy,
+  CompositionTrigger,
+} from "@koi/core";
+
+export const DEFAULT_COMPOSITION_APPROVAL_POLICY: CompositionApprovalPolicy = {
+  confidenceThreshold: 0.5,
+  maxEstimatedCost: 10,
+  requireApprovalOnNovelty: true,
+} as const;
+
+export function computeCompositionApproval(
+  trigger: CompositionTrigger,
+  estimatedCost: number,
+  policy: CompositionApprovalPolicy,
+  context: CompositionApprovalContext,
+): boolean {
+  if (trigger.confidence < policy.confidenceThreshold) return true;
+  if (estimatedCost > policy.maxEstimatedCost) return true;
+  if (policy.requireApprovalOnNovelty && context.isNovel) return true;
+  return false;
+}
+```
+
+- [ ] **Step 5: Implement the rule-based planner**
+
+Create `packages/lib/proactive/src/rule-based-composition-planner.ts`:
+
+```ts
+import type {
+  CompositionApprovalPolicy,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "@koi/core";
+import { DEFAULT_DELIVERY_POLICY } from "@koi/core";
+import {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
+
+export interface RuleBasedCompositionPlannerConfig {
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+}
+
+function estimateCost(steps: readonly CompositionStep[]): number {
+  return steps.reduce((total, step) => {
+    switch (step.kind) {
+      case "notify_user":
+        return total + 1;
+      case "tool_call":
+        return total + 2;
+      case "forge_skill":
+        return total + 4;
+      case "submit_task":
+      case "create_schedule":
+        return total + 3;
+      case "spawn_agent":
+        return total + 5;
+    }
+  }, 0);
+}
+
+export function createRuleBasedCompositionPlanner(
+  config: RuleBasedCompositionPlannerConfig = {},
+): CompositionPlanner {
+  const approvalPolicy = config.approvalPolicy ?? DEFAULT_COMPOSITION_APPROVAL_POLICY;
+  const classifyNovelty = config.classifyNovelty ?? (() => false);
+
+  return {
+    async plan(trigger, _capabilities): Promise<CompositionPlan> {
+      const steps: CompositionStep[] = [];
+
+      switch (trigger.moment.kind) {
+        case "capability_gap":
+          if ("forgeDemand" in trigger.context) {
+            steps.push({ kind: "forge_skill", demand: trigger.context.forgeDemand as never });
+          }
+          break;
+        case "threshold_crossed":
+          if (trigger.moment.sensor === "error_rate" && trigger.moment.direction === "above") {
+            steps.push({
+              kind: "spawn_agent",
+              agentType: "diagnostic",
+              input: {
+                kind: "text",
+                text: "Investigate elevated error_rate and summarize root causes.",
+              },
+              delivery: DEFAULT_DELIVERY_POLICY,
+            });
+            steps.push({
+              kind: "notify_user",
+              channel: "inbox",
+              message: "Error rate crossed its configured threshold.",
+              priority: "high",
+            });
+          }
+          break;
+        case "task_terminal":
+          if (trigger.moment.outcome !== "completed") {
+            steps.push({
+              kind: "spawn_agent",
+              agentType: "recovery",
+              input: {
+                kind: "text",
+                text: `Analyze failed scheduled task ${String(trigger.moment.taskId)} and propose recovery.`,
+              },
+              delivery: DEFAULT_DELIVERY_POLICY,
+            });
+          }
+          break;
+        case "frontier_changed":
+          steps.push({
+            kind: "spawn_agent",
+            agentType: "researcher",
+            input: {
+              kind: "text",
+              text: `Investigate frontier change in ${trigger.moment.metric}.`,
+            },
+            delivery: { kind: "deferred" },
+          });
+          break;
+        case "pattern_matched":
+        case "external_event":
+          break;
+      }
+
+      const estimatedCost = estimateCost(steps);
+      return {
+        triggerId: trigger.id,
+        steps,
+        estimatedCost,
+        requiresApproval:
+          steps.length === 0 ||
+          computeCompositionApproval(trigger, estimatedCost, approvalPolicy, {
+            isNovel: classifyNovelty(trigger),
+          }),
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Export the helper and planner**
+
+Update `packages/lib/proactive/src/index.ts`:
+
+```ts
+export {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
+export {
+  createRuleBasedCompositionPlanner,
+  type RuleBasedCompositionPlannerConfig,
+} from "./rule-based-composition-planner.js";
+```
+
+- [ ] **Step 7: Run the focused proactive tests**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/composition-approval.test.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 8: Commit the deterministic planning work**
+
+```bash
+git add packages/lib/proactive/src/composition-approval.ts \
+  packages/lib/proactive/src/composition-approval.test.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.test.ts \
+  packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): add rule-based composition planner"
+```
+
+---
+
+### Task 4: Add the LLM-Backed Planner With Validation and Fallback
+
+**Files:**
+- Create: `packages/lib/proactive/src/llm-composition-planner.ts`
+- Create: `packages/lib/proactive/src/llm-composition-planner.test.ts`
+- Modify: `packages/lib/proactive/src/index.ts`
+
+- [ ] **Step 1: Write failing LLM planner tests**
+
+Create `packages/lib/proactive/src/llm-composition-planner.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createLlmCompositionPlanner } from "./llm-composition-planner.js";
+import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
+
+describe("createLlmCompositionPlanner", () => {
+  test("returns a validated plan from adapter JSON", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "gov-1",
+            steps: [
+              {
+                kind: "notify_user",
+                channel: "inbox",
+                message: "Threshold crossed",
+                priority: "high",
+              },
+            ],
+            estimatedCost: 2,
+            requiresApproval: false,
+          });
+        },
+      },
+    });
+
+    const plan = await planner.plan(
+      {
+        id: "gov-1",
+        source: "governance",
+        confidence: 1,
+        moment: {
+          kind: "threshold_crossed",
+          sensor: "error_rate",
+          value: 0.5,
+          limit: 0.2,
+          direction: "above",
+        },
+        suggestedCapabilities: [],
+        context: {},
+        emittedAt: 1,
+      },
+      { tools: [], agents: [], schedules: [] },
+    );
+
+    expect(plan.triggerId).toBe("gov-1");
+    expect(plan.steps[0]).toMatchObject({ kind: "notify_user" });
+  });
+
+  test("falls back to the rule planner on malformed JSON", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: { async plan(): Promise<string> { return "{bad json"; } },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const plan = await planner.plan(
+      {
+        id: "gov-1",
+        source: "governance",
+        confidence: 1,
+        moment: {
+          kind: "threshold_crossed",
+          sensor: "error_rate",
+          value: 0.5,
+          limit: 0.2,
+          direction: "above",
+        },
+        suggestedCapabilities: ["spawn_agent"],
+        context: {},
+        emittedAt: 1,
+      },
+      { tools: [], agents: [], schedules: [] },
+    );
+
+    expect(plan.steps.some((step) => step.kind === "spawn_agent")).toBe(true);
+  });
+
+  test("recomputes requiresApproval locally", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "low-1",
+            steps: [],
+            estimatedCost: 0,
+            requiresApproval: false,
+          });
+        },
+      },
+    });
+
+    const plan = await planner.plan(
+      {
+        id: "low-1",
+        source: "governance",
+        confidence: 0.1,
+        moment: { kind: "capability_gap", missing: "diagnostics" },
+        suggestedCapabilities: [],
+        context: {},
+        emittedAt: 1,
+      },
+      { tools: [], agents: [], schedules: [] },
+    );
+
+    expect(plan.requiresApproval).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the LLM planner tests to verify they fail**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/llm-composition-planner.test.ts
+```
+
+Expected: FAIL with missing module/export errors.
+
+- [ ] **Step 3: Implement the validated LLM planner**
+
+Create `packages/lib/proactive/src/llm-composition-planner.ts`:
+
+```ts
+import type {
+  CompositionApprovalPolicy,
+  CompositionCapabilities,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "@koi/core";
+import {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
+
+export interface CompositionPlannerAdapterInput {
+  readonly trigger: CompositionTrigger;
+  readonly capabilities: CompositionCapabilities;
+}
+
+export interface CompositionPlannerAdapter {
+  readonly plan: (input: CompositionPlannerAdapterInput) => Promise<string>;
+}
+
+export interface LlmCompositionPlannerConfig {
+  readonly adapter: CompositionPlannerAdapter;
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+  readonly fallbackToRulePlanner?: CompositionPlanner | undefined;
+}
+
+function isPriority(value: unknown): value is "low" | "normal" | "high" {
+  return value === "low" || value === "normal" || value === "high";
+}
+
+function validateSteps(raw: unknown): readonly CompositionStep[] {
+  if (!Array.isArray(raw)) throw new Error("steps must be an array");
+  return raw.map((step) => {
+    if (typeof step !== "object" || step === null) throw new Error("step must be an object");
+    const value = step as Record<string, unknown>;
+    if (value.kind === "notify_user") {
+      if (
+        typeof value.channel !== "string" ||
+        typeof value.message !== "string" ||
+        !isPriority(value.priority)
+      ) {
+        throw new Error("invalid notify_user step");
+      }
+      return {
+        kind: "notify_user",
+        channel: value.channel,
+        message: value.message,
+        priority: value.priority,
+      };
+    }
+    throw new Error(`unsupported step kind: ${String(value.kind)}`);
+  });
+}
+
+function parsePlan(raw: string, trigger: CompositionTrigger): Omit<CompositionPlan, "requiresApproval"> {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  if (parsed.triggerId !== trigger.id) throw new Error("triggerId mismatch");
+  if (typeof parsed.estimatedCost !== "number" || !Number.isFinite(parsed.estimatedCost)) {
+    throw new Error("estimatedCost must be finite");
+  }
+  return {
+    triggerId: trigger.id,
+    steps: validateSteps(parsed.steps),
+    estimatedCost: parsed.estimatedCost,
+  };
+}
+
+export function createLlmCompositionPlanner(config: LlmCompositionPlannerConfig): CompositionPlanner {
+  const approvalPolicy = config.approvalPolicy ?? DEFAULT_COMPOSITION_APPROVAL_POLICY;
+  const classifyNovelty = config.classifyNovelty ?? (() => false);
+
+  return {
+    async plan(trigger, capabilities): Promise<CompositionPlan> {
+      try {
+        const raw = await config.adapter.plan({ trigger, capabilities });
+        const parsed = parsePlan(raw, trigger);
+        return {
+          ...parsed,
+          requiresApproval: computeCompositionApproval(
+            trigger,
+            parsed.estimatedCost,
+            approvalPolicy,
+            { isNovel: classifyNovelty(trigger) },
+          ),
+        };
+      } catch (error) {
+        if (config.fallbackToRulePlanner !== undefined) {
+          return config.fallbackToRulePlanner.plan(trigger, capabilities);
+        }
+        throw error;
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Export the LLM planner**
+
+Update `packages/lib/proactive/src/index.ts`:
+
+```ts
+export {
+  createLlmCompositionPlanner,
+  type CompositionPlannerAdapter,
+  type CompositionPlannerAdapterInput,
+  type LlmCompositionPlannerConfig,
+} from "./llm-composition-planner.js";
+```
+
+- [ ] **Step 5: Run the LLM planner tests**
+
+Run:
+
+```bash
+bun test packages/lib/proactive/src/llm-composition-planner.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the LLM planner work**
+
+```bash
+git add packages/lib/proactive/src/llm-composition-planner.ts \
+  packages/lib/proactive/src/llm-composition-planner.test.ts \
+  packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): add llm composition planner"
+```
+
+---
+
+### Task 5: Run Package Verification and Final Cleanup
+
+**Files:**
+- Verify only: `packages/kernel/core/src/composition-planner.ts`
+- Verify only: `packages/lib/proactive/src/*.ts`
+
+- [ ] **Step 1: Run the focused test suite for all new behavior**
+
+Run:
+
+```bash
+bun test packages/kernel/core/src/system-signal.test.ts \
+  packages/lib/proactive/src/composition-trigger.test.ts \
+  packages/lib/proactive/src/composition-approval.test.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.test.ts \
+  packages/lib/proactive/src/llm-composition-planner.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run package typechecks**
+
+Run:
+
+```bash
+bun run --cwd packages/kernel/core typecheck
+bun run --cwd packages/lib/proactive typecheck
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Run package builds**
+
+Run:
+
+```bash
+bun run --cwd packages/kernel/core build
+bun run --cwd packages/lib/proactive build
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Run package lint checks if prior steps are green**
+
+Run:
+
+```bash
+bun run --cwd packages/kernel/core lint
+bun run --cwd packages/lib/proactive lint
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Confirm git status is limited to intended files**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only the new composition-planner and proactive planning files, plus any intentional snapshot updates.
+
+- [ ] **Step 6: Create the final feature commit**
+
+```bash
+git add packages/kernel/core/src/composition-planner.ts \
+  packages/kernel/core/src/index.ts \
+  packages/kernel/core/src/system-signal.test.ts \
+  packages/lib/proactive/src/composition-trigger.ts \
+  packages/lib/proactive/src/composition-trigger.test.ts \
+  packages/lib/proactive/src/composition-approval.ts \
+  packages/lib/proactive/src/composition-approval.test.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.ts \
+  packages/lib/proactive/src/rule-based-composition-planner.test.ts \
+  packages/lib/proactive/src/llm-composition-planner.ts \
+  packages/lib/proactive/src/llm-composition-planner.test.ts \
+  packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): add composition planning"
+```
+
+---
+
+## Self-Review
+
+### Spec Coverage
+
+- L0 `CompositionTrigger` contract: covered in Task 1
+- `SystemSignal -> CompositionTrigger` mapper: covered in Task 2
+- Rule-based planner: covered in Task 3
+- LLM planner with validation/fallback: covered in Task 4
+- Approval classification: covered in Task 3 and exercised again in Task 4
+- Verification/build/typecheck: covered in Task 5
+
+### Placeholder Scan
+
+- No `TBD`, `TODO`, or “implement later” placeholders remain
+- Each task includes exact files, commands, and code snippets
+
+### Type Consistency
+
+- `task_terminal` is used consistently across contract, mapper, and planner steps
+- `submit_task` / `create_schedule` are the only scheduler-related step names in the plan
+- `CompositionPlannerAdapterInput` and `LlmCompositionPlannerConfig` naming is consistent across Task 4

--- a/docs/superpowers/specs/2026-05-06-composition-planner-design.md
+++ b/docs/superpowers/specs/2026-05-06-composition-planner-design.md
@@ -1,0 +1,427 @@
+# Composition Planner Design
+
+## Summary
+
+Issue `#1299` adds the missing bridge between raw system signals and autonomous multi-capability planning. Koi already has pieces that detect demand and operational state changes, but it does not yet normalize those events into a stable planning contract or generate composition plans that combine tools, agent spawns, scheduling, forge, and user notification.
+
+This design introduces:
+
+- a new L0 `CompositionTrigger` contract in `@koi/core`
+- a normalized `SystemSignal -> CompositionTrigger` mapping utility in `@koi/proactive`
+- a `CompositionPlanner` contract with both deterministic rule-based and optional LLM-backed implementations
+- explicit approval classification based on confidence, estimated cost, and novelty
+
+Execution remains out of scope. This work stops at validated plan generation.
+
+## Goals
+
+- Normalize planner-relevant `SystemSignal` events into a stable L0 trigger contract
+- Generate `CompositionPlan` values that describe multi-step autonomous actions without executing them
+- Ship a deterministic default planner that works without model access
+- Ship an optional adapter-driven LLM planner that can reason over available capabilities and produce structured plans
+- Keep approval decisions explicit and testable
+- Fit existing Koi contracts for `EngineInput`, `DeliveryPolicy`, `ToolDescriptor`, `RegistryEntry`, `CronSchedule`, and `ForgeDemandSignal`
+
+## Non-Goals
+
+- Executing composition plans
+- Adding new `SystemSignalSource` implementations
+- Persisting novelty history or learning state
+- Wiring planner execution into ACE, runtime, scheduler, or daemon flows
+- Introducing runtime dependencies from `@koi/core`
+
+## Current Repo Context
+
+Relevant existing contracts and packages:
+
+- [packages/kernel/core/src/system-signal.ts](/Users/sophiawj/.codex/worktrees/9345/koi/packages/kernel/core/src/system-signal.ts) defines raw system-facing events
+- [packages/kernel/core/src/forge-demand.ts](/Users/sophiawj/.codex/worktrees/9345/koi/packages/kernel/core/src/forge-demand.ts) already models demand-triggered forge signals
+- [packages/kernel/core/src/scheduler.ts](/Users/sophiawj/.codex/worktrees/9345/koi/packages/kernel/core/src/scheduler.ts) defines `ScheduleId`, `CronSchedule`, and scheduler event shapes
+- [packages/kernel/core/src/engine.ts](/Users/sophiawj/.codex/worktrees/9345/koi/packages/kernel/core/src/engine.ts) defines `EngineInput`
+- `DeliveryPolicy` and spawn delivery wiring already exist in `@koi/engine`
+- [packages/lib/proactive/src/index.ts](/Users/sophiawj/.codex/worktrees/9345/koi/packages/lib/proactive/src/index.ts) currently exports sleep/cron tools only
+
+The issue body references `.claude/plans/v2-rewrite.md`, but that file is not present in this checkout. The design therefore anchors on the current codebase rather than that missing document.
+
+## Design Overview
+
+The design splits the problem into three layers:
+
+1. Raw event contract: `SystemSignal` stays the source-facing event vocabulary.
+2. Normalized planning contract: `CompositionTrigger` becomes the planner-facing L0 vocabulary.
+3. Planner implementations: `@koi/proactive` converts signals into triggers, then produces plans using either deterministic rules or an injected LLM adapter.
+
+This keeps signal ingestion, planning, and execution as distinct responsibilities:
+
+- signal adapters emit `SystemSignal`
+- the mapper normalizes to `CompositionTrigger`
+- planners produce `CompositionPlan`
+- a future executor consumes `CompositionPlan`
+
+## L0 Contract Additions
+
+Add a new source file in `@koi/core` for composition planning types. These are L0 because they are shared contracts, not proactive-specific implementation details.
+
+### CompositionTrigger
+
+```ts
+export interface CompositionTrigger {
+  readonly id: string;
+  readonly source: string;
+  readonly confidence: number;
+  readonly moment: CompositionMoment;
+  readonly suggestedCapabilities: readonly string[];
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly emittedAt: number;
+}
+```
+
+### CompositionMoment
+
+```ts
+export type CompositionMoment =
+  | { readonly kind: "capability_gap"; readonly missing: string }
+  | {
+      readonly kind: "threshold_crossed";
+      readonly sensor: string;
+      readonly value: number;
+      readonly limit: number;
+      readonly direction: "above" | "below";
+    }
+  | { readonly kind: "pattern_matched"; readonly patternId: string; readonly description: string }
+  | {
+      readonly kind: "task_terminal";
+      readonly taskId: TaskId;
+      readonly outcome: "completed" | "failed" | "dead_letter" | "cancelled";
+    }
+  | { readonly kind: "external_event"; readonly source: string; readonly eventType: string }
+  | { readonly kind: "frontier_changed"; readonly metric: string; readonly improvement: number };
+```
+
+### Why `task_terminal` instead of `schedule_fired`
+
+The issue draft used `schedule_fired`, but the current `SystemSignal` contract exposes scheduler-relevant composition events as terminal task outcomes, not raw cron firings. Matching the current contract avoids inventing an event shape that no existing upstream source produces.
+
+### CompositionCapabilities
+
+```ts
+export interface CompositionCapabilities {
+  readonly tools: readonly ToolDescriptor[];
+  readonly agents: readonly RegistryEntry[];
+  readonly schedules: readonly CronSchedule[];
+  readonly forgeStore?: ForgeStore | undefined;
+}
+```
+
+### CompositionPlan and Steps
+
+```ts
+export interface CompositionPlan {
+  readonly triggerId: string;
+  readonly steps: readonly CompositionStep[];
+  readonly estimatedCost: number;
+  readonly requiresApproval: boolean;
+}
+
+export type CompositionStep =
+  | { readonly kind: "tool_call"; readonly toolName: string; readonly input: unknown }
+  | {
+      readonly kind: "spawn_agent";
+      readonly agentType: string;
+      readonly input: EngineInput;
+      readonly delivery: DeliveryPolicy;
+    }
+  | {
+      readonly kind: "submit_task";
+      readonly agentId: AgentId;
+      readonly input: EngineInput;
+      readonly delayMs: number;
+    }
+  | {
+      readonly kind: "create_schedule";
+      readonly expression: string;
+      readonly agentId: AgentId;
+      readonly input: EngineInput;
+      readonly timezone?: string | undefined;
+    }
+  | { readonly kind: "forge_skill"; readonly demand: ForgeDemandSignal }
+  | {
+      readonly kind: "notify_user";
+      readonly channel: string;
+      readonly message: string;
+      readonly priority: "low" | "normal" | "high";
+    };
+```
+
+### Why split scheduling into `submit_task` and `create_schedule`
+
+The current scheduler contract distinguishes one-shot delayed submission from recurring cron registration. A single generic `schedule_task` step would blur those two primitives and make executor work harder later.
+
+### Planner Contracts
+
+```ts
+export interface CompositionPlanner {
+  readonly plan: (
+    trigger: CompositionTrigger,
+    capabilities: CompositionCapabilities,
+  ) => Promise<CompositionPlan>;
+}
+
+export interface CompositionApprovalPolicy {
+  readonly confidenceThreshold: number;
+  readonly maxEstimatedCost: number;
+  readonly requireApprovalOnNovelty: boolean;
+}
+
+export interface CompositionApprovalContext {
+  readonly isNovel: boolean;
+}
+```
+
+The novelty input is explicit rather than inferred from persistence. That keeps this contract usable before any ACE learning loop or plan-history store exists.
+
+## Mapper Design
+
+Add a mapper module to `@koi/proactive`:
+
+```ts
+mapSystemSignalToCompositionTrigger(
+  signal: SystemSignal,
+): CompositionTrigger | undefined
+```
+
+This function is pure, deterministic, and side-effect free.
+
+### Mapping Rules
+
+- `SystemSignal.kind === "governance"`:
+  - map to `threshold_crossed`
+  - source becomes `"governance"`
+  - suggested capabilities depend on the sensor name when obvious, otherwise empty
+- `SystemSignal.kind === "forge_demand"`:
+  - map to `capability_gap`
+  - `missing` comes from the most specific trigger field available
+  - preserve the original `ForgeDemandSignal` inside `context`
+- `SystemSignal.kind === "schedule"`:
+  - map terminal scheduler outcomes to `task_terminal`
+- `SystemSignal.kind === "vfs"`:
+  - ignore in this first pass unless a future adapter promotes it to a stronger pattern signal
+- `SystemSignal.kind === "agent_lifecycle"`:
+  - ignore in the first pass
+- `SystemSignal.kind === "anomaly"`:
+  - map only anomaly shapes that clearly imply threshold or frontier movement; otherwise ignore
+- `SystemSignal.kind === "compaction"`:
+  - ignore in the first pass
+
+### Forge Demand Mapping
+
+Forge demand is treated as a subset of composition rather than a parallel planner input. The mapper turns a forge-demand signal into a normalized `CompositionTrigger` with `moment.kind = "capability_gap"`, which lets the planner consider forge as one possible step in a broader plan.
+
+## Rule-Based Planner Design
+
+The deterministic planner is the default implementation and lives in `@koi/proactive`.
+
+Suggested public factory:
+
+```ts
+createRuleBasedCompositionPlanner(config?: {
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+}): CompositionPlanner
+```
+
+### Rule Table
+
+- `capability_gap`
+  - produce a plan containing `forge_skill`
+  - optionally add `notify_user` for high-confidence missing capability scenarios
+- `threshold_crossed`
+  - if the sensor implies failure or degradation, spawn a diagnostic agent
+  - if the sensor implies resource pressure, notify the user and optionally schedule follow-up work
+- `pattern_matched`
+  - produce the specific combination implied by the pattern
+  - first pass can support a small hard-coded table keyed by `patternId`
+- `task_terminal` with failed or dead-letter outcome
+  - spawn a recovery or analysis agent
+  - optionally notify the user for repeated failures
+- `frontier_changed`
+  - spawn a researcher or replicator agent with a deferred or streaming delivery policy depending on urgency
+- `external_event`
+  - reserved for downstream callers that generate normalized external triggers directly
+
+### Rule Planner Behavior
+
+- Always return a valid `CompositionPlan`
+- Prefer empty `steps` plus `requiresApproval: true` over speculative behavior when a trigger is recognized but under-specified
+- Estimate cost with simple additive heuristics based on step kinds
+- Compute `requiresApproval` using:
+  - trigger confidence below threshold
+  - cost over budget
+  - novelty classification when configured
+
+## LLM Planner Design
+
+The optional LLM planner should be adapter-driven, similar in spirit to the archived ACE reflector pattern, but specialized for structured composition planning rather than reflection.
+
+### Public Shape
+
+```ts
+export interface CompositionPlannerAdapter {
+  readonly plan: (input: CompositionPlannerAdapterInput) => Promise<string>;
+}
+
+export interface CompositionPlannerAdapterInput {
+  readonly trigger: CompositionTrigger;
+  readonly capabilities: CompositionCapabilities;
+}
+
+createLlmCompositionPlanner(config: {
+  readonly adapter: CompositionPlannerAdapter;
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+  readonly fallbackToRulePlanner?: CompositionPlanner | undefined;
+}): CompositionPlanner
+```
+
+### Behavior
+
+- Build a structured prompt from:
+  - normalized trigger
+  - available tools
+  - available agents
+  - schedules
+  - forge availability
+- Require the adapter to return JSON only
+- Parse and validate the JSON into a `CompositionPlan`
+- Reject malformed output
+- If a fallback planner is configured, use it on parse/validation failure
+- Recompute `requiresApproval` after parsing so model output cannot bypass planner policy
+
+### Validation
+
+The LLM planner must not trust arbitrary model output. It should validate:
+
+- trigger ID matches the input trigger
+- step kinds are known
+- required fields exist for each step kind
+- `estimatedCost` is finite and non-negative
+- `requiresApproval` is overwritten by local policy calculation
+
+## Approval Policy
+
+Approval classification belongs to the planner layer in this first pass.
+
+Proposed helper:
+
+```ts
+computeCompositionApproval(
+  trigger: CompositionTrigger,
+  estimatedCost: number,
+  policy: CompositionApprovalPolicy,
+  context: CompositionApprovalContext,
+): boolean
+```
+
+Rules:
+
+- require approval when `trigger.confidence < confidenceThreshold`
+- require approval when `estimatedCost > maxEstimatedCost`
+- require approval when `requireApprovalOnNovelty` and `context.isNovel`
+
+This helper should be shared by both planner implementations so approval behavior stays consistent.
+
+## Error Handling
+
+### Mapper
+
+- Unsupported or intentionally ignored signals return `undefined`
+- No thrown errors for normal unsupported input
+
+### Rule Planner
+
+- Does not throw for known trigger shapes
+- Returns empty-step approval-gated plans for recognized but underspecified scenarios
+
+### LLM Planner
+
+- Parse and validation failures surface as deterministic planner errors or invoke configured fallback
+- Never emit unvalidated plans
+
+## File Layout
+
+### `@koi/core`
+
+- create `packages/kernel/core/src/composition-planner.ts`
+- export the new contracts from the relevant core entrypoint(s) and API surface tests
+
+### `@koi/proactive`
+
+- create `packages/lib/proactive/src/composition-trigger.ts`
+- create `packages/lib/proactive/src/composition-approval.ts`
+- create `packages/lib/proactive/src/rule-based-composition-planner.ts`
+- create `packages/lib/proactive/src/llm-composition-planner.ts`
+- update `packages/lib/proactive/src/index.ts`
+
+File responsibilities:
+
+- `composition-trigger.ts`: normalization only
+- `composition-approval.ts`: shared approval logic only
+- `rule-based-composition-planner.ts`: deterministic planner only
+- `llm-composition-planner.ts`: adapter prompt/parse/validate/fallback only
+
+## Testing Strategy
+
+### Core
+
+- API surface tests for newly exported contracts
+- Any type helper tests only if helpers are added in L0
+
+### Proactive Mapper
+
+Add table-driven tests covering:
+
+- governance threshold signal to `threshold_crossed`
+- forge demand to `capability_gap`
+- scheduler terminal completed/failed/dead-letter/cancelled to `task_terminal`
+- ignored signals returning `undefined`
+
+### Rule Planner
+
+Add deterministic tests asserting exact plans for:
+
+- capability gap
+- failure threshold crossed
+- frontier changed
+- approval required by low confidence
+- approval required by high cost
+- approval required by novelty
+
+### LLM Planner
+
+Add mocked-adapter tests for:
+
+- valid structured JSON output
+- malformed JSON
+- structurally invalid JSON
+- fallback-to-rule behavior
+- local approval recomputation overriding model-provided approval
+
+## Open Decisions Resolved In This Design
+
+- Include the optional LLM planner in this first pass: yes
+- Include `SystemSignal -> CompositionTrigger` normalization in this first pass: yes
+- Keep execution out of scope: yes
+- Match scheduler reality with `task_terminal` and split schedule-related step kinds: yes
+
+## Risks
+
+- The first-pass rule table may be intentionally conservative, which can produce empty-step approval-gated plans more often than a richer future planner.
+- An LLM planner without tight validation would be dangerous; this design avoids that by requiring local validation and approval recomputation.
+- Signal-to-trigger mapping will evolve as new `SystemSignal` sources land, so the mapper should stay focused and easily extensible.
+
+## Rollout
+
+1. Land L0 contracts and proactive exports.
+2. Land mapper and rule-based planner with deterministic tests.
+3. Land the optional LLM planner and validation/fallback tests.
+4. Defer executor integration to the follow-up issue.

--- a/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -2,9 +2,10 @@
 
 exports[`@koi/core API surface . has stable type surface 1`] = `
 "export { AdapterCapabilities, AdapterCapability, BackendDescriptor, BackendState, CapabilityRequirements } from './adapter-HASH.js';
-import { S as SessionId, A as AgentId, E as EngineState, P as ProcessState, B as BrickRef, a as PatchableRegistryFields, b as AgentGroupId, T as TransitionReason, c as AgentCondition, d as AgentStatus, R as RegistryEntry, e as Tool, f as SkillComponent, g as AgentDescriptor, I as ImplementationArtifact, h as BrickArtifact, D as DelegationDenyReason, i as PermissionConfig, C as CapabilityProof, j as BrickKind, k as SubsystemToken, l as ToolPolicy, m as Agent, n as ComponentProvider, o as BrickId, p as TaskBoardSnapshot, q as AgentManifest, K as KoiMiddleware, r as AgentRegistry, s as ToolCallId, t as TaskId, u as EngineEvent, v as SupervisionConfig, M as ModelChunk, w as TaskItemId } from './assembly-HASH.js';
-export { x as AGENT_SIGNALS, y as ALL_BRICK_KINDS, z as ANS_SCOPE_PRIORITY, F as AbortReason, G as AdvisoryLock, H as AgentArtifact, J as AgentEnv, L as AgentMessage, N as AgentMessageInput, O as AgentSignal, Q as AnsConfig, U as ApprovalDecision, V as ApprovalHandler, W as ApprovalRequest, X as ArtifactId, Y as ArtifactRef, Z as AskId, _ as AttachResult, $ as BROWSER, a0 as BrickArtifactBase, a1 as BrickComposition, a2 as BrickDisclosureLevel, a3 as BrickDriftContext, a4 as BrickFitnessMetrics, a5 as BrickLifecycle, a6 as BrickPage, a7 as BrickPort, a8 as BrickRegistryBackend, a9 as BrickRegistryChangeEvent, aa as BrickRegistryChangeKind, ab as BrickRegistryReader, ac as BrickRegistryWriter, ad as BrickRequires, ae as BrickSearchQuery, af as BrickSignature, ag as BrickSnapshot, ah as BrickSource, ai as BrickSummary, aj as BrickUpdate, ak as BrowserActionOptions, al as BrowserConsoleEntry, am as BrowserConsoleLevel, an as BrowserConsoleOptions, ao as BrowserConsoleResult, ap as BrowserDriver, aq as BrowserEvaluateOptions, ar as BrowserEvaluateResult, as as BrowserFormField, at as BrowserNavigateOptions, au as BrowserNavigateResult, av as BrowserRefInfo, aw as BrowserScreenshotOptions, ax as BrowserScreenshotResult, ay as BrowserScrollOptions, az as BrowserSnapshotOptions, aA as BrowserSnapshotResult, aB as BrowserTabCloseOptions, aC as BrowserTabFocusOptions, aD as BrowserTabInfo, aE as BrowserTabNewOptions, aF as BrowserTraceOptions, aG as BrowserTraceResult, aH as BrowserTypeOptions, aI as BrowserUploadFile, aJ as BrowserUploadOptions, aK as BrowserWaitOptions, aL as BrowserWaitUntil, aM as COLLECTIVE_MEMORY_DEFAULTS, aN as COMPONENT_PRIORITY, aO as CREDENTIALS, aP as CapabilityConfig, aQ as CapabilityFragment, aR as ChangeNotifier, aS as ChannelConfig, aT as ChannelIdentity, aU as ChildCompletionResult, aV as ChildHandle, aW as ChildIsolation, aX as ChildLifecycleEvent, aY as ChildSpec, aZ as CircuitBreakerConfig, a_ as CleanupPolicy, a$ as CollectiveMemory, b0 as CollectiveMemoryCategory, b1 as CollectiveMemoryDefaults, b2 as CollectiveMemoryEntry, b3 as CollectiveMemorySource, b4 as CompanionSkillDefinition, b5 as ComplianceRecord, b6 as ComplianceRecorder, b7 as ComponentEvent, b8 as ComponentEventKind, b9 as ComposedCallHandlers, ba as CompositeArtifact, bb as CompositionCheck, bc as CompositionError, bd as CompositionErrorKind, be as CompositionOperator, bf as CompositionPort, bg as CompositionWire, bh as CompositionWireEndpoint, bi as ConfigChange, bj as ConstraintChecker, bk as ConstraintQuery, bl as ContentMarker, bm as ContextManifestConfig, bn as ContextPressureTrend, bo as CorrelationIds, bp as CounterExample, bq as CredentialComponent, br as CredentialKind, bs as CredentialRequirement, bt as CronSchedule, bu as DATA_SOURCES, bv as DEFAULT_ANS_CONFIG, bw as DEFAULT_BRICK_FITNESS, bx as DEFAULT_BRICK_SEARCH_LIMIT, by as DEFAULT_CHILD_ISOLATION, bz as DEFAULT_CIRCUIT_BREAKER_CONFIG, bA as DEFAULT_CLEANUP_POLICY, bB as DEFAULT_CLEANUP_TIMEOUT_MS, bC as DEFAULT_COLLECTIVE_MEMORY, bD as DEFAULT_DEGENERACY_CONFIG, bE as DEFAULT_DELIVERY_POLICY, bF as DEFAULT_FORK_MAX_TURNS, bG as DEFAULT_INBOX_POLICY, bH as DEFAULT_MUTATION_PRESSURE_POLICY, bI as DEFAULT_REPUTATION_QUERY_LIMIT, bJ as DEFAULT_SANDBOXED_POLICY, bK as DEFAULT_SCHEDULER_CONFIG, bL as DEFAULT_SKILL_SEARCH_LIMIT, bM as DEFAULT_SUPERVISION_CONFIG, bN as DEFAULT_TASK_BOARD_CONFIG, bO as DEFAULT_TRAIL_CONFIG, bP as DEFAULT_TRAIL_STRENGTH, bQ as DEFAULT_UNSANDBOXED_POLICY, bR as DEFAULT_VIOLATION_QUERY_LIMIT, bS as DELEGATION, bT as DataClassification, bU as DataSourceDescriptor, bV as DataSourceProtocol, bW as DecisionRecord, bX as DeferredDeliveryPolicy, bY as DegeneracyConfig, bZ as DelegationBackend, b_ as DelegationComponent, b$ as DelegationConfig, c0 as DelegationEvent, c1 as DelegationGrant, c2 as DelegationId, c3 as DelegationManagerConfig, c4 as DelegationScope, c5 as DelegationVerifyResult, c6 as DeliveryPolicy, c7 as ENV, c8 as EVENTS, c9 as EXTERNAL_AGENTS, ca as EngineAdapter, cb as EngineCapabilities, cc as EngineInput, cd as EngineInputBase, ce as EngineMetrics, cf as EngineOutput, cg as EngineStopReason, ch as EventComponent, ci as EvolutionKind, cj as ExternalAgentDescriptor, ck as ExternalAgentProtocol, cl as ExternalAgentSource, cm as ExternalAgentTransport, cn as FILESYSTEM, co as FeedbackKind, cp as FileSystemConfig, cq as FilesystemCapability, cr as FilesystemSkillSource, cs as ForgeAttestationSignature, ct as ForgeBuildDefinition, cu as ForgeBuilder, cv as ForgeProvenance, cw as ForgeQuery, cx as ForgeResourceRef, cy as ForgeRunMetadata, cz as ForgeScope, cA as ForgeStageDigest, cB as ForgeStore, cC as ForgeVerificationSummary, cD as ForgedSkillSource, cE as GOVERNANCE, cF as GOVERNANCE_ALLOW, cG as GOVERNANCE_BACKEND, cH as GOVERNANCE_VARIABLES, cI as GovernanceBackend, cJ as GovernanceCheck, cK as GovernanceController, cL as GovernanceEvent, cM as GovernanceSnapshot, cN as GovernanceVariable, cO as GovernanceVariableContributor, cP as GovernanceVerdict, cQ as HANDOFF, cR as HandoffAcceptError, cS as HandoffAcceptResult, cT as HandoffComponent, cU as HandoffEnvelope, cV as HandoffEvent, cW as HandoffId, cX as HandoffStatus, cY as INBOX, cZ as InTotoStatementV1, c_ as InTotoSubject, c$ as InboxComponent, d0 as InboxItem, d1 as InboxMode, d2 as InboxPolicy, d3 as LatencySampler, d4 as LockHandle, d5 as LockMode, d6 as LockRequest, d7 as MAILBOX, d8 as MAX_PIPELINE_LENGTH, d9 as MAX_PIPELINE_STEPS, da as MEMORY, db as MailboxComponent, dc as ManagedTaskBoard, dd as ManifestSandboxConfig, de as ManifestSandboxPersistence, df as ManifestSpawnConfig, dg as MemoryComponent, dh as MemoryRecallOptions, di as MemoryResult, dj as MemoryStoreOptions, dk as MemoryTier, dl as MessageFilter, dm as MessageId, dn as MessageKind, dp as MiddlewareBundle, dq as MiddlewareConfig, dr as MiddlewarePhase, ds as ModelAdapter, dt as ModelConfig, du as ModelContentBlock, dv as ModelHandler, dw as ModelRequest, dx as ModelResponse, dy as ModelStopReason, dz as ModelStreamHandler, dA as ModelTextBlock, dB as ModelThinkingBlock, dC as ModelToolCallBlock, dD as MutationPressure, dE as MutationPressurePolicy, dF as NAME_SERVICE, dG as NameBinding, dH as NameChangeEvent, dI as NameChangeKind, dJ as NameQuery, dK as NameRecord, dL as NameRegistration, dM as NameResolution, dN as NameServiceBackend, dO as NameServiceReader, dP as NameServiceWriter, dQ as NameSuggestion, dR as NamespaceMode, dS as NetworkCapability, dT as OnDemandDeliveryPolicy, dU as PersistentGrant, dV as PersistentGrantCallback, dW as PipelineComposition, dX as PipelineStep, dY as PolicyEvaluator, dZ as PolicyRequest, d_ as PolicyRequestKind, d$ as PolicyValidationResult, e0 as ProcessAccounter, e1 as ProcessDescriptor, e2 as ProcessId, e3 as PublisherId, e4 as REGISTRY, e5 as REPUTATION, e6 as REPUTATION_LEVEL_ORDER, e7 as RESET_BOUNDARIES, e8 as RegistryComponent, e9 as RegistryEvent, ea as RegistryFilter, eb as ReputationBackend, ec as ReputationFeedback, ed as ReputationLevel, ee as ReputationQuery, ef as ReputationQueryResult, eg as ReputationScore, eh as ResolvedWorkspaceConfig, ei as ResourceCapability, ej as RestartType, ek as RevocationRegistry, el as RuleDescriptor, em as RunId, en as SANDBOX_REQUIRED_BY_KIND, eo as SCHEDULER, ep as SCRATCHPAD, eq as SCRATCHPAD_DEFAULTS, er as ScheduleId, es as ScheduleStore, et as ScheduledTask, eu as ScheduledTaskStatus, ev as SchedulerComponent, ew as SchedulerConfig, ex as SchedulerEvent, ey as SchedulerStats, ez as ScopeChecker, eA as ScratchpadChangeEvent, eB as ScratchpadComponent, eC as ScratchpadEntry, eD as ScratchpadEntrySummary, eE as ScratchpadFilter, eF as ScratchpadGeneration, eG as ScratchpadPath, eH as ScratchpadWriteInput, eI as ScratchpadWriteResult, eJ as SearchConfig, eK as SelectionStrategy, eL as SensorReading, eM as SessionContext, eN as ShadowWarning, eO as SignalSink, eP as SignalSource, eQ as SigningBackend, eR as SkillArtifact, eS as SkillConfig, eT as SkillExecutionMode, eU as SkillId, eV as SkillMetadata, eW as SkillPage, eX as SkillPublishRequest, eY as SkillRegistryBackend, eZ as SkillRegistryChangeEvent, e_ as SkillRegistryChangeKind, e$ as SkillRegistryEntry, f0 as SkillRegistryReader, f1 as SkillRegistryWriter, f2 as SkillSearchQuery, f3 as SkillSource, f4 as SkillVersion, f5 as SkippedComponent, f6 as SnapshotEvent, f7 as SnapshotId, f8 as SnapshotQuery, f9 as SnapshotStore, fa as SpawnFn, fb as SpawnInheritanceConfig, fc as SpawnLedger, fd as SpawnRequest, fe as SpawnResult, ff as StopGateResult, fg as StoreChangeEvent, fh as StoreChangeKind, fi as StoreChangeNotifier, fj as StreamingDeliveryPolicy, fk as SupervisionStrategy, fl as TASK_KIND_NAMES, fm as Task, fn as TaskBoard, fo as TaskBoardConfig, fp as TaskBoardEvent, fq as TaskBoardStore, fr as TaskBoardStoreEvent, fs as TaskBoardStoreFilter, ft as TaskBoardStoreNotifier, fu as TaskFilter, fv as TaskHistoryFilter, fw as TaskInput, fx as TaskItem, fy as TaskItemInput, fz as TaskItemPatch, fA as TaskItemStatus, fB as TaskKindName, fC as TaskOptions, fD as TaskPatch, fE as TaskQueueBackend, fF as TaskReconcileAction, fG as TaskReconciler, fH as TaskResult, fI as TaskRunRecord, fJ as TaskScheduler, fK as TaskSchedulingHints, fL as TaskStatus, fM as TaskStore, fN as TerminationOutcome, fO as TestCase, fP as ToolArtifact, fQ as ToolCapabilities, fR as ToolConfig, fS as ToolDescriptor, fT as ToolExecuteOptions, fU as ToolFilterSpec, fV as ToolHandler, fW as ToolOrigin, fX as ToolRequest, fY as ToolResponse, fZ as ToolSummary, f_ as TrailConfig, f$ as TrustTier, g0 as TrustTransitionCaller, g1 as TurnContext, g2 as TurnId, g3 as USER_MODEL, g4 as UserModelComponent, g5 as UserSignal, g6 as UserSnapshot, g7 as VALID_LIFECYCLE_TRANSITIONS, g8 as VALID_TASK_KIND_NAMES, g9 as VALID_TASK_TRANSITIONS, ga as VALID_TRANSITIONS, gb as VIOLATION_SEVERITY_ORDER, gc as VariantAttempt, gd as VersionChangeEvent, ge as VersionChangeKind, gf as VersionEntry, gg as VersionIndexBackend, gh as VersionIndexReader, gi as VersionIndexWriter, gj as VersionedBrickRef, gk as Violation, gl as ViolationFilter, gm as ViolationPage, gn as ViolationSeverity, go as ViolationStore, gp as VisibilityContext, gq as WEBHOOK, gr as WORKSPACE, gs as WorkspaceBackend, gt as WorkspaceComponent, gu as WorkspaceId, gv as WorkspaceInfo, gw as ZONE_REGISTRY, gx as agentGroupId, gy as agentId, gz as agentToken, gA as artifactId, gB as askId, gC as brickId, gD as channelToken, gE as delegationId, gF as exitCodeForTransitionReason, gG as forgedSkill, gH as fsSkill, gI as governanceContributorToken, gJ as handoffId, gK as intersectPermissions, gL as isAskVerdict, gM as isAttachResult, gN as isBrickKind, gO as isDeliveryPolicy, gP as isPermissionSubset, gQ as isTerminalTaskStatus, gR as isValidTaskKindName, gS as isValidTransition, gT as mapContentBlocksForEngine, gU as mapRegistryEntryToDescriptor, gV as mapScheduledTaskStatusToProcessState, gW as mapStopReasonToOutcome, gV as mapTaskStatusToProcessState, gX as matchesFilter, gY as messageId, gZ as middlewareToken, g_ as publisherId, g$ as runId, h0 as scheduleId, h1 as scratchpadPath, h2 as searchSummariesWithFallback, h3 as sessionId, h4 as skillId, h5 as skillToken, h6 as snapshotId, h7 as taskId, h8 as taskItemId, h9 as token, ha as toolCallId, hb as toolFilterFromManifest, hc as toolFilterFromSpawnRequest, hd as toolToken, he as turnId, hf as unionDenyLists, hg as validatePolicyForKind, hh as validateSpawnRequest, hi as workspaceId } from './assembly-HASH.js';
-export { AGENT_DEFINITION_PRIORITY, AgentDefinition, AgentDefinitionSource } from './agent-HASH.js';
+import { S as SessionId, A as AgentId, E as EngineState, P as ProcessState, B as BrickRef, a as PatchableRegistryFields, b as AgentGroupId, T as TransitionReason, c as AgentCondition, d as AgentStatus, R as RegistryEntry, e as Tool, f as SkillComponent, g as AgentDescriptor, I as ImplementationArtifact, h as BrickArtifact, D as DelegationDenyReason, i as PermissionConfig, C as CapabilityProof, j as BrickKind, k as BrickId, l as ToolDescriptor, m as CronSchedule, F as ForgeStore, n as TaskId, o as EngineInput, p as DeliveryPolicy, q as TaskOptions, r as SubsystemToken, s as ToolPolicy, t as Agent, u as ComponentProvider, v as TaskBoardSnapshot, w as AgentManifest, K as KoiMiddleware, x as AgentRegistry, y as ToolCallId, z as EngineEvent, G as SupervisionConfig, M as ModelChunk, H as TaskItemId } from './assembly-HASH.js';
+export { J as AGENT_SIGNALS, L as ALL_BRICK_KINDS, N as ANS_SCOPE_PRIORITY, O as AbortReason, Q as AdvisoryLock, U as AgentArtifact, V as AgentEnv, W as AgentMessage, X as AgentMessageInput, Y as AgentSignal, Z as AnsConfig, _ as ApprovalDecision, $ as ApprovalHandler, a0 as ApprovalRequest, a1 as ArtifactId, a2 as ArtifactRef, a3 as AskId, a4 as AttachResult, a5 as BROWSER, a6 as BrickArtifactBase, a7 as BrickComposition, a8 as BrickDisclosureLevel, a9 as BrickDriftContext, aa as BrickFitnessMetrics, ab as BrickLifecycle, ac as BrickPage, ad as BrickPort, ae as BrickRegistryBackend, af as BrickRegistryChangeEvent, ag as BrickRegistryChangeKind, ah as BrickRegistryReader, ai as BrickRegistryWriter, aj as BrickRequires, ak as BrickSearchQuery, al as BrickSignature, am as BrickSnapshot, an as BrickSource, ao as BrickSummary, ap as BrickUpdate, aq as BrowserActionOptions, ar as BrowserConsoleEntry, as as BrowserConsoleLevel, at as BrowserConsoleOptions, au as BrowserConsoleResult, av as BrowserDriver, aw as BrowserEvaluateOptions, ax as BrowserEvaluateResult, ay as BrowserFormField, az as BrowserNavigateOptions, aA as BrowserNavigateResult, aB as BrowserRefInfo, aC as BrowserScreenshotOptions, aD as BrowserScreenshotResult, aE as BrowserScrollOptions, aF as BrowserSnapshotOptions, aG as BrowserSnapshotResult, aH as BrowserTabCloseOptions, aI as BrowserTabFocusOptions, aJ as BrowserTabInfo, aK as BrowserTabNewOptions, aL as BrowserTraceOptions, aM as BrowserTraceResult, aN as BrowserTypeOptions, aO as BrowserUploadFile, aP as BrowserUploadOptions, aQ as BrowserWaitOptions, aR as BrowserWaitUntil, aS as COLLECTIVE_MEMORY_DEFAULTS, aT as COMPONENT_PRIORITY, aU as CREDENTIALS, aV as CapabilityConfig, aW as CapabilityFragment, aX as ChangeNotifier, aY as ChannelConfig, aZ as ChannelIdentity, a_ as ChildCompletionResult, a$ as ChildHandle, b0 as ChildIsolation, b1 as ChildLifecycleEvent, b2 as ChildSpec, b3 as CircuitBreakerConfig, b4 as CleanupPolicy, b5 as CollectiveMemory, b6 as CollectiveMemoryCategory, b7 as CollectiveMemoryDefaults, b8 as CollectiveMemoryEntry, b9 as CollectiveMemorySource, ba as CompanionSkillDefinition, bb as ComplianceRecord, bc as ComplianceRecorder, bd as ComponentEvent, be as ComponentEventKind, bf as ComposedCallHandlers, bg as CompositeArtifact, bh as CompositionCheck, bi as CompositionError, bj as CompositionErrorKind, bk as CompositionOperator, bl as CompositionPort, bm as CompositionWire, bn as CompositionWireEndpoint, bo as ConfigChange, bp as ConstraintChecker, bq as ConstraintQuery, br as ContentMarker, bs as ContextManifestConfig, bt as ContextPressureTrend, bu as CorrelationIds, bv as CounterExample, bw as CredentialComponent, bx as CredentialKind, by as CredentialRequirement, bz as DATA_SOURCES, bA as DEFAULT_ANS_CONFIG, bB as DEFAULT_BRICK_FITNESS, bC as DEFAULT_BRICK_SEARCH_LIMIT, bD as DEFAULT_CHILD_ISOLATION, bE as DEFAULT_CIRCUIT_BREAKER_CONFIG, bF as DEFAULT_CLEANUP_POLICY, bG as DEFAULT_CLEANUP_TIMEOUT_MS, bH as DEFAULT_COLLECTIVE_MEMORY, bI as DEFAULT_DEGENERACY_CONFIG, bJ as DEFAULT_DELIVERY_POLICY, bK as DEFAULT_FORK_MAX_TURNS, bL as DEFAULT_INBOX_POLICY, bM as DEFAULT_MUTATION_PRESSURE_POLICY, bN as DEFAULT_REPUTATION_QUERY_LIMIT, bO as DEFAULT_SANDBOXED_POLICY, bP as DEFAULT_SCHEDULER_CONFIG, bQ as DEFAULT_SKILL_SEARCH_LIMIT, bR as DEFAULT_SUPERVISION_CONFIG, bS as DEFAULT_TASK_BOARD_CONFIG, bT as DEFAULT_TRAIL_CONFIG, bU as DEFAULT_TRAIL_STRENGTH, bV as DEFAULT_UNSANDBOXED_POLICY, bW as DEFAULT_VIOLATION_QUERY_LIMIT, bX as DELEGATION, bY as DataClassification, bZ as DataSourceDescriptor, b_ as DataSourceProtocol, b$ as DecisionRecord, c0 as DeferredDeliveryPolicy, c1 as DegeneracyConfig, c2 as DelegationBackend, c3 as DelegationComponent, c4 as DelegationConfig, c5 as DelegationEvent, c6 as DelegationGrant, c7 as DelegationId, c8 as DelegationManagerConfig, c9 as DelegationScope, ca as DelegationVerifyResult, cb as ENV, cc as EVENTS, cd as EXTERNAL_AGENTS, ce as EngineAdapter, cf as EngineCapabilities, cg as EngineInputBase, ch as EngineMetrics, ci as EngineOutput, cj as EngineStopReason, ck as EventComponent, cl as EvolutionKind, cm as ExternalAgentDescriptor, cn as ExternalAgentProtocol, co as ExternalAgentSource, cp as ExternalAgentTransport, cq as FILESYSTEM, cr as FeedbackKind, cs as FileSystemConfig, ct as FilesystemCapability, cu as FilesystemSkillSource, cv as ForgeAttestationSignature, cw as ForgeBuildDefinition, cx as ForgeBuilder, cy as ForgeProvenance, cz as ForgeQuery, cA as ForgeResourceRef, cB as ForgeRunMetadata, cC as ForgeScope, cD as ForgeStageDigest, cE as ForgeVerificationSummary, cF as ForgedSkillSource, cG as GOVERNANCE, cH as GOVERNANCE_ALLOW, cI as GOVERNANCE_BACKEND, cJ as GOVERNANCE_VARIABLES, cK as GovernanceBackend, cL as GovernanceCheck, cM as GovernanceController, cN as GovernanceEvent, cO as GovernanceSnapshot, cP as GovernanceVariable, cQ as GovernanceVariableContributor, cR as GovernanceVerdict, cS as HANDOFF, cT as HandoffAcceptError, cU as HandoffAcceptResult, cV as HandoffComponent, cW as HandoffEnvelope, cX as HandoffEvent, cY as HandoffId, cZ as HandoffStatus, c_ as INBOX, c$ as InTotoStatementV1, d0 as InTotoSubject, d1 as InboxComponent, d2 as InboxItem, d3 as InboxMode, d4 as InboxPolicy, d5 as LatencySampler, d6 as LockHandle, d7 as LockMode, d8 as LockRequest, d9 as MAILBOX, da as MAX_PIPELINE_LENGTH, db as MAX_PIPELINE_STEPS, dc as MEMORY, dd as MailboxComponent, de as ManagedTaskBoard, df as ManifestSandboxConfig, dg as ManifestSandboxPersistence, dh as ManifestSpawnConfig, di as MemoryComponent, dj as MemoryRecallOptions, dk as MemoryResult, dl as MemoryStoreOptions, dm as MemoryTier, dn as MessageFilter, dp as MessageId, dq as MessageKind, dr as MiddlewareBundle, ds as MiddlewareConfig, dt as MiddlewarePhase, du as ModelAdapter, dv as ModelConfig, dw as ModelContentBlock, dx as ModelHandler, dy as ModelRequest, dz as ModelResponse, dA as ModelStopReason, dB as ModelStreamHandler, dC as ModelTextBlock, dD as ModelThinkingBlock, dE as ModelToolCallBlock, dF as MutationPressure, dG as MutationPressurePolicy, dH as NAME_SERVICE, dI as NameBinding, dJ as NameChangeEvent, dK as NameChangeKind, dL as NameQuery, dM as NameRecord, dN as NameRegistration, dO as NameResolution, dP as NameServiceBackend, dQ as NameServiceReader, dR as NameServiceWriter, dS as NameSuggestion, dT as NamespaceMode, dU as NetworkCapability, dV as OnDemandDeliveryPolicy, dW as PersistentGrant, dX as PersistentGrantCallback, dY as PipelineComposition, dZ as PipelineStep, d_ as PolicyEvaluator, d$ as PolicyRequest, e0 as PolicyRequestKind, e1 as PolicyValidationResult, e2 as ProcessAccounter, e3 as ProcessDescriptor, e4 as ProcessId, e5 as PublisherId, e6 as REGISTRY, e7 as REPUTATION, e8 as REPUTATION_LEVEL_ORDER, e9 as RESET_BOUNDARIES, ea as RegistryComponent, eb as RegistryEvent, ec as RegistryFilter, ed as ReputationBackend, ee as ReputationFeedback, ef as ReputationLevel, eg as ReputationQuery, eh as ReputationQueryResult, ei as ReputationScore, ej as ResolvedWorkspaceConfig, ek as ResourceCapability, el as RestartType, em as RevocationRegistry, en as RuleDescriptor, eo as RunId, ep as SANDBOX_REQUIRED_BY_KIND, eq as SCHEDULER, er as SCRATCHPAD, es as SCRATCHPAD_DEFAULTS, et as ScheduleId, eu as ScheduleStore, ev as ScheduledTask, ew as ScheduledTaskStatus, ex as SchedulerComponent, ey as SchedulerConfig, ez as SchedulerEvent, eA as SchedulerStats, eB as ScopeChecker, eC as ScratchpadChangeEvent, eD as ScratchpadComponent, eE as ScratchpadEntry, eF as ScratchpadEntrySummary, eG as ScratchpadFilter, eH as ScratchpadGeneration, eI as ScratchpadPath, eJ as ScratchpadWriteInput, eK as ScratchpadWriteResult, eL as SearchConfig, eM as SelectionStrategy, eN as SensorReading, eO as SessionContext, eP as ShadowWarning, eQ as SignalSink, eR as SignalSource, eS as SigningBackend, eT as SkillArtifact, eU as SkillConfig, eV as SkillExecutionMode, eW as SkillId, eX as SkillMetadata, eY as SkillPage, eZ as SkillPublishRequest, e_ as SkillRegistryBackend, e$ as SkillRegistryChangeEvent, f0 as SkillRegistryChangeKind, f1 as SkillRegistryEntry, f2 as SkillRegistryReader, f3 as SkillRegistryWriter, f4 as SkillSearchQuery, f5 as SkillSource, f6 as SkillVersion, f7 as SkippedComponent, f8 as SnapshotEvent, f9 as SnapshotId, fa as SnapshotQuery, fb as SnapshotStore, fc as SpawnFn, fd as SpawnInheritanceConfig, fe as SpawnLedger, ff as SpawnRequest, fg as SpawnResult, fh as StopGateResult, fi as StoreChangeEvent, fj as StoreChangeKind, fk as StoreChangeNotifier, fl as StreamingDeliveryPolicy, fm as SupervisionStrategy, fn as TASK_KIND_NAMES, fo as Task, fp as TaskBoard, fq as TaskBoardConfig, fr as TaskBoardEvent, fs as TaskBoardStore, ft as TaskBoardStoreEvent, fu as TaskBoardStoreFilter, fv as TaskBoardStoreNotifier, fw as TaskFilter, fx as TaskHistoryFilter, fy as TaskInput, fz as TaskItem, fA as TaskItemInput, fB as TaskItemPatch, fC as TaskItemStatus, fD as TaskKindName, fE as TaskPatch, fF as TaskQueueBackend, fG as TaskReconcileAction, fH as TaskReconciler, fI as TaskResult, fJ as TaskRunRecord, fK as TaskScheduler, fL as TaskSchedulingHints, fM as TaskStatus, fN as TaskStore, fO as TerminationOutcome, fP as TestCase, fQ as ToolArtifact, fR as ToolCapabilities, fS as ToolConfig, fT as ToolExecuteOptions, fU as ToolFilterSpec, fV as ToolHandler, fW as ToolOrigin, fX as ToolRequest, fY as ToolResponse, fZ as ToolSummary, f_ as TrailConfig, f$ as TrustTier, g0 as TrustTransitionCaller, g1 as TurnContext, g2 as TurnId, g3 as USER_MODEL, g4 as UserModelComponent, g5 as UserSignal, g6 as UserSnapshot, g7 as VALID_LIFECYCLE_TRANSITIONS, g8 as VALID_TASK_KIND_NAMES, g9 as VALID_TASK_TRANSITIONS, ga as VALID_TRANSITIONS, gb as VIOLATION_SEVERITY_ORDER, gc as VariantAttempt, gd as VersionChangeEvent, ge as VersionChangeKind, gf as VersionEntry, gg as VersionIndexBackend, gh as VersionIndexReader, gi as VersionIndexWriter, gj as VersionedBrickRef, gk as Violation, gl as ViolationFilter, gm as ViolationPage, gn as ViolationSeverity, go as ViolationStore, gp as VisibilityContext, gq as WEBHOOK, gr as WORKSPACE, gs as WorkspaceBackend, gt as WorkspaceComponent, gu as WorkspaceId, gv as WorkspaceInfo, gw as ZONE_REGISTRY, gx as agentGroupId, gy as agentId, gz as agentToken, gA as artifactId, gB as askId, gC as brickId, gD as channelToken, gE as delegationId, gF as exitCodeForTransitionReason, gG as forgedSkill, gH as fsSkill, gI as governanceContributorToken, gJ as handoffId, gK as intersectPermissions, gL as isAskVerdict, gM as isAttachResult, gN as isBrickKind, gO as isDeliveryPolicy, gP as isPermissionSubset, gQ as isTerminalTaskStatus, gR as isValidTaskKindName, gS as isValidTransition, gT as mapContentBlocksForEngine, gU as mapRegistryEntryToDescriptor, gV as mapScheduledTaskStatusToProcessState, gW as mapStopReasonToOutcome, gV as mapTaskStatusToProcessState, gX as matchesFilter, gY as messageId, gZ as middlewareToken, g_ as publisherId, g$ as runId, h0 as scheduleId, h1 as scratchpadPath, h2 as searchSummariesWithFallback, h3 as sessionId, h4 as skillId, h5 as skillToken, h6 as snapshotId, h7 as taskId, h8 as taskItemId, h9 as token, ha as toolCallId, hb as toolFilterFromManifest, hc as toolFilterFromSpawnRequest, hd as toolToken, he as turnId, hf as unionDenyLists, hg as validatePolicyForKind, hh as validateSpawnRequest, hi as workspaceId } from './assembly-HASH.js';
+import { AgentDefinition } from './agent-HASH.js';
+export { AGENT_DEFINITION_PRIORITY, AgentDefinitionSource } from './agent-HASH.js';
 export { AgentResolver, AgentResolverQuery, LiveAgentHandle, TaskableAgent, TaskableAgentSummary } from './agent-HASH.js';
 import { Result, KoiError } from './errors.js';
 export { BackendErrorMapper, KoiErrorCode, RETRYABLE_DEFAULTS } from './errors.js';
@@ -774,6 +775,206 @@ interface CatalogReader {
 }
 
 /**
+ * Forge demand types — demand-triggered forging signal system.
+ *
+ * Defines the signal and budget types for pull-based forge triggering.
+ * Middleware detects capability gaps and emits ForgeDemandSignal when
+ * environmental pressure demands new tool creation.
+ */
+
+/** Discriminated union of demand trigger kinds. */
+type ForgeTrigger = {
+    readonly kind: "repeated_failure";
+    readonly toolName: string;
+    readonly count: number;
+} | {
+    readonly kind: "no_matching_tool";
+    readonly query: string;
+    readonly attempts: number;
+} | {
+    readonly kind: "capability_gap";
+    readonly requiredCapability: string;
+} | {
+    readonly kind: "performance_degradation";
+    readonly toolName: string;
+    readonly metric: string;
+} | {
+    readonly kind: "agent_capability_gap";
+    readonly agentType: string;
+} | {
+    readonly kind: "agent_repeated_failure";
+    readonly agentType: string;
+    readonly brickId: BrickId;
+    readonly errorRate: number;
+} | {
+    readonly kind: "agent_latency_degradation";
+    readonly agentType: string;
+    readonly brickId: BrickId;
+    readonly p95Ms: number;
+} | {
+    readonly kind: "data_source_detected";
+    readonly sourceName: string;
+    readonly protocol: string;
+} | {
+    readonly kind: "data_source_gap";
+    readonly sourceName: string;
+    readonly missingCapability: string;
+} | {
+    readonly kind: "complex_task_completed";
+    readonly toolCallCount: number;
+    readonly taskDescription: string;
+    readonly toolsUsed: readonly string[];
+    readonly turnCount: number;
+} | {
+    readonly kind: "user_correction";
+    readonly correctionText: string;
+    readonly correctedToolCall: string;
+    readonly correctionDescription: string;
+    readonly originalToolName?: string | undefined;
+} | {
+    readonly kind: "novel_workflow";
+    readonly workflowDescription: string;
+    readonly toolSequence: readonly string[];
+} | {
+    /**
+     * A required capability or composition pattern was observed to be missing.
+     * Routed as a SystemSignal.forge_demand to the CompositionPlanner.
+     * @see SystemSignal in system-signal.ts
+     */
+    readonly kind: "composition_gap";
+    /** The capability name or composition pattern that is missing. */
+    readonly requiredCapability: string;
+    /** Number of times this gap has been observed in the current session. */
+    readonly observedCount: number;
+};
+/** Signal emitted by the demand detector middleware when a forge need is detected. */
+interface ForgeDemandSignal {
+    readonly id: string;
+    readonly kind: "forge_demand";
+    readonly trigger: ForgeTrigger;
+    /** Confidence score (0-1) that forging is warranted. */
+    readonly confidence: number;
+    readonly suggestedBrickKind: BrickKind;
+    readonly context: {
+        readonly failureCount: number;
+        readonly failedToolCalls: readonly string[];
+        readonly taskDescription?: string | undefined;
+    };
+    readonly emittedAt: number;
+}
+/** Demand-aware budget configuration for forge triggering. */
+interface ForgeBudget {
+    /** Hard cap on forges per session (safety limit). */
+    readonly maxForgesPerSession: number;
+    /** Total forge compute time budget in milliseconds. */
+    readonly computeTimeBudgetMs: number;
+    /** Minimum confidence to auto-suggest forge (0-1). */
+    readonly demandThreshold: number;
+    /** Minimum time between forge suggestions for the same trigger key (ms). */
+    readonly cooldownMs: number;
+}
+/** Sensible defaults for forge budget. */
+declare const DEFAULT_FORGE_BUDGET: ForgeBudget;
+
+/**
+ * Composition planning contracts — shared L0 vocabulary for proactive planning.
+ *
+ * These types define the normalized trigger, plan, and approval surface used by
+ * downstream planner implementations. No runtime logic lives here.
+ */
+
+interface CompositionTrigger {
+    readonly id: string;
+    readonly source: string;
+    readonly confidence: number;
+    readonly moment: CompositionMoment;
+    readonly suggestedCapabilities: readonly string[];
+    readonly context: Readonly<Record<string, unknown>>;
+    readonly emittedAt: number;
+}
+type CompositionMoment = {
+    readonly kind: "capability_gap";
+    readonly missing: string;
+} | {
+    readonly kind: "threshold_crossed";
+    readonly sensor: string;
+    readonly value: number;
+    readonly limit: number;
+    readonly direction: "above" | "below";
+} | {
+    readonly kind: "pattern_matched";
+    readonly patternId: string;
+    readonly description: string;
+} | {
+    readonly kind: "task_terminal";
+    readonly taskId: TaskId;
+    readonly outcome: "completed" | "failed" | "dead_letter" | "cancelled";
+} | {
+    readonly kind: "external_event";
+    readonly source: string;
+    readonly eventType: string;
+} | {
+    readonly kind: "frontier_changed";
+    readonly metric: string;
+    readonly improvement: number;
+};
+interface CompositionCapabilities {
+    readonly tools: readonly ToolDescriptor[];
+    readonly agents: readonly AgentDefinition[];
+    readonly schedules: readonly CronSchedule[];
+    readonly forgeStore?: ForgeStore | undefined;
+}
+interface CompositionPlan {
+    readonly triggerId: string;
+    readonly steps: readonly CompositionStep[];
+    readonly estimatedCost: number;
+    readonly requiresApproval: boolean;
+}
+type CompositionStep = {
+    readonly kind: "tool_call";
+    readonly toolName: string;
+    readonly input: unknown;
+} | {
+    readonly kind: "spawn_agent";
+    readonly agentType: string;
+    readonly input: EngineInput;
+    readonly delivery: DeliveryPolicy;
+} | {
+    readonly kind: "submit_task";
+    readonly agentId: AgentId;
+    readonly mode: "spawn" | "dispatch";
+    readonly input: EngineInput;
+    readonly taskOptions?: TaskOptions | undefined;
+} | {
+    readonly kind: "create_schedule";
+    readonly expression: string;
+    readonly agentId: AgentId;
+    readonly mode: "spawn" | "dispatch";
+    readonly input: EngineInput;
+    readonly timezone?: string | undefined;
+    readonly taskOptions?: TaskOptions | undefined;
+} | {
+    readonly kind: "forge_skill";
+    readonly demand: ForgeDemandSignal;
+} | {
+    readonly kind: "notify_user";
+    readonly channel: string;
+    readonly message: string;
+    readonly priority: "low" | "normal" | "high";
+};
+interface CompositionPlanner {
+    readonly plan: (trigger: CompositionTrigger, capabilities: CompositionCapabilities) => Promise<CompositionPlan>;
+}
+interface CompositionApprovalPolicy {
+    readonly confidenceThreshold: number;
+    readonly maxEstimatedCost: number;
+    readonly requireApprovalOnNovelty: boolean;
+}
+interface CompositionApprovalContext {
+    readonly isNovel: boolean;
+}
+
+/**
  * Generic Backend+Tools ComponentProvider factory.
  *
  * Extracts the common pattern from FileSystemProvider, BrowserProvider,
@@ -1040,108 +1241,6 @@ interface UsagePurposeObservation {
      */
     readonly eventId?: string;
 }
-
-/**
- * Forge demand types — demand-triggered forging signal system.
- *
- * Defines the signal and budget types for pull-based forge triggering.
- * Middleware detects capability gaps and emits ForgeDemandSignal when
- * environmental pressure demands new tool creation.
- */
-
-/** Discriminated union of demand trigger kinds. */
-type ForgeTrigger = {
-    readonly kind: "repeated_failure";
-    readonly toolName: string;
-    readonly count: number;
-} | {
-    readonly kind: "no_matching_tool";
-    readonly query: string;
-    readonly attempts: number;
-} | {
-    readonly kind: "capability_gap";
-    readonly requiredCapability: string;
-} | {
-    readonly kind: "performance_degradation";
-    readonly toolName: string;
-    readonly metric: string;
-} | {
-    readonly kind: "agent_capability_gap";
-    readonly agentType: string;
-} | {
-    readonly kind: "agent_repeated_failure";
-    readonly agentType: string;
-    readonly brickId: BrickId;
-    readonly errorRate: number;
-} | {
-    readonly kind: "agent_latency_degradation";
-    readonly agentType: string;
-    readonly brickId: BrickId;
-    readonly p95Ms: number;
-} | {
-    readonly kind: "data_source_detected";
-    readonly sourceName: string;
-    readonly protocol: string;
-} | {
-    readonly kind: "data_source_gap";
-    readonly sourceName: string;
-    readonly missingCapability: string;
-} | {
-    readonly kind: "complex_task_completed";
-    readonly toolCallCount: number;
-    readonly taskDescription: string;
-    readonly toolsUsed: readonly string[];
-    readonly turnCount: number;
-} | {
-    readonly kind: "user_correction";
-    readonly correctionText: string;
-    readonly correctedToolCall: string;
-    readonly correctionDescription: string;
-    readonly originalToolName?: string | undefined;
-} | {
-    readonly kind: "novel_workflow";
-    readonly workflowDescription: string;
-    readonly toolSequence: readonly string[];
-} | {
-    /**
-     * A required capability or composition pattern was observed to be missing.
-     * Routed as a SystemSignal.forge_demand to the CompositionPlanner.
-     * @see SystemSignal in system-signal.ts
-     */
-    readonly kind: "composition_gap";
-    /** The capability name or composition pattern that is missing. */
-    readonly requiredCapability: string;
-    /** Number of times this gap has been observed in the current session. */
-    readonly observedCount: number;
-};
-/** Signal emitted by the demand detector middleware when a forge need is detected. */
-interface ForgeDemandSignal {
-    readonly id: string;
-    readonly kind: "forge_demand";
-    readonly trigger: ForgeTrigger;
-    /** Confidence score (0-1) that forging is warranted. */
-    readonly confidence: number;
-    readonly suggestedBrickKind: BrickKind;
-    readonly context: {
-        readonly failureCount: number;
-        readonly failedToolCalls: readonly string[];
-        readonly taskDescription?: string | undefined;
-    };
-    readonly emittedAt: number;
-}
-/** Demand-aware budget configuration for forge triggering. */
-interface ForgeBudget {
-    /** Hard cap on forges per session (safety limit). */
-    readonly maxForgesPerSession: number;
-    /** Total forge compute time budget in milliseconds. */
-    readonly computeTimeBudgetMs: number;
-    /** Minimum confidence to auto-suggest forge (0-1). */
-    readonly demandThreshold: number;
-    /** Minimum time between forge suggestions for the same trigger key (ms). */
-    readonly cooldownMs: number;
-}
-/** Sensible defaults for forge budget. */
-declare const DEFAULT_FORGE_BUDGET: ForgeBudget;
 
 /**
  * Long-running harness types — multi-session agent lifecycle management.
@@ -3102,7 +3201,7 @@ type WorkerIpcMessageKind = WorkerIpcMessage["koi"];
  */
 declare function validateWorkerIpcMessage(raw: unknown): Result<WorkerIpcMessage, KoiError>;
 
-export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AnomalyBase, type AnomalyDetail, type AnomalySignal, type AuditEntry, type AuditSink, type AuthCompleteNotification, type AuthFailureNotification, type AuthRequiredNotification, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CoalescedMatch, type CompactResult, type CompensatingOp, ComponentProvider, type CompositionSchedulerEvent, type ContentReplacement, type ContextSummary, type ContextSummaryRef, type CriterionResult, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MatchEntry, type MessageThreadSnapshot, ModelChunk, type NexusPath, type NodeCapability, type NodeId, type OAuthChannel, type OutcomeEvaluation, type OutcomeEvaluationResult, type OutcomeReport, type OutcomeReportInput, type OutcomeRubric, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PatternMatch, type PendingFrame, type PendingMatchStore, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, type RubricCriterion, SNAPSHOT_STATUS_KEY, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, type SnapshotStatus, SubsystemToken, SupervisionConfig, type SystemSignal, type SystemSignalSource, type SystemSignalSourceOptions, TaskBoardSnapshot, TaskId, TaskItemId, type TaskOutputReader, type TaskOutputReaderMatchQuery, type TaskOutputReaderMatchesResult, type TaskOutputReaderSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type ToolsetDefinition, type ToolsetRegistry, type ToolsetResolution, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TruncateResult, type TuiAdapter, type TurnRequestKey, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, type WatchPattern, type WorkerIpcEngineEventMessage, type WorkerIpcHeartbeatMessage, type WorkerIpcMessage, type WorkerIpcMessageKind, type WorkerIpcMessageMessage, type WorkerIpcResultMessage, type WorkerIpcTerminateMessage, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isModelChunk, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validateSupervisionConfig, validateWorkerIpcMessage, validation };
+export { ALL_CATALOG_SOURCES, ALL_CHANGE_TARGETS, type AdvertisedTool, Agent, type AgentBundle, AgentCondition, AgentDefinition, type AgentDeregisteredEvent, AgentDescriptor, AgentGroupId, AgentId, AgentManifest, type AgentPatchedEvent, type AgentRegisteredEvent, AgentRegistry, type AgentSnapshot, type AgentSnapshotStore, type AgentStateEvent, type AgentStateEventKind, AgentStatus, type AgentTransitionedEvent, type AncestorQuery, type AnomalyBase, type AnomalyDetail, type AnomalySignal, type AuditEntry, type AuditSink, type AuthCompleteNotification, type AuthFailureNotification, type AuthRequiredNotification, BACKTRACK_REASON_KEY, BUNDLE_FORMAT_VERSION, type BacktrackConstraint, type BacktrackReason, type BacktrackReasonKind, BrickArtifact, type BrickComponentMap, BrickId, BrickKind, BrickRef, type BundleId, type CapabilityDenyReason, type CapabilityId, CapabilityProof, type CapabilityRegistry, type CapabilityScope, type CapabilityToken, type CapabilityVerifier, type CapabilityVerifyResult, type CapacityReport, type CatalogEntry, type CatalogPage, type CatalogQuery, type CatalogReader, type CatalogSource, type CatalogSourceError, type ChainCompactor, type ChainId, type ChangeKind, type ChangeTarget, type CheckpointPolicy, type CoalescedMatch, type CompactResult, type CompensatingOp, ComponentProvider, type CompositionApprovalContext, type CompositionApprovalPolicy, type CompositionCapabilities, type CompositionMoment, type CompositionPlan, type CompositionPlanner, type CompositionSchedulerEvent, type CompositionStep, type CompositionTrigger, type ContentReplacement, type ContextSummary, type ContextSummaryRef, type CriterionResult, CronSchedule, DEFAULT_CATALOG_SEARCH_LIMIT, DEFAULT_CHECKPOINT_POLICY, DEFAULT_FORGE_BUDGET, DEFAULT_RECONCILE_RUNNER_CONFIG, DEFAULT_THREAD_PRUNING_POLICY, type DecisionCorrelationId, DelegationDenyReason, DeliveryPolicy, type DiagnosticItem, type DiagnosticProvider, type DiagnosticRange, type DiagnosticSeverity, EXTENSION_PRIORITY, EngineEvent, EngineInput, EngineState, type PermissionDecision as EscalationDecision, type PermissionRequest as EscalationRequest, type EventCursor, type ExaptationKind, type ExaptationSignal, type FileOpKind, type FileOpRecord, type ForgeBudget, type ForgeDemandSignal, ForgeStore, type ForgeTrigger, type ForkRef, type GateRequirement, type GuardContext, type HarnessId, type HarnessMetrics, type HarnessPhase, type HarnessSnapshot, type HarnessSnapshotStore, type HarnessStatus, type HarnessThreadSnapshot, INITIAL_AGENT_STATUS, ImplementationArtifact, JsonObject, type KernelExtension, type KeyArtifact, KoiError, KoiMiddleware, MAX_NEXUS_PATH_LENGTH, type MatchEntry, type MessageThreadSnapshot, ModelChunk, type NexusPath, type NodeCapability, type NodeId, type OAuthChannel, type OutcomeEvaluation, type OutcomeEvaluationResult, type OutcomeReport, type OutcomeReportInput, type OutcomeRubric, type OutcomeStore, type OutcomeValence, PROPOSAL_GATE_REQUIREMENTS, PatchableRegistryFields, type PatternMatch, type PendingFrame, type PendingMatchStore, PermissionConfig, type PermissionEscalation, ProcessState, type Proposal, type ProposalEvent, type ProposalGate, type ProposalId, type ProposalInput, type ProposalResult, type ProposalStatus, type ProposalUnsubscribe, type PruningPolicy, type PutOptions, type ReconcileContext, type ReconcileResult, type ReconcileRunnerConfig, type ReconciliationController, type RecoveryPlan, type RedactionRule, RegistryEntry, Result, type ReviewDecision, type RubricCriterion, SNAPSHOT_STATUS_KEY, type ScopeAccessRequest, type ScopeEnforcer, type ScopeSubsystem, type ServiceProviderConfig, type SessionFilter, SessionId, type SessionPersistence, type SessionRecord, type SessionStatus, type SessionTranscript, type SingleToolProviderConfig, SkillComponent, type SkippedRecoveryEntry, type SkippedTranscriptEntry, type SnapshotChainStore, type SnapshotNode, type SnapshotStatus, SubsystemToken, SupervisionConfig, type SystemSignal, type SystemSignalSource, type SystemSignalSourceOptions, TaskBoardSnapshot, TaskId, TaskItemId, TaskOptions, type TaskOutputReader, type TaskOutputReaderMatchQuery, type TaskOutputReaderMatchesResult, type TaskOutputReaderSnapshot, type ThreadId, type ThreadMessage, type ThreadMessageId, type ThreadMessageRole, type ThreadMetrics, type ThreadPruningPolicy, type ThreadSnapshot, type ThreadSnapshotStore, type ThreadStore, Tool, ToolCallId, type ToolCallPayload, ToolDescriptor, type ToolErrorPayload, type ToolFailureRecord, type ToolHealthMetrics, type ToolHealthSnapshot, type ToolHealthState, ToolPolicy, type ToolResultPayload, type ToolsetDefinition, type ToolsetRegistry, type ToolsetResolution, type TraceEvent, type TraceEventKind, type TranscriptEntry, type TranscriptEntryId, type TranscriptEntryRole, type TranscriptLoadResult, type TranscriptPage, type TranscriptPageOptions, type TransitionContext, TransitionReason, type TruncateResult, type TuiAdapter, type TurnRequestKey, type TurnTrace, type UsagePurposeObservation, type ValidationDiagnostic, type ValidationResult, type VerifierCache, type VerifyContext, type WatchPattern, type WorkerIpcEngineEventMessage, type WorkerIpcHeartbeatMessage, type WorkerIpcMessage, type WorkerIpcMessageKind, type WorkerIpcMessageMessage, type WorkerIpcResultMessage, type WorkerIpcTerminateMessage, ZoneId, bundleId, capabilityId, chainId, conflict, createServiceProvider, createSingleToolProvider, decisionCorrelationId, evolveRegistryEntry, external, harnessId, internal, isAgentStateEvent, isCapabilityToken, isHarnessSnapshot, isMessageSnapshot, isModelChunk, isProcessState, isToolCallPayload, nexusPath, nodeId, notFound, permission, proposalId, rateLimit, staleRef, threadId, threadMessageId, timeout, transcriptEntryId, validateNonEmpty, validateSessionIdSyntax, validateSupervisionConfig, validateWorkerIpcMessage, validation };
 "
 `;
 
@@ -3172,7 +3271,7 @@ export { AGENT_DEFINITION_PRIORITY, type AgentDefinition, type AgentDefinitionSo
 `;
 
 exports[`@koi/core API surface ./agent-resolver has stable type surface 1`] = `
-"import { q as AgentManifest, o as BrickId, A as AgentId } from './assembly-HASH.js';
+"import { w as AgentManifest, k as BrickId, A as AgentId } from './assembly-HASH.js';
 import { Result, KoiError } from './errors.js';
 import './common.js';
 import './message.js';
@@ -3413,7 +3512,7 @@ export type { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, Feat
 `;
 
 exports[`@koi/core API surface ./assembly has stable type surface 1`] = `
-"export { q as AgentManifest, aP as CapabilityConfig, aS as ChannelConfig, aT as ChannelIdentity, bm as ContextManifestConfig, cp as FileSystemConfig, cr as FilesystemSkillSource, cD as ForgedSkillSource, dd as ManifestSandboxConfig, de as ManifestSandboxPersistence, df as ManifestSpawnConfig, dq as MiddlewareConfig, dt as ModelConfig, i as PermissionConfig, eJ as SearchConfig, eS as SkillConfig, f3 as SkillSource, fR as ToolConfig, gG as forgedSkill, gH as fsSkill } from './assembly-HASH.js';
+"export { w as AgentManifest, aV as CapabilityConfig, aY as ChannelConfig, aZ as ChannelIdentity, bs as ContextManifestConfig, cs as FileSystemConfig, cu as FilesystemSkillSource, cF as ForgedSkillSource, df as ManifestSandboxConfig, dg as ManifestSandboxPersistence, dh as ManifestSpawnConfig, ds as MiddlewareConfig, dv as ModelConfig, i as PermissionConfig, eL as SearchConfig, eU as SkillConfig, f5 as SkillSource, fS as ToolConfig, gG as forgedSkill, gH as fsSkill } from './assembly-HASH.js';
 import './channel.js';
 import './common.js';
 import './hook.js';
@@ -3540,7 +3639,7 @@ export type { CompactionResult, ContextCompactor, TokenEstimator };
 `;
 
 exports[`@koi/core API surface ./context-engine has stable type surface 1`] = `
-"import { k as SubsystemToken, g1 as TurnContext, g2 as TurnId } from './assembly-HASH.js';
+"import { r as SubsystemToken, g1 as TurnContext, g2 as TurnId } from './assembly-HASH.js';
 import { InboundMessage } from './message.js';
 import './errors.js';
 import './common.js';
@@ -3652,7 +3751,7 @@ export { CONTEXT_ENGINE, type ContextEngine, type ContextEngineIdentity, type Co
 `;
 
 exports[`@koi/core API surface ./delegation has stable type surface 1`] = `
-"export { C as CapabilityProof, aZ as CircuitBreakerConfig, bz as DEFAULT_CIRCUIT_BREAKER_CONFIG, bZ as DelegationBackend, b_ as DelegationComponent, b$ as DelegationConfig, D as DelegationDenyReason, c0 as DelegationEvent, c1 as DelegationGrant, c2 as DelegationId, c3 as DelegationManagerConfig, c4 as DelegationScope, c5 as DelegationVerifyResult, dR as NamespaceMode, ek as RevocationRegistry, ez as ScopeChecker, gE as delegationId, gK as intersectPermissions, gP as isPermissionSubset, hf as unionDenyLists } from './assembly-HASH.js';
+"export { C as CapabilityProof, b3 as CircuitBreakerConfig, bE as DEFAULT_CIRCUIT_BREAKER_CONFIG, c2 as DelegationBackend, c3 as DelegationComponent, c4 as DelegationConfig, D as DelegationDenyReason, c5 as DelegationEvent, c6 as DelegationGrant, c7 as DelegationId, c8 as DelegationManagerConfig, c9 as DelegationScope, ca as DelegationVerifyResult, dT as NamespaceMode, em as RevocationRegistry, eB as ScopeChecker, gE as delegationId, gK as intersectPermissions, gP as isPermissionSubset, hf as unionDenyLists } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -3671,7 +3770,7 @@ import './memory.js';
 
 exports[`@koi/core API surface ./daemon has stable type surface 1`] = `
 "import { JsonObject } from './common.js';
-import { A as AgentId, ej as RestartType, e1 as ProcessDescriptor, P as ProcessState } from './assembly-HASH.js';
+import { A as AgentId, el as RestartType, e3 as ProcessDescriptor, P as ProcessState } from './assembly-HASH.js';
 import { Result, KoiError } from './errors.js';
 import './message.js';
 import './channel.js';
@@ -4066,7 +4165,7 @@ export { type BackgroundSessionEvent, type BackgroundSessionRecord, type Backgro
 `;
 
 exports[`@koi/core API surface ./ecs has stable type surface 1`] = `
-"export { x as AGENT_SIGNALS, m as Agent, g as AgentDescriptor, J as AgentEnv, b as AgentGroupId, A as AgentId, O as AgentSignal, X as ArtifactId, _ as AttachResult, $ as BROWSER, aN as COMPONENT_PRIORITY, aO as CREDENTIALS, aV as ChildHandle, aX as ChildLifecycleEvent, b4 as CompanionSkillDefinition, b7 as ComponentEvent, b8 as ComponentEventKind, n as ComponentProvider, bq as CredentialComponent, bu as DATA_SOURCES, bJ as DEFAULT_SANDBOXED_POLICY, bQ as DEFAULT_UNSANDBOXED_POLICY, bS as DELEGATION, c7 as ENV, c8 as EVENTS, c9 as EXTERNAL_AGENTS, ch as EventComponent, cn as FILESYSTEM, cq as FilesystemCapability, cE as GOVERNANCE, cG as GOVERNANCE_BACKEND, cQ as HANDOFF, cY as INBOX, d7 as MAILBOX, da as MEMORY, dg as MemoryComponent, dh as MemoryRecallOptions, di as MemoryResult, dj as MemoryStoreOptions, dk as MemoryTier, dF as NAME_SERVICE, dS as NetworkCapability, e0 as ProcessAccounter, e2 as ProcessId, P as ProcessState, e4 as REGISTRY, e5 as REPUTATION, e8 as RegistryComponent, ei as ResourceCapability, em as RunId, eo as SCHEDULER, ep as SCRATCHPAD, S as SessionId, f as SkillComponent, eT as SkillExecutionMode, eV as SkillMetadata, f5 as SkippedComponent, fc as SpawnLedger, k as SubsystemToken, e as Tool, s as ToolCallId, fQ as ToolCapabilities, fS as ToolDescriptor, fT as ToolExecuteOptions, fW as ToolOrigin, l as ToolPolicy, fZ as ToolSummary, g2 as TurnId, g3 as USER_MODEL, gq as WEBHOOK, gr as WORKSPACE, gt as WorkspaceComponent, gw as ZONE_REGISTRY, gx as agentGroupId, gy as agentId, gz as agentToken, gA as artifactId, gD as channelToken, gM as isAttachResult, gZ as middlewareToken, g$ as runId, h3 as sessionId, h5 as skillToken, h9 as token, ha as toolCallId, hd as toolToken, he as turnId } from './assembly-HASH.js';
+"export { J as AGENT_SIGNALS, t as Agent, g as AgentDescriptor, V as AgentEnv, b as AgentGroupId, A as AgentId, Y as AgentSignal, a1 as ArtifactId, a4 as AttachResult, a5 as BROWSER, aT as COMPONENT_PRIORITY, aU as CREDENTIALS, a$ as ChildHandle, b1 as ChildLifecycleEvent, ba as CompanionSkillDefinition, bd as ComponentEvent, be as ComponentEventKind, u as ComponentProvider, bw as CredentialComponent, bz as DATA_SOURCES, bO as DEFAULT_SANDBOXED_POLICY, bV as DEFAULT_UNSANDBOXED_POLICY, bX as DELEGATION, cb as ENV, cc as EVENTS, cd as EXTERNAL_AGENTS, ck as EventComponent, cq as FILESYSTEM, ct as FilesystemCapability, cG as GOVERNANCE, cI as GOVERNANCE_BACKEND, cS as HANDOFF, c_ as INBOX, d9 as MAILBOX, dc as MEMORY, di as MemoryComponent, dj as MemoryRecallOptions, dk as MemoryResult, dl as MemoryStoreOptions, dm as MemoryTier, dH as NAME_SERVICE, dU as NetworkCapability, e2 as ProcessAccounter, e4 as ProcessId, P as ProcessState, e6 as REGISTRY, e7 as REPUTATION, ea as RegistryComponent, ek as ResourceCapability, eo as RunId, eq as SCHEDULER, er as SCRATCHPAD, S as SessionId, f as SkillComponent, eV as SkillExecutionMode, eX as SkillMetadata, f7 as SkippedComponent, fe as SpawnLedger, r as SubsystemToken, e as Tool, y as ToolCallId, fR as ToolCapabilities, l as ToolDescriptor, fT as ToolExecuteOptions, fW as ToolOrigin, s as ToolPolicy, fZ as ToolSummary, g2 as TurnId, g3 as USER_MODEL, gq as WEBHOOK, gr as WORKSPACE, gt as WorkspaceComponent, gw as ZONE_REGISTRY, gx as agentGroupId, gy as agentId, gz as agentToken, gA as artifactId, gD as channelToken, gM as isAttachResult, gZ as middlewareToken, g$ as runId, h3 as sessionId, h5 as skillToken, h9 as token, ha as toolCallId, hd as toolToken, he as turnId } from './assembly-HASH.js';
 import './channel.js';
 import './common.js';
 import './filesystem-HASH.js';
@@ -4085,7 +4184,7 @@ import './adapter-HASH.js';
 
 exports[`@koi/core API surface ./handoff has stable type surface 1`] = `
 "import './common.js';
-export { Y as ArtifactRef, bW as DecisionRecord, cR as HandoffAcceptError, cS as HandoffAcceptResult, cT as HandoffComponent, cU as HandoffEnvelope, cV as HandoffEvent, cW as HandoffId, cX as HandoffStatus, gJ as handoffId } from './assembly-HASH.js';
+export { a2 as ArtifactRef, b$ as DecisionRecord, cT as HandoffAcceptError, cU as HandoffAcceptResult, cV as HandoffComponent, cW as HandoffEnvelope, cX as HandoffEvent, cY as HandoffId, cZ as HandoffStatus, gJ as handoffId } from './assembly-HASH.js';
 import './errors.js';
 import './message.js';
 import './channel.js';
@@ -4103,7 +4202,7 @@ import './memory.js';
 
 exports[`@koi/core API surface ./engine has stable type surface 1`] = `
 "import './common.js';
-export { F as AbortReason, b9 as ComposedCallHandlers, ca as EngineAdapter, cb as EngineCapabilities, u as EngineEvent, cc as EngineInput, cd as EngineInputBase, ce as EngineMetrics, cf as EngineOutput, E as EngineState, cg as EngineStopReason, fN as TerminationOutcome, gT as mapContentBlocksForEngine, gW as mapStopReasonToOutcome } from './assembly-HASH.js';
+export { O as AbortReason, bf as ComposedCallHandlers, ce as EngineAdapter, cf as EngineCapabilities, z as EngineEvent, o as EngineInput, cg as EngineInputBase, ch as EngineMetrics, ci as EngineOutput, E as EngineState, cj as EngineStopReason, fO as TerminationOutcome, gT as mapContentBlocksForEngine, gW as mapStopReasonToOutcome } from './assembly-HASH.js';
 import './message.js';
 import './errors.js';
 import './channel.js';
@@ -4270,7 +4369,7 @@ export type { DeadLetterEntry, DeadLetterFilter, EventBackend, EventBackendConfi
 `;
 
 exports[`@koi/core API surface ./governance has stable type surface 1`] = `
-"export { bn as ContextPressureTrend, cH as GOVERNANCE_VARIABLES, cJ as GovernanceCheck, cK as GovernanceController, cL as GovernanceEvent, cM as GovernanceSnapshot, cN as GovernanceVariable, cO as GovernanceVariableContributor, e7 as RESET_BOUNDARIES, eL as SensorReading, gI as governanceContributorToken } from './assembly-HASH.js';
+"export { bt as ContextPressureTrend, cJ as GOVERNANCE_VARIABLES, cL as GovernanceCheck, cM as GovernanceController, cN as GovernanceEvent, cO as GovernanceSnapshot, cP as GovernanceVariable, cQ as GovernanceVariableContributor, e9 as RESET_BOUNDARIES, eN as SensorReading, gI as governanceContributorToken } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -4289,7 +4388,7 @@ import './memory.js';
 
 exports[`@koi/core API surface ./governance-backend has stable type surface 1`] = `
 "import './common.js';
-export { Z as AskId, b5 as ComplianceRecord, b6 as ComplianceRecorder, bj as ConstraintChecker, bk as ConstraintQuery, bR as DEFAULT_VIOLATION_QUERY_LIMIT, cF as GOVERNANCE_ALLOW, cI as GovernanceBackend, cP as GovernanceVerdict, dU as PersistentGrant, dV as PersistentGrantCallback, dY as PolicyEvaluator, dZ as PolicyRequest, d_ as PolicyRequestKind, el as RuleDescriptor, gb as VIOLATION_SEVERITY_ORDER, gk as Violation, gl as ViolationFilter, gm as ViolationPage, gn as ViolationSeverity, go as ViolationStore, gB as askId, gL as isAskVerdict } from './assembly-HASH.js';
+export { a3 as AskId, bb as ComplianceRecord, bc as ComplianceRecorder, bp as ConstraintChecker, bq as ConstraintQuery, bW as DEFAULT_VIOLATION_QUERY_LIMIT, cH as GOVERNANCE_ALLOW, cK as GovernanceBackend, cR as GovernanceVerdict, dW as PersistentGrant, dX as PersistentGrantCallback, d_ as PolicyEvaluator, d$ as PolicyRequest, e0 as PolicyRequestKind, en as RuleDescriptor, gb as VIOLATION_SEVERITY_ORDER, gk as Violation, gl as ViolationFilter, gm as ViolationPage, gn as ViolationSeverity, go as ViolationStore, gB as askId, gL as isAskVerdict } from './assembly-HASH.js';
 import './errors.js';
 import './message.js';
 import './channel.js';
@@ -4652,7 +4751,7 @@ export { type ButtonBlock, type ContentBlock, type CustomBlock, type Displayable
 exports[`@koi/core API surface ./middleware has stable type surface 1`] = `
 "import './channel.js';
 import './common.js';
-export { U as ApprovalDecision, V as ApprovalHandler, W as ApprovalRequest, aQ as CapabilityFragment, bi as ConfigChange, K as KoiMiddleware, dp as MiddlewareBundle, dr as MiddlewarePhase, M as ModelChunk, dv as ModelHandler, dw as ModelRequest, dx as ModelResponse, dz as ModelStreamHandler, eM as SessionContext, ff as StopGateResult, fV as ToolHandler, fX as ToolRequest, fY as ToolResponse, g1 as TurnContext } from './assembly-HASH.js';
+export { _ as ApprovalDecision, $ as ApprovalHandler, a0 as ApprovalRequest, aW as CapabilityFragment, bo as ConfigChange, K as KoiMiddleware, dr as MiddlewareBundle, dt as MiddlewarePhase, M as ModelChunk, dx as ModelHandler, dy as ModelRequest, dz as ModelResponse, dB as ModelStreamHandler, eO as SessionContext, fh as StopGateResult, fV as ToolHandler, fX as ToolRequest, fY as ToolResponse, g1 as TurnContext } from './assembly-HASH.js';
 import './errors.js';
 import './message.js';
 import './permission-HASH.js';
@@ -5232,7 +5331,7 @@ export { type AgentHookConfig, type CommandHookConfig, DEFAULT_AGENT_HOOK_TIMEOU
 `;
 
 exports[`@koi/core API surface ./lifecycle has stable type surface 1`] = `
-"export { c as AgentCondition, r as AgentRegistry, d as AgentStatus, aU as ChildCompletionResult, a as PatchableRegistryFields, R as RegistryEntry, e9 as RegistryEvent, ea as RegistryFilter, T as TransitionReason, ga as VALID_TRANSITIONS, gp as VisibilityContext, gF as exitCodeForTransitionReason, gX as matchesFilter } from './assembly-HASH.js';
+"export { c as AgentCondition, x as AgentRegistry, d as AgentStatus, a_ as ChildCompletionResult, a as PatchableRegistryFields, R as RegistryEntry, eb as RegistryEvent, ec as RegistryFilter, T as TransitionReason, ga as VALID_TRANSITIONS, gp as VisibilityContext, gF as exitCodeForTransitionReason, gX as matchesFilter } from './assembly-HASH.js';
 import './errors.js';
 import './zone.js';
 import './common.js';
@@ -5251,7 +5350,7 @@ import './memory.js';
 
 exports[`@koi/core API surface ./model-adapter has stable type surface 1`] = `
 "import './common.js';
-export { ds as ModelAdapter, du as ModelContentBlock, dy as ModelStopReason, dA as ModelTextBlock, dB as ModelThinkingBlock, dC as ModelToolCallBlock } from './assembly-HASH.js';
+export { du as ModelAdapter, dw as ModelContentBlock, dA as ModelStopReason, dC as ModelTextBlock, dD as ModelThinkingBlock, dE as ModelToolCallBlock } from './assembly-HASH.js';
 import './model-HASH.js';
 import './errors.js';
 import './message.js';
@@ -5518,7 +5617,7 @@ export type { RetrySignal, RetrySignalBroker, RetrySignalReader, RetrySignalWrit
 
 exports[`@koi/core API surface ./brick-snapshot has stable type surface 1`] = `
 "import './errors.js';
-export { o as BrickId, B as BrickRef, ag as BrickSnapshot, ah as BrickSource, f6 as SnapshotEvent, f7 as SnapshotId, f8 as SnapshotQuery, f9 as SnapshotStore, gC as brickId, h6 as snapshotId } from './assembly-HASH.js';
+export { k as BrickId, B as BrickRef, am as BrickSnapshot, an as BrickSource, f8 as SnapshotEvent, f9 as SnapshotId, fa as SnapshotQuery, fb as SnapshotStore, gC as brickId, h6 as snapshotId } from './assembly-HASH.js';
 import './common.js';
 import './message.js';
 import './channel.js';
@@ -5535,7 +5634,7 @@ import './memory.js';
 `;
 
 exports[`@koi/core API surface ./brick-store has stable type surface 1`] = `
-"export { G as AdvisoryLock, H as AgentArtifact, h as BrickArtifact, a0 as BrickArtifactBase, a2 as BrickDisclosureLevel, a3 as BrickDriftContext, a4 as BrickFitnessMetrics, a7 as BrickPort, ad as BrickRequires, ai as BrickSummary, aj as BrickUpdate, aM as COLLECTIVE_MEMORY_DEFAULTS, a$ as CollectiveMemory, b0 as CollectiveMemoryCategory, b1 as CollectiveMemoryDefaults, b2 as CollectiveMemoryEntry, b3 as CollectiveMemorySource, ba as CompositeArtifact, bp as CounterExample, br as CredentialKind, bs as CredentialRequirement, bw as DEFAULT_BRICK_FITNESS, bC as DEFAULT_COLLECTIVE_MEMORY, bO as DEFAULT_TRAIL_CONFIG, bP as DEFAULT_TRAIL_STRENGTH, cw as ForgeQuery, cB as ForgeStore, I as ImplementationArtifact, d3 as LatencySampler, d4 as LockHandle, d5 as LockMode, d6 as LockRequest, dX as PipelineStep, eR as SkillArtifact, fg as StoreChangeEvent, fh as StoreChangeKind, fi as StoreChangeNotifier, fO as TestCase, fP as ToolArtifact, f_ as TrailConfig, h2 as searchSummariesWithFallback } from './assembly-HASH.js';
+"export { Q as AdvisoryLock, U as AgentArtifact, h as BrickArtifact, a6 as BrickArtifactBase, a8 as BrickDisclosureLevel, a9 as BrickDriftContext, aa as BrickFitnessMetrics, ad as BrickPort, aj as BrickRequires, ao as BrickSummary, ap as BrickUpdate, aS as COLLECTIVE_MEMORY_DEFAULTS, b5 as CollectiveMemory, b6 as CollectiveMemoryCategory, b7 as CollectiveMemoryDefaults, b8 as CollectiveMemoryEntry, b9 as CollectiveMemorySource, bg as CompositeArtifact, bv as CounterExample, bx as CredentialKind, by as CredentialRequirement, bB as DEFAULT_BRICK_FITNESS, bH as DEFAULT_COLLECTIVE_MEMORY, bT as DEFAULT_TRAIL_CONFIG, bU as DEFAULT_TRAIL_STRENGTH, cz as ForgeQuery, F as ForgeStore, I as ImplementationArtifact, d5 as LatencySampler, d6 as LockHandle, d7 as LockMode, d8 as LockRequest, dZ as PipelineStep, eT as SkillArtifact, fi as StoreChangeEvent, fj as StoreChangeKind, fk as StoreChangeNotifier, fP as TestCase, fQ as ToolArtifact, f_ as TrailConfig, h2 as searchSummariesWithFallback } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -5893,7 +5992,7 @@ export type { FilesystemPolicy, NetworkPolicy, NexusFuseMount, ResourceLimits, S
 `;
 
 exports[`@koi/core API surface ./skill-registry has stable type surface 1`] = `
-"export { bL as DEFAULT_SKILL_SEARCH_LIMIT, eU as SkillId, eW as SkillPage, eX as SkillPublishRequest, eY as SkillRegistryBackend, eZ as SkillRegistryChangeEvent, e_ as SkillRegistryChangeKind, e$ as SkillRegistryEntry, f0 as SkillRegistryReader, f1 as SkillRegistryWriter, f2 as SkillSearchQuery, f4 as SkillVersion, h4 as skillId } from './assembly-HASH.js';
+"export { bQ as DEFAULT_SKILL_SEARCH_LIMIT, eW as SkillId, eY as SkillPage, eZ as SkillPublishRequest, e_ as SkillRegistryBackend, e$ as SkillRegistryChangeEvent, f0 as SkillRegistryChangeKind, f1 as SkillRegistryEntry, f2 as SkillRegistryReader, f3 as SkillRegistryWriter, f4 as SkillSearchQuery, f6 as SkillVersion, h4 as skillId } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -5998,7 +6097,7 @@ import './memory.js';
 `;
 
 exports[`@koi/core API surface ./version-types has stable type surface 1`] = `
-"export { e3 as PublisherId, eN as ShadowWarning, gd as VersionChangeEvent, ge as VersionChangeKind, gf as VersionEntry, gj as VersionedBrickRef, g_ as publisherId } from './assembly-HASH.js';
+"export { e5 as PublisherId, eP as ShadowWarning, gd as VersionChangeEvent, ge as VersionChangeKind, gf as VersionEntry, gj as VersionedBrickRef, g_ as publisherId } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -6017,7 +6116,7 @@ import './memory.js';
 
 exports[`@koi/core API surface ./run-report has stable type surface 1`] = `
 "import { JsonObject } from './common.js';
-import { A as AgentId, S as SessionId, em as RunId, Y as ArtifactRef } from './assembly-HASH.js';
+import { A as AgentId, S as SessionId, eo as RunId, a2 as ArtifactRef } from './assembly-HASH.js';
 import './errors.js';
 import './message.js';
 import './channel.js';
@@ -6148,7 +6247,7 @@ export type { ElicitationOption, ElicitationQuestion, ElicitationResult };
 
 exports[`@koi/core API surface ./mailbox has stable type surface 1`] = `
 "import './common.js';
-export { L as AgentMessage, N as AgentMessageInput, db as MailboxComponent, dl as MessageFilter, dm as MessageId, dn as MessageKind, gY as messageId } from './assembly-HASH.js';
+export { W as AgentMessage, X as AgentMessageInput, dd as MailboxComponent, dn as MessageFilter, dp as MessageId, dq as MessageKind, gY as messageId } from './assembly-HASH.js';
 import './errors.js';
 import './message.js';
 import './channel.js';
@@ -6532,7 +6631,7 @@ export type { ProcEntry, ProcFs, WritableProcEntry };
 `;
 
 exports[`@koi/core API surface ./process-descriptor has stable type surface 1`] = `
-"export { e1 as ProcessDescriptor, gU as mapRegistryEntryToDescriptor } from './assembly-HASH.js';
+"export { e3 as ProcessDescriptor, gU as mapRegistryEntryToDescriptor } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -6550,7 +6649,7 @@ import './memory.js';
 `;
 
 exports[`@koi/core API surface ./user-model has stable type surface 1`] = `
-"export { eO as SignalSink, eP as SignalSource, g4 as UserModelComponent, g5 as UserSignal, g6 as UserSnapshot } from './assembly-HASH.js';
+"export { eQ as SignalSink, eR as SignalSource, g4 as UserModelComponent, g5 as UserSignal, g6 as UserSnapshot } from './assembly-HASH.js';
 import './errors.js';
 import './common.js';
 import './message.js';
@@ -6818,7 +6917,7 @@ export { ALL_MEMORY_TYPES, MEMORY_INDEX_MAX_LINES, type MemoryFrontmatter, type 
 `;
 
 exports[`@koi/core API surface ./worker-protocol has stable type surface 1`] = `
-"import { E as EngineState, U as ApprovalDecision, u as EngineEvent, W as ApprovalRequest } from './assembly-HASH.js';
+"import { E as EngineState, _ as ApprovalDecision, z as EngineEvent, a0 as ApprovalRequest } from './assembly-HASH.js';
 import { InboundMessage } from './message.js';
 import './errors.js';
 import './common.js';

--- a/packages/kernel/core/src/composition-planner.ts
+++ b/packages/kernel/core/src/composition-planner.ts
@@ -1,0 +1,117 @@
+/**
+ * Composition planning contracts — shared L0 vocabulary for proactive planning.
+ *
+ * These types define the normalized trigger, plan, and approval surface used by
+ * downstream planner implementations. No runtime logic lives here.
+ */
+
+import type { AgentDefinition } from "./agent-definition.js";
+import type { ForgeStore } from "./brick-store.js";
+import type { DeliveryPolicy } from "./delivery.js";
+import type { AgentId, ToolDescriptor } from "./ecs.js";
+import type { EngineInput } from "./engine.js";
+import type { ForgeDemandSignal } from "./forge-demand.js";
+import type { CronSchedule, TaskId, TaskOptions } from "./scheduler.js";
+
+// ---------------------------------------------------------------------------
+// Trigger vocabulary
+// ---------------------------------------------------------------------------
+
+export interface CompositionTrigger {
+  readonly id: string;
+  readonly source: string;
+  readonly confidence: number;
+  readonly moment: CompositionMoment;
+  readonly suggestedCapabilities: readonly string[];
+  readonly context: Readonly<Record<string, unknown>>;
+  readonly emittedAt: number;
+}
+
+export type CompositionMoment =
+  | { readonly kind: "capability_gap"; readonly missing: string }
+  | {
+      readonly kind: "threshold_crossed";
+      readonly sensor: string;
+      readonly value: number;
+      readonly limit: number;
+      readonly direction: "above" | "below";
+    }
+  | { readonly kind: "pattern_matched"; readonly patternId: string; readonly description: string }
+  | {
+      readonly kind: "task_terminal";
+      readonly taskId: TaskId;
+      readonly outcome: "completed" | "failed" | "dead_letter" | "cancelled";
+    }
+  | { readonly kind: "external_event"; readonly source: string; readonly eventType: string }
+  | { readonly kind: "frontier_changed"; readonly metric: string; readonly improvement: number };
+
+// ---------------------------------------------------------------------------
+// Capabilities and plan shapes
+// ---------------------------------------------------------------------------
+
+export interface CompositionCapabilities {
+  readonly tools: readonly ToolDescriptor[];
+  readonly agents: readonly AgentDefinition[];
+  readonly schedules: readonly CronSchedule[];
+  readonly forgeStore?: ForgeStore | undefined;
+}
+
+export interface CompositionPlan {
+  readonly triggerId: string;
+  readonly steps: readonly CompositionStep[];
+  readonly estimatedCost: number;
+  readonly requiresApproval: boolean;
+}
+
+export type CompositionStep =
+  | { readonly kind: "tool_call"; readonly toolName: string; readonly input: unknown }
+  | {
+      readonly kind: "spawn_agent";
+      readonly agentType: string;
+      readonly input: EngineInput;
+      readonly delivery: DeliveryPolicy;
+    }
+  | {
+      readonly kind: "submit_task";
+      readonly agentId: AgentId;
+      readonly mode: "spawn" | "dispatch";
+      readonly input: EngineInput;
+      readonly taskOptions?: TaskOptions | undefined;
+    }
+  | {
+      readonly kind: "create_schedule";
+      readonly expression: string;
+      readonly agentId: AgentId;
+      readonly mode: "spawn" | "dispatch";
+      readonly input: EngineInput;
+      readonly timezone?: string | undefined;
+      readonly taskOptions?: TaskOptions | undefined;
+    }
+  | { readonly kind: "forge_skill"; readonly demand: ForgeDemandSignal }
+  | {
+      readonly kind: "notify_user";
+      readonly channel: string;
+      readonly message: string;
+      readonly priority: "low" | "normal" | "high";
+    };
+
+// ---------------------------------------------------------------------------
+// Planner and approval contracts
+// ---------------------------------------------------------------------------
+
+export interface CompositionPlanner {
+  readonly plan: (
+    trigger: CompositionTrigger,
+    capabilities: CompositionCapabilities,
+  ) => Promise<CompositionPlan>;
+}
+
+export interface CompositionApprovalPolicy {
+  readonly confidenceThreshold: number;
+  readonly maxEstimatedCost: number;
+  readonly requireApprovalOnNovelty: boolean;
+}
+
+export interface CompositionApprovalContext {
+  readonly isNovel: boolean;
+}

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -239,6 +239,17 @@ export type {
 export { DEFAULT_SPAWN_CHANNEL_POLICY } from "./channel.js";
 // common
 export type { JsonObject } from "./common.js";
+// composition planner — trigger and planning contracts
+export type {
+  CompositionApprovalContext,
+  CompositionApprovalPolicy,
+  CompositionCapabilities,
+  CompositionMoment,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "./composition-planner.js";
 // config
 export type {
   ConfigListener,

--- a/packages/kernel/core/src/system-signal.test.ts
+++ b/packages/kernel/core/src/system-signal.test.ts
@@ -13,6 +13,16 @@
  */
 
 import type { AnomalyDetail, AnomalySignal } from "./agent-anomaly.js";
+import type { AgentDefinition } from "./agent-definition.js";
+import type {
+  CompositionCapabilities,
+  CompositionMoment,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "./composition-planner.js";
+import type { AgentId } from "./ecs.js";
 import type { ForgeDemandSignal } from "./forge-demand.js";
 import type { SchedulerEvent } from "./scheduler.js";
 import type {
@@ -159,3 +169,104 @@ void _subsetCheck;
 type _IsStrictlyNarrow = SchedulerEvent extends CompositionSchedulerEvent ? false : true;
 const _strictCheck: _IsStrictlyNarrow = true;
 void _strictCheck;
+
+// ---------------------------------------------------------------------------
+// 7. Composition planning contracts
+// ---------------------------------------------------------------------------
+
+// CompositionMoment.kind must be accessible for discriminant narrowing.
+type _MomentKindCheck = CompositionMoment["kind"];
+const _momentKindCheck: _MomentKindCheck = "task_terminal";
+void _momentKindCheck;
+
+// Concrete trigger must satisfy the structural contract.
+const _triggerConformance: CompositionTrigger = {
+  id: "trigger-1",
+  source: "governance",
+  confidence: 0.8,
+  moment: { kind: "capability_gap", missing: "diagnostic-agent" },
+  suggestedCapabilities: ["spawn_agent"],
+  context: {},
+  emittedAt: 1,
+};
+void _triggerConformance;
+
+// CompositionCapabilities should describe declarative spawnable agent definitions.
+type _AgentsAreDefinitions = CompositionCapabilities["agents"] extends readonly AgentDefinition[]
+  ? true
+  : false;
+const _agentsShapeCheck: _AgentsAreDefinitions = true;
+void _agentsShapeCheck;
+
+const _capabilitiesConformance: CompositionCapabilities = {
+  tools: [],
+  agents: [
+    {
+      agentType: "researcher",
+      whenToUse: "Deep research on complex topics",
+      source: "built-in",
+      manifest: { name: "researcher", version: "1.0.0", model: { name: "sonnet" } },
+      name: "researcher",
+      description: "Deep research on complex topics",
+    },
+  ],
+  schedules: [],
+};
+void _capabilitiesConformance;
+
+// Spawn-related step variant should preserve the delivery contract and engine input.
+type _SpawnStep = Extract<CompositionStep, { kind: "spawn_agent" }>;
+const _spawnStepConformance: _SpawnStep = {
+  kind: "spawn_agent",
+  agentType: "researcher",
+  input: { kind: "text", text: "spawn a helper agent" },
+  delivery: { kind: "streaming" },
+};
+void _spawnStepConformance;
+
+// Task submission should include scheduler mode and task options.
+type _SubmitTaskStep = Extract<CompositionStep, { kind: "submit_task" }>;
+const _submitTaskStepConformance: _SubmitTaskStep = {
+  kind: "submit_task",
+  agentId: "agent-1" as AgentId,
+  mode: "dispatch",
+  input: { kind: "text", text: "queue follow-up work" },
+  taskOptions: { delayMs: 25, priority: 2, maxRetries: 3 },
+};
+void _submitTaskStepConformance;
+
+// Schedule creation should carry scheduler mode, timezone, and task options.
+type _CreateScheduleStep = Extract<CompositionStep, { kind: "create_schedule" }>;
+const _createScheduleStepConformance: _CreateScheduleStep = {
+  kind: "create_schedule",
+  expression: "0 9 * * 1-5",
+  agentId: "agent-2" as AgentId,
+  mode: "spawn",
+  input: { kind: "text", text: "morning check-in" },
+  timezone: "America/Los_Angeles",
+  taskOptions: { priority: 1, maxRetries: 1 },
+};
+void _createScheduleStepConformance;
+
+// Planner must return a valid plan containing a notify_user step.
+const _plannerConformance: CompositionPlanner = {
+  async plan(
+    trigger: CompositionTrigger,
+    _capabilities: CompositionCapabilities,
+  ): Promise<CompositionPlan> {
+    const step: CompositionStep = {
+      kind: "notify_user",
+      channel: "inbox",
+      message: trigger.id,
+      priority: "normal",
+    };
+
+    return {
+      triggerId: trigger.id,
+      steps: [step],
+      estimatedCost: 0,
+      requiresApproval: false,
+    };
+  },
+};
+void _plannerConformance;

--- a/packages/lib/proactive/src/composition-approval.test.ts
+++ b/packages/lib/proactive/src/composition-approval.test.ts
@@ -57,4 +57,49 @@ describe("computeCompositionApproval", () => {
       ),
     ).toBe(true);
   });
+
+  test("confidence equal to threshold does NOT require approval (boundary: < not <=)", () => {
+    expect(
+      computeCompositionApproval(
+        { ...trigger, confidence: 0.5 },
+        1,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: false,
+        },
+        { isNovel: false },
+      ),
+    ).toBe(false);
+  });
+
+  test("estimated cost equal to budget does NOT require approval (boundary: > not >=)", () => {
+    expect(
+      computeCompositionApproval(
+        trigger,
+        10,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: false,
+        },
+        { isNovel: false },
+      ),
+    ).toBe(false);
+  });
+
+  test("novelty gate is suppressed when requireApprovalOnNovelty is false", () => {
+    expect(
+      computeCompositionApproval(
+        trigger,
+        1,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: false,
+        },
+        { isNovel: true },
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/lib/proactive/src/composition-approval.test.ts
+++ b/packages/lib/proactive/src/composition-approval.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { CompositionTrigger } from "@koi/core";
+import { computeCompositionApproval } from "./composition-approval.js";
+
+const trigger: CompositionTrigger = {
+  id: "t-1",
+  source: "governance",
+  confidence: 0.9,
+  moment: { kind: "capability_gap", missing: "diagnostics" },
+  suggestedCapabilities: [],
+  context: {},
+  emittedAt: 1,
+};
+
+describe("computeCompositionApproval", () => {
+  test("requires approval below confidence threshold", () => {
+    expect(
+      computeCompositionApproval(
+        { ...trigger, confidence: 0.2 },
+        1,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: false,
+        },
+        { isNovel: false },
+      ),
+    ).toBe(true);
+  });
+
+  test("requires approval above cost budget", () => {
+    expect(
+      computeCompositionApproval(
+        trigger,
+        100,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: false,
+        },
+        { isNovel: false },
+      ),
+    ).toBe(true);
+  });
+
+  test("requires approval on novelty when configured", () => {
+    expect(
+      computeCompositionApproval(
+        trigger,
+        1,
+        {
+          confidenceThreshold: 0.5,
+          maxEstimatedCost: 10,
+          requireApprovalOnNovelty: true,
+        },
+        { isNovel: true },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/lib/proactive/src/composition-approval.ts
+++ b/packages/lib/proactive/src/composition-approval.ts
@@ -1,0 +1,23 @@
+import type {
+  CompositionApprovalContext,
+  CompositionApprovalPolicy,
+  CompositionTrigger,
+} from "@koi/core";
+
+export const DEFAULT_COMPOSITION_APPROVAL_POLICY: CompositionApprovalPolicy = {
+  confidenceThreshold: 0.5,
+  maxEstimatedCost: 10,
+  requireApprovalOnNovelty: true,
+};
+
+export function computeCompositionApproval(
+  trigger: CompositionTrigger,
+  estimatedCost: number,
+  policy: CompositionApprovalPolicy,
+  context: CompositionApprovalContext,
+): boolean {
+  if (trigger.confidence < policy.confidenceThreshold) return true;
+  if (estimatedCost > policy.maxEstimatedCost) return true;
+  if (policy.requireApprovalOnNovelty && context.isNovel) return true;
+  return false;
+}

--- a/packages/lib/proactive/src/composition-pipeline.test.ts
+++ b/packages/lib/proactive/src/composition-pipeline.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AgentDefinition,
+  DEFAULT_DELIVERY_POLICY,
+  type KoiError,
+  RETRYABLE_DEFAULTS,
+  type SystemSignal,
+  taskId,
+} from "@koi/core";
+import { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
+import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
+
+function agentDefinition(agentType: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: `Use ${agentType} when needed.`,
+    source: "built-in",
+    manifest: { name: agentType, version: "1.0.0", model: { name: "sonnet" } },
+    name: agentType,
+    description: `${agentType} agent`,
+  };
+}
+
+function koiError(): KoiError {
+  return {
+    code: "INTERNAL",
+    message: "task blew up",
+    retryable: RETRYABLE_DEFAULTS.INTERNAL,
+  };
+}
+
+describe("composition pipeline (signal → trigger → plan → approval)", () => {
+  test("governance error_rate signal flows end-to-end into spawn+notify plan", async () => {
+    const signal: SystemSignal = {
+      kind: "governance",
+      sensor: "error_rate",
+      value: 0.5,
+      limit: 0.2,
+      direction: "above",
+      emittedAt: 1_700_000_000_000,
+    };
+
+    const trigger = mapSystemSignalToCompositionTrigger(signal);
+    expect(trigger).toBeDefined();
+    if (trigger === undefined) return;
+
+    const planner = createRuleBasedCompositionPlanner();
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("diagnostic")],
+      schedules: [],
+    });
+
+    expect(plan.triggerId).toBe(trigger.id);
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "diagnostic",
+        input: {
+          kind: "text",
+          text: "Investigate elevated error_rate and summarize root causes.",
+        },
+        delivery: DEFAULT_DELIVERY_POLICY,
+      },
+      {
+        kind: "notify_user",
+        channel: "inbox",
+        message: "Error rate crossed its configured threshold.",
+        priority: "high",
+      },
+    ]);
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("schedule task:failed flows end-to-end into recovery spawn", async () => {
+    const signal: SystemSignal = {
+      kind: "schedule",
+      event: { kind: "task:failed", taskId: taskId("task-int-1"), error: koiError() },
+      emittedAt: 1_700_000_000_000,
+    };
+
+    const trigger = mapSystemSignalToCompositionTrigger(signal);
+    expect(trigger).toBeDefined();
+    if (trigger === undefined) return;
+
+    const planner = createRuleBasedCompositionPlanner();
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("recovery")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]).toMatchObject({
+      kind: "spawn_agent",
+      agentType: "recovery",
+    });
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("schedule task:cancelled flows to a no-op plan that requires approval", async () => {
+    const signal: SystemSignal = {
+      kind: "schedule",
+      event: { kind: "task:cancelled", taskId: taskId("task-int-2") },
+      emittedAt: 1_700_000_000_000,
+    };
+
+    const trigger = mapSystemSignalToCompositionTrigger(signal);
+    expect(trigger).toBeDefined();
+    if (trigger === undefined) return;
+
+    const planner = createRuleBasedCompositionPlanner();
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("recovery")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("ignored signal kinds (vfs/agent_lifecycle/compaction) produce no trigger", () => {
+    const vfsSignal: SystemSignal = {
+      kind: "vfs",
+      event: "write",
+      path: "/tmp/foo",
+      emittedAt: 1,
+    };
+    expect(mapSystemSignalToCompositionTrigger(vfsSignal)).toBeUndefined();
+  });
+});

--- a/packages/lib/proactive/src/composition-trigger.test.ts
+++ b/packages/lib/proactive/src/composition-trigger.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import { type SystemSignal, taskId } from "@koi/core";
+import { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
+
+describe("mapSystemSignalToCompositionTrigger", () => {
+  test("maps governance threshold crossings", () => {
+    const signal = {
+      kind: "governance",
+      sensor: "error_rate",
+      value: 0.4,
+      limit: 0.2,
+      direction: "above",
+      emittedAt: 123,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toEqual({
+      id: "governance:error_rate:123",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.4,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 123,
+    });
+  });
+
+  test("maps governance threshold crossings without special suggestions", () => {
+    const signal = {
+      kind: "governance",
+      sensor: "cpu_usage",
+      value: 0.9,
+      limit: 0.8,
+      direction: "above",
+      emittedAt: 124,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toMatchObject({
+      id: "governance:cpu_usage:124",
+      suggestedCapabilities: [],
+      context: {},
+    });
+  });
+
+  test("maps forge demand to capability_gap", () => {
+    const signal = {
+      id: "fd-1",
+      kind: "forge_demand",
+      confidence: 0.7,
+      suggestedBrickKind: "agent",
+      trigger: { kind: "capability_gap", requiredCapability: "diagnostics" },
+      context: { failureCount: 2, failedToolCalls: [] },
+      emittedAt: 50,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toEqual({
+      id: "fd-1",
+      source: "forge_demand",
+      confidence: 0.7,
+      moment: { kind: "capability_gap", missing: "diagnostics" },
+      suggestedCapabilities: ["forge_agent"],
+      context: { forgeDemand: signal },
+      emittedAt: 50,
+    });
+  });
+
+  test("maps other forge demand triggers to the most specific missing capability", () => {
+    const cases = [
+      {
+        trigger: { kind: "composition_gap", requiredCapability: "reporting" },
+        missing: "reporting",
+      },
+      {
+        trigger: { kind: "agent_capability_gap", agentType: "researcher" },
+        missing: "researcher",
+      },
+      {
+        trigger: {
+          kind: "agent_repeated_failure",
+          agentType: "builder",
+          brickId: "brick-1" as never,
+          errorRate: 0.7,
+        },
+        missing: "builder",
+      },
+      {
+        trigger: {
+          kind: "agent_latency_degradation",
+          agentType: "planner",
+          brickId: "brick-2" as never,
+          p95Ms: 2500,
+        },
+        missing: "planner",
+      },
+      {
+        trigger: { kind: "data_source_gap", sourceName: "jira", missingCapability: "tickets" },
+        missing: "tickets",
+      },
+      {
+        trigger: { kind: "data_source_detected", sourceName: "calendar", protocol: "ics" },
+        missing: "calendar",
+      },
+      {
+        trigger: { kind: "repeated_failure", toolName: "search", count: 3 },
+        missing: "search",
+      },
+      {
+        trigger: {
+          kind: "performance_degradation",
+          toolName: "fetch",
+          metric: "latency",
+        },
+        missing: "fetch",
+      },
+      {
+        trigger: { kind: "no_matching_tool", query: "sync contacts", attempts: 2 },
+        missing: "sync contacts",
+      },
+      {
+        trigger: {
+          kind: "complex_task_completed",
+          toolCallCount: 6,
+          taskDescription: "prepare release notes",
+          toolsUsed: ["edit", "search"],
+          turnCount: 4,
+        },
+        missing: "prepare release notes",
+      },
+      {
+        trigger: {
+          kind: "user_correction",
+          correctionText: "use the draft API",
+          correctedToolCall: "createDraft",
+          correctionDescription: "wrong tool call",
+        },
+        missing: "createDraft",
+      },
+      {
+        trigger: {
+          kind: "novel_workflow",
+          workflowDescription: "triage inbound issues",
+          toolSequence: ["search", "summarize"],
+        },
+        missing: "triage inbound issues",
+      },
+    ] as const;
+
+    for (const { trigger, missing } of cases) {
+      const signal = {
+        id: `fd-${trigger.kind}`,
+        kind: "forge_demand",
+        confidence: 0.5,
+        suggestedBrickKind: "skill",
+        trigger,
+        context: { failureCount: 1, failedToolCalls: [] },
+        emittedAt: 51,
+      } as const satisfies SystemSignal;
+
+      expect(mapSystemSignalToCompositionTrigger(signal)?.moment).toEqual({
+        kind: "capability_gap",
+        missing,
+      });
+    }
+  });
+
+  test("maps schedule terminal failure to task_terminal", () => {
+    const signal = {
+      kind: "schedule",
+      event: {
+        kind: "task:failed",
+        taskId: taskId("task-1"),
+        error: { message: "boom" } as never,
+      },
+      emittedAt: 77,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toEqual({
+      id: "schedule:task-1:77",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-1"),
+        outcome: "failed",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: { schedulerEvent: signal.event },
+      emittedAt: 77,
+    });
+  });
+
+  test("maps other terminal schedule outcomes", () => {
+    const cases = [
+      {
+        event: {
+          kind: "task:completed",
+          taskId: taskId("task-completed"),
+          result: { ok: true },
+        },
+        outcome: "completed" as const,
+        suggestions: [],
+      },
+      {
+        event: {
+          kind: "task:dead_letter",
+          taskId: taskId("task-dead-letter"),
+          error: { message: "dlq" } as never,
+        },
+        outcome: "dead_letter" as const,
+        suggestions: ["spawn_agent", "notify_user"],
+      },
+      {
+        event: {
+          kind: "task:cancelled",
+          taskId: taskId("task-cancelled"),
+        },
+        outcome: "cancelled" as const,
+        suggestions: [],
+      },
+    ] as const;
+
+    for (const { event, outcome, suggestions } of cases) {
+      const signal = {
+        kind: "schedule",
+        event,
+        emittedAt: 88,
+      } as const satisfies SystemSignal;
+
+      const trigger = mapSystemSignalToCompositionTrigger(signal);
+      expect(trigger?.moment).toEqual({
+        kind: "task_terminal",
+        taskId: event.taskId,
+        outcome,
+      });
+      expect(trigger?.suggestedCapabilities).toEqual(suggestions);
+    }
+  });
+
+  test("keeps cancelled schedule events terminal without noisy follow-up suggestions", () => {
+    const signal = {
+      kind: "schedule",
+      event: {
+        kind: "task:cancelled",
+        taskId: taskId("task-cancelled"),
+      },
+      emittedAt: 89,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toEqual({
+      id: "schedule:task-cancelled:89",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-cancelled"),
+        outcome: "cancelled",
+      },
+      suggestedCapabilities: [],
+      context: { schedulerEvent: signal.event },
+      emittedAt: 89,
+    });
+  });
+
+  test("ignores agent lifecycle in the first pass", () => {
+    const signal = {
+      kind: "agent_lifecycle",
+      agentId: "a-1" as never,
+      from: "created" as never,
+      to: "running" as never,
+      reason: "started" as never,
+      generation: 1,
+      emittedAt: 10,
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toBeUndefined();
+  });
+});

--- a/packages/lib/proactive/src/composition-trigger.test.ts
+++ b/packages/lib/proactive/src/composition-trigger.test.ts
@@ -72,7 +72,7 @@ describe("mapSystemSignalToCompositionTrigger", () => {
   test("maps other forge demand triggers to the most specific missing capability", () => {
     const cases = [
       {
-        trigger: { kind: "composition_gap", requiredCapability: "reporting" },
+        trigger: { kind: "composition_gap", requiredCapability: "reporting", observedCount: 2 },
         missing: "reporting",
       },
       {
@@ -264,6 +264,56 @@ describe("mapSystemSignalToCompositionTrigger", () => {
       context: { schedulerEvent: signal.event },
       emittedAt: 89,
     });
+  });
+
+  test("maps metric anomalies to frontier_changed", () => {
+    const signal = {
+      kind: "anomaly",
+      anomaly: {
+        kind: "model_latency_anomaly",
+        sessionId: "session-1" as never,
+        agentId: "agent-1" as never,
+        timestamp: 90,
+        turnIndex: 4,
+        latencyMs: 1800,
+        mean: 600,
+        stddev: 100,
+        factor: 12,
+      },
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toEqual({
+      id: "anomaly:agent-1:model_latency_anomaly:90",
+      source: "anomaly",
+      confidence: 1,
+      moment: {
+        kind: "frontier_changed",
+        metric: "model_latency_ms",
+        improvement: -1200,
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: { anomaly: signal.anomaly },
+      emittedAt: 90,
+    });
+  });
+
+  test("ignores non-metric anomalies in the first pass", () => {
+    const signal = {
+      kind: "anomaly",
+      anomaly: {
+        kind: "tool_ping_pong",
+        sessionId: "session-1" as never,
+        agentId: "agent-2" as never,
+        timestamp: 91,
+        turnIndex: 5,
+        toolIdA: "search",
+        toolIdB: "summarize",
+        altCount: 8,
+        threshold: 4,
+      },
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toBeUndefined();
   });
 
   test("ignores agent lifecycle in the first pass", () => {

--- a/packages/lib/proactive/src/composition-trigger.test.ts
+++ b/packages/lib/proactive/src/composition-trigger.test.ts
@@ -297,6 +297,24 @@ describe("mapSystemSignalToCompositionTrigger", () => {
     });
   });
 
+  test("ignores synthetic goal-drift sentinels", () => {
+    const signal = {
+      kind: "anomaly",
+      anomaly: {
+        kind: "goal_drift",
+        sessionId: "session-1" as never,
+        agentId: "agent-3" as never,
+        timestamp: 92,
+        turnIndex: 6,
+        driftScore: -1,
+        threshold: 0.6,
+        objectives: ["triage issues"],
+      },
+    } as const satisfies SystemSignal;
+
+    expect(mapSystemSignalToCompositionTrigger(signal)).toBeUndefined();
+  });
+
   test("ignores non-metric anomalies in the first pass", () => {
     const signal = {
       kind: "anomaly",

--- a/packages/lib/proactive/src/composition-trigger.ts
+++ b/packages/lib/proactive/src/composition-trigger.ts
@@ -107,62 +107,69 @@ function metricShiftFromAnomaly(
   }
 }
 
+function mapGovernanceSignal(
+  signal: Extract<SystemSignal, { kind: "governance" }>,
+): CompositionTrigger {
+  return {
+    id: `governance:${signal.sensor}:${String(signal.emittedAt)}`,
+    source: "governance",
+    confidence: 1,
+    moment: {
+      kind: "threshold_crossed",
+      sensor: signal.sensor,
+      value: signal.value,
+      limit: signal.limit,
+      direction: signal.direction,
+    },
+    suggestedCapabilities: signal.sensor === "error_rate" ? ["spawn_agent", "notify_user"] : [],
+    context: {},
+    emittedAt: signal.emittedAt,
+  };
+}
+
+function mapScheduleSignal(
+  signal: Extract<SystemSignal, { kind: "schedule" }>,
+): CompositionTrigger {
+  const outcome = mapTaskOutcome(signal.event);
+  return {
+    id: `schedule:${String(signal.event.taskId)}:${String(signal.emittedAt)}`,
+    source: "schedule",
+    confidence: 1,
+    moment: { kind: "task_terminal", taskId: signal.event.taskId, outcome },
+    suggestedCapabilities: suggestedCapabilitiesForTaskOutcome(outcome),
+    context: { schedulerEvent: signal.event },
+    emittedAt: signal.emittedAt,
+  };
+}
+
+function mapAnomalySignal(
+  signal: Extract<SystemSignal, { kind: "anomaly" }>,
+): CompositionTrigger | undefined {
+  const shift = metricShiftFromAnomaly(signal.anomaly);
+  if (shift === undefined) return undefined;
+  return {
+    id: `anomaly:${signal.anomaly.agentId}:${signal.anomaly.kind}:${String(signal.anomaly.timestamp)}`,
+    source: "anomaly",
+    confidence: 1,
+    moment: { kind: "frontier_changed", metric: shift.metric, improvement: shift.improvement },
+    suggestedCapabilities: ["spawn_agent"],
+    context: { anomaly: signal.anomaly },
+    emittedAt: signal.anomaly.timestamp,
+  };
+}
+
 export function mapSystemSignalToCompositionTrigger(
   signal: SystemSignal,
 ): CompositionTrigger | undefined {
   switch (signal.kind) {
     case "governance":
-      return {
-        id: `governance:${signal.sensor}:${String(signal.emittedAt)}`,
-        source: "governance",
-        confidence: 1,
-        moment: {
-          kind: "threshold_crossed",
-          sensor: signal.sensor,
-          value: signal.value,
-          limit: signal.limit,
-          direction: signal.direction,
-        },
-        suggestedCapabilities: signal.sensor === "error_rate" ? ["spawn_agent", "notify_user"] : [],
-        context: {},
-        emittedAt: signal.emittedAt,
-      };
+      return mapGovernanceSignal(signal);
     case "forge_demand":
       return mapForgeDemandToCompositionTrigger(signal);
-    case "schedule": {
-      const outcome = mapTaskOutcome(signal.event);
-      return {
-        id: `schedule:${String(signal.event.taskId)}:${String(signal.emittedAt)}`,
-        source: "schedule",
-        confidence: 1,
-        moment: {
-          kind: "task_terminal",
-          taskId: signal.event.taskId,
-          outcome,
-        },
-        suggestedCapabilities: suggestedCapabilitiesForTaskOutcome(outcome),
-        context: { schedulerEvent: signal.event },
-        emittedAt: signal.emittedAt,
-      };
-    }
-    case "anomaly": {
-      const shift = metricShiftFromAnomaly(signal.anomaly);
-      if (shift === undefined) return undefined;
-
-      return {
-        id: `anomaly:${signal.anomaly.agentId}:${signal.anomaly.kind}:${String(signal.anomaly.timestamp)}`,
-        source: "anomaly",
-        confidence: 1,
-        moment: {
-          kind: "frontier_changed",
-          metric: shift.metric,
-          improvement: shift.improvement,
-        },
-        suggestedCapabilities: ["spawn_agent"],
-        context: { anomaly: signal.anomaly },
-        emittedAt: signal.anomaly.timestamp,
-      };
-    }
+    case "schedule":
+      return mapScheduleSignal(signal);
+    case "anomaly":
+      return mapAnomalySignal(signal);
     case "vfs":
     case "agent_lifecycle":
     case "compaction":

--- a/packages/lib/proactive/src/composition-trigger.ts
+++ b/packages/lib/proactive/src/composition-trigger.ts
@@ -1,4 +1,10 @@
-import type { CompositionTrigger, ForgeDemandSignal, ForgeTrigger, SystemSignal } from "@koi/core";
+import type {
+  AnomalySignal,
+  CompositionTrigger,
+  ForgeDemandSignal,
+  ForgeTrigger,
+  SystemSignal,
+} from "@koi/core";
 
 function missingCapabilityFromForgeTrigger(trigger: ForgeTrigger): string {
   switch (trigger.kind) {
@@ -75,6 +81,31 @@ function suggestedCapabilitiesForTaskOutcome(
   }
 }
 
+function metricShiftFromAnomaly(
+  anomaly: AnomalySignal,
+): { readonly metric: string; readonly improvement: number } | undefined {
+  switch (anomaly.kind) {
+    case "error_spike":
+      return { metric: "error_count", improvement: anomaly.threshold - anomaly.errorCount };
+    case "model_latency_anomaly":
+      return { metric: "model_latency_ms", improvement: anomaly.mean - anomaly.latencyMs };
+    case "token_spike":
+      return { metric: "output_tokens", improvement: anomaly.mean - anomaly.outputTokens };
+    case "goal_drift":
+      return { metric: "goal_alignment", improvement: -anomaly.driftScore };
+    case "tool_rate_exceeded":
+      return { metric: "tool_rate", improvement: anomaly.threshold - anomaly.callsPerTurn };
+    case "tool_repeated":
+    case "denied_tool_calls":
+    case "irreversible_action_rate":
+    case "tool_diversity_spike":
+    case "tool_ping_pong":
+    case "session_duration_exceeded":
+    case "delegation_depth_exceeded":
+      return undefined;
+  }
+}
+
 export function mapSystemSignalToCompositionTrigger(
   signal: SystemSignal,
 ): CompositionTrigger | undefined {
@@ -113,9 +144,26 @@ export function mapSystemSignalToCompositionTrigger(
         emittedAt: signal.emittedAt,
       };
     }
+    case "anomaly": {
+      const shift = metricShiftFromAnomaly(signal.anomaly);
+      if (shift === undefined) return undefined;
+
+      return {
+        id: `anomaly:${signal.anomaly.agentId}:${signal.anomaly.kind}:${String(signal.anomaly.timestamp)}`,
+        source: "anomaly",
+        confidence: 1,
+        moment: {
+          kind: "frontier_changed",
+          metric: shift.metric,
+          improvement: shift.improvement,
+        },
+        suggestedCapabilities: ["spawn_agent"],
+        context: { anomaly: signal.anomaly },
+        emittedAt: signal.anomaly.timestamp,
+      };
+    }
     case "vfs":
     case "agent_lifecycle":
-    case "anomaly":
     case "compaction":
       return undefined;
   }

--- a/packages/lib/proactive/src/composition-trigger.ts
+++ b/packages/lib/proactive/src/composition-trigger.ts
@@ -1,0 +1,122 @@
+import type { CompositionTrigger, ForgeDemandSignal, ForgeTrigger, SystemSignal } from "@koi/core";
+
+function missingCapabilityFromForgeTrigger(trigger: ForgeTrigger): string {
+  switch (trigger.kind) {
+    case "capability_gap":
+    case "composition_gap":
+      return trigger.requiredCapability;
+    case "agent_capability_gap":
+      return trigger.agentType;
+    case "agent_repeated_failure":
+    case "agent_latency_degradation":
+      return trigger.agentType;
+    case "data_source_gap":
+      return trigger.missingCapability;
+    case "data_source_detected":
+      return trigger.sourceName;
+    case "repeated_failure":
+    case "performance_degradation":
+      return trigger.toolName;
+    case "no_matching_tool":
+      return trigger.query;
+    case "complex_task_completed":
+      return trigger.taskDescription;
+    case "user_correction":
+      return trigger.correctedToolCall;
+    case "novel_workflow":
+      return trigger.workflowDescription;
+  }
+}
+
+function suggestedCapabilitiesFromForgeDemand(signal: ForgeDemandSignal): readonly string[] {
+  return [`forge_${signal.suggestedBrickKind}`];
+}
+
+function mapForgeDemandToCompositionTrigger(signal: ForgeDemandSignal): CompositionTrigger {
+  return {
+    id: signal.id,
+    source: "forge_demand",
+    confidence: signal.confidence,
+    moment: {
+      kind: "capability_gap",
+      missing: missingCapabilityFromForgeTrigger(signal.trigger),
+    },
+    suggestedCapabilities: suggestedCapabilitiesFromForgeDemand(signal),
+    context: { forgeDemand: signal },
+    emittedAt: signal.emittedAt,
+  };
+}
+
+function mapTaskOutcome(
+  event: Extract<SystemSignal, { kind: "schedule" }>["event"],
+): "completed" | "failed" | "dead_letter" | "cancelled" {
+  switch (event.kind) {
+    case "task:completed":
+      return "completed";
+    case "task:failed":
+      return "failed";
+    case "task:dead_letter":
+      return "dead_letter";
+    case "task:cancelled":
+      return "cancelled";
+  }
+}
+
+function suggestedCapabilitiesForTaskOutcome(
+  outcome: ReturnType<typeof mapTaskOutcome>,
+): readonly string[] {
+  switch (outcome) {
+    case "completed":
+    case "cancelled":
+      return [];
+    case "failed":
+    case "dead_letter":
+      return ["spawn_agent", "notify_user"];
+  }
+}
+
+export function mapSystemSignalToCompositionTrigger(
+  signal: SystemSignal,
+): CompositionTrigger | undefined {
+  switch (signal.kind) {
+    case "governance":
+      return {
+        id: `governance:${signal.sensor}:${String(signal.emittedAt)}`,
+        source: "governance",
+        confidence: 1,
+        moment: {
+          kind: "threshold_crossed",
+          sensor: signal.sensor,
+          value: signal.value,
+          limit: signal.limit,
+          direction: signal.direction,
+        },
+        suggestedCapabilities: signal.sensor === "error_rate" ? ["spawn_agent", "notify_user"] : [],
+        context: {},
+        emittedAt: signal.emittedAt,
+      };
+    case "forge_demand":
+      return mapForgeDemandToCompositionTrigger(signal);
+    case "schedule": {
+      const outcome = mapTaskOutcome(signal.event);
+      return {
+        id: `schedule:${String(signal.event.taskId)}:${String(signal.emittedAt)}`,
+        source: "schedule",
+        confidence: 1,
+        moment: {
+          kind: "task_terminal",
+          taskId: signal.event.taskId,
+          outcome,
+        },
+        suggestedCapabilities: suggestedCapabilitiesForTaskOutcome(outcome),
+        context: { schedulerEvent: signal.event },
+        emittedAt: signal.emittedAt,
+      };
+    }
+    case "vfs":
+    case "agent_lifecycle":
+    case "anomaly":
+    case "compaction":
+      return undefined;
+  }
+}

--- a/packages/lib/proactive/src/composition-trigger.ts
+++ b/packages/lib/proactive/src/composition-trigger.ts
@@ -92,6 +92,7 @@ function metricShiftFromAnomaly(
     case "token_spike":
       return { metric: "output_tokens", improvement: anomaly.mean - anomaly.outputTokens };
     case "goal_drift":
+      if (anomaly.driftScore < 0) return undefined;
       return { metric: "goal_alignment", improvement: -anomaly.driftScore };
     case "tool_rate_exceeded":
       return { metric: "tool_rate", improvement: anomaly.threshold - anomaly.callsPerTurn };

--- a/packages/lib/proactive/src/index.ts
+++ b/packages/lib/proactive/src/index.ts
@@ -5,8 +5,16 @@
  * SchedulerComponent. Channel/webhook/monitor surfaces ship in later phases.
  */
 
+export {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
 export { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
 export { createProactiveTools } from "./create-proactive-tools.js";
 export { createProactiveToolsProvider } from "./provider.js";
+export {
+  createRuleBasedCompositionPlanner,
+  type RuleBasedCompositionPlannerConfig,
+} from "./rule-based-composition-planner.js";
 export type { ProactiveToolsConfig, ProactiveToolsProviderConfig } from "./types.js";
 export { DEFAULT_MAX_SLEEP_MS, DEFAULT_WAKE_MESSAGE } from "./types.js";

--- a/packages/lib/proactive/src/index.ts
+++ b/packages/lib/proactive/src/index.ts
@@ -5,6 +5,7 @@
  * SchedulerComponent. Channel/webhook/monitor surfaces ship in later phases.
  */
 
+export { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
 export { createProactiveTools } from "./create-proactive-tools.js";
 export { createProactiveToolsProvider } from "./provider.js";
 export type { ProactiveToolsConfig, ProactiveToolsProviderConfig } from "./types.js";

--- a/packages/lib/proactive/src/index.ts
+++ b/packages/lib/proactive/src/index.ts
@@ -11,6 +11,12 @@ export {
 } from "./composition-approval.js";
 export { mapSystemSignalToCompositionTrigger } from "./composition-trigger.js";
 export { createProactiveTools } from "./create-proactive-tools.js";
+export {
+  type CompositionPlannerAdapter,
+  type CompositionPlannerAdapterInput,
+  createLlmCompositionPlanner,
+  type LlmCompositionPlannerConfig,
+} from "./llm-composition-planner.js";
 export { createProactiveToolsProvider } from "./provider.js";
 export {
   createRuleBasedCompositionPlanner,

--- a/packages/lib/proactive/src/llm-composition-planner.test.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, test } from "bun:test";
+import { type AgentDefinition, type CompositionTrigger, DEFAULT_DELIVERY_POLICY } from "@koi/core";
+import { createLlmCompositionPlanner } from "./llm-composition-planner.js";
+import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
+
+function agentDefinition(agentType: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: `Use ${agentType} when needed.`,
+    source: "built-in",
+    manifest: { name: agentType, version: "1.0.0", model: { name: "sonnet" } },
+    name: agentType,
+    description: `${agentType} agent`,
+  };
+}
+
+describe("createLlmCompositionPlanner", () => {
+  test("valid adapter JSON returns a parsed plan", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "gov-1",
+            steps: [
+              {
+                kind: "notify_user",
+                channel: "inbox",
+                message: "Threshold crossed",
+                priority: "high",
+              },
+            ],
+            estimatedCost: 2,
+            requiresApproval: false,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "gov-1",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.5,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan).toEqual({
+      triggerId: "gov-1",
+      steps: [
+        {
+          kind: "notify_user",
+          channel: "inbox",
+          message: "Threshold crossed",
+          priority: "high",
+        },
+      ],
+      estimatedCost: 2,
+      requiresApproval: false,
+    });
+  });
+
+  test("malformed JSON falls back to the rule planner when configured", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return "{bad json";
+        },
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "gov-1",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.5,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("diagnostic")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "diagnostic",
+        input: {
+          kind: "text",
+          text: "Investigate elevated error_rate and summarize root causes.",
+        },
+        delivery: DEFAULT_DELIVERY_POLICY,
+      },
+      {
+        kind: "notify_user",
+        channel: "inbox",
+        message: "Error rate crossed its configured threshold.",
+        priority: "high",
+      },
+    ]);
+    expect(plan.estimatedCost).toBe(6);
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("trigger-id mismatch falls back to the rule planner when configured", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "wrong-id",
+            steps: [],
+            estimatedCost: 0,
+          });
+        },
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "event-1",
+      source: "external",
+      confidence: 1,
+      moment: {
+        kind: "external_event",
+        source: "slack",
+        eventType: "mention",
+      },
+      suggestedCapabilities: [],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan).toEqual({
+      triggerId: "event-1",
+      steps: [],
+      estimatedCost: 0,
+      requiresApproval: true,
+    });
+  });
+
+  test("parseable but schema-invalid JSON falls back to the rule planner when configured", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "event-2",
+            steps: "not-an-array",
+            estimatedCost: 0,
+          });
+        },
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "event-2",
+      source: "external",
+      confidence: 1,
+      moment: {
+        kind: "external_event",
+        source: "slack",
+        eventType: "mention",
+      },
+      suggestedCapabilities: [],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan).toEqual({
+      triggerId: "event-2",
+      steps: [],
+      estimatedCost: 0,
+      requiresApproval: true,
+    });
+  });
+
+  test("rejects nested invalid message input that previously slipped through", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "bad-nested-1",
+            steps: [
+              {
+                kind: "spawn_agent",
+                agentType: "researcher",
+                input: {
+                  kind: "messages",
+                  messages: [
+                    {
+                      content: [],
+                      threadId: "t-1",
+                      timestamp: 1,
+                    },
+                  ],
+                },
+                delivery: { kind: "deferred" },
+              },
+            ],
+            estimatedCost: 5,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "bad-nested-1",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "frontier_changed",
+        metric: "retrieval_quality",
+        improvement: 0.2,
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    await expect(
+      planner.plan(trigger, {
+        tools: [],
+        agents: [],
+        schedules: [],
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("local approval recomputation overrides model-provided approval", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "low-1",
+            steps: [
+              {
+                kind: "notify_user",
+                channel: "inbox",
+                message: "Low confidence plan",
+                priority: "normal",
+              },
+            ],
+            estimatedCost: 1,
+            requiresApproval: false,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "low-1",
+      source: "governance",
+      confidence: 0.1,
+      moment: { kind: "capability_gap", missing: "diagnostics" },
+      suggestedCapabilities: ["notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "notify_user",
+        channel: "inbox",
+        message: "Low confidence plan",
+        priority: "normal",
+      },
+    ]);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("local classify logic errors are not silently replaced with fallback output", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "local-bug-1",
+            steps: [],
+            estimatedCost: 0,
+          });
+        },
+      },
+      classifyNovelty(): boolean {
+        throw new Error("novelty exploded");
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "local-bug-1",
+      source: "external",
+      confidence: 1,
+      moment: {
+        kind: "external_event",
+        source: "slack",
+        eventType: "mention",
+      },
+      suggestedCapabilities: [],
+      context: {},
+      emittedAt: 1,
+    };
+
+    await expect(
+      planner.plan(trigger, {
+        tools: [],
+        agents: [],
+        schedules: [],
+      }),
+    ).rejects.toThrow("novelty exploded");
+  });
+});

--- a/packages/lib/proactive/src/llm-composition-planner.test.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { type AgentDefinition, type CompositionTrigger, DEFAULT_DELIVERY_POLICY } from "@koi/core";
+import {
+  type AgentDefinition,
+  agentId,
+  type CompositionTrigger,
+  DEFAULT_DELIVERY_POLICY,
+} from "@koi/core";
 import { createLlmCompositionPlanner } from "./llm-composition-planner.js";
 import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
 
@@ -417,6 +422,178 @@ describe("createLlmCompositionPlanner", () => {
       },
     ]);
     expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("round-trips tool_call step kind", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "tc-1",
+            steps: [
+              {
+                kind: "tool_call",
+                toolName: "search",
+                input: { query: "needle" },
+              },
+            ],
+            estimatedCost: 2,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "tc-1",
+      source: "external",
+      confidence: 1,
+      moment: { kind: "external_event", source: "slack", eventType: "mention" },
+      suggestedCapabilities: ["tool_call"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, { tools: [], agents: [], schedules: [] });
+    expect(plan.steps).toEqual([
+      { kind: "tool_call", toolName: "search", input: { query: "needle" } },
+    ]);
+  });
+
+  test("round-trips submit_task step kind", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "st-1",
+            steps: [
+              {
+                kind: "submit_task",
+                agentId: "agent-42",
+                mode: "dispatch",
+                input: { kind: "text", text: "process queue" },
+                taskOptions: { priority: 5, timeoutMs: 30000 },
+              },
+            ],
+            estimatedCost: 3,
+          });
+        },
+      },
+    });
+
+    const expectedAgentId = agentId("agent-42");
+    const trigger: CompositionTrigger = {
+      id: "st-1",
+      source: "external",
+      confidence: 1,
+      moment: { kind: "external_event", source: "slack", eventType: "mention" },
+      suggestedCapabilities: ["submit_task"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, { tools: [], agents: [], schedules: [] });
+    expect(plan.steps).toEqual([
+      {
+        kind: "submit_task",
+        agentId: expectedAgentId,
+        mode: "dispatch",
+        input: { kind: "text", text: "process queue" },
+        taskOptions: { priority: 5, timeoutMs: 30000 },
+      },
+    ]);
+  });
+
+  test("round-trips create_schedule step kind", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "cs-1",
+            steps: [
+              {
+                kind: "create_schedule",
+                expression: "0 9 * * *",
+                agentId: "agent-1",
+                mode: "spawn",
+                input: { kind: "text", text: "daily standup" },
+                timezone: "America/Los_Angeles",
+              },
+            ],
+            estimatedCost: 3,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "cs-1",
+      source: "external",
+      confidence: 1,
+      moment: { kind: "external_event", source: "cron", eventType: "setup" },
+      suggestedCapabilities: ["create_schedule"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, { tools: [], agents: [], schedules: [] });
+    expect(plan.steps).toEqual([
+      {
+        kind: "create_schedule",
+        expression: "0 9 * * *",
+        agentId: agentId("agent-1"),
+        mode: "spawn",
+        input: { kind: "text", text: "daily standup" },
+        timezone: "America/Los_Angeles",
+      },
+    ]);
+  });
+
+  test("round-trips forge_skill step kind", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "fs-1",
+            steps: [
+              {
+                kind: "forge_skill",
+                demand: {
+                  id: "demand-1",
+                  kind: "forge_demand",
+                  trigger: { kind: "capability_gap", requiredCapability: "csv-parse" },
+                  confidence: 0.9,
+                  suggestedBrickKind: "skill",
+                  context: {
+                    failureCount: 3,
+                    failedToolCalls: ["read_file:csv"],
+                    taskDescription: "parse quarterly report",
+                  },
+                  emittedAt: 100,
+                },
+              },
+            ],
+            estimatedCost: 4,
+          });
+        },
+      },
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "fs-1",
+      source: "forge_demand",
+      confidence: 1,
+      moment: { kind: "capability_gap", missing: "csv-parse" },
+      suggestedCapabilities: ["forge_skill"],
+      context: {},
+      emittedAt: 100,
+    };
+
+    const plan = await planner.plan(trigger, { tools: [], agents: [], schedules: [] });
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]).toMatchObject({
+      kind: "forge_skill",
+      demand: { id: "demand-1", suggestedBrickKind: "skill" },
+    });
   });
 
   test("local classify logic errors are not silently replaced with fallback output", async () => {

--- a/packages/lib/proactive/src/llm-composition-planner.test.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.test.ts
@@ -210,6 +210,48 @@ describe("createLlmCompositionPlanner", () => {
     });
   });
 
+  test("negative estimated cost is rejected and can fall back to the rule planner", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return JSON.stringify({
+            triggerId: "event-3",
+            steps: [],
+            estimatedCost: -1,
+          });
+        },
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner(),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "event-3",
+      source: "external",
+      confidence: 1,
+      moment: {
+        kind: "external_event",
+        source: "slack",
+        eventType: "mention",
+      },
+      suggestedCapabilities: [],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan).toEqual({
+      triggerId: "event-3",
+      steps: [],
+      estimatedCost: 0,
+      requiresApproval: true,
+    });
+  });
+
   test("rejects nested invalid message input that previously slipped through", async () => {
     const planner = createLlmCompositionPlanner({
       adapter: {

--- a/packages/lib/proactive/src/llm-composition-planner.test.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.test.ts
@@ -164,7 +164,7 @@ describe("createLlmCompositionPlanner", () => {
       triggerId: "event-1",
       steps: [],
       estimatedCost: 0,
-      requiresApproval: true,
+      requiresApproval: false,
     });
   });
 
@@ -206,7 +206,7 @@ describe("createLlmCompositionPlanner", () => {
       triggerId: "event-2",
       steps: [],
       estimatedCost: 0,
-      requiresApproval: true,
+      requiresApproval: false,
     });
   });
 
@@ -248,8 +248,75 @@ describe("createLlmCompositionPlanner", () => {
       triggerId: "event-3",
       steps: [],
       estimatedCost: 0,
-      requiresApproval: true,
+      requiresApproval: false,
     });
+  });
+
+  test("fallback plans are reclassified with the outer llm approval policy", async () => {
+    const planner = createLlmCompositionPlanner({
+      adapter: {
+        async plan(): Promise<string> {
+          return "{bad json";
+        },
+      },
+      approvalPolicy: {
+        confidenceThreshold: 0,
+        maxEstimatedCost: 100,
+        requireApprovalOnNovelty: true,
+      },
+      classifyNovelty(): boolean {
+        return true;
+      },
+      fallbackToRulePlanner: createRuleBasedCompositionPlanner({
+        approvalPolicy: {
+          confidenceThreshold: 0,
+          maxEstimatedCost: 100,
+          requireApprovalOnNovelty: false,
+        },
+      }),
+    });
+
+    const trigger: CompositionTrigger = {
+      id: "gov-novel-1",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.5,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("diagnostic")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "diagnostic",
+        input: {
+          kind: "text",
+          text: "Investigate elevated error_rate and summarize root causes.",
+        },
+        delivery: DEFAULT_DELIVERY_POLICY,
+      },
+      {
+        kind: "notify_user",
+        channel: "inbox",
+        message: "Error rate crossed its configured threshold.",
+        priority: "high",
+      },
+    ]);
+    expect(plan.estimatedCost).toBe(6);
+    expect(plan.requiresApproval).toBe(true);
   });
 
   test("rejects nested invalid message input that previously slipped through", async () => {

--- a/packages/lib/proactive/src/llm-composition-planner.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.ts
@@ -326,6 +326,20 @@ function parseAdapterResponse(
   }
 }
 
+function withComputedApproval(
+  plan: Omit<CompositionPlan, "requiresApproval">,
+  trigger: CompositionTrigger,
+  approvalPolicy: CompositionApprovalPolicy,
+  isNovel: boolean,
+): CompositionPlan {
+  return {
+    ...plan,
+    requiresApproval: computeCompositionApproval(trigger, plan.estimatedCost, approvalPolicy, {
+      isNovel,
+    }),
+  };
+}
+
 export function createLlmCompositionPlanner(
   config: LlmCompositionPlannerConfig,
 ): CompositionPlanner {
@@ -334,28 +348,20 @@ export function createLlmCompositionPlanner(
 
   return {
     async plan(trigger, capabilities): Promise<CompositionPlan> {
+      const isNovel = classifyNovelty(trigger);
       let parsed: Omit<CompositionPlan, "requiresApproval">;
       try {
         const raw = await config.adapter.plan({ trigger, capabilities });
         parsed = parseAdapterResponse(raw, trigger);
       } catch (error) {
         if (config.fallbackToRulePlanner !== undefined && error instanceof AdapterPlanParseError) {
-          return config.fallbackToRulePlanner.plan(trigger, capabilities);
+          const fallbackPlan = await config.fallbackToRulePlanner.plan(trigger, capabilities);
+          return withComputedApproval(fallbackPlan, trigger, approvalPolicy, isNovel);
         }
         throw error;
       }
 
-      return {
-        ...parsed,
-        requiresApproval: computeCompositionApproval(
-          trigger,
-          parsed.estimatedCost,
-          approvalPolicy,
-          {
-            isNovel: classifyNovelty(trigger),
-          },
-        ),
-      };
+      return withComputedApproval(parsed, trigger, approvalPolicy, isNovel);
     },
   };
 }

--- a/packages/lib/proactive/src/llm-composition-planner.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.ts
@@ -289,7 +289,7 @@ const llmPlanSchema = z
   .object({
     triggerId: z.string(),
     steps: z.array(compositionStepSchema),
-    estimatedCost: z.number().finite(),
+    estimatedCost: z.number().finite().nonnegative(),
   })
   .passthrough();
 

--- a/packages/lib/proactive/src/llm-composition-planner.ts
+++ b/packages/lib/proactive/src/llm-composition-planner.ts
@@ -1,0 +1,361 @@
+import type {
+  CompositionApprovalPolicy,
+  CompositionCapabilities,
+  CompositionPlan,
+  CompositionPlanner,
+  CompositionStep,
+  CompositionTrigger,
+} from "@koi/core";
+import { z } from "zod";
+import {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
+
+class AdapterPlanParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "AdapterPlanParseError";
+  }
+}
+
+export interface CompositionPlannerAdapterInput {
+  readonly trigger: CompositionTrigger;
+  readonly capabilities: CompositionCapabilities;
+}
+
+export interface CompositionPlannerAdapter {
+  readonly plan: (input: CompositionPlannerAdapterInput) => Promise<string>;
+}
+
+export interface LlmCompositionPlannerConfig {
+  readonly adapter: CompositionPlannerAdapter;
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+  readonly fallbackToRulePlanner?: CompositionPlanner | undefined;
+}
+
+const jsonValueSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    metadataSchema,
+  ]),
+);
+
+const metadataSchema: z.ZodType<Readonly<Record<string, unknown>>> = z.record(
+  z.string(),
+  jsonValueSchema,
+);
+
+const contentBlockSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("text"), text: z.string() }).strict(),
+  z
+    .object({
+      kind: z.literal("file"),
+      url: z.string(),
+      mimeType: z.string(),
+      name: z.string().optional(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("image"), url: z.string(), alt: z.string().optional() }).strict(),
+  z
+    .object({
+      kind: z.literal("button"),
+      label: z.string(),
+      action: z.string(),
+      payload: jsonValueSchema.optional(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("custom"), type: z.string(), data: jsonValueSchema }).strict(),
+]);
+
+const inboundMessageSchema = z
+  .object({
+    content: z.array(contentBlockSchema),
+    senderId: z.string(),
+    threadId: z.string().optional(),
+    timestamp: z.number(),
+    metadata: metadataSchema.optional(),
+    pinned: z.boolean().optional(),
+  })
+  .strict();
+
+const taskOptionsSchema = z
+  .object({
+    priority: z.number().optional(),
+    delayMs: z.number().optional(),
+    maxRetries: z.number().optional(),
+    timeoutMs: z.number().optional(),
+    metadata: metadataSchema.optional(),
+    idempotencyKey: z.string().optional(),
+  })
+  .strict();
+
+const deliveryPolicySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("streaming") }).strict(),
+  z
+    .object({
+      kind: z.literal("deferred"),
+      inboxMode: z
+        .union([z.literal("collect"), z.literal("followup"), z.literal("steer")])
+        .optional(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("on_demand") }).strict(),
+]);
+
+const engineInputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("text"), text: z.string() }).strict(),
+  z.object({ kind: z.literal("messages"), messages: z.array(inboundMessageSchema) }).strict(),
+  z
+    .object({
+      kind: z.literal("resume"),
+      state: z.object({ engineId: z.string(), data: jsonValueSchema }).strict(),
+    })
+    .strict(),
+]);
+
+const forgeTriggerSchema = z.discriminatedUnion("kind", [
+  z
+    .object({ kind: z.literal("repeated_failure"), toolName: z.string(), count: z.number() })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("no_matching_tool"),
+      query: z.string(),
+      attempts: z.number(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("capability_gap"),
+      requiredCapability: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("performance_degradation"),
+      toolName: z.string(),
+      metric: z.string(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("agent_capability_gap"), agentType: z.string() }).strict(),
+  z
+    .object({
+      kind: z.literal("agent_repeated_failure"),
+      agentType: z.string(),
+      brickId: z.string(),
+      errorRate: z.number(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("agent_latency_degradation"),
+      agentType: z.string(),
+      brickId: z.string(),
+      p95Ms: z.number(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("data_source_detected"),
+      sourceName: z.string(),
+      protocol: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("data_source_gap"),
+      sourceName: z.string(),
+      missingCapability: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("complex_task_completed"),
+      toolCallCount: z.number(),
+      taskDescription: z.string(),
+      toolsUsed: z.array(z.string()),
+      turnCount: z.number(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("user_correction"),
+      correctionText: z.string(),
+      correctedToolCall: z.string(),
+      correctionDescription: z.string(),
+      originalToolName: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("novel_workflow"),
+      workflowDescription: z.string(),
+      toolSequence: z.array(z.string()),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("composition_gap"),
+      requiredCapability: z.string(),
+      observedCount: z.number(),
+    })
+    .strict(),
+]);
+
+const forgeDemandSchema = z
+  .object({
+    id: z.string(),
+    kind: z.literal("forge_demand"),
+    trigger: forgeTriggerSchema,
+    confidence: z.number(),
+    suggestedBrickKind: z.union([
+      z.literal("tool"),
+      z.literal("skill"),
+      z.literal("agent"),
+      z.literal("middleware"),
+      z.literal("channel"),
+      z.literal("composite"),
+    ]),
+    context: z
+      .object({
+        failureCount: z.number(),
+        failedToolCalls: z.array(z.string()),
+        taskDescription: z.string().optional(),
+      })
+      .strict(),
+    emittedAt: z.number(),
+  })
+  .strict();
+
+const compositionStepSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("tool_call"),
+      toolName: z.string(),
+      input: z.unknown(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("spawn_agent"),
+      agentType: z.string(),
+      input: engineInputSchema,
+      delivery: deliveryPolicySchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("submit_task"),
+      agentId: z.string(),
+      mode: z.union([z.literal("spawn"), z.literal("dispatch")]),
+      input: engineInputSchema,
+      taskOptions: taskOptionsSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("create_schedule"),
+      expression: z.string(),
+      agentId: z.string(),
+      mode: z.union([z.literal("spawn"), z.literal("dispatch")]),
+      input: engineInputSchema,
+      timezone: z.string().optional(),
+      taskOptions: taskOptionsSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("forge_skill"),
+      demand: forgeDemandSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("notify_user"),
+      channel: z.string(),
+      message: z.string(),
+      priority: z.union([z.literal("low"), z.literal("normal"), z.literal("high")]),
+    })
+    .strict(),
+]);
+
+const llmPlanSchema = z
+  .object({
+    triggerId: z.string(),
+    steps: z.array(compositionStepSchema),
+    estimatedCost: z.number().finite(),
+  })
+  .passthrough();
+
+function parseAdapterResponse(
+  raw: string,
+  trigger: CompositionTrigger,
+): Omit<CompositionPlan, "requiresApproval"> {
+  try {
+    const normalized = raw
+      .trim()
+      .replace(/^```(?:json)?\s*/u, "")
+      .replace(/\s*```$/u, "")
+      .trim();
+
+    const parsed = JSON.parse(normalized) as unknown;
+    const plan = llmPlanSchema.parse(parsed);
+
+    if (plan.triggerId !== trigger.id) {
+      throw new AdapterPlanParseError(
+        `planner triggerId mismatch: expected ${trigger.id}, got ${plan.triggerId}`,
+      );
+    }
+
+    return {
+      triggerId: plan.triggerId,
+      steps: plan.steps as readonly CompositionStep[],
+      estimatedCost: plan.estimatedCost,
+    };
+  } catch (error) {
+    if (error instanceof AdapterPlanParseError) throw error;
+    throw new AdapterPlanParseError("adapter returned an invalid composition plan", {
+      cause: error,
+    });
+  }
+}
+
+export function createLlmCompositionPlanner(
+  config: LlmCompositionPlannerConfig,
+): CompositionPlanner {
+  const approvalPolicy = config.approvalPolicy ?? DEFAULT_COMPOSITION_APPROVAL_POLICY;
+  const classifyNovelty = config.classifyNovelty ?? (() => false);
+
+  return {
+    async plan(trigger, capabilities): Promise<CompositionPlan> {
+      let parsed: Omit<CompositionPlan, "requiresApproval">;
+      try {
+        const raw = await config.adapter.plan({ trigger, capabilities });
+        parsed = parseAdapterResponse(raw, trigger);
+      } catch (error) {
+        if (config.fallbackToRulePlanner !== undefined && error instanceof AdapterPlanParseError) {
+          return config.fallbackToRulePlanner.plan(trigger, capabilities);
+        }
+        throw error;
+      }
+
+      return {
+        ...parsed,
+        requiresApproval: computeCompositionApproval(
+          trigger,
+          parsed.estimatedCost,
+          approvalPolicy,
+          {
+            isNovel: classifyNovelty(trigger),
+          },
+        ),
+      };
+    },
+  };
+}

--- a/packages/lib/proactive/src/rule-based-composition-planner.test.ts
+++ b/packages/lib/proactive/src/rule-based-composition-planner.test.ts
@@ -303,4 +303,91 @@ describe("createRuleBasedCompositionPlanner", () => {
     expect(plan.estimatedCost).toBe(1);
     expect(plan.requiresApproval).toBe(false);
   });
+
+  test("plans recovery spawn for dead_letter task terminals", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "task-dl-1",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-dl-1"),
+        outcome: "dead_letter",
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("recovery")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "recovery",
+        input: {
+          kind: "text",
+          text: "Analyze failed scheduled task task-dl-1 and propose recovery.",
+        },
+        delivery: DEFAULT_DELIVERY_POLICY,
+      },
+    ]);
+  });
+
+  test("failed task without recovery agent emits no spawn (capability gating)", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "task-no-rec",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-no-rec"),
+        outcome: "failed",
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("frontier change without researcher agent emits no spawn (capability gating)", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "frontier-no-res",
+      source: "anomaly",
+      confidence: 1,
+      moment: {
+        kind: "frontier_changed",
+        metric: "retrieval_quality",
+        improvement: 0.3,
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.requiresApproval).toBe(true);
+  });
 });

--- a/packages/lib/proactive/src/rule-based-composition-planner.test.ts
+++ b/packages/lib/proactive/src/rule-based-composition-planner.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AgentDefinition,
+  type CompositionTrigger,
+  DEFAULT_DELIVERY_POLICY,
+  type SystemSignal,
+  taskId,
+} from "@koi/core";
+import { createRuleBasedCompositionPlanner } from "./rule-based-composition-planner.js";
+
+function agentDefinition(agentType: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: `Use ${agentType} when needed.`,
+    source: "built-in",
+    manifest: { name: agentType, version: "1.0.0", model: { name: "sonnet" } },
+    name: agentType,
+    description: `${agentType} agent`,
+  };
+}
+
+describe("createRuleBasedCompositionPlanner", () => {
+  test("plans forge work for capability gap triggers carrying forge demand context", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const forgeDemand = {
+      id: "fd-1",
+      kind: "forge_demand",
+      confidence: 0.9,
+      suggestedBrickKind: "skill",
+      trigger: { kind: "capability_gap", requiredCapability: "diagnostics" },
+      context: { failureCount: 1, failedToolCalls: [] },
+      emittedAt: 1,
+    } as const satisfies SystemSignal;
+
+    const trigger: CompositionTrigger = {
+      id: "gap-1",
+      source: "forge_demand",
+      confidence: 0.9,
+      moment: { kind: "capability_gap", missing: "diagnostics" },
+      suggestedCapabilities: ["forge_skill"],
+      context: { forgeDemand },
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([{ kind: "forge_skill", demand: forgeDemand }]);
+    expect(plan.estimatedCost).toBe(4);
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("plans diagnostic spawn for error_rate thresholds", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "gov-1",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.6,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("diagnostic")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toContainEqual({
+      kind: "spawn_agent",
+      agentType: "diagnostic",
+      input: { kind: "text", text: "Investigate elevated error_rate and summarize root causes." },
+      delivery: DEFAULT_DELIVERY_POLICY,
+    });
+  });
+
+  test("plans recovery spawn for failed task terminals", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "task-1",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-1"),
+        outcome: "failed",
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("recovery")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "recovery",
+        input: {
+          kind: "text",
+          text: "Analyze failed scheduled task task-1 and propose recovery.",
+        },
+        delivery: DEFAULT_DELIVERY_POLICY,
+      },
+    ]);
+    expect(plan.requiresApproval).toBe(false);
+  });
+
+  test("plans deferred frontier research for frontier changes", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "frontier-1",
+      source: "anomaly",
+      confidence: 1,
+      moment: {
+        kind: "frontier_changed",
+        metric: "retrieval_quality",
+        improvement: 0.2,
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("researcher")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "spawn_agent",
+        agentType: "researcher",
+        input: {
+          kind: "text",
+          text: "Investigate frontier change in retrieval_quality.",
+        },
+        delivery: { kind: "deferred" },
+      },
+    ]);
+  });
+
+  test("requires approval for recognized triggers that yield no deterministic steps", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "event-1",
+      source: "external",
+      confidence: 1,
+      moment: {
+        kind: "external_event",
+        source: "slack",
+        eventType: "mention",
+      },
+      suggestedCapabilities: [],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.estimatedCost).toBe(0);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("cancelled terminal outcome stays quiet", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "task-cancelled",
+      source: "schedule",
+      confidence: 1,
+      moment: {
+        kind: "task_terminal",
+        taskId: taskId("task-cancelled"),
+        outcome: "cancelled",
+      },
+      suggestedCapabilities: ["spawn_agent"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [agentDefinition("recovery")],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("non-skill forge demand does not auto-plan a misleading forge step", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const forgeDemand = {
+      id: "fd-agent-1",
+      kind: "forge_demand",
+      confidence: 0.9,
+      suggestedBrickKind: "agent",
+      trigger: { kind: "agent_capability_gap", agentType: "researcher" },
+      context: { failureCount: 1, failedToolCalls: [] },
+      emittedAt: 1,
+    } as const satisfies SystemSignal;
+
+    const trigger: CompositionTrigger = {
+      id: "gap-agent-1",
+      source: "forge_demand",
+      confidence: 0.9,
+      moment: { kind: "capability_gap", missing: "researcher" },
+      suggestedCapabilities: ["forge_agent"],
+      context: { forgeDemand },
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("malformed forge demand context does not emit forge work", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "gap-malformed-1",
+      source: "forge_demand",
+      confidence: 0.9,
+      moment: { kind: "capability_gap", missing: "diagnostics" },
+      suggestedCapabilities: ["forge_skill"],
+      context: {
+        forgeDemand: {
+          suggestedBrickKind: "skill",
+        },
+      },
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.estimatedCost).toBe(0);
+    expect(plan.requiresApproval).toBe(true);
+  });
+
+  test("error-rate alerts still notify when diagnostic agents are unavailable", async () => {
+    const planner = createRuleBasedCompositionPlanner();
+    const trigger: CompositionTrigger = {
+      id: "gov-missing-agent",
+      source: "governance",
+      confidence: 1,
+      moment: {
+        kind: "threshold_crossed",
+        sensor: "error_rate",
+        value: 0.6,
+        limit: 0.2,
+        direction: "above",
+      },
+      suggestedCapabilities: ["spawn_agent", "notify_user"],
+      context: {},
+      emittedAt: 1,
+    };
+
+    const plan = await planner.plan(trigger, {
+      tools: [],
+      agents: [],
+      schedules: [],
+    });
+
+    expect(plan.steps).toEqual([
+      {
+        kind: "notify_user",
+        channel: "inbox",
+        message: "Error rate crossed its configured threshold.",
+        priority: "high",
+      },
+    ]);
+    expect(plan.estimatedCost).toBe(1);
+    expect(plan.requiresApproval).toBe(false);
+  });
+});

--- a/packages/lib/proactive/src/rule-based-composition-planner.ts
+++ b/packages/lib/proactive/src/rule-based-composition-planner.ts
@@ -84,6 +84,107 @@ function isRepresentableSkillForgeDemand(
   return demand;
 }
 
+function stepsForCapabilityGap(trigger: CompositionTrigger): readonly CompositionStep[] {
+  const forgeDemand = isRepresentableSkillForgeDemand(trigger);
+  return forgeDemand === undefined ? [] : [{ kind: "forge_skill", demand: forgeDemand }];
+}
+
+function stepsForThresholdCrossed(
+  trigger: CompositionTrigger,
+  capabilities: CompositionCapabilities,
+): readonly CompositionStep[] {
+  if (
+    trigger.moment.kind !== "threshold_crossed" ||
+    trigger.moment.sensor !== "error_rate" ||
+    trigger.moment.direction !== "above"
+  ) {
+    return [];
+  }
+  const steps: CompositionStep[] = [];
+  if (hasAgentType(capabilities, "diagnostic")) {
+    steps.push({
+      kind: "spawn_agent",
+      agentType: "diagnostic",
+      input: {
+        kind: "text",
+        text: "Investigate elevated error_rate and summarize root causes.",
+      },
+      delivery: DEFAULT_DELIVERY_POLICY,
+    });
+  }
+  steps.push({
+    kind: "notify_user",
+    channel: "inbox",
+    message: "Error rate crossed its configured threshold.",
+    priority: "high",
+  });
+  return steps;
+}
+
+function stepsForTaskTerminal(
+  trigger: CompositionTrigger,
+  capabilities: CompositionCapabilities,
+): readonly CompositionStep[] {
+  if (trigger.moment.kind !== "task_terminal") return [];
+  const { outcome, taskId } = trigger.moment;
+  if (
+    (outcome !== "failed" && outcome !== "dead_letter") ||
+    !hasAgentType(capabilities, "recovery")
+  ) {
+    return [];
+  }
+  return [
+    {
+      kind: "spawn_agent",
+      agentType: "recovery",
+      input: {
+        kind: "text",
+        text: `Analyze failed scheduled task ${String(taskId)} and propose recovery.`,
+      },
+      delivery: DEFAULT_DELIVERY_POLICY,
+    },
+  ];
+}
+
+function stepsForFrontierChanged(
+  trigger: CompositionTrigger,
+  capabilities: CompositionCapabilities,
+): readonly CompositionStep[] {
+  if (trigger.moment.kind !== "frontier_changed" || !hasAgentType(capabilities, "researcher")) {
+    return [];
+  }
+  return [
+    {
+      kind: "spawn_agent",
+      agentType: "researcher",
+      input: {
+        kind: "text",
+        text: `Investigate frontier change in ${trigger.moment.metric}.`,
+      },
+      delivery: { kind: "deferred" },
+    },
+  ];
+}
+
+function stepsForTrigger(
+  trigger: CompositionTrigger,
+  capabilities: CompositionCapabilities,
+): readonly CompositionStep[] {
+  switch (trigger.moment.kind) {
+    case "capability_gap":
+      return stepsForCapabilityGap(trigger);
+    case "threshold_crossed":
+      return stepsForThresholdCrossed(trigger, capabilities);
+    case "task_terminal":
+      return stepsForTaskTerminal(trigger, capabilities);
+    case "frontier_changed":
+      return stepsForFrontierChanged(trigger, capabilities);
+    case "pattern_matched":
+    case "external_event":
+      return [];
+  }
+}
+
 export function createRuleBasedCompositionPlanner(
   config: RuleBasedCompositionPlannerConfig = {},
 ): CompositionPlanner {
@@ -92,73 +193,8 @@ export function createRuleBasedCompositionPlanner(
 
   return {
     async plan(trigger, capabilities): Promise<CompositionPlan> {
-      const steps: CompositionStep[] = [];
-
-      switch (trigger.moment.kind) {
-        case "capability_gap": {
-          const forgeDemand = isRepresentableSkillForgeDemand(trigger);
-          if (forgeDemand !== undefined) {
-            steps.push({ kind: "forge_skill", demand: forgeDemand });
-          }
-          break;
-        }
-        case "threshold_crossed":
-          if (trigger.moment.sensor === "error_rate" && trigger.moment.direction === "above") {
-            if (hasAgentType(capabilities, "diagnostic")) {
-              steps.push({
-                kind: "spawn_agent",
-                agentType: "diagnostic",
-                input: {
-                  kind: "text",
-                  text: "Investigate elevated error_rate and summarize root causes.",
-                },
-                delivery: DEFAULT_DELIVERY_POLICY,
-              });
-            }
-            steps.push({
-              kind: "notify_user",
-              channel: "inbox",
-              message: "Error rate crossed its configured threshold.",
-              priority: "high",
-            });
-          }
-          break;
-        case "task_terminal":
-          if (
-            (trigger.moment.outcome === "failed" || trigger.moment.outcome === "dead_letter") &&
-            hasAgentType(capabilities, "recovery")
-          ) {
-            steps.push({
-              kind: "spawn_agent",
-              agentType: "recovery",
-              input: {
-                kind: "text",
-                text: `Analyze failed scheduled task ${String(trigger.moment.taskId)} and propose recovery.`,
-              },
-              delivery: DEFAULT_DELIVERY_POLICY,
-            });
-          }
-          break;
-        case "frontier_changed":
-          if (hasAgentType(capabilities, "researcher")) {
-            steps.push({
-              kind: "spawn_agent",
-              agentType: "researcher",
-              input: {
-                kind: "text",
-                text: `Investigate frontier change in ${trigger.moment.metric}.`,
-              },
-              delivery: { kind: "deferred" },
-            });
-          }
-          break;
-        case "pattern_matched":
-        case "external_event":
-          break;
-      }
-
+      const steps = stepsForTrigger(trigger, capabilities);
       const estimatedCost = estimateCost(steps);
-
       return {
         triggerId: trigger.id,
         steps,

--- a/packages/lib/proactive/src/rule-based-composition-planner.ts
+++ b/packages/lib/proactive/src/rule-based-composition-planner.ts
@@ -1,0 +1,174 @@
+import {
+  type CompositionApprovalPolicy,
+  type CompositionCapabilities,
+  type CompositionPlan,
+  type CompositionPlanner,
+  type CompositionStep,
+  type CompositionTrigger,
+  DEFAULT_DELIVERY_POLICY,
+  type ForgeDemandSignal,
+} from "@koi/core";
+import {
+  computeCompositionApproval,
+  DEFAULT_COMPOSITION_APPROVAL_POLICY,
+} from "./composition-approval.js";
+
+export interface RuleBasedCompositionPlannerConfig {
+  readonly approvalPolicy?: CompositionApprovalPolicy | undefined;
+  readonly classifyNovelty?: ((trigger: CompositionTrigger) => boolean) | undefined;
+}
+
+function estimateStepCost(step: CompositionStep): number {
+  switch (step.kind) {
+    case "notify_user":
+      return 1;
+    case "tool_call":
+      return 2;
+    case "submit_task":
+    case "create_schedule":
+      return 3;
+    case "forge_skill":
+      return 4;
+    case "spawn_agent":
+      return 5;
+  }
+
+  const _exhaustive: never = step;
+  return _exhaustive;
+}
+
+function estimateCost(steps: readonly CompositionStep[]): number {
+  return steps.reduce((total, step) => total + estimateStepCost(step), 0);
+}
+
+function isForgeDemandSignal(value: unknown): value is ForgeDemandSignal {
+  if (typeof value !== "object" || value === null) return false;
+
+  const demand = value as Record<string, unknown>;
+  const context = demand.context;
+  const trigger = demand.trigger;
+
+  return (
+    typeof demand.id === "string" &&
+    demand.kind === "forge_demand" &&
+    typeof demand.confidence === "number" &&
+    Number.isFinite(demand.confidence) &&
+    typeof demand.suggestedBrickKind === "string" &&
+    typeof demand.emittedAt === "number" &&
+    Number.isFinite(demand.emittedAt) &&
+    typeof trigger === "object" &&
+    trigger !== null &&
+    typeof (trigger as Record<string, unknown>).kind === "string" &&
+    typeof context === "object" &&
+    context !== null &&
+    typeof (context as Record<string, unknown>).failureCount === "number" &&
+    Array.isArray((context as Record<string, unknown>).failedToolCalls)
+  );
+}
+
+function getForgeDemand(trigger: CompositionTrigger): ForgeDemandSignal | undefined {
+  const demand = trigger.context.forgeDemand;
+  if (!isForgeDemandSignal(demand)) return undefined;
+  return demand;
+}
+
+function hasAgentType(capabilities: CompositionCapabilities, agentType: string): boolean {
+  return capabilities.agents.some((agent) => agent.agentType === agentType);
+}
+
+function isRepresentableSkillForgeDemand(
+  trigger: CompositionTrigger,
+): ForgeDemandSignal | undefined {
+  const demand = getForgeDemand(trigger);
+  if (demand?.suggestedBrickKind !== "skill") return undefined;
+  return demand;
+}
+
+export function createRuleBasedCompositionPlanner(
+  config: RuleBasedCompositionPlannerConfig = {},
+): CompositionPlanner {
+  const approvalPolicy = config.approvalPolicy ?? DEFAULT_COMPOSITION_APPROVAL_POLICY;
+  const classifyNovelty = config.classifyNovelty ?? (() => false);
+
+  return {
+    async plan(trigger, capabilities): Promise<CompositionPlan> {
+      const steps: CompositionStep[] = [];
+
+      switch (trigger.moment.kind) {
+        case "capability_gap": {
+          const forgeDemand = isRepresentableSkillForgeDemand(trigger);
+          if (forgeDemand !== undefined) {
+            steps.push({ kind: "forge_skill", demand: forgeDemand });
+          }
+          break;
+        }
+        case "threshold_crossed":
+          if (trigger.moment.sensor === "error_rate" && trigger.moment.direction === "above") {
+            if (hasAgentType(capabilities, "diagnostic")) {
+              steps.push({
+                kind: "spawn_agent",
+                agentType: "diagnostic",
+                input: {
+                  kind: "text",
+                  text: "Investigate elevated error_rate and summarize root causes.",
+                },
+                delivery: DEFAULT_DELIVERY_POLICY,
+              });
+            }
+            steps.push({
+              kind: "notify_user",
+              channel: "inbox",
+              message: "Error rate crossed its configured threshold.",
+              priority: "high",
+            });
+          }
+          break;
+        case "task_terminal":
+          if (
+            (trigger.moment.outcome === "failed" || trigger.moment.outcome === "dead_letter") &&
+            hasAgentType(capabilities, "recovery")
+          ) {
+            steps.push({
+              kind: "spawn_agent",
+              agentType: "recovery",
+              input: {
+                kind: "text",
+                text: `Analyze failed scheduled task ${String(trigger.moment.taskId)} and propose recovery.`,
+              },
+              delivery: DEFAULT_DELIVERY_POLICY,
+            });
+          }
+          break;
+        case "frontier_changed":
+          if (hasAgentType(capabilities, "researcher")) {
+            steps.push({
+              kind: "spawn_agent",
+              agentType: "researcher",
+              input: {
+                kind: "text",
+                text: `Investigate frontier change in ${trigger.moment.metric}.`,
+              },
+              delivery: { kind: "deferred" },
+            });
+          }
+          break;
+        case "pattern_matched":
+        case "external_event":
+          break;
+      }
+
+      const estimatedCost = estimateCost(steps);
+
+      return {
+        triggerId: trigger.id,
+        steps,
+        estimatedCost,
+        requiresApproval:
+          steps.length === 0 ||
+          computeCompositionApproval(trigger, estimatedCost, approvalPolicy, {
+            isNovel: classifyNovelty(trigger),
+          }),
+      };
+    },
+  };
+}

--- a/packages/lib/proactive/tsconfig.json
+++ b/packages/lib/proactive/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../../kernel/core"
     },
     {
+      "path": "../../sched/scheduler"
+    },
+    {
       "path": "../tools-core"
     }
   ]


### PR DESCRIPTION
## Summary

- Adds L0 composition-planning contracts (`@koi/core`): `CompositionTrigger`, `CompositionStep`, `CompositionPlan`, `CompositionCapabilities`, `CompositionApprovalPolicy`, plus `SystemSignal` extensions.
- Adds `@koi/proactive` planner layer: `mapSystemSignalToCompositionTrigger`, `createRuleBasedCompositionPlanner`, `createLlmCompositionPlanner` (with adapter + Zod schema), `computeCompositionApproval`. Execution stays out of scope — this PR ends at plan generation + approval classification.
- 14 new corner-case tests pinning the contract: full step-kind round-trip in the LLM planner, capability gating (`recovery`, `researcher`, diagnostic-missing parity), `dead_letter` outcome, approval `<` vs `<=` boundaries, and an end-to-end `signal → trigger → plan → approval` smoke (`composition-pipeline.test.ts`).
- Pre-implementation plan in `docs/superpowers/plans/` marked **HISTORICAL**; code + spec at `docs/superpowers/specs/2026-05-06-composition-planner-design.md` are the source of truth.

## Test plan

- [x] `bun run test --filter=@koi/proactive` — 117 pass / 0 fail
- [x] `bun run typecheck` (proactive + core)
- [x] `bun run check:layers`
- [x] `bun run check:orphans` (proactive marked `optional: true` — assembly-time wiring)
- [x] `bun run check:golden-queries`
- [x] Adversarial review (`/codex:adversarial-review`) → approve

Closes #1299