### PR TITLE
chore(lint): clear hard biome errors blocking CI

### DIFF
--- a/packages/lib/harness-synth/src/synthesize.test.ts
+++ b/packages/lib/harness-synth/src/synthesize.test.ts
@@ -1162,7 +1162,9 @@ describe("synthesize", () => {
     if (!result.ok) return;
     // Verifier mutates its live reference AFTER synthesize() resolved.
     live.totalDurationMs = 9999;
-    live.stageResults[0]!.passed = false;
+    const stage0 = live.stageResults[0];
+    if (stage0 === undefined) throw new Error("expected stage 0");
+    stage0.passed = false;
     // Returned value must be unaffected.
     expect(result.value.verification.totalDurationMs).toBe(17);
     expect(result.value.verification.stageResults[0]?.passed).toBe(true);

--- a/packages/net/gateway/src/__tests__/e2e.test.ts
+++ b/packages/net/gateway/src/__tests__/e2e.test.ts
@@ -617,8 +617,12 @@ describe("e2e: server send seq monotonicity", () => {
     await waitForMessages(4); // ack + 3 sends
 
     const seqs = messages.slice(1).map((m) => parseFrame(m).seq);
-    expect(seqs[0]! < seqs[1]!).toBe(true);
-    expect(seqs[1]! < seqs[2]!).toBe(true);
+    const [s0, s1, s2] = seqs;
+    if (s0 === undefined || s1 === undefined || s2 === undefined) {
+      throw new Error(`expected 3 seqs, got ${seqs.length}`);
+    }
+    expect(s0 < s1).toBe(true);
+    expect(s1 < s2).toBe(true);
 
     ws.close();
   });

--- a/packages/sandbox/sandbox-cloudflare/src/corner-cases.test.ts
+++ b/packages/sandbox/sandbox-cloudflare/src/corner-cases.test.ts
@@ -230,6 +230,7 @@ describe("scanModuleGraphForFenceViolations — corner cases", () => {
   it("CATCHES a target reference inside a template literal substitution", () => {
     const v = scanModuleGraphForFenceViolations({
       entryPath: "h.ts",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: source fixture, not interpolation
       modules: { "h.ts": "export default () => `done at ${fetch}`;" },
     });
     // Template literal substitutions are stripped along with the literal,

--- a/scripts/sandbox-hosted-e2e.ts
+++ b/scripts/sandbox-hosted-e2e.ts
@@ -359,8 +359,10 @@ async function makeRealE2bAdapter(): Promise<SandboxAdapter> {
     supportsTeardown: true,
     supportsCancelCreate: false,
     createSandbox: async (opts) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sb = await (sdk as any).Sandbox.create({ apiKey, metadata: { label: opts.label } });
+      const sb = await (sdk as unknown as E2bSdkModule).Sandbox.create({
+        apiKey,
+        metadata: { label: opts.label },
+      });
       return wrapE2bSandbox(sb);
     },
   };
@@ -369,8 +371,43 @@ async function makeRealE2bAdapter(): Promise<SandboxAdapter> {
   return r.value;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function wrapE2bSandbox(sb: any): E2bSdkSandbox {
+interface E2bRawCommandResult {
+  readonly exitCode?: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}
+
+interface E2bRawCommandOpts {
+  readonly cwd?: string | undefined;
+  readonly envs?: Readonly<Record<string, string>> | undefined;
+  readonly timeoutMs?: number | undefined;
+  readonly onStdout?: ((d: string) => void) | undefined;
+  readonly onStderr?: ((d: string) => void) | undefined;
+}
+
+interface E2bRawSandbox {
+  readonly commands: {
+    readonly run: (cmd: string, opts: E2bRawCommandOpts) => Promise<E2bRawCommandResult>;
+  };
+  readonly files: {
+    readonly read: (p: string) => Promise<string>;
+    readonly write: (p: string, c: string) => Promise<void>;
+    readonly readBytes?: (p: string) => Promise<Uint8Array>;
+    readonly writeBytes?: (p: string, c: Uint8Array) => Promise<void>;
+  };
+  readonly kill: () => Promise<void>;
+}
+
+interface E2bSdkModule {
+  readonly Sandbox: {
+    readonly create: (opts: {
+      readonly apiKey: string;
+      readonly metadata: { readonly label: string };
+    }) => Promise<E2bRawSandbox>;
+  };
+}
+
+function wrapE2bSandbox(sb: E2bRawSandbox): E2bSdkSandbox {
   return {
     commands: {
       run: async (cmd, opts) => {
@@ -402,8 +439,8 @@ function wrapE2bSandbox(sb: any): E2bSdkSandbox {
     files: {
       read: (p) => sb.files.read(p),
       write: (p, c) => sb.files.write(p, c),
-      readBytes: (p) => sb.files.readBytes?.(p),
-      writeBytes: (p, c) => sb.files.writeBytes?.(p, c),
+      ...(sb.files.readBytes !== undefined ? { readBytes: sb.files.readBytes } : {}),
+      ...(sb.files.writeBytes !== undefined ? { writeBytes: sb.files.writeBytes } : {}),
     },
     kill: () => sb.kill(),
   };
@@ -420,8 +457,8 @@ async function makeRealDaytonaAdapter(): Promise<SandboxAdapter> {
     supportsWorkspaceDelete: true,
     supportsCancelCreate: false,
     createSandbox: async (opts) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const dt = new (sdk as any).Daytona({ apiKey });
+      const SdkModule = sdk as unknown as DaytonaSdkModule;
+      const dt = new SdkModule.Daytona({ apiKey });
       const ws = await dt.create({ labels: { "koi-label": opts.label } });
       return wrapDaytonaSandbox(ws);
     },
@@ -431,8 +468,41 @@ async function makeRealDaytonaAdapter(): Promise<SandboxAdapter> {
   return r.value;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function wrapDaytonaSandbox(ws: any): DaytonaSdkSandbox {
+interface DaytonaRawCommandResult {
+  readonly exitCode?: number;
+  readonly result?: string;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}
+
+interface DaytonaRawWorkspace {
+  readonly process: {
+    readonly executeCommand: (
+      cmd: string,
+      cwd: string | undefined,
+      envs: Readonly<Record<string, string>> | undefined,
+      timeoutMs: number | undefined,
+    ) => Promise<DaytonaRawCommandResult>;
+  };
+  readonly fs: {
+    readonly downloadFile: (p: string) => Promise<Uint8Array>;
+    readonly uploadFile: (c: Uint8Array, p: string) => Promise<void>;
+  };
+  readonly close?: () => Promise<void>;
+  readonly delete: () => Promise<void>;
+}
+
+interface DaytonaSdkModule {
+  readonly Daytona: new (opts: {
+    readonly apiKey: string;
+  }) => {
+    readonly create: (opts: {
+      readonly labels: Readonly<Record<string, string>>;
+    }) => Promise<DaytonaRawWorkspace>;
+  };
+}
+
+function wrapDaytonaSandbox(ws: DaytonaRawWorkspace): DaytonaSdkSandbox {
   return {
     commands: {
       run: async (cmd, opts) => {


### PR DESCRIPTION
chore(lint): clear hard biome errors from main

After the edge-sandboxes (#2144), scheduler (#2149), and other recent merges,
the workspace-root "bun run check" had 7+ hard lint errors blocking CI on every
PR branch. Clear them so PRs can go green again.

- scripts/sandbox-hosted-e2e.ts: replace (sdk as any) and wrap*Sandbox(_: any)
  with minimal interface declarations for the dynamically-imported E2B and
  Daytona SDK shapes; use conditional spread for optional readBytes/writeBytes
  so the wrapper output matches E2bSdkSandbox's optional contract.
- packages/sandbox/sandbox-cloudflare/src/corner-cases.test.ts: biome-ignore
  the noTemplateCurlyInString rule on a test fixture that embeds source code.
- packages/net/gateway/src/__tests__/e2e.test.ts: replace seqs[0]! non-null
  assertions with explicit destructure + undefined check.
- packages/lib/harness-synth/src/synthesize.test.ts: replace stageResults[0]!
  non-null assertion with explicit undefined check.

No behavioral changes. Pure lint hygiene to unblock CI on existing PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
