### PR TITLE
feat: add runtime golden replay verifier (refs #1413)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",
+    "test:runtime-golden-replay": "bun scripts/run-runtime-golden-replay.ts",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "format": "biome format --write .",

--- a/scripts/run-runtime-golden-replay.test.ts
+++ b/scripts/run-runtime-golden-replay.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  buildCommands,
+  type CommandSpec,
+  createNoCoverageRunDir,
+  runCommands,
+  runRuntimeGoldenReplay,
+  spawnCommand,
+} from "./run-runtime-golden-replay.ts";
+
+describe("createNoCoverageRunDir", () => {
+  test("writes a local bunfig.toml that disables coverage", () => {
+    const runDir = createNoCoverageRunDir();
+
+    try {
+      expect(existsSync(join(runDir, "bunfig.toml"))).toBe(true);
+      expect(readFileSync(join(runDir, "bunfig.toml"), "utf8")).toContain("coverage = false");
+    } finally {
+      rmSync(runDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("buildCommands", () => {
+  test("builds @koi/runtime before running golden-replay from a no-coverage cwd", () => {
+    const repoRoot = resolve(process.cwd());
+    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-test-"));
+
+    try {
+      const commands = buildCommands(repoRoot, runDir, []);
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0]).toEqual({
+        cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+        cwd: repoRoot,
+      });
+      expect(commands[1]).toEqual({
+        cmd: [
+          process.execPath,
+          "test",
+          join(repoRoot, "packages/meta/runtime/src/__tests__/golden-replay.test.ts"),
+        ],
+        cwd: runDir,
+      });
+    } finally {
+      rmSync(runDir, { force: true, recursive: true });
+    }
+  });
+
+  test("forwards extra Bun test arguments to golden-replay", () => {
+    const repoRoot = resolve(process.cwd());
+    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-test-"));
+
+    try {
+      const commands = buildCommands(repoRoot, runDir, [
+        "-t",
+        "middleware-feedback-loop|middleware-semantic-retry",
+      ]);
+
+      expect(commands[1]).toEqual({
+        cmd: [
+          process.execPath,
+          "test",
+          join(repoRoot, "packages/meta/runtime/src/__tests__/golden-replay.test.ts"),
+          "-t",
+          "middleware-feedback-loop|middleware-semantic-retry",
+        ],
+        cwd: runDir,
+      });
+    } finally {
+      rmSync(runDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("runCommands", () => {
+  test("runs commands in order", () => {
+    const seen: CommandSpec[] = [];
+
+    runCommands(
+      [
+        { cmd: ["bun", "run", "build"], cwd: "/repo" },
+        { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/tmp/run" },
+      ],
+      (command) => {
+        seen.push(command);
+        return { exitCode: 0 };
+      },
+    );
+
+    expect(seen).toEqual([
+      { cmd: ["bun", "run", "build"], cwd: "/repo" },
+      { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/tmp/run" },
+    ]);
+  });
+});
+
+describe("spawnCommand", () => {
+  test("runs a Bun subprocess in the provided cwd", () => {
+    const result = spawnCommand({
+      cmd: [process.execPath, "-e", "process.exit(0)"],
+      cwd: process.cwd(),
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("runRuntimeGoldenReplay", () => {
+  test("creates and removes a no-coverage run dir around the targeted commands", () => {
+    const spawn = mock(() => ({ exitCode: 0 }));
+    const createRunDir = mock(() => "/tmp/koi-runtime-golden-replay");
+    const removeRunDir = mock(() => {});
+
+    runRuntimeGoldenReplay(
+      ["-t", "Golden: feedback-loop"],
+      "/repo",
+      createRunDir,
+      removeRunDir,
+      spawn,
+    );
+
+    expect(createRunDir).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenNthCalledWith(1, {
+      cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+      cwd: "/repo",
+    });
+    expect(spawn).toHaveBeenNthCalledWith(2, {
+      cmd: [
+        process.execPath,
+        "test",
+        "/repo/packages/meta/runtime/src/__tests__/golden-replay.test.ts",
+        "-t",
+        "Golden: feedback-loop",
+      ],
+      cwd: "/tmp/koi-runtime-golden-replay",
+    });
+    expect(removeRunDir).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay");
+  });
+
+  test("removes the run dir even if command execution throws", () => {
+    const removeRunDir = mock(() => {});
+
+    expect(() =>
+      runRuntimeGoldenReplay(
+        [],
+        "/repo",
+        () => "/tmp/koi-runtime-golden-replay",
+        removeRunDir,
+        () => {
+          throw new Error("boom");
+        },
+      ),
+    ).toThrow("boom");
+
+    expect(removeRunDir).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay");
+  });
+
+  test("uses the default run-dir cleanup when no override is provided", () => {
+    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-default-"));
+
+    runRuntimeGoldenReplay(
+      [],
+      "/repo",
+      () => runDir,
+      undefined,
+      () => ({ exitCode: 0 }),
+    );
+
+    expect(existsSync(runDir)).toBe(false);
+  });
+});

--- a/scripts/run-runtime-golden-replay.test.ts
+++ b/scripts/run-runtime-golden-replay.test.ts
@@ -7,12 +7,36 @@ import {
   buildCommands,
   type CommandSpec,
   createNoCoverageBunfig,
+  defaultRepoRoot,
   resolveExitStatus,
   runCommands,
   runRuntimeGoldenReplay,
   signalExitCode,
   spawnCommand,
 } from "./run-runtime-golden-replay.js";
+
+describe("defaultRepoRoot", () => {
+  test("resolves to the repo root from the script location, independent of cwd", () => {
+    const repoRoot = defaultRepoRoot();
+
+    expect(existsSync(join(repoRoot, "package.json"))).toBe(true);
+    expect(existsSync(join(repoRoot, "scripts", "run-runtime-golden-replay.ts"))).toBe(true);
+    expect(
+      existsSync(join(repoRoot, "packages/meta/runtime/src/__tests__/golden-replay.test.ts")),
+    ).toBe(true);
+  });
+
+  test("returns the same path regardless of process.cwd()", () => {
+    const fromHere = defaultRepoRoot();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(dirname(originalCwd));
+      expect(defaultRepoRoot()).toBe(fromHere);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});
 
 describe("createNoCoverageBunfig", () => {
   test("writes a bunfig.toml that disables coverage", () => {

--- a/scripts/run-runtime-golden-replay.test.ts
+++ b/scripts/run-runtime-golden-replay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { existsSync, readFileSync, rmSync } from "node:fs";
+import { constants as osConstants } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
@@ -9,6 +10,7 @@ import {
   resolveExitStatus,
   runCommands,
   runRuntimeGoldenReplay,
+  signalExitCode,
   spawnCommand,
 } from "./run-runtime-golden-replay.js";
 
@@ -66,14 +68,34 @@ describe("buildCommands", () => {
   });
 });
 
+describe("signalExitCode", () => {
+  test("returns 128 + signo for known POSIX signals (SIGINT -> 130, SIGTERM -> 143)", () => {
+    const signals = osConstants.signals as unknown as Record<string, number | undefined>;
+    const sigint = signals.SIGINT ?? 0;
+    const sigterm = signals.SIGTERM ?? 0;
+    expect(signalExitCode("SIGINT")).toBe(128 + sigint);
+    expect(signalExitCode("SIGTERM")).toBe(128 + sigterm);
+  });
+
+  test("distinguishes SIGINT from SIGTERM", () => {
+    expect(signalExitCode("SIGINT")).not.toBe(signalExitCode("SIGTERM"));
+  });
+
+  test("falls back to 128 when the signal name is unknown", () => {
+    expect(signalExitCode("SIGNOPE_NOT_REAL")).toBe(128);
+  });
+});
+
 describe("resolveExitStatus", () => {
   test("returns the child's exit code on a normal exit", () => {
     expect(resolveExitStatus({ exitCode: 0 })).toBe(0);
     expect(resolveExitStatus({ exitCode: 2 })).toBe(2);
   });
 
-  test("returns 128 when the child was killed by a signal", () => {
-    expect(resolveExitStatus({ exitCode: null, signalCode: "SIGTERM" })).toBe(128);
+  test("maps signaled children to 128 + signo (SIGTERM -> 143)", () => {
+    const signals = osConstants.signals as unknown as Record<string, number | undefined>;
+    const sigterm = signals.SIGTERM ?? 0;
+    expect(resolveExitStatus({ exitCode: null, signalCode: "SIGTERM" })).toBe(128 + sigterm);
   });
 
   test("returns 1 when the child has neither a code nor a signal", () => {
@@ -83,10 +105,10 @@ describe("resolveExitStatus", () => {
 });
 
 describe("runCommands", () => {
-  test("runs commands in order", () => {
+  test("runs commands in order and returns 0 when all succeed", () => {
     const seen: CommandSpec[] = [];
 
-    runCommands(
+    const status = runCommands(
       [
         { cmd: ["bun", "run", "build"], cwd: "/repo" },
         { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/repo" },
@@ -97,30 +119,36 @@ describe("runCommands", () => {
       },
     );
 
-    expect(seen).toEqual([
-      { cmd: ["bun", "run", "build"], cwd: "/repo" },
-      { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/repo" },
-    ]);
+    expect(status).toBe(0);
+    expect(seen).toHaveLength(2);
   });
 
-  test("propagates a signaled subprocess as a non-zero exit", () => {
-    const exitSpy = mock((_code?: string | number | null | undefined) => {
-      throw new Error("process.exit called");
-    });
-    const originalExit = process.exit;
-    process.exit = exitSpy as unknown as typeof process.exit;
+  test("returns the failing exit code and stops at the first failure", () => {
+    const seen: CommandSpec[] = [];
+    const status = runCommands(
+      [
+        { cmd: ["bun", "run", "build"], cwd: "/repo" },
+        { cmd: ["bun", "test"], cwd: "/repo" },
+      ],
+      (command) => {
+        seen.push(command);
+        return { exitCode: command.cmd[1] === "run" ? 0 : 7 };
+      },
+    );
 
-    try {
-      expect(() =>
-        runCommands([{ cmd: ["bun", "test"], cwd: "/repo" }], () => ({
-          exitCode: null,
-          signalCode: "SIGTERM",
-        })),
-      ).toThrow("process.exit called");
-      expect(exitSpy).toHaveBeenCalledWith(128);
-    } finally {
-      process.exit = originalExit;
-    }
+    expect(status).toBe(7);
+    expect(seen).toHaveLength(2);
+  });
+
+  test("returns 128 + signo when a child is killed by signal", () => {
+    const signals = osConstants.signals as unknown as Record<string, number | undefined>;
+    const sigterm = signals.SIGTERM ?? 0;
+    const status = runCommands([{ cmd: ["bun", "test"], cwd: "/repo" }], () => ({
+      exitCode: null,
+      signalCode: "SIGTERM",
+    }));
+
+    expect(status).toBe(128 + sigterm);
   });
 });
 
@@ -136,12 +164,12 @@ describe("spawnCommand", () => {
 });
 
 describe("runRuntimeGoldenReplay", () => {
-  test("creates a bunfig and removes its dir around the targeted commands", () => {
+  test("returns 0 and runs build + golden-replay with the supplied repo root", () => {
     const spawn = mock(() => ({ exitCode: 0 }));
     const createBunfig = mock(() => "/tmp/koi-runtime-golden-replay/bunfig.toml");
     const removeBunfig = mock(() => {});
 
-    runRuntimeGoldenReplay(
+    const status = runRuntimeGoldenReplay(
       ["-t", "Golden: feedback-loop"],
       "/repo",
       createBunfig,
@@ -149,6 +177,7 @@ describe("runRuntimeGoldenReplay", () => {
       spawn,
     );
 
+    expect(status).toBe(0);
     expect(createBunfig).toHaveBeenCalledTimes(1);
     expect(spawn).toHaveBeenNthCalledWith(1, {
       cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
@@ -165,6 +194,21 @@ describe("runRuntimeGoldenReplay", () => {
       ],
       cwd: "/repo",
     });
+    expect(removeBunfig).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay/bunfig.toml");
+  });
+
+  test("returns the failing status and still removes the bunfig on a non-zero child exit", () => {
+    const removeBunfig = mock(() => {});
+
+    const status = runRuntimeGoldenReplay(
+      [],
+      "/repo",
+      () => "/tmp/koi-runtime-golden-replay/bunfig.toml",
+      removeBunfig,
+      () => ({ exitCode: 5 }),
+    );
+
+    expect(status).toBe(5);
     expect(removeBunfig).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay/bunfig.toml");
   });
 
@@ -186,11 +230,27 @@ describe("runRuntimeGoldenReplay", () => {
     expect(removeBunfig).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay/bunfig.toml");
   });
 
-  test("uses the default cleanup to remove the bunfig dir when no override is provided", () => {
+  test("default cleanup removes the temp bunfig dir on failure (no leak)", () => {
     const bunfigPath = createNoCoverageBunfig();
     const bunfigDir = dirname(bunfigPath);
 
-    runRuntimeGoldenReplay(
+    const status = runRuntimeGoldenReplay(
+      [],
+      "/repo",
+      () => bunfigPath,
+      undefined,
+      () => ({ exitCode: 9 }),
+    );
+
+    expect(status).toBe(9);
+    expect(existsSync(bunfigDir)).toBe(false);
+  });
+
+  test("default cleanup removes the temp bunfig dir on success", () => {
+    const bunfigPath = createNoCoverageBunfig();
+    const bunfigDir = dirname(bunfigPath);
+
+    const status = runRuntimeGoldenReplay(
       [],
       "/repo",
       () => bunfigPath,
@@ -198,6 +258,7 @@ describe("runRuntimeGoldenReplay", () => {
       () => ({ exitCode: 0 }),
     );
 
+    expect(status).toBe(0);
     expect(existsSync(bunfigDir)).toBe(false);
   });
 

--- a/scripts/run-runtime-golden-replay.test.ts
+++ b/scripts/run-runtime-golden-replay.test.ts
@@ -1,79 +1,84 @@
 import { describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import {
   buildCommands,
   type CommandSpec,
-  createNoCoverageRunDir,
+  createNoCoverageBunfig,
+  resolveExitStatus,
   runCommands,
   runRuntimeGoldenReplay,
   spawnCommand,
-} from "./run-runtime-golden-replay.ts";
+} from "./run-runtime-golden-replay.js";
 
-describe("createNoCoverageRunDir", () => {
-  test("writes a local bunfig.toml that disables coverage", () => {
-    const runDir = createNoCoverageRunDir();
+describe("createNoCoverageBunfig", () => {
+  test("writes a bunfig.toml that disables coverage", () => {
+    const bunfigPath = createNoCoverageBunfig();
 
     try {
-      expect(existsSync(join(runDir, "bunfig.toml"))).toBe(true);
-      expect(readFileSync(join(runDir, "bunfig.toml"), "utf8")).toContain("coverage = false");
+      expect(existsSync(bunfigPath)).toBe(true);
+      expect(readFileSync(bunfigPath, "utf8")).toContain("coverage = false");
     } finally {
-      rmSync(runDir, { force: true, recursive: true });
+      rmSync(dirname(bunfigPath), { force: true, recursive: true });
     }
   });
 });
 
 describe("buildCommands", () => {
-  test("builds @koi/runtime before running golden-replay from a no-coverage cwd", () => {
-    const repoRoot = resolve(process.cwd());
-    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-test-"));
+  test("builds @koi/runtime then runs golden-replay from repo root with --config", () => {
+    const commands = buildCommands("/repo", "/tmp/bunfig.toml", []);
 
-    try {
-      const commands = buildCommands(repoRoot, runDir, []);
-
-      expect(commands).toHaveLength(2);
-      expect(commands[0]).toEqual({
+    expect(commands).toEqual([
+      {
         cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
-        cwd: repoRoot,
-      });
-      expect(commands[1]).toEqual({
+        cwd: "/repo",
+      },
+      {
         cmd: [
           process.execPath,
+          "--config=/tmp/bunfig.toml",
           "test",
-          join(repoRoot, "packages/meta/runtime/src/__tests__/golden-replay.test.ts"),
+          "/repo/packages/meta/runtime/src/__tests__/golden-replay.test.ts",
         ],
-        cwd: runDir,
-      });
-    } finally {
-      rmSync(runDir, { force: true, recursive: true });
-    }
+        cwd: "/repo",
+      },
+    ]);
   });
 
   test("forwards extra Bun test arguments to golden-replay", () => {
-    const repoRoot = resolve(process.cwd());
-    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-test-"));
+    const commands = buildCommands("/repo", "/tmp/bunfig.toml", [
+      "-t",
+      "middleware-feedback-loop|middleware-semantic-retry",
+    ]);
 
-    try {
-      const commands = buildCommands(repoRoot, runDir, [
+    expect(commands[1]).toEqual({
+      cmd: [
+        process.execPath,
+        "--config=/tmp/bunfig.toml",
+        "test",
+        "/repo/packages/meta/runtime/src/__tests__/golden-replay.test.ts",
         "-t",
         "middleware-feedback-loop|middleware-semantic-retry",
-      ]);
+      ],
+      cwd: "/repo",
+    });
+  });
+});
 
-      expect(commands[1]).toEqual({
-        cmd: [
-          process.execPath,
-          "test",
-          join(repoRoot, "packages/meta/runtime/src/__tests__/golden-replay.test.ts"),
-          "-t",
-          "middleware-feedback-loop|middleware-semantic-retry",
-        ],
-        cwd: runDir,
-      });
-    } finally {
-      rmSync(runDir, { force: true, recursive: true });
-    }
+describe("resolveExitStatus", () => {
+  test("returns the child's exit code on a normal exit", () => {
+    expect(resolveExitStatus({ exitCode: 0 })).toBe(0);
+    expect(resolveExitStatus({ exitCode: 2 })).toBe(2);
+  });
+
+  test("returns 128 when the child was killed by a signal", () => {
+    expect(resolveExitStatus({ exitCode: null, signalCode: "SIGTERM" })).toBe(128);
+  });
+
+  test("returns 1 when the child has neither a code nor a signal", () => {
+    expect(resolveExitStatus({ exitCode: null })).toBe(1);
+    expect(resolveExitStatus({ exitCode: null, signalCode: null })).toBe(1);
   });
 });
 
@@ -84,7 +89,7 @@ describe("runCommands", () => {
     runCommands(
       [
         { cmd: ["bun", "run", "build"], cwd: "/repo" },
-        { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/tmp/run" },
+        { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/repo" },
       ],
       (command) => {
         seen.push(command);
@@ -94,8 +99,28 @@ describe("runCommands", () => {
 
     expect(seen).toEqual([
       { cmd: ["bun", "run", "build"], cwd: "/repo" },
-      { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/tmp/run" },
+      { cmd: ["bun", "test", "/repo/test.ts"], cwd: "/repo" },
     ]);
+  });
+
+  test("propagates a signaled subprocess as a non-zero exit", () => {
+    const exitSpy = mock((_code?: string | number | null | undefined) => {
+      throw new Error("process.exit called");
+    });
+    const originalExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+
+    try {
+      expect(() =>
+        runCommands([{ cmd: ["bun", "test"], cwd: "/repo" }], () => ({
+          exitCode: null,
+          signalCode: "SIGTERM",
+        })),
+      ).toThrow("process.exit called");
+      expect(exitSpy).toHaveBeenCalledWith(128);
+    } finally {
+      process.exit = originalExit;
+    }
   });
 });
 
@@ -111,20 +136,20 @@ describe("spawnCommand", () => {
 });
 
 describe("runRuntimeGoldenReplay", () => {
-  test("creates and removes a no-coverage run dir around the targeted commands", () => {
+  test("creates a bunfig and removes its dir around the targeted commands", () => {
     const spawn = mock(() => ({ exitCode: 0 }));
-    const createRunDir = mock(() => "/tmp/koi-runtime-golden-replay");
-    const removeRunDir = mock(() => {});
+    const createBunfig = mock(() => "/tmp/koi-runtime-golden-replay/bunfig.toml");
+    const removeBunfig = mock(() => {});
 
     runRuntimeGoldenReplay(
       ["-t", "Golden: feedback-loop"],
       "/repo",
-      createRunDir,
-      removeRunDir,
+      createBunfig,
+      removeBunfig,
       spawn,
     );
 
-    expect(createRunDir).toHaveBeenCalledTimes(1);
+    expect(createBunfig).toHaveBeenCalledTimes(1);
     expect(spawn).toHaveBeenNthCalledWith(1, {
       cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
       cwd: "/repo",
@@ -132,45 +157,70 @@ describe("runRuntimeGoldenReplay", () => {
     expect(spawn).toHaveBeenNthCalledWith(2, {
       cmd: [
         process.execPath,
+        "--config=/tmp/koi-runtime-golden-replay/bunfig.toml",
         "test",
         "/repo/packages/meta/runtime/src/__tests__/golden-replay.test.ts",
         "-t",
         "Golden: feedback-loop",
       ],
-      cwd: "/tmp/koi-runtime-golden-replay",
+      cwd: "/repo",
     });
-    expect(removeRunDir).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay");
+    expect(removeBunfig).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay/bunfig.toml");
   });
 
-  test("removes the run dir even if command execution throws", () => {
-    const removeRunDir = mock(() => {});
+  test("removes the bunfig even if command execution throws", () => {
+    const removeBunfig = mock(() => {});
 
     expect(() =>
       runRuntimeGoldenReplay(
         [],
         "/repo",
-        () => "/tmp/koi-runtime-golden-replay",
-        removeRunDir,
+        () => "/tmp/koi-runtime-golden-replay/bunfig.toml",
+        removeBunfig,
         () => {
           throw new Error("boom");
         },
       ),
     ).toThrow("boom");
 
-    expect(removeRunDir).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay");
+    expect(removeBunfig).toHaveBeenCalledWith("/tmp/koi-runtime-golden-replay/bunfig.toml");
   });
 
-  test("uses the default run-dir cleanup when no override is provided", () => {
-    const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-default-"));
+  test("uses the default cleanup to remove the bunfig dir when no override is provided", () => {
+    const bunfigPath = createNoCoverageBunfig();
+    const bunfigDir = dirname(bunfigPath);
 
     runRuntimeGoldenReplay(
       [],
       "/repo",
-      () => runDir,
+      () => bunfigPath,
       undefined,
       () => ({ exitCode: 0 }),
     );
 
-    expect(existsSync(runDir)).toBe(false);
+    expect(existsSync(bunfigDir)).toBe(false);
+  });
+
+  test("--config path resolves to the temp bunfig under the repo root", () => {
+    const seen: CommandSpec[] = [];
+
+    runRuntimeGoldenReplay(
+      [],
+      "/repo",
+      () => "/tmp/koi-runtime-golden-replay/bunfig.toml",
+      () => {},
+      (command) => {
+        seen.push(command);
+        return { exitCode: 0 };
+      },
+    );
+
+    const testCommand = seen[1];
+    if (!testCommand) throw new Error("expected a second spawn call");
+    expect(testCommand.cwd).toBe("/repo");
+    expect(testCommand.cmd).toContain("--config=/tmp/koi-runtime-golden-replay/bunfig.toml");
+    expect(testCommand.cmd).toContain(
+      join("/repo", "packages/meta/runtime/src/__tests__/golden-replay.test.ts"),
+    );
   });
 });

--- a/scripts/run-runtime-golden-replay.ts
+++ b/scripts/run-runtime-golden-replay.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { constants as osConstants, tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const GOLDEN_REPLAY_PATH = "packages/meta/runtime/src/__tests__/golden-replay.test.ts";
 const NO_COVERAGE_BUNFIG = `[test]
@@ -50,6 +51,11 @@ export function buildCommands(
   ];
 }
 
+export function defaultRepoRoot(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(scriptDir, "..");
+}
+
 export function spawnCommand(command: CommandSpec): SpawnResult {
   const result = Bun.spawnSync({
     cmd: [...command.cmd],
@@ -95,7 +101,7 @@ export function runCommands(
 
 export function runRuntimeGoldenReplay(
   extraArgs: readonly string[],
-  repoRoot: string = resolve(process.cwd()),
+  repoRoot: string = defaultRepoRoot(),
   createBunfig: () => string = createNoCoverageBunfig,
   removeBunfig: (bunfigPath: string) => void = (bunfigPath: string): void => {
     rmSync(join(bunfigPath, ".."), { force: true, recursive: true });

--- a/scripts/run-runtime-golden-replay.ts
+++ b/scripts/run-runtime-golden-replay.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const GOLDEN_REPLAY_PATH = "packages/meta/runtime/src/__tests__/golden-replay.test.ts";
+const NO_COVERAGE_BUNFIG = `[test]
+coverage = false
+`;
+
+export type CommandSpec = {
+  readonly cmd: readonly string[];
+  readonly cwd: string;
+};
+
+export type SpawnResult = {
+  readonly exitCode: number;
+};
+
+export type SpawnSync = (command: CommandSpec) => SpawnResult;
+
+export function createNoCoverageRunDir(): string {
+  const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-"));
+  writeFileSync(join(runDir, "bunfig.toml"), NO_COVERAGE_BUNFIG);
+  writeFileSync(join(runDir, ".gitignore"), "*\n");
+  return runDir;
+}
+
+export function buildCommands(
+  repoRoot: string,
+  runDir: string,
+  extraArgs: readonly string[],
+): readonly CommandSpec[] {
+  return [
+    {
+      cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+      cwd: repoRoot,
+    },
+    {
+      cmd: [process.execPath, "test", join(repoRoot, GOLDEN_REPLAY_PATH), ...extraArgs],
+      cwd: runDir,
+    },
+  ];
+}
+
+export function spawnCommand(command: CommandSpec): SpawnResult {
+  return Bun.spawnSync({
+    cmd: [...command.cmd],
+    cwd: command.cwd,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+}
+
+export function runCommands(
+  commands: readonly CommandSpec[],
+  spawn: SpawnSync = spawnCommand,
+): void {
+  for (const command of commands) {
+    const result = spawn(command);
+    if (result.exitCode !== 0) {
+      process.exit(result.exitCode);
+    }
+  }
+}
+
+export function runRuntimeGoldenReplay(
+  extraArgs: readonly string[],
+  repoRoot = resolve(process.cwd()),
+  createRunDir: () => string = createNoCoverageRunDir,
+  removeRunDir: (runDir: string) => void = (runDir) =>
+    rmSync(runDir, { force: true, recursive: true }),
+  spawn: SpawnSync = spawnCommand,
+): void {
+  const runDir = createRunDir();
+
+  try {
+    runCommands(buildCommands(repoRoot, runDir, extraArgs), spawn);
+  } finally {
+    removeRunDir(runDir);
+  }
+}
+
+if (import.meta.main) {
+  runRuntimeGoldenReplay(process.argv.slice(2));
+}

--- a/scripts/run-runtime-golden-replay.ts
+++ b/scripts/run-runtime-golden-replay.ts
@@ -1,11 +1,12 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { constants as osConstants, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const GOLDEN_REPLAY_PATH = "packages/meta/runtime/src/__tests__/golden-replay.test.ts";
 const NO_COVERAGE_BUNFIG = `[test]
 coverage = false
 `;
+const DEFAULT_SIGNAL_EXIT_CODE = 128;
 
 export type CommandSpec = {
   readonly cmd: readonly string[];
@@ -60,9 +61,18 @@ export function spawnCommand(command: CommandSpec): SpawnResult {
   return { exitCode: result.exitCode, signalCode: result.signalCode ?? null };
 }
 
+export function signalExitCode(signalCode: string): number {
+  const signals = osConstants.signals as unknown as Record<string, number | undefined>;
+  const signo = signals[signalCode];
+  if (typeof signo === "number" && signo > 0) {
+    return 128 + signo;
+  }
+  return DEFAULT_SIGNAL_EXIT_CODE;
+}
+
 export function resolveExitStatus(result: SpawnResult): number {
   if (result.signalCode != null) {
-    return 128;
+    return signalExitCode(result.signalCode);
   }
   if (result.exitCode == null) {
     return 1;
@@ -73,14 +83,14 @@ export function resolveExitStatus(result: SpawnResult): number {
 export function runCommands(
   commands: readonly CommandSpec[],
   spawn: SpawnSync = spawnCommand,
-): void {
+): number {
   for (const command of commands) {
-    const result = spawn(command);
-    const status = resolveExitStatus(result);
+    const status = resolveExitStatus(spawn(command));
     if (status !== 0) {
-      process.exit(status);
+      return status;
     }
   }
+  return 0;
 }
 
 export function runRuntimeGoldenReplay(
@@ -91,16 +101,19 @@ export function runRuntimeGoldenReplay(
     rmSync(join(bunfigPath, ".."), { force: true, recursive: true });
   },
   spawn: SpawnSync = spawnCommand,
-): void {
+): number {
   const bunfigPath = createBunfig();
 
   try {
-    runCommands(buildCommands(repoRoot, bunfigPath, extraArgs), spawn);
+    return runCommands(buildCommands(repoRoot, bunfigPath, extraArgs), spawn);
   } finally {
     removeBunfig(bunfigPath);
   }
 }
 
 if (import.meta.main) {
-  runRuntimeGoldenReplay(process.argv.slice(2));
+  const status = runRuntimeGoldenReplay(process.argv.slice(2));
+  if (status !== 0) {
+    process.exit(status);
+  }
 }

--- a/scripts/run-runtime-golden-replay.ts
+++ b/scripts/run-runtime-golden-replay.ts
@@ -13,21 +13,22 @@ export type CommandSpec = {
 };
 
 export type SpawnResult = {
-  readonly exitCode: number;
+  readonly exitCode: number | null;
+  readonly signalCode?: string | null;
 };
 
 export type SpawnSync = (command: CommandSpec) => SpawnResult;
 
-export function createNoCoverageRunDir(): string {
-  const runDir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-"));
-  writeFileSync(join(runDir, "bunfig.toml"), NO_COVERAGE_BUNFIG);
-  writeFileSync(join(runDir, ".gitignore"), "*\n");
-  return runDir;
+export function createNoCoverageBunfig(): string {
+  const dir = mkdtempSync(join(tmpdir(), "koi-runtime-golden-replay-"));
+  const bunfigPath = join(dir, "bunfig.toml");
+  writeFileSync(bunfigPath, NO_COVERAGE_BUNFIG);
+  return bunfigPath;
 }
 
 export function buildCommands(
   repoRoot: string,
-  runDir: string,
+  bunfigPath: string,
   extraArgs: readonly string[],
 ): readonly CommandSpec[] {
   return [
@@ -36,20 +37,37 @@ export function buildCommands(
       cwd: repoRoot,
     },
     {
-      cmd: [process.execPath, "test", join(repoRoot, GOLDEN_REPLAY_PATH), ...extraArgs],
-      cwd: runDir,
+      cmd: [
+        process.execPath,
+        `--config=${bunfigPath}`,
+        "test",
+        join(repoRoot, GOLDEN_REPLAY_PATH),
+        ...extraArgs,
+      ],
+      cwd: repoRoot,
     },
   ];
 }
 
 export function spawnCommand(command: CommandSpec): SpawnResult {
-  return Bun.spawnSync({
+  const result = Bun.spawnSync({
     cmd: [...command.cmd],
     cwd: command.cwd,
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",
   });
+  return { exitCode: result.exitCode, signalCode: result.signalCode ?? null };
+}
+
+export function resolveExitStatus(result: SpawnResult): number {
+  if (result.signalCode != null) {
+    return 128;
+  }
+  if (result.exitCode == null) {
+    return 1;
+  }
+  return result.exitCode;
 }
 
 export function runCommands(
@@ -58,26 +76,28 @@ export function runCommands(
 ): void {
   for (const command of commands) {
     const result = spawn(command);
-    if (result.exitCode !== 0) {
-      process.exit(result.exitCode);
+    const status = resolveExitStatus(result);
+    if (status !== 0) {
+      process.exit(status);
     }
   }
 }
 
 export function runRuntimeGoldenReplay(
   extraArgs: readonly string[],
-  repoRoot = resolve(process.cwd()),
-  createRunDir: () => string = createNoCoverageRunDir,
-  removeRunDir: (runDir: string) => void = (runDir) =>
-    rmSync(runDir, { force: true, recursive: true }),
+  repoRoot: string = resolve(process.cwd()),
+  createBunfig: () => string = createNoCoverageBunfig,
+  removeBunfig: (bunfigPath: string) => void = (bunfigPath: string): void => {
+    rmSync(join(bunfigPath, ".."), { force: true, recursive: true });
+  },
   spawn: SpawnSync = spawnCommand,
 ): void {
-  const runDir = createRunDir();
+  const bunfigPath = createBunfig();
 
   try {
-    runCommands(buildCommands(repoRoot, runDir, extraArgs), spawn);
+    runCommands(buildCommands(repoRoot, bunfigPath, extraArgs), spawn);
   } finally {
-    removeRunDir(runDir);
+    removeBunfig(bunfigPath);
   }
 }
 


### PR DESCRIPTION
## Summary
Adds `scripts/run-runtime-golden-replay.ts` — a verifier that builds `@koi/runtime` and runs its golden-replay test suite with coverage disabled via a temp `bunfig.toml` passed through Bun's `--config` flag.

Refs #1413.

### Design notes
- **Repo root via `import.meta.url`** — `defaultRepoRoot()` resolves the repo from the script's own location, so the verifier works whether launched from the repo root, a CI wrapper, or an absolute-path invocation in any cwd.
- **Run from repo root** — golden-replay tests assume `process.cwd()` is the repo (e.g. `createGlobTool({ cwd: process.cwd() })`). Coverage is disabled per-invocation through `bun --config=<temp>/bunfig.toml` instead of swapping cwd.
- **Cleanup-safe** — `runCommands` returns the failing status; `runRuntimeGoldenReplay` returns it from a `try { … } finally { removeBunfig(…) }`. The CLI entrypoint exits only after cleanup completes (Bun's `process.exit` does not unwind `finally`).
- **POSIX signal exit codes** — signaled children map to `128 + signo` via `node:os` constants (SIGINT → 130, SIGTERM → 143). Null exit with no signal → 1.

## Test plan
- [x] `bun test scripts/run-runtime-golden-replay.test.ts` — 21 unit tests cover: build/test command construction, `--config` arg shape, signal-code mapping, cleanup-on-failure, cleanup-on-throw, cwd-independence of `defaultRepoRoot()`.
- [x] Smoke 1 (from repo root): `bun scripts/run-runtime-golden-replay.ts -t "tool_call_start with add_numbers"` → 1 pass, exit 0, no temp leak.
- [x] Smoke 2 (from `/tmp` via absolute path): same prompt → 1 pass, exit 0, no temp leak. Confirms repo-root resolution is cwd-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
