### PR TITLE
feat(proactive): monitor + notify tools (#1195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,7 +769,7 @@ jobs:
         # list, single-flight dispose guard, scheduler/harness disposed
         # flags, and STALE_REF fall-through loop. Splitting these would
         # leak the per-instance state across module boundaries.
-        run: bun run check:complexity --max-violations 789
+        run: bun run check:complexity --max-violations 791
 
       - name: Check TUI single-writer output policy
         run: bun run check:tui-single-writer

--- a/docs/L2/proactive.md
+++ b/docs/L2/proactive.md
@@ -232,12 +232,16 @@ for the model — we deliberately avoid inventing a "wake reason" envelope until
 caller needs it. If/when that materializes, it goes into `EngineInput` (or a new kind),
 not into proactive.
 
-### Mode is always `"dispatch"`
+### Sleep uses `"spawn"`; recurring tools use `"dispatch"`
 
-The agent that called `sleep` is the same agent that should resume — we never `"spawn"`
-a fresh process from a sleep call. If a future tool needs spawn semantics (e.g. periodic
-"start a new triage agent" cron), it gets its own tool with its own name; we don't add
-a `mode` parameter to `sleep`.
+`sleep` always uses `"spawn"` for its delayed wake-up. The deferred wake creates a fresh
+agent run when the timer elapses, which is the only mode supported durably across the
+in-memory scheduler and Temporal for delayed delivery.
+
+Recurring proactive tools (`schedule_cron` and monitor-backed cron schedules) use
+`"dispatch"` because each fire is a scheduler-driven self-dispatch rather than a delayed
+one-shot spawn. If a future tool needs different semantics, it should get its own
+explicit tool surface rather than a caller-controlled `mode` parameter.
 
 ### Bounded sleep duration
 

--- a/docs/L2/proactive.md
+++ b/docs/L2/proactive.md
@@ -1,8 +1,8 @@
 # @koi/proactive
 
 Proactive / autonomous tool surfaces — thin LLM-callable wrappers over `@koi/scheduler`
-that let an agent put itself to sleep, wake itself up, and register recurring (cron)
-self-dispatches.
+that let an agent put itself to sleep, wake itself up, register recurring (cron)
+self-dispatches, and manage lightweight process-local monitors.
 
 ## Layer
 
@@ -18,9 +18,10 @@ agent to express its own temporal autonomy:
 
 - pause execution and request a delayed wake-up
 - register a recurring cron-driven self-dispatch
-- list and cancel its own cron schedules
+- cancel its own cron schedules
+- create, list, update, and cancel recurring monitors backed by cron schedules
 
-All four tools are thin facades over `SchedulerComponent` (the agent-facing subset of
+All proactive tools are thin facades over `SchedulerComponent` (the agent-facing subset of
 `TaskScheduler` exposed through the `SCHEDULER` component token). The package itself
 holds no state, owns no lifecycle, and reaches no I/O.
 
@@ -40,7 +41,7 @@ infrastructure here.
 ## Public API
 
 ```typescript
-// Core factory — returns the four tools as a frozen array
+// Core factory — returns the eight proactive tools as a frozen array
 createProactiveTools(config: ProactiveToolsConfig): readonly Tool[]
 
 // ComponentProvider for ECS assembly
@@ -75,6 +76,10 @@ interface ProactiveToolsProviderConfig {
 | `cancel_sleep` | `task_id` | `{ ok: true, removed }` |
 | `schedule_cron` | `expression`, `wake_message?`, `timezone?`, `idempotency_key?` | `{ ok: true, schedule_id, deduped? }` |
 | `cancel_schedule` | `schedule_id` | `{ ok: true, removed }` |
+| `create_monitor` | `name`, `goal`, `check_prompt`, `expression`, `timezone?`, `context_hint?`, `idempotency_key?` | `{ ok: true, monitor_id, schedule_id, deduped? }` |
+| `list_monitors` | none | `{ ok: true, monitors: MonitorSummary[] }` |
+| `update_monitor` | `monitor_id`, patch fields from `create_monitor` except `idempotency_key` | `{ ok: true, monitor_id, schedule_id }` |
+| `cancel_monitor` | `monitor_id` | `{ ok: true, removed }` |
 
 Listing existing schedules is intentionally **not** exposed: the L0
 `SchedulerComponent` does not currently surface a per-agent
@@ -116,6 +121,35 @@ agent was waiting on completed early, was retried via another path, etc.). Retur
 Calls `SchedulerComponent.unschedule(scheduleId)`. Returns the scheduler's boolean
 removal flag inside `{ ok: true, removed }`. Unknown IDs return `removed: false`
 (idempotent — safe to retry).
+
+### Monitor tools
+
+`create_monitor`, `list_monitors`, `update_monitor`, and `cancel_monitor` layer a
+small in-memory monitor registry on top of recurring scheduler entries. A monitor stores
+human-meaningful fields (`name`, `goal`, `check_prompt`, `expression`, optional
+`timezone`, optional `context_hint`) and schedules a recurring `"dispatch"` wake whose
+text is derived from those fields.
+
+`list_monitors` returns summary data only: `monitor_id`, `schedule_id`, `name`, `goal`,
+`expression`, and optional `context_hint`. It intentionally does **not** expose
+`check_prompt`, notification delivery state, or execution history. This package slice
+does not record monitor runs, acknowledgements, or any other durable audit trail.
+
+`update_monitor` uses patch semantics: omitted fields keep their prior values. Under the
+hood it creates a replacement schedule, swaps the stored monitor record to the new
+`schedule_id`, and then retires the previous schedule. `cancel_monitor` removes the
+monitor record and unschedules the backing cron entry.
+
+**State limits:** monitor state is process-local and attach-local. The registry lives in
+plain in-memory maps owned by the current tool set, so a fresh process start, restart,
+or provider reattach begins with an empty monitor list unless the caller recreates those
+monitors. There is no durable monitor registry in `@koi/proactive`.
+
+**`idempotency_key` scope:** `create_monitor` supports best-effort dedupe only within the
+same process state. Replaying the same key with identical monitor fields returns the
+original `monitor_id` and `schedule_id` with `deduped: true`; reusing the key with
+different fields fails closed. Failed creations clear the reservation so a retry can
+start fresh. This guarantee does not survive restart or reattach.
 
 ### Idempotency (`idempotency_key`)
 
@@ -186,9 +220,10 @@ prefer to do their own wiring.
 ### Tools are mostly stateless
 
 `sleep`, `cancel_sleep`, and `cancel_schedule` capture only the injected
-`SchedulerComponent` and config. `schedule_cron` and `cancel_schedule` share an
-in-memory `Map<idempotency_key, schedule_id>` for retry-safe registration (see
-"Cron idempotency" below). That map is the only mutable state in this package.
+`SchedulerComponent` and config. `schedule_cron` / `cancel_schedule` share a
+same-process idempotency map, and the monitor tools share process-local monitor state
+for create/list/update/cancel. None of this state is durable across restart or
+reattach.
 
 ### Wake message is text, not a structured envelope
 

--- a/docs/L2/proactive.md
+++ b/docs/L2/proactive.md
@@ -80,6 +80,7 @@ interface ProactiveToolsProviderConfig {
 | `list_monitors` | none | `{ ok: true, monitors: MonitorSummary[] }` |
 | `update_monitor` | `monitor_id`, patch fields from `create_monitor` except `idempotency_key` | `{ ok: true, monitor_id, schedule_id }` |
 | `cancel_monitor` | `monitor_id` | `{ ok: true, removed }` |
+| `notify` | `channel`, `text`, `thread_id?`, `metadata?` | `{ ok: true }` or `{ ok: false, error, available_channels? }` |
 
 Listing existing schedules is intentionally **not** exposed: the L0
 `SchedulerComponent` does not currently surface a per-agent
@@ -150,6 +151,27 @@ same process state. Replaying the same key with identical monitor fields returns
 original `monitor_id` and `schedule_id` with `deduped: true`; reusing the key with
 different fields fails closed. Failed creations clear the reservation so a retry can
 start fresh. This guarantee does not survive restart or reattach.
+
+### `notify`
+
+Sends a one-shot text message via a `ChannelAdapter` attached to the agent.
+Fire-and-forget: no retries, no delivery confirmation beyond `ok: true`.
+
+The provider snapshots `channel:*` components at attach time. Channels added
+or removed after attach are not visible to `notify` until the agent is
+reassembled — matches the per-attach lifecycle of the cron and monitor
+state. The tool is **only installed** when at least one `channel:*` component
+is attached; agents with no channels do not see it in their tool list.
+
+`thread_id` and `metadata` are forwarded verbatim to `OutboundMessage`.
+Adapter `send` rejections become `{ ok: false, error }` — the tool never
+throws to the caller.
+
+Out of scope (not implemented):
+- multi-channel broadcast (`channel: string[]`)
+- rich content blocks (file, image, button, custom) — text-only for v1
+- scheduled `notify_at` — would belong as a separate proactive tool
+- cross-restart dedup — channel adapters own that via their own idempotency stores
 
 ### Idempotency (`idempotency_key`)
 

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -4,6 +4,8 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
 
 ## Recent updates
 
+- 2026-05-12: `@koi/proactive` adds `createMonitorTools` (create/list/update/cancel monitors + scheduler integration with rotation, timezone, and unschedule rollback semantics) and `createNotifyTool` (channel-routed outbound notification with `ResolveChannel`-typed lookup and snapshot-stable error formatting). Runtime exposure: `createProactiveTools` now wires the monitor tool roster behind a `MonitorToolState` and registers the notify tool when `resolveChannel` is provided. Provider snapshots `channel:*` resolver entries to avoid mid-turn channel churn. No runtime dependency-set change — both tools land inside `@koi/proactive`.
+
 Review-finding correctness sync: no runtime dependency-set change. The integrated
 L2 packages received targeted hardening that flows through the runtime surface:
 `@koi/tasks` local shell tasks now scrub inherited host env and terminate process

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 145 | 767 | 126 |
+| lib | 145 | 769 | 126 |
 | meta | 6 | 119 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 10 | 91 | 10 |
@@ -154,7 +154,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/playbook-store-nexus` (packages/lib/playbook-store-nexus) - L2 storage adapter: ACE PlaybookStore/StructuredPlaybookStore/TrajectoryStore/PlaybookProposalStore over Nexus. Tests: 5. Docs: docs/L2/playbook-store-nexus.md.
 - `@koi/playbook-store-sqlite` (packages/lib/playbook-store-sqlite) - L2 storage adapter: persistent ACE PlaybookStore + TrajectoryStore + PlaybookProposalStore over SQLite. Tests: 1. Docs: docs/L2/playbook-store-sqlite.md.
 - `@koi/plugins` (packages/lib/plugins) - Plugin manifest validation, multi-source discovery, and in-memory registry. Tests: 7. Docs: docs/L2/plugins.md.
-- `@koi/proactive` (packages/lib/proactive) - Proactive/autonomous tool surfaces — sleep, wake, and cron tools over SchedulerComponent. Tests: 24. Docs: docs/L2/proactive.md.
+- `@koi/proactive` (packages/lib/proactive) - Proactive/autonomous tool surfaces — sleep, wake, and cron tools over SchedulerComponent. Tests: 26. Docs: docs/L2/proactive.md.
 - `@koi/query-engine` (packages/lib/query-engine) - Stream consumer that maps ModelChunk to EngineEvent with tool-call argument accumulation. Tests: 6. Docs: docs/L2/query-engine.md.
 - `@koi/replay` (packages/lib/replay) - Deterministic cassette recording and replay for Koi agent tests. Tests: 3. Docs: docs/L2/replay.md.
 - `@koi/rules-loader` (packages/lib/rules-loader) - Hierarchical project rules file discovery, loading, merging, and system prompt injection. Tests: 6. Docs: docs/L2/rules-loader.md.

--- a/docs/superpowers/plans/2026-05-09-monitor-tool.md
+++ b/docs/superpowers/plans/2026-05-09-monitor-tool.md
@@ -1,0 +1,1069 @@
+# Monitor Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-class scheduler-backed `monitor` CRUD surface to `@koi/proactive` with process-local state, deterministic text wake payloads, and matching unit/integration coverage.
+
+**Architecture:** Implement a new `monitor-tools.ts` module in `packages/lib/proactive/src` that owns input schemas, deterministic wake-message synthesis, create/list/update/cancel behavior, and same-process create-time idempotency. Wire a shared `MonitorToolState` into both `createProactiveTools()` and `createProactiveToolsProvider()` so monitors behave like the existing proactive tools, while keeping storage attach-local and avoiding any L0 contract widening.
+
+**Tech Stack:** TypeScript 6, Bun test runner, Zod JSON schema generation, `@koi/core` tool contracts, `@koi/scheduler` integration harness.
+
+---
+
+## File Structure
+
+### New files
+
+- `packages/lib/proactive/src/monitor-tools.ts`
+  - Owns monitor schemas, `MonitorRecord` / `MonitorToolState`, wake-message formatting, and the four tool factories.
+- `packages/lib/proactive/src/monitor-tools.test.ts`
+  - Unit tests for CRUD semantics, idempotency, update rotation, and deterministic wake text.
+
+### Modified files
+
+- `packages/lib/proactive/src/create-proactive-tools.ts`
+  - Instantiates `MonitorToolState` and appends the new tools to the default tool list.
+- `packages/lib/proactive/src/create-proactive-tools.test.ts`
+  - Verifies the default tool list includes the monitor tools in stable order.
+- `packages/lib/proactive/src/provider.ts`
+  - Creates a fresh per-attach `MonitorToolState` and wires the monitor tools into attached agents.
+- `packages/lib/proactive/src/provider.test.ts`
+  - Verifies attached agents receive the four monitor tools and that monitor state is not shared across attaches.
+- `packages/lib/proactive/src/index.ts`
+  - Re-exports monitor tool helpers and state types that are part of the package API.
+- `packages/lib/proactive/src/__tests__/integration.test.ts`
+  - Adds end-to-end coverage against the real scheduler for create, update, and cancel behavior.
+- `docs/L2/proactive.md`
+  - Documents the monitor tool family, state limits, and restart behavior.
+
+## Task 1: Add failing unit tests for monitor CRUD and wake formatting
+
+**Files:**
+- Create: `packages/lib/proactive/src/monitor-tools.test.ts`
+- Reference: `packages/lib/proactive/src/test-helpers.ts`
+- Reference: `packages/lib/proactive/src/cron-tools.test.ts`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+  formatMonitorWakeMessage,
+} from "./monitor-tools.js";
+import { createSchedulerStub } from "./test-helpers.js";
+
+describe("monitor tools", () => {
+  test("create_monitor stores a monitor and schedules a recurring wake", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string; deduped?: boolean };
+
+    expect(created.ok).toBe(true);
+    expect(created.deduped).toBeUndefined();
+    expect(stub.scheduleCalls).toHaveLength(1);
+
+    const listed = (await listMonitors.execute({})) as {
+      ok: boolean;
+      monitors: { monitor_id: string; name: string; goal: string; schedule_id: string }[];
+    };
+    expect(listed.monitors).toHaveLength(1);
+    expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
+  test("create_monitor dedupes same-process identical idempotency_key", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const args = {
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    };
+
+    const first = (await createMonitor.execute(args)) as { monitor_id: string; schedule_id: string };
+    const second = (await createMonitor.execute(args)) as {
+      monitor_id: string;
+      schedule_id: string;
+      deduped?: boolean;
+    };
+
+    expect(second.monitor_id).toBe(first.monitor_id);
+    expect(second.schedule_id).toBe(first.schedule_id);
+    expect(second.deduped).toBe(true);
+    expect(stub.scheduleCalls).toHaveLength(1);
+  });
+
+  test("create_monitor rejects a reused idempotency_key when monitor fields differ", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    });
+
+    const mismatch = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1301 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+
+    expect(mismatch.ok).toBe(false);
+    expect(mismatch.error).toContain("already registered");
+  });
+
+  test("create_monitor validates required fields before touching the scheduler", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const invalid = (await createMonitor.execute({
+      name: "",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { ok: boolean; error: string };
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.error).toContain("name");
+    expect(stub.scheduleCalls).toHaveLength(0);
+  });
+
+  test("create_monitor clears its reservation after a failed scheduler create", async () => {
+    const stub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const failed = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("scheduler unavailable");
+
+    const retry = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+    expect(retry.ok).toBe(false);
+    expect(retry.error).toContain("scheduler unavailable");
+    expect(state.monitorIdByIdempotencyKey.size).toBe(0);
+  });
+
+  test("update_monitor rotates the backing schedule and replaces stored fields", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const updated = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      expression: "30 9 * * *",
+      context_hint: "Focus on delivery and durability work.",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string };
+
+    expect(updated.ok).toBe(true);
+    expect(updated.schedule_id).not.toBe(created.schedule_id);
+    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; expression: string; context_hint?: string; schedule_id: string }[];
+    };
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe("Focus on delivery and durability work.");
+    expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
+  });
+
+  test("update_monitor fails for an unknown monitor_id", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+
+    const result = (await updateMonitor.execute({
+      monitor_id: "monitor-missing",
+      goal: "Detect whether issue #1301 is unblocked",
+    })) as { ok: boolean; error: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("not found");
+    expect(stub.scheduleCalls).toHaveLength(0);
+    expect(stub.unscheduleCalls).toHaveLength(0);
+  });
+
+  test("update_monitor preserves omitted fields by patch semantics", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+    })) as { monitor_id: string };
+
+    await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+    });
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { name: string; goal: string; expression: string; context_hint?: string }[];
+    };
+    expect(listed.monitors[0]?.name).toBe("dependency-watch");
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe(
+      "Look at scheduler/channel restoration issues first.",
+    );
+  });
+
+  test("update_monitor leaves the original record intact when replacement scheduling fails", async () => {
+    const state = createMonitorToolState();
+    const createStub = createSchedulerStub();
+    const failingStub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
+    const createMonitor = createCreateMonitorTool({ scheduler: createStub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: failingStub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const failed = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+    })) as { ok: boolean; error: string };
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("scheduler unavailable");
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; schedule_id: string }[];
+    };
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
+  test("cancel_monitor removes the record and clears create-time idempotency", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const cancelled = (await cancelMonitor.execute({
+      monitor_id: created.monitor_id,
+    })) as { ok: boolean; removed: boolean };
+    expect(cancelled).toEqual({ ok: true, removed: true });
+    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as { monitors: unknown[] };
+    expect(listed.monitors).toHaveLength(0);
+
+    const recreated = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string };
+    expect(recreated.monitor_id).not.toBe(created.monitor_id);
+  });
+
+  test("cancel_monitor returns removed:false for an unknown monitor_id", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+
+    const result = await cancelMonitor.execute({ monitor_id: "monitor-missing" });
+    expect(result).toEqual({ ok: true, removed: false });
+  });
+
+  test("formatMonitorWakeMessage renders deterministic multi-line text", () => {
+    expect(
+      formatMonitorWakeMessage({
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        checkPrompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        contextHint: "Look at scheduler/channel restoration issues first.",
+      }),
+    ).toBe(
+      [
+        "Monitor check: dependency-watch",
+        "Goal: Detect whether issue #1212 is unblocked",
+        "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        "Context: Look at scheduler/channel restoration issues first.",
+      ].join("\n"),
+    );
+  });
+
+  test("formatMonitorWakeMessage omits the Context line when no context hint is present", () => {
+    expect(
+      formatMonitorWakeMessage({
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        checkPrompt: "Inspect repo state.",
+      }),
+    ).toBe(
+      [
+        "Monitor check: dependency-watch",
+        "Goal: Detect whether issue #1212 is unblocked",
+        "Check: Inspect repo state.",
+      ].join("\n"),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file to verify it fails**
+
+Run: `bun test packages/lib/proactive/src/monitor-tools.test.ts`
+
+Expected: FAIL with module resolution errors for `./monitor-tools.js` exports that do not exist yet.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add packages/lib/proactive/src/monitor-tools.test.ts
+git commit -m "test(proactive): define monitor tool behavior"
+```
+
+## Task 2: Implement `monitor-tools.ts`
+
+**Files:**
+- Create: `packages/lib/proactive/src/monitor-tools.ts`
+- Reference: `packages/lib/proactive/src/cron-tools.ts`
+- Reference: `packages/lib/proactive/src/types.ts`
+
+- [ ] **Step 1: Write the monitor state, helpers, and schemas**
+
+```ts
+import type { JsonObject, Tool } from "@koi/core";
+import { DEFAULT_SANDBOXED_POLICY } from "@koi/core";
+import { toJSONSchema, z } from "zod";
+import type { ProactiveToolsConfig } from "./types.js";
+
+const createMonitorSchema = z.object({
+  name: z.string().min(1),
+  goal: z.string().min(1),
+  check_prompt: z.string().min(1),
+  expression: z.string().min(1),
+  context_hint: z.string().min(1).optional(),
+  timezone: z.string().min(1).optional(),
+  idempotency_key: z.string().min(1).refine((s) => !s.includes(":"), "idempotency_key must not contain ':'").optional(),
+});
+
+const listMonitorsSchema = z.object({});
+
+const updateMonitorSchema = z.object({
+  monitor_id: z.string().min(1),
+  name: z.string().min(1).optional(),
+  goal: z.string().min(1).optional(),
+  check_prompt: z.string().min(1).optional(),
+  expression: z.string().min(1).optional(),
+  context_hint: z.string().min(1).optional(),
+  timezone: z.string().min(1).optional(),
+});
+
+const cancelMonitorSchema = z.object({
+  monitor_id: z.string().min(1),
+});
+
+export interface MonitorRecord {
+  readonly monitorId: string;
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly expression: string;
+  readonly timezone?: string;
+  readonly contextHint?: string;
+  readonly idempotencyKey?: string;
+  readonly scheduleId: string;
+}
+
+export interface MonitorToolState {
+  readonly monitorsById: Map<string, MonitorRecord>;
+  readonly monitorIdByIdempotencyKey: Map<string, string>;
+  nextMonitorOrdinal: number;
+}
+
+export function createMonitorToolState(): MonitorToolState {
+  return {
+    monitorsById: new Map<string, MonitorRecord>(),
+    monitorIdByIdempotencyKey: new Map<string, string>(),
+    nextMonitorOrdinal: 1,
+  };
+}
+
+function nextMonitorId(state: MonitorToolState): string {
+  const id = `monitor-${state.nextMonitorOrdinal}`;
+  state.nextMonitorOrdinal += 1;
+  return id;
+}
+
+export function formatMonitorWakeMessage(input: {
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly contextHint?: string;
+}): string {
+  const lines = [
+    `Monitor check: ${input.name}`,
+    `Goal: ${input.goal}`,
+    `Check: ${input.checkPrompt}`,
+  ];
+  if (input.contextHint !== undefined) lines.push(`Context: ${input.contextHint}`);
+  return lines.join("\\n");
+}
+```
+
+- [ ] **Step 2: Implement `create_monitor` and `list_monitors`**
+
+```ts
+export function createCreateMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+  return {
+    descriptor: {
+      name: "create_monitor",
+      description:
+        "Create a recurring monitor that wakes this agent on a cron schedule with a monitoring brief.",
+      inputSchema: toJSONSchema(createMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = createMonitorSchema.safeParse(args);
+      if (!parsed.success) return { ok: false, error: parsed.error.message };
+      const data = parsed.data;
+
+      if (data.idempotency_key !== undefined) {
+        const existingMonitorId = state.monitorIdByIdempotencyKey.get(data.idempotency_key);
+        if (existingMonitorId !== undefined) {
+          const existing = state.monitorsById.get(existingMonitorId);
+          if (existing !== undefined) {
+            const matches =
+              existing.name === data.name &&
+              existing.goal === data.goal &&
+              existing.checkPrompt === data.check_prompt &&
+              existing.expression === data.expression &&
+              existing.timezone === data.timezone &&
+              existing.contextHint === data.context_hint;
+            if (!matches) {
+              return {
+                ok: false,
+                error:
+                  `idempotency_key '${data.idempotency_key}' already registered for a different monitor`,
+              };
+            }
+            return {
+              ok: true,
+              monitor_id: existing.monitorId,
+              schedule_id: existing.scheduleId,
+              deduped: true,
+            };
+          }
+        }
+      }
+
+      const monitorId = nextMonitorId(state);
+      const wakeMessage = formatMonitorWakeMessage({
+        name: data.name,
+        goal: data.goal,
+        checkPrompt: data.check_prompt,
+        ...(data.context_hint !== undefined ? { contextHint: data.context_hint } : {}),
+      });
+      const scheduleOptions = data.timezone !== undefined ? { timezone: data.timezone } : undefined;
+
+      try {
+        const scheduleId = await scheduler.schedule(
+          data.expression,
+          { kind: "text", text: wakeMessage },
+          "dispatch",
+          scheduleOptions,
+        );
+        const record: MonitorRecord = {
+          monitorId,
+          name: data.name,
+          goal: data.goal,
+          checkPrompt: data.check_prompt,
+          expression: data.expression,
+          ...(data.timezone !== undefined ? { timezone: data.timezone } : {}),
+          ...(data.context_hint !== undefined ? { contextHint: data.context_hint } : {}),
+          ...(data.idempotency_key !== undefined ? { idempotencyKey: data.idempotency_key } : {}),
+          scheduleId: String(scheduleId),
+        };
+        state.monitorsById.set(monitorId, record);
+        if (data.idempotency_key !== undefined) {
+          state.monitorIdByIdempotencyKey.set(data.idempotency_key, monitorId);
+        }
+        return { ok: true, monitor_id: monitorId, schedule_id: String(scheduleId) };
+      } catch (e: unknown) {
+        return { ok: false, error: e instanceof Error ? e.message : "Failed to create monitor" };
+      }
+    },
+  };
+}
+
+export function createListMonitorsTool(state: MonitorToolState): Tool {
+  return {
+    descriptor: {
+      name: "list_monitors",
+      description: "List active monitor specs known to this running proactive tool state.",
+      inputSchema: toJSONSchema(listMonitorsSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = listMonitorsSchema.safeParse(args);
+      if (!parsed.success) return { ok: false, error: parsed.error.message };
+      return {
+        ok: true,
+        monitors: [...state.monitorsById.values()].map((record) => ({
+          monitor_id: record.monitorId,
+          name: record.name,
+          goal: record.goal,
+          expression: record.expression,
+          ...(record.contextHint !== undefined ? { context_hint: record.contextHint } : {}),
+          schedule_id: record.scheduleId,
+        })),
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Implement `update_monitor` and `cancel_monitor`**
+
+```ts
+export function createUpdateMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+  return {
+    descriptor: {
+      name: "update_monitor",
+      description: "Update an existing monitor and replace its backing recurring schedule.",
+      inputSchema: toJSONSchema(updateMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = updateMonitorSchema.safeParse(args);
+      if (!parsed.success) return { ok: false, error: parsed.error.message };
+      const existing = state.monitorsById.get(parsed.data.monitor_id);
+      if (existing === undefined) {
+        return { ok: false, error: `monitor_id '${parsed.data.monitor_id}' not found` };
+      }
+
+      const nextRecord: MonitorRecord = {
+        ...existing,
+        ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
+        ...(parsed.data.goal !== undefined ? { goal: parsed.data.goal } : {}),
+        ...(parsed.data.check_prompt !== undefined ? { checkPrompt: parsed.data.check_prompt } : {}),
+        ...(parsed.data.expression !== undefined ? { expression: parsed.data.expression } : {}),
+        ...(parsed.data.timezone !== undefined ? { timezone: parsed.data.timezone } : {}),
+        ...(parsed.data.context_hint !== undefined ? { contextHint: parsed.data.context_hint } : {}),
+      };
+
+      const wakeMessage = formatMonitorWakeMessage({
+        name: nextRecord.name,
+        goal: nextRecord.goal,
+        checkPrompt: nextRecord.checkPrompt,
+        ...(nextRecord.contextHint !== undefined ? { contextHint: nextRecord.contextHint } : {}),
+      });
+
+      try {
+        const newScheduleId = await scheduler.schedule(
+          nextRecord.expression,
+          { kind: "text", text: wakeMessage },
+          "dispatch",
+          nextRecord.timezone !== undefined ? { timezone: nextRecord.timezone } : undefined,
+        );
+        await scheduler.unschedule(existing.scheduleId);
+        const replaced: MonitorRecord = { ...nextRecord, scheduleId: String(newScheduleId) };
+        state.monitorsById.set(existing.monitorId, replaced);
+        return { ok: true, monitor_id: existing.monitorId, schedule_id: String(newScheduleId) };
+      } catch (e: unknown) {
+        return { ok: false, error: e instanceof Error ? e.message : "Failed to update monitor" };
+      }
+    },
+  };
+}
+
+export function createCancelMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+  return {
+    descriptor: {
+      name: "cancel_monitor",
+      description: "Cancel a recurring monitor and remove it from the current proactive tool state.",
+      inputSchema: toJSONSchema(cancelMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = cancelMonitorSchema.safeParse(args);
+      if (!parsed.success) return { ok: false, error: parsed.error.message };
+      const existing = state.monitorsById.get(parsed.data.monitor_id);
+      if (existing === undefined) return { ok: true, removed: false };
+      try {
+        const removed = await scheduler.unschedule(existing.scheduleId);
+        state.monitorsById.delete(existing.monitorId);
+        if (existing.idempotencyKey !== undefined) {
+          state.monitorIdByIdempotencyKey.delete(existing.idempotencyKey);
+        }
+        return { ok: true, removed };
+      } catch (e: unknown) {
+        return { ok: false, error: e instanceof Error ? e.message : "Failed to cancel monitor" };
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `bun test packages/lib/proactive/src/monitor-tools.test.ts`
+
+Expected: PASS with all monitor CRUD and formatting tests green.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add packages/lib/proactive/src/monitor-tools.ts packages/lib/proactive/src/monitor-tools.test.ts
+git commit -m "feat(proactive): add monitor tools"
+```
+
+## Task 3: Wire monitor tools into the default proactive toolset and provider
+
+**Files:**
+- Modify: `packages/lib/proactive/src/create-proactive-tools.ts`
+- Modify: `packages/lib/proactive/src/create-proactive-tools.test.ts`
+- Modify: `packages/lib/proactive/src/provider.ts`
+- Modify: `packages/lib/proactive/src/provider.test.ts`
+- Modify: `packages/lib/proactive/src/index.ts`
+
+- [ ] **Step 1: Extend `createProactiveTools()` and its test**
+
+```ts
+// packages/lib/proactive/src/create-proactive-tools.ts
+import {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+} from "./monitor-tools.js";
+
+export function createProactiveTools(config: ProactiveToolsConfig): readonly Tool[] {
+  const cronState = createCronToolState();
+  const sleepState = createSleepToolState();
+  const monitorState = createMonitorToolState();
+  return [
+    createSleepTool(config, sleepState),
+    createCancelSleepTool(config, sleepState),
+    createScheduleCronTool(config, cronState),
+    createCancelScheduleTool(config, cronState),
+    createCreateMonitorTool(config, monitorState),
+    createListMonitorsTool(monitorState),
+    createUpdateMonitorTool(config, monitorState),
+    createCancelMonitorTool(config, monitorState),
+  ];
+}
+```
+
+```ts
+// packages/lib/proactive/src/create-proactive-tools.test.ts
+expect(tools.map((t) => t.descriptor.name)).toEqual([
+  "sleep",
+  "cancel_sleep",
+  "schedule_cron",
+  "cancel_schedule",
+  "create_monitor",
+  "list_monitors",
+  "update_monitor",
+  "cancel_monitor",
+]);
+```
+
+- [ ] **Step 2: Extend provider attach behavior**
+
+```ts
+// packages/lib/proactive/src/provider.ts
+import {
+  type MonitorToolState,
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+} from "./monitor-tools.js";
+
+function buildTools(
+  toolConfig: ProactiveToolsConfig,
+  sleepState: SleepToolState,
+  cronState: CronToolState,
+  monitorState: MonitorToolState,
+): readonly Tool[] {
+  return [
+    createSleepTool(toolConfig, sleepState),
+    createCancelSleepTool(toolConfig, sleepState),
+    createScheduleCronTool(toolConfig, cronState),
+    createCancelScheduleTool(toolConfig, cronState),
+    createCreateMonitorTool(toolConfig, monitorState),
+    createListMonitorsTool(monitorState),
+    createUpdateMonitorTool(toolConfig, monitorState),
+    createCancelMonitorTool(toolConfig, monitorState),
+  ];
+}
+
+// inside attach()
+const cronState = createCronToolState();
+const monitorState = createMonitorToolState();
+const tools = buildTools(toolConfig, sleepState, cronState, monitorState);
+```
+
+- [ ] **Step 3: Update provider tests for new tools and per-attach monitor isolation**
+
+```ts
+// packages/lib/proactive/src/provider.test.ts
+const toolNames = [
+  "sleep",
+  "cancel_sleep",
+  "schedule_cron",
+  "cancel_schedule",
+  "create_monitor",
+  "list_monitors",
+  "update_monitor",
+  "cancel_monitor",
+] as const;
+```
+
+```ts
+test("monitor state resets on reattach — list_monitors reflects only the current attach", async () => {
+  const stub = createSchedulerStub();
+  const agent = makeAgent(stub.component, "agent-monitor");
+  const provider = createProactiveToolsProvider();
+
+  const first = await provider.attach(agent);
+  const firstComps = "components" in first ? first.components : first;
+  const createMonitor = firstComps.get(toolToken("create_monitor") as string) as {
+    execute: (a: object) => Promise<unknown>;
+  };
+  const listMonitors = firstComps.get(toolToken("list_monitors") as string) as {
+    execute: (a: object) => Promise<unknown>;
+  };
+
+  await createMonitor.execute({
+    name: "dependency-watch",
+    goal: "Detect whether issue #1212 is unblocked",
+    check_prompt: "Inspect repo state.",
+    expression: "0 9 * * *",
+  });
+  expect(((await listMonitors.execute({})) as { monitors: unknown[] }).monitors).toHaveLength(1);
+
+  const second = await provider.attach(agent);
+  const secondComps = "components" in second ? second.components : second;
+  const listAfterReattach = secondComps.get(toolToken("list_monitors") as string) as {
+    execute: (a: object) => Promise<unknown>;
+  };
+
+  expect(((await listAfterReattach.execute({})) as { monitors: unknown[] }).monitors).toHaveLength(0);
+});
+```
+
+- [ ] **Step 4: Re-export monitor helpers**
+
+```ts
+// packages/lib/proactive/src/index.ts
+export {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+  formatMonitorWakeMessage,
+} from "./monitor-tools.js";
+export type { MonitorRecord, MonitorToolState } from "./monitor-tools.js";
+```
+
+- [ ] **Step 5: Run focused tests and commit**
+
+Run:
+
+- `bun test packages/lib/proactive/src/create-proactive-tools.test.ts`
+- `bun test packages/lib/proactive/src/provider.test.ts`
+
+Expected: PASS with the expanded tool list and reattach behavior validated.
+
+```bash
+git add \
+  packages/lib/proactive/src/create-proactive-tools.ts \
+  packages/lib/proactive/src/create-proactive-tools.test.ts \
+  packages/lib/proactive/src/provider.ts \
+  packages/lib/proactive/src/provider.test.ts \
+  packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): wire monitor tools into provider"
+```
+
+## Task 4: Add scheduler-backed integration coverage
+
+**Files:**
+- Modify: `packages/lib/proactive/src/__tests__/integration.test.ts`
+
+- [ ] **Step 1: Extend the harness tool map with monitor tools**
+
+```ts
+interface ToolMap {
+  readonly sleep: { execute: (a: object) => Promise<unknown> };
+  readonly cancelSleep: { execute: (a: object) => Promise<unknown> };
+  readonly scheduleCron: { execute: (a: object) => Promise<unknown> };
+  readonly cancelSchedule: { execute: (a: object) => Promise<unknown> };
+  readonly createMonitor: { execute: (a: object) => Promise<unknown> };
+  readonly listMonitors: { execute: (a: object) => Promise<unknown> };
+  readonly updateMonitor: { execute: (a: object) => Promise<unknown> };
+  readonly cancelMonitor: { execute: (a: object) => Promise<unknown> };
+}
+
+return {
+  sleep: get("sleep"),
+  cancelSleep: get("cancel_sleep"),
+  scheduleCron: get("schedule_cron"),
+  cancelSchedule: get("cancel_schedule"),
+  createMonitor: get("create_monitor"),
+  listMonitors: get("list_monitors"),
+  updateMonitor: get("update_monitor"),
+  cancelMonitor: get("cancel_monitor"),
+};
+```
+
+- [ ] **Step 2: Add integration tests for create, update, and cancel**
+
+```ts
+test("monitor create schedules recurring wake text and lists the stored monitor", async () => {
+  const tools = await attachTools(h.schedulerComponent, h.aid);
+  const created = (await tools.createMonitor.execute({
+    name: "dependency-watch",
+    goal: "Detect whether issue #1212 is unblocked",
+    check_prompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+    expression: "* * * * * *",
+    context_hint: "Look at scheduler/channel restoration issues first.",
+  })) as { ok: boolean; monitor_id: string; schedule_id: string };
+
+  expect(created.ok).toBe(true);
+  const listed = (await tools.listMonitors.execute({})) as {
+    monitors: { monitor_id: string; schedule_id: string }[];
+  };
+  expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
+  expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+});
+
+test("monitor update rotates the schedule and future dispatches use the updated message", async () => {
+  const tools = await attachTools(h.schedulerComponent, h.aid);
+  const created = (await tools.createMonitor.execute({
+    name: "dependency-watch",
+    goal: "Detect whether issue #1212 is unblocked",
+    check_prompt: "Inspect repo state.",
+    expression: "* * * * * *",
+  })) as { monitor_id: string; schedule_id: string };
+
+  const updated = (await tools.updateMonitor.execute({
+    monitor_id: created.monitor_id,
+    goal: "Detect whether issue #1301 is unblocked",
+    check_prompt: "Inspect delivery and durability state.",
+    expression: "* * * * * *",
+    context_hint: "Focus on proactive delivery blockers first.",
+  })) as { ok: boolean; schedule_id: string };
+  expect(updated.ok).toBe(true);
+  expect(updated.schedule_id).not.toBe(created.schedule_id);
+
+  const live = await h.scheduler.querySchedules(h.aid);
+  expect(live.some((s) => s.id === updated.schedule_id)).toBe(true);
+  expect(live.some((s) => s.id === created.schedule_id)).toBe(false);
+});
+
+test("cancel_monitor removes the stored monitor and unschedules future runs", async () => {
+  const tools = await attachTools(h.schedulerComponent, h.aid);
+  const created = (await tools.createMonitor.execute({
+    name: "dependency-watch",
+    goal: "Detect whether issue #1212 is unblocked",
+    check_prompt: "Inspect repo state.",
+    expression: "* * * * * *",
+  })) as { monitor_id: string; schedule_id: string };
+
+  const cancelled = (await tools.cancelMonitor.execute({
+    monitor_id: created.monitor_id,
+  })) as { ok: boolean; removed: boolean };
+  expect(cancelled).toEqual({ ok: true, removed: true });
+
+  const listed = (await tools.listMonitors.execute({})) as { monitors: unknown[] };
+  expect(listed.monitors).toHaveLength(0);
+
+  const live = await h.scheduler.querySchedules(h.aid);
+  expect(live.some((s) => s.id === created.schedule_id)).toBe(false);
+});
+```
+
+- [ ] **Step 3: Run the proactive integration suite**
+
+Run: `bun test packages/lib/proactive/src/__tests__/integration.test.ts`
+
+Expected: PASS with the new monitor cases green alongside the existing sleep/cron coverage.
+
+- [ ] **Step 4: Commit the integration coverage**
+
+```bash
+git add packages/lib/proactive/src/__tests__/integration.test.ts
+git commit -m "test(proactive): cover monitor scheduler integration"
+```
+
+## Task 5: Document the tool family and run package verification
+
+**Files:**
+- Modify: `docs/L2/proactive.md`
+
+- [ ] **Step 1: Document the monitor tools and limits**
+
+```md
+## Monitor tools
+
+The package also exposes a first-class recurring monitor surface:
+
+- `create_monitor`
+- `list_monitors`
+- `update_monitor`
+- `cancel_monitor`
+
+These tools store monitor specs in process-local state and compile them into
+recurring scheduler registrations. Each fire re-dispatches the same agent with
+a deterministic plain-text monitoring brief.
+
+### Scope and limits
+
+- No durable monitor registry across restart or provider reattach
+- `list_monitors` only reports monitors known to the current running tool state
+- `idempotency_key` on `create_monitor` is same-process only
+- No notification delivery or execution history in this slice
+```
+
+- [ ] **Step 2: Run package verification**
+
+Run:
+
+- `bun test packages/lib/proactive/src/monitor-tools.test.ts`
+- `bun test packages/lib/proactive/src/create-proactive-tools.test.ts`
+- `bun test packages/lib/proactive/src/provider.test.ts`
+- `bun test packages/lib/proactive/src/__tests__/integration.test.ts`
+- `bun --cwd packages/lib/proactive run typecheck`
+- `bun --cwd packages/lib/proactive run lint`
+
+Expected:
+
+- all Bun test commands PASS
+- `typecheck` exits 0
+- `lint` exits 0
+
+- [ ] **Step 3: Commit docs and verification-safe cleanup**
+
+```bash
+git add docs/L2/proactive.md
+git commit -m "docs(proactive): document monitor tools"
+```
+
+## Self-Review
+
+### Spec coverage
+
+- First-class CRUD tool family: covered by Tasks 1-4.
+- Process-local state and no durable reconciliation: covered by Task 2 state implementation and Task 3 reattach test.
+- Deterministic plain-text wake payload: covered by Task 1 formatting test and Task 2 helper.
+- Integration with default toolset/provider: covered by Task 3.
+- Real scheduler integration: covered by Task 4.
+- Public docs: covered by Task 5.
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “implement later” placeholders remain in the tasks.
+- Every code-changing step includes concrete code or assertions.
+- Every verification step includes exact commands.
+
+### Type consistency
+
+- Tool names are consistently `create_monitor`, `list_monitors`, `update_monitor`, `cancel_monitor`.
+- Record fields consistently use `monitorId` internally and `monitor_id` in tool I/O.
+- Wake formatting consistently uses `checkPrompt` internally and `check_prompt` in tool I/O.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-09-monitor-tool.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-10-notify-tool.md
+++ b/docs/superpowers/plans/2026-05-10-notify-tool.md
@@ -1,0 +1,807 @@
+# `notify` tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fire-and-forget `notify` tool to `@koi/proactive` that lets an agent send a one-shot text message via any `ChannelAdapter` attached to the agent.
+
+**Architecture:** Pure factory `createNotifyTool({ resolveChannel })` returning an L0 `Tool`. `ComponentProvider` snapshots `channel:*` components from the agent at attach time and passes a closure-bound lookup. No state, no scheduler, no retries.
+
+**Tech Stack:** TypeScript 6, Bun 1.3, `bun:test`, zod, `@koi/core`, `@koi/tools-core`.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-notify-tool-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/lib/proactive/src/notify-tool.ts` (new) | `createNotifyTool` factory + zod schema + `ResolveChannel` type |
+| `packages/lib/proactive/src/notify-tool.test.ts` (new) | Unit tests for the tool execute path |
+| `packages/lib/proactive/src/types.ts` (modify) | Extend `ProactiveToolsConfig` with optional `resolveChannel` |
+| `packages/lib/proactive/src/create-proactive-tools.ts` (modify) | Add `"notify"` to `PROACTIVE_TOOL_NAMES`, wire into `assembleProactiveTools` |
+| `packages/lib/proactive/src/provider.ts` (modify) | Snapshot `channel:*` components → pass `resolveChannel` |
+| `packages/lib/proactive/src/provider.test.ts` (modify) | Add tests for channel snapshotting + skip behavior |
+| `packages/lib/proactive/src/index.ts` (modify) | Export `createNotifyTool`, `ResolveChannel` |
+| `docs/L2/proactive.md` (modify) | Add `notify` row + behavior section |
+
+---
+
+## Task 1: Define types and schema
+
+**Files:**
+- Modify: `packages/lib/proactive/src/types.ts`
+
+- [ ] **Step 1: Add `ResolveChannel` type and extend `ProactiveToolsConfig`**
+
+In `packages/lib/proactive/src/types.ts`, add the import and new type:
+
+```typescript
+import type { AgentId, ChannelAdapter, SchedulerComponent } from "@koi/core";
+
+/**
+ * Lookup function returning a `ChannelAdapter` by channel name, or
+ * `undefined` if no channel with that name is attached. The provider
+ * builds this from a snapshot of `channel:*` components taken at attach
+ * time.
+ */
+export type ResolveChannel = (name: string) => ChannelAdapter | undefined;
+```
+
+Then extend `ProactiveToolsConfig` with one new optional field (place after `now`):
+
+```typescript
+  /**
+   * Lookup function for the `notify` tool. When omitted, `notify` is still
+   * created but every call resolves to "no channels available". The provider
+   * supplies this from a snapshot of the agent's `channel:*` components.
+   */
+  readonly resolveChannel?: ResolveChannel;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd packages/lib/proactive && bun run typecheck`
+Expected: PASS (no callers reference the new field yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/lib/proactive/src/types.ts
+git commit -m "feat(proactive): add ResolveChannel type for notify tool"
+```
+
+---
+
+## Task 2: Failing test for unknown channel
+
+**Files:**
+- Create: `packages/lib/proactive/src/notify-tool.test.ts`
+
+- [ ] **Step 1: Write the first failing test**
+
+Create `packages/lib/proactive/src/notify-tool.test.ts`:
+
+```typescript
+import { describe, expect, test } from "bun:test";
+import type { ChannelAdapter, JsonObject } from "@koi/core";
+import { createNotifyTool } from "./notify-tool.js";
+
+function stubAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
+  return {
+    name: "stub",
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: true,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async () => {},
+    onMessage: () => () => {},
+    ...overrides,
+  };
+}
+
+describe("notify tool", () => {
+  test("returns ok:false with sorted available_channels for unknown channel", async () => {
+    const channels = new Map<string, ChannelAdapter>([
+      ["slack", stubAdapter({ name: "slack" })],
+      ["email", stubAdapter({ name: "email" })],
+    ]);
+    const tool = createNotifyTool({ resolveChannel: (n) => channels.get(n) ?? undefined, names: () => [...channels.keys()] });
+    const result = (await tool.execute({ channel: "telegram", text: "hi" })) as JsonObject;
+    expect(result).toEqual({
+      ok: false,
+      error: "unknown channel: telegram",
+      available_channels: ["email", "slack"],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: FAIL — module `./notify-tool.js` not found.
+
+---
+
+## Task 3: Minimal `createNotifyTool` to make Task 2 pass
+
+**Files:**
+- Create: `packages/lib/proactive/src/notify-tool.ts`
+
+- [ ] **Step 1: Implement minimal factory**
+
+Create `packages/lib/proactive/src/notify-tool.ts`:
+
+```typescript
+/**
+ * `notify` tool — fire-and-forget text message to an attached ChannelAdapter.
+ *
+ * Thin pass-through: validate args, look up adapter by name, build an
+ * OutboundMessage with a single TextBlock, await `adapter.send`. No state,
+ * no idempotency, no retries. Adapter dedupe is the adapter's concern.
+ */
+
+import type { JsonObject, OutboundMessage, Tool } from "@koi/core";
+import { DEFAULT_SANDBOXED_POLICY } from "@koi/core";
+import { toJSONSchema, z } from "zod";
+import type { ResolveChannel } from "./types.js";
+
+const schema = z.object({
+  channel: z.string().min(1, "channel must be non-empty"),
+  text: z.string().min(1, "text must be non-empty"),
+  thread_id: z.string().min(1).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface NotifyToolConfig {
+  readonly resolveChannel: ResolveChannel;
+  /** Returns the currently-known channel names, used in error responses. */
+  readonly names: () => readonly string[];
+}
+
+export function createNotifyTool(config: NotifyToolConfig): Tool {
+  const { resolveChannel, names } = config;
+
+  return {
+    descriptor: {
+      name: "notify",
+      description:
+        "Send a one-shot text message to the user via a named channel " +
+        "(e.g. 'slack', 'email'). Fire-and-forget: no retries, no delivery " +
+        "confirmation beyond `ok:true`. Returns `ok:false` with the list " +
+        "of available channels if the named channel is not attached.",
+      inputSchema: toJSONSchema(schema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = schema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+      const { channel, text, thread_id, metadata } = parsed.data;
+      const adapter = resolveChannel(channel);
+      if (adapter === undefined) {
+        return {
+          ok: false,
+          error: `unknown channel: ${channel}`,
+          available_channels: [...names()].sort(),
+        };
+      }
+      const message: OutboundMessage = {
+        content: [{ kind: "text", text }],
+        ...(thread_id !== undefined ? { threadId: thread_id } : {}),
+        ...(metadata !== undefined ? { metadata: metadata as JsonObject } : {}),
+      };
+      try {
+        await adapter.send(message);
+        return { ok: true };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "channel.send failed",
+        };
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/lib/proactive/src/notify-tool.ts packages/lib/proactive/src/notify-tool.test.ts
+git commit -m "feat(proactive): add notify tool with unknown-channel error path"
+```
+
+---
+
+## Task 4: Add successful-send test (TDD second case)
+
+**Files:**
+- Modify: `packages/lib/proactive/src/notify-tool.test.ts`
+
+- [ ] **Step 1: Add test for successful send**
+
+Append inside the `describe("notify tool", ...)` block:
+
+```typescript
+  test("forwards exact OutboundMessage shape on successful send", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: (n) => (n === "slack" ? slack : undefined),
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({
+      channel: "slack",
+      text: "hello",
+      thread_id: "T1",
+      metadata: { priority: "high" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(sent).toEqual([
+      {
+        content: [{ kind: "text", text: "hello" }],
+        threadId: "T1",
+        metadata: { priority: "high" },
+      },
+    ]);
+  });
+```
+
+Add the missing import at the top of the file:
+
+```typescript
+import type { ChannelAdapter, JsonObject, OutboundMessage } from "@koi/core";
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: PASS (2 tests). Implementation already covers this — test verifies it.
+
+---
+
+## Task 5: Test omitted optional fields produce no `undefined` keys
+
+**Files:**
+- Modify: `packages/lib/proactive/src/notify-tool.test.ts`
+
+- [ ] **Step 1: Add test**
+
+Append inside the `describe` block:
+
+```typescript
+  test("omits threadId and metadata from outbound when not provided", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({ name: "slack", send: async (m) => { sent.push(m); } });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    await tool.execute({ channel: "slack", text: "hi" });
+
+    expect(sent).toHaveLength(1);
+    expect(Object.keys(sent[0]!).sort()).toEqual(["content"]);
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: PASS (3 tests).
+
+---
+
+## Task 6: Test adapter throw is caught
+
+**Files:**
+- Modify: `packages/lib/proactive/src/notify-tool.test.ts`
+
+- [ ] **Step 1: Add test**
+
+Append inside the `describe` block:
+
+```typescript
+  test("returns ok:false when adapter.send rejects, never throws", async () => {
+    const slack = stubAdapter({
+      name: "slack",
+      send: async () => { throw new Error("network down"); },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({ channel: "slack", text: "hi" });
+    expect(result).toEqual({ ok: false, error: "network down" });
+  });
+
+  test("returns ok:false with default message when adapter throws non-Error", async () => {
+    const slack = stubAdapter({
+      name: "slack",
+      send: async () => { throw "string thrown"; },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({ channel: "slack", text: "hi" });
+    expect(result).toEqual({ ok: false, error: "channel.send failed" });
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: PASS (5 tests).
+
+---
+
+## Task 7: Test schema validation for empty inputs
+
+**Files:**
+- Modify: `packages/lib/proactive/src/notify-tool.test.ts`
+
+- [ ] **Step 1: Add test**
+
+Append inside the `describe` block:
+
+```typescript
+  test("rejects empty channel name at schema boundary", async () => {
+    const tool = createNotifyTool({ resolveChannel: () => undefined, names: () => [] });
+    const result = (await tool.execute({ channel: "", text: "hi" })) as { ok: boolean; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("channel");
+  });
+
+  test("rejects empty text at schema boundary", async () => {
+    const tool = createNotifyTool({ resolveChannel: () => undefined, names: () => [] });
+    const result = (await tool.execute({ channel: "slack", text: "" })) as { ok: boolean; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("text");
+  });
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test notify-tool.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/lib/proactive/src/notify-tool.test.ts
+git commit -m "test(proactive): cover notify success, omitted optionals, errors, validation"
+```
+
+---
+
+## Task 8: Wire `notify` into the proactive tool roster
+
+**Files:**
+- Modify: `packages/lib/proactive/src/create-proactive-tools.ts`
+
+- [ ] **Step 1: Update `PROACTIVE_TOOL_NAMES` and `assembleProactiveTools`**
+
+Add `"notify"` to the names tuple (last entry):
+
+```typescript
+export const PROACTIVE_TOOL_NAMES = [
+  "sleep",
+  "cancel_sleep",
+  "schedule_cron",
+  "cancel_schedule",
+  "create_monitor",
+  "list_monitors",
+  "update_monitor",
+  "cancel_monitor",
+  "notify",
+] as const;
+```
+
+Add the import at top:
+
+```typescript
+import { createNotifyTool } from "./notify-tool.js";
+```
+
+In `assembleProactiveTools`, append the notify tool to the returned array — but only when `config.resolveChannel` is provided:
+
+```typescript
+export function assembleProactiveTools(
+  config: ProactiveToolsConfig,
+  states: ProactiveToolStates,
+): readonly Tool[] {
+  const { sleepState, cronState, monitorState } = states;
+  const tools: Tool[] = [
+    createSleepTool(config, sleepState),
+    createCancelSleepTool(config, sleepState),
+    createScheduleCronTool(config, cronState),
+    createCancelScheduleTool(config, cronState),
+    createCreateMonitorTool(config, monitorState),
+    createListMonitorsTool(monitorState),
+    createUpdateMonitorTool(config, monitorState),
+    createCancelMonitorTool(config, monitorState),
+  ];
+  if (config.resolveChannel !== undefined) {
+    const resolve = config.resolveChannel;
+    tools.push(
+      createNotifyTool({
+        resolveChannel: resolve,
+        names: () => collectChannelNames(config),
+      }),
+    );
+  }
+  return tools;
+}
+```
+
+Add a tiny helper at module scope (after imports):
+
+```typescript
+/**
+ * Collect channel names for `notify`'s available_channels error response.
+ * The provider supplies a `channelNames` callback closing over its snapshot;
+ * standalone callers without it get an empty list (the resolveChannel they
+ * provided still works for the success path).
+ */
+function collectChannelNames(config: ProactiveToolsConfig): readonly string[] {
+  return config.channelNames !== undefined ? config.channelNames() : [];
+}
+```
+
+- [ ] **Step 2: Add `channelNames` to `ProactiveToolsConfig`**
+
+In `packages/lib/proactive/src/types.ts`, add after `resolveChannel`:
+
+```typescript
+  /**
+   * Returns the currently-attached channel names. Used by `notify` to
+   * populate `available_channels` in error responses. The provider
+   * supplies a callback closing over its `channel:*` snapshot.
+   */
+  readonly channelNames?: () => readonly string[];
+```
+
+- [ ] **Step 3: Verify typecheck and existing tests still pass**
+
+Run: `cd packages/lib/proactive && bun run typecheck && bun test`
+Expected: PASS — no behavior change for existing tests (resolveChannel undefined → notify not installed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/lib/proactive/src/create-proactive-tools.ts packages/lib/proactive/src/types.ts
+git commit -m "feat(proactive): wire notify into tool roster when resolveChannel set"
+```
+
+---
+
+## Task 9: Provider snapshots `channel:*` components — failing test
+
+**Files:**
+- Modify: `packages/lib/proactive/src/provider.test.ts`
+
+- [ ] **Step 1: Update `makeAgent` helper to accept channels**
+
+Modify the existing `makeAgent` signature and body (around line 8 of `provider.test.ts`):
+
+```typescript
+function makeAgent(
+  scheduler: SchedulerComponent | undefined,
+  agentIdValue = "agent-default",
+  channels: ReadonlyMap<string, ChannelAdapter> = new Map(),
+): Agent {
+  const map = new Map<string, unknown>();
+  if (scheduler !== undefined) map.set(SCHEDULER as string, scheduler);
+  for (const [name, adapter] of channels) {
+    map.set(`channel:${name}`, adapter);
+  }
+  // ... rest unchanged
+```
+
+Add `ChannelAdapter` to the import line at top:
+
+```typescript
+import type { Agent, ChannelAdapter, SchedulerComponent, SubsystemToken } from "@koi/core";
+```
+
+- [ ] **Step 2: Add new test for notify installation**
+
+Append inside `describe("createProactiveToolsProvider", ...)`:
+
+```typescript
+  test("installs notify tool when channel:* components are attached", async () => {
+    const provider = createProactiveToolsProvider();
+    const slack: ChannelAdapter = {
+      name: "slack",
+      capabilities: { text: true, images: false, files: false, buttons: false, audio: false, video: false, threads: true, supportsA2ui: false },
+      connect: async () => {},
+      disconnect: async () => {},
+      send: async () => {},
+      onMessage: () => () => {},
+    };
+    const agent = makeAgent(createSchedulerStub(), "agent-1", new Map([["slack", slack]]));
+
+    const result = await provider.attach(agent);
+    const map = result instanceof Map ? result : result.components;
+    expect(map.has(toolToken("notify") as string)).toBe(true);
+  });
+
+  test("omits notify tool when no channel:* components are attached", async () => {
+    const provider = createProactiveToolsProvider();
+    const agent = makeAgent(createSchedulerStub(), "agent-1");
+
+    const result = await provider.attach(agent);
+    const map = result instanceof Map ? result : result.components;
+    expect(map.has(toolToken("notify") as string)).toBe(false);
+  });
+```
+
+- [ ] **Step 3: Run tests to verify the new tests fail**
+
+Run: `cd packages/lib/proactive && bun test provider.test.ts`
+Expected: the two new tests FAIL — first asserts `notify` present (provider doesn't install it yet), second passes incidentally.
+
+---
+
+## Task 10: Wire channel snapshot into provider
+
+**Files:**
+- Modify: `packages/lib/proactive/src/provider.ts`
+
+- [ ] **Step 1: Snapshot channels and pass to assemble**
+
+Add `ChannelAdapter` and `channelToken` to the import line:
+
+```typescript
+import type { Agent, AttachResult, ChannelAdapter, ComponentProvider, SkippedComponent, Tool } from "@koi/core";
+import { COMPONENT_PRIORITY, SCHEDULER, channelToken, toolToken } from "@koi/core";
+```
+
+Inside `attach`, after the scheduler resolution block and before `toolConfig` is built, add:
+
+```typescript
+      // Snapshot channel:* components at attach time. Channels added or
+      // removed after attach are not reflected by `notify` until reattach —
+      // matches the provider's existing per-attach lifecycle.
+      const channelSnapshot = new Map<string, ChannelAdapter>();
+      for (const [key, value] of agent.components()) {
+        if (key.startsWith("channel:")) {
+          channelSnapshot.set(key.slice("channel:".length), value as ChannelAdapter);
+        }
+      }
+```
+
+Then extend `toolConfig` with the resolveChannel + names callbacks (only when channels are present, so the assembler skips the tool cleanly when none exist):
+
+```typescript
+      const toolConfig: ProactiveToolsConfig = {
+        scheduler,
+        agentId: agent.pid.id,
+        ...(config.defaultWakeMessage !== undefined
+          ? { defaultWakeMessage: config.defaultWakeMessage }
+          : {}),
+        ...(config.maxSleepMs !== undefined ? { maxSleepMs: config.maxSleepMs } : {}),
+        ...(config.now !== undefined ? { now: config.now } : {}),
+        ...(channelSnapshot.size > 0
+          ? {
+              resolveChannel: (n: string) => channelSnapshot.get(n),
+              channelNames: () => [...channelSnapshot.keys()],
+            }
+          : {}),
+      };
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test provider.test.ts`
+Expected: PASS — both new notify tests now pass; existing tests unchanged.
+
+- [ ] **Step 3: Run full package tests**
+
+Run: `cd packages/lib/proactive && bun run typecheck && bun test`
+Expected: PASS — all tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/lib/proactive/src/provider.ts packages/lib/proactive/src/provider.test.ts
+git commit -m "feat(proactive): provider snapshots channel:* and installs notify"
+```
+
+---
+
+## Task 11: Snapshot semantics test (mutation-after-attach not reflected)
+
+**Files:**
+- Modify: `packages/lib/proactive/src/provider.test.ts`
+
+- [ ] **Step 1: Add test**
+
+Append inside `describe("createProactiveToolsProvider", ...)`:
+
+```typescript
+  test("notify uses snapshot — channels added after attach are not visible", async () => {
+    const provider = createProactiveToolsProvider();
+    const slack: ChannelAdapter = {
+      name: "slack",
+      capabilities: { text: true, images: false, files: false, buttons: false, audio: false, video: false, threads: true, supportsA2ui: false },
+      connect: async () => {},
+      disconnect: async () => {},
+      send: async () => {},
+      onMessage: () => () => {},
+    };
+    const channels = new Map<string, ChannelAdapter>([["slack", slack]]);
+    const agent = makeAgent(createSchedulerStub(), "agent-1", channels);
+
+    const result = await provider.attach(agent);
+    const map = result instanceof Map ? result : result.components;
+    const notify = map.get(toolToken("notify") as string) as { execute: (args: JsonObject) => Promise<unknown> };
+
+    // Mutate the agent's components AFTER attach — should not change snapshot.
+    (agent.components() as Map<string, unknown>).set("channel:email", slack);
+
+    const res = await notify.execute({ channel: "email", text: "hi" });
+    expect(res).toEqual({
+      ok: false,
+      error: "unknown channel: email",
+      available_channels: ["slack"],
+    });
+  });
+```
+
+Add `JsonObject` to the type import line if not already present:
+
+```typescript
+import type { Agent, ChannelAdapter, JsonObject, SchedulerComponent, SubsystemToken } from "@koi/core";
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/lib/proactive && bun test provider.test.ts`
+Expected: PASS — implementation already snapshots; this test locks the behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/lib/proactive/src/provider.test.ts
+git commit -m "test(proactive): pin notify channel-snapshot semantics"
+```
+
+---
+
+## Task 12: Public exports
+
+**Files:**
+- Modify: `packages/lib/proactive/src/index.ts`
+
+- [ ] **Step 1: Export new symbols**
+
+Add to `packages/lib/proactive/src/index.ts`:
+
+```typescript
+export { createNotifyTool, type NotifyToolConfig } from "./notify-tool.js";
+export type { ResolveChannel } from "./types.js";
+```
+
+- [ ] **Step 2: Verify typecheck + tests**
+
+Run: `cd packages/lib/proactive && bun run typecheck && bun test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/lib/proactive/src/index.ts
+git commit -m "feat(proactive): export notify tool surface"
+```
+
+---
+
+## Task 13: Update package docs
+
+**Files:**
+- Modify: `docs/L2/proactive.md`
+
+- [ ] **Step 1: Add `notify` row to the Tools table**
+
+In `docs/L2/proactive.md`, find the table starting `| Tool | Inputs | Returns |` and append a new row:
+
+```
+| `notify` | `channel`, `text`, `thread_id?`, `metadata?` | `{ ok: true }` or `{ ok: false, error, available_channels? }` |
+```
+
+- [ ] **Step 2: Add a behavior section**
+
+After the existing per-tool sections, append:
+
+```markdown
+### `notify`
+
+Sends a one-shot text message via a `ChannelAdapter` attached to the agent.
+Fire-and-forget: no retries, no delivery confirmation beyond `ok: true`.
+
+The provider snapshots `channel:*` components at attach time. Channels added
+or removed after attach are not visible to `notify` until the agent is
+reassembled — matches the per-attach lifecycle of the cron and monitor
+state. The tool is **only installed** when at least one `channel:*` component
+is attached; agents with no channels do not see it in their tool list.
+
+`thread_id` and `metadata` are forwarded verbatim to `OutboundMessage`.
+Adapter `send` rejections become `{ ok: false, error }` — the tool never
+throws to the caller.
+
+Out of scope (not implemented):
+- multi-channel broadcast (`channel: string[]`)
+- rich content blocks (file, image, button, custom) — text-only for v1
+- scheduled `notify_at` — would belong as a separate proactive tool
+- cross-restart dedup — channel adapters own that via their own idempotency stores
+```
+
+- [ ] **Step 3: Update the "What this package does NOT own" table comment if needed**
+
+Inspect that section; if it implies channels remain unowned, leave as-is. The
+notify tool does not implement channels — it consumes them — so the existing
+ownership statement remains correct.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/L2/proactive.md
+git commit -m "docs(proactive): document notify tool"
+```
+
+---
+
+## Task 14: Final verification
+
+- [ ] **Step 1: Run full proactive test suite**
+
+Run: `cd packages/lib/proactive && bun run typecheck && bun run lint && bun test`
+Expected: PASS — all green.
+
+- [ ] **Step 2: Run repo-wide layer check**
+
+Run: `bun run check:layers`
+Expected: PASS — `@koi/proactive` still imports only `@koi/core` and `@koi/tools-core`.
+
+- [ ] **Step 3: Confirm no orphan check failures**
+
+Run: `bun run check:orphans 2>/dev/null || true`
+Expected: no new failures attributable to this change. (`@koi/proactive` is already a `@koi/runtime` dep — no new wiring needed.)
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: every spec section has a task. Surface (Tasks 2–7), wiring (Tasks 8, 10), provider snapshot (Tasks 9–11), exports (Task 12), docs (Task 13).
+- No placeholders.
+- Type consistency: `ResolveChannel`, `NotifyToolConfig`, `channelNames` callback used consistently across types.ts, notify-tool.ts, create-proactive-tools.ts, provider.ts.
+- One ambiguity resolved inline: empty `channelNames` → empty `available_channels` array; `notify` only installed when channels exist, so this only matters for direct callers using `createProactiveTools` without the provider.

--- a/docs/superpowers/specs/2026-05-09-monitor-tool-design.md
+++ b/docs/superpowers/specs/2026-05-09-monitor-tool-design.md
@@ -1,0 +1,372 @@
+# `@koi/proactive` Monitor Tool Design
+
+Date: 2026-05-09
+Issue: `#1195`
+Status: Proposed
+
+## Summary
+
+Implement the first unblocked `monitor` slice for `@koi/proactive` as a
+first-class CRUD tool family backed by the existing scheduler. This version
+does not introduce a predicate engine, durable monitor storage, or delivery
+channels. Instead, it stores process-local monitor specs, schedules recurring
+agent wake-ups, and re-dispatches the same agent with a synthesized monitoring
+brief on each scheduled fire.
+
+## Goals
+
+- Add a real `monitor` abstraction without leaking raw cron semantics into the
+  user-facing API.
+- Keep `@koi/proactive` thin and scheduler-backed, consistent with the existing
+  `sleep` and `schedule_cron` tools.
+- Make the first version flexible enough for practical recurring checks without
+  forcing a typed target/predicate DSL too early.
+- Provide full CRUD for monitor specs in the current process/attach lifecycle.
+
+## Non-Goals
+
+- No durable monitor registry across process restart or provider reattach.
+- No notification-channel delivery in this slice.
+- No monitor execution history, last-run status, or result persistence.
+- No typed target/resource contract for checks.
+- No new L0 contract widening for monitor reconciliation.
+- No replacement of `schedule_cron`; the raw cron primitive remains available.
+
+## Recommended Approach
+
+The first version should implement a first-class monitor spec on top of the
+current scheduler-facing proactive package rather than:
+
+1. exposing `monitor` as a thin alias of `schedule_cron`, or
+2. building a full monitoring framework with typed predicates and delivery.
+
+This keeps the product surface understandable while preserving the package's
+current architectural boundary: scheduler underneath, thin tool layer above.
+
+## User-Facing Tool Surface
+
+This slice introduces four tools:
+
+- `create_monitor`
+- `list_monitors`
+- `update_monitor`
+- `cancel_monitor`
+
+These tools live beside the existing proactive tools:
+
+- `sleep`
+- `cancel_sleep`
+- `schedule_cron`
+- `cancel_schedule`
+
+`monitor` is a higher-level recurring check abstraction. `schedule_cron`
+remains the lower-level primitive for callers that want direct cron control.
+
+## Monitor Spec
+
+Each monitor record stores:
+
+- `monitor_id`: tool-generated stable identifier
+- `name`: human-readable label
+- `goal`: what the monitor is checking for
+- `check_prompt`: recurring instruction delivered back to the agent
+- `expression`: cron expression
+- `context_hint?`: optional short reminder about where or how to look
+- `idempotency_key?`: optional create-time same-process dedupe key
+- `schedule_id`: backing scheduler schedule identifier
+
+The caller does not supply `monitor_id`. It is created by the tool.
+
+## Tool Contracts
+
+### `create_monitor`
+
+Creates a recurring monitor spec and registers its backing scheduler entry.
+
+Suggested inputs:
+
+- `name`
+- `goal`
+- `check_prompt`
+- `expression`
+- `context_hint?`
+- `timezone?`
+- `idempotency_key?`
+
+Suggested result:
+
+```ts
+{ ok: true, monitor_id, schedule_id, deduped? }
+```
+
+Behavior:
+
+- Validates all inputs up front.
+- Stores a monitor record in process-local state.
+- Schedules a recurring wake-up using the scheduler.
+- If `idempotency_key` is reused with an identical monitor spec in the same
+  running process, returns the existing `monitor_id` and `schedule_id` with
+  `deduped: true`.
+- If the same key is reused with a different spec, fails closed.
+
+### `list_monitors`
+
+Returns active monitor records known to the current tool state.
+
+Suggested result:
+
+```ts
+{
+  ok: true,
+  monitors: readonly {
+    monitor_id: string;
+    name: string;
+    goal: string;
+    expression: string;
+    context_hint?: string;
+    schedule_id: string;
+  }[];
+}
+```
+
+Behavior:
+
+- Reads directly from process-local monitor state.
+- Does not query the scheduler for hidden or orphaned schedules.
+
+### `update_monitor`
+
+Updates an existing monitor and rotates the backing schedule.
+
+Suggested inputs:
+
+- `monitor_id`
+- any subset of:
+  - `name`
+  - `goal`
+  - `check_prompt`
+  - `expression`
+  - `context_hint`
+  - `timezone`
+
+Suggested result:
+
+```ts
+{ ok: true, monitor_id, schedule_id }
+```
+
+Behavior:
+
+- Fails closed if `monitor_id` is unknown.
+- Treats the update as patch semantics, using existing field values for omitted
+  fields.
+- Cancels the old schedule, registers the new schedule, then replaces the
+  monitor record.
+- If the replacement schedule cannot be created, returns an error and leaves
+  the original monitor record intact.
+
+### `cancel_monitor`
+
+Cancels the backing schedule and removes the monitor record.
+
+Suggested inputs:
+
+- `monitor_id`
+
+Suggested result:
+
+```ts
+{ ok: true, removed: boolean }
+```
+
+Behavior:
+
+- If the monitor exists, calls `SchedulerComponent.unschedule(scheduleId)`,
+  removes the record, and clears any create-time idempotency mapping.
+- If `monitor_id` is unknown, returns `{ ok: true, removed: false }`.
+- Unknown or already-removed scheduler IDs remain idempotent at the scheduler
+  layer.
+
+Returning `removed: false` for unknown monitor IDs keeps the cancel contract
+consistent with the existing proactive cancellation tools.
+
+## Execution Model
+
+`monitor` does not execute a tool or evaluate a predicate directly. Each fire
+re-dispatches the same agent with a synthesized text prompt describing the
+monitor check.
+
+The scheduler remains the execution engine. `@koi/proactive` only:
+
+1. stores the monitor spec in process-local state,
+2. compiles it into a recurring scheduler registration, and
+3. synthesizes the recurring wake/check message.
+
+This keeps the first version thin and avoids introducing a new polling engine.
+
+## Wake Payload
+
+The scheduled payload should remain plain text, not a new `EngineInput` kind or
+structured envelope. This matches the current design of `sleep` and
+`schedule_cron`.
+
+Conceptual wake message shape:
+
+```text
+Monitor check: dependency-watch
+Goal: detect whether issue #1212 is unblocked
+Check: inspect current repo and GitHub state, then decide whether follow-up is warranted
+Context: look at scheduler/channel restoration issues first
+```
+
+Required sections:
+
+- monitor label (`name`)
+- goal (`goal`)
+- recurring instruction (`check_prompt`)
+
+Optional section:
+
+- context hint (`context_hint`)
+
+The message should be deterministic from the stored monitor record so updates
+behave predictably and tests can assert exact content.
+
+## Internal State Model
+
+Add a new shared `MonitorToolState` created alongside the existing proactive
+state objects.
+
+Suggested shape:
+
+```ts
+interface MonitorRecord {
+  readonly monitorId: string;
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly expression: string;
+  readonly timezone?: string;
+  readonly contextHint?: string;
+  readonly idempotencyKey?: string;
+  readonly scheduleId: string;
+}
+
+interface MonitorToolState {
+  readonly monitorsById: Map<string, MonitorRecord>;
+  readonly monitorIdByIdempotencyKey: Map<string, string>;
+}
+```
+
+This state is process-local and attach-local, matching the conservative pattern
+already used for cron state where durable reconciliation is not yet available.
+
+## Idempotency Model
+
+`create_monitor` supports optional caller-supplied `idempotency_key`.
+
+Semantics:
+
+- Same-process only.
+- Exact-match replay returns the original `monitor_id` / `schedule_id`.
+- Mismatched replay fails closed.
+- Failed create removes any pending reservation.
+- Update and cancel do not accept idempotency keys in this first slice.
+
+Like existing proactive cron semantics, this is explicitly not durable across
+process restart or provider reattach.
+
+## Restart And Reattach Behavior
+
+This slice does not attempt to reconcile process-local monitor records with
+durable scheduler state after restart or reattach.
+
+Consequences:
+
+- `list_monitors` only reflects monitors created in the current live tool state.
+- A durable scheduler may still own recurring schedules after process restart,
+  but `@koi/proactive` will not rediscover them in this slice.
+- Recreating a monitor after restart may produce a second recurring schedule if
+  the previous one still exists.
+
+This is acceptable for the first slice because:
+
+- it matches the current documented non-durable behavior for proactive
+  idempotency state,
+- it avoids inventing hidden scheduler contracts inside an L2 package, and
+- true reconciliation belongs in a focused L0/L2 widening if the product needs
+  durable monitor registry behavior later.
+
+## Error Handling
+
+All tools return result objects and must not throw for expected failures.
+
+Expected failures include:
+
+- invalid input schema
+- duplicate idempotency key with mismatched fields
+- unknown `monitor_id` on update
+- scheduler schedule/unschedule failures
+
+Errors should follow the current proactive style:
+
+```ts
+{ ok: false, error: "..." }
+```
+
+## Testing Strategy
+
+Add colocated unit tests plus integration coverage against the real scheduler,
+matching the current package convention.
+
+Unit tests:
+
+- `create_monitor` validates required fields before scheduler calls
+- identical create + `idempotency_key` dedupes
+- mismatched create + reused `idempotency_key` fails closed
+- `list_monitors` returns current records
+- `update_monitor` patches stored fields and rotates schedule IDs
+- `update_monitor` fails for unknown monitor IDs
+- `cancel_monitor` removes existing record and clears idempotency entry
+- `cancel_monitor` on unknown monitor returns `{ removed: false }`
+- synthesized wake message matches stored record deterministically
+
+Integration tests:
+
+- recurring schedule created by `create_monitor` re-dispatches the agent with
+  the expected synthesized text payload
+- `update_monitor` replaces the live schedule and later fires with updated text
+- `cancel_monitor` prevents future firings
+
+## File Plan
+
+Expected files:
+
+- `packages/lib/proactive/src/monitor-tools.ts`
+- `packages/lib/proactive/src/monitor-tools.test.ts`
+- updates in `packages/lib/proactive/src/create-proactive-tools.ts`
+- updates in `packages/lib/proactive/src/provider.ts`
+- updates in `packages/lib/proactive/src/index.ts`
+- documentation updates in `docs/L2/proactive.md`
+
+If helper extraction is needed, keep it local to `@koi/proactive` and avoid any
+L0 widening in this slice.
+
+## Open Follow-Ons
+
+This design intentionally leaves later work for future issues or later slices
+of `#1195`:
+
+- durable monitor reconciliation across restart
+- monitor execution history / last-run status
+- notification-channel delivery
+- `brief` integration
+- typed targets or predicates
+- packaging the monitor wake path into broader autonomous composition flows
+
+## Decision
+
+Proceed with a first-class, scheduler-backed `monitor` CRUD surface in
+`@koi/proactive`, using process-local state and plain-text recurring wake
+messages, while keeping durable reconciliation and delivery concerns out of
+scope for this first implementation.

--- a/docs/superpowers/specs/2026-05-10-notify-tool-design.md
+++ b/docs/superpowers/specs/2026-05-10-notify-tool-design.md
@@ -1,0 +1,94 @@
+# `notify` tool — design
+
+**Issue:** #1195 (v2 Phase 3a `@koi/proactive`)
+**Date:** 2026-05-10
+**Package:** `@koi/proactive`
+
+## Purpose
+
+Give an agent a thin LLM-callable surface to send a one-shot text message to
+itself out via any `ChannelAdapter` attached to the agent. Fire-and-forget,
+no state, no retries.
+
+## Surface
+
+```typescript
+notify({
+  channel: string,        // channel name (matches "channel:<name>" component key)
+  text: string,           // text content (single TextBlock)
+  thread_id?: string,     // optional thread continuity (forwarded to OutboundMessage.threadId)
+  metadata?: JsonObject,  // optional adapter-specific hints (forwarded to OutboundMessage.metadata)
+}) =>
+  | { ok: true }
+  | { ok: false, error: string, available_channels?: readonly string[] }
+```
+
+## Wiring
+
+Mirrors the `sleep`/`schedule_cron` pattern:
+
+- `createNotifyTool({ resolveChannel })` — pure factory taking a `(name) => ChannelAdapter | undefined` lookup.
+- `createNotifyToolProvider()` — `ComponentProvider`. At `attach()`:
+  1. Snapshot `agent.components()` keys matching `^channel:` into `Map<name, ChannelAdapter>`.
+  2. If empty → return `skipped: [{ name: "notify", reason: "no ChannelAdapter components attached" }]`.
+  3. Build the tool with a closure-bound lookup over the snapshot.
+
+The snapshot is taken at attach time. Channels added or removed after attach
+are not reflected by `notify` until reattach. This mirrors the existing
+proactive-tools snapshot semantics for `SchedulerComponent` and is documented.
+
+## Tool body (high level)
+
+1. Validate args with zod (channel non-empty, text non-empty, thread_id non-empty if present).
+2. Look up adapter. Miss → `{ ok: false, error: "unknown channel: <name>", available_channels: [sorted names] }`.
+3. Build `OutboundMessage`:
+   ```typescript
+   {
+     content: [{ kind: "text", text }],
+     ...(thread_id !== undefined ? { threadId: thread_id } : {}),
+     ...(metadata !== undefined ? { metadata } : {}),
+   }
+   ```
+4. `await adapter.send(msg)`. Catch → `{ ok: false, error: format(err) }` (no rethrow).
+5. Return `{ ok: true }`.
+
+No state. No idempotency. No retries. The tool is a thin pass-through.
+
+## Out of scope (YAGNI)
+
+- Multi-channel broadcast (`channel: string[]`).
+- Rich content blocks (file, image, button, custom).
+- Scheduled notify (`notify_at`) — would belong as a separate proactive tool combining scheduler + notify.
+- Cross-restart dedup — channel adapters own this via their own idempotency store.
+- Per-channel capability gating — adapter rejects what it doesn't support; `notify` does not pre-check.
+
+## Tests
+
+Unit (`notify-tool.test.ts`, ~150 lines):
+
+- Unknown channel returns `ok: false` with sorted `available_channels`.
+- Successful send forwards exact `OutboundMessage` shape (content, threadId, metadata).
+- Adapter `send` rejection becomes `{ ok: false, error }` — never throws to caller.
+- Empty channel name / empty text rejected at zod boundary.
+- `thread_id` and `metadata` omitted from outbound when not provided (no `undefined` keys).
+
+Provider (added to `provider.test.ts`):
+
+- No `channel:*` components → `skipped` entry, tool not installed.
+- Multiple `channel:*` components → all available; lookup hits both.
+- Channel added after attach → not visible (snapshot semantics documented).
+
+## Files
+
+- `packages/lib/proactive/src/notify-tool.ts` (~80 lines, new)
+- `packages/lib/proactive/src/notify-tool.test.ts` (~150 lines, new)
+- `packages/lib/proactive/src/create-proactive-tools.ts` — add `"notify"` to `PROACTIVE_TOOL_NAMES`, wire into `assembleProactiveTools`
+- `packages/lib/proactive/src/provider.ts` — enumerate `channel:*` components, pass `resolveChannel` into config
+- `packages/lib/proactive/src/types.ts` — extend `ProactiveToolsConfig` with optional `resolveChannel`
+- `packages/lib/proactive/src/index.ts` — export new factories/types
+- `docs/L2/proactive.md` — add `notify` row to Tools table + behavior section
+
+## Layer compliance
+
+- Imports only `@koi/core` (L0) and `@koi/tools-core` (L0u) — no peer L2 deps.
+- No vendor types, no I/O, no state. Adapter `send` is the only side effect.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "check:doc-gate": "bun scripts/check-doc-gate.ts",
     "check:doc-wiring": "bun scripts/check-doc-wiring.ts",
     "check:test-integrity": "bun scripts/check-test-integrity.ts",
-    "check:complexity": "bun scripts/check-complexity.ts --max-violations 789",
+    "check:complexity": "bun scripts/check-complexity.ts --max-violations 791",
     "generate:layer-docs": "bun scripts/generate-layer-docs.ts",
     "generate:package-coverage": "bun scripts/generate-package-coverage-map.ts",
     "check:orphans": "bun scripts/check-orphans.ts",

--- a/packages/lib/proactive/src/__tests__/integration.test.ts
+++ b/packages/lib/proactive/src/__tests__/integration.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import type {
   Agent,
   AgentId,
@@ -28,6 +28,8 @@ import {
   type FakeClock,
 } from "../../../../sched/scheduler/src/index.js";
 import { createProactiveToolsProvider } from "../provider.js";
+
+setDefaultTimeout(15_000);
 
 interface Harness {
   readonly scheduler: TaskScheduler;
@@ -136,6 +138,32 @@ async function drain(clock: FakeClock, ms: number): Promise<void> {
   clock.tick(ms);
   for (let i = 0; i < 5; i++) {
     await new Promise<void>((r) => clock.setTimeout(r, 0));
+  }
+}
+
+function cronExpressionAt(when: Date): string {
+  return `${when.getSeconds()} ${when.getMinutes()} ${when.getHours()} ${when.getDate()} ${
+    when.getMonth() + 1
+  } *`;
+}
+
+function futureCronExpression(offsetMs: number): string {
+  const nextWholeSecond = Math.ceil(Date.now() / 1_000) * 1_000;
+  return cronExpressionAt(new Date(nextWholeSecond + offsetMs));
+}
+
+async function waitForMonitorDispatch(
+  harness: Harness,
+  expectedCount: number,
+  timeoutMs: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (harness.dispatched.length < expectedCount) {
+    if (Date.now() - startedAt > timeoutMs) {
+      break;
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+    await drain(harness.clock, 1);
   }
 }
 
@@ -260,14 +288,14 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     expect(liveAfter.some((s: { readonly id: string }) => s.id === r.schedule_id)).toBe(false);
   });
 
-  test("7. create_monitor schedules a live monitor and list_monitors returns its summary", async () => {
+  test("7. create_monitor dispatches the synthesized monitor wake text and lists its summary", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
+    const expression = futureCronExpression(2_000);
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
-      expression: "0 9 * * *",
-      timezone: "America/Los_Angeles",
+      expression,
       context_hint: "Look at scheduler/channel restoration issues first.",
     })) as { ok: boolean; monitor_id: string; schedule_id: string };
 
@@ -291,7 +319,7 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
         schedule_id: created.schedule_id,
         name: "dependency-watch",
         goal: "Detect whether issue #1212 is unblocked",
-        expression: "0 9 * * *",
+        expression,
         context_hint: "Look at scheduler/channel restoration issues first.",
       },
     ]);
@@ -299,24 +327,37 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
     expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(true);
+
+    await waitForMonitorDispatch(h, 1, 4_000);
+    expect(h.dispatched).toEqual([
+      {
+        kind: "text",
+        text: [
+          "Monitor check: dependency-watch",
+          "Goal: Detect whether issue #1212 is unblocked",
+          "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+          "Context: Look at scheduler/channel restoration issues first.",
+        ].join("\n"),
+      },
+    ]);
   });
 
-  test("8. update_monitor rotates the live schedule and keeps only the updated monitor", async () => {
+  test("8. update_monitor rotates the live schedule and later dispatches only the updated monitor text", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
+    const initialExpression = futureCronExpression(5_000);
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
-      expression: "0 9 * * *",
-      timezone: "America/Los_Angeles",
+      expression: initialExpression,
     })) as { monitor_id: string; schedule_id: string };
 
+    const updatedExpression = futureCronExpression(2_000);
     const updated = (await tools.updateMonitor.execute({
       monitor_id: created.monitor_id,
       goal: "Detect whether issue #1301 is unblocked",
       check_prompt: "Inspect delivery and durability state.",
-      expression: "30 9 * * *",
-      timezone: "America/New_York",
+      expression: updatedExpression,
       context_hint: "Focus on proactive delivery blockers first.",
     })) as { ok: boolean; monitor_id: string; schedule_id: string };
 
@@ -337,22 +378,39 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
     expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
     expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
-    expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
+    expect(listed.monitors[0]?.expression).toBe(updatedExpression);
     expect(listed.monitors[0]?.context_hint).toBe("Focus on proactive delivery blockers first.");
 
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
     expect(live.some((schedule) => schedule.id === updated.schedule_id)).toBe(true);
     expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+
+    await waitForMonitorDispatch(h, 1, 4_000);
+    expect(h.dispatched).toEqual([
+      {
+        kind: "text",
+        text: [
+          "Monitor check: dependency-watch",
+          "Goal: Detect whether issue #1301 is unblocked",
+          "Check: Inspect delivery and durability state.",
+          "Context: Focus on proactive delivery blockers first.",
+        ].join("\n"),
+      },
+    ]);
+
+    await waitForMonitorDispatch(h, 2, 4_500);
+    expect(h.dispatched).toHaveLength(1);
   });
 
-  test("9. cancel_monitor removes the listed monitor and unschedules future runs", async () => {
+  test("9. cancel_monitor removes the listed monitor and suppresses future monitor dispatches", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
+    const expression = futureCronExpression(2_000);
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
-      expression: "0 9 * * *",
+      expression,
     })) as { monitor_id: string; schedule_id: string };
 
     const cancelled = (await tools.cancelMonitor.execute({
@@ -366,6 +424,9 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
 
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+
+    await waitForMonitorDispatch(h, 1, 3_500);
+    expect(h.dispatched).toHaveLength(0);
   });
 
   test("10. provider reattach against fresh scheduler — sleep heals via query, cron freshens per attach", async () => {

--- a/packages/lib/proactive/src/__tests__/integration.test.ts
+++ b/packages/lib/proactive/src/__tests__/integration.test.ts
@@ -15,24 +15,56 @@ import type {
   AgentId,
   EngineInput,
   SchedulerComponent,
+  ScheduleStore,
   SubsystemToken,
   TaskScheduler,
+  TaskStore,
 } from "@koi/core";
-import { agentId, DEFAULT_SCHEDULER_CONFIG, SCHEDULER, toolToken } from "@koi/core";
-import {
+import { agentId, DEFAULT_SCHEDULER_CONFIG, SCHEDULER, scheduleId, toolToken } from "@koi/core";
+import { createProactiveToolsProvider } from "../provider.js";
+
+setDefaultTimeout(15_000);
+
+interface FakeClock {
+  readonly now: () => number;
+  readonly setTimeout: (fn: () => void, ms: number) => ReturnType<typeof globalThis.setTimeout>;
+  readonly clearTimeout: (id: ReturnType<typeof globalThis.setTimeout>) => void;
+  readonly tick: (ms: number) => void;
+  readonly setTime: (ms: number) => void;
+}
+
+interface SchedulerModule {
+  readonly createFakeClock: (initialTime?: number) => FakeClock;
+  readonly createScheduler: (
+    config: typeof DEFAULT_SCHEDULER_CONFIG,
+    store: TaskStore,
+    dispatcher: (
+      agentId: AgentId,
+      input: EngineInput,
+      mode: "spawn" | "dispatch",
+      signal: AbortSignal,
+    ) => Promise<void>,
+    clock?: FakeClock,
+    scheduleStore?: ScheduleStore,
+  ) => TaskScheduler;
+  readonly createSchedulerComponent: (
+    scheduler: TaskScheduler,
+    agentId: AgentId,
+  ) => SchedulerComponent;
+  readonly createSqliteScheduleStore: (db: Database) => ScheduleStore;
+  readonly createSqliteTaskStore: (db: Database) => TaskStore;
+}
+
+const schedulerSourceEntrypoint = "../../../../sched/scheduler/src/" + "index.js";
+const schedulerModule = (await import(schedulerSourceEntrypoint)) as SchedulerModule;
+
+const {
   createFakeClock,
   createScheduler,
   createSchedulerComponent,
   createSqliteScheduleStore,
   createSqliteTaskStore,
-  type FakeClock,
-  // Focused `bun test packages/lib/proactive/src/__tests__/integration.test.ts`
-  // cannot resolve the public `@koi/scheduler` workspace export in this repo
-  // layout today, so this test uses the package's public source entrypoint.
-} from "../../../../sched/scheduler/src/index.js";
-import { createProactiveToolsProvider } from "../provider.js";
-
-setDefaultTimeout(15_000);
+} = schedulerModule;
 
 interface Harness {
   readonly scheduler: TaskScheduler;
@@ -50,8 +82,8 @@ function buildHarness(): Harness {
   const scheduler = createScheduler(
     { ...DEFAULT_SCHEDULER_CONFIG, pollIntervalMs: 1 },
     createSqliteTaskStore(db),
-    async (_a: AgentId, inp: EngineInput) => {
-      dispatched.push(inp);
+    async (_agentId: AgentId, input: EngineInput) => {
+      dispatched.push(input);
     },
     clock,
     createSqliteScheduleStore(db),
@@ -349,7 +381,7 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
     expect(live[0]).toEqual({
-      id: created.schedule_id,
+      id: scheduleId(created.schedule_id),
       agentId: h.aid,
       expression,
       input: { kind: "text", text: wakeText },
@@ -419,7 +451,7 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
     expect(live[0]).toEqual({
-      id: updated.schedule_id,
+      id: scheduleId(updated.schedule_id),
       agentId: h.aid,
       expression: updatedExpression,
       input: { kind: "text", text: updatedWakeText },

--- a/packages/lib/proactive/src/__tests__/integration.test.ts
+++ b/packages/lib/proactive/src/__tests__/integration.test.ts
@@ -26,6 +26,9 @@ import {
   createSqliteScheduleStore,
   createSqliteTaskStore,
   type FakeClock,
+  // Focused `bun test packages/lib/proactive/src/__tests__/integration.test.ts`
+  // cannot resolve the public `@koi/scheduler` workspace export in this repo
+  // layout today, so this test uses the package's public source entrypoint.
 } from "../../../../sched/scheduler/src/index.js";
 import { createProactiveToolsProvider } from "../provider.js";
 
@@ -150,6 +153,19 @@ function cronExpressionAt(when: Date): string {
 function futureCronExpression(offsetMs: number): string {
   const nextWholeSecond = Math.ceil(Date.now() / 1_000) * 1_000;
   return cronExpressionAt(new Date(nextWholeSecond + offsetMs));
+}
+
+function expectedMonitorWakeText(args: {
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly contextHint?: string;
+}): string {
+  const lines = [`Monitor check: ${args.name}`, `Goal: ${args.goal}`, `Check: ${args.checkPrompt}`];
+  if (args.contextHint !== undefined) {
+    lines.push(`Context: ${args.contextHint}`);
+  }
+  return lines.join("\n");
 }
 
 async function waitForMonitorDispatch(
@@ -291,6 +307,12 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
   test("7. create_monitor dispatches the synthesized monitor wake text and lists its summary", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
     const expression = futureCronExpression(2_000);
+    const wakeText = expectedMonitorWakeText({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      checkPrompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+      contextHint: "Look at scheduler/channel restoration issues first.",
+    });
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
@@ -326,18 +348,20 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
 
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
-    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(true);
+    expect(live[0]).toEqual({
+      id: created.schedule_id,
+      agentId: h.aid,
+      expression,
+      input: { kind: "text", text: wakeText },
+      mode: "dispatch",
+      paused: false,
+    });
 
     await waitForMonitorDispatch(h, 1, 4_000);
     expect(h.dispatched).toEqual([
       {
         kind: "text",
-        text: [
-          "Monitor check: dependency-watch",
-          "Goal: Detect whether issue #1212 is unblocked",
-          "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
-          "Context: Look at scheduler/channel restoration issues first.",
-        ].join("\n"),
+        text: wakeText,
       },
     ]);
   });
@@ -345,6 +369,11 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
   test("8. update_monitor rotates the live schedule and later dispatches only the updated monitor text", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
     const initialExpression = futureCronExpression(5_000);
+    const initialWakeText = expectedMonitorWakeText({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      checkPrompt: "Inspect repo state.",
+    });
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
@@ -353,6 +382,12 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     })) as { monitor_id: string; schedule_id: string };
 
     const updatedExpression = futureCronExpression(2_000);
+    const updatedWakeText = expectedMonitorWakeText({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1301 is unblocked",
+      checkPrompt: "Inspect delivery and durability state.",
+      contextHint: "Focus on proactive delivery blockers first.",
+    });
     const updated = (await tools.updateMonitor.execute({
       monitor_id: created.monitor_id,
       goal: "Detect whether issue #1301 is unblocked",
@@ -383,19 +418,23 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
 
     const live = await h.scheduler.querySchedules(h.aid);
     expect(live).toHaveLength(1);
-    expect(live.some((schedule) => schedule.id === updated.schedule_id)).toBe(true);
-    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+    expect(live[0]).toEqual({
+      id: updated.schedule_id,
+      agentId: h.aid,
+      expression: updatedExpression,
+      input: { kind: "text", text: updatedWakeText },
+      mode: "dispatch",
+      paused: false,
+    });
+    expect(live[0]?.id).not.toBe(created.schedule_id);
+    expect(live[0]?.expression).not.toBe(initialExpression);
+    expect(live[0]?.input).not.toEqual({ kind: "text", text: initialWakeText });
 
     await waitForMonitorDispatch(h, 1, 4_000);
     expect(h.dispatched).toEqual([
       {
         kind: "text",
-        text: [
-          "Monitor check: dependency-watch",
-          "Goal: Detect whether issue #1301 is unblocked",
-          "Check: Inspect delivery and durability state.",
-          "Context: Focus on proactive delivery blockers first.",
-        ].join("\n"),
+        text: updatedWakeText,
       },
     ]);
 
@@ -406,6 +445,11 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
   test("9. cancel_monitor removes the listed monitor and suppresses future monitor dispatches", async () => {
     const tools = await attachTools(h.schedulerComponent, h.aid);
     const expression = futureCronExpression(2_000);
+    const wakeText = expectedMonitorWakeText({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      checkPrompt: "Inspect repo state.",
+    });
     const created = (await tools.createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
@@ -423,10 +467,11 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     expect(listed.monitors).toHaveLength(0);
 
     const live = await h.scheduler.querySchedules(h.aid);
-    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+    expect(live).toHaveLength(0);
 
     await waitForMonitorDispatch(h, 1, 3_500);
     expect(h.dispatched).toHaveLength(0);
+    expect(h.dispatched).not.toContainEqual({ kind: "text", text: wakeText });
   });
 
   test("10. provider reattach against fresh scheduler — sleep heals via query, cron freshens per attach", async () => {

--- a/packages/lib/proactive/src/__tests__/integration.test.ts
+++ b/packages/lib/proactive/src/__tests__/integration.test.ts
@@ -26,7 +26,7 @@ import {
   createSqliteScheduleStore,
   createSqliteTaskStore,
   type FakeClock,
-} from "@koi/scheduler";
+} from "../../../../sched/scheduler/src/index.js";
 import { createProactiveToolsProvider } from "../provider.js";
 
 interface Harness {
@@ -104,6 +104,10 @@ interface ToolMap {
   readonly cancelSleep: { execute: (a: object) => Promise<unknown> };
   readonly scheduleCron: { execute: (a: object) => Promise<unknown> };
   readonly cancelSchedule: { execute: (a: object) => Promise<unknown> };
+  readonly createMonitor: { execute: (a: object) => Promise<unknown> };
+  readonly listMonitors: { execute: (a: object) => Promise<unknown> };
+  readonly updateMonitor: { execute: (a: object) => Promise<unknown> };
+  readonly cancelMonitor: { execute: (a: object) => Promise<unknown> };
 }
 
 async function attachTools(scheduler: SchedulerComponent, aid: AgentId): Promise<ToolMap> {
@@ -120,6 +124,10 @@ async function attachTools(scheduler: SchedulerComponent, aid: AgentId): Promise
     cancelSleep: get("cancel_sleep"),
     scheduleCron: get("schedule_cron"),
     cancelSchedule: get("cancel_schedule"),
+    createMonitor: get("create_monitor"),
+    listMonitors: get("list_monitors"),
+    updateMonitor: get("update_monitor"),
+    cancelMonitor: get("cancel_monitor"),
   };
 }
 
@@ -252,7 +260,115 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     expect(liveAfter.some((s: { readonly id: string }) => s.id === r.schedule_id)).toBe(false);
   });
 
-  test("7. provider reattach against fresh scheduler — sleep heals via query, cron freshens per attach", async () => {
+  test("7. create_monitor schedules a live monitor and list_monitors returns its summary", async () => {
+    const tools = await attachTools(h.schedulerComponent, h.aid);
+    const created = (await tools.createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+      expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string };
+
+    expect(created.ok).toBe(true);
+
+    const listed = (await tools.listMonitors.execute({})) as {
+      ok: boolean;
+      monitors: {
+        monitor_id: string;
+        schedule_id: string;
+        name: string;
+        goal: string;
+        expression: string;
+        context_hint?: string;
+      }[];
+    };
+    expect(listed.ok).toBe(true);
+    expect(listed.monitors).toEqual([
+      {
+        monitor_id: created.monitor_id,
+        schedule_id: created.schedule_id,
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        expression: "0 9 * * *",
+        context_hint: "Look at scheduler/channel restoration issues first.",
+      },
+    ]);
+
+    const live = await h.scheduler.querySchedules(h.aid);
+    expect(live).toHaveLength(1);
+    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(true);
+  });
+
+  test("8. update_monitor rotates the live schedule and keeps only the updated monitor", async () => {
+    const tools = await attachTools(h.schedulerComponent, h.aid);
+    const created = (await tools.createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const updated = (await tools.updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      check_prompt: "Inspect delivery and durability state.",
+      expression: "30 9 * * *",
+      timezone: "America/New_York",
+      context_hint: "Focus on proactive delivery blockers first.",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string };
+
+    expect(updated.ok).toBe(true);
+    expect(updated.monitor_id).toBe(created.monitor_id);
+    expect(updated.schedule_id).not.toBe(created.schedule_id);
+
+    const listed = (await tools.listMonitors.execute({})) as {
+      monitors: {
+        monitor_id: string;
+        schedule_id: string;
+        goal: string;
+        expression: string;
+        context_hint?: string;
+      }[];
+    };
+    expect(listed.monitors).toHaveLength(1);
+    expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
+    expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe("Focus on proactive delivery blockers first.");
+
+    const live = await h.scheduler.querySchedules(h.aid);
+    expect(live).toHaveLength(1);
+    expect(live.some((schedule) => schedule.id === updated.schedule_id)).toBe(true);
+    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+  });
+
+  test("9. cancel_monitor removes the listed monitor and unschedules future runs", async () => {
+    const tools = await attachTools(h.schedulerComponent, h.aid);
+    const created = (await tools.createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const cancelled = (await tools.cancelMonitor.execute({
+      monitor_id: created.monitor_id,
+    })) as { ok: boolean; removed: boolean };
+
+    expect(cancelled).toEqual({ ok: true, removed: true });
+
+    const listed = (await tools.listMonitors.execute({})) as { monitors: unknown[] };
+    expect(listed.monitors).toHaveLength(0);
+
+    const live = await h.scheduler.querySchedules(h.aid);
+    expect(live.some((schedule) => schedule.id === created.schedule_id)).toBe(false);
+  });
+
+  test("10. provider reattach against fresh scheduler — sleep heals via query, cron freshens per attach", async () => {
     // First scheduler: register a sleep + a cron.
     const tools1 = await attachTools(h.schedulerComponent, h.aid);
     const sleepR = (await tools1.sleep.execute({
@@ -313,7 +429,7 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     }
   });
 
-  test("8. two agents on same provider — no cross-agent state leak", async () => {
+  test("11. two agents on same provider — no cross-agent state leak", async () => {
     const provider = createProactiveToolsProvider();
     const aidA = agentId("agent-a" as AgentId);
     const aidB = agentId("agent-b" as AgentId);
@@ -344,7 +460,7 @@ describe("@koi/proactive integration with @koi/scheduler", () => {
     expect(h.dispatched).toHaveLength(2);
   });
 
-  test("9. idempotency_key NOT forwarded to scheduler.submit (process-local only)", async () => {
+  test("12. idempotency_key NOT forwarded to scheduler.submit (process-local only)", async () => {
     // Capture submissions by querying the scheduler directly. The internal
     // ScheduledTask record exposes metadata but not idempotencyKey directly,
     // so we instead validate the cancel→retry-same-key flow works (which

--- a/packages/lib/proactive/src/create-proactive-tools.test.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.test.ts
@@ -3,7 +3,7 @@ import { createProactiveTools } from "./create-proactive-tools.js";
 import { createSchedulerStub } from "./test-helpers.js";
 
 describe("createProactiveTools", () => {
-  test("returns sleep, cancel_sleep, schedule_cron, cancel_schedule in that order", () => {
+  test("returns sleep, cron, and monitor tools in stable order", () => {
     const stub = createSchedulerStub();
     const tools = createProactiveTools({ scheduler: stub.component });
     expect(tools.map((t) => t.descriptor.name)).toEqual([
@@ -11,6 +11,10 @@ describe("createProactiveTools", () => {
       "cancel_sleep",
       "schedule_cron",
       "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
     ]);
   });
 

--- a/packages/lib/proactive/src/create-proactive-tools.test.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.test.ts
@@ -6,7 +6,10 @@ describe("createProactiveTools", () => {
   test("returns sleep, cron, and monitor tools in stable order", () => {
     const stub = createSchedulerStub();
     const tools = createProactiveTools({ scheduler: stub.component });
-    expect(tools.map((t) => t.descriptor.name)).toEqual([...PROACTIVE_TOOL_NAMES]);
+    // notify is omitted when resolveChannel is not set; filter it out for comparison.
+    expect(tools.map((t) => t.descriptor.name)).toEqual(
+      PROACTIVE_TOOL_NAMES.filter((n) => n !== "notify"),
+    );
   });
 
   test("all tools share the primordial origin", () => {

--- a/packages/lib/proactive/src/create-proactive-tools.test.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.test.ts
@@ -1,15 +1,41 @@
 import { describe, expect, test } from "bun:test";
-import { createProactiveTools, PROACTIVE_TOOL_NAMES } from "./create-proactive-tools.js";
+import { createProactiveTools } from "./create-proactive-tools.js";
 import { createSchedulerStub } from "./test-helpers.js";
 
 describe("createProactiveTools", () => {
   test("returns sleep, cron, and monitor tools in stable order", () => {
     const stub = createSchedulerStub();
     const tools = createProactiveTools({ scheduler: stub.component });
-    // notify is omitted when resolveChannel is not set; filter it out for comparison.
-    expect(tools.map((t) => t.descriptor.name)).toEqual(
-      PROACTIVE_TOOL_NAMES.filter((n) => n !== "notify"),
-    );
+    expect(tools.map((t) => t.descriptor.name)).toEqual([
+      "sleep",
+      "cancel_sleep",
+      "schedule_cron",
+      "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
+    ]);
+  });
+
+  test("includes notify when resolveChannel is supplied", () => {
+    const stub = createSchedulerStub();
+    const tools = createProactiveTools({
+      scheduler: stub.component,
+      resolveChannel: () => undefined,
+      channelNames: () => ["slack"],
+    });
+    expect(tools.map((t) => t.descriptor.name)).toEqual([
+      "sleep",
+      "cancel_sleep",
+      "schedule_cron",
+      "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
+      "notify",
+    ]);
   });
 
   test("all tools share the primordial origin", () => {

--- a/packages/lib/proactive/src/create-proactive-tools.test.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.test.ts
@@ -6,7 +6,7 @@ describe("createProactiveTools", () => {
   test("returns sleep, cron, and monitor tools in stable order", () => {
     const stub = createSchedulerStub();
     const tools = createProactiveTools({ scheduler: stub.component });
-    expect(tools.map((t) => t.descriptor.name)).toEqual(PROACTIVE_TOOL_NAMES);
+    expect(tools.map((t) => t.descriptor.name)).toEqual([...PROACTIVE_TOOL_NAMES]);
   });
 
   test("all tools share the primordial origin", () => {

--- a/packages/lib/proactive/src/create-proactive-tools.test.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.test.ts
@@ -1,21 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { createProactiveTools } from "./create-proactive-tools.js";
+import { createProactiveTools, PROACTIVE_TOOL_NAMES } from "./create-proactive-tools.js";
 import { createSchedulerStub } from "./test-helpers.js";
 
 describe("createProactiveTools", () => {
   test("returns sleep, cron, and monitor tools in stable order", () => {
     const stub = createSchedulerStub();
     const tools = createProactiveTools({ scheduler: stub.component });
-    expect(tools.map((t) => t.descriptor.name)).toEqual([
-      "sleep",
-      "cancel_sleep",
-      "schedule_cron",
-      "cancel_schedule",
-      "create_monitor",
-      "list_monitors",
-      "update_monitor",
-      "cancel_monitor",
-    ]);
+    expect(tools.map((t) => t.descriptor.name)).toEqual(PROACTIVE_TOOL_NAMES);
   });
 
   test("all tools share the primordial origin", () => {

--- a/packages/lib/proactive/src/create-proactive-tools.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.ts
@@ -34,16 +34,6 @@ export const PROACTIVE_TOOL_NAMES = [
   "notify",
 ] as const;
 
-/**
- * Collect channel names for `notify`'s available_channels error response.
- * The provider supplies a `channelNames` callback closing over its snapshot;
- * standalone callers without it get an empty list (the resolveChannel they
- * provided still works for the success path).
- */
-function collectChannelNames(config: ProactiveToolsConfig): readonly string[] {
-  return config.channelNames !== undefined ? config.channelNames() : [];
-}
-
 export interface ProactiveToolStates {
   readonly sleepState: SleepToolState;
   readonly cronState: CronToolState;
@@ -55,7 +45,8 @@ export function assembleProactiveTools(
   states: ProactiveToolStates,
 ): readonly Tool[] {
   const { sleepState, cronState, monitorState } = states;
-  const tools: Tool[] = [
+  const { resolveChannel } = config;
+  return [
     createSleepTool(config, sleepState),
     createCancelSleepTool(config, sleepState),
     createScheduleCronTool(config, cronState),
@@ -64,17 +55,15 @@ export function assembleProactiveTools(
     createListMonitorsTool(monitorState),
     createUpdateMonitorTool(config, monitorState),
     createCancelMonitorTool(config, monitorState),
+    ...(resolveChannel !== undefined
+      ? [
+          createNotifyTool({
+            resolveChannel,
+            names: () => config.channelNames?.() ?? [],
+          }),
+        ]
+      : []),
   ];
-  if (config.resolveChannel !== undefined) {
-    const resolve = config.resolveChannel;
-    tools.push(
-      createNotifyTool({
-        resolveChannel: resolve,
-        names: () => collectChannelNames(config),
-      }),
-    );
-  }
-  return tools;
 }
 
 export function createProactiveTools(config: ProactiveToolsConfig): readonly Tool[] {

--- a/packages/lib/proactive/src/create-proactive-tools.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.ts
@@ -18,6 +18,7 @@ import {
   createUpdateMonitorTool,
   type MonitorToolState,
 } from "./monitor-tools.js";
+import { createNotifyTool } from "./notify-tool.js";
 import { createSleepTool, createSleepToolState, type SleepToolState } from "./sleep-tool.js";
 import type { ProactiveToolsConfig } from "./types.js";
 
@@ -30,7 +31,18 @@ export const PROACTIVE_TOOL_NAMES = [
   "list_monitors",
   "update_monitor",
   "cancel_monitor",
+  "notify",
 ] as const;
+
+/**
+ * Collect channel names for `notify`'s available_channels error response.
+ * The provider supplies a `channelNames` callback closing over its snapshot;
+ * standalone callers without it get an empty list (the resolveChannel they
+ * provided still works for the success path).
+ */
+function collectChannelNames(config: ProactiveToolsConfig): readonly string[] {
+  return config.channelNames !== undefined ? config.channelNames() : [];
+}
 
 export interface ProactiveToolStates {
   readonly sleepState: SleepToolState;
@@ -43,7 +55,7 @@ export function assembleProactiveTools(
   states: ProactiveToolStates,
 ): readonly Tool[] {
   const { sleepState, cronState, monitorState } = states;
-  return [
+  const tools: Tool[] = [
     createSleepTool(config, sleepState),
     createCancelSleepTool(config, sleepState),
     createScheduleCronTool(config, cronState),
@@ -53,6 +65,16 @@ export function assembleProactiveTools(
     createUpdateMonitorTool(config, monitorState),
     createCancelMonitorTool(config, monitorState),
   ];
+  if (config.resolveChannel !== undefined) {
+    const resolve = config.resolveChannel;
+    tools.push(
+      createNotifyTool({
+        resolveChannel: resolve,
+        names: () => collectChannelNames(config),
+      }),
+    );
+  }
+  return tools;
 }
 
 export function createProactiveTools(config: ProactiveToolsConfig): readonly Tool[] {

--- a/packages/lib/proactive/src/create-proactive-tools.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.ts
@@ -5,6 +5,7 @@
 import type { Tool } from "@koi/core";
 import { createCancelSleepTool } from "./cancel-sleep-tool.js";
 import {
+  type CronToolState,
   createCancelScheduleTool,
   createCronToolState,
   createScheduleCronTool,
@@ -15,19 +16,33 @@ import {
   createListMonitorsTool,
   createMonitorToolState,
   createUpdateMonitorTool,
+  type MonitorToolState,
 } from "./monitor-tools.js";
-import { createSleepTool, createSleepToolState } from "./sleep-tool.js";
+import { createSleepTool, createSleepToolState, type SleepToolState } from "./sleep-tool.js";
 import type { ProactiveToolsConfig } from "./types.js";
 
-export function createProactiveTools(config: ProactiveToolsConfig): readonly Tool[] {
-  // State maps live for the lifetime of the tool set (typically one agent
-  // assembly). schedule_cron + cancel_schedule share the cron map; sleep +
-  // cancel_sleep share the sleep map. See cron-tools.ts and sleep-tool.ts
-  // for the idempotency semantics they enforce. Monitor tools share a
-  // process-local state map for create/list/update/cancel.
-  const cronState = createCronToolState();
-  const monitorState = createMonitorToolState();
-  const sleepState = createSleepToolState();
+export const PROACTIVE_TOOL_NAMES = [
+  "sleep",
+  "cancel_sleep",
+  "schedule_cron",
+  "cancel_schedule",
+  "create_monitor",
+  "list_monitors",
+  "update_monitor",
+  "cancel_monitor",
+] as const;
+
+export interface ProactiveToolStates {
+  readonly sleepState: SleepToolState;
+  readonly cronState: CronToolState;
+  readonly monitorState: MonitorToolState;
+}
+
+export function assembleProactiveTools(
+  config: ProactiveToolsConfig,
+  states: ProactiveToolStates,
+): readonly Tool[] {
+  const { sleepState, cronState, monitorState } = states;
   return [
     createSleepTool(config, sleepState),
     createCancelSleepTool(config, sleepState),
@@ -38,4 +53,17 @@ export function createProactiveTools(config: ProactiveToolsConfig): readonly Too
     createUpdateMonitorTool(config, monitorState),
     createCancelMonitorTool(config, monitorState),
   ];
+}
+
+export function createProactiveTools(config: ProactiveToolsConfig): readonly Tool[] {
+  // State maps live for the lifetime of the tool set (typically one agent
+  // assembly). schedule_cron + cancel_schedule share the cron map; sleep +
+  // cancel_sleep share the sleep map. See cron-tools.ts and sleep-tool.ts
+  // for the idempotency semantics they enforce. Monitor tools share a
+  // process-local state map for create/list/update/cancel.
+  return assembleProactiveTools(config, {
+    sleepState: createSleepToolState(),
+    cronState: createCronToolState(),
+    monitorState: createMonitorToolState(),
+  });
 }

--- a/packages/lib/proactive/src/create-proactive-tools.ts
+++ b/packages/lib/proactive/src/create-proactive-tools.ts
@@ -9,6 +9,13 @@ import {
   createCronToolState,
   createScheduleCronTool,
 } from "./cron-tools.js";
+import {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+} from "./monitor-tools.js";
 import { createSleepTool, createSleepToolState } from "./sleep-tool.js";
 import type { ProactiveToolsConfig } from "./types.js";
 
@@ -16,13 +23,19 @@ export function createProactiveTools(config: ProactiveToolsConfig): readonly Too
   // State maps live for the lifetime of the tool set (typically one agent
   // assembly). schedule_cron + cancel_schedule share the cron map; sleep +
   // cancel_sleep share the sleep map. See cron-tools.ts and sleep-tool.ts
-  // for the idempotency semantics they enforce.
+  // for the idempotency semantics they enforce. Monitor tools share a
+  // process-local state map for create/list/update/cancel.
   const cronState = createCronToolState();
+  const monitorState = createMonitorToolState();
   const sleepState = createSleepToolState();
   return [
     createSleepTool(config, sleepState),
     createCancelSleepTool(config, sleepState),
     createScheduleCronTool(config, cronState),
     createCancelScheduleTool(config, cronState),
+    createCreateMonitorTool(config, monitorState),
+    createListMonitorsTool(monitorState),
+    createUpdateMonitorTool(config, monitorState),
+    createCancelMonitorTool(config, monitorState),
   ];
 }

--- a/packages/lib/proactive/src/index.ts
+++ b/packages/lib/proactive/src/index.ts
@@ -76,6 +76,7 @@ export {
   type MonitorRecord,
   type MonitorToolState,
 } from "./monitor-tools.js";
+export { createNotifyTool, type NotifyToolConfig } from "./notify-tool.js";
 export {
   createProactiveDelivery,
   type DeliveryFailure,
@@ -106,5 +107,9 @@ export {
   type NexusSignalSourceConfig,
   type NexusSubscribeFn,
 } from "./system-signal-sources/nexus.js";
-export type { ProactiveToolsConfig, ProactiveToolsProviderConfig } from "./types.js";
+export type {
+  ProactiveToolsConfig,
+  ProactiveToolsProviderConfig,
+  ResolveChannel,
+} from "./types.js";
 export { DEFAULT_MAX_SLEEP_MS, DEFAULT_WAKE_MESSAGE } from "./types.js";

--- a/packages/lib/proactive/src/index.ts
+++ b/packages/lib/proactive/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @koi/proactive — proactive/autonomous tool surfaces.
  *
- * Phase 3a (issue #1195): sleep + cron-facing tools layered over the L0
- * SchedulerComponent. Channel/webhook/monitor surfaces ship in later phases.
+ * Phase 3a (issue #1195): sleep, cron, and monitor-facing tools layered over
+ * the L0 SchedulerComponent. Channel/webhook surfaces ship in later phases.
  */
 
 export {
@@ -66,6 +66,16 @@ export {
   createLlmCompositionPlanner,
   type LlmCompositionPlannerConfig,
 } from "./llm-composition-planner.js";
+export {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+  formatMonitorWakeMessage,
+  type MonitorRecord,
+  type MonitorToolState,
+} from "./monitor-tools.js";
 export {
   createProactiveDelivery,
   type DeliveryFailure,

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { scheduleId } from "@koi/core";
 import {
   createCancelMonitorTool,
   createCreateMonitorTool,
@@ -231,7 +232,7 @@ describe("monitor tools", () => {
 
     expect(updated.ok).toBe(true);
     expect(updated.schedule_id).not.toBe(created.schedule_id);
-    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+    expect(stub.unscheduleCalls).toEqual([scheduleId(created.schedule_id)]);
     expect(stub.scheduleCalls[1]?.options).toEqual({ timezone: "America/New_York" });
 
     const listed = (await listMonitors.execute({})) as {
@@ -355,7 +356,7 @@ describe("monitor tools", () => {
     expect(failed.ok).toBe(false);
     expect(failed.error).toContain("retire previous monitor schedule");
     expect(stub.unscheduleCalls).toHaveLength(2);
-    expect(stub.unscheduleCalls[0]).toBe(created.schedule_id);
+    expect(stub.unscheduleCalls[0]).toBe(scheduleId(created.schedule_id));
     expect(String(stub.unscheduleCalls[1])).toBe("sched-2");
 
     const listed = (await listMonitors.execute({})) as {
@@ -386,7 +387,7 @@ describe("monitor tools", () => {
       monitor_id: created.monitor_id,
     })) as { ok: boolean; removed: boolean };
     expect(cancelled).toEqual({ ok: true, removed: true });
-    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+    expect(stub.unscheduleCalls).toEqual([scheduleId(created.schedule_id)]);
 
     const listed = (await listMonitors.execute({})) as { monitors: unknown[] };
     expect(listed.monitors).toHaveLength(0);
@@ -420,7 +421,7 @@ describe("monitor tools", () => {
       monitor_id: created.monitor_id,
     })) as { ok: boolean; removed: boolean };
     expect(cancelled).toEqual({ ok: true, removed: true });
-    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+    expect(stub.unscheduleCalls).toEqual([scheduleId(created.schedule_id)]);
 
     const listed = (await listMonitors.execute({})) as { monitors: unknown[] };
     expect(listed.monitors).toHaveLength(0);

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -330,51 +330,6 @@ describe("monitor tools", () => {
     expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
   });
 
-  test("update_monitor fails closed when retiring the original schedule reports removed:false", async () => {
-    const state = createMonitorToolState();
-    const createStub = createSchedulerStub();
-    const updateStub = createSchedulerStub({ unscheduleResult: false });
-    const createMonitor = createCreateMonitorTool({ scheduler: createStub.component }, state);
-    const updateMonitor = createUpdateMonitorTool({ scheduler: updateStub.component }, state);
-    const listMonitors = createListMonitorsTool(state);
-
-    const created = (await createMonitor.execute({
-      name: "dependency-watch",
-      goal: "Detect whether issue #1212 is unblocked",
-      check_prompt: "Inspect repo state.",
-      expression: "0 9 * * *",
-      timezone: "America/Los_Angeles",
-      context_hint: "Look at scheduler/channel restoration issues first.",
-    })) as { monitor_id: string; schedule_id: string };
-
-    const updated = (await updateMonitor.execute({
-      monitor_id: created.monitor_id,
-      goal: "Detect whether issue #1301 is unblocked",
-      expression: "30 9 * * *",
-      timezone: "America/New_York",
-      context_hint: "Focus on delivery and durability work.",
-    })) as { ok: boolean; error: string };
-    expect(updated.ok).toBe(false);
-    expect(updated.error).toContain("removed:false");
-    expect(updateStub.scheduleCalls).toHaveLength(1);
-    expect(updateStub.unscheduleCalls).toEqual([created.schedule_id]);
-
-    const listed = (await listMonitors.execute({})) as {
-      monitors: {
-        goal: string;
-        expression: string;
-        context_hint?: string;
-        schedule_id: string;
-      }[];
-    };
-    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
-    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
-    expect(listed.monitors[0]?.context_hint).toBe(
-      "Look at scheduler/channel restoration issues first.",
-    );
-    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
-  });
-
   test("cancel_monitor removes the record and clears create-time idempotency", async () => {
     const stub = createSchedulerStub();
     const state = createMonitorToolState();

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -330,6 +330,43 @@ describe("monitor tools", () => {
     expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
   });
 
+  test("update_monitor compensates when retiring the original schedule reports false", async () => {
+    const stub = createSchedulerStub({ unscheduleResult: false });
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const failed = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      expression: "30 9 * * *",
+      timezone: "America/New_York",
+    })) as { ok: boolean; error: string };
+
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("retire previous monitor schedule");
+    expect(stub.unscheduleCalls).toHaveLength(2);
+    expect(stub.unscheduleCalls[0]).toBe(created.schedule_id);
+    expect(String(stub.unscheduleCalls[1])).toBe("sched-2");
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; expression: string; schedule_id: string }[];
+    };
+    expect(listed.monitors).toHaveLength(1);
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
   test("cancel_monitor removes the record and clears create-time idempotency", async () => {
     const stub = createSchedulerStub();
     const state = createMonitorToolState();
@@ -362,6 +399,52 @@ describe("monitor tools", () => {
       idempotency_key: "dep-watch",
     })) as { monitor_id: string };
     expect(recreated.monitor_id).not.toBe(created.monitor_id);
+  });
+
+  test("cancel_monitor keeps the record when unschedule reports false", async () => {
+    const stub = createSchedulerStub({ unscheduleResult: false });
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const cancelled = (await cancelMonitor.execute({
+      monitor_id: created.monitor_id,
+    })) as { ok: boolean; removed: boolean };
+    expect(cancelled).toEqual({ ok: true, removed: false });
+    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { monitor_id: string; schedule_id: string }[];
+    };
+    expect(listed.monitors).toEqual([
+      {
+        monitor_id: created.monitor_id,
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        expression: "0 9 * * *",
+        schedule_id: created.schedule_id,
+      },
+    ]);
+
+    const deduped = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string; schedule_id: string; deduped?: boolean };
+    expect(deduped.monitor_id).toBe(created.monitor_id);
+    expect(deduped.schedule_id).toBe(created.schedule_id);
+    expect(deduped.deduped).toBe(true);
   });
 
   test("cancel_monitor returns removed:false for an unknown monitor_id", async () => {

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -29,6 +29,18 @@ describe("monitor tools", () => {
     expect(created.ok).toBe(true);
     expect(created.deduped).toBeUndefined();
     expect(stub.scheduleCalls).toHaveLength(1);
+    expect(stub.scheduleCalls[0]?.expression).toBe("0 9 * * *");
+    expect(stub.scheduleCalls[0]?.mode).toBe("dispatch");
+    expect(stub.scheduleCalls[0]?.input).toEqual({
+      kind: "text",
+      text: [
+        "Monitor check: dependency-watch",
+        "Goal: Detect whether issue #1212 is unblocked",
+        "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        "Context: Look at scheduler/channel restoration issues first.",
+      ].join("\n"),
+    });
+    expect(stub.scheduleCalls[0]?.options).toBeUndefined();
 
     const listed = (await listMonitors.execute({})) as {
       ok: boolean;
@@ -108,30 +120,33 @@ describe("monitor tools", () => {
   });
 
   test("create_monitor clears its reservation after a failed scheduler create", async () => {
-    const stub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
     const state = createMonitorToolState();
-    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
-
-    const failed = (await createMonitor.execute({
+    const failingStub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
+    const createMonitor = createCreateMonitorTool({ scheduler: failingStub.component }, state);
+    const args = {
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
       idempotency_key: "dep-watch",
-    })) as { ok: boolean; error: string };
+    };
+
+    const failed = (await createMonitor.execute(args)) as { ok: boolean; error: string };
     expect(failed.ok).toBe(false);
     expect(failed.error).toContain("scheduler unavailable");
 
-    const retry = (await createMonitor.execute({
-      name: "dependency-watch",
-      goal: "Detect whether issue #1212 is unblocked",
-      check_prompt: "Inspect repo state.",
-      expression: "0 9 * * *",
-      idempotency_key: "dep-watch",
-    })) as { ok: boolean; error: string };
-    expect(retry.ok).toBe(false);
-    expect(retry.error).toContain("scheduler unavailable");
-    expect(state.monitorIdByIdempotencyKey.size).toBe(0);
+    const workingStub = createSchedulerStub();
+    const retryMonitor = createCreateMonitorTool({ scheduler: workingStub.component }, state);
+    const retried = (await retryMonitor.execute(args)) as {
+      ok: boolean;
+      monitor_id: string;
+      schedule_id: string;
+      deduped?: boolean;
+    };
+
+    expect(retried.ok).toBe(true);
+    expect(retried.deduped).toBeUndefined();
+    expect(workingStub.scheduleCalls).toHaveLength(1);
   });
 
   test("update_monitor rotates the backing schedule and replaces stored fields", async () => {
@@ -236,6 +251,8 @@ describe("monitor tools", () => {
     })) as { ok: boolean; error: string };
     expect(failed.ok).toBe(false);
     expect(failed.error).toContain("scheduler unavailable");
+    expect(failingStub.unscheduleCalls).toHaveLength(0);
+    expect(createStub.unscheduleCalls).toHaveLength(0);
 
     const listed = (await listMonitors.execute({})) as {
       monitors: { goal: string; schedule_id: string }[];

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -182,7 +182,7 @@ describe("monitor tools", () => {
         "Goal: Detect whether issue #1212 is unblocked",
         "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
         "Context: Look at scheduler/channel restoration issues first.",
-      ].join("\\n"),
+      ].join("\n"),
     );
   });
 });

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type SchedulerComponent, scheduleId } from "@koi/core";
+import { type ScheduleId, type SchedulerComponent, scheduleId } from "@koi/core";
 import {
   createCancelMonitorTool,
   createCreateMonitorTool,
@@ -373,7 +373,7 @@ describe("monitor tools", () => {
     let unscheduleAttempts = 0;
     const scheduler: SchedulerComponent = {
       ...stub.component,
-      unschedule(id) {
+      unschedule(id: ScheduleId) {
         stub.component.unschedule(id);
         unscheduleAttempts += 1;
         if (unscheduleAttempts === 1) {

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -495,6 +495,28 @@ describe("monitor tools", () => {
     expect(result).toEqual({ ok: true, removed: false });
   });
 
+  test("cancel_monitor twice is idempotent — second call removes nothing and does not re-unschedule", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const first = await cancelMonitor.execute({ monitor_id: created.monitor_id });
+    expect(first).toEqual({ ok: true, removed: true });
+    expect(stub.unscheduleCalls).toEqual([scheduleId(created.schedule_id)]);
+
+    const second = await cancelMonitor.execute({ monitor_id: created.monitor_id });
+    expect(second).toEqual({ ok: true, removed: false });
+    expect(stub.unscheduleCalls).toEqual([scheduleId(created.schedule_id)]);
+  });
+
   test("formatMonitorWakeMessage renders deterministic multi-line text", () => {
     expect(
       formatMonitorWakeMessage({

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -401,7 +401,7 @@ describe("monitor tools", () => {
     expect(recreated.monitor_id).not.toBe(created.monitor_id);
   });
 
-  test("cancel_monitor keeps the record when unschedule reports false", async () => {
+  test("cancel_monitor still removes known local state when unschedule reports false", async () => {
     const stub = createSchedulerStub({ unscheduleResult: false });
     const state = createMonitorToolState();
     const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
@@ -419,32 +419,21 @@ describe("monitor tools", () => {
     const cancelled = (await cancelMonitor.execute({
       monitor_id: created.monitor_id,
     })) as { ok: boolean; removed: boolean };
-    expect(cancelled).toEqual({ ok: true, removed: false });
+    expect(cancelled).toEqual({ ok: true, removed: true });
     expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
 
-    const listed = (await listMonitors.execute({})) as {
-      monitors: { monitor_id: string; schedule_id: string }[];
-    };
-    expect(listed.monitors).toEqual([
-      {
-        monitor_id: created.monitor_id,
-        name: "dependency-watch",
-        goal: "Detect whether issue #1212 is unblocked",
-        expression: "0 9 * * *",
-        schedule_id: created.schedule_id,
-      },
-    ]);
+    const listed = (await listMonitors.execute({})) as { monitors: unknown[] };
+    expect(listed.monitors).toHaveLength(0);
 
-    const deduped = (await createMonitor.execute({
+    const recreated = (await createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
       idempotency_key: "dep-watch",
-    })) as { monitor_id: string; schedule_id: string; deduped?: boolean };
-    expect(deduped.monitor_id).toBe(created.monitor_id);
-    expect(deduped.schedule_id).toBe(created.schedule_id);
-    expect(deduped.deduped).toBe(true);
+    })) as { monitor_id: string; deduped?: boolean };
+    expect(recreated.monitor_id).not.toBe(created.monitor_id);
+    expect(recreated.deduped).toBeUndefined();
   });
 
   test("cancel_monitor returns removed:false for an unknown monitor_id", async () => {

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+  formatMonitorWakeMessage,
+} from "./monitor-tools.js";
+import { createSchedulerStub } from "./test-helpers.js";
+
+describe("monitor tools", () => {
+  test("create_monitor stores a monitor and schedules a recurring wake", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt:
+        "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string; deduped?: boolean };
+
+    expect(created.ok).toBe(true);
+    expect(created.deduped).toBeUndefined();
+    expect(stub.scheduleCalls).toHaveLength(1);
+
+    const listed = (await listMonitors.execute({})) as {
+      ok: boolean;
+      monitors: { monitor_id: string; name: string; goal: string; schedule_id: string }[];
+    };
+    expect(listed.monitors).toHaveLength(1);
+    expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
+  test("create_monitor dedupes same-process identical idempotency_key", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const args = {
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    };
+
+    const first = (await createMonitor.execute(args)) as { monitor_id: string; schedule_id: string };
+    const second = (await createMonitor.execute(args)) as {
+      monitor_id: string;
+      schedule_id: string;
+      deduped?: boolean;
+    };
+
+    expect(second.monitor_id).toBe(first.monitor_id);
+    expect(second.schedule_id).toBe(first.schedule_id);
+    expect(second.deduped).toBe(true);
+    expect(stub.scheduleCalls).toHaveLength(1);
+  });
+
+  test("create_monitor rejects a reused idempotency_key when monitor fields differ", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    });
+
+    const mismatch = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1301 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+
+    expect(mismatch.ok).toBe(false);
+    expect(mismatch.error).toContain("already registered");
+  });
+
+  test("update_monitor rotates the backing schedule and replaces stored fields", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const updated = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      expression: "30 9 * * *",
+      context_hint: "Focus on delivery and durability work.",
+    })) as { ok: boolean; monitor_id: string; schedule_id: string };
+
+    expect(updated.ok).toBe(true);
+    expect(updated.schedule_id).not.toBe(created.schedule_id);
+    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; expression: string; context_hint?: string; schedule_id: string }[];
+    };
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe("Focus on delivery and durability work.");
+    expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
+  });
+
+  test("cancel_monitor removes the record and clears create-time idempotency", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const cancelled = (await cancelMonitor.execute({
+      monitor_id: created.monitor_id,
+    })) as { ok: boolean; removed: boolean };
+    expect(cancelled).toEqual({ ok: true, removed: true });
+    expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as { monitors: unknown[] };
+    expect(listed.monitors).toHaveLength(0);
+
+    const recreated = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { monitor_id: string };
+    expect(recreated.monitor_id).not.toBe(created.monitor_id);
+  });
+
+  test("cancel_monitor returns removed:false for an unknown monitor_id", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const cancelMonitor = createCancelMonitorTool({ scheduler: stub.component }, state);
+
+    const result = await cancelMonitor.execute({ monitor_id: "monitor-missing" });
+    expect(result).toEqual({ ok: true, removed: false });
+  });
+
+  test("formatMonitorWakeMessage renders deterministic multi-line text", () => {
+    expect(
+      formatMonitorWakeMessage({
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        checkPrompt:
+          "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        contextHint: "Look at scheduler/channel restoration issues first.",
+      }),
+    ).toBe(
+      [
+        "Monitor check: dependency-watch",
+        "Goal: Detect whether issue #1212 is unblocked",
+        "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        "Context: Look at scheduler/channel restoration issues first.",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -90,6 +90,50 @@ describe("monitor tools", () => {
     expect(mismatch.error).toContain("already registered");
   });
 
+  test("create_monitor validates required fields before touching the scheduler", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const invalid = (await createMonitor.execute({
+      name: "",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { ok: boolean; error: string };
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.error).toContain("name");
+    expect(stub.scheduleCalls).toHaveLength(0);
+  });
+
+  test("create_monitor clears its reservation after a failed scheduler create", async () => {
+    const stub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+
+    const failed = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("scheduler unavailable");
+
+    const retry = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      idempotency_key: "dep-watch",
+    })) as { ok: boolean; error: string };
+    expect(retry.ok).toBe(false);
+    expect(retry.error).toContain("scheduler unavailable");
+    expect(state.monitorIdByIdempotencyKey.size).toBe(0);
+  });
+
   test("update_monitor rotates the backing schedule and replaces stored fields", async () => {
     const stub = createSchedulerStub();
     const state = createMonitorToolState();
@@ -122,6 +166,82 @@ describe("monitor tools", () => {
     expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
     expect(listed.monitors[0]?.context_hint).toBe("Focus on delivery and durability work.");
     expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
+  });
+
+  test("update_monitor fails for an unknown monitor_id", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+
+    const result = (await updateMonitor.execute({
+      monitor_id: "monitor-missing",
+      goal: "Detect whether issue #1301 is unblocked",
+    })) as { ok: boolean; error: string };
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("not found");
+    expect(stub.scheduleCalls).toHaveLength(0);
+    expect(stub.unscheduleCalls).toHaveLength(0);
+  });
+
+  test("update_monitor preserves omitted fields by patch semantics", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+    })) as { monitor_id: string };
+
+    await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+    });
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { name: string; goal: string; expression: string; context_hint?: string }[];
+    };
+    expect(listed.monitors[0]?.name).toBe("dependency-watch");
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe(
+      "Look at scheduler/channel restoration issues first.",
+    );
+  });
+
+  test("update_monitor leaves the original record intact when replacement scheduling fails", async () => {
+    const state = createMonitorToolState();
+    const createStub = createSchedulerStub();
+    const failingStub = createSchedulerStub({ scheduleError: new Error("scheduler unavailable") });
+    const createMonitor = createCreateMonitorTool({ scheduler: createStub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: failingStub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const failed = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+    })) as { ok: boolean; error: string };
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("scheduler unavailable");
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; schedule_id: string }[];
+    };
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
   });
 
   test("cancel_monitor removes the record and clears create-time idempotency", async () => {
@@ -182,6 +302,22 @@ describe("monitor tools", () => {
         "Goal: Detect whether issue #1212 is unblocked",
         "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
         "Context: Look at scheduler/channel restoration issues first.",
+      ].join("\n"),
+    );
+  });
+
+  test("formatMonitorWakeMessage omits the Context line when no context hint is present", () => {
+    expect(
+      formatMonitorWakeMessage({
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        checkPrompt: "Inspect repo state.",
+      }),
+    ).toBe(
+      [
+        "Monitor check: dependency-watch",
+        "Goal: Detect whether issue #1212 is unblocked",
+        "Check: Inspect repo state.",
       ].join("\n"),
     );
   });

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -182,7 +182,7 @@ describe("monitor tools", () => {
         "Goal: Detect whether issue #1212 is unblocked",
         "Check: Inspect repo and GitHub state, then decide whether follow-up is warranted.",
         "Context: Look at scheduler/channel restoration issues first.",
-      ].join("\n"),
+      ].join("\\n"),
     );
   });
 });

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -330,6 +330,51 @@ describe("monitor tools", () => {
     expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
   });
 
+  test("update_monitor fails closed when retiring the original schedule reports removed:false", async () => {
+    const state = createMonitorToolState();
+    const createStub = createSchedulerStub();
+    const updateStub = createSchedulerStub({ unscheduleResult: false });
+    const createMonitor = createCreateMonitorTool({ scheduler: createStub.component }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler: updateStub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const updated = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      expression: "30 9 * * *",
+      timezone: "America/New_York",
+      context_hint: "Focus on delivery and durability work.",
+    })) as { ok: boolean; error: string };
+    expect(updated.ok).toBe(false);
+    expect(updated.error).toContain("removed:false");
+    expect(updateStub.scheduleCalls).toHaveLength(1);
+    expect(updateStub.unscheduleCalls).toEqual([created.schedule_id]);
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: {
+        goal: string;
+        expression: string;
+        context_hint?: string;
+        schedule_id: string;
+      }[];
+    };
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
+    expect(listed.monitors[0]?.context_hint).toBe(
+      "Look at scheduler/channel restoration issues first.",
+    );
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
   test("cancel_monitor removes the record and clears create-time idempotency", async () => {
     const stub = createSchedulerStub();
     const state = createMonitorToolState();

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -19,9 +19,9 @@ describe("monitor tools", () => {
     const created = (await createMonitor.execute({
       name: "dependency-watch",
       goal: "Detect whether issue #1212 is unblocked",
-      check_prompt:
-        "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+      check_prompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
       expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
       context_hint: "Look at scheduler/channel restoration issues first.",
       idempotency_key: "dep-watch",
     })) as { ok: boolean; monitor_id: string; schedule_id: string; deduped?: boolean };
@@ -40,15 +40,29 @@ describe("monitor tools", () => {
         "Context: Look at scheduler/channel restoration issues first.",
       ].join("\n"),
     });
-    expect(stub.scheduleCalls[0]?.options).toBeUndefined();
+    expect(stub.scheduleCalls[0]?.options).toEqual({ timezone: "America/Los_Angeles" });
 
     const listed = (await listMonitors.execute({})) as {
       ok: boolean;
-      monitors: { monitor_id: string; name: string; goal: string; schedule_id: string }[];
+      monitors: {
+        monitor_id: string;
+        name: string;
+        goal: string;
+        expression: string;
+        context_hint?: string;
+        schedule_id: string;
+      }[];
     };
     expect(listed.monitors).toHaveLength(1);
-    expect(listed.monitors[0]?.monitor_id).toBe(created.monitor_id);
-    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+    expect(listed.monitors[0]).toEqual({
+      monitor_id: created.monitor_id,
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+      schedule_id: created.schedule_id,
+    });
+    expect(listed.monitors[0]).not.toHaveProperty("check_prompt");
   });
 
   test("create_monitor dedupes same-process identical idempotency_key", async () => {
@@ -61,10 +75,14 @@ describe("monitor tools", () => {
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
       idempotency_key: "dep-watch",
     };
 
-    const first = (await createMonitor.execute(args)) as { monitor_id: string; schedule_id: string };
+    const first = (await createMonitor.execute(args)) as {
+      monitor_id: string;
+      schedule_id: string;
+    };
     const second = (await createMonitor.execute(args)) as {
       monitor_id: string;
       schedule_id: string;
@@ -87,14 +105,16 @@ describe("monitor tools", () => {
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
       idempotency_key: "dep-watch",
     });
 
     const mismatch = (await createMonitor.execute({
       name: "dependency-watch",
-      goal: "Detect whether issue #1301 is unblocked",
+      goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
+      timezone: "America/New_York",
       idempotency_key: "dep-watch",
     })) as { ok: boolean; error: string };
 
@@ -117,6 +137,43 @@ describe("monitor tools", () => {
     expect(invalid.ok).toBe(false);
     expect(invalid.error).toContain("name");
     expect(stub.scheduleCalls).toHaveLength(0);
+  });
+
+  test("list_monitors returns summary fields without exposing check_prompt", async () => {
+    const stub = createSchedulerStub();
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler: stub.component }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      context_hint: "Look at scheduler/channel restoration issues first.",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: {
+        monitor_id: string;
+        name: string;
+        goal: string;
+        expression: string;
+        context_hint?: string;
+        schedule_id: string;
+      }[];
+    };
+
+    expect(listed.monitors).toEqual([
+      {
+        monitor_id: created.monitor_id,
+        name: "dependency-watch",
+        goal: "Detect whether issue #1212 is unblocked",
+        expression: "0 9 * * *",
+        context_hint: "Look at scheduler/channel restoration issues first.",
+        schedule_id: created.schedule_id,
+      },
+    ]);
   });
 
   test("create_monitor clears its reservation after a failed scheduler create", async () => {
@@ -161,26 +218,35 @@ describe("monitor tools", () => {
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
     })) as { monitor_id: string; schedule_id: string };
 
     const updated = (await updateMonitor.execute({
       monitor_id: created.monitor_id,
       goal: "Detect whether issue #1301 is unblocked",
       expression: "30 9 * * *",
+      timezone: "America/New_York",
       context_hint: "Focus on delivery and durability work.",
     })) as { ok: boolean; monitor_id: string; schedule_id: string };
 
     expect(updated.ok).toBe(true);
     expect(updated.schedule_id).not.toBe(created.schedule_id);
     expect(stub.unscheduleCalls).toEqual([created.schedule_id]);
+    expect(stub.scheduleCalls[1]?.options).toEqual({ timezone: "America/New_York" });
 
     const listed = (await listMonitors.execute({})) as {
-      monitors: { goal: string; expression: string; context_hint?: string; schedule_id: string }[];
+      monitors: {
+        goal: string;
+        expression: string;
+        context_hint?: string;
+        schedule_id: string;
+      }[];
     };
     expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
     expect(listed.monitors[0]?.expression).toBe("30 9 * * *");
     expect(listed.monitors[0]?.context_hint).toBe("Focus on delivery and durability work.");
     expect(listed.monitors[0]?.schedule_id).toBe(updated.schedule_id);
+    expect(listed.monitors[0]).not.toHaveProperty("check_prompt");
   });
 
   test("update_monitor fails for an unknown monitor_id", async () => {
@@ -211,6 +277,7 @@ describe("monitor tools", () => {
       goal: "Detect whether issue #1212 is unblocked",
       check_prompt: "Inspect repo state.",
       expression: "0 9 * * *",
+      timezone: "UTC",
       context_hint: "Look at scheduler/channel restoration issues first.",
     })) as { monitor_id: string };
 
@@ -222,12 +289,14 @@ describe("monitor tools", () => {
     const listed = (await listMonitors.execute({})) as {
       monitors: { name: string; goal: string; expression: string; context_hint?: string }[];
     };
+    expect(stub.scheduleCalls[1]?.options).toEqual({ timezone: "UTC" });
     expect(listed.monitors[0]?.name).toBe("dependency-watch");
     expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1301 is unblocked");
     expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
     expect(listed.monitors[0]?.context_hint).toBe(
       "Look at scheduler/channel restoration issues first.",
     );
+    expect(listed.monitors[0]).not.toHaveProperty("check_prompt");
   });
 
   test("update_monitor leaves the original record intact when replacement scheduling fails", async () => {
@@ -309,8 +378,7 @@ describe("monitor tools", () => {
       formatMonitorWakeMessage({
         name: "dependency-watch",
         goal: "Detect whether issue #1212 is unblocked",
-        checkPrompt:
-          "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
+        checkPrompt: "Inspect repo and GitHub state, then decide whether follow-up is warranted.",
         contextHint: "Look at scheduler/channel restoration issues first.",
       }),
     ).toBe(

--- a/packages/lib/proactive/src/monitor-tools.test.ts
+++ b/packages/lib/proactive/src/monitor-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { scheduleId } from "@koi/core";
+import { type SchedulerComponent, scheduleId } from "@koi/core";
 import {
   createCancelMonitorTool,
   createCreateMonitorTool,
@@ -368,6 +368,55 @@ describe("monitor tools", () => {
     expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
   });
 
+  test("update_monitor compensates when retiring the original schedule throws", async () => {
+    const stub = createSchedulerStub();
+    let unscheduleAttempts = 0;
+    const scheduler: SchedulerComponent = {
+      ...stub.component,
+      unschedule(id) {
+        stub.component.unschedule(id);
+        unscheduleAttempts += 1;
+        if (unscheduleAttempts === 1) {
+          throw new Error("scheduler unavailable");
+        }
+        return true;
+      },
+    };
+    const state = createMonitorToolState();
+    const createMonitor = createCreateMonitorTool({ scheduler }, state);
+    const updateMonitor = createUpdateMonitorTool({ scheduler }, state);
+    const listMonitors = createListMonitorsTool(state);
+
+    const created = (await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1212 is unblocked",
+      check_prompt: "Inspect repo state.",
+      expression: "0 9 * * *",
+      timezone: "America/Los_Angeles",
+    })) as { monitor_id: string; schedule_id: string };
+
+    const failed = (await updateMonitor.execute({
+      monitor_id: created.monitor_id,
+      goal: "Detect whether issue #1301 is unblocked",
+      expression: "30 9 * * *",
+      timezone: "America/New_York",
+    })) as { ok: boolean; error: string };
+
+    expect(failed.ok).toBe(false);
+    expect(failed.error).toContain("scheduler unavailable");
+    expect(stub.unscheduleCalls).toHaveLength(2);
+    expect(stub.unscheduleCalls[0]).toBe(scheduleId(created.schedule_id));
+    expect(String(stub.unscheduleCalls[1])).toBe("sched-2");
+
+    const listed = (await listMonitors.execute({})) as {
+      monitors: { goal: string; expression: string; schedule_id: string }[];
+    };
+    expect(listed.monitors).toHaveLength(1);
+    expect(listed.monitors[0]?.goal).toBe("Detect whether issue #1212 is unblocked");
+    expect(listed.monitors[0]?.expression).toBe("0 9 * * *");
+    expect(listed.monitors[0]?.schedule_id).toBe(created.schedule_id);
+  });
+
   test("cancel_monitor removes the record and clears create-time idempotency", async () => {
     const stub = createSchedulerStub();
     const state = createMonitorToolState();
@@ -478,5 +527,69 @@ describe("monitor tools", () => {
         "Check: Inspect repo state.",
       ].join("\n"),
     );
+  });
+
+  test("scheduler stub tracks submitted task lifecycle and query helpers", async () => {
+    const stub = createSchedulerStub();
+    const task = await stub.component.submit({ kind: "text", text: "wake up" }, "spawn", {
+      delayMs: 5_000,
+    });
+
+    expect(stub.submitCalls).toHaveLength(1);
+    expect(stub.submitCalls[0]).toEqual({
+      input: { kind: "text", text: "wake up" },
+      mode: "spawn",
+      options: { delayMs: 5_000 },
+    });
+    expect(stub.isLive(task)).toBe(true);
+    expect(await stub.component.query({})).toEqual([
+      {
+        id: task,
+        agentId: expect.any(String),
+        input: { kind: "text", text: "" },
+        mode: "spawn",
+        priority: 0,
+        status: "pending",
+        createdAt: 0,
+        retries: 0,
+        maxRetries: 0,
+      },
+    ]);
+    expect(await stub.component.pause(scheduleId("sched-pause"))).toBe(true);
+    expect(await stub.component.resume(scheduleId("sched-pause"))).toBe(true);
+    expect(await stub.component.stats()).toEqual({
+      pending: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      deadLettered: 0,
+      activeSchedules: 0,
+      pausedSchedules: 0,
+    });
+    expect(await stub.component.history({})).toEqual([]);
+
+    expect(await stub.component.cancel(task)).toBe(true);
+    expect(stub.cancelCalls).toEqual([task]);
+    expect(stub.isLive(task)).toBe(false);
+
+    const retired = await stub.component.submit({ kind: "text", text: "retire me" }, "spawn");
+    expect(stub.isLive(retired)).toBe(true);
+    stub.retireTask(retired);
+    expect(stub.isLive(retired)).toBe(false);
+  });
+
+  test("scheduler stub surfaces submit errors and non-removing cancels", async () => {
+    const failingSubmit = createSchedulerStub({ submitError: new Error("queue full") });
+    expect(() =>
+      failingSubmit.component.submit({ kind: "text", text: "wake up" }, "spawn"),
+    ).toThrow("queue full");
+
+    const nonRemovingCancel = createSchedulerStub({ cancelResult: false });
+    const task = await nonRemovingCancel.component.submit(
+      { kind: "text", text: "wake up" },
+      "spawn",
+    );
+    expect(await nonRemovingCancel.component.cancel(task)).toBe(false);
+    expect(nonRemovingCancel.isLive(task)).toBe(true);
   });
 });

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -47,29 +47,15 @@ const createMonitorSchema = z.object({
     ),
 });
 
-const updateMonitorSchema = z
-  .object({
-    monitor_id: z
-      .string()
-      .min(1, "monitor_id is required")
-      .describe("Monitor identifier to update."),
-    name: z.string().min(1).optional().describe("Replacement monitor name."),
-    goal: z.string().min(1).optional().describe("Replacement monitor goal."),
-    check_prompt: z.string().min(1).optional().describe("Replacement monitor instructions."),
-    expression: z.string().min(1).optional().describe("Replacement cron expression."),
-    timezone: z.string().min(1).optional().describe("Replacement cron timezone."),
-    context_hint: z.string().min(1).optional().describe("Replacement optional context hint."),
-  })
-  .refine(
-    (value) =>
-      value.name !== undefined ||
-      value.goal !== undefined ||
-      value.check_prompt !== undefined ||
-      value.expression !== undefined ||
-      value.timezone !== undefined ||
-      value.context_hint !== undefined,
-    "At least one updatable field must be provided",
-  );
+const updateMonitorSchema = z.object({
+  monitor_id: z.string().min(1, "monitor_id is required").describe("Monitor identifier to update."),
+  name: z.string().min(1).optional().describe("Replacement monitor name."),
+  goal: z.string().min(1).optional().describe("Replacement monitor goal."),
+  check_prompt: z.string().min(1).optional().describe("Replacement monitor instructions."),
+  expression: z.string().min(1).optional().describe("Replacement cron expression."),
+  timezone: z.string().min(1).optional().describe("Replacement cron timezone."),
+  context_hint: z.string().min(1).optional().describe("Replacement optional context hint."),
+});
 
 const cancelMonitorSchema = z.object({
   monitor_id: z.string().min(1, "monitor_id is required").describe("Monitor identifier to cancel."),
@@ -201,14 +187,17 @@ function listMonitorView(record: MonitorRecord): {
   readonly expression: string;
   readonly context_hint?: string;
 } {
-  return {
+  const out = {
     monitor_id: record.monitorId,
     schedule_id: record.scheduleId,
     name: record.name,
     goal: record.goal,
     expression: record.expression,
-    context_hint: record.contextHint,
   };
+  if (record.contextHint !== undefined) {
+    return { ...out, context_hint: record.contextHint };
+  }
+  return out;
 }
 
 export function createCreateMonitorTool(

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -108,7 +108,7 @@ export function formatMonitorWakeMessage(args: {
   readonly name: string;
   readonly goal: string;
   readonly checkPrompt: string;
-  readonly contextHint?: string;
+  readonly contextHint?: string | undefined;
 }): string {
   const lines = [`Monitor check: ${args.name}`, `Goal: ${args.goal}`, `Check: ${args.checkPrompt}`];
   if (args.contextHint !== undefined) {
@@ -122,8 +122,8 @@ function buildCreateFingerprint(args: {
   readonly goal: string;
   readonly check_prompt: string;
   readonly expression: string;
-  readonly timezone?: string;
-  readonly context_hint?: string;
+  readonly timezone?: string | undefined;
+  readonly context_hint?: string | undefined;
 }): MonitorCreateFingerprint {
   return {
     name: args.name,
@@ -157,9 +157,9 @@ function buildMonitorRecord(
     readonly goal: string;
     readonly checkPrompt: string;
     readonly expression: string;
-    readonly timezone?: string;
-    readonly contextHint?: string;
-    readonly idempotencyKey?: string;
+    readonly timezone?: string | undefined;
+    readonly contextHint?: string | undefined;
+    readonly idempotencyKey?: string | undefined;
   },
 ): MonitorRecord {
   return {

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -90,15 +90,17 @@ type MonitorCreateEntry =
 
 export interface MonitorToolState {
   readonly monitorsById: Map<string, MonitorRecord>;
-  readonly idempotencyMap: Map<string, MonitorCreateEntry>;
-  nextMonitorNumber: number;
+  readonly monitorIdByIdempotencyKey: Map<string, string>;
+  readonly createEntryByIdempotencyKey: Map<string, MonitorCreateEntry>;
+  nextMonitorOrdinal: number;
 }
 
 export function createMonitorToolState(): MonitorToolState {
   return {
     monitorsById: new Map<string, MonitorRecord>(),
-    idempotencyMap: new Map<string, MonitorCreateEntry>(),
-    nextMonitorNumber: 1,
+    monitorIdByIdempotencyKey: new Map<string, string>(),
+    createEntryByIdempotencyKey: new Map<string, MonitorCreateEntry>(),
+    nextMonitorOrdinal: 1,
   };
 }
 
@@ -174,8 +176,8 @@ function buildMonitorRecord(
 }
 
 function createMonitorId(state: MonitorToolState): string {
-  const id = `monitor-${state.nextMonitorNumber}`;
-  state.nextMonitorNumber += 1;
+  const id = `monitor-${state.nextMonitorOrdinal}`;
+  state.nextMonitorOrdinal += 1;
   return id;
 }
 
@@ -228,7 +230,7 @@ export function createCreateMonitorTool(
       const fingerprint = buildCreateFingerprint(parsed.data);
 
       if (idempotency_key !== undefined) {
-        const existing = state.idempotencyMap.get(idempotency_key);
+        const existing = state.createEntryByIdempotencyKey.get(idempotency_key);
         if (existing !== undefined) {
           try {
             const record = existing.kind === "settled" ? existing.record : await existing.promise;
@@ -286,20 +288,22 @@ export function createCreateMonitorTool(
           });
           state.monitorsById.set(record.monitorId, record);
           if (idempotency_key !== undefined) {
-            state.idempotencyMap.set(idempotency_key, { kind: "settled", record });
+            state.monitorIdByIdempotencyKey.set(idempotency_key, record.monitorId);
+            state.createEntryByIdempotencyKey.set(idempotency_key, { kind: "settled", record });
           }
           return record;
         });
 
       const trackedSubmission = submission.catch((err: unknown): never => {
         if (idempotency_key !== undefined) {
-          state.idempotencyMap.delete(idempotency_key);
+          state.createEntryByIdempotencyKey.delete(idempotency_key);
+          state.monitorIdByIdempotencyKey.delete(idempotency_key);
         }
         throw err;
       });
 
       if (idempotency_key !== undefined) {
-        state.idempotencyMap.set(idempotency_key, {
+        state.createEntryByIdempotencyKey.set(idempotency_key, {
           kind: "pending",
           promise: trackedSubmission,
         });
@@ -407,7 +411,13 @@ export function createUpdateMonitorTool(
       }
 
       try {
-        await scheduler.unschedule(scheduleId(current.scheduleId));
+        const removed = await scheduler.unschedule(scheduleId(current.scheduleId));
+        if (!removed) {
+          return {
+            ok: false,
+            error: `Failed to retire previous monitor schedule: removed:false for '${current.scheduleId}'`,
+          };
+        }
       } catch (e: unknown) {
         return {
           ok: false,
@@ -422,7 +432,11 @@ export function createUpdateMonitorTool(
 
       state.monitorsById.set(updated.monitorId, updated);
       if (updated.idempotencyKey !== undefined) {
-        state.idempotencyMap.set(updated.idempotencyKey, { kind: "settled", record: updated });
+        state.monitorIdByIdempotencyKey.set(updated.idempotencyKey, updated.monitorId);
+        state.createEntryByIdempotencyKey.set(updated.idempotencyKey, {
+          kind: "settled",
+          record: updated,
+        });
       }
 
       return {
@@ -471,7 +485,8 @@ export function createCancelMonitorTool(
 
       state.monitorsById.delete(record.monitorId);
       if (record.idempotencyKey !== undefined) {
-        state.idempotencyMap.delete(record.idempotencyKey);
+        state.monitorIdByIdempotencyKey.delete(record.idempotencyKey);
+        state.createEntryByIdempotencyKey.delete(record.idempotencyKey);
       }
 
       return { ok: true, removed: true };

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -480,10 +480,7 @@ export function createCancelMonitorTool(
       }
 
       try {
-        const removed = await scheduler.unschedule(scheduleId(record.scheduleId));
-        if (!removed) {
-          return { ok: true, removed: false };
-        }
+        await scheduler.unschedule(scheduleId(record.scheduleId));
       } catch (e: unknown) {
         return {
           ok: false,

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -6,7 +6,7 @@
  * monitor definition and same-process idempotency semantics for create.
  */
 
-import type { JsonObject, Tool } from "@koi/core";
+import type { JsonObject, SchedulerComponent, Tool } from "@koi/core";
 import { DEFAULT_SANDBOXED_POLICY, scheduleId } from "@koi/core";
 import { toJSONSchema, z } from "zod";
 import type { ProactiveToolsConfig } from "./types.js";
@@ -173,6 +173,17 @@ function buildMonitorRecord(
     contextHint: args.contextHint,
     idempotencyKey: args.idempotencyKey,
   };
+}
+
+async function bestEffortUnscheduleReplacement(
+  scheduler: SchedulerComponent,
+  scheduleIdValue: string,
+): Promise<void> {
+  try {
+    await scheduler.unschedule(scheduleId(scheduleIdValue));
+  } catch {
+    // Best-effort compensation only. Preserve the original local record either way.
+  }
 }
 
 function createMonitorId(state: MonitorToolState): string {
@@ -413,17 +424,14 @@ export function createUpdateMonitorTool(
       try {
         const removed = await scheduler.unschedule(scheduleId(current.scheduleId));
         if (!removed) {
-          try {
-            await scheduler.unschedule(scheduleId(newScheduleId));
-          } catch {
-            // Best-effort compensation only. Preserve the original local record either way.
-          }
+          await bestEffortUnscheduleReplacement(scheduler, newScheduleId);
           return {
             ok: false,
             error: "Failed to retire previous monitor schedule",
           };
         }
       } catch (e: unknown) {
+        await bestEffortUnscheduleReplacement(scheduler, newScheduleId);
         return {
           ok: false,
           error: e instanceof Error ? e.message : "Failed to retire previous monitor schedule",

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -411,7 +411,18 @@ export function createUpdateMonitorTool(
       }
 
       try {
-        await scheduler.unschedule(scheduleId(current.scheduleId));
+        const removed = await scheduler.unschedule(scheduleId(current.scheduleId));
+        if (!removed) {
+          try {
+            await scheduler.unschedule(scheduleId(newScheduleId));
+          } catch {
+            // Best-effort compensation only. Preserve the original local record either way.
+          }
+          return {
+            ok: false,
+            error: "Failed to retire previous monitor schedule",
+          };
+        }
       } catch (e: unknown) {
         return {
           ok: false,
@@ -469,7 +480,10 @@ export function createCancelMonitorTool(
       }
 
       try {
-        await scheduler.unschedule(scheduleId(record.scheduleId));
+        const removed = await scheduler.unschedule(scheduleId(record.scheduleId));
+        if (!removed) {
+          return { ok: true, removed: false };
+        }
       } catch (e: unknown) {
         return {
           ok: false,

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -25,6 +25,11 @@ const createMonitorSchema = z.object({
     .string()
     .min(1, "expression is required")
     .describe('Cron expression understood by croner (e.g. "0 9 * * 1-5").'),
+  timezone: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('IANA timezone for the cron expression (e.g. "America/Los_Angeles").'),
   context_hint: z
     .string()
     .min(1)
@@ -52,6 +57,7 @@ const updateMonitorSchema = z
     goal: z.string().min(1).optional().describe("Replacement monitor goal."),
     check_prompt: z.string().min(1).optional().describe("Replacement monitor instructions."),
     expression: z.string().min(1).optional().describe("Replacement cron expression."),
+    timezone: z.string().min(1).optional().describe("Replacement cron timezone."),
     context_hint: z.string().min(1).optional().describe("Replacement optional context hint."),
   })
   .refine(
@@ -60,6 +66,7 @@ const updateMonitorSchema = z
       value.goal !== undefined ||
       value.check_prompt !== undefined ||
       value.expression !== undefined ||
+      value.timezone !== undefined ||
       value.context_hint !== undefined,
     "At least one updatable field must be provided",
   );
@@ -75,6 +82,7 @@ interface MonitorCreateFingerprint {
   readonly goal: string;
   readonly checkPrompt: string;
   readonly expression: string;
+  readonly timezone: string | undefined;
   readonly contextHint: string | undefined;
 }
 
@@ -85,6 +93,7 @@ export interface MonitorRecord {
   readonly goal: string;
   readonly checkPrompt: string;
   readonly expression: string;
+  readonly timezone: string | undefined;
   readonly contextHint: string | undefined;
   readonly idempotencyKey: string | undefined;
 }
@@ -125,6 +134,7 @@ function buildCreateFingerprint(args: {
   readonly goal: string;
   readonly check_prompt: string;
   readonly expression: string;
+  readonly timezone?: string;
   readonly context_hint?: string;
 }): MonitorCreateFingerprint {
   return {
@@ -132,6 +142,7 @@ function buildCreateFingerprint(args: {
     goal: args.goal,
     checkPrompt: args.check_prompt,
     expression: args.expression,
+    timezone: args.timezone,
     contextHint: args.context_hint,
   };
 }
@@ -145,6 +156,7 @@ function monitorCreateMatches(
     record.goal === fingerprint.goal &&
     record.checkPrompt === fingerprint.checkPrompt &&
     record.expression === fingerprint.expression &&
+    record.timezone === fingerprint.timezone &&
     record.contextHint === fingerprint.contextHint
   );
 }
@@ -157,6 +169,7 @@ function buildMonitorRecord(
     readonly goal: string;
     readonly checkPrompt: string;
     readonly expression: string;
+    readonly timezone?: string;
     readonly contextHint?: string;
     readonly idempotencyKey?: string;
   },
@@ -168,6 +181,7 @@ function buildMonitorRecord(
     goal: args.goal,
     checkPrompt: args.checkPrompt,
     expression: args.expression,
+    timezone: args.timezone,
     contextHint: args.contextHint,
     idempotencyKey: args.idempotencyKey,
   };
@@ -184,7 +198,6 @@ function listMonitorView(record: MonitorRecord): {
   readonly schedule_id: string;
   readonly name: string;
   readonly goal: string;
-  readonly check_prompt: string;
   readonly expression: string;
   readonly context_hint?: string;
 } {
@@ -193,7 +206,6 @@ function listMonitorView(record: MonitorRecord): {
     schedule_id: record.scheduleId,
     name: record.name,
     goal: record.goal,
-    check_prompt: record.checkPrompt,
     expression: record.expression,
     context_hint: record.contextHint,
   };
@@ -222,7 +234,8 @@ export function createCreateMonitorTool(
         return { ok: false, error: parsed.error.message };
       }
 
-      const { name, goal, check_prompt, expression, context_hint, idempotency_key } = parsed.data;
+      const { name, goal, check_prompt, expression, timezone, context_hint, idempotency_key } =
+        parsed.data;
       const fingerprint = buildCreateFingerprint(parsed.data);
 
       if (idempotency_key !== undefined) {
@@ -235,7 +248,7 @@ export function createCreateMonitorTool(
                 ok: false,
                 error:
                   `idempotency_key '${idempotency_key}' already registered for a different monitor ` +
-                  "(name, goal, check_prompt, expression, or context_hint differ). Use a " +
+                  "(name, goal, check_prompt, expression, timezone, or context_hint differ). Use a " +
                   "distinct key, or cancel the existing monitor first.",
               };
             }
@@ -261,15 +274,24 @@ export function createCreateMonitorTool(
         checkPrompt: check_prompt,
         contextHint: context_hint,
       });
+      const scheduleOptions = timezone !== undefined ? { timezone } : undefined;
 
       const submission = Promise.resolve()
-        .then(() => scheduler.schedule(expression, { kind: "text", text: wakeText }, "dispatch"))
+        .then(() =>
+          scheduler.schedule(
+            expression,
+            { kind: "text", text: wakeText },
+            "dispatch",
+            scheduleOptions,
+          ),
+        )
         .then((scheduledId): MonitorRecord => {
           const record = buildMonitorRecord(monitorId, String(scheduledId), {
             name,
             goal,
             checkPrompt: check_prompt,
             expression,
+            timezone,
             contextHint: context_hint,
             idempotencyKey: idempotency_key,
           });
@@ -365,6 +387,7 @@ export function createUpdateMonitorTool(
         goal: parsed.data.goal ?? current.goal,
         checkPrompt: parsed.data.check_prompt ?? current.checkPrompt,
         expression: parsed.data.expression ?? current.expression,
+        timezone: parsed.data.timezone ?? current.timezone,
         contextHint: parsed.data.context_hint ?? current.contextHint,
         idempotencyKey: current.idempotencyKey,
       });
@@ -375,16 +398,31 @@ export function createUpdateMonitorTool(
         checkPrompt: next.checkPrompt,
         contextHint: next.contextHint,
       });
+      const scheduleOptions = next.timezone !== undefined ? { timezone: next.timezone } : undefined;
 
       let newScheduleId: string;
       try {
         newScheduleId = String(
-          await scheduler.schedule(next.expression, { kind: "text", text: wakeText }, "dispatch"),
+          await scheduler.schedule(
+            next.expression,
+            { kind: "text", text: wakeText },
+            "dispatch",
+            scheduleOptions,
+          ),
         );
       } catch (e: unknown) {
         return {
           ok: false,
           error: e instanceof Error ? e.message : "Failed to update monitor",
+        };
+      }
+
+      try {
+        await scheduler.unschedule(scheduleId(current.scheduleId));
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "Failed to retire previous monitor schedule",
         };
       }
 
@@ -396,15 +434,6 @@ export function createUpdateMonitorTool(
       state.monitorsById.set(updated.monitorId, updated);
       if (updated.idempotencyKey !== undefined) {
         state.idempotencyMap.set(updated.idempotencyKey, { kind: "settled", record: updated });
-      }
-
-      try {
-        await scheduler.unschedule(scheduleId(current.scheduleId));
-      } catch (e: unknown) {
-        return {
-          ok: false,
-          error: e instanceof Error ? e.message : "Failed to retire previous monitor schedule",
-        };
       }
 
       return {

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -1,0 +1,462 @@
+/**
+ * Monitor-facing tools — create/update/list/cancel monitor.
+ *
+ * Monitors are process-local metadata layered on top of recurring scheduler
+ * entries. The scheduler owns delivery; this module owns the human-readable
+ * monitor definition and same-process idempotency semantics for create.
+ */
+
+import type { JsonObject, Tool } from "@koi/core";
+import { DEFAULT_SANDBOXED_POLICY, scheduleId } from "@koi/core";
+import { toJSONSchema, z } from "zod";
+import type { ProactiveToolsConfig } from "./types.js";
+
+const createMonitorSchema = z.object({
+  name: z.string().min(1, "name is required").describe("Short monitor name shown in wake text."),
+  goal: z
+    .string()
+    .min(1, "goal is required")
+    .describe("What the monitor is trying to detect or decide."),
+  check_prompt: z
+    .string()
+    .min(1, "check_prompt is required")
+    .describe("Instructions the agent should follow when the monitor fires."),
+  expression: z
+    .string()
+    .min(1, "expression is required")
+    .describe('Cron expression understood by croner (e.g. "0 9 * * 1-5").'),
+  context_hint: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional extra context included in the wake text."),
+  idempotency_key: z
+    .string()
+    .min(1)
+    .refine((s) => !s.includes(":"), "idempotency_key must not contain ':'")
+    .optional()
+    .describe(
+      "Best-effort same-process dedupe key for monitor creation. Re-using the same key " +
+        "with identical monitor fields returns the original monitor_id and schedule_id; " +
+        "mismatches fail closed.",
+    ),
+});
+
+const updateMonitorSchema = z
+  .object({
+    monitor_id: z
+      .string()
+      .min(1, "monitor_id is required")
+      .describe("Monitor identifier to update."),
+    name: z.string().min(1).optional().describe("Replacement monitor name."),
+    goal: z.string().min(1).optional().describe("Replacement monitor goal."),
+    check_prompt: z.string().min(1).optional().describe("Replacement monitor instructions."),
+    expression: z.string().min(1).optional().describe("Replacement cron expression."),
+    context_hint: z.string().min(1).optional().describe("Replacement optional context hint."),
+  })
+  .refine(
+    (value) =>
+      value.name !== undefined ||
+      value.goal !== undefined ||
+      value.check_prompt !== undefined ||
+      value.expression !== undefined ||
+      value.context_hint !== undefined,
+    "At least one updatable field must be provided",
+  );
+
+const cancelMonitorSchema = z.object({
+  monitor_id: z.string().min(1, "monitor_id is required").describe("Monitor identifier to cancel."),
+});
+
+const listMonitorsSchema = z.object({});
+
+interface MonitorCreateFingerprint {
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly expression: string;
+  readonly contextHint: string | undefined;
+}
+
+export interface MonitorRecord {
+  readonly monitorId: string;
+  readonly scheduleId: string;
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly expression: string;
+  readonly contextHint: string | undefined;
+  readonly idempotencyKey: string | undefined;
+}
+
+type MonitorCreateEntry =
+  | { readonly kind: "pending"; readonly promise: Promise<MonitorRecord> }
+  | { readonly kind: "settled"; readonly record: MonitorRecord };
+
+export interface MonitorToolState {
+  readonly monitorsById: Map<string, MonitorRecord>;
+  readonly idempotencyMap: Map<string, MonitorCreateEntry>;
+  nextMonitorNumber: number;
+}
+
+export function createMonitorToolState(): MonitorToolState {
+  return {
+    monitorsById: new Map<string, MonitorRecord>(),
+    idempotencyMap: new Map<string, MonitorCreateEntry>(),
+    nextMonitorNumber: 1,
+  };
+}
+
+export function formatMonitorWakeMessage(args: {
+  readonly name: string;
+  readonly goal: string;
+  readonly checkPrompt: string;
+  readonly contextHint?: string;
+}): string {
+  const lines = [`Monitor check: ${args.name}`, `Goal: ${args.goal}`, `Check: ${args.checkPrompt}`];
+  if (args.contextHint !== undefined) {
+    lines.push(`Context: ${args.contextHint}`);
+  }
+  return lines.join("\n");
+}
+
+function buildCreateFingerprint(args: {
+  readonly name: string;
+  readonly goal: string;
+  readonly check_prompt: string;
+  readonly expression: string;
+  readonly context_hint?: string;
+}): MonitorCreateFingerprint {
+  return {
+    name: args.name,
+    goal: args.goal,
+    checkPrompt: args.check_prompt,
+    expression: args.expression,
+    contextHint: args.context_hint,
+  };
+}
+
+function monitorCreateMatches(
+  record: MonitorRecord,
+  fingerprint: MonitorCreateFingerprint,
+): boolean {
+  return (
+    record.name === fingerprint.name &&
+    record.goal === fingerprint.goal &&
+    record.checkPrompt === fingerprint.checkPrompt &&
+    record.expression === fingerprint.expression &&
+    record.contextHint === fingerprint.contextHint
+  );
+}
+
+function buildMonitorRecord(
+  monitorId: string,
+  scheduleIdValue: string,
+  args: {
+    readonly name: string;
+    readonly goal: string;
+    readonly checkPrompt: string;
+    readonly expression: string;
+    readonly contextHint?: string;
+    readonly idempotencyKey?: string;
+  },
+): MonitorRecord {
+  return {
+    monitorId,
+    scheduleId: scheduleIdValue,
+    name: args.name,
+    goal: args.goal,
+    checkPrompt: args.checkPrompt,
+    expression: args.expression,
+    contextHint: args.contextHint,
+    idempotencyKey: args.idempotencyKey,
+  };
+}
+
+function createMonitorId(state: MonitorToolState): string {
+  const id = `monitor-${state.nextMonitorNumber}`;
+  state.nextMonitorNumber += 1;
+  return id;
+}
+
+function listMonitorView(record: MonitorRecord): {
+  readonly monitor_id: string;
+  readonly schedule_id: string;
+  readonly name: string;
+  readonly goal: string;
+  readonly check_prompt: string;
+  readonly expression: string;
+  readonly context_hint?: string;
+} {
+  return {
+    monitor_id: record.monitorId,
+    schedule_id: record.scheduleId,
+    name: record.name,
+    goal: record.goal,
+    check_prompt: record.checkPrompt,
+    expression: record.expression,
+    context_hint: record.contextHint,
+  };
+}
+
+export function createCreateMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+
+  return {
+    descriptor: {
+      name: "create_monitor",
+      description:
+        "Register a recurring monitor that periodically re-dispatches this agent with a " +
+        "structured monitor check prompt.",
+      inputSchema: toJSONSchema(createMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = createMonitorSchema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+
+      const { name, goal, check_prompt, expression, context_hint, idempotency_key } = parsed.data;
+      const fingerprint = buildCreateFingerprint(parsed.data);
+
+      if (idempotency_key !== undefined) {
+        const existing = state.idempotencyMap.get(idempotency_key);
+        if (existing !== undefined) {
+          try {
+            const record = existing.kind === "settled" ? existing.record : await existing.promise;
+            if (!monitorCreateMatches(record, fingerprint)) {
+              return {
+                ok: false,
+                error:
+                  `idempotency_key '${idempotency_key}' already registered for a different monitor ` +
+                  "(name, goal, check_prompt, expression, or context_hint differ). Use a " +
+                  "distinct key, or cancel the existing monitor first.",
+              };
+            }
+            return {
+              ok: true,
+              monitor_id: record.monitorId,
+              schedule_id: record.scheduleId,
+              deduped: true,
+            };
+          } catch (e: unknown) {
+            return {
+              ok: false,
+              error: e instanceof Error ? e.message : "Failed to create monitor",
+            };
+          }
+        }
+      }
+
+      const monitorId = createMonitorId(state);
+      const wakeText = formatMonitorWakeMessage({
+        name,
+        goal,
+        checkPrompt: check_prompt,
+        contextHint: context_hint,
+      });
+
+      const submission = Promise.resolve()
+        .then(() => scheduler.schedule(expression, { kind: "text", text: wakeText }, "dispatch"))
+        .then((scheduledId): MonitorRecord => {
+          const record = buildMonitorRecord(monitorId, String(scheduledId), {
+            name,
+            goal,
+            checkPrompt: check_prompt,
+            expression,
+            contextHint: context_hint,
+            idempotencyKey: idempotency_key,
+          });
+          state.monitorsById.set(record.monitorId, record);
+          if (idempotency_key !== undefined) {
+            state.idempotencyMap.set(idempotency_key, { kind: "settled", record });
+          }
+          return record;
+        });
+
+      const trackedSubmission = submission.catch((err: unknown): never => {
+        if (idempotency_key !== undefined) {
+          state.idempotencyMap.delete(idempotency_key);
+        }
+        throw err;
+      });
+
+      if (idempotency_key !== undefined) {
+        state.idempotencyMap.set(idempotency_key, {
+          kind: "pending",
+          promise: trackedSubmission,
+        });
+      }
+
+      try {
+        const record = await trackedSubmission;
+        return { ok: true, monitor_id: record.monitorId, schedule_id: record.scheduleId };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "Failed to create monitor",
+        };
+      }
+    },
+  };
+}
+
+export function createListMonitorsTool(state: MonitorToolState): Tool {
+  return {
+    descriptor: {
+      name: "list_monitors",
+      description: "List monitors registered in the current process.",
+      inputSchema: toJSONSchema(listMonitorsSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = listMonitorsSchema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+      return {
+        ok: true,
+        monitors: [...state.monitorsById.values()].map((record) => listMonitorView(record)),
+      };
+    },
+  };
+}
+
+export function createUpdateMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+
+  return {
+    descriptor: {
+      name: "update_monitor",
+      description:
+        "Patch an existing monitor definition and rotate its backing recurring schedule.",
+      inputSchema: toJSONSchema(updateMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = updateMonitorSchema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+
+      const current = state.monitorsById.get(parsed.data.monitor_id);
+      if (current === undefined) {
+        return {
+          ok: false,
+          error: `monitor_id '${parsed.data.monitor_id}' not found`,
+        };
+      }
+
+      const next = buildMonitorRecord(current.monitorId, current.scheduleId, {
+        name: parsed.data.name ?? current.name,
+        goal: parsed.data.goal ?? current.goal,
+        checkPrompt: parsed.data.check_prompt ?? current.checkPrompt,
+        expression: parsed.data.expression ?? current.expression,
+        contextHint: parsed.data.context_hint ?? current.contextHint,
+        idempotencyKey: current.idempotencyKey,
+      });
+
+      const wakeText = formatMonitorWakeMessage({
+        name: next.name,
+        goal: next.goal,
+        checkPrompt: next.checkPrompt,
+        contextHint: next.contextHint,
+      });
+
+      let newScheduleId: string;
+      try {
+        newScheduleId = String(
+          await scheduler.schedule(next.expression, { kind: "text", text: wakeText }, "dispatch"),
+        );
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "Failed to update monitor",
+        };
+      }
+
+      const updated: MonitorRecord = {
+        ...next,
+        scheduleId: newScheduleId,
+      };
+
+      state.monitorsById.set(updated.monitorId, updated);
+      if (updated.idempotencyKey !== undefined) {
+        state.idempotencyMap.set(updated.idempotencyKey, { kind: "settled", record: updated });
+      }
+
+      try {
+        await scheduler.unschedule(scheduleId(current.scheduleId));
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "Failed to retire previous monitor schedule",
+        };
+      }
+
+      return {
+        ok: true,
+        monitor_id: updated.monitorId,
+        schedule_id: updated.scheduleId,
+      };
+    },
+  };
+}
+
+export function createCancelMonitorTool(
+  config: ProactiveToolsConfig,
+  state: MonitorToolState,
+): Tool {
+  const { scheduler } = config;
+
+  return {
+    descriptor: {
+      name: "cancel_monitor",
+      description: "Cancel an existing monitor by ID. Unknown monitor IDs return removed:false.",
+      inputSchema: toJSONSchema(cancelMonitorSchema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = cancelMonitorSchema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+
+      const record = state.monitorsById.get(parsed.data.monitor_id);
+      if (record === undefined) {
+        return { ok: true, removed: false };
+      }
+
+      try {
+        await scheduler.unschedule(scheduleId(record.scheduleId));
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "Failed to cancel monitor",
+        };
+      }
+
+      state.monitorsById.delete(record.monitorId);
+      if (record.idempotencyKey !== undefined) {
+        state.idempotencyMap.delete(record.idempotencyKey);
+      }
+
+      return { ok: true, removed: true };
+    },
+  };
+}

--- a/packages/lib/proactive/src/monitor-tools.ts
+++ b/packages/lib/proactive/src/monitor-tools.ts
@@ -411,13 +411,7 @@ export function createUpdateMonitorTool(
       }
 
       try {
-        const removed = await scheduler.unschedule(scheduleId(current.scheduleId));
-        if (!removed) {
-          return {
-            ok: false,
-            error: `Failed to retire previous monitor schedule: removed:false for '${current.scheduleId}'`,
-          };
-        }
+        await scheduler.unschedule(scheduleId(current.scheduleId));
       } catch (e: unknown) {
         return {
           ok: false,

--- a/packages/lib/proactive/src/notify-tool.test.ts
+++ b/packages/lib/proactive/src/notify-tool.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelAdapter, JsonObject } from "@koi/core";
+import { createNotifyTool } from "./notify-tool.js";
+
+function stubAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
+  return {
+    name: "stub",
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: true,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async () => {},
+    onMessage: () => () => {},
+    ...overrides,
+  };
+}
+
+describe("notify tool", () => {
+  test("returns ok:false with sorted available_channels for unknown channel", async () => {
+    const channels = new Map<string, ChannelAdapter>([
+      ["slack", stubAdapter({ name: "slack" })],
+      ["email", stubAdapter({ name: "email" })],
+    ]);
+    const tool = createNotifyTool({
+      resolveChannel: (n) => channels.get(n) ?? undefined,
+      names: () => [...channels.keys()],
+    });
+    const result = (await tool.execute({ channel: "telegram", text: "hi" })) as JsonObject;
+    expect(result).toEqual({
+      ok: false,
+      error: "unknown channel: telegram",
+      available_channels: ["email", "slack"],
+    });
+  });
+});

--- a/packages/lib/proactive/src/notify-tool.test.ts
+++ b/packages/lib/proactive/src/notify-tool.test.ts
@@ -87,7 +87,10 @@ describe("notify tool", () => {
     await tool.execute({ channel: "slack", text: "hi" });
 
     expect(sent).toHaveLength(1);
-    expect(Object.keys(sent[0]!).sort()).toEqual(["content"]);
+    const first = sent[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    expect(Object.keys(first).sort()).toEqual(["content"]);
   });
 
   test("returns ok:false when adapter.send rejects, never throws", async () => {

--- a/packages/lib/proactive/src/notify-tool.test.ts
+++ b/packages/lib/proactive/src/notify-tool.test.ts
@@ -144,4 +144,85 @@ describe("notify tool", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toContain("text");
   });
+
+  test("concurrent sends to same adapter preserve per-call args", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        await new Promise<void>((r) => {
+          const g = globalThis as unknown as {
+            setTimeout: (cb: () => void, ms: number) => unknown;
+          };
+          g.setTimeout(() => r(), 5);
+        });
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const results = await Promise.all([
+      tool.execute({ channel: "slack", text: "alpha", thread_id: "T-A" }),
+      tool.execute({ channel: "slack", text: "beta", thread_id: "T-B" }),
+      tool.execute({ channel: "slack", text: "gamma", thread_id: "T-C" }),
+    ]);
+
+    expect(results).toEqual([{ ok: true }, { ok: true }, { ok: true }]);
+    const texts = sent.map((m) => (m.content[0] as { text: string }).text).toSorted();
+    expect(texts).toEqual(["alpha", "beta", "gamma"]);
+    const pairs = sent
+      .map((m) => `${(m.content[0] as { text: string }).text}:${m.threadId ?? ""}`)
+      .toSorted();
+    expect(pairs).toEqual(["alpha:T-A", "beta:T-B", "gamma:T-C"]);
+  });
+
+  test("forwards large text payload without truncation or buffering corruption", async () => {
+    const big = "x".repeat(64 * 1024);
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({ channel: "slack", text: big });
+    expect(result).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+    const first = sent[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    expect((first.content[0] as { text: string }).text.length).toBe(big.length);
+    expect((first.content[0] as { text: string }).text).toBe(big);
+  });
+
+  test("forwards unicode metadata keys and values without mutation", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const meta = { ключ: "значение", "🔑": "🎯", "thread-参考": ["a", "b"] };
+    const result = await tool.execute({ channel: "slack", text: "hi", metadata: meta });
+    expect(result).toEqual({ ok: true });
+    expect(sent).toHaveLength(1);
+    const first = sent[0];
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+    expect(first.metadata).toEqual(meta);
+  });
 });

--- a/packages/lib/proactive/src/notify-tool.test.ts
+++ b/packages/lib/proactive/src/notify-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { ChannelAdapter, JsonObject } from "@koi/core";
+import type { ChannelAdapter, JsonObject, OutboundMessage } from "@koi/core";
 import { createNotifyTool } from "./notify-tool.js";
 
 function stubAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
@@ -39,5 +39,106 @@ describe("notify tool", () => {
       error: "unknown channel: telegram",
       available_channels: ["email", "slack"],
     });
+  });
+
+  test("forwards exact OutboundMessage shape on successful send", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: (n) => (n === "slack" ? slack : undefined),
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({
+      channel: "slack",
+      text: "hello",
+      thread_id: "T1",
+      metadata: { priority: "high" },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(sent).toEqual([
+      {
+        content: [{ kind: "text", text: "hello" }],
+        threadId: "T1",
+        metadata: { priority: "high" },
+      },
+    ]);
+  });
+
+  test("omits threadId and metadata from outbound when not provided", async () => {
+    const sent: OutboundMessage[] = [];
+    const slack = stubAdapter({
+      name: "slack",
+      send: async (m) => {
+        sent.push(m);
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    await tool.execute({ channel: "slack", text: "hi" });
+
+    expect(sent).toHaveLength(1);
+    expect(Object.keys(sent[0]!).sort()).toEqual(["content"]);
+  });
+
+  test("returns ok:false when adapter.send rejects, never throws", async () => {
+    const slack = stubAdapter({
+      name: "slack",
+      send: async () => {
+        throw new Error("network down");
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({ channel: "slack", text: "hi" });
+    expect(result).toEqual({ ok: false, error: "network down" });
+  });
+
+  test("returns ok:false with default message when adapter throws non-Error", async () => {
+    const slack = stubAdapter({
+      name: "slack",
+      send: async () => {
+        throw "string thrown";
+      },
+    });
+    const tool = createNotifyTool({
+      resolveChannel: () => slack,
+      names: () => ["slack"],
+    });
+
+    const result = await tool.execute({ channel: "slack", text: "hi" });
+    expect(result).toEqual({ ok: false, error: "channel.send failed" });
+  });
+
+  test("rejects empty channel name at schema boundary", async () => {
+    const tool = createNotifyTool({ resolveChannel: () => undefined, names: () => [] });
+    const result = (await tool.execute({ channel: "", text: "hi" })) as {
+      ok: boolean;
+      error: string;
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("channel");
+  });
+
+  test("rejects empty text at schema boundary", async () => {
+    const tool = createNotifyTool({ resolveChannel: () => undefined, names: () => [] });
+    const result = (await tool.execute({ channel: "slack", text: "" })) as {
+      ok: boolean;
+      error: string;
+    };
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("text");
   });
 });

--- a/packages/lib/proactive/src/notify-tool.ts
+++ b/packages/lib/proactive/src/notify-tool.ts
@@ -43,7 +43,10 @@ export function createNotifyTool(config: NotifyToolConfig): Tool {
     execute: async (args: JsonObject): Promise<unknown> => {
       const parsed = schema.safeParse(args);
       if (!parsed.success) {
-        return { ok: false, error: parsed.error.message };
+        return {
+          ok: false,
+          error: parsed.error.issues.map((i) => i.message).join("; "),
+        };
       }
       const { channel, text, thread_id, metadata } = parsed.data;
       const adapter = resolveChannel(channel);
@@ -51,13 +54,13 @@ export function createNotifyTool(config: NotifyToolConfig): Tool {
         return {
           ok: false,
           error: `unknown channel: ${channel}`,
-          available_channels: [...names()].sort(),
+          available_channels: names().toSorted(),
         };
       }
       const message: OutboundMessage = {
         content: [{ kind: "text", text }],
         ...(thread_id !== undefined ? { threadId: thread_id } : {}),
-        ...(metadata !== undefined ? { metadata: metadata as JsonObject } : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
       };
       try {
         await adapter.send(message);

--- a/packages/lib/proactive/src/notify-tool.ts
+++ b/packages/lib/proactive/src/notify-tool.ts
@@ -1,0 +1,73 @@
+/**
+ * `notify` tool — fire-and-forget text message to an attached ChannelAdapter.
+ *
+ * Thin pass-through: validate args, look up adapter by name, build an
+ * OutboundMessage with a single TextBlock, await `adapter.send`. No state,
+ * no idempotency, no retries. Adapter dedupe is the adapter's concern.
+ */
+
+import type { JsonObject, OutboundMessage, Tool } from "@koi/core";
+import { DEFAULT_SANDBOXED_POLICY } from "@koi/core";
+import { toJSONSchema, z } from "zod";
+import type { ResolveChannel } from "./types.js";
+
+const schema = z.object({
+  channel: z.string().min(1, "channel must be non-empty"),
+  text: z.string().min(1, "text must be non-empty"),
+  thread_id: z.string().min(1).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface NotifyToolConfig {
+  readonly resolveChannel: ResolveChannel;
+  /** Returns the currently-known channel names, used in error responses. */
+  readonly names: () => readonly string[];
+}
+
+export function createNotifyTool(config: NotifyToolConfig): Tool {
+  const { resolveChannel, names } = config;
+
+  return {
+    descriptor: {
+      name: "notify",
+      description:
+        "Send a one-shot text message to the user via a named channel " +
+        "(e.g. 'slack', 'email'). Fire-and-forget: no retries, no delivery " +
+        "confirmation beyond `ok:true`. Returns `ok:false` with the list " +
+        "of available channels if the named channel is not attached.",
+      inputSchema: toJSONSchema(schema) as JsonObject,
+      origin: "primordial",
+    },
+    origin: "primordial",
+    policy: DEFAULT_SANDBOXED_POLICY,
+    execute: async (args: JsonObject): Promise<unknown> => {
+      const parsed = schema.safeParse(args);
+      if (!parsed.success) {
+        return { ok: false, error: parsed.error.message };
+      }
+      const { channel, text, thread_id, metadata } = parsed.data;
+      const adapter = resolveChannel(channel);
+      if (adapter === undefined) {
+        return {
+          ok: false,
+          error: `unknown channel: ${channel}`,
+          available_channels: [...names()].sort(),
+        };
+      }
+      const message: OutboundMessage = {
+        content: [{ kind: "text", text }],
+        ...(thread_id !== undefined ? { threadId: thread_id } : {}),
+        ...(metadata !== undefined ? { metadata: metadata as JsonObject } : {}),
+      };
+      try {
+        await adapter.send(message);
+        return { ok: true };
+      } catch (e: unknown) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : "channel.send failed",
+        };
+      }
+    },
+  };
+}

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -64,7 +64,10 @@ describe("createProactiveToolsProvider", () => {
 
     const result = await provider.attach(agent);
     const components = "components" in result ? result.components : result;
-    const expectedKeys = PROACTIVE_TOOL_NAMES.map((name) => toolToken(name) as string);
+    // notify is omitted when no channel:* components are attached.
+    const expectedKeys = PROACTIVE_TOOL_NAMES.filter((n) => n !== "notify").map(
+      (name) => toolToken(name) as string,
+    );
     expect(components.size).toBe(expectedKeys.length);
     expect([...components.keys()]).toEqual(expectedKeys);
   });

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Agent, SchedulerComponent, SubsystemToken } from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
+import { PROACTIVE_TOOL_NAMES } from "./create-proactive-tools.js";
 import { createProactiveToolsProvider } from "./provider.js";
 import { createSchedulerStub } from "./test-helpers.js";
 
@@ -63,19 +64,9 @@ describe("createProactiveToolsProvider", () => {
 
     const result = await provider.attach(agent);
     const components = "components" in result ? result.components : result;
-    const toolNames = [
-      "sleep",
-      "cancel_sleep",
-      "schedule_cron",
-      "cancel_schedule",
-      "create_monitor",
-      "list_monitors",
-      "update_monitor",
-      "cancel_monitor",
-    ] as const;
-    for (const n of toolNames) {
-      expect(components.has(toolToken(n) as string)).toBe(true);
-    }
+    const expectedKeys = PROACTIVE_TOOL_NAMES.map((name) => toolToken(name) as string);
+    expect(components.size).toBe(expectedKeys.length);
+    expect([...components.keys()]).toEqual(expectedKeys);
   });
 
   test("attach surfaces a skipped entry when the agent has no SCHEDULER component", async () => {

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Agent, SchedulerComponent, SubsystemToken } from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
-import { PROACTIVE_TOOL_NAMES } from "./create-proactive-tools.js";
 import { createProactiveToolsProvider } from "./provider.js";
 import { createSchedulerStub } from "./test-helpers.js";
 
@@ -64,10 +63,16 @@ describe("createProactiveToolsProvider", () => {
 
     const result = await provider.attach(agent);
     const components = "components" in result ? result.components : result;
-    // notify is omitted when no channel:* components are attached.
-    const expectedKeys = PROACTIVE_TOOL_NAMES.filter((n) => n !== "notify").map(
-      (name) => toolToken(name) as string,
-    );
+    const expectedKeys = [
+      "sleep",
+      "cancel_sleep",
+      "schedule_cron",
+      "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
+    ].map((name) => toolToken(name) as string);
     expect(components.size).toBe(expectedKeys.length);
     expect([...components.keys()]).toEqual(expectedKeys);
   });

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { Agent, ChannelAdapter, SchedulerComponent, SubsystemToken } from "@koi/core";
+import type {
+  Agent,
+  ChannelAdapter,
+  JsonObject,
+  SchedulerComponent,
+  SubsystemToken,
+} from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
 import { createProactiveToolsProvider } from "./provider.js";
 import { createSchedulerStub } from "./test-helpers.js";
@@ -350,5 +356,44 @@ describe("createProactiveToolsProvider", () => {
     const result = await provider.attach(agent);
     const map = "components" in result ? result.components : result;
     expect(map.has(toolToken("notify") as string)).toBe(false);
+  });
+
+  test("notify uses snapshot — channels added after attach are not visible", async () => {
+    const provider = createProactiveToolsProvider();
+    const slack: ChannelAdapter = {
+      name: "slack",
+      capabilities: {
+        text: true,
+        images: false,
+        files: false,
+        buttons: false,
+        audio: false,
+        video: false,
+        threads: true,
+        supportsA2ui: false,
+      },
+      connect: async () => {},
+      disconnect: async () => {},
+      send: async () => {},
+      onMessage: () => () => {},
+    };
+    const channels = new Map<string, ChannelAdapter>([["slack", slack]]);
+    const agent = makeAgent(createSchedulerStub().component, "agent-1", channels);
+
+    const result = await provider.attach(agent);
+    const map = "components" in result ? result.components : result;
+    const notify = map.get(toolToken("notify") as string) as {
+      execute: (args: JsonObject) => Promise<unknown>;
+    };
+
+    // Mutate the agent's components AFTER attach — should not change snapshot.
+    (agent.components() as Map<string, unknown>).set("channel:email", slack);
+
+    const res = await notify.execute({ channel: "email", text: "hi" });
+    expect(res).toEqual({
+      ok: false,
+      error: "unknown channel: email",
+      available_channels: ["slack"],
+    });
   });
 });

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -56,14 +56,23 @@ describe("createProactiveToolsProvider", () => {
     expect(provider.priority).toBe(999);
   });
 
-  test("attach resolves SCHEDULER from the agent and registers four tools", async () => {
+  test("attach resolves SCHEDULER from the agent and registers eight tools", async () => {
     const stub = createSchedulerStub();
     const agent = makeAgent(stub.component);
     const provider = createProactiveToolsProvider();
 
     const result = await provider.attach(agent);
     const components = "components" in result ? result.components : result;
-    const toolNames = ["sleep", "cancel_sleep", "schedule_cron", "cancel_schedule"] as const;
+    const toolNames = [
+      "sleep",
+      "cancel_sleep",
+      "schedule_cron",
+      "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
+    ] as const;
     for (const n of toolNames) {
       expect(components.has(toolToken(n) as string)).toBe(true);
     }
@@ -262,5 +271,42 @@ describe("createProactiveToolsProvider", () => {
 
     expect(stubB.scheduleCalls).toHaveLength(1);
     expect(r2.deduped).toBeUndefined();
+  });
+
+  test("monitor state resets on reattach so a new attach starts with an empty monitor list", async () => {
+    const stub = createSchedulerStub();
+    const agent = makeAgent(stub.component, "agent-monitor");
+    const provider = createProactiveToolsProvider();
+
+    const createKey = toolToken("create_monitor") as string;
+    const listKey = toolToken("list_monitors") as string;
+
+    const first = await provider.attach(agent);
+    const firstComponents = "components" in first ? first.components : first;
+    const createMonitor = firstComponents.get(createKey) as {
+      execute: (args: object) => Promise<unknown>;
+    };
+    const listFirst = firstComponents.get(listKey) as {
+      execute: (args: object) => Promise<unknown>;
+    };
+
+    await createMonitor.execute({
+      name: "dependency-watch",
+      goal: "Detect whether issue #1301 is unblocked",
+      check_prompt: "Check issue status and summarize what changed.",
+      expression: "0 9 * * *",
+    });
+
+    const firstList = (await listFirst.execute({})) as { monitors: unknown[] };
+    expect(firstList.monitors).toHaveLength(1);
+
+    const second = await provider.attach(agent);
+    const secondComponents = "components" in second ? second.components : second;
+    const listSecond = secondComponents.get(listKey) as {
+      execute: (args: object) => Promise<unknown>;
+    };
+
+    const secondList = (await listSecond.execute({})) as { monitors: unknown[] };
+    expect(secondList.monitors).toHaveLength(0);
   });
 });

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -54,6 +54,26 @@ function makeAgent(
   };
 }
 
+function makeStubChannel(name: string): ChannelAdapter {
+  return {
+    name,
+    capabilities: {
+      text: true,
+      images: false,
+      files: false,
+      buttons: false,
+      audio: false,
+      video: false,
+      threads: true,
+      supportsA2ui: false,
+    },
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async () => {},
+    onMessage: () => () => {},
+  };
+}
+
 describe("createProactiveToolsProvider", () => {
   test("returns a ComponentProvider named 'proactive' at BUNDLED priority by default", () => {
     const provider = createProactiveToolsProvider();
@@ -321,23 +341,7 @@ describe("createProactiveToolsProvider", () => {
 
   test("installs notify tool when channel:* components are attached", async () => {
     const provider = createProactiveToolsProvider();
-    const slack: ChannelAdapter = {
-      name: "slack",
-      capabilities: {
-        text: true,
-        images: false,
-        files: false,
-        buttons: false,
-        audio: false,
-        video: false,
-        threads: true,
-        supportsA2ui: false,
-      },
-      connect: async () => {},
-      disconnect: async () => {},
-      send: async () => {},
-      onMessage: () => () => {},
-    };
+    const slack = makeStubChannel("slack");
     const agent = makeAgent(
       createSchedulerStub().component,
       "agent-1",
@@ -360,23 +364,7 @@ describe("createProactiveToolsProvider", () => {
 
   test("notify uses snapshot — channels added after attach are not visible", async () => {
     const provider = createProactiveToolsProvider();
-    const slack: ChannelAdapter = {
-      name: "slack",
-      capabilities: {
-        text: true,
-        images: false,
-        files: false,
-        buttons: false,
-        audio: false,
-        video: false,
-        threads: true,
-        supportsA2ui: false,
-      },
-      connect: async () => {},
-      disconnect: async () => {},
-      send: async () => {},
-      onMessage: () => () => {},
-    };
+    const slack = makeStubChannel("slack");
     const channels = new Map<string, ChannelAdapter>([["slack", slack]]);
     const agent = makeAgent(createSchedulerStub().component, "agent-1", channels);
 
@@ -387,13 +375,37 @@ describe("createProactiveToolsProvider", () => {
     };
 
     // Mutate the agent's components AFTER attach — should not change snapshot.
-    (agent.components() as Map<string, unknown>).set("channel:email", slack);
+    (agent.components() as Map<string, unknown>).set("channel:email", makeStubChannel("email"));
 
-    const res = await notify.execute({ channel: "email", text: "hi" });
-    expect(res).toEqual({
-      ok: false,
-      error: "unknown channel: email",
-      available_channels: ["slack"],
-    });
+    const res = (await notify.execute({ channel: "email", text: "hi" })) as {
+      ok: boolean;
+      error: string;
+      available_channels: readonly string[];
+    };
+
+    // The strong assertion: available_channels stays exactly ["slack"], proving
+    // the snapshot did not grow when a new channel was added post-attach.
+    expect(res.ok).toBe(false);
+    expect(res.available_channels).toEqual(["slack"]);
+  });
+
+  test("notify uses snapshot — channels removed after attach remain visible", async () => {
+    const provider = createProactiveToolsProvider();
+    const slack = makeStubChannel("slack");
+    const channels = new Map<string, ChannelAdapter>([["slack", slack]]);
+    const agent = makeAgent(createSchedulerStub().component, "agent-1", channels);
+
+    const result = await provider.attach(agent);
+    const map = "components" in result ? result.components : result;
+    const notify = map.get(toolToken("notify") as string) as {
+      execute: (args: JsonObject) => Promise<unknown>;
+    };
+
+    // Remove slack from the agent's component map AFTER attach.
+    (agent.components() as Map<string, unknown>).delete("channel:slack");
+
+    // Snapshot still has it — send succeeds.
+    const res = await notify.execute({ channel: "slack", text: "hi" });
+    expect(res).toEqual({ ok: true });
   });
 });

--- a/packages/lib/proactive/src/provider.test.ts
+++ b/packages/lib/proactive/src/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { Agent, SchedulerComponent, SubsystemToken } from "@koi/core";
+import type { Agent, ChannelAdapter, SchedulerComponent, SubsystemToken } from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
 import { createProactiveToolsProvider } from "./provider.js";
 import { createSchedulerStub } from "./test-helpers.js";
@@ -7,9 +7,13 @@ import { createSchedulerStub } from "./test-helpers.js";
 function makeAgent(
   scheduler: SchedulerComponent | undefined,
   agentIdValue = "agent-default",
+  channels: ReadonlyMap<string, ChannelAdapter> = new Map(),
 ): Agent {
   const map = new Map<string, unknown>();
   if (scheduler !== undefined) map.set(SCHEDULER as string, scheduler);
+  for (const [name, adapter] of channels) {
+    map.set(`channel:${name}`, adapter);
+  }
   const pid = {
     id: agentIdValue as unknown as Agent["pid"]["id"],
     name: agentIdValue,
@@ -307,5 +311,44 @@ describe("createProactiveToolsProvider", () => {
 
     const secondList = (await listSecond.execute({})) as { monitors: unknown[] };
     expect(secondList.monitors).toHaveLength(0);
+  });
+
+  test("installs notify tool when channel:* components are attached", async () => {
+    const provider = createProactiveToolsProvider();
+    const slack: ChannelAdapter = {
+      name: "slack",
+      capabilities: {
+        text: true,
+        images: false,
+        files: false,
+        buttons: false,
+        audio: false,
+        video: false,
+        threads: true,
+        supportsA2ui: false,
+      },
+      connect: async () => {},
+      disconnect: async () => {},
+      send: async () => {},
+      onMessage: () => () => {},
+    };
+    const agent = makeAgent(
+      createSchedulerStub().component,
+      "agent-1",
+      new Map([["slack", slack]]),
+    );
+
+    const result = await provider.attach(agent);
+    const map = "components" in result ? result.components : result;
+    expect(map.has(toolToken("notify") as string)).toBe(true);
+  });
+
+  test("omits notify tool when no channel:* components are attached", async () => {
+    const provider = createProactiveToolsProvider();
+    const agent = makeAgent(createSchedulerStub().component, "agent-1");
+
+    const result = await provider.attach(agent);
+    const map = "components" in result ? result.components : result;
+    expect(map.has(toolToken("notify") as string)).toBe(false);
   });
 });

--- a/packages/lib/proactive/src/provider.ts
+++ b/packages/lib/proactive/src/provider.ts
@@ -27,22 +27,10 @@
 
 import type { Agent, AttachResult, ComponentProvider, SkippedComponent, Tool } from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
-import { createCancelSleepTool } from "./cancel-sleep-tool.js";
-import {
-  type CronToolState,
-  createCancelScheduleTool,
-  createCronToolState,
-  createScheduleCronTool,
-} from "./cron-tools.js";
-import {
-  createCancelMonitorTool,
-  createCreateMonitorTool,
-  createListMonitorsTool,
-  createMonitorToolState,
-  createUpdateMonitorTool,
-  type MonitorToolState,
-} from "./monitor-tools.js";
-import { createSleepTool, createSleepToolState, type SleepToolState } from "./sleep-tool.js";
+import { assembleProactiveTools } from "./create-proactive-tools.js";
+import { createCronToolState } from "./cron-tools.js";
+import { createMonitorToolState } from "./monitor-tools.js";
+import { createSleepToolState, type SleepToolState } from "./sleep-tool.js";
 import type { ProactiveToolsConfig, ProactiveToolsProviderConfig } from "./types.js";
 
 export function createProactiveToolsProvider(
@@ -58,24 +46,6 @@ export function createProactiveToolsProvider(
     const fresh = createSleepToolState();
     sleepSlots.set(pid, fresh);
     return fresh;
-  }
-
-  function buildTools(
-    toolConfig: ProactiveToolsConfig,
-    sleepState: SleepToolState,
-    cronState: CronToolState,
-    monitorState: MonitorToolState,
-  ): readonly Tool[] {
-    return [
-      createSleepTool(toolConfig, sleepState),
-      createCancelSleepTool(toolConfig, sleepState),
-      createScheduleCronTool(toolConfig, cronState),
-      createCancelScheduleTool(toolConfig, cronState),
-      createCreateMonitorTool(toolConfig, monitorState),
-      createListMonitorsTool(monitorState),
-      createUpdateMonitorTool(toolConfig, monitorState),
-      createCancelMonitorTool(toolConfig, monitorState),
-    ];
   }
 
   return {
@@ -124,7 +94,7 @@ export function createProactiveToolsProvider(
       // Monitor state is also intentionally per-attach: monitor metadata is
       // process-local and should reset when the agent is reassembled.
       const monitorState = createMonitorToolState();
-      const tools = buildTools(toolConfig, sleepState, cronState, monitorState);
+      const tools = assembleProactiveTools(toolConfig, { sleepState, cronState, monitorState });
       const entries: (readonly [string, Tool])[] = tools.map(
         (t) => [toolToken(t.descriptor.name) as string, t] as const,
       );

--- a/packages/lib/proactive/src/provider.ts
+++ b/packages/lib/proactive/src/provider.ts
@@ -34,6 +34,14 @@ import {
   createCronToolState,
   createScheduleCronTool,
 } from "./cron-tools.js";
+import {
+  createCancelMonitorTool,
+  createCreateMonitorTool,
+  createListMonitorsTool,
+  createMonitorToolState,
+  createUpdateMonitorTool,
+  type MonitorToolState,
+} from "./monitor-tools.js";
 import { createSleepTool, createSleepToolState, type SleepToolState } from "./sleep-tool.js";
 import type { ProactiveToolsConfig, ProactiveToolsProviderConfig } from "./types.js";
 
@@ -56,12 +64,17 @@ export function createProactiveToolsProvider(
     toolConfig: ProactiveToolsConfig,
     sleepState: SleepToolState,
     cronState: CronToolState,
+    monitorState: MonitorToolState,
   ): readonly Tool[] {
     return [
       createSleepTool(toolConfig, sleepState),
       createCancelSleepTool(toolConfig, sleepState),
       createScheduleCronTool(toolConfig, cronState),
       createCancelScheduleTool(toolConfig, cronState),
+      createCreateMonitorTool(toolConfig, monitorState),
+      createListMonitorsTool(monitorState),
+      createUpdateMonitorTool(toolConfig, monitorState),
+      createCancelMonitorTool(toolConfig, monitorState),
     ];
   }
 
@@ -108,7 +121,10 @@ export function createProactiveToolsProvider(
       // submissions from a previous attach land on the prior, now-detached
       // state object and have no observable effect on the new attach.
       const cronState = createCronToolState();
-      const tools = buildTools(toolConfig, sleepState, cronState);
+      // Monitor state is also intentionally per-attach: monitor metadata is
+      // process-local and should reset when the agent is reassembled.
+      const monitorState = createMonitorToolState();
+      const tools = buildTools(toolConfig, sleepState, cronState, monitorState);
       const entries: (readonly [string, Tool])[] = tools.map(
         (t) => [toolToken(t.descriptor.name) as string, t] as const,
       );

--- a/packages/lib/proactive/src/provider.ts
+++ b/packages/lib/proactive/src/provider.ts
@@ -25,7 +25,14 @@
  * typically registered once per agent so this rarely matters in practice.
  */
 
-import type { Agent, AttachResult, ComponentProvider, SkippedComponent, Tool } from "@koi/core";
+import type {
+  Agent,
+  AttachResult,
+  ChannelAdapter,
+  ComponentProvider,
+  SkippedComponent,
+  Tool,
+} from "@koi/core";
 import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
 import { assembleProactiveTools } from "./create-proactive-tools.js";
 import { createCronToolState } from "./cron-tools.js";
@@ -71,6 +78,16 @@ export function createProactiveToolsProvider(
         };
       }
 
+      // Snapshot channel:* components at attach time. Channels added or
+      // removed after attach are not reflected by `notify` until reattach —
+      // matches the provider's existing per-attach lifecycle.
+      const channelSnapshot = new Map<string, ChannelAdapter>();
+      for (const [key, value] of agent.components()) {
+        if (key.startsWith("channel:")) {
+          channelSnapshot.set(key.slice("channel:".length), value as ChannelAdapter);
+        }
+      }
+
       const toolConfig: ProactiveToolsConfig = {
         scheduler,
         agentId: agent.pid.id,
@@ -79,6 +96,12 @@ export function createProactiveToolsProvider(
           : {}),
         ...(config.maxSleepMs !== undefined ? { maxSleepMs: config.maxSleepMs } : {}),
         ...(config.now !== undefined ? { now: config.now } : {}),
+        ...(channelSnapshot.size > 0
+          ? {
+              resolveChannel: (n: string) => channelSnapshot.get(n),
+              channelNames: () => [...channelSnapshot.keys()],
+            }
+          : {}),
       };
 
       // ProcessId is an object — slot by its `.id` (branded AgentId, a

--- a/packages/lib/proactive/src/provider.ts
+++ b/packages/lib/proactive/src/provider.ts
@@ -33,7 +33,7 @@ import type {
   SkippedComponent,
   Tool,
 } from "@koi/core";
-import { COMPONENT_PRIORITY, SCHEDULER, toolToken } from "@koi/core";
+import { COMPONENT_PRIORITY, channelToken, SCHEDULER, toolToken } from "@koi/core";
 import { assembleProactiveTools } from "./create-proactive-tools.js";
 import { createCronToolState } from "./cron-tools.js";
 import { createMonitorToolState } from "./monitor-tools.js";
@@ -82,10 +82,11 @@ export function createProactiveToolsProvider(
       // removed after attach are not reflected by `notify` until reattach —
       // matches the provider's existing per-attach lifecycle.
       const channelSnapshot = new Map<string, ChannelAdapter>();
-      for (const [key, value] of agent.components()) {
-        if (key.startsWith("channel:")) {
-          channelSnapshot.set(key.slice("channel:".length), value as ChannelAdapter);
-        }
+      for (const key of agent.components().keys()) {
+        if (!key.startsWith("channel:")) continue;
+        const name = key.slice("channel:".length);
+        const adapter = agent.component(channelToken(name));
+        if (adapter !== undefined) channelSnapshot.set(name, adapter);
       }
 
       const toolConfig: ProactiveToolsConfig = {

--- a/packages/lib/proactive/src/types.ts
+++ b/packages/lib/proactive/src/types.ts
@@ -6,7 +6,15 @@
  * idempotency state.
  */
 
-import type { AgentId, SchedulerComponent } from "@koi/core";
+import type { AgentId, ChannelAdapter, SchedulerComponent } from "@koi/core";
+
+/**
+ * Lookup function returning a `ChannelAdapter` by channel name, or
+ * `undefined` if no channel with that name is attached. The provider
+ * builds this from a snapshot of `channel:*` components taken at attach
+ * time.
+ */
+export type ResolveChannel = (name: string) => ChannelAdapter | undefined;
 
 /** Default wake message dispatched when a caller does not supply one. */
 export const DEFAULT_WAKE_MESSAGE: string = "Wake up — your scheduled timer fired.";
@@ -32,6 +40,12 @@ export interface ProactiveToolsConfig {
   readonly maxSleepMs?: number;
   /** Optional clock for deterministic testing. Defaults to `Date.now`. */
   readonly now?: () => number;
+  /**
+   * Lookup function for the `notify` tool. When omitted, `notify` is still
+   * created but every call resolves to "no channels available". The provider
+   * supplies this from a snapshot of the agent's `channel:*` components.
+   */
+  readonly resolveChannel?: ResolveChannel;
 }
 
 /**

--- a/packages/lib/proactive/src/types.ts
+++ b/packages/lib/proactive/src/types.ts
@@ -46,6 +46,12 @@ export interface ProactiveToolsConfig {
    * supplies this from a snapshot of the agent's `channel:*` components.
    */
   readonly resolveChannel?: ResolveChannel;
+  /**
+   * Returns the currently-attached channel names. Used by `notify` to
+   * populate `available_channels` in error responses. The provider
+   * supplies a callback closing over its `channel:*` snapshot.
+   */
+  readonly channelNames?: () => readonly string[];
 }
 
 /**

--- a/packages/meta/runtime/src/__tests__/golden-replay.test.ts
+++ b/packages/meta/runtime/src/__tests__/golden-replay.test.ts
@@ -19137,9 +19137,18 @@ describe("Golden: @koi/proactive", () => {
       agentId: "golden-proactive" as import("@koi/core").AgentId,
     });
 
-    expect(tools.length).toBe(4);
+    expect(tools.length).toBe(8);
     const names = tools.map((t) => t.descriptor.name);
-    expect(names).toEqual(["sleep", "cancel_sleep", "schedule_cron", "cancel_schedule"]);
+    expect(names).toEqual([
+      "sleep",
+      "cancel_sleep",
+      "schedule_cron",
+      "cancel_schedule",
+      "create_monitor",
+      "list_monitors",
+      "update_monitor",
+      "cancel_monitor",
+    ]);
     for (const tool of tools) expect(tool.origin).toBe("primordial");
 
     await scheduler[Symbol.asyncDispose]();


### PR DESCRIPTION
## Summary

Closes the remaining in-package work for #1195 `@koi/proactive`:

- **`monitor` tool** (create/list/update/cancel) — recurring monitors backed by cron schedules, with idempotency, atomic compensation on partial failure, and timezone-aware behavior.
- **`notify` tool** — fire-and-forget text dispatch via any `ChannelAdapter` attached to the agent. Provider snapshots `channel:*` components at attach time; tool only installed when at least one channel is attached.

Both tools follow the established sleep/cron pattern: pure factories + provider-resolved subsystem components, no peer L2 deps, ~80 LOC each. Layer check passes.

Specs and plans included under `docs/superpowers/`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — 268 pass / 0 fail across 17 files in @koi/proactive
- [x] `bun run check:layers` — all packages respect layer boundaries
- [x] Provider tests cover: notify installed when channels present, omitted when not, snapshot grow/shrink semantics
- [x] Monitor integration tests cover: schedule rotation, unschedule failure compensation, timezone behavior