### PR TITLE
chore(runtime): build workspace deps before package tests

### DIFF
--- a/packages/meta/runtime/package.json
+++ b/packages/meta/runtime/package.json
@@ -202,7 +202,7 @@
     "build": "bun ../../../scripts/run-tsup.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "bun test",
+    "test": "bun ../../../scripts/run-runtime-package-tests.ts",
     "record": "bun scripts/record-cassettes.ts"
   }
 }

--- a/scripts/run-runtime-package-tests.test.ts
+++ b/scripts/run-runtime-package-tests.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCommands,
+  runCommands,
+  runRuntimePackageTests,
+  type SpawnSync,
+} from "./run-runtime-package-tests.ts";
+
+describe("buildCommands", () => {
+  test("builds runtime and its workspace deps before running package tests", () => {
+    const commands = buildCommands("/repo", "/repo/packages/meta/runtime", [
+      "src/create-runtime.test.ts",
+      "--bail",
+    ]);
+
+    expect(commands).toEqual([
+      {
+        cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+        cwd: "/repo",
+      },
+      {
+        cmd: [process.execPath, "test", "src/create-runtime.test.ts", "--bail"],
+        cwd: "/repo/packages/meta/runtime",
+      },
+    ]);
+  });
+});
+
+describe("runCommands", () => {
+  test("stops after the first failing command", () => {
+    const seen: string[] = [];
+    const spawn: SpawnSync = (command) => {
+      seen.push(command.cwd);
+      return seen.length === 1 ? { exitCode: 7 } : { exitCode: 0 };
+    };
+
+    const status = runCommands(
+      [
+        { cmd: ["a"], cwd: "/repo" },
+        { cmd: ["b"], cwd: "/repo/packages/meta/runtime" },
+      ],
+      spawn,
+    );
+
+    expect(status).toBe(7);
+    expect(seen).toEqual(["/repo"]);
+  });
+});
+
+describe("runRuntimePackageTests", () => {
+  test("runs build first, then tests from the runtime package dir", () => {
+    const calls: Array<{ readonly cmd: readonly string[]; readonly cwd: string }> = [];
+    const spawn: SpawnSync = (command) => {
+      calls.push(command);
+      return { exitCode: 0 };
+    };
+
+    const status = runRuntimePackageTests(
+      ["src/__tests__/golden-replay.test.ts"],
+      "/repo",
+      "/repo/packages/meta/runtime",
+      spawn,
+    );
+
+    expect(status).toBe(0);
+    expect(calls).toEqual([
+      {
+        cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+        cwd: "/repo",
+      },
+      {
+        cmd: [process.execPath, "test", "src/__tests__/golden-replay.test.ts"],
+        cwd: "/repo/packages/meta/runtime",
+      },
+    ]);
+  });
+});

--- a/scripts/run-runtime-package-tests.test.ts
+++ b/scripts/run-runtime-package-tests.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { constants as osConstants } from "node:os";
 import {
   buildCommands,
+  resolveExitStatus,
   runCommands,
   runRuntimePackageTests,
   type SpawnSync,
+  signalExitCode,
 } from "./run-runtime-package-tests.ts";
 
 describe("buildCommands", () => {
@@ -23,6 +26,41 @@ describe("buildCommands", () => {
         cwd: "/repo/packages/meta/runtime",
       },
     ]);
+  });
+
+  test("omits forwarded args when none are supplied", () => {
+    const commands = buildCommands("/repo", "/repo/pkg", []);
+
+    expect(commands[1]).toEqual({
+      cmd: [process.execPath, "test"],
+      cwd: "/repo/pkg",
+    });
+  });
+});
+
+describe("signalExitCode", () => {
+  test("returns 128 + signo for a known signal", () => {
+    expect(signalExitCode("SIGTERM")).toBe(128 + osConstants.signals.SIGTERM);
+  });
+
+  test("falls back to 128 for an unknown signal", () => {
+    expect(signalExitCode("SIGNOT_A_REAL_SIGNAL")).toBe(128);
+  });
+});
+
+describe("resolveExitStatus", () => {
+  test("prefers signalCode over exitCode", () => {
+    expect(resolveExitStatus({ exitCode: 0, signalCode: "SIGINT" })).toBe(
+      128 + osConstants.signals.SIGINT,
+    );
+  });
+
+  test("returns 1 when both exitCode and signalCode are absent", () => {
+    expect(resolveExitStatus({ exitCode: null, signalCode: null })).toBe(1);
+  });
+
+  test("returns the numeric exit code when set and no signal", () => {
+    expect(resolveExitStatus({ exitCode: 42, signalCode: null })).toBe(42);
   });
 });
 
@@ -48,6 +86,19 @@ describe("runCommands", () => {
 });
 
 describe("runRuntimePackageTests", () => {
+  test("does not run the test command when the build command fails", () => {
+    const calls: string[] = [];
+    const spawn: SpawnSync = (command) => {
+      calls.push(command.cmd[1] ?? "");
+      return calls.length === 1 ? { exitCode: 3 } : { exitCode: 0 };
+    };
+
+    const status = runRuntimePackageTests([], "/repo", "/repo/pkg", spawn);
+
+    expect(status).toBe(3);
+    expect(calls).toEqual(["run"]);
+  });
+
   test("runs build first, then tests from the runtime package dir", () => {
     const calls: Array<{ readonly cmd: readonly string[]; readonly cwd: string }> = [];
     const spawn: SpawnSync = (command) => {

--- a/scripts/run-runtime-package-tests.ts
+++ b/scripts/run-runtime-package-tests.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+import { constants as osConstants } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type CommandSpec = {
+  readonly cmd: readonly string[];
+  readonly cwd: string;
+};
+
+export type SpawnResult = {
+  readonly exitCode: number | null;
+  readonly signalCode?: string | null;
+};
+
+export type SpawnSync = (command: CommandSpec) => SpawnResult;
+
+const DEFAULT_SIGNAL_EXIT_CODE = 128;
+
+export function defaultRepoRoot(): string {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(scriptDir, "..");
+}
+
+export function defaultRuntimePackageDir(repoRoot: string = defaultRepoRoot()): string {
+  return join(repoRoot, "packages/meta/runtime");
+}
+
+export function buildCommands(
+  repoRoot: string,
+  packageDir: string,
+  extraArgs: readonly string[],
+): readonly CommandSpec[] {
+  return [
+    {
+      cmd: [process.execPath, "run", "build", "--filter=@koi/runtime"],
+      cwd: repoRoot,
+    },
+    {
+      cmd: [process.execPath, "test", ...extraArgs],
+      cwd: packageDir,
+    },
+  ];
+}
+
+export function spawnCommand(command: CommandSpec): SpawnResult {
+  const result = Bun.spawnSync({
+    cmd: [...command.cmd],
+    cwd: command.cwd,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return { exitCode: result.exitCode, signalCode: result.signalCode ?? null };
+}
+
+export function signalExitCode(signalCode: string): number {
+  const signo = osConstants.signals[signalCode as keyof typeof osConstants.signals];
+  if (typeof signo === "number" && signo > 0) {
+    return 128 + signo;
+  }
+  return DEFAULT_SIGNAL_EXIT_CODE;
+}
+
+export function resolveExitStatus(result: SpawnResult): number {
+  if (result.signalCode != null) {
+    return signalExitCode(result.signalCode);
+  }
+  if (result.exitCode == null) {
+    return 1;
+  }
+  return result.exitCode;
+}
+
+export function runCommands(
+  commands: readonly CommandSpec[],
+  spawn: SpawnSync = spawnCommand,
+): number {
+  for (const command of commands) {
+    const status = resolveExitStatus(spawn(command));
+    if (status !== 0) {
+      return status;
+    }
+  }
+  return 0;
+}
+
+export function runRuntimePackageTests(
+  extraArgs: readonly string[],
+  repoRoot: string = defaultRepoRoot(),
+  packageDir: string = defaultRuntimePackageDir(repoRoot),
+  spawn: SpawnSync = spawnCommand,
+): number {
+  return runCommands(buildCommands(repoRoot, packageDir, extraArgs), spawn);
+}
+
+if (import.meta.main) {
+  const status = runRuntimePackageTests(process.argv.slice(2));
+  if (status !== 0) {
+    process.exit(status);
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,12 @@
     },
     "test": {
       "dependsOn": ["^build", "build"],
-      "inputs": ["src/**/*.ts", "tsconfig.json", "../../tsconfig.base.json"],
+      "inputs": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../tsconfig.base.json",
+        "../../../scripts/run-runtime-package-tests.ts"
+      ],
       "outputs": ["coverage/**"]
     },
     "test:api": {


### PR DESCRIPTION
## Summary
- Route the `@koi/runtime` package `test` script through a wrapper that builds the package (with workspace filter) before invoking `bun test`, so dependent workspace builds are no longer skipped.
- Add `scripts/run-runtime-package-tests.ts` plus co-located unit tests covering command construction, fail-fast behavior, and the end-to-end orchestrator.

## Test plan
- [ ] `bun test scripts/run-runtime-package-tests.test.ts`
- [ ] `bun --filter=@koi/runtime test`

Generated with Claude Code
