### PR TITLE
[codex] Add neuroskill signal sensor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1131,6 +1131,13 @@
         "@koi/core": "workspace:*",
       },
     },
+    "packages/lib/sensor-neuroskill": {
+      "name": "@koi/sensor-neuroskill",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/lib/session": {
       "name": "@koi/session",
       "version": "0.0.0",
@@ -3158,6 +3165,8 @@
     "@koi/secure-storage": ["@koi/secure-storage@workspace:packages/lib/secure-storage"],
 
     "@koi/sensor-ide": ["@koi/sensor-ide@workspace:packages/lib/sensor-ide"],
+
+    "@koi/sensor-neuroskill": ["@koi/sensor-neuroskill@workspace:packages/lib/sensor-neuroskill"],
 
     "@koi/session": ["@koi/session@workspace:packages/lib/session"],
 

--- a/docs/L2/sensor-neuroskill.md
+++ b/docs/L2/sensor-neuroskill.md
@@ -1,0 +1,76 @@
+# @koi/sensor-neuroskill
+
+**Layer:** L2 · **Contract:** `SignalSource` (L0)
+
+Real-time BCI/EXG signal sensor for host integrations. Hosts can either feed
+validated frames directly with `record()` or connect a WebSocket stream with
+`connect(url)`. Each accepted frame is preprocessed synchronously, converted
+into signal features, estimated as cognitive state, and emitted to subscribers.
+
+## What it owns
+
+- Normalized BCI/EXG frame and channel types
+- WebSocket receiver lifecycle with injectable socket construction
+- Per-frame preprocessing:
+  - finite-sample validation
+  - bounded sample counts
+  - median baseline removal
+  - robust outlier clipping
+- Feature extraction:
+  - mean, RMS, variance, peak amplitude
+  - zero-crossing rate
+  - EEG band powers: delta, theta, alpha, beta, gamma
+- Cognitive-state estimates:
+  - attention
+  - fatigue
+  - engagement
+  - confidence
+- Bounded recent cognitive-state event summaries
+- `SignalSource.read()` integration for `@koi/middleware-user-model`
+
+## What it does NOT own
+
+- Hardware drivers, BLE, USB, or serial device discovery
+- Long-term raw signal persistence
+- Batch/offline signal processing
+- Medical diagnosis, clinical interpretation, or calibration workflows
+- Runtime wiring into a specific host or gateway
+
+## Dependencies
+
+| Package | Layer | Purpose |
+|---------|-------|---------|
+| `@koi/core` | L0 | `SignalSource`, `UserSignal` |
+
+## API
+
+### `createNeuroSkillSensor(config?): NeuroSkillSensor`
+
+Returns a `SignalSource`-compatible object with:
+
+| Method | Description |
+|--------|-------------|
+| `connect(url)` | Open a WebSocket stream. Use `socketFactory` in config for hosts/tests that provide their own transport. |
+| `disconnect()` | Close the active socket and mark the sensor disconnected. |
+| `record(frame)` | Validate and process one normalized frame immediately. Returns `true` when accepted. |
+| `subscribe(handler)` | Observe cognitive-state events as frames are accepted. Returns an unsubscribe function. |
+| `snapshot()` | Return current connection state, latest features, latest cognitive estimate, rejected-frame count, and bounded event summaries. |
+| `read()` | Return `{ kind: "sensor", source: "neuroskill", values: snapshot() }`. |
+| `clear()` | Drop retained in-memory state and rejected-frame count. |
+
+### Frame Shape
+
+```ts
+{
+  timestamp: number;
+  samplingRateHz: number;
+  channels: readonly {
+    name: string;
+    type?: "eeg" | "emg" | "eog" | "ecg" | "unknown";
+    samples: readonly number[];
+  }[];
+}
+```
+
+Frames are processed as they arrive. There is no timer, queue, or batch window in
+the sensor; rolling retention only bounds memory for snapshots.

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -4,10 +4,10 @@ Generated from active workspace packages with `bun scripts/generate-package-cove
 
 Current snapshot:
 
-- 230 workspace packages
+- 231 workspace packages
 - 11 package families
-- 230 packages with local test files
-- 205 packages with dedicated package docs
+- 231 packages with local test files
+- 206 packages with dedicated package docs
 
 ## Family Summary
 
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 149 | 781 | 130 |
+| lib | 150 | 782 | 131 |
 | meta | 7 | 121 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 12 | 98 | 12 |
@@ -47,7 +47,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/engine-compose` (packages/kernel/engine-compose) - Middleware composition and guard factories for the Koi kernel. Tests: 7. Docs: -.
 - `@koi/engine-reconcile` (packages/kernel/engine-reconcile) - Reconciliation, supervision, and process management for the Koi kernel. Tests: 22. Docs: -.
 
-## lib (149)
+## lib (150)
 
 - `@koi/ace-types` (packages/lib/ace-types) - Shared domain types for ACE (Adaptive Continuous Enhancement) middleware and stores. Tests: 1. Docs: -.
 - `@koi/agent-discovery` (packages/lib/agent-discovery) - Runtime discovery of external coding agents (CLI, filesystem registry, MCP). Tests: 8. Docs: docs/L2/agent-discovery.md.
@@ -168,6 +168,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/search-nexus` (packages/lib/search-nexus) - Nexus-backed SearchBackend — Retriever + Indexer via Nexus search RPC. Tests: 3. Docs: docs/L2/search-nexus.md.
 - `@koi/secure-storage` (packages/lib/secure-storage) - OS keychain token storage with file-based locking for concurrent access. Tests: 3. Docs: -.
 - `@koi/sensor-ide` (packages/lib/sensor-ide) - Low-overhead IDE activity sensor for typing, diagnostics, file switching, and flow signals. Tests: 1. Docs: docs/L2/sensor-ide.md.
+- `@koi/sensor-neuroskill` (packages/lib/sensor-neuroskill) - Real-time BCI/EXG signal sensor with preprocessing, cognitive-state estimates, and event streaming. Tests: 1. Docs: docs/L2/sensor-neuroskill.md.
 - `@koi/session` (packages/lib/session) - Session persistence (SQLite/WAL) and transcript (append-only JSONL) for crash recovery. Tests: 9. Docs: docs/L2/session.md.
 - `@koi/settings` (packages/lib/settings) - Hierarchical settings cascade: user → project → local → flag → policy. Tests: 4. Docs: docs/L2/settings.md.
 - `@koi/shutdown` (packages/lib/shutdown) - Handle graceful shutdown signals and map exit codes for CLI and deploy. Tests: 3. Docs: -.

--- a/packages/lib/sensor-neuroskill/package.json
+++ b/packages/lib/sensor-neuroskill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/sensor-neuroskill",
+  "description": "Real-time BCI/EXG signal sensor with preprocessing, cognitive-state estimates, and event streaming",
+  "version": "0.0.0",
+  "private": true,
+  "koi": {
+    "optional": true
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "bun ../../../scripts/run-tsup.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  }
+}

--- a/packages/lib/sensor-neuroskill/src/index.ts
+++ b/packages/lib/sensor-neuroskill/src/index.ts
@@ -1,0 +1,18 @@
+export type {
+  CognitiveStateEstimate,
+  NeuroBandPowers,
+  NeuroChannelFeatures,
+  NeuroSignalChannel,
+  NeuroSignalFeatures,
+  NeuroSignalFrame,
+  NeuroSignalKind,
+  NeuroSkillConnectionState,
+  NeuroSkillEventSummary,
+  NeuroSkillSensor,
+  NeuroSkillSensorConfig,
+  NeuroSkillSnapshot,
+  NeuroSkillSocket,
+  NeuroSkillSocketFactory,
+  NeuroSkillStateEvent,
+} from "./neuroskill-sensor.js";
+export { createNeuroSkillSensor } from "./neuroskill-sensor.js";

--- a/packages/lib/sensor-neuroskill/src/neuroskill-sensor.test.ts
+++ b/packages/lib/sensor-neuroskill/src/neuroskill-sensor.test.ts
@@ -206,4 +206,78 @@ describe("createNeuroSkillSensor", () => {
       values: sensor.snapshot(),
     });
   });
+
+  test("default socket path supports error, disconnect, unsubscribe, and clear", () => {
+    const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+    const sockets: FakeSocket[] = [];
+
+    class FakeWebSocket implements FakeSocket {
+      private messageHandler: ((event: { readonly data: string }) => void) | undefined;
+      private closeHandler: ((event: { readonly data?: unknown }) => void) | undefined;
+      private errorHandler: ((event: { readonly data?: unknown }) => void) | undefined;
+
+      constructor() {
+        sockets.push(this);
+      }
+
+      close(): void {
+        this.closeHandler?.({});
+      }
+
+      addEventListener(
+        type: "message" | "close" | "error",
+        handler: (event: { readonly data?: unknown }) => void,
+      ): void {
+        if (type === "message") this.messageHandler = handler;
+        if (type === "close") this.closeHandler = handler;
+        if (type === "error") this.errorHandler = handler;
+      }
+
+      emitMessage(data: string): void {
+        this.messageHandler?.({ data });
+      }
+
+      emitClose(): void {
+        this.closeHandler?.({});
+      }
+
+      emitError(): void {
+        this.errorHandler?.({});
+      }
+    }
+
+    Object.defineProperty(globalThis, "WebSocket", {
+      configurable: true,
+      value: FakeWebSocket,
+      writable: true,
+    });
+    try {
+      const sensor = createNeuroSkillSensor({ now: () => 2_000 });
+      const seen: string[] = [];
+      const unsubscribe = sensor.subscribe((event) => seen.push(event.kind));
+
+      sensor.connect("ws://localhost:8765/exg");
+      sockets[0]?.emitMessage(JSON.stringify(attentiveFrame));
+      unsubscribe();
+      sockets[0]?.emitMessage(JSON.stringify({ ...attentiveFrame, timestamp: 2_000 }));
+
+      expect(seen).toEqual(["cognitive_state"]);
+      expect(sensor.snapshot().retainedEventCount).toBe(2);
+      (sockets[0] as (FakeSocket & { readonly emitError?: () => void }) | undefined)?.emitError?.();
+      expect(sensor.snapshot().connectionState).toBe("error");
+      sensor.disconnect();
+      expect(sensor.snapshot().connectionState).toBe("disconnected");
+      sensor.clear();
+      expect(sensor.snapshot()).toMatchObject({
+        retainedEventCount: 0,
+        rejectedFrames: 0,
+      });
+    } finally {
+      if (originalWebSocket === undefined) {
+        Reflect.deleteProperty(globalThis, "WebSocket");
+      } else {
+        Object.defineProperty(globalThis, "WebSocket", originalWebSocket);
+      }
+    }
+  });
 });

--- a/packages/lib/sensor-neuroskill/src/neuroskill-sensor.test.ts
+++ b/packages/lib/sensor-neuroskill/src/neuroskill-sensor.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createNeuroSkillSensor,
+  type NeuroSkillSocket,
+  type NeuroSkillSocketFactory,
+} from "./neuroskill-sensor.js";
+
+interface FakeSocket extends NeuroSkillSocket {
+  readonly emitMessage: (data: string) => void;
+  readonly emitClose: () => void;
+}
+
+function createFakeSocket(): {
+  readonly factory: NeuroSkillSocketFactory;
+  readonly sockets: readonly FakeSocket[];
+} {
+  const sockets: FakeSocket[] = [];
+
+  const factory: NeuroSkillSocketFactory = () => {
+    let messageHandler: ((event: { readonly data: string }) => void) | undefined;
+    let closeHandler: ((event: { readonly data?: unknown }) => void) | undefined;
+
+    const socket: FakeSocket = {
+      close() {
+        closeHandler?.({});
+      },
+      addEventListener(type, handler) {
+        if (type === "message") messageHandler = handler;
+        if (type === "close") closeHandler = handler;
+      },
+      emitMessage(data) {
+        messageHandler?.({ data });
+      },
+      emitClose() {
+        closeHandler?.({});
+      },
+    };
+
+    sockets.push(socket);
+    return socket;
+  };
+
+  return { factory, sockets };
+}
+
+const attentiveFrame = {
+  timestamp: 1_000,
+  samplingRateHz: 128,
+  channels: [
+    {
+      name: "eeg.fz",
+      type: "eeg",
+      samples: [0, 1, 0, -1, 0, 1, 0, -1, 0, 1, 0, -1, 0, 1, 0, -1],
+    },
+  ],
+} as const;
+
+describe("createNeuroSkillSensor", () => {
+  test("receives a WebSocket BCI stream and emits a state update immediately", () => {
+    const { factory, sockets } = createFakeSocket();
+    const sensor = createNeuroSkillSensor({ socketFactory: factory });
+    const states: unknown[] = [];
+
+    sensor.subscribe((event) => {
+      states.push(event);
+    });
+
+    sensor.connect("ws://localhost:8765/exg");
+    sockets[0]?.emitMessage(JSON.stringify(attentiveFrame));
+
+    expect(sensor.snapshot().connectionState).toBe("connected");
+    expect(states).toHaveLength(1);
+    expect(sensor.snapshot().cognitiveState.attention).toBeGreaterThan(0.5);
+  });
+
+  test("preprocessing rejects outlier noise from feature extraction", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 2_000 });
+
+    sensor.record({
+      timestamp: 1_000,
+      samplingRateHz: 128,
+      channels: [
+        {
+          name: "eeg.fz",
+          type: "eeg",
+          samples: [1, 1, 1, 1, 1, 1, 250, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        },
+      ],
+    });
+
+    const channel = sensor.snapshot().latestFeatures.channels[0];
+    expect(channel?.noiseRejectedSamples).toBe(1);
+    expect(channel?.peakAmplitude).toBeLessThan(30);
+  });
+
+  test("estimates fatigue from theta-heavy EEG features", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 2_000 });
+
+    sensor.record({
+      timestamp: 1_000,
+      samplingRateHz: 64,
+      channels: [
+        {
+          name: "eeg.fz",
+          type: "eeg",
+          samples: [
+            0, 0.38, 0.7, 0.92, 1, 0.92, 0.7, 0.38, 0, -0.38, -0.7, -0.92, -1, -0.92, -0.7, -0.38,
+          ],
+        },
+      ],
+    });
+
+    const state = sensor.snapshot().cognitiveState;
+    expect(state.fatigue).toBeGreaterThan(state.attention);
+    expect(state.confidence).toBeGreaterThan(0);
+  });
+
+  test("event stream delivers state updates and bounds retained events", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 3_000, maxEvents: 2 });
+    const seen: string[] = [];
+
+    sensor.subscribe((event) => {
+      seen.push(event.kind);
+    });
+
+    sensor.record({ ...attentiveFrame, timestamp: 1_000 });
+    sensor.record({ ...attentiveFrame, timestamp: 2_000 });
+    sensor.record({ ...attentiveFrame, timestamp: 3_000 });
+
+    expect(seen).toEqual(["cognitive_state", "cognitive_state", "cognitive_state"]);
+    expect(sensor.snapshot().recentEvents).toEqual([
+      { kind: "cognitive_state", timestamp: 2_000 },
+      { kind: "cognitive_state", timestamp: 3_000 },
+    ]);
+  });
+
+  test("connection loss is reflected without clearing the last state", () => {
+    const { factory, sockets } = createFakeSocket();
+    const sensor = createNeuroSkillSensor({ socketFactory: factory });
+
+    sensor.connect("ws://localhost:8765/exg");
+    sockets[0]?.emitMessage(JSON.stringify(attentiveFrame));
+    sockets[0]?.emitClose();
+
+    const snapshot = sensor.snapshot();
+    expect(snapshot.connectionState).toBe("disconnected");
+    expect(snapshot.cognitiveState.attention).toBeGreaterThan(0);
+  });
+
+  test("signal validation rejects malformed data", () => {
+    const { factory, sockets } = createFakeSocket();
+    const sensor = createNeuroSkillSensor({ socketFactory: factory });
+    const seen: unknown[] = [];
+
+    sensor.subscribe((event) => {
+      seen.push(event);
+    });
+
+    sensor.connect("ws://localhost:8765/exg");
+    sockets[0]?.emitMessage(JSON.stringify({ timestamp: 1, channels: [] }));
+    sockets[0]?.emitMessage("{not-json");
+
+    expect(sensor.snapshot().rejectedFrames).toBe(2);
+    expect(seen).toEqual([]);
+  });
+
+  test("signal validation rejects channels with non-finite samples", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 2_000 });
+
+    expect(
+      sensor.record({
+        timestamp: 1_000,
+        samplingRateHz: 128,
+        channels: [{ name: "eeg.fz", type: "eeg", samples: [0, Number.NaN, 1] }],
+      }),
+    ).toBe(false);
+
+    expect(sensor.snapshot()).toMatchObject({
+      retainedEventCount: 0,
+      rejectedFrames: 1,
+    });
+  });
+
+  test("read returns a user-model sensor signal", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 60_000 });
+
+    sensor.record(attentiveFrame);
+
+    expect(sensor.name).toBe("neuroskill");
+    expect(sensor.read()).toEqual({
+      kind: "sensor",
+      source: "neuroskill",
+      values: sensor.snapshot(),
+    });
+  });
+
+  test("read remains stable when passed as an unbound SignalSource callback", () => {
+    const sensor = createNeuroSkillSensor({ now: () => 60_000 });
+    sensor.record(attentiveFrame);
+
+    const read = sensor.read;
+
+    expect(read()).toEqual({
+      kind: "sensor",
+      source: "neuroskill",
+      values: sensor.snapshot(),
+    });
+  });
+});

--- a/packages/lib/sensor-neuroskill/src/neuroskill-sensor.ts
+++ b/packages/lib/sensor-neuroskill/src/neuroskill-sensor.ts
@@ -1,0 +1,522 @@
+import type { SignalSource, UserSignal } from "@koi/core";
+
+export type NeuroSignalKind = "eeg" | "emg" | "eog" | "ecg" | "unknown";
+export type NeuroSkillConnectionState = "idle" | "connected" | "disconnected" | "error";
+
+export interface NeuroSignalChannel {
+  readonly name: string;
+  readonly type?: NeuroSignalKind | undefined;
+  readonly samples: readonly number[];
+}
+
+export interface NeuroSignalFrame {
+  readonly timestamp: number;
+  readonly samplingRateHz: number;
+  readonly channels: readonly NeuroSignalChannel[];
+}
+
+export interface NeuroBandPowers {
+  readonly delta: number;
+  readonly theta: number;
+  readonly alpha: number;
+  readonly beta: number;
+  readonly gamma: number;
+}
+
+export interface NeuroChannelFeatures {
+  readonly name: string;
+  readonly type: NeuroSignalKind;
+  readonly sampleCount: number;
+  readonly mean: number;
+  readonly rms: number;
+  readonly variance: number;
+  readonly peakAmplitude: number;
+  readonly zeroCrossingRate: number;
+  readonly noiseRejectedSamples: number;
+  readonly bandPowers: NeuroBandPowers;
+}
+
+export interface NeuroSignalFeatures {
+  readonly timestamp: number;
+  readonly samplingRateHz: number;
+  readonly channels: readonly NeuroChannelFeatures[];
+}
+
+export interface CognitiveStateEstimate {
+  readonly attention: number;
+  readonly fatigue: number;
+  readonly engagement: number;
+  readonly confidence: number;
+  readonly sampledAt: number;
+}
+
+export interface NeuroSkillStateEvent {
+  readonly kind: "cognitive_state";
+  readonly timestamp: number;
+  readonly features: NeuroSignalFeatures;
+  readonly state: CognitiveStateEstimate;
+}
+
+export interface NeuroSkillEventSummary {
+  readonly kind: NeuroSkillStateEvent["kind"];
+  readonly timestamp: number;
+}
+
+export interface NeuroSkillSnapshot {
+  readonly [key: string]: unknown;
+  readonly connectionState: NeuroSkillConnectionState;
+  readonly cognitiveState: CognitiveStateEstimate;
+  readonly latestFeatures: NeuroSignalFeatures;
+  readonly recentEvents: readonly NeuroSkillEventSummary[];
+  readonly retainedEventCount: number;
+  readonly rejectedFrames: number;
+  readonly sampledAt: number;
+  readonly windowMs: number;
+}
+
+export interface NeuroSkillSocket {
+  readonly close?: (() => void) | undefined;
+  readonly addEventListener?: (
+    type: "message" | "close" | "error",
+    handler: (event: { readonly data?: unknown }) => void,
+  ) => void;
+  onmessage?: ((event: { readonly data?: unknown }) => void) | undefined;
+  onclose?: (() => void) | undefined;
+  onerror?: (() => void) | undefined;
+}
+
+export type NeuroSkillSocketFactory = (url: string) => NeuroSkillSocket;
+
+export interface NeuroSkillSensorConfig {
+  readonly name?: string | undefined;
+  readonly source?: string | undefined;
+  readonly now?: (() => number) | undefined;
+  readonly socketFactory?: NeuroSkillSocketFactory | undefined;
+  readonly windowMs?: number | undefined;
+  readonly maxEvents?: number | undefined;
+  readonly maxSamplesPerChannel?: number | undefined;
+  readonly noiseSigma?: number | undefined;
+}
+
+export interface NeuroSkillSensor extends SignalSource {
+  readonly connect: (url: string) => void;
+  readonly disconnect: () => void;
+  readonly record: (frame: unknown) => boolean;
+  readonly subscribe: (handler: (event: NeuroSkillStateEvent) => void) => () => void;
+  readonly snapshot: () => NeuroSkillSnapshot;
+  readonly clear: () => void;
+}
+
+interface ResolvedConfig {
+  readonly name: string;
+  readonly source: string;
+  readonly now: () => number;
+  readonly socketFactory: NeuroSkillSocketFactory | undefined;
+  readonly windowMs: number;
+  readonly maxEvents: number;
+  readonly maxSamplesPerChannel: number;
+  readonly noiseSigma: number;
+}
+
+interface MutableState {
+  connectionState: NeuroSkillConnectionState;
+  socket: NeuroSkillSocket | undefined;
+  events: readonly NeuroSkillStateEvent[];
+  rejectedFrames: number;
+  latestFeatures: NeuroSignalFeatures;
+  cognitiveState: CognitiveStateEstimate;
+}
+
+type NeuroSkillSubscriber = (event: NeuroSkillStateEvent) => void;
+
+const DEFAULT_WINDOW_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_EVENTS = 256;
+const DEFAULT_MAX_SAMPLES_PER_CHANNEL = 512;
+const DEFAULT_NOISE_SIGMA = 6;
+const EMPTY_FEATURES: NeuroSignalFeatures = {
+  timestamp: 0,
+  samplingRateHz: 0,
+  channels: [],
+};
+const EMPTY_STATE: CognitiveStateEstimate = {
+  attention: 0,
+  fatigue: 0,
+  engagement: 0,
+  confidence: 0,
+  sampledAt: 0,
+};
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return value;
+}
+
+function resolveConfig(config: NeuroSkillSensorConfig): ResolvedConfig {
+  return {
+    name: config.name ?? "neuroskill",
+    source: config.source ?? "neuroskill",
+    now: config.now ?? Date.now,
+    socketFactory: config.socketFactory,
+    windowMs: positiveInt(config.windowMs, DEFAULT_WINDOW_MS),
+    maxEvents: positiveInt(config.maxEvents, DEFAULT_MAX_EVENTS),
+    maxSamplesPerChannel: positiveInt(config.maxSamplesPerChannel, DEFAULT_MAX_SAMPLES_PER_CHANNEL),
+    noiseSigma: positiveNumber(config.noiseSigma, DEFAULT_NOISE_SIGMA),
+  };
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return roundMetric(value);
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJson(data: unknown): unknown {
+  if (typeof data !== "string") return data;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function validateFrame(input: unknown, maxSamples: number): NeuroSignalFrame | null {
+  if (!isRecord(input)) return null;
+  const timestamp = input.timestamp;
+  const samplingRateHz = input.samplingRateHz;
+  const channels = input.channels;
+  if (typeof timestamp !== "number" || typeof samplingRateHz !== "number") return null;
+  if (!Number.isFinite(timestamp) || !Number.isFinite(samplingRateHz)) return null;
+  if (samplingRateHz <= 0 || !Array.isArray(channels) || channels.length === 0) return null;
+
+  const parsedChannels = channels.flatMap((channel): readonly NeuroSignalChannel[] => {
+    if (!isRecord(channel)) return [];
+    const name = channel.name;
+    const rawSamples = channel.samples;
+    if (typeof name !== "string" || name.length === 0 || !Array.isArray(rawSamples)) return [];
+    if (!rawSamples.every((sample) => typeof sample === "number" && Number.isFinite(sample))) {
+      return [];
+    }
+    const samples = rawSamples.slice(0, maxSamples);
+    if (samples.length === 0) return [];
+    const type = typeof channel.type === "string" ? channel.type : "unknown";
+    return [{ name, type: normalizeKind(type), samples }];
+  });
+
+  if (parsedChannels.length === 0) return null;
+  return { timestamp, samplingRateHz, channels: parsedChannels };
+}
+
+function normalizeKind(kind: string): NeuroSignalKind {
+  if (kind === "eeg" || kind === "emg" || kind === "eog" || kind === "ecg") return kind;
+  return "unknown";
+}
+
+function mean(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  return samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+}
+
+function median(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const midpoint = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[midpoint] ?? 0;
+  return ((sorted[midpoint - 1] ?? 0) + (sorted[midpoint] ?? 0)) / 2;
+}
+
+function variance(samples: readonly number[], sampleMean: number): number {
+  if (samples.length === 0) return 0;
+  return samples.reduce((sum, sample) => sum + (sample - sampleMean) ** 2, 0) / samples.length;
+}
+
+function rms(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  return Math.sqrt(samples.reduce((sum, sample) => sum + sample ** 2, 0) / samples.length);
+}
+
+function removeNoise(
+  samples: readonly number[],
+  sigma: number,
+): { readonly samples: readonly number[]; readonly rejected: number } {
+  const baseline = median(samples);
+  const centered = samples.map((sample) => sample - baseline);
+  const absoluteDeviations = centered.map((sample) => Math.abs(sample));
+  const robustStd = median(absoluteDeviations) * 1.4826;
+  const limit = robustStd > 0 ? robustStd * sigma : sigma;
+  const rejected = centered.filter((sample) => Math.abs(sample) > limit).length;
+  return {
+    samples: centered.map((sample) => Math.max(-limit, Math.min(limit, sample))),
+    rejected,
+  };
+}
+
+function zeroCrossingRate(samples: readonly number[]): number {
+  if (samples.length < 2) return 0;
+  const crossings = samples.slice(1).filter((sample, index) => {
+    const previous = samples[index] ?? 0;
+    return (previous < 0 && sample >= 0) || (previous >= 0 && sample < 0);
+  }).length;
+  return roundMetric(crossings / (samples.length - 1));
+}
+
+function computeBandPowers(samples: readonly number[], samplingRateHz: number): NeuroBandPowers {
+  const bins = samples.map((_, index) => index).slice(1, Math.floor(samples.length / 2) + 1);
+  const powers = bins.map((bin) => {
+    const frequency = (bin * samplingRateHz) / samples.length;
+    const real = samples.reduce(
+      (sum, sample, index) => sum + sample * Math.cos((2 * Math.PI * bin * index) / samples.length),
+      0,
+    );
+    const imaginary = samples.reduce(
+      (sum, sample, index) => sum - sample * Math.sin((2 * Math.PI * bin * index) / samples.length),
+      0,
+    );
+    return { frequency, power: real ** 2 + imaginary ** 2 };
+  });
+
+  const sumBand = (low: number, high: number): number =>
+    roundMetric(
+      powers
+        .filter((entry) => entry.frequency >= low && entry.frequency < high)
+        .reduce((sum, entry) => sum + entry.power, 0),
+    );
+
+  return {
+    delta: sumBand(0.5, 4),
+    theta: sumBand(4, 8),
+    alpha: sumBand(8, 13),
+    beta: sumBand(13, 30),
+    gamma: sumBand(30, 100),
+  };
+}
+
+function extractFeatures(frame: NeuroSignalFrame, cfg: ResolvedConfig): NeuroSignalFeatures {
+  return {
+    timestamp: frame.timestamp,
+    samplingRateHz: frame.samplingRateHz,
+    channels: frame.channels.map((channel) => {
+      const filtered = removeNoise(channel.samples, cfg.noiseSigma);
+      const sampleMean = mean(filtered.samples);
+      const sampleVariance = variance(filtered.samples, sampleMean);
+      const peakAmplitude = filtered.samples.reduce(
+        (peak, sample) => Math.max(peak, Math.abs(sample)),
+        0,
+      );
+      return {
+        name: channel.name,
+        type: channel.type ?? "unknown",
+        sampleCount: filtered.samples.length,
+        mean: roundMetric(sampleMean),
+        rms: roundMetric(rms(filtered.samples)),
+        variance: roundMetric(sampleVariance),
+        peakAmplitude: roundMetric(peakAmplitude),
+        zeroCrossingRate: zeroCrossingRate(filtered.samples),
+        noiseRejectedSamples: filtered.rejected,
+        bandPowers: computeBandPowers(filtered.samples, frame.samplingRateHz),
+      };
+    }),
+  };
+}
+
+function aggregateBand(features: NeuroSignalFeatures, band: keyof NeuroBandPowers): number {
+  const eeg = features.channels.filter((channel) => channel.type === "eeg");
+  if (eeg.length === 0) return 0;
+  return eeg.reduce((sum, channel) => sum + channel.bandPowers[band], 0) / eeg.length;
+}
+
+function estimateCognitiveState(
+  features: NeuroSignalFeatures,
+  sampledAt: number,
+): CognitiveStateEstimate {
+  const theta = aggregateBand(features, "theta");
+  const alpha = aggregateBand(features, "alpha");
+  const beta = aggregateBand(features, "beta");
+  const gamma = aggregateBand(features, "gamma");
+  const total = theta + alpha + beta + gamma;
+  const confidence = clamp01(features.channels.length / 4);
+  if (total <= 0) return { ...EMPTY_STATE, sampledAt };
+
+  const attention = clamp01((beta + gamma) / total);
+  const fatigue = clamp01((theta + alpha * 0.5) / total);
+  const engagement = clamp01((beta + alpha) / total);
+  return { attention, fatigue, engagement, confidence, sampledAt };
+}
+
+function pruneEvents(
+  events: readonly NeuroSkillStateEvent[],
+  cfg: ResolvedConfig,
+  now: number,
+): readonly NeuroSkillStateEvent[] {
+  const cutoff = now - cfg.windowMs;
+  return events
+    .filter((event) => event.timestamp >= cutoff && event.timestamp <= now)
+    .slice(-cfg.maxEvents);
+}
+
+function notifySubscribers(
+  subscribers: ReadonlySet<NeuroSkillSubscriber>,
+  event: NeuroSkillStateEvent,
+): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(event);
+    } catch {
+      // Sensor consumers are isolated so one broken stream listener cannot stop ingestion.
+    }
+  }
+}
+
+function wrapSocket(raw: unknown): NeuroSkillSocket {
+  if ((typeof raw !== "object" && typeof raw !== "function") || raw === null) {
+    throw new Error("WebSocket constructor returned a non-object socket");
+  }
+
+  return {
+    close() {
+      const close = Reflect.get(raw, "close");
+      if (typeof close === "function") Reflect.apply(close, raw, []);
+    },
+    addEventListener(type, handler) {
+      const addEventListener = Reflect.get(raw, "addEventListener");
+      if (typeof addEventListener !== "function") return;
+      Reflect.apply(addEventListener, raw, [type, handler]);
+    },
+  };
+}
+
+function defaultSocketFactory(url: string): NeuroSkillSocket {
+  const maybeWebSocket: unknown = Reflect.get(globalThis, "WebSocket");
+  if (typeof maybeWebSocket !== "function") {
+    throw new Error("WebSocket is unavailable; pass socketFactory to createNeuroSkillSensor");
+  }
+  return wrapSocket(Reflect.construct(maybeWebSocket, [url]));
+}
+
+export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): NeuroSkillSensor {
+  const cfg = resolveConfig(config);
+  const subscribers = new Set<NeuroSkillSubscriber>();
+  // Mutable state is held inside the sensor instance; public snapshots are immutable copies.
+  const state: MutableState = {
+    connectionState: "idle",
+    socket: undefined,
+    events: [],
+    rejectedFrames: 0,
+    latestFeatures: EMPTY_FEATURES,
+    cognitiveState: EMPTY_STATE,
+  };
+
+  const rejectFrame = (): false => {
+    state.rejectedFrames += 1;
+    return false;
+  };
+
+  const record = (frameInput: unknown): boolean => {
+    const frame = validateFrame(frameInput, cfg.maxSamplesPerChannel);
+    if (frame === null) return rejectFrame();
+    const features = extractFeatures(frame, cfg);
+    const cognitiveState = estimateCognitiveState(features, cfg.now());
+    const event: NeuroSkillStateEvent = {
+      kind: "cognitive_state",
+      timestamp: frame.timestamp,
+      features,
+      state: cognitiveState,
+    };
+    state.latestFeatures = features;
+    state.cognitiveState = cognitiveState;
+    state.events = pruneEvents([...state.events, event], cfg, cfg.now());
+    notifySubscribers(subscribers, event);
+    return true;
+  };
+
+  const snapshot = (): NeuroSkillSnapshot => {
+    const now = cfg.now();
+    state.events = pruneEvents(state.events, cfg, now);
+    return {
+      connectionState: state.connectionState,
+      cognitiveState: state.cognitiveState,
+      latestFeatures: state.latestFeatures,
+      recentEvents: state.events.map((event) => ({
+        kind: event.kind,
+        timestamp: event.timestamp,
+      })),
+      retainedEventCount: state.events.length,
+      rejectedFrames: state.rejectedFrames,
+      sampledAt: now,
+      windowMs: cfg.windowMs,
+    };
+  };
+
+  return {
+    name: cfg.name,
+    connect(url) {
+      state.socket?.close?.();
+      const socket = (cfg.socketFactory ?? defaultSocketFactory)(url);
+      state.socket = socket;
+      state.connectionState = "connected";
+      const onMessage = (event: { readonly data?: unknown }): void => {
+        const parsed = parseJson(event.data);
+        if (parsed === null) {
+          rejectFrame();
+          return;
+        }
+        record(parsed);
+      };
+      const onClose = (): void => {
+        state.connectionState = "disconnected";
+      };
+      const onError = (): void => {
+        state.connectionState = "error";
+      };
+      if (socket.addEventListener !== undefined) {
+        socket.addEventListener("message", onMessage);
+        socket.addEventListener("close", onClose);
+        socket.addEventListener("error", onError);
+      }
+      socket.onmessage = onMessage;
+      socket.onclose = onClose;
+      socket.onerror = onError;
+    },
+    disconnect() {
+      state.socket?.close?.();
+      state.socket = undefined;
+      state.connectionState = "disconnected";
+    },
+    record,
+    subscribe(handler) {
+      subscribers.add(handler);
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+    snapshot,
+    read(): UserSignal {
+      return {
+        kind: "sensor",
+        source: cfg.source,
+        values: snapshot(),
+      };
+    },
+    clear() {
+      state.events = [];
+      state.rejectedFrames = 0;
+      state.latestFeatures = EMPTY_FEATURES;
+      state.cognitiveState = EMPTY_STATE;
+    },
+  };
+}

--- a/packages/lib/sensor-neuroskill/src/neuroskill-sensor.ts
+++ b/packages/lib/sensor-neuroskill/src/neuroskill-sensor.ts
@@ -1,4 +1,5 @@
 import type { SignalSource, UserSignal } from "@koi/core";
+import { estimateCognitiveState, extractFeatures, validateFrame } from "./signal-processing.js";
 
 export type NeuroSignalKind = "eeg" | "emg" | "eog" | "ecg" | "unknown";
 export type NeuroSkillConnectionState = "idle" | "connected" | "disconnected" | "error";
@@ -169,22 +170,6 @@ function resolveConfig(config: NeuroSkillSensorConfig): ResolvedConfig {
   };
 }
 
-function roundMetric(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * 1000) / 1000;
-}
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  if (value < 0) return 0;
-  if (value > 1) return 1;
-  return roundMetric(value);
-}
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function parseJson(data: unknown): unknown {
   if (typeof data !== "string") return data;
   try {
@@ -193,169 +178,6 @@ function parseJson(data: unknown): unknown {
   } catch {
     return null;
   }
-}
-
-function validateFrame(input: unknown, maxSamples: number): NeuroSignalFrame | null {
-  if (!isRecord(input)) return null;
-  const timestamp = input.timestamp;
-  const samplingRateHz = input.samplingRateHz;
-  const channels = input.channels;
-  if (typeof timestamp !== "number" || typeof samplingRateHz !== "number") return null;
-  if (!Number.isFinite(timestamp) || !Number.isFinite(samplingRateHz)) return null;
-  if (samplingRateHz <= 0 || !Array.isArray(channels) || channels.length === 0) return null;
-
-  const parsedChannels = channels.flatMap((channel): readonly NeuroSignalChannel[] => {
-    if (!isRecord(channel)) return [];
-    const name = channel.name;
-    const rawSamples = channel.samples;
-    if (typeof name !== "string" || name.length === 0 || !Array.isArray(rawSamples)) return [];
-    if (!rawSamples.every((sample) => typeof sample === "number" && Number.isFinite(sample))) {
-      return [];
-    }
-    const samples = rawSamples.slice(0, maxSamples);
-    if (samples.length === 0) return [];
-    const type = typeof channel.type === "string" ? channel.type : "unknown";
-    return [{ name, type: normalizeKind(type), samples }];
-  });
-
-  if (parsedChannels.length === 0) return null;
-  return { timestamp, samplingRateHz, channels: parsedChannels };
-}
-
-function normalizeKind(kind: string): NeuroSignalKind {
-  if (kind === "eeg" || kind === "emg" || kind === "eog" || kind === "ecg") return kind;
-  return "unknown";
-}
-
-function mean(samples: readonly number[]): number {
-  if (samples.length === 0) return 0;
-  return samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
-}
-
-function median(samples: readonly number[]): number {
-  if (samples.length === 0) return 0;
-  const sorted = [...samples].sort((a, b) => a - b);
-  const midpoint = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) return sorted[midpoint] ?? 0;
-  return ((sorted[midpoint - 1] ?? 0) + (sorted[midpoint] ?? 0)) / 2;
-}
-
-function variance(samples: readonly number[], sampleMean: number): number {
-  if (samples.length === 0) return 0;
-  return samples.reduce((sum, sample) => sum + (sample - sampleMean) ** 2, 0) / samples.length;
-}
-
-function rms(samples: readonly number[]): number {
-  if (samples.length === 0) return 0;
-  return Math.sqrt(samples.reduce((sum, sample) => sum + sample ** 2, 0) / samples.length);
-}
-
-function removeNoise(
-  samples: readonly number[],
-  sigma: number,
-): { readonly samples: readonly number[]; readonly rejected: number } {
-  const baseline = median(samples);
-  const centered = samples.map((sample) => sample - baseline);
-  const absoluteDeviations = centered.map((sample) => Math.abs(sample));
-  const robustStd = median(absoluteDeviations) * 1.4826;
-  const limit = robustStd > 0 ? robustStd * sigma : sigma;
-  const rejected = centered.filter((sample) => Math.abs(sample) > limit).length;
-  return {
-    samples: centered.map((sample) => Math.max(-limit, Math.min(limit, sample))),
-    rejected,
-  };
-}
-
-function zeroCrossingRate(samples: readonly number[]): number {
-  if (samples.length < 2) return 0;
-  const crossings = samples.slice(1).filter((sample, index) => {
-    const previous = samples[index] ?? 0;
-    return (previous < 0 && sample >= 0) || (previous >= 0 && sample < 0);
-  }).length;
-  return roundMetric(crossings / (samples.length - 1));
-}
-
-function computeBandPowers(samples: readonly number[], samplingRateHz: number): NeuroBandPowers {
-  const bins = samples.map((_, index) => index).slice(1, Math.floor(samples.length / 2) + 1);
-  const powers = bins.map((bin) => {
-    const frequency = (bin * samplingRateHz) / samples.length;
-    const real = samples.reduce(
-      (sum, sample, index) => sum + sample * Math.cos((2 * Math.PI * bin * index) / samples.length),
-      0,
-    );
-    const imaginary = samples.reduce(
-      (sum, sample, index) => sum - sample * Math.sin((2 * Math.PI * bin * index) / samples.length),
-      0,
-    );
-    return { frequency, power: real ** 2 + imaginary ** 2 };
-  });
-
-  const sumBand = (low: number, high: number): number =>
-    roundMetric(
-      powers
-        .filter((entry) => entry.frequency >= low && entry.frequency < high)
-        .reduce((sum, entry) => sum + entry.power, 0),
-    );
-
-  return {
-    delta: sumBand(0.5, 4),
-    theta: sumBand(4, 8),
-    alpha: sumBand(8, 13),
-    beta: sumBand(13, 30),
-    gamma: sumBand(30, 100),
-  };
-}
-
-function extractFeatures(frame: NeuroSignalFrame, cfg: ResolvedConfig): NeuroSignalFeatures {
-  return {
-    timestamp: frame.timestamp,
-    samplingRateHz: frame.samplingRateHz,
-    channels: frame.channels.map((channel) => {
-      const filtered = removeNoise(channel.samples, cfg.noiseSigma);
-      const sampleMean = mean(filtered.samples);
-      const sampleVariance = variance(filtered.samples, sampleMean);
-      const peakAmplitude = filtered.samples.reduce(
-        (peak, sample) => Math.max(peak, Math.abs(sample)),
-        0,
-      );
-      return {
-        name: channel.name,
-        type: channel.type ?? "unknown",
-        sampleCount: filtered.samples.length,
-        mean: roundMetric(sampleMean),
-        rms: roundMetric(rms(filtered.samples)),
-        variance: roundMetric(sampleVariance),
-        peakAmplitude: roundMetric(peakAmplitude),
-        zeroCrossingRate: zeroCrossingRate(filtered.samples),
-        noiseRejectedSamples: filtered.rejected,
-        bandPowers: computeBandPowers(filtered.samples, frame.samplingRateHz),
-      };
-    }),
-  };
-}
-
-function aggregateBand(features: NeuroSignalFeatures, band: keyof NeuroBandPowers): number {
-  const eeg = features.channels.filter((channel) => channel.type === "eeg");
-  if (eeg.length === 0) return 0;
-  return eeg.reduce((sum, channel) => sum + channel.bandPowers[band], 0) / eeg.length;
-}
-
-function estimateCognitiveState(
-  features: NeuroSignalFeatures,
-  sampledAt: number,
-): CognitiveStateEstimate {
-  const theta = aggregateBand(features, "theta");
-  const alpha = aggregateBand(features, "alpha");
-  const beta = aggregateBand(features, "beta");
-  const gamma = aggregateBand(features, "gamma");
-  const total = theta + alpha + beta + gamma;
-  const confidence = clamp01(features.channels.length / 4);
-  if (total <= 0) return { ...EMPTY_STATE, sampledAt };
-
-  const attention = clamp01((beta + gamma) / total);
-  const fatigue = clamp01((theta + alpha * 0.5) / total);
-  const engagement = clamp01((beta + alpha) / total);
-  return { attention, fatigue, engagement, confidence, sampledAt };
 }
 
 function pruneEvents(
@@ -408,11 +230,8 @@ function defaultSocketFactory(url: string): NeuroSkillSocket {
   return wrapSocket(Reflect.construct(maybeWebSocket, [url]));
 }
 
-export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): NeuroSkillSensor {
-  const cfg = resolveConfig(config);
-  const subscribers = new Set<NeuroSkillSubscriber>();
-  // Mutable state is held inside the sensor instance; public snapshots are immutable copies.
-  const state: MutableState = {
+function createInitialState(): MutableState {
+  return {
     connectionState: "idle",
     socket: undefined,
     events: [],
@@ -420,15 +239,21 @@ export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): Neu
     latestFeatures: EMPTY_FEATURES,
     cognitiveState: EMPTY_STATE,
   };
+}
 
-  const rejectFrame = (): false => {
-    state.rejectedFrames += 1;
-    return false;
-  };
+function rejectFrame(state: MutableState): false {
+  state.rejectedFrames += 1;
+  return false;
+}
 
-  const record = (frameInput: unknown): boolean => {
+function createRecorder(
+  state: MutableState,
+  cfg: ResolvedConfig,
+  subscribers: ReadonlySet<NeuroSkillSubscriber>,
+): (frame: unknown) => boolean {
+  return (frameInput: unknown): boolean => {
     const frame = validateFrame(frameInput, cfg.maxSamplesPerChannel);
-    if (frame === null) return rejectFrame();
+    if (frame === null) return rejectFrame(state);
     const features = extractFeatures(frame, cfg);
     const cognitiveState = estimateCognitiveState(features, cfg.now());
     const event: NeuroSkillStateEvent = {
@@ -443,8 +268,10 @@ export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): Neu
     notifySubscribers(subscribers, event);
     return true;
   };
+}
 
-  const snapshot = (): NeuroSkillSnapshot => {
+function createSnapshotReader(state: MutableState, cfg: ResolvedConfig): () => NeuroSkillSnapshot {
+  return () => {
     const now = cfg.now();
     state.events = pruneEvents(state.events, cfg, now);
     return {
@@ -461,6 +288,41 @@ export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): Neu
       windowMs: cfg.windowMs,
     };
   };
+}
+
+function attachSocketHandlers(
+  socket: NeuroSkillSocket,
+  state: MutableState,
+  record: (frame: unknown) => boolean,
+): void {
+  const onMessage = (event: { readonly data?: unknown }): void => {
+    const parsed = parseJson(event.data);
+    if (parsed === null) {
+      rejectFrame(state);
+      return;
+    }
+    record(parsed);
+  };
+  const onClose = (): void => {
+    state.connectionState = "disconnected";
+  };
+  const onError = (): void => {
+    state.connectionState = "error";
+  };
+  socket.addEventListener?.("message", onMessage);
+  socket.addEventListener?.("close", onClose);
+  socket.addEventListener?.("error", onError);
+  socket.onmessage = onMessage;
+  socket.onclose = onClose;
+  socket.onerror = onError;
+}
+
+export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): NeuroSkillSensor {
+  const cfg = resolveConfig(config);
+  const subscribers = new Set<NeuroSkillSubscriber>();
+  const state = createInitialState();
+  const record = createRecorder(state, cfg, subscribers);
+  const snapshot = createSnapshotReader(state, cfg);
 
   return {
     name: cfg.name,
@@ -469,28 +331,7 @@ export function createNeuroSkillSensor(config: NeuroSkillSensorConfig = {}): Neu
       const socket = (cfg.socketFactory ?? defaultSocketFactory)(url);
       state.socket = socket;
       state.connectionState = "connected";
-      const onMessage = (event: { readonly data?: unknown }): void => {
-        const parsed = parseJson(event.data);
-        if (parsed === null) {
-          rejectFrame();
-          return;
-        }
-        record(parsed);
-      };
-      const onClose = (): void => {
-        state.connectionState = "disconnected";
-      };
-      const onError = (): void => {
-        state.connectionState = "error";
-      };
-      if (socket.addEventListener !== undefined) {
-        socket.addEventListener("message", onMessage);
-        socket.addEventListener("close", onClose);
-        socket.addEventListener("error", onError);
-      }
-      socket.onmessage = onMessage;
-      socket.onclose = onClose;
-      socket.onerror = onError;
+      attachSocketHandlers(socket, state, record);
     },
     disconnect() {
       state.socket?.close?.();

--- a/packages/lib/sensor-neuroskill/src/signal-processing.ts
+++ b/packages/lib/sensor-neuroskill/src/signal-processing.ts
@@ -1,0 +1,193 @@
+import type {
+  CognitiveStateEstimate,
+  NeuroBandPowers,
+  NeuroSignalFeatures,
+  NeuroSignalFrame,
+  NeuroSignalKind,
+} from "./neuroskill-sensor.js";
+
+interface ProcessingConfig {
+  readonly maxSamplesPerChannel: number;
+  readonly noiseSigma: number;
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 1000) / 1000;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return roundMetric(value);
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeKind(kind: string): NeuroSignalKind {
+  if (kind === "eeg" || kind === "emg" || kind === "eog" || kind === "ecg") return kind;
+  return "unknown";
+}
+
+export function validateFrame(input: unknown, maxSamples: number): NeuroSignalFrame | null {
+  if (!isRecord(input)) return null;
+  const { timestamp, samplingRateHz, channels } = input;
+  if (typeof timestamp !== "number" || typeof samplingRateHz !== "number") return null;
+  if (!Number.isFinite(timestamp) || !Number.isFinite(samplingRateHz)) return null;
+  if (samplingRateHz <= 0 || !Array.isArray(channels) || channels.length === 0) return null;
+
+  const parsedChannels = channels.flatMap((channel) => {
+    if (!isRecord(channel)) return [];
+    const { name, samples: rawSamples } = channel;
+    if (typeof name !== "string" || name.length === 0 || !Array.isArray(rawSamples)) return [];
+    if (!rawSamples.every((sample) => typeof sample === "number" && Number.isFinite(sample))) {
+      return [];
+    }
+    const samples = rawSamples.slice(0, maxSamples);
+    if (samples.length === 0) return [];
+    const type = typeof channel.type === "string" ? channel.type : "unknown";
+    return [{ name, type: normalizeKind(type), samples }];
+  });
+
+  if (parsedChannels.length === 0) return null;
+  return { timestamp, samplingRateHz, channels: parsedChannels };
+}
+
+function mean(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  return samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+}
+
+function median(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const midpoint = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[midpoint] ?? 0;
+  return ((sorted[midpoint - 1] ?? 0) + (sorted[midpoint] ?? 0)) / 2;
+}
+
+function variance(samples: readonly number[], sampleMean: number): number {
+  if (samples.length === 0) return 0;
+  return samples.reduce((sum, sample) => sum + (sample - sampleMean) ** 2, 0) / samples.length;
+}
+
+function rms(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  return Math.sqrt(samples.reduce((sum, sample) => sum + sample ** 2, 0) / samples.length);
+}
+
+function removeNoise(
+  samples: readonly number[],
+  sigma: number,
+): { readonly samples: readonly number[]; readonly rejected: number } {
+  const baseline = median(samples);
+  const centered = samples.map((sample) => sample - baseline);
+  const absoluteDeviations = centered.map((sample) => Math.abs(sample));
+  const robustStd = median(absoluteDeviations) * 1.4826;
+  const limit = robustStd > 0 ? robustStd * sigma : sigma;
+  const rejected = centered.filter((sample) => Math.abs(sample) > limit).length;
+  return {
+    samples: centered.map((sample) => Math.max(-limit, Math.min(limit, sample))),
+    rejected,
+  };
+}
+
+function zeroCrossingRate(samples: readonly number[]): number {
+  if (samples.length < 2) return 0;
+  const crossings = samples.slice(1).filter((sample, index) => {
+    const previous = samples[index] ?? 0;
+    return (previous < 0 && sample >= 0) || (previous >= 0 && sample < 0);
+  }).length;
+  return roundMetric(crossings / (samples.length - 1));
+}
+
+function computeBandPowers(samples: readonly number[], samplingRateHz: number): NeuroBandPowers {
+  const bins = samples.map((_, index) => index).slice(1, Math.floor(samples.length / 2) + 1);
+  const powers = bins.map((bin) => {
+    const frequency = (bin * samplingRateHz) / samples.length;
+    const real = samples.reduce(
+      (sum, sample, index) => sum + sample * Math.cos((2 * Math.PI * bin * index) / samples.length),
+      0,
+    );
+    const imaginary = samples.reduce(
+      (sum, sample, index) => sum - sample * Math.sin((2 * Math.PI * bin * index) / samples.length),
+      0,
+    );
+    return { frequency, power: real ** 2 + imaginary ** 2 };
+  });
+
+  const sumBand = (low: number, high: number): number =>
+    roundMetric(
+      powers
+        .filter((entry) => entry.frequency >= low && entry.frequency < high)
+        .reduce((sum, entry) => sum + entry.power, 0),
+    );
+
+  return {
+    delta: sumBand(0.5, 4),
+    theta: sumBand(4, 8),
+    alpha: sumBand(8, 13),
+    beta: sumBand(13, 30),
+    gamma: sumBand(30, 100),
+  };
+}
+
+export function extractFeatures(
+  frame: NeuroSignalFrame,
+  cfg: ProcessingConfig,
+): NeuroSignalFeatures {
+  return {
+    timestamp: frame.timestamp,
+    samplingRateHz: frame.samplingRateHz,
+    channels: frame.channels.map((channel) => {
+      const filtered = removeNoise(channel.samples, cfg.noiseSigma);
+      const sampleMean = mean(filtered.samples);
+      const sampleVariance = variance(filtered.samples, sampleMean);
+      const peakAmplitude = filtered.samples.reduce(
+        (peak, sample) => Math.max(peak, Math.abs(sample)),
+        0,
+      );
+      return {
+        name: channel.name,
+        type: channel.type ?? "unknown",
+        sampleCount: filtered.samples.length,
+        mean: roundMetric(sampleMean),
+        rms: roundMetric(rms(filtered.samples)),
+        variance: roundMetric(sampleVariance),
+        peakAmplitude: roundMetric(peakAmplitude),
+        zeroCrossingRate: zeroCrossingRate(filtered.samples),
+        noiseRejectedSamples: filtered.rejected,
+        bandPowers: computeBandPowers(filtered.samples, frame.samplingRateHz),
+      };
+    }),
+  };
+}
+
+function aggregateBand(features: NeuroSignalFeatures, band: keyof NeuroBandPowers): number {
+  const eeg = features.channels.filter((channel) => channel.type === "eeg");
+  if (eeg.length === 0) return 0;
+  return eeg.reduce((sum, channel) => sum + channel.bandPowers[band], 0) / eeg.length;
+}
+
+export function estimateCognitiveState(
+  features: NeuroSignalFeatures,
+  sampledAt: number,
+): CognitiveStateEstimate {
+  const theta = aggregateBand(features, "theta");
+  const alpha = aggregateBand(features, "alpha");
+  const beta = aggregateBand(features, "beta");
+  const gamma = aggregateBand(features, "gamma");
+  const total = theta + alpha + beta + gamma;
+  const confidence = clamp01(features.channels.length / 4);
+  if (total <= 0) {
+    return { attention: 0, fatigue: 0, engagement: 0, confidence: 0, sampledAt };
+  }
+
+  const attention = clamp01((beta + gamma) / total);
+  const fatigue = clamp01((theta + alpha * 0.5) / total);
+  const engagement = clamp01((beta + alpha) / total);
+  return { attention, fatigue, engagement, confidence, sampledAt };
+}

--- a/packages/lib/sensor-neuroskill/tsconfig.json
+++ b/packages/lib/sensor-neuroskill/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../kernel/core"
+    }
+  ]
+}

--- a/packages/lib/sensor-neuroskill/tsup.config.ts
+++ b/packages/lib/sensor-neuroskill/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -215,6 +215,7 @@ export const L2_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/scheduler-provider",
   "@koi/search-nexus",
   "@koi/sensor-ide",
+  "@koi/sensor-neuroskill",
   "@koi/session",
   "@koi/skill-distiller",
   "@koi/skill-tool",


### PR DESCRIPTION
## Summary
- Adds optional L2 package `@koi/sensor-neuroskill` for real-time BCI/EXG signal ingestion.
- Implements WebSocket/direct frame ingestion, validation, preprocessing, feature extraction, cognitive-state estimates, bounded event streaming, and `SignalSource.read()` integration.
- Registers the package in layer metadata and adds L2/package coverage docs.

## Review-loop hardening
- Rejects channels containing non-finite samples instead of silently dropping malformed values.
- Makes `read()` stable when used as an unbound `SignalSource` callback.

## Test Plan
- `bun test packages/lib/sensor-neuroskill/src/neuroskill-sensor.test.ts` (10 pass, 0 fail)
- `cd packages/lib/sensor-neuroskill && bun run typecheck && bun run build && bun run lint`
- `bun scripts/check-layers.ts && bun scripts/check-descriptions.ts && bun scripts/check-doc-sync.ts && git diff --check`
- Golden-check: `bun run test --filter=@koi/runtime && bun run check:orphans && bun run check:golden-queries` (runtime: 1092 pass, 7 skip, 0 fail)
- Manual TUI E2E via tmux: TUI booted to `Type a message...`, smoke prompt returned `TUI smoke ok`, permission dialog surfaced on process probe, and precise NeuroSkill prompt confirmed no active live BCI feed is wired into the current TUI session by default
- Full build before TUI: `bun run build` (231 successful, 231 total)
- CI fix: `bun scripts/check-complexity.ts --max-violations 795` reports `795 within ratchet budget of 795`
- Pre-push hook: scoped build/typecheck skipped because branch was already up to date

## Issue Closure
Closes #1385 after this PR merges into `main`.


