### PR TITLE
fix(cli): headless emits accurate tool_call args for streamed adapters

### DIFF
--- a/packages/meta/cli/src/headless/run.test.ts
+++ b/packages/meta/cli/src/headless/run.test.ts
@@ -221,6 +221,58 @@ describe("runHeadless", () => {
     expect(JSON.stringify(result)).not.toContain("file.txt");
   });
 
+  test("streamed tool args (start without args, delta, end) summarize from AccumulatedToolCall", async () => {
+    // Regression: OpenAI-compatible adapters stream tool arguments —
+    // `tool_call_start` carries no args, args arrive via `tool_call_delta`,
+    // and the finalized AccumulatedToolCall lands on `tool_call_end.result`.
+    // Headless used to emit `tool_call` at start, so every streamed call
+    // logged `args:{type:"undefined"}`, blinding CI/headless debugging.
+    const stdout: string[] = [];
+    const callId = toolCallId("c1");
+    await runAndEmit({
+      sessionId: "s",
+      prompt: "x",
+      maxDurationMs: undefined,
+      writeStdout: (s) => stdout.push(s),
+      writeStderr: () => {},
+      runtime: runtimeFromEvents([
+        { kind: "tool_call_start", callId, toolName: "fs_write" },
+        { kind: "tool_call_delta", callId, delta: '{"path":"a.txt",' },
+        { kind: "tool_call_delta", callId, delta: '"content":"hi"}' },
+        {
+          kind: "tool_call_end",
+          callId,
+          result: {
+            toolName: "fs_write",
+            callId,
+            rawArgs: '{"path":"a.txt","content":"hi"}',
+            parsedArgs: { path: "a.txt", content: "hi" },
+          },
+        },
+        { kind: "tool_result", callId, output: { ok: true } },
+        DONE,
+      ]),
+    });
+    const parsed = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const calls = parsed.filter((e) => e.kind === "tool_call");
+    // Exactly one tool_call event, with an accurate (non-undefined) shape.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      toolName: "fs_write",
+      args: { type: "object", size: 2 },
+    });
+    // CI-log safety preserved: still no raw values.
+    expect(JSON.stringify(calls[0])).not.toContain("a.txt");
+    expect(JSON.stringify(calls[0])).not.toContain("hi");
+    // tool_call must still precede its tool_result.
+    const kinds = parsed.map((e) => e.kind);
+    expect(kinds.indexOf("tool_call")).toBeLessThan(kinds.indexOf("tool_result"));
+  });
+
   test("redacts TOOL_EXECUTION_ERROR payload (code + errorSize, no raw message)", async () => {
     // Raw error messages from query-engine can include Bash stderr
     // fragments, URLs, or tokens. Headless emits only the fixed-vocabulary

--- a/packages/meta/cli/src/headless/run.test.ts
+++ b/packages/meta/cli/src/headless/run.test.ts
@@ -273,6 +273,112 @@ describe("runHeadless", () => {
     expect(kinds.indexOf("tool_call")).toBeLessThan(kinds.indexOf("tool_result"));
   });
 
+  test("many sequential tool-call cycles emit exactly one tool_call each (no leak/double-emit)", async () => {
+    // The pending map must be drained per call: each completed cycle deletes
+    // its entry so the map cannot grow unbounded and the finally-flush has
+    // nothing left to re-emit. Observable proxy for "map size does not grow".
+    const stdout: string[] = [];
+    const cycles = 50;
+    const events: EngineEvent[] = [];
+    for (let i = 0; i < cycles; i++) {
+      const callId = toolCallId(`c${i}`);
+      events.push(
+        { kind: "tool_call_start", callId, toolName: `t${i}` },
+        {
+          kind: "tool_call_end",
+          callId,
+          result: { toolName: `t${i}`, callId, rawArgs: "{}", parsedArgs: { i } },
+        },
+        { kind: "tool_result", callId, output: { ok: true } },
+      );
+    }
+    events.push(DONE);
+    await runAndEmit({
+      sessionId: "s",
+      prompt: "x",
+      maxDurationMs: undefined,
+      writeStdout: (s) => stdout.push(s),
+      writeStderr: () => {},
+      runtime: runtimeFromEvents(events),
+    });
+    const parsed = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const calls = parsed.filter((e) => e.kind === "tool_call");
+    // Exactly one tool_call per cycle — no duplicates from a retained entry,
+    // no extras from the finally flush.
+    expect(calls).toHaveLength(cycles);
+    expect(calls.map((c) => c.toolName)).toEqual(Array.from({ length: cycles }, (_, i) => `t${i}`));
+  });
+
+  test("flushes a started tool call when the stream aborts before tool_call_end/tool_result", async () => {
+    // Regression: emission is deferred to tool_call_end (or the tool_result
+    // fallback). If the run is interrupted (timeout, SIGINT, mid-stream
+    // exception) after tool_call_start but before either event, the call
+    // would silently vanish from the NDJSON — operators could not tell which
+    // tool was in flight. The finally-block flush must still emit it once.
+    const stdout: string[] = [];
+    const callId = toolCallId("c1");
+    const { exitCode } = await runAndEmit({
+      sessionId: "s",
+      prompt: "x",
+      maxDurationMs: undefined,
+      writeStdout: (s) => stdout.push(s),
+      writeStderr: () => {},
+      // Stream ends after tool_call_start: no tool_call_end, no tool_result,
+      // no done — the non-done exit path.
+      runtime: runtimeFromEvents([
+        { kind: "tool_call_start", callId, toolName: "Bash", args: { command: "ls" } },
+      ]),
+    });
+    expect(exitCode).toBe(1);
+    const parsed = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const calls = parsed.filter((e) => e.kind === "tool_call");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      toolName: "Bash",
+      args: { type: "object", size: 1 },
+    });
+    // CI-log safety preserved on the flush path too: no raw arg values.
+    expect(JSON.stringify(calls[0])).not.toContain("ls");
+  });
+
+  test("flushes a started tool call when the stream throws mid-run", async () => {
+    const stdout: string[] = [];
+    const callId = toolCallId("c1");
+    const { exitCode } = await runAndEmit({
+      sessionId: "s",
+      prompt: "x",
+      maxDurationMs: undefined,
+      writeStdout: (s) => stdout.push(s),
+      writeStderr: () => {},
+      runtime: runtimeFromFn(
+        (): AsyncIterable<EngineEvent> => ({
+          async *[Symbol.asyncIterator](): AsyncIterator<EngineEvent> {
+            yield { kind: "tool_call_start", callId, toolName: "fs_write", args: { path: "a" } };
+            throw new Error("stream blew up");
+          },
+        }),
+      ),
+    });
+    // mapErrorToExitCode for a generic Error → INTERNAL (5).
+    expect(exitCode).toBe(5);
+    const calls = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      .filter((e) => e.kind === "tool_call");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ toolName: "fs_write", args: { type: "object", size: 1 } });
+  });
+
   test("redacts TOOL_EXECUTION_ERROR payload (code + errorSize, no raw message)", async () => {
     // Raw error messages from query-engine can include Bash stderr
     // fragments, URLs, or tokens. Headless emits only the fixed-vocabulary

--- a/packages/meta/cli/src/headless/run.ts
+++ b/packages/meta/cli/src/headless/run.ts
@@ -120,6 +120,7 @@ export async function runHeadless(opts: RunHeadlessOptions): Promise<HeadlessOut
   opts.externalSignal?.addEventListener("abort", externalAbortHandler, { once: true });
 
   const toolNamesByCallId = new Map<string, string>();
+  const pendingToolCalls = new Map<string, PendingToolCall>();
   // let: mutable across event loop iterations.
   let exitCode: HeadlessExitCode = HEADLESS_EXIT.SUCCESS;
   let errMessage: string | undefined;
@@ -140,7 +141,14 @@ export async function runHeadless(opts: RunHeadlessOptions): Promise<HeadlessOut
       signal: controller.signal,
     })) {
       if (
-        translateEvent(event, emit, toolNamesByCallId, opts.onRawAssistantText, handleToolResult)
+        translateEvent(
+          event,
+          emit,
+          toolNamesByCallId,
+          pendingToolCalls,
+          opts.onRawAssistantText,
+          handleToolResult,
+        )
       ) {
         emittedAssistantText = true;
       }
@@ -494,11 +502,29 @@ export function redactEngineBanners(text: string): string {
   });
 }
 
+/** Per-call accumulation so the headless `tool_call` event reflects the
+ *  FINAL arguments. OpenAI-compatible adapters stream args: `tool_call_start`
+ *  carries none, args arrive via `tool_call_delta`, and the parsed
+ *  AccumulatedToolCall lands on `tool_call_end.result`. Emitting at start
+ *  therefore logged `args:{type:"undefined"}` for every streamed call. */
+interface PendingToolCall {
+  readonly toolName: string;
+  readonly startArgs: unknown;
+  emitted: boolean;
+}
+
+/** Structural guard for the AccumulatedToolCall carried on
+ *  `tool_call_end.result` (typed `unknown` in the EngineEvent contract). */
+function hasParsedArgs(v: unknown): v is { readonly parsedArgs?: unknown } {
+  return typeof v === "object" && v !== null && "parsedArgs" in v;
+}
+
 /** Returns `true` if the event caused assistant text to be emitted. */
 function translateEvent(
   event: EngineEvent,
   emit: ReturnType<typeof createEmitter>,
   toolNamesByCallId: Map<string, string>,
+  pendingToolCalls: Map<string, PendingToolCall>,
   onRawAssistantText: ((text: string) => void) | undefined,
   onToolResult: (() => void) | undefined,
 ): boolean {
@@ -513,13 +539,47 @@ function translateEvent(
     }
     case "tool_call_start": {
       toolNamesByCallId.set(event.callId, event.toolName);
-      // Default to redacted: emit only tool identity + args shape, never
-      // the actual args. CI log exfiltration risk (see summarizePayload).
-      emit({ kind: "tool_call", toolName: event.toolName, args: summarizePayload(event.args) });
+      // Defer emission: streamed args are not known yet. Stash any args the
+      // adapter did provide up front (non-streaming adapters) as a fallback.
+      pendingToolCalls.set(event.callId, {
+        toolName: event.toolName,
+        startArgs: event.args,
+        emitted: false,
+      });
+      return false;
+    }
+    case "tool_call_delta": {
+      // Args accumulate inside the engine; the parsed result arrives on
+      // tool_call_end. Nothing to emit per-fragment.
+      return false;
+    }
+    case "tool_call_end": {
+      const pending = pendingToolCalls.get(event.callId);
+      const toolName = pending?.toolName ?? toolNamesByCallId.get(event.callId) ?? "unknown";
+      if (pending?.emitted) return false;
+      // Prefer the finalized parsed args from the AccumulatedToolCall; fall
+      // back to any args the adapter supplied on tool_call_start. Still
+      // redacted: only the shape (type + size) reaches CI logs.
+      const finalArgs = hasParsedArgs(event.result) ? event.result.parsedArgs : undefined;
+      const argsForSummary = finalArgs !== undefined ? finalArgs : pending?.startArgs;
+      emit({ kind: "tool_call", toolName, args: summarizePayload(argsForSummary) });
+      if (pending) pending.emitted = true;
       return false;
     }
     case "tool_result": {
       const toolName = toolNamesByCallId.get(event.callId) ?? "unknown";
+      // Fallback: some adapters never emit tool_call_end. Ensure the
+      // tool_call event is still logged (once) before its result, using
+      // whatever args were provided up front.
+      const pending = pendingToolCalls.get(event.callId);
+      if (pending && !pending.emitted) {
+        emit({
+          kind: "tool_call",
+          toolName: pending.toolName,
+          args: summarizePayload(pending.startArgs),
+        });
+        pending.emitted = true;
+      }
       const ok = !isToolExecutionError(event.output);
       // TOOL_EXECUTION_ERROR payloads carry { error, code } where `error`
       // is the caught exception's .message — for Bash/HTTP tools that can

--- a/packages/meta/cli/src/headless/run.ts
+++ b/packages/meta/cli/src/headless/run.ts
@@ -242,6 +242,21 @@ export async function runHeadless(opts: RunHeadlessOptions): Promise<HeadlessOut
   } finally {
     if (timer !== undefined) clearTimeout(timer);
     opts.externalSignal?.removeEventListener("abort", externalAbortHandler);
+    // Flush any tool call that started but never reached tool_call_end /
+    // tool_result. On abort (timeout, SIGINT) or a mid-stream exception the
+    // loop exits before those events, so without this every interrupted
+    // invocation would silently drop its tool_call record — operators could
+    // not tell which tool was in flight or correlate partial side effects.
+    // Emit-on-completion is the normal path; this is the only safety net for
+    // the non-done exit paths.
+    for (const [callId, pending] of pendingToolCalls) {
+      emit({
+        kind: "tool_call",
+        toolName: pending.toolName,
+        args: pending.startArgsSummary,
+      });
+      pendingToolCalls.delete(callId);
+    }
   }
 
   // let: true once emitResult has been invoked. Guards against double-emit
@@ -509,8 +524,10 @@ export function redactEngineBanners(text: string): string {
  *  therefore logged `args:{type:"undefined"}` for every streamed call. */
 interface PendingToolCall {
   readonly toolName: string;
-  readonly startArgs: unknown;
-  emitted: boolean;
+  // Only the redacted shape is retained — never the raw argument object.
+  // Storing the summary at start time keeps zero sensitive payload in memory
+  // for the lifetime of the run (heap-snapshot / crash-artifact safety).
+  readonly startArgsSummary: { readonly type: string; readonly size?: number };
 }
 
 /** Structural guard for the AccumulatedToolCall carried on
@@ -543,8 +560,7 @@ function translateEvent(
       // adapter did provide up front (non-streaming adapters) as a fallback.
       pendingToolCalls.set(event.callId, {
         toolName: event.toolName,
-        startArgs: event.args,
-        emitted: false,
+        startArgsSummary: summarizePayload(event.args),
       });
       return false;
     }
@@ -556,14 +572,19 @@ function translateEvent(
     case "tool_call_end": {
       const pending = pendingToolCalls.get(event.callId);
       const toolName = pending?.toolName ?? toolNamesByCallId.get(event.callId) ?? "unknown";
-      if (pending?.emitted) return false;
       // Prefer the finalized parsed args from the AccumulatedToolCall; fall
       // back to any args the adapter supplied on tool_call_start. Still
       // redacted: only the shape (type + size) reaches CI logs.
       const finalArgs = hasParsedArgs(event.result) ? event.result.parsedArgs : undefined;
-      const argsForSummary = finalArgs !== undefined ? finalArgs : pending?.startArgs;
-      emit({ kind: "tool_call", toolName, args: summarizePayload(argsForSummary) });
-      if (pending) pending.emitted = true;
+      const argsSummary =
+        finalArgs !== undefined
+          ? summarizePayload(finalArgs)
+          : (pending?.startArgsSummary ?? summarizePayload(undefined));
+      emit({ kind: "tool_call", toolName, args: argsSummary });
+      // Drop the pending record now that it's emitted: bounds the map on
+      // many-tool-call streams and shrinks the abort-path flush set.
+      // toolNamesByCallId is intentionally kept — tool_result still reads it.
+      pendingToolCalls.delete(event.callId);
       return false;
     }
     case "tool_result": {
@@ -572,14 +593,16 @@ function translateEvent(
       // tool_call event is still logged (once) before its result, using
       // whatever args were provided up front.
       const pending = pendingToolCalls.get(event.callId);
-      if (pending && !pending.emitted) {
+      if (pending !== undefined) {
         emit({
           kind: "tool_call",
           toolName: pending.toolName,
-          args: summarizePayload(pending.startArgs),
+          args: pending.startArgsSummary,
         });
-        pending.emitted = true;
       }
+      // Whether emitted here or earlier at tool_call_end, the call is now
+      // accounted for — drop it so the map doesn't grow across the run.
+      pendingToolCalls.delete(event.callId);
       const ok = !isToolExecutionError(event.output);
       // TOOL_EXECUTION_ERROR payloads carry { error, code } where `error`
       // is the caught exception's .message — for Bash/HTTP tools that can


### PR DESCRIPTION
## Summary

Fixes a headless/CI observability bug found while root-causing ClawBench failures.

OpenAI-compatible adapters **stream** tool arguments: `tool_call_start` carries no args, args arrive via `tool_call_delta`, and the parsed `AccumulatedToolCall` lands on `tool_call_end.result`. The headless NDJSON translator emitted the `tool_call` event at `tool_call_start`, so **every streamed tool call logged `args:{"type":"undefined"}`** — making headless/CI runs blind to tool inputs (this is exactly why the `cs-003` ClawBench failure was hard to diagnose).

## Change

- Defer the `tool_call` emission to `tool_call_end` and summarize the finalized `parsedArgs`.
- CI-log redaction is **preserved** — still only `{type, size}`, never raw values.
- Fallbacks for non-streaming adapters (args on `tool_call_start`, or no `tool_call_end` at all) guarantee **exactly one `tool_call` per `callId`, always before its `tool_result`**.
- Regression test added covering the streamed start→delta→end→result sequence.

## Test plan

- [x] New regression test fails before the fix, passes after
- [x] Full headless suite green (47 tests, incl. existing non-streaming + TOOL_EXECUTION_ERROR redaction tests — no regressions)
- [x] `@koi-agent/cli` typecheck clean, Biome clean, `check:layers` + `check:doc-wiring` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
