### PR TITLE
[codex] Add federation zone routing and Raft consensus

### DIFF
--- a/docs/L2/federation.md
+++ b/docs/L2/federation.md
@@ -7,8 +7,10 @@ monotonic per-zone sequence number.
 
 > **Current contract:** zone registry, fixed-poll sync engine, sequence-cursor
 > deduplication, optional vector-clock metadata, concurrent shared-resource
-> conflict reports (`lww`, `merge`, `manual`), and cross-zone tool routing.
-> Adaptive polling and durable snapshot/truncation policy remain future work.
+> conflict reports (`lww`, `merge`, `manual`), explicit and zone-router driven
+> cross-zone tool routing, plus in-memory Raft-style consensus primitives for
+> federation critical state. Adaptive polling and durable snapshot/truncation
+> policy remain future work.
 
 ---
 
@@ -72,8 +74,15 @@ index.ts                  ← public re-exports
 ├── zone-registry-nexus.ts ← createZoneRegistryNexus() — Nexus-backed
 │                             ZoneRegistry with in-memory projection
 │
-└── federation-middleware.ts ← createFederationMiddleware() — cross-zone
-                               tool call routing via wrapToolCall
+├── zone-router.ts        ← createZoneRouter(), pickHealthyZone() —
+│                            health-aware remote-zone selection
+│
+├── raft-consensus.ts     ← createInMemoryRaftCluster() — deterministic
+│                            leader election, quorum append, partition,
+│                            split-brain detection, and healing
+│
+└── federation-middleware.ts ← createFederationMiddleware() — explicit or
+                               router-selected cross-zone tool routing
 ```
 
 ---
@@ -140,6 +149,12 @@ Agent in Zone B → bash("ls") with targetZoneId: "zone-a"
               ▼
          ToolResponse from Zone A
 ```
+
+When the middleware is constructed with `zoneRouter`, it can also select a
+remote zone when `ctx.metadata.targetZoneId` is absent. This keeps explicit
+operator or gateway routing authoritative: only `undefined` triggers
+auto-routing. Present-but-invalid metadata, such as a numeric `targetZoneId`,
+falls through locally rather than being silently replaced by a router choice.
 
 ### Event-sourced sync
 
@@ -299,16 +314,23 @@ await engine[Symbol.asyncDispose]();
 
 ### `createFederationMiddleware(config)`
 
-`KoiMiddleware` that transparently routes cross-zone tool calls.
+`KoiMiddleware` that transparently routes cross-zone tool calls. Explicit
+`ctx.metadata.targetZoneId` still wins. If it is absent and `zoneRouter` is
+configured, the middleware asks the router for the healthiest target zone.
 
 ```typescript
-import { createFederationMiddleware } from "@koi/federation";
+import { createFederationMiddleware, createZoneRouter } from "@koi/federation";
+
+const zoneRouter = createZoneRouter({
+  healthMonitor,
+});
 
 const mw = createFederationMiddleware({
   localZoneId: zoneId("us-east-1"),
   remoteClients: new Map([
     ["us-west-2", nexusClientForWest],
   ]),
+  zoneRouter,
   onDelegated: (targetZone, request) => {
     console.log(`Delegated ${request.toolId} to ${targetZone}`);
   },
@@ -322,12 +344,64 @@ const mw = createFederationMiddleware({
 
 | `ctx.metadata.targetZoneId` | Behavior |
 |-----------------------------|----------|
-| absent | Pass through (local) |
+| absent + no `zoneRouter` | Pass through (local) |
+| absent + `zoneRouter` selects remote | Route via `rpc("federation.zone_execute")` |
+| present but not a string | Pass through (local) |
 | matches `localZoneId` | Pass through (local) |
 | known remote zone | Route via `rpc("federation.zone_execute")` |
 | unknown zone | Return `EXTERNAL` error |
 
 ---
+
+### `createZoneRouter(config)` and `pickHealthyZone(candidates)`
+
+Zone routing is intentionally small and deterministic. A
+`StaticZoneHealthMonitor` snapshot lists remote candidates with health, latency,
+and optional load. `pickHealthyZone()` filters to `active` zones, then chooses by
+lowest latency, lowest load, and finally zone id for stable tie-breaking.
+
+```typescript
+import { createStaticZoneHealthMonitor, createZoneRouter } from "@koi/federation";
+
+const healthMonitor = createStaticZoneHealthMonitor([
+  { zoneId: "us-west-2", status: "active", latencyMs: 35, load: 0.6 },
+  { zoneId: "eu-west-1", status: "offline", latencyMs: 20, load: 0.1 },
+]);
+
+const router = createZoneRouter({ healthMonitor });
+const target = router.selectZone({ toolId: "bash", input: { command: "uptime" } });
+// → { zoneId: "us-west-2", ... }
+```
+
+Routers return `undefined` when every known zone is unhealthy, allowing the
+middleware to keep the call local instead of fabricating a remote target.
+
+### `createInMemoryRaftCluster(config)`
+
+The Raft helper is a deterministic in-memory consensus model for federation
+critical state. It is not a durable transport implementation; it is the package
+contract and replacement point for production backends that need leader
+election, quorum replication, partition behavior, split-brain detection, and
+healing semantics.
+
+```typescript
+import { createInMemoryRaftCluster } from "@koi/federation";
+
+const cluster = createInMemoryRaftCluster({
+  nodeIds: ["zone-a", "zone-b", "zone-c"],
+});
+
+const leader = cluster.electLeader();
+const append = cluster.append({
+  kind: "zone_descriptor_put",
+  key: "zone-a",
+  value: { status: "active" },
+});
+```
+
+`append()` requires a quorum and fails closed while split-brain is detected.
+After partitions heal, `healPartition()` converges nodes onto the longest
+committed log and elects a single leader.
 
 ## Sync cursor
 
@@ -433,6 +507,9 @@ isVisibleToAgent(brick, "agent-1", "us-east-1");
 | `createSyncEngine(config)` | `SyncEngineHandle` | Fixed-interval sync engine with conflict reporting |
 | `createNexusSyncClient(config)` | `SyncClient` | Nexus-backed sync client |
 | `createFederationMiddleware(config)` | `KoiMiddleware` | Cross-zone tool call routing |
+| `createStaticZoneHealthMonitor(candidates)` | `StaticZoneHealthMonitor` | Immutable health snapshot for routing |
+| `createZoneRouter(config)` | `ZoneRouter` | Health-aware remote-zone selector |
+| `createInMemoryRaftCluster(config)` | `InMemoryRaftCluster` | Deterministic Raft-style consensus cluster |
 | `validateFederationConfig(config)` | `Result<FederationConfig>` | Config validation with defaults |
 
 ### Pure functions
@@ -441,6 +518,7 @@ isVisibleToAgent(brick, "agent-1", "us-east-1");
 |----------|-------------|
 | `advanceCursor(cursor, events)` | Advance cursor through highest contiguous prefix (gaps stop progression) |
 | `deduplicateEvents(events, cursor)` | Filter already-seen events (seq > lastSequence) |
+| `pickHealthyZone(candidates)` | Select the active zone with best latency/load ordering |
 | `incrementVectorClock(clock, zoneId)` | Return a clock with the zone component incremented |
 | `mergeVectorClock(left, right)` | Return the component-wise maximum clock |
 | `compareVectorClock(left, right)` | Classify clocks as before, after, equal, or concurrent |

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -13,6 +13,19 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
   overlay/fork/accept UI exists. Standalone golden coverage exercises the
   runtime export and an in-memory pre-exec accept path. See
   `docs/L2/speculation.md` for the full contract.
+- 2026-05-18: `@koi/federation` adds zone-aware routing and deterministic
+  Raft-style consensus primitives (#1410). Runtime dependency set is unchanged,
+  but the integrated federation surface now includes `createZoneRouter`,
+  `createStaticZoneHealthMonitor`, `pickHealthyZone`, and
+  `createInMemoryRaftCluster`. `createFederationMiddleware` can route to the
+  healthiest remote zone when `ctx.metadata.targetZoneId` is absent and a
+  `zoneRouter` is configured; explicit targets still win, and present
+  non-string targets pass through locally. The Raft helper provides an
+  in-memory replacement point for leader election, quorum append, split-brain
+  detection, append rejection during split-brain, and heal convergence. Golden
+  runtime tool exposure is unchanged because these are library-level federation
+  primitives covered by `@koi/federation` tests. See
+  `docs/L2/federation.md`.
 - 2026-05-16: Integrated `@koi/model-openai-compat` now honors a `KOI_MAX_TOKENS`
   output-token cap (sends `min(request.maxTokens, KOI_MAX_TOKENS)`, or the cap alone
   when the request omits `maxTokens`). No-op when unset/non-positive, so runtime

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 153 | 791 | 134 |
+| lib | 153 | 793 | 134 |
 | meta | 7 | 122 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 12 | 99 | 12 |
@@ -95,7 +95,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/event-delivery` (packages/lib/event-delivery) - Manage event subscriptions with serialized delivery, retry, dead letter queue, and replay. Tests: 2. Docs: -.
 - `@koi/event-trace` (packages/lib/event-trace) - ATIF trajectory recording middleware — records every model/tool call to an inspectable trajectory document. Tests: 5. Docs: docs/L2/event-trace.md.
 - `@koi/execution-context` (packages/lib/execution-context) - Store and retrieve session context via AsyncLocalStorage for tool execution. Tests: 4. Docs: -.
-- `@koi/federation` (packages/lib/federation) - Multi-zone agent coordination — zone registry, sequence-cursor sync, cross-zone tool routing. Tests: 7. Docs: docs/L2/federation.md.
+- `@koi/federation` (packages/lib/federation) - Multi-zone agent coordination — zone registry, sequence-cursor sync, cross-zone tool routing. Tests: 9. Docs: docs/L2/federation.md.
 - `@koi/file-resolution` (packages/lib/file-resolution) - Read markdown files, resolve directory structures, enforce token budgets. Tests: 7. Docs: docs/L2/file-resolution.md.
 - `@koi/file-type` (packages/lib/file-type) - Magic-byte MIME detection for user-originated file content — clipboard, @-reference, upload. Tests: 1. Docs: docs/L2/file-type.md.
 - `@koi/forge-demand` (packages/lib/forge-demand) - Demand-triggered forge detection: capability gaps, repeated failures, latency degradation, user corrections.. Tests: 4. Docs: docs/L2/forge-demand.md.

--- a/packages/lib/federation/src/federation-middleware.test.ts
+++ b/packages/lib/federation/src/federation-middleware.test.ts
@@ -11,6 +11,7 @@ import type {
 import { runId, sessionId, zoneId } from "@koi/core";
 import type { NexusTransport } from "@koi/nexus-client";
 import { createFederationMiddleware } from "./federation-middleware.js";
+import { createStaticZoneHealthMonitor, createZoneRouter } from "./zone-router.js";
 
 const ZA = zoneId("zone-a");
 const ZB = zoneId("zone-b");
@@ -105,6 +106,31 @@ describe("createFederationMiddleware", () => {
     expect(result?.output).toBe("remote-result");
     expect(calledMethod).toBe("federation.zone_execute");
     expect(delegated).toEqual([{ zoneId: "zone-b", toolId: "bash" }]);
+  });
+
+  test("routes to the nearest healthy zone when no explicit targetZoneId is provided", async () => {
+    const nearTransport = makeTransport(() => ({ output: "near" }) as ToolResponse);
+    const farTransport = makeTransport(() => ({ output: "far" }) as ToolResponse);
+    const router = createZoneRouter({
+      monitor: createStaticZoneHealthMonitor([
+        { zoneId: zoneId("zone-near"), status: "active", latencyMs: 8 },
+        { zoneId: zoneId("zone-far"), status: "active", latencyMs: 50 },
+      ]),
+    });
+    const mw = createFederationMiddleware({
+      localZoneId: ZA,
+      remoteTransports: new Map([
+        ["zone-near", nearTransport.transport],
+        ["zone-far", farTransport.transport],
+      ]),
+      zoneRouter: router,
+    });
+
+    const result = await mw.wrapToolCall?.(makeCtx({}), baseRequest, localHandler);
+
+    expect(result?.output).toBe("near");
+    expect(nearTransport.calls).toHaveLength(1);
+    expect(farTransport.calls).toHaveLength(0);
   });
 
   test("throws when targetZoneId is unknown", async () => {

--- a/packages/lib/federation/src/federation-middleware.test.ts
+++ b/packages/lib/federation/src/federation-middleware.test.ts
@@ -133,6 +133,29 @@ describe("createFederationMiddleware", () => {
     expect(farTransport.calls).toHaveLength(0);
   });
 
+  test("does not auto-route when targetZoneId is present but non-string", async () => {
+    const remote = makeTransport(() => ({ output: "remote" }) as ToolResponse);
+    const router = createZoneRouter({
+      monitor: createStaticZoneHealthMonitor([
+        { zoneId: zoneId("zone-b"), status: "active", latencyMs: 1 },
+      ]),
+    });
+    const mw = createFederationMiddleware({
+      localZoneId: ZA,
+      remoteTransports: new Map([["zone-b", remote.transport]]),
+      zoneRouter: router,
+    });
+
+    const result = await mw.wrapToolCall?.(
+      makeCtx({ targetZoneId: 123 }),
+      baseRequest,
+      localHandler,
+    );
+
+    expect(result?.output).toBe("local-result");
+    expect(remote.calls).toHaveLength(0);
+  });
+
   test("throws when targetZoneId is unknown", async () => {
     const mw = createFederationMiddleware({
       localZoneId: ZA,

--- a/packages/lib/federation/src/federation-middleware.ts
+++ b/packages/lib/federation/src/federation-middleware.ts
@@ -6,6 +6,7 @@
 import type { KoiMiddleware, ToolRequest, ToolResponse, ZoneId } from "@koi/core";
 import type { NexusTransport } from "@koi/nexus-client";
 import { FEDERATION_PROTOCOL_VERSION } from "./types.js";
+import type { ZoneRouter } from "./zone-router.js";
 
 /**
  * How the local origin's principal (agent/session/turn identity) is
@@ -120,6 +121,12 @@ export interface FederationMiddlewareConfig {
    * lands in #1410.
    */
   readonly forwardedMetadataKeys?: ReadonlySet<string>;
+  /**
+   * Optional zone-aware router. When `ctx.metadata.targetZoneId` is absent,
+   * the router selects the best healthy zone for the request. Returning
+   * `undefined` keeps the call local.
+   */
+  readonly zoneRouter?: ZoneRouter | undefined;
   /** Optional callback invoked when a tool call is delegated to a remote zone. */
   readonly onDelegated?: (zoneId: string, request: ToolRequest) => void;
 }
@@ -145,6 +152,7 @@ export function createFederationMiddleware(config: FederationMiddlewareConfig): 
     principalForwarding,
     tenantIdResolver,
     forwardedMetadataKeys,
+    zoneRouter,
     onDelegated,
   } = config;
 
@@ -188,10 +196,15 @@ export function createFederationMiddleware(config: FederationMiddlewareConfig): 
     },
 
     wrapToolCall: async (ctx, request, next) => {
-      const targetZoneId = ctx.metadata.targetZoneId;
+      const explicitTargetZoneId = ctx.metadata.targetZoneId;
+      const routedTargetZoneId =
+        typeof explicitTargetZoneId === "string"
+          ? explicitTargetZoneId
+          : zoneRouter?.selectZone({ toolId: request.toolId, input: request.input })?.zoneId;
+      const targetZoneId = routedTargetZoneId;
 
       // No target zone or non-string → local execution
-      if (typeof targetZoneId !== "string") {
+      if (targetZoneId === undefined) {
         return next(request);
       }
 

--- a/packages/lib/federation/src/federation-middleware.ts
+++ b/packages/lib/federation/src/federation-middleware.ts
@@ -200,7 +200,9 @@ export function createFederationMiddleware(config: FederationMiddlewareConfig): 
       const routedTargetZoneId =
         typeof explicitTargetZoneId === "string"
           ? explicitTargetZoneId
-          : zoneRouter?.selectZone({ toolId: request.toolId, input: request.input })?.zoneId;
+          : explicitTargetZoneId === undefined
+            ? zoneRouter?.selectZone({ toolId: request.toolId, input: request.input })?.zoneId
+            : undefined;
       const targetZoneId = routedTargetZoneId;
 
       // No target zone or non-string → local execution

--- a/packages/lib/federation/src/index.ts
+++ b/packages/lib/federation/src/index.ts
@@ -4,7 +4,8 @@
  * L2 feature package. Depends on @koi/core (L0) and @koi/nexus-client (L0u).
  *
  * Includes sequence-cursor sync, vector-clock metadata, conflict reporting,
- * and cross-zone tool routing.
+ * cross-zone tool routing, zone-aware routing, and Raft-style critical-state
+ * consensus primitives.
  */
 
 // config
@@ -18,6 +19,16 @@ export type {
   TenantResolverContext,
 } from "./federation-middleware.js";
 export { createFederationMiddleware } from "./federation-middleware.js";
+// consensus
+export type {
+  InMemoryRaftCluster,
+  RaftCommand,
+  RaftLogEntry,
+  RaftNodeRole,
+  RaftNodeSnapshot,
+  SplitBrainSnapshot,
+} from "./raft-consensus.js";
+export { createInMemoryRaftCluster } from "./raft-consensus.js";
 // sync engine
 export type { RemoteHealth, SyncEngineConfig, SyncEngineHandle } from "./sync-engine.js";
 export { createSyncEngine } from "./sync-engine.js";
@@ -50,3 +61,11 @@ export {
 // zone registry (Nexus-backed)
 export type { ServerReadsMode, ZoneRegistryNexusConfig } from "./zone-registry-nexus.js";
 export { createZoneRegistryNexus } from "./zone-registry-nexus.js";
+// zone-aware routing
+export type {
+  StaticZoneHealthMonitor,
+  ZoneRouteCandidate,
+  ZoneRouteRequest,
+  ZoneRouter,
+} from "./zone-router.js";
+export { createStaticZoneHealthMonitor, createZoneRouter, pickHealthyZone } from "./zone-router.js";

--- a/packages/lib/federation/src/raft-consensus.test.ts
+++ b/packages/lib/federation/src/raft-consensus.test.ts
@@ -58,6 +58,33 @@ describe("createInMemoryRaftCluster", () => {
     });
   });
 
+  test("refuses to append while split-brain is detected", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [
+        zoneId("zone-a"),
+        zoneId("zone-b"),
+        zoneId("zone-c"),
+        zoneId("zone-d"),
+        zoneId("zone-e"),
+      ],
+    });
+
+    cluster.partition([
+      [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],
+      [zoneId("zone-d"), zoneId("zone-e")],
+    ]);
+    cluster.forceElection(zoneId("zone-a"));
+    cluster.forceElection(zoneId("zone-d"));
+
+    const result = cluster.append({ kind: "set", key: "epoch", value: 2 });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("split-brain");
+    }
+    expect(cluster.getCommittedState()).toEqual({});
+  });
+
   test("recovery converges on the longest committed log after partition heals", () => {
     const cluster = createInMemoryRaftCluster({
       nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],

--- a/packages/lib/federation/src/raft-consensus.test.ts
+++ b/packages/lib/federation/src/raft-consensus.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { zoneId } from "@koi/core";
+import { createInMemoryRaftCluster } from "./raft-consensus.js";
+
+describe("createInMemoryRaftCluster", () => {
+  test("elects a leader from the healthy quorum", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],
+    });
+
+    expect(cluster.getLeader()).toBe(zoneId("zone-a"));
+    expect(cluster.getNode(zoneId("zone-a"))?.role).toBe("leader");
+  });
+
+  test("replicates committed log entries to followers", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],
+    });
+
+    const result = cluster.append({ kind: "set", key: "policy", value: "locked" });
+
+    expect(result.ok).toBe(true);
+    expect(cluster.getLog(zoneId("zone-a"))).toEqual(cluster.getLog(zoneId("zone-b")));
+    expect(cluster.getLog(zoneId("zone-b"))).toEqual(cluster.getLog(zoneId("zone-c")));
+    expect(cluster.getCommittedState()).toEqual({ policy: "locked" });
+  });
+
+  test("leader failure triggers re-election and preserves committed log", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],
+    });
+
+    expect(cluster.append({ kind: "set", key: "generation", value: 1 }).ok).toBe(true);
+
+    cluster.markNodeUnhealthy(zoneId("zone-a"));
+
+    expect(cluster.getLeader()).toBe(zoneId("zone-b"));
+    expect(cluster.append({ kind: "set", key: "generation", value: 2 }).ok).toBe(true);
+    expect(cluster.getCommittedState()).toEqual({ generation: 2 });
+    expect(cluster.getLog(zoneId("zone-b"))).toEqual(cluster.getLog(zoneId("zone-c")));
+  });
+
+  test("detects split-brain when partitions elect different leaders", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c"), zoneId("zone-d")],
+    });
+
+    cluster.partition([
+      [zoneId("zone-a"), zoneId("zone-b")],
+      [zoneId("zone-c"), zoneId("zone-d")],
+    ]);
+    cluster.forceElection(zoneId("zone-a"));
+    cluster.forceElection(zoneId("zone-c"));
+
+    expect(cluster.detectSplitBrain()).toEqual({
+      term: 3,
+      leaders: [zoneId("zone-a"), zoneId("zone-c")],
+    });
+  });
+
+  test("recovery converges on the longest committed log after partition heals", () => {
+    const cluster = createInMemoryRaftCluster({
+      nodes: [zoneId("zone-a"), zoneId("zone-b"), zoneId("zone-c")],
+    });
+
+    expect(cluster.append({ kind: "set", key: "epoch", value: 1 }).ok).toBe(true);
+    cluster.partition([[zoneId("zone-a")], [zoneId("zone-b"), zoneId("zone-c")]]);
+    cluster.markNodeUnhealthy(zoneId("zone-a"));
+    expect(cluster.append({ kind: "set", key: "epoch", value: 2 }).ok).toBe(true);
+
+    cluster.healPartition();
+    cluster.markNodeHealthy(zoneId("zone-a"));
+
+    expect(cluster.detectSplitBrain()).toBeUndefined();
+    expect(cluster.getCommittedState()).toEqual({ epoch: 2 });
+    expect(cluster.getLog(zoneId("zone-a"))).toEqual(cluster.getLog(zoneId("zone-b")));
+    expect(cluster.getLog(zoneId("zone-b"))).toEqual(cluster.getLog(zoneId("zone-c")));
+  });
+});

--- a/packages/lib/federation/src/raft-consensus.ts
+++ b/packages/lib/federation/src/raft-consensus.ts
@@ -1,0 +1,285 @@
+/**
+ * Deterministic in-memory Raft-style consensus for critical federation state.
+ *
+ * This is intentionally small and adapter-shaped: production deployments can
+ * replace it with an etcd/Coaty-backed implementation while tests and local
+ * runtimes get leader election, quorum replication, split-brain detection, and
+ * convergence semantics without a native storage dependency.
+ */
+
+import type { KoiError, Result, ZoneId } from "@koi/core";
+
+export type RaftNodeRole = "leader" | "follower" | "candidate";
+export type RaftCommand = { readonly kind: "set"; readonly key: string; readonly value: unknown };
+
+export interface RaftLogEntry {
+  readonly term: number;
+  readonly index: number;
+  readonly command: RaftCommand;
+  readonly committed: boolean;
+}
+
+export interface RaftNodeSnapshot {
+  readonly zoneId: ZoneId;
+  readonly role: RaftNodeRole;
+  readonly term: number;
+  readonly healthy: boolean;
+}
+
+export interface SplitBrainSnapshot {
+  readonly term: number;
+  readonly leaders: readonly ZoneId[];
+}
+
+export interface InMemoryRaftCluster {
+  readonly getLeader: () => ZoneId | undefined;
+  readonly getNode: (zoneId: ZoneId) => RaftNodeSnapshot | undefined;
+  readonly getLog: (zoneId: ZoneId) => readonly RaftLogEntry[];
+  readonly getCommittedState: () => Readonly<Record<string, unknown>>;
+  readonly append: (command: RaftCommand) => Result<RaftLogEntry, KoiError>;
+  readonly markNodeUnhealthy: (zoneId: ZoneId) => void;
+  readonly markNodeHealthy: (zoneId: ZoneId) => void;
+  readonly partition: (groups: readonly (readonly ZoneId[])[]) => void;
+  readonly healPartition: () => void;
+  readonly forceElection: (zoneId: ZoneId) => void;
+  readonly detectSplitBrain: () => SplitBrainSnapshot | undefined;
+}
+
+export function createInMemoryRaftCluster(config: {
+  readonly nodes: readonly ZoneId[];
+}): InMemoryRaftCluster {
+  const nodeIds = uniqueSorted(config.nodes);
+  const nodeState = new Map<ZoneId, { role: RaftNodeRole; term: number; healthy: boolean }>(
+    nodeIds.map((id) => [id, { role: "follower", term: 0, healthy: true }]),
+  );
+  const logs = new Map<ZoneId, readonly RaftLogEntry[]>(nodeIds.map((id) => [id, []]));
+  const partitions = new Map<ZoneId, number>(nodeIds.map((id) => [id, 0]));
+
+  electLeader();
+
+  function getLeader(): ZoneId | undefined {
+    return [...nodeState.entries()].find(([, node]) => node.role === "leader" && node.healthy)?.[0];
+  }
+
+  function electLeader(): void {
+    clearLeaders();
+    const eligible = healthyNodesInLargestPartition();
+    if (eligible.length < quorumSize()) return;
+
+    const leaderId = eligible[0];
+    if (leaderId === undefined) return;
+
+    const nextTerm = currentTerm() + 1;
+    for (const id of nodeIds) {
+      const current = nodeState.get(id);
+      if (current === undefined) continue;
+      nodeState.set(id, {
+        ...current,
+        role: id === leaderId ? "leader" : "follower",
+        term: nextTerm,
+      });
+    }
+  }
+
+  function append(command: RaftCommand): Result<RaftLogEntry, KoiError> {
+    const leader = getLeader();
+    if (leader === undefined) {
+      return {
+        ok: false,
+        error: { code: "EXTERNAL", message: "Raft append failed: no leader", retryable: true },
+      };
+    }
+
+    const replicaIds = reachableHealthyNodes(leader);
+    if (replicaIds.length < quorumSize()) {
+      return {
+        ok: false,
+        error: {
+          code: "EXTERNAL",
+          message: "Raft append failed: leader cannot reach quorum",
+          retryable: true,
+        },
+      };
+    }
+
+    const entry: RaftLogEntry = {
+      term: nodeState.get(leader)?.term ?? currentTerm(),
+      index: longestLog().length + 1,
+      command,
+      committed: true,
+    };
+
+    for (const id of replicaIds) {
+      logs.set(id, [...(logs.get(id) ?? []), entry]);
+    }
+    convergePartitionFor(leader);
+
+    return { ok: true, value: entry };
+  }
+
+  function markNodeUnhealthy(id: ZoneId): void {
+    const current = nodeState.get(id);
+    if (current === undefined) return;
+    nodeState.set(id, { ...current, healthy: false, role: "follower" });
+    if (getLeader() === undefined) electLeader();
+  }
+
+  function markNodeHealthy(id: ZoneId): void {
+    const current = nodeState.get(id);
+    if (current === undefined) return;
+    nodeState.set(id, { ...current, healthy: true, role: "follower", term: currentTerm() });
+    convergeAll();
+    if (getLeader() === undefined) electLeader();
+  }
+
+  function partition(groups: readonly (readonly ZoneId[])[]): void {
+    const next = new Map<ZoneId, number>();
+    groups.forEach((group, groupIndex) => {
+      for (const id of group) {
+        next.set(id, groupIndex);
+      }
+    });
+    for (const id of nodeIds) {
+      partitions.set(id, next.get(id) ?? groups.length);
+    }
+    clearLeaders();
+  }
+
+  function healPartition(): void {
+    for (const id of nodeIds) {
+      partitions.set(id, 0);
+    }
+    convergeAll();
+    electLeader();
+  }
+
+  function forceElection(id: ZoneId): void {
+    const current = nodeState.get(id);
+    if (current === undefined || !current.healthy) return;
+    const group = partitions.get(id) ?? 0;
+    const nextTerm = currentTerm() + 1;
+    for (const nodeId of nodeIds) {
+      const node = nodeState.get(nodeId);
+      if (node === undefined) continue;
+      const sameGroup = (partitions.get(nodeId) ?? 0) === group;
+      nodeState.set(nodeId, {
+        ...node,
+        role: nodeId === id ? "leader" : sameGroup ? "follower" : node.role,
+        term: sameGroup ? nextTerm : node.term,
+      });
+    }
+  }
+
+  function detectSplitBrain(): SplitBrainSnapshot | undefined {
+    const leaders = [...nodeState.entries()]
+      .filter(([, node]) => node.role === "leader" && node.healthy)
+      .map(([id]) => id)
+      .toSorted();
+
+    if (leaders.length < 2) return undefined;
+    return { term: currentTerm(), leaders };
+  }
+
+  function getNode(id: ZoneId): RaftNodeSnapshot | undefined {
+    const node = nodeState.get(id);
+    if (node === undefined) return undefined;
+    return { zoneId: id, ...node };
+  }
+
+  function getCommittedState(): Readonly<Record<string, unknown>> {
+    return Object.fromEntries(
+      longestLog()
+        .filter((entry) => entry.committed)
+        .map((entry) => [entry.command.key, entry.command.value]),
+    );
+  }
+
+  function convergeAll(): void {
+    const committed = longestLog();
+    for (const id of nodeIds) {
+      if (nodeState.get(id)?.healthy === true) {
+        logs.set(id, committed);
+      }
+    }
+  }
+
+  function convergePartitionFor(id: ZoneId): void {
+    const group = partitions.get(id) ?? 0;
+    const committed = longestLogInGroup(group);
+    for (const nodeId of nodeIds) {
+      if ((partitions.get(nodeId) ?? 0) === group && nodeState.get(nodeId)?.healthy === true) {
+        logs.set(nodeId, committed);
+      }
+    }
+  }
+
+  function clearLeaders(): void {
+    for (const [id, node] of nodeState.entries()) {
+      nodeState.set(id, { ...node, role: "follower" });
+    }
+  }
+
+  function healthyNodesInLargestPartition(): readonly ZoneId[] {
+    const groups = new Map<number, readonly ZoneId[]>();
+    for (const id of nodeIds) {
+      if (nodeState.get(id)?.healthy !== true) continue;
+      const group = partitions.get(id) ?? 0;
+      groups.set(group, [...(groups.get(group) ?? []), id]);
+    }
+    return (
+      [...groups.values()].toSorted(
+        (a, b) => b.length - a.length || a[0]?.localeCompare(b[0] ?? "") || 0,
+      )[0] ?? []
+    );
+  }
+
+  function reachableHealthyNodes(from: ZoneId): readonly ZoneId[] {
+    const group = partitions.get(from) ?? 0;
+    return nodeIds.filter(
+      (id) => nodeState.get(id)?.healthy === true && (partitions.get(id) ?? 0) === group,
+    );
+  }
+
+  function longestLog(): readonly RaftLogEntry[] {
+    return [...logs.values()].toSorted(compareLogs)[0] ?? [];
+  }
+
+  function longestLogInGroup(group: number): readonly RaftLogEntry[] {
+    const groupLogs = nodeIds
+      .filter((id) => (partitions.get(id) ?? 0) === group && nodeState.get(id)?.healthy === true)
+      .map((id) => logs.get(id) ?? []);
+    return groupLogs.toSorted(compareLogs)[0] ?? [];
+  }
+
+  function currentTerm(): number {
+    return Math.max(0, ...[...nodeState.values()].map((node) => node.term));
+  }
+
+  function quorumSize(): number {
+    return Math.floor(nodeIds.length / 2) + 1;
+  }
+
+  return {
+    getLeader,
+    getNode,
+    getLog: (id) => logs.get(id) ?? [],
+    getCommittedState,
+    append,
+    markNodeUnhealthy,
+    markNodeHealthy,
+    partition,
+    healPartition,
+    forceElection,
+    detectSplitBrain,
+  };
+}
+
+function uniqueSorted(ids: readonly ZoneId[]): readonly ZoneId[] {
+  return [...new Set(ids)].toSorted();
+}
+
+function compareLogs(a: readonly RaftLogEntry[], b: readonly RaftLogEntry[]): number {
+  const lengthDelta = b.length - a.length;
+  if (lengthDelta !== 0) return lengthDelta;
+  return (b.at(-1)?.term ?? 0) - (a.at(-1)?.term ?? 0);
+}

--- a/packages/lib/federation/src/raft-consensus.ts
+++ b/packages/lib/federation/src/raft-consensus.ts
@@ -82,6 +82,17 @@ export function createInMemoryRaftCluster(config: {
   }
 
   function append(command: RaftCommand): Result<RaftLogEntry, KoiError> {
+    if (detectSplitBrain() !== undefined) {
+      return {
+        ok: false,
+        error: {
+          code: "EXTERNAL",
+          message: "Raft append failed: split-brain detected",
+          retryable: true,
+        },
+      };
+    }
+
     const leader = getLeader();
     if (leader === undefined) {
       return {

--- a/packages/lib/federation/src/raft-consensus.ts
+++ b/packages/lib/federation/src/raft-consensus.ts
@@ -48,32 +48,47 @@ export interface InMemoryRaftCluster {
 export function createInMemoryRaftCluster(config: {
   readonly nodes: readonly ZoneId[];
 }): InMemoryRaftCluster {
-  const nodeIds = uniqueSorted(config.nodes);
-  const nodeState = new Map<ZoneId, { role: RaftNodeRole; term: number; healthy: boolean }>(
-    nodeIds.map((id) => [id, { role: "follower", term: 0, healthy: true }]),
-  );
-  const logs = new Map<ZoneId, readonly RaftLogEntry[]>(nodeIds.map((id) => [id, []]));
-  const partitions = new Map<ZoneId, number>(nodeIds.map((id) => [id, 0]));
+  return new InMemoryRaftClusterState(config.nodes);
+}
 
-  electLeader();
+type MutableRaftNodeState = { role: RaftNodeRole; term: number; healthy: boolean };
 
-  function getLeader(): ZoneId | undefined {
-    return [...nodeState.entries()].find(([, node]) => node.role === "leader" && node.healthy)?.[0];
+class InMemoryRaftClusterState implements InMemoryRaftCluster {
+  private readonly nodeIds: readonly ZoneId[];
+  private readonly nodeState: Map<ZoneId, MutableRaftNodeState>;
+  private readonly logs: Map<ZoneId, readonly RaftLogEntry[]>;
+  private readonly partitions: Map<ZoneId, number>;
+
+  constructor(nodes: readonly ZoneId[]) {
+    this.nodeIds = uniqueSorted(nodes);
+    this.nodeState = new Map(
+      this.nodeIds.map((id) => [id, { role: "follower", term: 0, healthy: true }]),
+    );
+    this.logs = new Map(this.nodeIds.map((id) => [id, []]));
+    this.partitions = new Map(this.nodeIds.map((id) => [id, 0]));
+
+    this.electLeader();
   }
 
-  function electLeader(): void {
-    clearLeaders();
-    const eligible = healthyNodesInLargestPartition();
-    if (eligible.length < quorumSize()) return;
+  getLeader(): ZoneId | undefined {
+    return [...this.nodeState.entries()].find(
+      ([, node]) => node.role === "leader" && node.healthy,
+    )?.[0];
+  }
+
+  private electLeader(): void {
+    this.clearLeaders();
+    const eligible = this.healthyNodesInLargestPartition();
+    if (eligible.length < this.quorumSize()) return;
 
     const leaderId = eligible[0];
     if (leaderId === undefined) return;
 
-    const nextTerm = currentTerm() + 1;
-    for (const id of nodeIds) {
-      const current = nodeState.get(id);
+    const nextTerm = this.currentTerm() + 1;
+    for (const id of this.nodeIds) {
+      const current = this.nodeState.get(id);
       if (current === undefined) continue;
-      nodeState.set(id, {
+      this.nodeState.set(id, {
         ...current,
         role: id === leaderId ? "leader" : "follower",
         term: nextTerm,
@@ -81,8 +96,8 @@ export function createInMemoryRaftCluster(config: {
     }
   }
 
-  function append(command: RaftCommand): Result<RaftLogEntry, KoiError> {
-    if (detectSplitBrain() !== undefined) {
+  append(command: RaftCommand): Result<RaftLogEntry, KoiError> {
+    if (this.detectSplitBrain() !== undefined) {
       return {
         ok: false,
         error: {
@@ -93,7 +108,7 @@ export function createInMemoryRaftCluster(config: {
       };
     }
 
-    const leader = getLeader();
+    const leader = this.getLeader();
     if (leader === undefined) {
       return {
         ok: false,
@@ -101,8 +116,8 @@ export function createInMemoryRaftCluster(config: {
       };
     }
 
-    const replicaIds = reachableHealthyNodes(leader);
-    if (replicaIds.length < quorumSize()) {
+    const replicaIds = this.reachableHealthyNodes(leader);
+    if (replicaIds.length < this.quorumSize()) {
       return {
         ok: false,
         error: {
@@ -114,66 +129,71 @@ export function createInMemoryRaftCluster(config: {
     }
 
     const entry: RaftLogEntry = {
-      term: nodeState.get(leader)?.term ?? currentTerm(),
-      index: longestLog().length + 1,
+      term: this.nodeState.get(leader)?.term ?? this.currentTerm(),
+      index: this.longestLog().length + 1,
       command,
       committed: true,
     };
 
     for (const id of replicaIds) {
-      logs.set(id, [...(logs.get(id) ?? []), entry]);
+      this.logs.set(id, [...(this.logs.get(id) ?? []), entry]);
     }
-    convergePartitionFor(leader);
+    this.convergePartitionFor(leader);
 
     return { ok: true, value: entry };
   }
 
-  function markNodeUnhealthy(id: ZoneId): void {
-    const current = nodeState.get(id);
+  markNodeUnhealthy(id: ZoneId): void {
+    const current = this.nodeState.get(id);
     if (current === undefined) return;
-    nodeState.set(id, { ...current, healthy: false, role: "follower" });
-    if (getLeader() === undefined) electLeader();
+    this.nodeState.set(id, { ...current, healthy: false, role: "follower" });
+    if (this.getLeader() === undefined) this.electLeader();
   }
 
-  function markNodeHealthy(id: ZoneId): void {
-    const current = nodeState.get(id);
+  markNodeHealthy(id: ZoneId): void {
+    const current = this.nodeState.get(id);
     if (current === undefined) return;
-    nodeState.set(id, { ...current, healthy: true, role: "follower", term: currentTerm() });
-    convergeAll();
-    if (getLeader() === undefined) electLeader();
+    this.nodeState.set(id, {
+      ...current,
+      healthy: true,
+      role: "follower",
+      term: this.currentTerm(),
+    });
+    this.convergeAll();
+    if (this.getLeader() === undefined) this.electLeader();
   }
 
-  function partition(groups: readonly (readonly ZoneId[])[]): void {
+  partition(groups: readonly (readonly ZoneId[])[]): void {
     const next = new Map<ZoneId, number>();
     groups.forEach((group, groupIndex) => {
       for (const id of group) {
         next.set(id, groupIndex);
       }
     });
-    for (const id of nodeIds) {
-      partitions.set(id, next.get(id) ?? groups.length);
+    for (const id of this.nodeIds) {
+      this.partitions.set(id, next.get(id) ?? groups.length);
     }
-    clearLeaders();
+    this.clearLeaders();
   }
 
-  function healPartition(): void {
-    for (const id of nodeIds) {
-      partitions.set(id, 0);
+  healPartition(): void {
+    for (const id of this.nodeIds) {
+      this.partitions.set(id, 0);
     }
-    convergeAll();
-    electLeader();
+    this.convergeAll();
+    this.electLeader();
   }
 
-  function forceElection(id: ZoneId): void {
-    const current = nodeState.get(id);
+  forceElection(id: ZoneId): void {
+    const current = this.nodeState.get(id);
     if (current === undefined || !current.healthy) return;
-    const group = partitions.get(id) ?? 0;
-    const nextTerm = currentTerm() + 1;
-    for (const nodeId of nodeIds) {
-      const node = nodeState.get(nodeId);
+    const group = this.partitions.get(id) ?? 0;
+    const nextTerm = this.currentTerm() + 1;
+    for (const nodeId of this.nodeIds) {
+      const node = this.nodeState.get(nodeId);
       if (node === undefined) continue;
-      const sameGroup = (partitions.get(nodeId) ?? 0) === group;
-      nodeState.set(nodeId, {
+      const sameGroup = (this.partitions.get(nodeId) ?? 0) === group;
+      this.nodeState.set(nodeId, {
         ...node,
         role: nodeId === id ? "leader" : sameGroup ? "follower" : node.role,
         term: sameGroup ? nextTerm : node.term,
@@ -181,60 +201,67 @@ export function createInMemoryRaftCluster(config: {
     }
   }
 
-  function detectSplitBrain(): SplitBrainSnapshot | undefined {
-    const leaders = [...nodeState.entries()]
+  detectSplitBrain(): SplitBrainSnapshot | undefined {
+    const leaders = [...this.nodeState.entries()]
       .filter(([, node]) => node.role === "leader" && node.healthy)
       .map(([id]) => id)
       .toSorted();
 
     if (leaders.length < 2) return undefined;
-    return { term: currentTerm(), leaders };
+    return { term: this.currentTerm(), leaders };
   }
 
-  function getNode(id: ZoneId): RaftNodeSnapshot | undefined {
-    const node = nodeState.get(id);
+  getNode(id: ZoneId): RaftNodeSnapshot | undefined {
+    const node = this.nodeState.get(id);
     if (node === undefined) return undefined;
     return { zoneId: id, ...node };
   }
 
-  function getCommittedState(): Readonly<Record<string, unknown>> {
+  getLog(id: ZoneId): readonly RaftLogEntry[] {
+    return this.logs.get(id) ?? [];
+  }
+
+  getCommittedState(): Readonly<Record<string, unknown>> {
     return Object.fromEntries(
-      longestLog()
+      this.longestLog()
         .filter((entry) => entry.committed)
         .map((entry) => [entry.command.key, entry.command.value]),
     );
   }
 
-  function convergeAll(): void {
-    const committed = longestLog();
-    for (const id of nodeIds) {
-      if (nodeState.get(id)?.healthy === true) {
-        logs.set(id, committed);
+  private convergeAll(): void {
+    const committed = this.longestLog();
+    for (const id of this.nodeIds) {
+      if (this.nodeState.get(id)?.healthy === true) {
+        this.logs.set(id, committed);
       }
     }
   }
 
-  function convergePartitionFor(id: ZoneId): void {
-    const group = partitions.get(id) ?? 0;
-    const committed = longestLogInGroup(group);
-    for (const nodeId of nodeIds) {
-      if ((partitions.get(nodeId) ?? 0) === group && nodeState.get(nodeId)?.healthy === true) {
-        logs.set(nodeId, committed);
+  private convergePartitionFor(id: ZoneId): void {
+    const group = this.partitions.get(id) ?? 0;
+    const committed = this.longestLogInGroup(group);
+    for (const nodeId of this.nodeIds) {
+      if (
+        (this.partitions.get(nodeId) ?? 0) === group &&
+        this.nodeState.get(nodeId)?.healthy === true
+      ) {
+        this.logs.set(nodeId, committed);
       }
     }
   }
 
-  function clearLeaders(): void {
-    for (const [id, node] of nodeState.entries()) {
-      nodeState.set(id, { ...node, role: "follower" });
+  private clearLeaders(): void {
+    for (const [id, node] of this.nodeState.entries()) {
+      this.nodeState.set(id, { ...node, role: "follower" });
     }
   }
 
-  function healthyNodesInLargestPartition(): readonly ZoneId[] {
+  private healthyNodesInLargestPartition(): readonly ZoneId[] {
     const groups = new Map<number, readonly ZoneId[]>();
-    for (const id of nodeIds) {
-      if (nodeState.get(id)?.healthy !== true) continue;
-      const group = partitions.get(id) ?? 0;
+    for (const id of this.nodeIds) {
+      if (this.nodeState.get(id)?.healthy !== true) continue;
+      const group = this.partitions.get(id) ?? 0;
       groups.set(group, [...(groups.get(group) ?? []), id]);
     }
     return (
@@ -244,45 +271,34 @@ export function createInMemoryRaftCluster(config: {
     );
   }
 
-  function reachableHealthyNodes(from: ZoneId): readonly ZoneId[] {
-    const group = partitions.get(from) ?? 0;
-    return nodeIds.filter(
-      (id) => nodeState.get(id)?.healthy === true && (partitions.get(id) ?? 0) === group,
+  private reachableHealthyNodes(from: ZoneId): readonly ZoneId[] {
+    const group = this.partitions.get(from) ?? 0;
+    return this.nodeIds.filter(
+      (id) => this.nodeState.get(id)?.healthy === true && (this.partitions.get(id) ?? 0) === group,
     );
   }
 
-  function longestLog(): readonly RaftLogEntry[] {
-    return [...logs.values()].toSorted(compareLogs)[0] ?? [];
+  private longestLog(): readonly RaftLogEntry[] {
+    return [...this.logs.values()].toSorted(compareLogs)[0] ?? [];
   }
 
-  function longestLogInGroup(group: number): readonly RaftLogEntry[] {
-    const groupLogs = nodeIds
-      .filter((id) => (partitions.get(id) ?? 0) === group && nodeState.get(id)?.healthy === true)
-      .map((id) => logs.get(id) ?? []);
+  private longestLogInGroup(group: number): readonly RaftLogEntry[] {
+    const groupLogs = this.nodeIds
+      .filter(
+        (id) =>
+          (this.partitions.get(id) ?? 0) === group && this.nodeState.get(id)?.healthy === true,
+      )
+      .map((id) => this.logs.get(id) ?? []);
     return groupLogs.toSorted(compareLogs)[0] ?? [];
   }
 
-  function currentTerm(): number {
-    return Math.max(0, ...[...nodeState.values()].map((node) => node.term));
+  private currentTerm(): number {
+    return Math.max(0, ...[...this.nodeState.values()].map((node) => node.term));
   }
 
-  function quorumSize(): number {
-    return Math.floor(nodeIds.length / 2) + 1;
+  private quorumSize(): number {
+    return Math.floor(this.nodeIds.length / 2) + 1;
   }
-
-  return {
-    getLeader,
-    getNode,
-    getLog: (id) => logs.get(id) ?? [],
-    getCommittedState,
-    append,
-    markNodeUnhealthy,
-    markNodeHealthy,
-    partition,
-    healPartition,
-    forceElection,
-    detectSplitBrain,
-  };
 }
 
 function uniqueSorted(ids: readonly ZoneId[]): readonly ZoneId[] {

--- a/packages/lib/federation/src/zone-router.test.ts
+++ b/packages/lib/federation/src/zone-router.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { zoneId } from "@koi/core";
+import { createStaticZoneHealthMonitor, createZoneRouter, pickHealthyZone } from "./zone-router.js";
+
+describe("pickHealthyZone", () => {
+  test("selects the lowest-latency healthy zone", () => {
+    const selected = pickHealthyZone([
+      { zoneId: zoneId("zone-far"), status: "active", latencyMs: 80 },
+      { zoneId: zoneId("zone-near"), status: "active", latencyMs: 12 },
+      { zoneId: zoneId("zone-mid"), status: "active", latencyMs: 35 },
+    ]);
+
+    expect(selected?.zoneId).toBe(zoneId("zone-near"));
+  });
+
+  test("bypasses unhealthy zones even when they are nearest", () => {
+    const selected = pickHealthyZone([
+      { zoneId: zoneId("zone-near"), status: "offline", latencyMs: 1 },
+      { zoneId: zoneId("zone-mid"), status: "draining", latencyMs: 8 },
+      { zoneId: zoneId("zone-far"), status: "active", latencyMs: 40 },
+    ]);
+
+    expect(selected?.zoneId).toBe(zoneId("zone-far"));
+  });
+});
+
+describe("createZoneRouter", () => {
+  test("routes by live health snapshot and updates when zone health changes", () => {
+    const monitor = createStaticZoneHealthMonitor([
+      { zoneId: zoneId("zone-a"), status: "active", latencyMs: 50 },
+      { zoneId: zoneId("zone-b"), status: "active", latencyMs: 10 },
+    ]);
+    const router = createZoneRouter({ monitor });
+
+    expect(router.selectZone({ toolId: "bash" })?.zoneId).toBe(zoneId("zone-b"));
+
+    monitor.setHealth(zoneId("zone-b"), { status: "offline", latencyMs: 10 });
+
+    expect(router.selectZone({ toolId: "bash" })?.zoneId).toBe(zoneId("zone-a"));
+  });
+
+  test("returns undefined when every known zone is unhealthy", () => {
+    const router = createZoneRouter({
+      monitor: createStaticZoneHealthMonitor([
+        { zoneId: zoneId("zone-a"), status: "offline", latencyMs: 5 },
+        { zoneId: zoneId("zone-b"), status: "draining", latencyMs: 10 },
+      ]),
+    });
+
+    expect(router.selectZone({ toolId: "bash" })).toBeUndefined();
+  });
+});

--- a/packages/lib/federation/src/zone-router.ts
+++ b/packages/lib/federation/src/zone-router.ts
@@ -1,0 +1,81 @@
+/**
+ * Zone-aware routing primitives for federation.
+ */
+
+import type { JsonObject, ZoneId, ZoneStatus } from "@koi/core";
+
+/** Health and routing signal for a candidate zone. */
+export interface ZoneRouteCandidate {
+  readonly zoneId: ZoneId;
+  readonly status: ZoneStatus;
+  readonly latencyMs: number;
+  readonly load?: number | undefined;
+}
+
+/** Request context passed to zone routers. */
+export interface ZoneRouteRequest {
+  readonly toolId: string;
+  readonly input?: JsonObject | undefined;
+}
+
+/** Mutable health monitor used by tests and in-memory deployments. */
+export interface StaticZoneHealthMonitor {
+  readonly listHealth: () => readonly ZoneRouteCandidate[];
+  readonly getHealth: (zoneId: ZoneId) => ZoneRouteCandidate | undefined;
+  readonly setHealth: (zoneId: ZoneId, health: Omit<ZoneRouteCandidate, "zoneId">) => void;
+}
+
+/** Selects the best zone for a federated request. */
+export interface ZoneRouter {
+  readonly selectZone: (request: ZoneRouteRequest) => ZoneRouteCandidate | undefined;
+}
+
+/** Create an in-memory health monitor for zone routing. */
+export function createStaticZoneHealthMonitor(
+  initial: readonly ZoneRouteCandidate[],
+): StaticZoneHealthMonitor {
+  const health = new Map<string, ZoneRouteCandidate>(
+    initial.map((candidate) => [candidate.zoneId, candidate]),
+  );
+
+  return {
+    listHealth: () => [...health.values()],
+    getHealth: (id) => health.get(id),
+    setHealth: (id, next) => {
+      health.set(id, { zoneId: id, ...next });
+    },
+  };
+}
+
+/** Select the nearest active zone, using load and id as deterministic tie-breakers. */
+export function pickHealthyZone(
+  candidates: readonly ZoneRouteCandidate[],
+): ZoneRouteCandidate | undefined {
+  const healthy = candidates.filter(
+    (candidate) =>
+      candidate.status === "active" &&
+      Number.isFinite(candidate.latencyMs) &&
+      candidate.latencyMs >= 0,
+  );
+  const sorted = healthy.toSorted(compareCandidates);
+  return sorted[0];
+}
+
+/** Create a router backed by a live health monitor. */
+export function createZoneRouter(config: {
+  readonly monitor: Pick<StaticZoneHealthMonitor, "listHealth">;
+}): ZoneRouter {
+  return {
+    selectZone: () => pickHealthyZone(config.monitor.listHealth()),
+  };
+}
+
+function compareCandidates(a: ZoneRouteCandidate, b: ZoneRouteCandidate): number {
+  const latencyDelta = a.latencyMs - b.latencyMs;
+  if (latencyDelta !== 0) return latencyDelta;
+
+  const loadDelta = (a.load ?? 0) - (b.load ?? 0);
+  if (loadDelta !== 0) return loadDelta;
+
+  return a.zoneId.localeCompare(b.zoneId);
+}


### PR DESCRIPTION
## Summary

- Adds a zone-aware routing helper for choosing the nearest healthy federation zone.
- Adds an in-memory Raft-style consensus cluster for deterministic federation election, replication, partition, and recovery behavior.
- Wires federation middleware to use the zone router when no explicit target zone is provided.
- Exports the new federation APIs and covers them with focused tests.
- Hardens review-loop findings: non-string `targetZoneId` no longer auto-routes, and Raft append refuses while split-brain is detected.

Closes #1410.

## Validation

- `bun --filter @koi/federation test`
- `bun --filter @koi/federation typecheck`
- `bun --filter @koi/federation build`
- `bun --filter @koi/federation lint`
- `bun run check:golden-queries`
- `bun run test:runtime-golden-replay`
- `bun --filter @koi/tui test`
- CLI TUI targeted tests after rebuilding `@koi/runtime`
- `bun run check:tui-tools`
- `bun run check:tui-single-writer`
- Manual `koi tui` verification from the issue worktree running `bun --filter @koi/federation test`; covered absent/non-string/unknown/local `targetZoneId`, router ordering, Raft quorum append, split-brain rejection, and heal convergence.
- Pre-push hook completed successfully; latest push reported everything up-to-date.

## Notes

This uses an adapter-shaped in-memory Raft implementation rather than adding an old native/framework Raft dependency, keeping the federation package lightweight while preserving a production replacement point.
