### PR TITLE
[codex] Add SLSA trust checks for forged bricks

### DIFF
--- a/docs/L2/forge-integrity.md
+++ b/docs/L2/forge-integrity.md
@@ -1,15 +1,16 @@
 # @koi/forge-integrity
 
-Content-consistency verification, minimal provenance construction, and
-lineage helpers for forged bricks (L2). Issue #1348.
+Content-consistency verification, minimal provenance construction,
+cryptographic attestations, SLSA serialization, install-time provenance
+verification, and trust scoring helpers for forged bricks (L2). Issues
+#1348 and #1402.
 
-**Scope: content-consistency, not authenticity.** A successful verification
-result proves only that the brick's stored `id` matches the canonical
-recomputation under the expected producer's identity scheme. It does NOT
-prove cryptographic authorship — `provenance.builder.id` is read from the
-unverified artifact, so a brick fabricated under a trusted producer's name
-will still pass here. Producer authenticity requires a separate
-signed-attestation check (out of scope for this package).
+**Scope: content-consistency and provenance authenticity are separate
+checks.** A successful `BrickVerifier` result proves only that the brick's
+stored `id` matches the canonical recomputation under the expected
+producer's identity scheme. Producer authenticity requires
+`verifyAttestation()` over the unsigned provenance payload. Install-time
+callers should use `verifyInstallProvenance()` to compose both checks.
 
 ## Surface (exact `src/index.ts` exports)
 
@@ -34,6 +35,41 @@ signed-attestation check (out of scope for this package).
   values (Map/Set/Date/functions) are rejected so the record stays stable
   across persist/sign round-trips. The returned struct (and its mutable
   subtrees) is deep-frozen.
+- `mapProvenanceToSlsa(provenance): SlsaProvenanceV1` — maps Koi
+  provenance to a SLSA v1.0 predicate and preserves Koi verification,
+  classification, content markers, source, and content hash as explicit
+  extensions.
+- `mapProvenanceToStatement(provenance, brickId): InTotoStatementV1<SlsaProvenanceV1>`
+  — wraps the SLSA predicate in an in-toto Statement v1 envelope.
+- `signAttestation(provenance, signer, options?): Promise<ForgeProvenance>`
+  — signs the canonical unsigned provenance payload with the provided
+  `SigningBackend` and returns a new provenance value with
+  `attestation` attached.
+- `verifyAttestation(provenance, signer, options?): Promise<AttestationVerificationResult>`
+  — verifies the signed unsigned-provenance payload, rejects missing or
+  invalid signatures, and can reject expired provenance with
+  `maxAgeMs`.
+- `verifyInstallProvenance(brick, options): Promise<InstallProvenanceResult>`
+  — fail-closed install boundary that requires both content integrity and
+  attestation verification to pass.
+- `mapVirusTotalAnalysisToSignal(analysis): VirusTotalSignal` — converts
+  an injected VirusTotal analysis result into a local trust signal. The
+  package defines a `VirusTotalClient` interface but does not hard-code
+  HTTP calls or API keys.
+- `scanBrickWithVirusTotal(brick, client): Promise<VirusTotalSignal>` —
+  submits the brick's executable or declared content bytes through an
+  injected `VirusTotalClient` and maps the returned analysis to a local
+  trust signal.
+- `computeTrustScore(input): TrustScoreResult` — deterministic scoring
+  model that combines provenance, local scanner results, VirusTotal,
+  publisher identity, and community feedback.
+- `evaluateMarketplaceTrust(brick, options): Promise<MarketplaceTrustResult>`
+  — publish/install gate that composes `verifyInstallProvenance()`, an
+  optional local scanner result, an optional VirusTotal signal, an
+  optional publisher identity verifier, and optional community trust
+  inputs. It blocks failed integrity or attestation, local scanner
+  rejection, malicious VirusTotal findings, unverified publishers, and
+  blocked trust scores.
 - `getParentBrickId(brick): BrickId | undefined` — defensive accessor for
   `provenance.parentBrickId`. Returns `undefined` for malformed shapes.
 - `isDerivedFromUnchecked(child, ancestor, store): Promise<LineageOutcome>`
@@ -84,10 +120,9 @@ trusted producer → recompute pairs into `createBrickVerifier`.
 
 ## Out of scope
 
-- Cryptographic attestation / signing (`brick-signing` from v1).
-- SLSA v1.0 serialization (`slsa-serializer` from v1).
 - LRU attestation caches (`attestation-cache` from v1).
-- Producer authenticity beyond content-consistency.
+- Concrete VirusTotal HTTP client wiring and API-key storage.
+- Active v2 community-registry publish/install route integration.
 - The canonical identity scheme itself (lives with each producer).
 - Verification pipeline orchestration (`@koi/forge-verifier`, #1347).
 - Forge policy enforcement (`@koi/forge-policy`, #1349).
@@ -106,6 +141,10 @@ trusted producer → recompute pairs into `createBrickVerifier`.
   caller must supply `expectedBuilderId` out-of-band.
 - `createForgeProvenance` never invents trust- or sensitivity-bearing
   values (`verification`, `classification`, `contentMarkers`).
+- Attestation signatures are computed over canonical provenance with the
+  `attestation` field removed, so signatures never sign themselves.
+- Install verification fails closed on any integrity, attestation, or
+  expiry failure.
 - `isDerivedFrom` reads through `ForgeStore.load`; cycles, depth overruns,
   store errors, missing ancestors, and integrity failures all surface as
   distinct `LineageOutcome` variants rather than collapsing to `false`.

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 151 | 783 | 132 |
+| lib | 151 | 789 | 132 |
 | meta | 7 | 121 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 12 | 99 | 12 |
@@ -100,7 +100,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/file-type` (packages/lib/file-type) - Magic-byte MIME detection for user-originated file content — clipboard, @-reference, upload. Tests: 1. Docs: docs/L2/file-type.md.
 - `@koi/forge-demand` (packages/lib/forge-demand) - Demand-triggered forge detection: capability gaps, repeated failures, latency degradation, user corrections.. Tests: 4. Docs: docs/L2/forge-demand.md.
 - `@koi/forge-exaptation` (packages/lib/forge-exaptation) - Purpose-drift detection for forge artifacts: pure functions over usage observations.. Tests: 3. Docs: docs/L2/forge-exaptation.md.
-- `@koi/forge-integrity` (packages/lib/forge-integrity) - Content-addressable integrity, provenance, and lineage helpers for forged bricks. L2.. Tests: 3. Docs: docs/L2/forge-integrity.md.
+- `@koi/forge-integrity` (packages/lib/forge-integrity) - Content-addressable integrity, provenance, and lineage helpers for forged bricks. L2.. Tests: 9. Docs: docs/L2/forge-integrity.md.
 - `@koi/forge-optimizer` (packages/lib/forge-optimizer) - Advisory artifact-optimization helpers: scoring, merge/simplify/retirement suggestions, lifecycle validation (L2).. Tests: 7. Docs: docs/L2/forge-optimizer.md.
 - `@koi/forge-policy` (packages/lib/forge-policy) - Sync deterministic policy evaluator + audit log for forge candidates. L2.. Tests: 6. Docs: docs/L2/forge-policy.md.
 - `@koi/forge-tools` (packages/lib/forge-tools) - Primordial forge tools and in-memory ForgeStore (L2). Tests: 6. Docs: docs/L2/forge-tools.md.

--- a/docs/superpowers/plans/2026-05-18-issue-1402-slsa-trust.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1402-slsa-trust.md
@@ -1,0 +1,68 @@
+# Issue 1402 SLSA Trust Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SLSA provenance, attestation verification, VirusTotal scan contracts, and deterministic trust scoring primitives for marketplace bricks.
+
+**Architecture:** Keep the implementation in `@koi/forge-integrity`, where provenance and content integrity already live. Use small files for serialization, attestation, install verification, VirusTotal contracts, and trust scoring. All expected security failures return typed results and fail closed.
+
+**Tech Stack:** Bun, TypeScript 6, `bun:test`, existing `@koi/core` and `@koi/hash` contracts.
+
+---
+
+### Task 1: SLSA Serialization
+
+**Files:**
+- Create: `packages/lib/forge-integrity/src/slsa.ts`
+- Test: `packages/lib/forge-integrity/src/slsa.test.ts`
+- Modify: `packages/lib/forge-integrity/src/index.ts`
+
+- [ ] Write failing tests for `mapProvenanceToSlsa` and `mapProvenanceToStatement`.
+- [ ] Run `bun test packages/lib/forge-integrity/src/slsa.test.ts` and confirm missing exports fail.
+- [ ] Implement SLSA v1.0 predicate mapping and in-toto Statement mapping.
+- [ ] Re-run the test and confirm it passes.
+
+### Task 2: Attestation Signing
+
+**Files:**
+- Create: `packages/lib/forge-integrity/src/attestation.ts`
+- Test: `packages/lib/forge-integrity/src/attestation.test.ts`
+- Modify: `packages/lib/forge-integrity/src/index.ts`
+
+- [ ] Write failing tests for signing, verification, tamper rejection, missing attestation, and expiry.
+- [ ] Run `bun test packages/lib/forge-integrity/src/attestation.test.ts` and confirm missing exports fail.
+- [ ] Implement canonical unsigned provenance serialization, `signAttestation`, and `verifyAttestation`.
+- [ ] Re-run the test and confirm it passes.
+
+### Task 3: Install Verification
+
+**Files:**
+- Create: `packages/lib/forge-integrity/src/install-verification.ts`
+- Test: `packages/lib/forge-integrity/src/install-verification.test.ts`
+- Modify: `packages/lib/forge-integrity/src/index.ts`
+
+- [ ] Write failing tests for ok install verification, integrity rejection, and attestation rejection.
+- [ ] Implement `verifyInstallProvenance` by composing `BrickVerifier` and attestation verification.
+- [ ] Re-run the test and confirm it passes.
+
+### Task 4: VirusTotal Contracts And Trust Scoring
+
+**Files:**
+- Create: `packages/lib/forge-integrity/src/virustotal.ts`
+- Create: `packages/lib/forge-integrity/src/trust-score.ts`
+- Test: `packages/lib/forge-integrity/src/trust-score.test.ts`
+- Modify: `packages/lib/forge-integrity/src/index.ts`
+
+- [ ] Write failing tests for malicious VirusTotal verdicts, all-signal trust composition, and publisher identity contribution.
+- [ ] Implement injectable VirusTotal types and deterministic `computeTrustScore`.
+- [ ] Re-run the test and confirm it passes.
+
+### Task 5: Verification
+
+**Files:**
+- Modify only files changed by Tasks 1-4.
+
+- [ ] Run `bunx turbo run test --filter=@koi/forge-integrity`.
+- [ ] Run `bunx turbo run typecheck --filter=@koi/forge-integrity`.
+- [ ] Run `bunx turbo run lint --filter=@koi/forge-integrity`.
+- [ ] Inspect `git diff --stat` and `git status --short`.

--- a/docs/superpowers/specs/2026-05-18-issue-1402-slsa-trust-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-1402-slsa-trust-design.md
@@ -1,0 +1,36 @@
+# Issue 1402 SLSA Trust Design
+
+## Scope
+
+This slice builds marketplace trust primitives in `@koi/forge-integrity`. It does not revive the archived v1 community registry server. The package already owns provenance and content integrity, and the v2 docs list SLSA serialization, signing, and attestation verification as deferred forge-integrity work.
+
+## Approach
+
+`@koi/forge-integrity` will expose pure, injectable APIs:
+
+- SLSA v1.0 predicate and in-toto Statement mapping from existing `ForgeProvenance`.
+- Attestation signing and verification using the L0 `SigningBackend` contract.
+- Install-time provenance verification that composes content integrity with attestation verification.
+- VirusTotal scan result types plus a client contract, with no hard-coded network dependency.
+- Deterministic trust scoring from provenance, local scanner, VirusTotal, publisher identity, and community reputation signals.
+
+## Boundaries
+
+The implementation stays L2-clean: imports only from `@koi/core` and L0 utilities. Active registry/server wiring is deferred until a v2 community-registry package exists. The archived v1 registry remains reference material for publish-time gate behavior and scoring thresholds.
+
+## Failure Model
+
+Verification fails closed. Missing attestations, invalid signatures, expired provenance, content mismatch, malicious VirusTotal verdicts, and unverified publishers reduce or block trust. The APIs return typed result objects instead of throwing for expected security failures.
+
+## Tests
+
+Targeted tests cover:
+
+- SLSA statement shape.
+- Signed provenance verifies.
+- Tampered provenance is rejected.
+- Expired provenance is rejected.
+- Install verification rejects integrity or attestation failures.
+- VirusTotal malicious verdict maps to a blocking signal.
+- Trust score incorporates all issue signals.
+- Publisher identity verification raises trust only when explicitly verified.

--- a/packages/lib/forge-integrity/src/attestation.test.ts
+++ b/packages/lib/forge-integrity/src/attestation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { ForgeProvenance, SigningBackend } from "@koi/core";
+import { createHmacSigner } from "@koi/hash";
+import { makeTool } from "./__tests__/fixtures.js";
+import { signAttestation, verifyAttestation } from "./attestation.js";
+
+const signer: SigningBackend = createHmacSigner(new TextEncoder().encode("secret"));
+
+function provenance(): ForgeProvenance {
+  return makeTool().provenance;
+}
+
+describe("attestation signing", () => {
+  test("signed provenance verifies with the same signer", async () => {
+    const signed = await signAttestation(provenance(), signer, { keyId: "local-key" });
+    const result = await verifyAttestation(signed, signer);
+
+    expect(signed.attestation?.algorithm).toBe("hmac-sha256");
+    expect(signed.attestation?.keyId).toBe("local-key");
+    expect(result.kind).toBe("ok");
+    expect(result.ok).toBe(true);
+  });
+
+  test("tampered provenance is rejected", async () => {
+    const signed = await signAttestation(provenance(), signer);
+    const tampered: ForgeProvenance = {
+      ...signed,
+      contentHash: "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    };
+    const result = await verifyAttestation(tampered, signer);
+
+    expect(result.kind).toBe("signature_invalid");
+    expect(result.ok).toBe(false);
+  });
+
+  test("missing attestation is rejected", async () => {
+    const result = await verifyAttestation(provenance(), signer);
+
+    expect(result.kind).toBe("missing_attestation");
+    expect(result.ok).toBe(false);
+  });
+
+  test("malformed base64 signature is rejected before verifier execution", async () => {
+    const signed = await signAttestation(provenance(), signer);
+    const malformed: ForgeProvenance = {
+      ...signed,
+      attestation: {
+        algorithm: "hmac-sha256",
+        signature: "not base64!",
+      },
+    };
+    const result = await verifyAttestation(malformed, signer);
+
+    expect(result.kind).toBe("malformed");
+    expect(result.ok).toBe(false);
+  });
+
+  test("expired provenance is rejected before signature trust is granted", async () => {
+    const signed = await signAttestation(provenance(), signer);
+    const result = await verifyAttestation(signed, signer, {
+      now: 10_000,
+      maxAgeMs: 1,
+    });
+
+    expect(result.kind).toBe("expired");
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/lib/forge-integrity/src/attestation.ts
+++ b/packages/lib/forge-integrity/src/attestation.ts
@@ -1,0 +1,128 @@
+import { Buffer } from "node:buffer";
+import type { ForgeProvenance, SigningBackend } from "@koi/core";
+import { canonicalBytes } from "./canonical-json.js";
+
+export interface SignAttestationOptions {
+  readonly keyId?: string | undefined;
+}
+
+export interface VerifyAttestationOptions {
+  readonly now?: number | undefined;
+  readonly maxAgeMs?: number | undefined;
+}
+
+export interface AttestationOk {
+  readonly kind: "ok";
+  readonly ok: true;
+  readonly algorithm: string;
+  readonly keyId?: string | undefined;
+}
+
+export interface AttestationMissing {
+  readonly kind: "missing_attestation";
+  readonly ok: false;
+}
+
+export interface AttestationInvalid {
+  readonly kind: "signature_invalid";
+  readonly ok: false;
+  readonly algorithm: string;
+}
+
+export interface AttestationExpired {
+  readonly kind: "expired";
+  readonly ok: false;
+  readonly finishedAt: number;
+  readonly now: number;
+  readonly maxAgeMs: number;
+}
+
+export interface AttestationMalformed {
+  readonly kind: "malformed";
+  readonly ok: false;
+  readonly reason: string;
+}
+
+export type AttestationVerificationResult =
+  | AttestationOk
+  | AttestationMissing
+  | AttestationInvalid
+  | AttestationExpired
+  | AttestationMalformed;
+
+function unsignedProvenance(provenance: ForgeProvenance): Omit<ForgeProvenance, "attestation"> {
+  const { attestation: _attestation, ...unsigned } = provenance;
+  return unsigned;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function decodeBase64(value: string): Uint8Array | undefined {
+  if (
+    value.length === 0 ||
+    value.length % 4 !== 0 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
+    return undefined;
+  }
+  try {
+    return new Uint8Array(Buffer.from(value, "base64"));
+  } catch {
+    return undefined;
+  }
+}
+
+export async function signAttestation(
+  provenance: ForgeProvenance,
+  signer: SigningBackend,
+  options: SignAttestationOptions = {},
+): Promise<ForgeProvenance> {
+  const signature = await signer.sign(canonicalBytes(unsignedProvenance(provenance)));
+  return Object.freeze({
+    ...unsignedProvenance(provenance),
+    attestation: Object.freeze({
+      algorithm: signer.algorithm,
+      signature: encodeBase64(signature),
+      ...(options.keyId !== undefined ? { keyId: options.keyId } : {}),
+    }),
+  });
+}
+
+export async function verifyAttestation(
+  provenance: ForgeProvenance,
+  signer: SigningBackend,
+  options: VerifyAttestationOptions = {},
+): Promise<AttestationVerificationResult> {
+  const attestation = provenance.attestation;
+  if (attestation === undefined) return { kind: "missing_attestation", ok: false };
+  if (attestation.algorithm !== signer.algorithm) {
+    return { kind: "signature_invalid", ok: false, algorithm: attestation.algorithm };
+  }
+  const signature = decodeBase64(attestation.signature);
+  if (signature === undefined || signature.length === 0) {
+    return { kind: "malformed", ok: false, reason: "attestation.signature is not base64" };
+  }
+  if (options.maxAgeMs !== undefined) {
+    const now = options.now ?? Date.now();
+    const age = now - provenance.metadata.finishedAt;
+    if (age > options.maxAgeMs) {
+      return {
+        kind: "expired",
+        ok: false,
+        finishedAt: provenance.metadata.finishedAt,
+        now,
+        maxAgeMs: options.maxAgeMs,
+      };
+    }
+  }
+  const valid = await signer.verify(canonicalBytes(unsignedProvenance(provenance)), signature);
+  if (!valid) return { kind: "signature_invalid", ok: false, algorithm: attestation.algorithm };
+  return {
+    kind: "ok",
+    ok: true,
+    algorithm: attestation.algorithm,
+    ...(attestation.keyId !== undefined ? { keyId: attestation.keyId } : {}),
+  };
+}

--- a/packages/lib/forge-integrity/src/canonical-json.ts
+++ b/packages/lib/forge-integrity/src/canonical-json.ts
@@ -1,0 +1,17 @@
+function isPlainObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Stable JSON encoding for trust-bearing attestation payloads. */
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (!isPlainObject(value)) return JSON.stringify(value);
+  const entries = Object.entries(value)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(",")}}`;
+}
+
+export function canonicalBytes(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalJson(value));
+}

--- a/packages/lib/forge-integrity/src/index.ts
+++ b/packages/lib/forge-integrity/src/index.ts
@@ -4,6 +4,22 @@
  */
 
 export type {
+  AttestationExpired,
+  AttestationInvalid,
+  AttestationMalformed,
+  AttestationMissing,
+  AttestationOk,
+  AttestationVerificationResult,
+  SignAttestationOptions,
+  VerifyAttestationOptions,
+} from "./attestation.js";
+export { signAttestation, verifyAttestation } from "./attestation.js";
+export type {
+  InstallProvenanceResult,
+  VerifyInstallProvenanceOptions,
+} from "./install-verification.js";
+export { verifyInstallProvenance } from "./install-verification.js";
+export type {
   BrickVerifier,
   IntegrityContentMismatch,
   IntegrityMalformed,
@@ -21,7 +37,6 @@ export type {
 // preventing request-scoped or attacker-controlled registries from being
 // passed into the verifier on each call.
 export { createBrickVerifier } from "./integrity.js";
-
 export type { ProvenanceEquivalent } from "./lineage.js";
 // Both lineage helpers (`isDerivedFrom`, `isDerivedFromUnchecked`) are
 // intentionally NOT exported in this release. The trusted variant
@@ -33,6 +48,27 @@ export type { ProvenanceEquivalent } from "./lineage.js";
 // `getParentBrickId` accessor is exported so callers can implement
 // narrow, non-policy-bearing inspections without a walk.
 export { findContentEquivalentById, getParentBrickId } from "./lineage.js";
-
+export type {
+  CommunityTrustSignal,
+  EvaluateMarketplaceTrustOptions,
+  LocalScanSignal,
+  MarketplaceDecision,
+  MarketplaceTrustResult,
+  PublisherIdentityResult,
+  PublisherIdentityVerifier,
+} from "./marketplace.js";
+export { evaluateMarketplaceTrust } from "./marketplace.js";
 export type { CreateProvenanceOptions } from "./provenance.js";
 export { createForgeProvenance, MAX_PROVENANCE_DEPTH } from "./provenance.js";
+export type { SlsaProvenanceV1 } from "./slsa.js";
+export { mapProvenanceToSlsa, mapProvenanceToStatement, SLSA_PROVENANCE_V1_TYPE } from "./slsa.js";
+export type { TrustScoreInput, TrustScoreLevel, TrustScoreResult } from "./trust-score.js";
+export { computeTrustScore } from "./trust-score.js";
+export type {
+  VirusTotalAnalysis,
+  VirusTotalClient,
+  VirusTotalSignal,
+  VirusTotalStats,
+  VirusTotalVerdict,
+} from "./virustotal.js";
+export { mapVirusTotalAnalysisToSignal, scanBrickWithVirusTotal } from "./virustotal.js";

--- a/packages/lib/forge-integrity/src/install-verification.test.ts
+++ b/packages/lib/forge-integrity/src/install-verification.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { SigningBackend } from "@koi/core";
+import { createHmacSigner } from "@koi/hash";
+import { makeTool, recomputeFixtureId, tamper } from "./__tests__/fixtures.js";
+import { signAttestation } from "./attestation.js";
+import { verifyInstallProvenance } from "./install-verification.js";
+import { createBrickVerifier } from "./integrity.js";
+
+const TRUSTED_BUILDER = "koi/forge";
+const signer: SigningBackend = createHmacSigner(new TextEncoder().encode("secret"));
+const verifier = createBrickVerifier({ [TRUSTED_BUILDER]: recomputeFixtureId });
+
+describe("install provenance verification", () => {
+  test("accepts a brick with valid integrity and attestation", async () => {
+    const brick = makeTool();
+    const signed = { ...brick, provenance: await signAttestation(brick.provenance, signer) };
+    const result = await verifyInstallProvenance(signed, {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+    });
+
+    expect(result.kind).toBe("ok");
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a tampered brick before install", async () => {
+    const brick = makeTool();
+    const signed = { ...brick, provenance: await signAttestation(brick.provenance, signer) };
+    const result = await verifyInstallProvenance(tamper(signed), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+    });
+
+    expect(result.kind).toBe("integrity_failed");
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a brick with missing attestation", async () => {
+    const result = await verifyInstallProvenance(makeTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+    });
+
+    expect(result.kind).toBe("attestation_failed");
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/lib/forge-integrity/src/install-verification.ts
+++ b/packages/lib/forge-integrity/src/install-verification.ts
@@ -1,0 +1,35 @@
+import type { BrickArtifact, SigningBackend } from "@koi/core";
+import type { AttestationVerificationResult, VerifyAttestationOptions } from "./attestation.js";
+import { verifyAttestation } from "./attestation.js";
+import type { BrickVerifier, IntegrityResult } from "./integrity.js";
+
+export interface VerifyInstallProvenanceOptions {
+  readonly expectedBuilderId: string;
+  readonly verifier: BrickVerifier;
+  readonly signer: SigningBackend;
+  readonly attestation?: VerifyAttestationOptions | undefined;
+}
+
+export type InstallProvenanceResult =
+  | { readonly kind: "ok"; readonly ok: true }
+  | { readonly kind: "integrity_failed"; readonly ok: false; readonly integrity: IntegrityResult }
+  | {
+      readonly kind: "attestation_failed";
+      readonly ok: false;
+      readonly attestation: AttestationVerificationResult;
+    };
+
+export async function verifyInstallProvenance(
+  brick: BrickArtifact,
+  options: VerifyInstallProvenanceOptions,
+): Promise<InstallProvenanceResult> {
+  const integrity = options.verifier(brick, options.expectedBuilderId);
+  if (!integrity.ok) return { kind: "integrity_failed", ok: false, integrity };
+  const attestation = await verifyAttestation(
+    brick.provenance,
+    options.signer,
+    options.attestation,
+  );
+  if (!attestation.ok) return { kind: "attestation_failed", ok: false, attestation };
+  return { kind: "ok", ok: true };
+}

--- a/packages/lib/forge-integrity/src/marketplace.test.ts
+++ b/packages/lib/forge-integrity/src/marketplace.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { BrickArtifact, SigningBackend } from "@koi/core";
+import { createHmacSigner } from "@koi/hash";
+import { makeTool, recomputeFixtureId } from "./__tests__/fixtures.js";
+import { signAttestation } from "./attestation.js";
+import { createBrickVerifier } from "./integrity.js";
+import { evaluateMarketplaceTrust } from "./marketplace.js";
+
+const TRUSTED_BUILDER = "koi/forge";
+const signer: SigningBackend = createHmacSigner(new TextEncoder().encode("secret"));
+const verifier = createBrickVerifier({ [TRUSTED_BUILDER]: recomputeFixtureId });
+
+async function signedTool(): Promise<BrickArtifact> {
+  const brick = makeTool();
+  return { ...brick, provenance: await signAttestation(brick.provenance, signer) };
+}
+
+describe("marketplace trust evaluation", () => {
+  test("accepts a signed brick with clean scans and verified publisher", async () => {
+    const result = await evaluateMarketplaceTrust(await signedTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+      localScan: { passed: true, score: 95 },
+      virusTotal: { passed: true, verdict: "clean", score: 100 },
+      publisherVerifier: async () => ({ verified: true, publisherId: "publisher:koi" }),
+      community: { score: 0.8, feedbackCount: 10 },
+    });
+
+    expect(result.decision).toBe("accepted");
+    expect(result.trust.level).toBe("verified");
+    expect(result.publisher.verified).toBe(true);
+  });
+
+  test("blocks publication when provenance attestation is missing", async () => {
+    const result = await evaluateMarketplaceTrust(makeTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+      localScan: { passed: true, score: 95 },
+      virusTotal: { passed: true, verdict: "clean", score: 100 },
+      publisherVerifier: async () => ({ verified: true, publisherId: "publisher:koi" }),
+      community: { score: 0.8, feedbackCount: 10 },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.reasons).toContain("attestation_failed:missing_attestation");
+  });
+
+  test("blocks publication when publisher identity is not verified", async () => {
+    const result = await evaluateMarketplaceTrust(await signedTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+      localScan: { passed: true, score: 95 },
+      virusTotal: { passed: true, verdict: "clean", score: 100 },
+      publisherVerifier: async () => ({ verified: false, publisherId: "publisher:unknown" }),
+      community: { score: 0.8, feedbackCount: 10 },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.reasons).toContain("publisher_unverified");
+  });
+
+  test("blocks publication when VirusTotal reports malicious code", async () => {
+    const result = await evaluateMarketplaceTrust(await signedTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+      localScan: { passed: true, score: 95 },
+      virusTotal: { passed: false, verdict: "malicious", score: 0 },
+      publisherVerifier: async () => ({ verified: true, publisherId: "publisher:koi" }),
+      community: { score: 0.8, feedbackCount: 10 },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.reasons).toContain("virustotal_malicious");
+  });
+
+  test("blocks publication when local scanner rejects code", async () => {
+    const result = await evaluateMarketplaceTrust(await signedTool(), {
+      expectedBuilderId: TRUSTED_BUILDER,
+      verifier,
+      signer,
+      localScan: { passed: false, score: 10 },
+      virusTotal: { passed: true, verdict: "clean", score: 100 },
+      publisherVerifier: async () => ({ verified: true, publisherId: "publisher:koi" }),
+      community: { score: 0.8, feedbackCount: 10 },
+    });
+
+    expect(result.decision).toBe("blocked");
+    expect(result.reasons).toContain("local_scan_failed");
+  });
+});

--- a/packages/lib/forge-integrity/src/marketplace.ts
+++ b/packages/lib/forge-integrity/src/marketplace.ts
@@ -1,0 +1,106 @@
+import type { BrickArtifact, SigningBackend } from "@koi/core";
+import type {
+  InstallProvenanceResult,
+  VerifyInstallProvenanceOptions,
+} from "./install-verification.js";
+import { verifyInstallProvenance } from "./install-verification.js";
+import type { BrickVerifier } from "./integrity.js";
+import { computeTrustScore, type TrustScoreResult } from "./trust-score.js";
+import type { VirusTotalSignal } from "./virustotal.js";
+
+export type MarketplaceDecision = "accepted" | "warning" | "blocked";
+
+export interface LocalScanSignal {
+  readonly passed: boolean;
+  readonly score: number;
+}
+
+export interface CommunityTrustSignal {
+  readonly score: number;
+  readonly feedbackCount: number;
+}
+
+export interface PublisherIdentityResult {
+  readonly verified: boolean;
+  readonly publisherId: string;
+}
+
+export interface PublisherIdentityVerifier {
+  readonly verifyPublisher: (
+    brick: BrickArtifact,
+  ) => PublisherIdentityResult | Promise<PublisherIdentityResult>;
+}
+
+export interface EvaluateMarketplaceTrustOptions {
+  readonly expectedBuilderId: string;
+  readonly verifier: BrickVerifier;
+  readonly signer: SigningBackend;
+  readonly attestation?: VerifyInstallProvenanceOptions["attestation"];
+  readonly localScan: LocalScanSignal;
+  readonly virusTotal: Pick<VirusTotalSignal, "passed" | "verdict" | "score">;
+  readonly publisherVerifier:
+    | PublisherIdentityVerifier
+    | ((brick: BrickArtifact) => PublisherIdentityResult | Promise<PublisherIdentityResult>);
+  readonly community: CommunityTrustSignal;
+}
+
+export interface MarketplaceTrustResult {
+  readonly decision: MarketplaceDecision;
+  readonly install: InstallProvenanceResult;
+  readonly publisher: PublisherIdentityResult;
+  readonly trust: TrustScoreResult;
+  readonly reasons: readonly string[];
+}
+
+async function verifyPublisher(
+  brick: BrickArtifact,
+  verifier: EvaluateMarketplaceTrustOptions["publisherVerifier"],
+): Promise<PublisherIdentityResult> {
+  if (typeof verifier === "function") return verifier(brick);
+  return verifier.verifyPublisher(brick);
+}
+
+function installReason(result: InstallProvenanceResult): string | undefined {
+  if (result.ok) return undefined;
+  if (result.kind === "integrity_failed") return `integrity_failed:${result.integrity.kind}`;
+  return `attestation_failed:${result.attestation.kind}`;
+}
+
+export async function evaluateMarketplaceTrust(
+  brick: BrickArtifact,
+  options: EvaluateMarketplaceTrustOptions,
+): Promise<MarketplaceTrustResult> {
+  const install = await verifyInstallProvenance(brick, {
+    expectedBuilderId: options.expectedBuilderId,
+    verifier: options.verifier,
+    signer: options.signer,
+    attestation: options.attestation,
+  });
+  const publisher = await verifyPublisher(brick, options.publisherVerifier);
+  const trust = computeTrustScore({
+    provenance: {
+      verified: install.ok,
+      expired: install.kind === "attestation_failed" && install.attestation.kind === "expired",
+    },
+    localScan: options.localScan,
+    virusTotal: options.virusTotal,
+    publisher: { verified: publisher.verified },
+    community: options.community,
+  });
+
+  const reasons = [
+    installReason(install),
+    options.localScan.passed ? undefined : "local_scan_failed",
+    options.virusTotal.verdict === "malicious" ? "virustotal_malicious" : undefined,
+    publisher.verified ? undefined : "publisher_unverified",
+    trust.level === "blocked" ? "trust_score_blocked" : undefined,
+  ].filter((reason): reason is string => reason !== undefined);
+
+  return {
+    decision: reasons.length > 0 ? "blocked" : trust.level === "low" ? "warning" : "accepted",
+    install,
+    publisher,
+    trust,
+    reasons,
+  };
+}

--- a/packages/lib/forge-integrity/src/slsa.test.ts
+++ b/packages/lib/forge-integrity/src/slsa.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { ForgeProvenance } from "@koi/core";
+import { brickId } from "@koi/core";
+import { mapProvenanceToSlsa, mapProvenanceToStatement, SLSA_PROVENANCE_V1_TYPE } from "./slsa.js";
+
+const provenance: ForgeProvenance = {
+  source: { origin: "forged", forgedBy: "agent-1", sessionId: "sess-1" },
+  buildDefinition: {
+    buildType: "https://koi.dev/forge-tools/v1",
+    externalParameters: { name: "csv-parser" },
+    internalParameters: { policy: "sandboxed" },
+    resolvedDependencies: [{ uri: "pkg:bun/zod@4.3.6", digest: { sha256: "abc" } }],
+  },
+  builder: { id: "koi/forge-tools", version: "1.0.0", nodeId: "node-a" },
+  metadata: {
+    invocationId: "inv-1",
+    startedAt: 1_700_000_000_000,
+    finishedAt: 1_700_000_001_500,
+    sessionId: "sess-1",
+    agentId: "agent-1",
+    depth: 0,
+  },
+  verification: {
+    passed: true,
+    sandbox: true,
+    totalDurationMs: 1500,
+    stageResults: [{ stage: "static", passed: true, durationMs: 25 }],
+  },
+  classification: "internal",
+  contentMarkers: ["pii"],
+  contentHash: "sha256:cafebabe000000000000000000000000000000000000000000000000000000ff",
+};
+
+describe("SLSA provenance mapping", () => {
+  test("maps ForgeProvenance to a SLSA v1.0 predicate with Koi extensions", () => {
+    const slsa = mapProvenanceToSlsa(provenance);
+
+    expect(slsa.buildDefinition.buildType).toBe("https://koi.dev/forge-tools/v1");
+    expect(slsa.buildDefinition.externalParameters).toEqual({ name: "csv-parser" });
+    expect(slsa.runDetails.builder.id).toBe("koi/forge-tools");
+    expect(slsa.runDetails.metadata.invocationId).toBe("inv-1");
+    expect(slsa.runDetails.metadata.startedOn).toBe("2023-11-14T22:13:20.000Z");
+    expect(slsa.runDetails.metadata.finishedOn).toBe("2023-11-14T22:13:21.500Z");
+    expect(slsa.koiVerification.passed).toBe(true);
+    expect(slsa.koiClassification).toBe("internal");
+    expect(slsa.koiContentMarkers).toEqual(["pii"]);
+  });
+
+  test("wraps the SLSA predicate in an in-toto Statement v1", () => {
+    const statement = mapProvenanceToStatement(
+      provenance,
+      brickId("sha256:cafebabe000000000000000000000000000000000000000000000000000000ff"),
+    );
+
+    expect(statement._type).toBe("https://in-toto.io/Statement/v1");
+    expect(statement.predicateType).toBe(SLSA_PROVENANCE_V1_TYPE);
+    expect(statement.subject).toEqual([
+      {
+        name: "koi-brick",
+        digest: {
+          sha256: "cafebabe000000000000000000000000000000000000000000000000000000ff",
+        },
+      },
+    ]);
+    expect(statement.predicate.runDetails.builder.id).toBe("koi/forge-tools");
+  });
+});

--- a/packages/lib/forge-integrity/src/slsa.ts
+++ b/packages/lib/forge-integrity/src/slsa.ts
@@ -1,0 +1,63 @@
+import type {
+  BrickId,
+  ForgeBuildDefinition,
+  ForgeBuilder,
+  ForgeProvenance,
+  ForgeVerificationSummary,
+  InTotoStatementV1,
+} from "@koi/core";
+
+export const SLSA_PROVENANCE_V1_TYPE = "https://slsa.dev/provenance/v1" as const;
+
+export interface SlsaProvenanceV1 {
+  readonly buildDefinition: ForgeBuildDefinition;
+  readonly runDetails: {
+    readonly builder: ForgeBuilder;
+    readonly metadata: {
+      readonly invocationId: string;
+      readonly startedOn: string;
+      readonly finishedOn: string;
+    };
+  };
+  readonly koiVerification: ForgeVerificationSummary;
+  readonly koiClassification: ForgeProvenance["classification"];
+  readonly koiContentMarkers: ForgeProvenance["contentMarkers"];
+  readonly koiSource: ForgeProvenance["source"];
+  readonly koiContentHash: string;
+}
+
+export function mapProvenanceToSlsa(provenance: ForgeProvenance): SlsaProvenanceV1 {
+  return {
+    buildDefinition: provenance.buildDefinition,
+    runDetails: {
+      builder: provenance.builder,
+      metadata: {
+        invocationId: provenance.metadata.invocationId,
+        startedOn: new Date(provenance.metadata.startedAt).toISOString(),
+        finishedOn: new Date(provenance.metadata.finishedAt).toISOString(),
+      },
+    },
+    koiVerification: provenance.verification,
+    koiClassification: provenance.classification,
+    koiContentMarkers: provenance.contentMarkers,
+    koiSource: provenance.source,
+    koiContentHash: provenance.contentHash,
+  };
+}
+
+function subjectDigest(brickId: BrickId): Readonly<Record<string, string>> {
+  const [algorithm, digest] = brickId.split(":");
+  return { [algorithm ?? "sha256"]: digest ?? brickId };
+}
+
+export function mapProvenanceToStatement(
+  provenance: ForgeProvenance,
+  brickId: BrickId,
+): InTotoStatementV1<SlsaProvenanceV1> {
+  return {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: [{ name: "koi-brick", digest: subjectDigest(brickId) }],
+    predicateType: SLSA_PROVENANCE_V1_TYPE,
+    predicate: mapProvenanceToSlsa(provenance),
+  };
+}

--- a/packages/lib/forge-integrity/src/trust-score.test.ts
+++ b/packages/lib/forge-integrity/src/trust-score.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { computeTrustScore } from "./trust-score.js";
+import { mapVirusTotalAnalysisToSignal } from "./virustotal.js";
+
+describe("VirusTotal and trust scoring", () => {
+  test("VirusTotal malicious verdict maps to a blocking signal", () => {
+    const signal = mapVirusTotalAnalysisToSignal({
+      id: "analysis-1",
+      status: "completed",
+      stats: { harmless: 3, malicious: 1, suspicious: 0, undetected: 10, timeout: 0 },
+      permalink: "https://www.virustotal.com/gui/file/example",
+      scannedAt: 1,
+    });
+
+    expect(signal.verdict).toBe("malicious");
+    expect(signal.passed).toBe(false);
+    expect(signal.score).toBe(0);
+  });
+
+  test("trust score incorporates provenance, scans, publisher identity, and community signals", () => {
+    const trusted = computeTrustScore({
+      provenance: { verified: true, expired: false },
+      localScan: { passed: true, score: 92 },
+      virusTotal: { passed: true, verdict: "clean", score: 98 },
+      publisher: { verified: true },
+      community: { score: 0.8, feedbackCount: 12 },
+    });
+    const untrusted = computeTrustScore({
+      provenance: { verified: false, expired: false },
+      localScan: { passed: false, score: 20 },
+      virusTotal: { passed: false, verdict: "malicious", score: 0 },
+      publisher: { verified: false },
+      community: { score: 0.2, feedbackCount: 2 },
+    });
+
+    expect(trusted.score).toBeGreaterThan(85);
+    expect(trusted.level).toBe("verified");
+    expect(trusted.signals.publisherIdentity).toBe("verified");
+    expect(untrusted.score).toBeLessThan(30);
+    expect(untrusted.level).toBe("blocked");
+    expect(untrusted.signals.virusTotal).toBe("malicious");
+  });
+
+  test("publisher identity does not raise trust unless explicitly verified", () => {
+    const withoutPublisher = computeTrustScore({
+      provenance: { verified: true, expired: false },
+      localScan: { passed: true, score: 90 },
+      virusTotal: { passed: true, verdict: "clean", score: 90 },
+      publisher: { verified: false },
+      community: { score: 0.9, feedbackCount: 25 },
+    });
+    const withPublisher = computeTrustScore({
+      provenance: { verified: true, expired: false },
+      localScan: { passed: true, score: 90 },
+      virusTotal: { passed: true, verdict: "clean", score: 90 },
+      publisher: { verified: true },
+      community: { score: 0.9, feedbackCount: 25 },
+    });
+
+    expect(withPublisher.score).toBeGreaterThan(withoutPublisher.score);
+    expect(withoutPublisher.signals.publisherIdentity).toBe("unverified");
+  });
+});

--- a/packages/lib/forge-integrity/src/trust-score.ts
+++ b/packages/lib/forge-integrity/src/trust-score.ts
@@ -1,0 +1,81 @@
+import type { VirusTotalSignal } from "./virustotal.js";
+
+export type TrustScoreLevel = "blocked" | "low" | "medium" | "high" | "verified";
+
+export interface TrustScoreInput {
+  readonly provenance: {
+    readonly verified: boolean;
+    readonly expired: boolean;
+  };
+  readonly localScan: {
+    readonly passed: boolean;
+    readonly score: number;
+  };
+  readonly virusTotal: Pick<VirusTotalSignal, "passed" | "verdict" | "score">;
+  readonly publisher: {
+    readonly verified: boolean;
+  };
+  readonly community: {
+    readonly score: number;
+    readonly feedbackCount: number;
+  };
+}
+
+export interface TrustScoreResult {
+  readonly score: number;
+  readonly level: TrustScoreLevel;
+  readonly signals: {
+    readonly provenance: "verified" | "missing" | "expired";
+    readonly localScan: "passed" | "failed";
+    readonly virusTotal: VirusTotalSignal["verdict"];
+    readonly publisherIdentity: "verified" | "unverified";
+    readonly communityFeedback: "none" | "present";
+  };
+}
+
+function clampScore(score: number): number {
+  if (!Number.isFinite(score)) return 0;
+  return Math.max(0, Math.min(100, score));
+}
+
+function levelFor(score: number): TrustScoreLevel {
+  if (score < 30) return "blocked";
+  if (score < 50) return "low";
+  if (score < 75) return "medium";
+  if (score < 90) return "high";
+  return "verified";
+}
+
+export function computeTrustScore(input: TrustScoreInput): TrustScoreResult {
+  const provenanceScore = input.provenance.expired ? 0 : input.provenance.verified ? 100 : 20;
+  const localScanScore = input.localScan.passed ? clampScore(input.localScan.score) : 0;
+  const vtScore = input.virusTotal.passed ? clampScore(input.virusTotal.score) : 0;
+  const publisherScore = input.publisher.verified ? 100 : 40;
+  const communityScore =
+    input.community.feedbackCount > 0 ? clampScore(input.community.score * 100) : 50;
+  const score = Math.round(
+    provenanceScore * 0.3 +
+      localScanScore * 0.2 +
+      vtScore * 0.2 +
+      publisherScore * 0.15 +
+      communityScore * 0.15,
+  );
+  const forcedBlocked =
+    input.provenance.expired || !input.localScan.passed || input.virusTotal.verdict === "malicious";
+  const effectiveScore = forcedBlocked ? Math.min(score, 29) : score;
+  return {
+    score: effectiveScore,
+    level: levelFor(effectiveScore),
+    signals: {
+      provenance: input.provenance.expired
+        ? "expired"
+        : input.provenance.verified
+          ? "verified"
+          : "missing",
+      localScan: input.localScan.passed ? "passed" : "failed",
+      virusTotal: input.virusTotal.verdict,
+      publisherIdentity: input.publisher.verified ? "verified" : "unverified",
+      communityFeedback: input.community.feedbackCount > 0 ? "present" : "none",
+    },
+  };
+}

--- a/packages/lib/forge-integrity/src/virustotal.test.ts
+++ b/packages/lib/forge-integrity/src/virustotal.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { makeTool } from "./__tests__/fixtures.js";
+import { scanBrickWithVirusTotal } from "./virustotal.js";
+
+describe("VirusTotal brick scanning", () => {
+  test("submits tool implementation bytes to the injected VirusTotal client", async () => {
+    const seen: string[] = [];
+    const signal = await scanBrickWithVirusTotal(
+      makeTool({ implementation: "export default 1;" }),
+      {
+        scan: async (content) => {
+          seen.push(new TextDecoder().decode(content));
+          return {
+            id: "analysis-1",
+            status: "completed",
+            stats: { harmless: 8, malicious: 0, suspicious: 0, undetected: 1, timeout: 0 },
+            scannedAt: 123,
+          };
+        },
+      },
+    );
+
+    expect(seen).toEqual(["export default 1;"]);
+    expect(signal.verdict).toBe("clean");
+    expect(signal.passed).toBe(true);
+  });
+
+  test("submits skill content bytes to the injected VirusTotal client", async () => {
+    const brick = {
+      ...makeTool({ name: "skillish" }),
+      kind: "skill" as const,
+      content: "# Skill\n\n```ts\nconst x = 1;\n```",
+    };
+    const seen: string[] = [];
+    const signal = await scanBrickWithVirusTotal(brick, {
+      scan: async (content) => {
+        seen.push(new TextDecoder().decode(content));
+        return {
+          id: "analysis-2",
+          status: "completed",
+          stats: { harmless: 0, malicious: 1, suspicious: 0, undetected: 0, timeout: 0 },
+          scannedAt: 124,
+        };
+      },
+    });
+
+    expect(seen[0]).toContain("# Skill");
+    expect(signal.verdict).toBe("malicious");
+    expect(signal.passed).toBe(false);
+  });
+});

--- a/packages/lib/forge-integrity/src/virustotal.ts
+++ b/packages/lib/forge-integrity/src/virustotal.ts
@@ -1,0 +1,83 @@
+import type { BrickArtifact } from "@koi/core";
+
+export type VirusTotalVerdict = "clean" | "suspicious" | "malicious" | "unknown";
+
+export interface VirusTotalStats {
+  readonly harmless: number;
+  readonly malicious: number;
+  readonly suspicious: number;
+  readonly undetected: number;
+  readonly timeout: number;
+}
+
+export interface VirusTotalAnalysis {
+  readonly id: string;
+  readonly status: "queued" | "completed" | "failed";
+  readonly stats: VirusTotalStats;
+  readonly permalink?: string | undefined;
+  readonly scannedAt: number;
+}
+
+export interface VirusTotalSignal {
+  readonly passed: boolean;
+  readonly verdict: VirusTotalVerdict;
+  readonly score: number;
+  readonly analysisId: string;
+  readonly permalink?: string | undefined;
+  readonly scannedAt: number;
+}
+
+export interface VirusTotalClient {
+  readonly scan: (content: Uint8Array) => Promise<VirusTotalAnalysis>;
+}
+
+export function mapVirusTotalAnalysisToSignal(analysis: VirusTotalAnalysis): VirusTotalSignal {
+  const verdict: VirusTotalVerdict =
+    analysis.status !== "completed"
+      ? "unknown"
+      : analysis.stats.malicious > 0
+        ? "malicious"
+        : analysis.stats.suspicious > 0
+          ? "suspicious"
+          : "clean";
+  const score =
+    verdict === "malicious" ? 0 : verdict === "suspicious" ? 40 : verdict === "clean" ? 100 : 50;
+  return {
+    passed: verdict === "clean",
+    verdict,
+    score,
+    analysisId: analysis.id,
+    ...(analysis.permalink !== undefined ? { permalink: analysis.permalink } : {}),
+    scannedAt: analysis.scannedAt,
+  };
+}
+
+function extractBrickContent(brick: BrickArtifact): string {
+  if (brick.kind === "skill") return brick.content;
+  if (brick.kind === "tool" || brick.kind === "middleware" || brick.kind === "channel") {
+    return brick.implementation;
+  }
+  if (brick.kind === "agent") return brick.manifestYaml;
+  if (brick.kind === "composite") {
+    return JSON.stringify({
+      steps: brick.steps,
+      exposedInput: brick.exposedInput,
+      exposedOutput: brick.exposedOutput,
+      outputKind: brick.outputKind,
+    });
+  }
+  return JSON.stringify({
+    id: brick.id,
+    kind: brick.kind,
+    name: brick.name,
+  });
+}
+
+export async function scanBrickWithVirusTotal(
+  brick: BrickArtifact,
+  client: VirusTotalClient,
+): Promise<VirusTotalSignal> {
+  const content = new TextEncoder().encode(extractBrickContent(brick));
+  const analysis = await client.scan(content);
+  return mapVirusTotalAnalysisToSignal(analysis);
+}


### PR DESCRIPTION
## Summary

Adds the issue #1402 forge-integrity trust layer for forged bricks:

- SLSA v1 provenance mapping and in-toto statement generation
- canonical provenance signing and attestation verification
- install-time composition of content integrity plus attestation verification
- VirusTotal signal mapping and injected brick scanning
- deterministic trust scoring across provenance, local scan, VirusTotal, publisher identity, and community signals
- marketplace trust evaluation that blocks missing attestations, tampering, malicious VT results, local scanner failures, and unverified publishers

Closes #1402.

The implementation stays inside `@koi/forge-integrity`; concrete VirusTotal HTTP/API-key wiring and active marketplace route integration remain out of scope and are documented as such.

## Validation

- `bunx turbo run test typecheck lint --filter=@koi/forge-integrity`
- `bun run check:golden-queries`
- `bun run check:orphans`
- `bunx turbo run test typecheck lint --filter=@koi/tui`
- `bun run check:tui-tools`
- `bun run check:tui-single-writer`
- Manual throwaway E2E via `bun --eval` covering signed provenance, wrong key, malformed base64, expiry, tampering, missing attestation, VirusTotal clean/suspicious/unknown, marketplace accept/block/warning cases
- Pre-commit hook: `biome-check`, `bun-test-filter`
- Pre-push hook: full build/typecheck, `419 successful, 419 total`
