### PR TITLE
[codex] Add node gateway capability advertising

### DIFF
--- a/docs/L2/device.md
+++ b/docs/L2/device.md
@@ -20,12 +20,14 @@ names.
 - `createDeviceComponentProvider()` aggregate provider
 - Per-capability providers for hosts that want to advertise a smaller set
 - Typed `UNAVAILABLE` errors when a platform capability is not injected
+- `createDeviceGatewayClient()` for thin nodes that advertise injected
+  device providers to `@koi/gateway`
 
 ## What it does NOT own
 
 - Native iOS, Android, desktop, browser, or OS API calls
 - Permission prompts or OS-level consent UX
-- Gateway connection and network capability advertising
+- Gateway server ownership, node registry persistence, or remote tool execution
 - Durable delivery, retry, or fan-out for SMS or push messages
 
 ## Dependencies
@@ -33,6 +35,28 @@ names.
 | Package | Layer | Purpose |
 |---------|-------|---------|
 | `@koi/core` | L0 | `ComponentProvider`, `SubsystemToken`, `Result`, `KoiError` |
+
+## Gateway Advertising
+
+`createDeviceGatewayClient(config)` is the thin-node bridge for issue #1396.
+Hosts pass a gateway URL, stable `nodeId`, optional capacity report, and the
+currently injected `ComponentProvider[]`. On WebSocket open the client sends:
+
+- `node:handshake` with `nodeId`, version, and capacity
+- `node:capabilities` with `nodeType: "thin"` and advertised device tools
+- periodic `node:heartbeat` frames
+
+Provider names are mapped onto stable tool names (`device.location`,
+`device.motion`, `device.sms`, `device.push`, `device.camera`,
+`device.contacts`). Duplicate tool names are collapsed before advertising.
+When `updateProviders(nextProviders)` changes the provider set, the client
+sends `node:tools_updated` with added tool descriptors and removed tool names.
+If the gateway sends `node:capabilities_query` for this node, the client
+replies with a fresh `node:capabilities` frame using the query correlation id.
+
+The client owns only connection/reconnect timers and capability advertisement;
+actual platform permissions and operation implementations still live in the
+host-injected providers.
 
 ## API
 

--- a/docs/L2/gateway.md
+++ b/docs/L2/gateway.md
@@ -1,8 +1,15 @@
 # @koi/gateway — WebSocket Gateway Core
 
-Minimal WebSocket gateway for Koi v2. Manages client connections via a single transport: **client sessions** exchanging `GatewayFrame` messages. Handles authentication, protocol negotiation, session sequencing, backpressure, and routing.
+Minimal WebSocket gateway for Koi v2. Manages client connections via two
+transport lanes: authenticated **client sessions** exchanging `GatewayFrame`
+messages, and issue #1396 **node connections** exchanging `node:*` frames for
+capability advertisement. Handles authentication, protocol negotiation, session
+sequencing, backpressure, routing, and in-memory node capability resolution.
 
-**v2 scope** (Issue #1365): single-node, no Nexus/HA, no node registry, no tool routing. Those are future issues.
+**v2 scope** (Issue #1365 + #1396): single-node, no Nexus/HA and no remote tool
+invocation. Nodes can connect, heartbeat, advertise tools, refresh capabilities
+on query, and update tool membership; capacity is captured at handshake time.
+Request routing to those tools remains a future issue.
 
 **Gateway contract (Issue #1639)**: implements the L0u `Gateway` interface from `@koi/gateway-types` so peer L2 packages (notably `@koi/gateway-http`) can drive ingress without depending on this package directly. The contract surface is `ingest(session, frame)` + `pauseIngress()` + `forceClose()` + `activeConnections()`. `pauseIngress()` blocks new ingress AND sends a graceful WS close (1001 SERVER_SHUTTING_DOWN) on every live connection so callers' shutdown drain can actually complete.
 
@@ -30,6 +37,8 @@ Agents need a stable connection endpoint that:
 │  @koi/gateway  (L2)                             │
 │                                                 │
 │  gateway.ts          ← createGateway() factory  │
+│  node-protocol.ts    ← node:* frame validation   │
+│  node-registry.ts    ← in-memory tool index      │
 │  transport.ts        ← Bun.serve() WebSocket    │
 │  auth.ts             ← handshake orchestration  │
 │  protocol.ts         ← frame parsing/encoding   │
@@ -111,6 +120,52 @@ interface Gateway {
 ---
 
 ## Wire Protocol
+
+### Node Connections
+
+Gateway accepts unauthenticated `node:*` WebSocket messages on the same
+transport. A node starts with:
+
+```json
+{
+  "kind": "node:handshake",
+  "nodeId": "device-1",
+  "agentId": "",
+  "correlationId": "c-1",
+  "payload": {
+    "nodeId": "device-1",
+    "version": "1.0.0",
+    "capacity": { "current": 0, "max": 1, "available": 1 }
+  }
+}
+```
+
+The gateway records the connection and replies with `node:registered`.
+Capabilities are advertised separately:
+
+```json
+{
+  "kind": "node:capabilities",
+  "nodeId": "device-1",
+  "agentId": "",
+  "correlationId": "c-2",
+  "payload": {
+    "nodeType": "thin",
+    "tools": [{ "name": "device.camera", "description": "Device camera" }]
+  }
+}
+```
+
+`node:heartbeat` refreshes liveness, `node:capabilities_query` asks a node to
+re-advertise its current tools, and `node:tools_updated` applies incremental
+additions/removals to the registry.
+Malformed node frames close with `INVALID_HANDSHAKE`; frames for unknown nodes
+return `node:error` instead of mutating the registry.
+
+`createInMemoryNodeRegistry()` indexes advertised tool names to
+`NodeCapability[]`. `gateway.discoverNodeCapabilities(toolName)` exposes that
+lookup for future routing layers while keeping this package free of execution
+ownership.
 
 ### Handshake
 
@@ -294,7 +349,7 @@ These hooks are inert when `preserveSessionsOnStop` is unset — single-node beh
 
 | Feature | Issue |
 |---------|-------|
-| Node registry + tool routing | gateway-2 |
+| Remote tool routing/execution over node registry | gateway-2 |
 | Session resume TTL + pending frame buffer | gateway-3 |
 | Heartbeat re-validation sweep | gateway-3 |
 | Channel runtime binding | gateway-4 |

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -26,6 +26,15 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
   runtime tool exposure is unchanged because these are library-level federation
   primitives covered by `@koi/federation` tests. See
   `docs/L2/federation.md`.
+- 2026-05-18: node gateway capability advertising (#1396). No
+  `@koi/runtime` dependency-set change: the new behavior is contained in
+  `@koi/gateway` and `@koi/device`. `@koi/gateway` now accepts `node:*`
+  WebSocket frames for thin/full node handshakes, heartbeat, capability refresh,
+  and incremental tool updates, with an in-memory registry
+  resolving advertised tool names to `NodeCapability[]`. `@koi/device` adds
+  `createDeviceGatewayClient()` so host-injected device providers can advertise
+  stable `device.*` tools to the gateway and answer capability queries.
+  Runtime-level remote tool routing/execution is still tracked separately.
 - 2026-05-16: Integrated `@koi/model-openai-compat` now honors a `KOI_MAX_TOKENS`
   output-token cap (sends `min(request.maxTokens, KOI_MAX_TOKENS)`, or the cap alone
   when the request omits `maxTokens`). No-op when unset/non-positive, so runtime

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -16,10 +16,10 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 153 | 793 | 134 |
+| lib | 153 | 794 | 134 |
 | meta | 7 | 122 | 5 |
 | mm | 12 | 54 | 12 |
-| net | 12 | 99 | 12 |
+| net | 12 | 100 | 12 |
 | sandbox | 12 | 67 | 12 |
 | sched | 5 | 22 | 5 |
 | security | 22 | 122 | 22 |
@@ -88,7 +88,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/decision-graph` (packages/lib/decision-graph) - Materialized decision trace graph over ledger snapshots. Tests: 3. Docs: docs/L2/decision-graph.md.
 - `@koi/decision-index` (packages/lib/decision-index) - Search-backed cross-session decision index over ledger snapshots. Tests: 1. Docs: docs/L2/decision-index.md.
 - `@koi/decision-ledger` (packages/lib/decision-ledger) - Per-session decision ledger projection — read-only join over trajectory + audit with run report as a sidecar summary. Tests: 1. Docs: docs/L2/decision-ledger.md.
-- `@koi/device` (packages/lib/device) - Device capability ComponentProviders for location, motion, SMS, push, camera, and contacts. Tests: 1. Docs: docs/L2/device.md.
+- `@koi/device` (packages/lib/device) - Device capability ComponentProviders for location, motion, SMS, push, camera, and contacts. Tests: 2. Docs: docs/L2/device.md.
 - `@koi/edit-match` (packages/lib/edit-match) - Search and replace files using cascading match strategies from exact to fuzzy. Tests: 4. Docs: -.
 - `@koi/errors` (packages/lib/errors) - Provide KoiRuntimeError class, circuit breaker, retry logic, and filesystem error mapping. Tests: 7. Docs: -.
 - `@koi/eval` (packages/lib/eval) - Agent eval framework: run suites, score transcripts, persist runs, detect regressions, self-test capabilities. Tests: 8. Docs: docs/L2/eval.md.
@@ -232,7 +232,7 @@ Each line shows package name, package directory, package description, test-file 
 
 - `@koi/community-registry` (packages/net/community-registry) - Standalone marketplace HTTP registry for publishing, discovering, searching, and installing Koi skills and plugins. Tests: 1. Docs: docs/L2/community-registry.md.
 - `@koi/daemon` (packages/net/daemon) - OS-process supervisor and worker backends (subprocess) for long-running agent workers. Tests: 15. Docs: docs/L2/daemon.md.
-- `@koi/gateway` (packages/net/gateway) - WebSocket gateway core — routing, auth, sequencing, backpressure (v2 minimal, no node registry or tool routing). Tests: 9. Docs: docs/L2/gateway.md.
+- `@koi/gateway` (packages/net/gateway) - WebSocket gateway core — routing, auth, sequencing, backpressure (v2 minimal, no node registry or tool routing). Tests: 10. Docs: docs/L2/gateway.md.
 - `@koi/gateway-canvas` (packages/net/gateway-canvas) - Canvas HTTP server: surface CRUD with ETag CAS and SSE streaming for real-time agent-rendered content. Tests: 3. Docs: docs/L2/gateway-canvas.md.
 - `@koi/gateway-http` (packages/net/gateway-http) - Production HTTP/WS gateway: HMAC auth, replay/idempotency, rate limits, CORS, audit log, graceful shutdown. Tests: 22. Docs: docs/L2/gateway-http.md.
 - `@koi/gateway-nexus` (packages/net/gateway-nexus) - Nexus-backed SessionStore for HA gateway: write-through cache, coalesced async writes, degradation state machine. Tests: 4. Docs: docs/L2/gateway-nexus.md.

--- a/packages/lib/device/src/gateway-client.test.ts
+++ b/packages/lib/device/src/gateway-client.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { createDeviceGatewayClient } from "./gateway-client.js";
+import { createCameraProvider, createLocationProvider } from "./provider.js";
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readonly sent: string[] = [];
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances = [...FakeWebSocket.instances, this];
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.onclose?.(new CloseEvent("close"));
+  }
+}
+
+function sentKinds(ws: FakeWebSocket): readonly string[] {
+  return ws.sent.map((raw) => JSON.parse(raw).kind as string);
+}
+
+describe("createDeviceGatewayClient", () => {
+  test("connects, advertises provider capabilities, heartbeats, updates, and reconnects", async () => {
+    FakeWebSocket.instances = [];
+    const client = createDeviceGatewayClient({
+      gatewayUrl: "ws://gateway.test",
+      nodeId: "device-1",
+      providers: [createLocationProvider({}), createCameraProvider({})],
+      heartbeatIntervalMs: 10,
+      reconnectDelayMs: 1,
+      webSocketFactory: (url) => new FakeWebSocket(url),
+    });
+
+    client.connect();
+    const first = FakeWebSocket.instances[0];
+    if (first === undefined) throw new Error("expected first websocket");
+    first.onopen?.(new Event("open"));
+
+    expect(sentKinds(first).slice(0, 2)).toEqual(["node:handshake", "node:capabilities"]);
+    expect(JSON.parse(first.sent[1] ?? "{}").payload.tools).toEqual([
+      { name: "device.location", description: "Device provider: device:location" },
+      { name: "device.camera", description: "Device provider: device:camera" },
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(sentKinds(first)).toContain("node:heartbeat");
+
+    client.updateProviders([createCameraProvider({})]);
+    expect(JSON.parse(first.sent.at(-1) ?? "{}")).toMatchObject({
+      kind: "node:tools_updated",
+      payload: {
+        added: [],
+        removed: ["device.location"],
+      },
+    });
+
+    first.onmessage?.(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          kind: "node:capabilities_query",
+          nodeId: "device-1",
+          agentId: "",
+          correlationId: "query-1",
+          payload: null,
+        }),
+      }),
+    );
+    expect(JSON.parse(first.sent.at(-1) ?? "{}")).toMatchObject({
+      kind: "node:capabilities",
+      correlationId: "query-1",
+      payload: {
+        nodeType: "thin",
+        tools: [{ name: "device.camera", description: "Device provider: device:camera" }],
+      },
+    });
+
+    first.onclose?.(new CloseEvent("close"));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = FakeWebSocket.instances[1];
+    if (second === undefined) throw new Error("expected reconnect websocket");
+    second.onopen?.(new Event("open"));
+    expect(sentKinds(second).slice(0, 2)).toEqual(["node:handshake", "node:capabilities"]);
+
+    client.disconnect();
+  });
+});

--- a/packages/lib/device/src/gateway-client.ts
+++ b/packages/lib/device/src/gateway-client.ts
@@ -1,0 +1,197 @@
+import type { AdvertisedTool, CapacityReport, ComponentProvider } from "@koi/core";
+
+export interface DeviceGatewayClient {
+  readonly connect: () => void;
+  readonly disconnect: () => void;
+  readonly updateProviders: (providers: readonly ComponentProvider[]) => void;
+}
+
+export interface DeviceGatewaySocket {
+  onopen: ((event: Event) => void) | null;
+  onclose: ((event: CloseEvent) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  readonly send: (data: string) => void;
+  readonly close: () => void;
+}
+
+export interface DeviceGatewayClientConfig {
+  readonly gatewayUrl: string;
+  readonly nodeId: string;
+  readonly providers: readonly ComponentProvider[];
+  readonly version?: string | undefined;
+  readonly capacity?: CapacityReport | undefined;
+  readonly heartbeatIntervalMs?: number | undefined;
+  readonly reconnectDelayMs?: number | undefined;
+  readonly webSocketFactory?: ((url: string) => DeviceGatewaySocket) | undefined;
+}
+
+const DEVICE_TOOL_NAMES: Readonly<Record<string, readonly string[]>> = {
+  device: [
+    "device.location",
+    "device.motion",
+    "device.sms",
+    "device.push",
+    "device.camera",
+    "device.contacts",
+  ],
+  "device:location": ["device.location"],
+  "device:motion": ["device.motion"],
+  "device:sms": ["device.sms"],
+  "device:push": ["device.push"],
+  "device:camera": ["device.camera"],
+  "device:contacts": ["device.contacts"],
+} as const;
+
+function providerTools(provider: ComponentProvider): readonly AdvertisedTool[] {
+  const names = DEVICE_TOOL_NAMES[provider.name] ?? [provider.name.replace(":", ".")];
+  return names.map((name) => ({
+    name,
+    description: `Device provider: ${provider.name}`,
+  }));
+}
+
+function advertiseProviders(providers: readonly ComponentProvider[]): readonly AdvertisedTool[] {
+  const allTools = providers.flatMap((provider) => providerTools(provider));
+  const names = new Set<string>();
+  return allTools.filter((tool) => {
+    if (names.has(tool.name)) return false;
+    names.add(tool.name);
+    return true;
+  });
+}
+
+function frame(kind: string, nodeId: string, payload: unknown, correlationId?: string): string {
+  return JSON.stringify({
+    kind,
+    nodeId,
+    agentId: "",
+    correlationId: correlationId ?? crypto.randomUUID(),
+    payload,
+  });
+}
+
+function parseCapabilitiesQuery(data: string, nodeId: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+  const msg = parsed as Record<string, unknown>;
+  if (msg.kind !== "node:capabilities_query") return undefined;
+  if (msg.nodeId !== nodeId) return undefined;
+  return typeof msg.correlationId === "string" ? msg.correlationId : undefined;
+}
+
+function diffTools(
+  before: readonly AdvertisedTool[],
+  after: readonly AdvertisedTool[],
+): { readonly added: readonly AdvertisedTool[]; readonly removed: readonly string[] } {
+  const beforeNames = new Set(before.map((tool) => tool.name));
+  const afterNames = new Set(after.map((tool) => tool.name));
+  return {
+    added: after.filter((tool) => !beforeNames.has(tool.name)),
+    removed: before.filter((tool) => !afterNames.has(tool.name)).map((tool) => tool.name),
+  };
+}
+
+class DefaultDeviceGatewayClient implements DeviceGatewayClient {
+  private readonly config: DeviceGatewayClientConfig;
+  private providers: readonly ComponentProvider[];
+  private socket: DeviceGatewaySocket | undefined;
+  private heartbeat: ReturnType<typeof setInterval> | undefined;
+  private reconnect: ReturnType<typeof setTimeout> | undefined;
+  private shouldReconnect = true;
+
+  private readonly capacity: CapacityReport;
+  private readonly heartbeatIntervalMs: number;
+  private readonly reconnectDelayMs: number;
+  private readonly webSocketFactory: (url: string) => DeviceGatewaySocket;
+
+  constructor(config: DeviceGatewayClientConfig) {
+    this.config = config;
+    this.providers = config.providers;
+    this.capacity = config.capacity ?? { current: 0, max: 1, available: 1 };
+    this.heartbeatIntervalMs = config.heartbeatIntervalMs ?? 10_000;
+    this.reconnectDelayMs = config.reconnectDelayMs ?? 1_000;
+    this.webSocketFactory =
+      config.webSocketFactory ?? ((url: string): DeviceGatewaySocket => new WebSocket(url));
+  }
+
+  connect(): void {
+    this.shouldReconnect = true;
+    this.open();
+  }
+
+  disconnect(): void {
+    this.shouldReconnect = false;
+    this.clearTimers();
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  updateProviders(nextProviders: readonly ComponentProvider[]): void {
+    const before = advertiseProviders(this.providers);
+    const after = advertiseProviders(nextProviders);
+    this.providers = nextProviders;
+    this.send("node:tools_updated", diffTools(before, after));
+  }
+
+  private send(kind: string, payload: unknown): void {
+    this.socket?.send(frame(kind, this.config.nodeId, payload));
+  }
+
+  private sendCapabilities(correlationId?: string): void {
+    this.socket?.send(
+      frame(
+        "node:capabilities",
+        this.config.nodeId,
+        {
+          nodeType: "thin",
+          tools: advertiseProviders(this.providers),
+        },
+        correlationId,
+      ),
+    );
+  }
+
+  private clearTimers(): void {
+    if (this.heartbeat !== undefined) clearInterval(this.heartbeat);
+    if (this.reconnect !== undefined) clearTimeout(this.reconnect);
+    this.heartbeat = undefined;
+    this.reconnect = undefined;
+  }
+
+  private open(): void {
+    this.clearTimers();
+    this.socket = this.webSocketFactory(this.config.gatewayUrl);
+    this.socket.onopen = () => {
+      this.send("node:handshake", {
+        nodeId: this.config.nodeId,
+        version: this.config.version ?? "0.0.0",
+        capacity: this.capacity,
+      });
+      this.sendCapabilities();
+      this.heartbeat = setInterval(
+        () => this.send("node:heartbeat", null),
+        this.heartbeatIntervalMs,
+      );
+    };
+    this.socket.onmessage = (event) => {
+      const correlationId = parseCapabilitiesQuery(event.data, this.config.nodeId);
+      if (correlationId !== undefined) this.sendCapabilities(correlationId);
+    };
+    this.socket.onclose = () => {
+      this.clearTimers();
+      this.socket = undefined;
+      if (this.shouldReconnect) {
+        this.reconnect = setTimeout(() => this.open(), this.reconnectDelayMs);
+      }
+    };
+  }
+}
+
+export function createDeviceGatewayClient(config: DeviceGatewayClientConfig): DeviceGatewayClient {
+  return new DefaultDeviceGatewayClient(config);
+}

--- a/packages/lib/device/src/index.ts
+++ b/packages/lib/device/src/index.ts
@@ -1,3 +1,9 @@
+export type {
+  DeviceGatewayClient,
+  DeviceGatewayClientConfig,
+  DeviceGatewaySocket,
+} from "./gateway-client.js";
+export { createDeviceGatewayClient } from "./gateway-client.js";
 export {
   createCameraProvider,
   createContactsProvider,

--- a/packages/net/gateway-stack/src/remote-bridge.test.ts
+++ b/packages/net/gateway-stack/src/remote-bridge.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "@koi/core";
 import { agentId, RETRYABLE_DEFAULTS, workspaceId } from "@koi/core";
 import type { Gateway, GatewayFrame, Session, SessionEvent, Transport } from "@koi/gateway";
+import { createInMemoryNodeRegistry } from "@koi/gateway";
 import {
   attachRemoteSessionBridge,
   createGatewayRemoteSessionRuntime,
@@ -36,6 +37,7 @@ interface HarnessGateway extends Gateway {
 }
 
 function makeGateway(): HarnessGateway {
+  const nodeRegistry = createInMemoryNodeRegistry();
   const frameHandlers = new Map<
     string,
     (session: Session, frame: GatewayFrame) => void | Promise<void>
@@ -54,6 +56,10 @@ function makeGateway(): HarnessGateway {
     sessions: () => {
       throw new Error("not needed");
     },
+    nodeRegistry: () => nodeRegistry,
+    discoverNodeCapabilities: () => [],
+    queryNodeCapabilities: () => ({ ok: true, value: 0 }),
+    onNodeEvent: () => () => {},
     onFrame: (agent, handler) => {
       frameHandlers.set(agent, handler);
       return () => frameHandlers.delete(agent);

--- a/packages/net/gateway/src/__tests__/e2e.test.ts
+++ b/packages/net/gateway/src/__tests__/e2e.test.ts
@@ -617,8 +617,16 @@ describe("e2e: server send seq monotonicity", () => {
     await waitForMessages(4); // ack + 3 sends
 
     const seqs = messages.slice(1).map((m) => parseFrame(m).seq);
-    expect(seqs[0]! < seqs[1]!).toBe(true);
-    expect(seqs[1]! < seqs[2]!).toBe(true);
+    expect(seqs.length).toBe(3);
+    const [firstSeq, secondSeq, thirdSeq] = seqs;
+    expect(firstSeq).toBeDefined();
+    expect(secondSeq).toBeDefined();
+    expect(thirdSeq).toBeDefined();
+    if (firstSeq === undefined || secondSeq === undefined || thirdSeq === undefined) {
+      throw new Error("expected three server frames");
+    }
+    expect(firstSeq < secondSeq).toBe(true);
+    expect(secondSeq < thirdSeq).toBe(true);
 
     ws.close();
   });

--- a/packages/net/gateway/src/__tests__/node-connection.test.ts
+++ b/packages/net/gateway/src/__tests__/node-connection.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { AdvertisedTool, CapacityReport } from "@koi/core";
+import type { Gateway } from "../gateway.js";
+import { createGateway } from "../gateway.js";
+import type { MockTransport } from "./test-utils.js";
+import { createMockTransport, createTestAuthenticator, waitForCondition } from "./test-utils.js";
+
+function nodeFrame(
+  kind: string,
+  nodeId: string,
+  payload: unknown,
+  correlationId = `${kind}:1`,
+): string {
+  return JSON.stringify({
+    kind,
+    nodeId,
+    agentId: "",
+    correlationId,
+    payload,
+  });
+}
+
+function handshake(nodeId: string, capacity?: CapacityReport): string {
+  return nodeFrame("node:handshake", nodeId, {
+    nodeId,
+    version: "0.0.0-test",
+    capacity: capacity ?? { current: 0, max: 4, available: 4 },
+  });
+}
+
+function capabilities(
+  nodeId: string,
+  tools: readonly AdvertisedTool[],
+  nodeType: "full" | "thin" = "thin",
+): string {
+  return nodeFrame("node:capabilities", nodeId, { nodeType, tools });
+}
+
+function heartbeat(nodeId: string): string {
+  return nodeFrame("node:heartbeat", nodeId, null);
+}
+
+function toolsUpdated(
+  nodeId: string,
+  added: readonly AdvertisedTool[],
+  removed: readonly string[],
+): string {
+  return nodeFrame("node:tools_updated", nodeId, { added, removed });
+}
+
+describe("node-gateway capability advertising", () => {
+  let transport: MockTransport;
+  let gateway: Gateway;
+
+  beforeEach(async () => {
+    transport = createMockTransport();
+    gateway = createGateway(
+      { nodeHeartbeatTimeoutMs: 200, nodeSweepIntervalMs: 10 },
+      { transport, auth: createTestAuthenticator() },
+    );
+    await gateway.start(0);
+  });
+
+  test("node handshakes, advertises capabilities, and can be discovered by tool", async () => {
+    const events: string[] = [];
+    gateway.onNodeEvent((event) => {
+      events.push(event.kind);
+    });
+
+    const conn = transport.simulateOpen();
+    transport.simulateMessage(conn.id, handshake("device-1"));
+    transport.simulateMessage(conn.id, capabilities("device-1", [{ name: "device.location" }]));
+
+    await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+    expect(JSON.parse(conn.sent[0] ?? "{}")).toMatchObject({
+      kind: "node:registered",
+      nodeId: "device-1",
+    });
+    expect(gateway.nodeRegistry().lookup("device-1")?.nodeType).toBe("thin");
+    expect(gateway.discoverNodeCapabilities("device.location")).toEqual([
+      {
+        nodeId: "device-1",
+        nodeType: "thin",
+        tools: [{ name: "device.location" }],
+      },
+    ]);
+    expect(events).toContain("registered");
+  });
+
+  test("heartbeat keeps a node online until the stale-node sweep marks it offline", async () => {
+    const events: string[] = [];
+    gateway.onNodeEvent((event) => {
+      events.push(event.kind);
+    });
+
+    const conn = transport.simulateOpen();
+    transport.simulateMessage(conn.id, handshake("device-1"));
+    transport.simulateMessage(conn.id, capabilities("device-1", [{ name: "device.location" }]));
+    await waitForCondition(() => gateway.nodeRegistry().size() === 1);
+
+    transport.simulateMessage(conn.id, heartbeat("device-1"));
+    await waitForCondition(() => events.includes("heartbeat"));
+    expect(gateway.nodeRegistry().lookup("device-1")).toBeDefined();
+
+    await waitForCondition(() => gateway.nodeRegistry().lookup("device-1") === undefined, 1000);
+    expect(conn.closed).toBe(true);
+    expect(events).toContain("offline");
+  });
+
+  test("capability change notifications update discovery results", async () => {
+    const events: string[] = [];
+    gateway.onNodeEvent((event) => {
+      events.push(event.kind);
+    });
+
+    const conn = transport.simulateOpen();
+    transport.simulateMessage(conn.id, handshake("device-1"));
+    transport.simulateMessage(conn.id, capabilities("device-1", [{ name: "device.location" }]));
+    await waitForCondition(() => gateway.discoverNodeCapabilities("device.location").length === 1);
+
+    transport.simulateMessage(
+      conn.id,
+      toolsUpdated("device-1", [{ name: "device.camera" }], ["device.location"]),
+    );
+
+    await waitForCondition(() => events.includes("capabilities_updated"));
+    expect(gateway.discoverNodeCapabilities("device.location")).toEqual([]);
+    expect(gateway.discoverNodeCapabilities("device.camera")).toHaveLength(1);
+  });
+
+  test("gateway can query a connected node for its current capabilities", async () => {
+    const events: string[] = [];
+    gateway.onNodeEvent((event) => {
+      events.push(event.kind);
+    });
+
+    const conn = transport.simulateOpen();
+    transport.simulateMessage(conn.id, handshake("device-1"));
+    transport.simulateMessage(conn.id, capabilities("device-1", [{ name: "device.location" }]));
+    await waitForCondition(() => gateway.discoverNodeCapabilities("device.location").length === 1);
+
+    const query = gateway.queryNodeCapabilities("device-1");
+
+    expect(query.ok).toBe(true);
+    expect(JSON.parse(conn.sent.at(-1) ?? "{}")).toMatchObject({
+      kind: "node:capabilities_query",
+      nodeId: "device-1",
+    });
+
+    transport.simulateMessage(
+      conn.id,
+      capabilities("device-1", [{ name: "device.camera" }], "full"),
+    );
+
+    await waitForCondition(
+      () => events.filter((kind) => kind === "capabilities_updated").length === 1,
+    );
+    expect(gateway.discoverNodeCapabilities("device.location")).toEqual([]);
+    expect(gateway.discoverNodeCapabilities("device.camera")).toEqual([
+      {
+        nodeId: "device-1",
+        nodeType: "full",
+        tools: [{ name: "device.camera" }],
+      },
+    ]);
+    expect(gateway.nodeRegistry().lookup("device-1")?.nodeType).toBe("full");
+  });
+
+  test("gateway rejects capability queries before node registration completes", async () => {
+    const conn = transport.simulateOpen();
+    transport.simulateMessage(conn.id, handshake("device-1"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const query = gateway.queryNodeCapabilities("device-1");
+
+    expect(query.ok).toBe(false);
+    expect(conn.sent).toEqual([]);
+  });
+});

--- a/packages/net/gateway/src/gateway.ts
+++ b/packages/net/gateway/src/gateway.ts
@@ -2,12 +2,12 @@
  * Gateway factory: wires transport, auth, sessions, sequencing, and backpressure
  * into a minimal WebSocket control-plane entry point.
  *
- * Intentionally omits: node registry, tool routing, channel binding, scheduler,
- * heartbeat sweep, and per-route onFrame handler isolation (routing enforcement
- * lives in the node-registry layer) — those belong in future issues.
+ * Includes the v2 transport/session control plane plus thin node registration
+ * and capability discovery. Heavy scheduling/tool routing remains outside this
+ * gateway core.
  */
 
-import type { KoiError, Result } from "@koi/core";
+import type { KoiError, NodeCapability, Result } from "@koi/core";
 import { notFound } from "@koi/core";
 import { swallowError } from "@koi/errors";
 import type { Gateway as GatewayContract } from "@koi/gateway-types";
@@ -15,6 +15,17 @@ import type { GatewayAuthenticator, HandshakeOptions } from "./auth.js";
 import { handleHandshake } from "./auth.js";
 import { createBackpressureMonitor } from "./backpressure.js";
 import { CLOSE_CODES } from "./close-codes.js";
+import type { NodeCapabilitiesPayload, NodeFrame, NodeHandshakePayload } from "./node-protocol.js";
+import {
+  encodeNodeFrame,
+  parseNodeFrame,
+  peekNodeFrameKind,
+  validateNodeCapabilitiesPayload,
+  validateNodeHandshakePayload,
+  validateNodeToolsUpdatedPayload,
+} from "./node-protocol.js";
+import type { NodeRegistry, NodeRegistryEvent, RegisteredNode } from "./node-registry.js";
+import { createInMemoryNodeRegistry } from "./node-registry.js";
 import {
   createAckFrame,
   createErrorFrame,
@@ -58,6 +69,10 @@ export interface Gateway {
   readonly dispatch: (session: Session, frame: GatewayFrame) => void;
   readonly destroySession: (sessionId: string, reason?: string) => Promise<Result<void, KoiError>>;
   readonly onSessionEvent: (handler: (event: SessionEvent) => void) => () => void;
+  readonly nodeRegistry: () => NodeRegistry;
+  readonly discoverNodeCapabilities: (toolName: string) => readonly NodeCapability[];
+  readonly queryNodeCapabilities: (nodeId: string) => Result<number, KoiError>;
+  readonly onNodeEvent: (handler: (event: NodeRegistryEvent) => void) => () => void;
   // Ingestion contract methods (additive; satisfies @koi/gateway-types Gateway).
   // `ingest` reuses the in-process dispatch path so HTTP ingestion shares the same
   // subscriber fan-out as WS frames. `pauseIngress` silences external WS-frame ingress
@@ -93,6 +108,7 @@ export function createGateway(
 ): Gateway {
   const config: GatewayConfig = { ...DEFAULT_GATEWAY_CONFIG, ...configOverrides };
   const store = deps.store ?? createInMemorySessionStore();
+  const nodeRegistry = createInMemoryNodeRegistry();
   const bp = createBackpressureMonitor(config);
   const nextId = createFrameIdGenerator();
 
@@ -142,6 +158,12 @@ export function createGateway(
   // Used by send() to fire a best-effort outbound-seq persist without a store.get()
   // round-trip, reducing the seq-reuse window after a process crash.
   const connSessionCache = new Map<string, Session>();
+  const nodeIdByConn = new Map<string, string>();
+  const connIdByNode = new Map<string, string>();
+  const pendingNodeHandshakes = new Map<
+    string,
+    { readonly nodeId: string; readonly capacity: RegisteredNode["capacity"] }
+  >();
   // Set to true by stop() so pending handshake continuations bail out before store.set().
   let stopped = false;
   // Set to true by pauseIngress() so external WS-frame ingestion is silenced during
@@ -157,6 +179,7 @@ export function createGateway(
     Set<(session: Session, frame: GatewayFrame) => void | Promise<void>>
   >();
   const sessionEventHandlers = new Set<(event: SessionEvent) => void>();
+  const nodeEventHandlers = new Set<(event: NodeRegistryEvent) => void>();
 
   let criticalSweep: ReturnType<typeof setInterval> | undefined;
 
@@ -174,6 +197,189 @@ export function createGateway(
         swallowError(err, { package: "gateway", operation: "onSessionEvent" });
       }
     }
+  }
+
+  function emitNodeEvent(event: NodeRegistryEvent): void {
+    for (const handler of nodeEventHandlers) {
+      try {
+        handler(event);
+      } catch (err: unknown) {
+        swallowError(err, { package: "gateway", operation: "onNodeEvent" });
+      }
+    }
+  }
+
+  function cleanupNodeConnection(conn: TransportConnection, reason: string): boolean {
+    const pending = pendingNodeHandshakes.get(conn.id);
+    const nodeId = nodeIdByConn.get(conn.id) ?? pending?.nodeId;
+    pendingNodeHandshakes.delete(conn.id);
+    if (nodeId === undefined) return false;
+    nodeIdByConn.delete(conn.id);
+    connIdByNode.delete(nodeId);
+    const removed = nodeRegistry.deregister(nodeId);
+    if (removed.ok && removed.value) {
+      emitNodeEvent({ kind: "deregistered", nodeId, reason });
+    }
+    return true;
+  }
+
+  function handleNodeFirstMessage(conn: TransportConnection, data: string): void {
+    const frameResult = parseNodeFrame(data);
+    if (!frameResult.ok || frameResult.value.kind !== "node:handshake") {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, "Invalid node handshake");
+      cleanupConn(conn, "invalid node handshake");
+      return;
+    }
+    const payloadResult = validateNodeHandshakePayload(frameResult.value.payload);
+    if (!payloadResult.ok || payloadResult.value.nodeId !== frameResult.value.nodeId) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, "Invalid node handshake payload");
+      cleanupConn(conn, "invalid node handshake payload");
+      return;
+    }
+
+    const previousConnId = connIdByNode.get(frameResult.value.nodeId);
+    if (previousConnId !== undefined && previousConnId !== conn.id) {
+      const previousConn = connMap.get(previousConnId);
+      if (previousConn !== undefined) {
+        cleanupConn(previousConn, "node reconnected");
+        previousConn.close(CLOSE_CODES.ADMIN_CLOSED, "Node reconnected");
+      }
+    }
+
+    nodeIdByConn.set(conn.id, frameResult.value.nodeId);
+    connIdByNode.set(frameResult.value.nodeId, conn.id);
+    pendingNodeHandshakes.set(conn.id, {
+      nodeId: frameResult.value.nodeId,
+      capacity: payloadResult.value.capacity,
+    });
+  }
+
+  function handleNodeMessage(conn: TransportConnection, data: string): void {
+    const frameResult = parseNodeFrame(data);
+    if (!frameResult.ok) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, frameResult.error.message);
+      cleanupConn(conn, "invalid node frame");
+      return;
+    }
+    const frame = frameResult.value;
+    const nodeId = nodeIdByConn.get(conn.id);
+    if (nodeId === undefined || nodeId !== frame.nodeId) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, "Node identity mismatch");
+      cleanupConn(conn, "node identity mismatch");
+      return;
+    }
+
+    if (frame.kind === "node:capabilities") {
+      handleNodeCapabilities(conn, nodeId, frame);
+      return;
+    }
+
+    if (frame.kind === "node:heartbeat") {
+      handleNodeHeartbeat(nodeId);
+      return;
+    }
+
+    if (frame.kind === "node:tools_updated") {
+      handleNodeToolsUpdated(conn, nodeId, frame);
+    }
+  }
+
+  function handleNodeCapabilities(
+    conn: TransportConnection,
+    nodeId: string,
+    frame: NodeFrame,
+  ): void {
+    const payloadResult = validateNodeCapabilitiesPayload(frame.payload);
+    if (!payloadResult.ok) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, payloadResult.error.message);
+      cleanupConn(conn, "invalid node capabilities");
+      return;
+    }
+    const pending = pendingNodeHandshakes.get(conn.id);
+    if (pending === undefined) {
+      updateNodeCapabilities(nodeId, payloadResult.value.nodeType, payloadResult.value.tools);
+      return;
+    }
+    registerNodeCapabilities(conn, nodeId, frame.correlationId, pending, payloadResult.value);
+  }
+
+  function updateNodeCapabilities(
+    nodeId: string,
+    nodeType: RegisteredNode["nodeType"],
+    tools: RegisteredNode["tools"],
+  ): void {
+    const updateResult = nodeRegistry.updateCapabilities(nodeId, nodeType, tools);
+    if (updateResult.ok) emitNodeEvent({ kind: "capabilities_updated", nodeId });
+  }
+
+  function registerNodeCapabilities(
+    conn: TransportConnection,
+    nodeId: string,
+    correlationId: string,
+    pending: Pick<NodeHandshakePayload, "nodeId" | "capacity">,
+    payload: NodeCapabilitiesPayload,
+  ): void {
+    pendingNodeHandshakes.delete(conn.id);
+    const now = Date.now();
+    const node = createRegisteredNode(conn.id, nodeId, pending.capacity, payload, now);
+    const result = nodeRegistry.register(node);
+    if (!result.ok) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, result.error.message);
+      cleanupConn(conn, "node registration failed");
+      return;
+    }
+    conn.send(
+      encodeNodeFrame({
+        kind: "node:registered",
+        nodeId,
+        agentId: "",
+        correlationId,
+        payload: { registeredAt: now },
+      }),
+    );
+    emitNodeEvent({ kind: "registered", node });
+  }
+
+  function createRegisteredNode(
+    connId: string,
+    nodeId: string,
+    capacity: RegisteredNode["capacity"],
+    payload: NodeCapabilitiesPayload,
+    now: number,
+  ): RegisteredNode {
+    return {
+      nodeId,
+      nodeType: payload.nodeType,
+      tools: payload.tools,
+      capacity,
+      connectedAt: now,
+      lastHeartbeat: now,
+      connId,
+    };
+  }
+
+  function handleNodeHeartbeat(nodeId: string): void {
+    const result = nodeRegistry.updateHeartbeat(nodeId);
+    if (result.ok) emitNodeEvent({ kind: "heartbeat", nodeId });
+  }
+
+  function handleNodeToolsUpdated(
+    conn: TransportConnection,
+    nodeId: string,
+    frame: NodeFrame,
+  ): void {
+    const payloadResult = validateNodeToolsUpdatedPayload(frame.payload);
+    if (!payloadResult.ok) {
+      conn.close(CLOSE_CODES.INVALID_HANDSHAKE, payloadResult.error.message);
+      cleanupConn(conn, "invalid node tools update");
+      return;
+    }
+    const updateResult = nodeRegistry.updateTools(
+      nodeId,
+      payloadResult.value.added,
+      payloadResult.value.removed,
+    );
+    if (updateResult.ok) emitNodeEvent({ kind: "capabilities_updated", nodeId });
   }
 
   // Deliver a single frame to all registered handlers for the session's agentId.
@@ -292,6 +498,7 @@ export function createGateway(
   }
 
   function cleanupConn(conn: TransportConnection, reason: string): void {
+    cleanupNodeConnection(conn, reason);
     const sessionId = sessionByConn.get(conn.id);
     // Capture before deleting: the current server outbound counter for this connection.
     const seqToSave = connOutboundSeq.get(conn.id) ?? 0;
@@ -401,7 +608,19 @@ export function createGateway(
 
     const handshakeHandler = pendingHandshakes.get(conn.id);
     if (handshakeHandler !== undefined) {
+      if (peekNodeFrameKind(data) === "node:handshake") {
+        handshakeAborts.get(conn.id)?.();
+        pendingHandshakes.delete(conn.id);
+        handshakeAborts.delete(conn.id);
+        handleNodeFirstMessage(conn, data);
+        return;
+      }
       handshakeHandler(data);
+      return;
+    }
+
+    if (nodeIdByConn.has(conn.id)) {
+      handleNodeMessage(conn, data);
       return;
     }
 
@@ -921,8 +1140,10 @@ export function createGateway(
         .catch(() => {
           pendingHandshakes.delete(conn.id);
           handshakeAborts.delete(conn.id);
-          connMap.delete(conn.id);
-          bp.remove(conn.id);
+          if (!nodeIdByConn.has(conn.id)) {
+            connMap.delete(conn.id);
+            bp.remove(conn.id);
+          }
         });
       pendingHandshakePromises.add(handshakeChain);
       void handshakeChain.finally(() => {
@@ -1126,7 +1347,19 @@ export function createGateway(
             }
           }
         }
-      }, 5_000);
+
+        for (const [nodeId, connId] of connIdByNode) {
+          const node = nodeRegistry.lookup(nodeId);
+          if (node === undefined) continue;
+          if (now - node.lastHeartbeat <= config.nodeHeartbeatTimeoutMs) continue;
+          const conn = connMap.get(connId);
+          if (conn !== undefined) {
+            emitNodeEvent({ kind: "offline", nodeId, reason: "heartbeat timeout" });
+            cleanupConn(conn, "node heartbeat timeout");
+            conn.close(CLOSE_CODES.ADMIN_CLOSED, "Node heartbeat timeout");
+          }
+        }
+      }, config.nodeSweepIntervalMs);
     },
 
     async stop(): Promise<Result<void, KoiError>> {
@@ -1230,6 +1463,9 @@ export function createGateway(
       ownedSessionIds.clear();
 
       connMap.clear();
+      nodeIdByConn.clear();
+      connIdByNode.clear();
+      pendingNodeHandshakes.clear();
       sessionByConn.clear();
       connBySession.clear();
       trackers.clear();
@@ -1258,6 +1494,58 @@ export function createGateway(
 
     sessions(): SessionStore {
       return store;
+    },
+
+    nodeRegistry(): NodeRegistry {
+      return nodeRegistry;
+    },
+
+    discoverNodeCapabilities(toolName: string): readonly NodeCapability[] {
+      return nodeRegistry.resolve(toolName);
+    },
+
+    queryNodeCapabilities(nodeId: string): Result<number, KoiError> {
+      if (nodeRegistry.lookup(nodeId) === undefined) {
+        return { ok: false, error: notFound(nodeId, `Node not registered: ${nodeId}`) };
+      }
+      const connId = connIdByNode.get(nodeId);
+      if (connId === undefined) {
+        return { ok: false, error: notFound(nodeId, `Node not connected: ${nodeId}`) };
+      }
+      const conn = connMap.get(connId);
+      if (conn === undefined) {
+        return { ok: false, error: notFound(connId, `Connection not found for node: ${nodeId}`) };
+      }
+      const bytes = conn.send(
+        encodeNodeFrame({
+          kind: "node:capabilities_query",
+          nodeId,
+          agentId: "",
+          correlationId: crypto.randomUUID(),
+          payload: null,
+        }),
+      );
+      if (bytes < 0) {
+        cleanupConn(conn, "node query send failed");
+        conn.close(CLOSE_CODES.ADMIN_CLOSED, "Node query send failed");
+        return {
+          ok: false,
+          error: {
+            code: "EXTERNAL",
+            message: `Node query send failed: ${nodeId}`,
+            retryable: false,
+            context: { nodeId },
+          },
+        };
+      }
+      return { ok: true, value: bytes };
+    },
+
+    onNodeEvent(handler: (event: NodeRegistryEvent) => void): () => void {
+      nodeEventHandlers.add(handler);
+      return () => {
+        nodeEventHandlers.delete(handler);
+      };
     },
 
     // Trust model: onFrame and send() are in-process APIs used by the koi engine whose

--- a/packages/net/gateway/src/index.ts
+++ b/packages/net/gateway/src/index.ts
@@ -16,6 +16,25 @@ export {
   type SessionEvent,
 } from "./gateway.js";
 export {
+  encodeNodeFrame,
+  type NodeCapabilitiesPayload,
+  type NodeFrame,
+  type NodeFrameKind,
+  type NodeHandshakePayload,
+  type NodeToolsUpdatedPayload,
+  parseNodeFrame,
+  peekNodeFrameKind,
+  validateNodeCapabilitiesPayload,
+  validateNodeHandshakePayload,
+  validateNodeToolsUpdatedPayload,
+} from "./node-protocol.js";
+export {
+  createInMemoryNodeRegistry,
+  type NodeRegistry,
+  type NodeRegistryEvent,
+  type RegisteredNode,
+} from "./node-registry.js";
+export {
   createAckFrame,
   createErrorFrame,
   createFrameIdGenerator,

--- a/packages/net/gateway/src/node-protocol.ts
+++ b/packages/net/gateway/src/node-protocol.ts
@@ -1,0 +1,186 @@
+import type { AdvertisedTool, CapacityReport, KoiError, Result } from "@koi/core";
+import { validation } from "@koi/core";
+
+const NODE_FRAME_KINDS = new Set([
+  "node:handshake",
+  "node:capabilities",
+  "node:capabilities_query",
+  "node:registered",
+  "node:heartbeat",
+  "node:capacity",
+  "node:tools_updated",
+  "node:error",
+] as const);
+
+export type NodeFrameKind =
+  | "node:handshake"
+  | "node:capabilities"
+  | "node:capabilities_query"
+  | "node:registered"
+  | "node:heartbeat"
+  | "node:capacity"
+  | "node:tools_updated"
+  | "node:error";
+
+export interface NodeFrame {
+  readonly kind: NodeFrameKind;
+  readonly nodeId: string;
+  readonly agentId: string;
+  readonly correlationId: string;
+  readonly payload: unknown;
+}
+
+export interface NodeHandshakePayload {
+  readonly nodeId: string;
+  readonly version: string;
+  readonly capacity: CapacityReport;
+}
+
+export interface NodeCapabilitiesPayload {
+  readonly nodeType: "full" | "thin";
+  readonly tools: readonly AdvertisedTool[];
+}
+
+export interface NodeToolsUpdatedPayload {
+  readonly added: readonly AdvertisedTool[];
+  readonly removed: readonly string[];
+}
+
+export function peekNodeFrameKind(data: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+    const obj = parsed as Record<string, unknown>;
+    return typeof obj.kind === "string" ? obj.kind : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function encodeNodeFrame(frame: NodeFrame): string {
+  return JSON.stringify(frame);
+}
+
+export function parseNodeFrame(data: string): Result<NodeFrame, KoiError> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return { ok: false, error: validation("Invalid JSON in node frame") };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, error: validation("Node frame must be an object") };
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.kind !== "string" || !NODE_FRAME_KINDS.has(obj.kind as NodeFrameKind)) {
+    return { ok: false, error: validation(`Invalid node frame kind: ${String(obj.kind)}`) };
+  }
+  if (typeof obj.nodeId !== "string" || obj.nodeId.length === 0) {
+    return { ok: false, error: validation("nodeId must be a non-empty string") };
+  }
+  if (typeof obj.agentId !== "string") {
+    return { ok: false, error: validation("agentId must be a string") };
+  }
+  if (typeof obj.correlationId !== "string" || obj.correlationId.length === 0) {
+    return { ok: false, error: validation("correlationId must be a non-empty string") };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: obj.kind as NodeFrameKind,
+      nodeId: obj.nodeId,
+      agentId: obj.agentId,
+      correlationId: obj.correlationId,
+      payload: obj.payload ?? null,
+    },
+  };
+}
+
+function isCapacityReport(value: unknown): value is CapacityReport {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.current === "number" &&
+    typeof obj.max === "number" &&
+    typeof obj.available === "number"
+  );
+}
+
+function parseTools(value: unknown): Result<readonly AdvertisedTool[], KoiError> {
+  if (!Array.isArray(value)) return { ok: false, error: validation("tools must be an array") };
+  const parsed = value.reduce<Result<readonly AdvertisedTool[], KoiError>>(
+    (result, entry) => {
+      if (!result.ok) return result;
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return { ok: false, error: validation("Each advertised tool must be an object") };
+      }
+      const obj = entry as Record<string, unknown>;
+      if (typeof obj.name !== "string" || obj.name.length === 0) {
+        return { ok: false, error: validation("Each advertised tool needs a non-empty name") };
+      }
+      const tool: AdvertisedTool = {
+        name: obj.name,
+        ...(typeof obj.description === "string" ? { description: obj.description } : {}),
+        ...(typeof obj.schema === "object" && obj.schema !== null && !Array.isArray(obj.schema)
+          ? { schema: obj.schema as Readonly<Record<string, unknown>> }
+          : {}),
+      };
+      return { ok: true, value: [...result.value, tool] };
+    },
+    { ok: true, value: [] },
+  );
+  return parsed;
+}
+
+export function validateNodeHandshakePayload(
+  payload: unknown,
+): Result<NodeHandshakePayload, KoiError> {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { ok: false, error: validation("Handshake payload must be an object") };
+  }
+  const obj = payload as Record<string, unknown>;
+  if (typeof obj.nodeId !== "string" || obj.nodeId.length === 0) {
+    return { ok: false, error: validation("payload.nodeId must be a non-empty string") };
+  }
+  if (typeof obj.version !== "string") {
+    return { ok: false, error: validation("payload.version must be a string") };
+  }
+  if (!isCapacityReport(obj.capacity)) {
+    return { ok: false, error: validation("payload.capacity must be a CapacityReport") };
+  }
+  return { ok: true, value: { nodeId: obj.nodeId, version: obj.version, capacity: obj.capacity } };
+}
+
+export function validateNodeCapabilitiesPayload(
+  payload: unknown,
+): Result<NodeCapabilitiesPayload, KoiError> {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { ok: false, error: validation("Capabilities payload must be an object") };
+  }
+  const obj = payload as Record<string, unknown>;
+  if (obj.nodeType !== "full" && obj.nodeType !== "thin") {
+    return { ok: false, error: validation("payload.nodeType must be 'full' or 'thin'") };
+  }
+  const toolsResult = parseTools(obj.tools);
+  if (!toolsResult.ok) return toolsResult;
+  return { ok: true, value: { nodeType: obj.nodeType, tools: toolsResult.value } };
+}
+
+export function validateNodeToolsUpdatedPayload(
+  payload: unknown,
+): Result<NodeToolsUpdatedPayload, KoiError> {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return { ok: false, error: validation("Tools update payload must be an object") };
+  }
+  const obj = payload as Record<string, unknown>;
+  const addedResult = parseTools(obj.added);
+  if (!addedResult.ok) return addedResult;
+  if (!Array.isArray(obj.removed)) {
+    return { ok: false, error: validation("removed must be an array") };
+  }
+  const removed = obj.removed.filter((name): name is string => typeof name === "string");
+  if (removed.length !== obj.removed.length) {
+    return { ok: false, error: validation("removed entries must be strings") };
+  }
+  return { ok: true, value: { added: addedResult.value, removed } };
+}

--- a/packages/net/gateway/src/node-registry.ts
+++ b/packages/net/gateway/src/node-registry.ts
@@ -1,0 +1,185 @@
+import type { AdvertisedTool, CapacityReport, KoiError, NodeCapability, Result } from "@koi/core";
+import { notFound, validation } from "@koi/core";
+
+export interface RegisteredNode {
+  readonly nodeId: string;
+  readonly nodeType: "full" | "thin";
+  readonly tools: readonly AdvertisedTool[];
+  readonly capacity: CapacityReport;
+  readonly connectedAt: number;
+  readonly lastHeartbeat: number;
+  readonly connId: string;
+}
+
+export type NodeRegistryEvent =
+  | { readonly kind: "registered"; readonly node: RegisteredNode }
+  | { readonly kind: "deregistered"; readonly nodeId: string; readonly reason: string }
+  | { readonly kind: "offline"; readonly nodeId: string; readonly reason: string }
+  | { readonly kind: "heartbeat"; readonly nodeId: string }
+  | { readonly kind: "capabilities_updated"; readonly nodeId: string };
+
+export interface NodeRegistry {
+  readonly register: (node: RegisteredNode) => Result<void, KoiError>;
+  readonly deregister: (nodeId: string) => Result<boolean, KoiError>;
+  readonly lookup: (nodeId: string) => RegisteredNode | undefined;
+  readonly resolve: (toolName: string) => readonly NodeCapability[];
+  readonly nodes: () => ReadonlyMap<string, RegisteredNode>;
+  readonly size: () => number;
+  readonly updateHeartbeat: (nodeId: string, now?: number) => Result<void, KoiError>;
+  readonly updateCapabilities: (
+    nodeId: string,
+    nodeType: RegisteredNode["nodeType"],
+    tools: readonly AdvertisedTool[],
+  ) => Result<void, KoiError>;
+  readonly updateTools: (
+    nodeId: string,
+    added: readonly AdvertisedTool[],
+    removed: readonly string[],
+  ) => Result<void, KoiError>;
+}
+
+function addIndexed(
+  index: ReadonlyMap<string, ReadonlySet<string>>,
+  nodeId: string,
+  tools: readonly AdvertisedTool[],
+): Map<string, ReadonlySet<string>> {
+  let next = new Map(index);
+  for (const tool of tools) {
+    const existing = next.get(tool.name) ?? new Set<string>();
+    next = new Map(next).set(tool.name, new Set([...existing, nodeId]));
+  }
+  return next;
+}
+
+function removeIndexed(
+  index: ReadonlyMap<string, ReadonlySet<string>>,
+  nodeId: string,
+  tools: readonly AdvertisedTool[],
+): Map<string, ReadonlySet<string>> {
+  let next = new Map(index);
+  for (const tool of tools) {
+    const existing = next.get(tool.name);
+    if (existing === undefined) continue;
+    const remaining = new Set([...existing].filter((id) => id !== nodeId));
+    next =
+      remaining.size === 0
+        ? new Map([...next].filter(([name]) => name !== tool.name))
+        : new Map(next).set(tool.name, remaining);
+  }
+  return next;
+}
+
+class InMemoryNodeRegistry implements NodeRegistry {
+  private nodeMap = new Map<string, RegisteredNode>();
+  private toolIndex = new Map<string, ReadonlySet<string>>();
+
+  register(node: RegisteredNode): Result<void, KoiError> {
+    if (node.nodeId.length === 0) {
+      return { ok: false, error: validation("nodeId must not be empty") };
+    }
+    const previous = this.nodeMap.get(node.nodeId);
+    if (previous !== undefined) {
+      this.toolIndex = removeIndexed(this.toolIndex, node.nodeId, previous.tools);
+    }
+    this.nodeMap = new Map(this.nodeMap).set(node.nodeId, node);
+    this.toolIndex = addIndexed(this.toolIndex, node.nodeId, node.tools);
+    return { ok: true, value: undefined };
+  }
+
+  deregister(nodeId: string): Result<boolean, KoiError> {
+    const existing = this.nodeMap.get(nodeId);
+    if (existing === undefined) return { ok: true, value: false };
+    this.nodeMap = new Map([...this.nodeMap].filter(([id]) => id !== nodeId));
+    this.toolIndex = removeIndexed(this.toolIndex, nodeId, existing.tools);
+    return { ok: true, value: true };
+  }
+
+  lookup(nodeId: string): RegisteredNode | undefined {
+    return this.nodeMap.get(nodeId);
+  }
+
+  resolve(toolName: string): readonly NodeCapability[] {
+    const ids = this.toolIndex.get(toolName) ?? new Set<string>();
+    return [...ids].flatMap((nodeId): readonly NodeCapability[] => {
+      const node = this.nodeMap.get(nodeId);
+      if (node === undefined) return [];
+      return [
+        { nodeId, nodeType: node.nodeType, tools: node.tools.filter((t) => t.name === toolName) },
+      ];
+    });
+  }
+
+  nodes(): ReadonlyMap<string, RegisteredNode> {
+    return this.nodeMap;
+  }
+
+  size(): number {
+    return this.nodeMap.size;
+  }
+
+  updateHeartbeat(nodeId: string, now = Date.now()): Result<void, KoiError> {
+    const existing = this.find(nodeId);
+    if (!existing.ok) return { ok: false, error: existing.error };
+    this.nodeMap = new Map(this.nodeMap).set(nodeId, { ...existing.value, lastHeartbeat: now });
+    return { ok: true, value: undefined };
+  }
+
+  updateCapabilities(
+    nodeId: string,
+    nodeType: RegisteredNode["nodeType"],
+    tools: readonly AdvertisedTool[],
+  ): Result<void, KoiError> {
+    const existing = this.find(nodeId);
+    if (!existing.ok) return { ok: false, error: existing.error };
+    this.toolIndex = removeIndexed(this.toolIndex, nodeId, existing.value.tools);
+    this.toolIndex = addIndexed(this.toolIndex, nodeId, tools);
+    this.nodeMap = new Map(this.nodeMap).set(nodeId, { ...existing.value, nodeType, tools });
+    return { ok: true, value: undefined };
+  }
+
+  updateTools(
+    nodeId: string,
+    added: readonly AdvertisedTool[],
+    removed: readonly string[],
+  ): Result<void, KoiError> {
+    const existing = this.find(nodeId);
+    if (!existing.ok) return { ok: false, error: existing.error };
+    const next = mergeTools(existing.value.tools, added, removed);
+    this.toolIndex = removeIndexed(this.toolIndex, nodeId, next.removed);
+    this.toolIndex = removeIndexed(this.toolIndex, nodeId, next.replaced);
+    this.toolIndex = addIndexed(this.toolIndex, nodeId, added);
+    this.nodeMap = new Map(this.nodeMap).set(nodeId, { ...existing.value, tools: next.tools });
+    return { ok: true, value: undefined };
+  }
+
+  private find(nodeId: string): Result<RegisteredNode, KoiError> {
+    const existing = this.nodeMap.get(nodeId);
+    if (existing === undefined) {
+      return { ok: false, error: notFound(nodeId, `Node not found: ${nodeId}`) };
+    }
+    return { ok: true, value: existing };
+  }
+}
+
+function mergeTools(
+  existing: readonly AdvertisedTool[],
+  added: readonly AdvertisedTool[],
+  removed: readonly string[],
+): {
+  readonly tools: readonly AdvertisedTool[];
+  readonly removed: readonly AdvertisedTool[];
+  readonly replaced: readonly AdvertisedTool[];
+} {
+  const removedSet = new Set(removed);
+  const addedNames = new Set(added.map((tool) => tool.name));
+  const kept = existing.filter((tool) => !removedSet.has(tool.name));
+  return {
+    tools: [...kept.filter((tool) => !addedNames.has(tool.name)), ...added],
+    removed: existing.filter((tool) => removedSet.has(tool.name)),
+    replaced: kept.filter((tool) => addedNames.has(tool.name)),
+  };
+}
+
+export function createInMemoryNodeRegistry(): NodeRegistry {
+  return new InMemoryNodeRegistry();
+}

--- a/packages/net/gateway/src/types.ts
+++ b/packages/net/gateway/src/types.ts
@@ -138,6 +138,10 @@ export interface GatewayConfig {
    *  the store is shared/persistent (e.g. Nexus-backed) and sessions must survive
    *  a SIGTERM/restart so peers can reconnect. Default: false. */
   readonly preserveSessionsOnStop?: boolean | undefined;
+  /** Time without node heartbeat before the gateway marks a node offline. */
+  readonly nodeHeartbeatTimeoutMs: number;
+  /** How often to sweep connected nodes for missed heartbeats. */
+  readonly nodeSweepIntervalMs: number;
   // routing?: RoutingConfig — deferred: per-route handler isolation belongs to
   // the node registry layer, not the transport gateway. See intentional omissions.
 }
@@ -158,4 +162,6 @@ export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
   // without accumulating stale replay-window state indefinitely. Set to 0 to disable
   // retention (delete on disconnect) or increase for longer grace periods.
   disconnectedSessionTtlMs: 300_000,
+  nodeHeartbeatTimeoutMs: 30_000,
+  nodeSweepIntervalMs: 5_000,
 } as const;


### PR DESCRIPTION
## Summary

Implements issue #1396 node-gateway capability advertising and discovery.

Closes #1396.

- Adds a node frame protocol, in-memory node registry, node registration lifecycle, heartbeat timeout sweep, and gateway capability query/discovery APIs.
- Adds a device gateway client that advertises device component providers, heartbeats, reconnects, handles capability queries, and sends incremental provider updates.
- Adds focused gateway/device tests for registration, discovery, offline handling, capability updates, explicit queries, reconnect behavior, and the review-loop regressions.

## Validation

- `bun run typecheck` in `packages/net/gateway`
- `bun run typecheck` in `packages/lib/device`
- `bun run lint` in `packages/net/gateway`
- `bun run lint` in `packages/lib/device`
- `bun test` in `packages/net/gateway`: 131 pass
- `bun test` in `packages/lib/device`: 12 pass
- `bunx turbo run build --filter=@koi/gateway --filter=@koi/device`: 5 successful tasks
- `bun run check:golden-queries`: passed
- `bun run test:runtime-golden-replay`: 553 pass
- TUI gate: `bun run test`, `bun run typecheck`, `bun run lint`, root `check:tui-tools`, root `check:tui-single-writer`, and `bun run build` for `packages/ui/tui`
- Pre-commit hook: biome-check and bun-test-filter passed
- Pre-push hook: filtered build and typecheck passed for `@koi/device` and `@koi/gateway`

## Notes

The TUI gate reported existing non-failing informational/soft warnings only: two Biome template-literal suggestions in `SessionPicker.test.ts` and one `check:tui-single-writer` soft warning in `profiling/integration.ts`.
