### PR TITLE
[codex] Add speculation controller

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1226,6 +1226,13 @@
         "@koi/tasks": "workspace:*",
       },
     },
+    "packages/lib/speculation": {
+      "name": "@koi/speculation",
+      "version": "0.0.0",
+      "dependencies": {
+        "@koi/core": "workspace:*",
+      },
+    },
     "packages/lib/swarm": {
       "name": "@koi/swarm",
       "version": "0.0.0",
@@ -1789,6 +1796,7 @@
         "@koi/skills-runtime": "workspace:*",
         "@koi/snapshot-store-sqlite": "workspace:*",
         "@koi/spawn-tools": "workspace:*",
+        "@koi/speculation": "workspace:*",
         "@koi/task-spawn": "workspace:*",
         "@koi/task-tools": "workspace:*",
         "@koi/tasks": "workspace:*",
@@ -3216,6 +3224,8 @@
     "@koi/snapshot-store-sqlite": ["@koi/snapshot-store-sqlite@workspace:packages/lib/snapshot-store-sqlite"],
 
     "@koi/spawn-tools": ["@koi/spawn-tools@workspace:packages/lib/spawn-tools"],
+
+    "@koi/speculation": ["@koi/speculation@workspace:packages/lib/speculation"],
 
     "@koi/swarm": ["@koi/swarm@workspace:packages/lib/swarm"],
 

--- a/docs/L2/speculation.md
+++ b/docs/L2/speculation.md
@@ -1,0 +1,76 @@
+# @koi/speculation
+
+Speculative fork execution coordinator for hosts that want to pre-compute a likely next agent response before the user explicitly accepts it.
+
+The package is an opt-in L2 helper. It does not run an engine, create worktrees, or render UI itself. Hosts inject three collaborators:
+
+- `forkAgent` runs the speculative child agent.
+- `overlayManager` creates, accepts, and rejects isolated workspace overlays.
+- `presentResult` displays a completed speculative result to the host UI.
+
+This keeps the coordinator independent from `@koi/engine`, `@koi/workspace`, and `@koi/tui` while still giving those packages a shared lifecycle contract.
+
+## Public API
+
+```ts
+import { createSpeculationController } from "@koi/speculation";
+
+const controller = createSpeculationController({
+  overlayManager,
+  forkAgent,
+  presentResult,
+  maxConcurrent: 1,
+  timeoutMs: 30_000,
+});
+```
+
+### `start(request)`
+
+Creates an overlay and starts speculative fork execution in the background.
+
+Returns:
+
+- `{ kind: "started", id, overlay }` when speculation was admitted.
+- `{ kind: "fallback", reason, error? }` when normal execution should continue without speculation.
+
+The request includes `description`, `agentName`, and an optional `spawnRequest` payload for hosts that adapt from the L0 `SpawnRequest` contract.
+
+### `accept(id)`
+
+Aborts the speculative fork if it is still running, asks the overlay manager to merge the overlay, removes the active speculation, and returns the changed paths.
+
+Accept failures return a fallback response rather than throwing.
+
+### `reject(id)`
+
+Aborts the speculative fork if it is still running, rejects the overlay, and removes the active speculation.
+
+Reject failures return a fallback response rather than throwing.
+
+### `cancelAll(reason)`
+
+Cancels all active speculation and rejects their overlays. Hosts should call this when new user input arrives so old predictions cannot race the new turn.
+
+## Failure Model
+
+Speculation is best-effort. Overlay creation failures, fork failures, presentation failures, timeouts, and resource-limit refusals all resolve to fallback states so the caller can continue normal execution.
+
+The controller does not persist transcript state and does not mutate the real workspace directly. Real workspace changes happen only through the injected `overlayManager.accept(id)` implementation.
+
+## Overlay Integration
+
+Use `@koi/workspace` for the local git-worktree overlay implementation:
+
+```ts
+import { createGitWorktreeOverlayManager } from "@koi/workspace";
+
+const overlayManager = createGitWorktreeOverlayManager({ repoPath });
+```
+
+Future hosts can provide Nexus-backed or sandbox-backed overlay managers as long as they implement the same `create` / `accept` / `reject` shape.
+
+## UI Integration
+
+`presentResult` is the accept/reject UI seam. Terminal or app hosts should render the speculative output and call `accept(id)` or `reject(id)` from their own input handlers.
+
+The package intentionally does not define keybindings, modal layout, or transcript injection. Those are host-level concerns because TUI, daemon, and remote sessions have different interaction models.

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -4,6 +4,15 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
 
 ## Recent updates
 
+- 2026-05-18: `@koi/speculation` wired (#1406). Runtime now depends on and
+  re-exports the host-injected speculation controller for best-effort
+  pre-execution forks. The controller coordinates overlay creation, speculative
+  fork execution, presentation, accept/reject, cancellation on new user input,
+  resource limits, timeouts, and fallback behavior. It is library-only at the
+  runtime boundary: default TUI wiring is intentionally exempt until a concrete
+  overlay/fork/accept UI exists. Standalone golden coverage exercises the
+  runtime export and an in-memory pre-exec accept path. See
+  `docs/L2/speculation.md` for the full contract.
 - 2026-05-16: Integrated `@koi/model-openai-compat` now honors a `KOI_MAX_TOKENS`
   output-token cap (sends `min(request.maxTokens, KOI_MAX_TOKENS)`, or the cap alone
   when the request omits `maxTokens`). No-op when unset/non-positive, so runtime

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -4,10 +4,10 @@ Generated from active workspace packages with `bun scripts/generate-package-cove
 
 Current snapshot:
 
-- 233 workspace packages
+- 234 workspace packages
 - 11 package families
-- 233 packages with local test files
-- 208 packages with dedicated package docs
+- 234 packages with local test files
+- 209 packages with dedicated package docs
 
 ## Family Summary
 
@@ -16,8 +16,8 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 152 | 790 | 133 |
-| meta | 7 | 121 | 5 |
+| lib | 153 | 791 | 134 |
+| meta | 7 | 122 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 12 | 99 | 12 |
 | sandbox | 12 | 67 | 12 |
@@ -47,7 +47,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/engine-compose` (packages/kernel/engine-compose) - Middleware composition and guard factories for the Koi kernel. Tests: 7. Docs: -.
 - `@koi/engine-reconcile` (packages/kernel/engine-reconcile) - Reconciliation, supervision, and process management for the Koi kernel. Tests: 22. Docs: -.
 
-## lib (152)
+## lib (153)
 
 - `@koi/ace-types` (packages/lib/ace-types) - Shared domain types for ACE (Adaptive Continuous Enhancement) middleware and stores. Tests: 1. Docs: -.
 - `@koi/agent-discovery` (packages/lib/agent-discovery) - Runtime discovery of external coding agents (CLI, filesystem registry, MCP). Tests: 8. Docs: docs/L2/agent-discovery.md.
@@ -179,6 +179,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/snapshot-store-nexus` (packages/lib/snapshot-store-nexus) - L2 storage adapter: SnapshotChainStore<T> over Nexus JSON-RPC. Tests: 4. Docs: docs/L2/snapshot-store-nexus.md.
 - `@koi/snapshot-store-sqlite` (packages/lib/snapshot-store-sqlite) - L2 storage adapter: SnapshotChainStore<T> over SQLite with recursive-CTE walks and mark-sweep GC. Tests: 5. Docs: docs/L2/snapshot-store-sqlite.md.
 - `@koi/spawn-tools` (packages/lib/spawn-tools) - LLM-callable agent spawn tool + TaskCascade helper for coordinator orchestration (L2). Tests: 6. Docs: docs/L2/spawn-tools.md.
+- `@koi/speculation` (packages/lib/speculation) - Speculative fork execution coordinator with overlay accept/reject lifecycle. Tests: 1. Docs: docs/L2/speculation.md.
 - `@koi/swarm` (packages/lib/swarm) - Team swarm coordination over local IPC with optional federation bridge. Tests: 1. Docs: docs/L2/swarm.md.
 - `@koi/task-board` (packages/lib/task-board) - Immutable TaskBoard with DAG validation, cycle detection, and topological sort. Tests: 3. Docs: -.
 - `@koi/task-spawn` (packages/lib/task-spawn) - Lightweight task tool for zero-friction subagent spawning + copilot routing. Tests: 8. Docs: docs/L2/task-spawn.md.
@@ -210,7 +211,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/autonomous` (packages/meta/autonomous) - L3 autonomous composition facade for long-running harness, scheduler, and task-aware helper wiring. Tests: 1. Docs: docs/L2/autonomous.md, docs/L3/autonomous.md.
 - `@koi/nexus` (packages/meta/nexus) - L3 Nexus composition wiring for the active v2 Nexus package set. Tests: 6. Docs: docs/L3/nexus.md.
 - `@koi/rlm-stack` (packages/meta/rlm-stack) - L3 composition wiring @koi/middleware-rlm with @koi/context-manager threshold coordination. Tests: 3. Docs: docs/L2/rlm-stack.md, docs/L3/rlm-stack.md.
-- `@koi/runtime` (packages/meta/runtime) - L3 meta-package: wires Phase 1 kernel + L2 packages into a bootable runtime with progressive stub replacement. Tests: 40. Docs: docs/L3/runtime.md.
+- `@koi/runtime` (packages/meta/runtime) - L3 meta-package: wires Phase 1 kernel + L2 packages into a bootable runtime with progressive stub replacement. Tests: 41. Docs: docs/L3/runtime.md.
 
 ## mm (12)
 

--- a/packages/lib/speculation/package.json
+++ b/packages/lib/speculation/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@koi/speculation",
+  "description": "Speculative fork execution coordinator with overlay accept/reject lifecycle",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../../scripts/run-tsup.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@koi/core": "workspace:*"
+  },
+  "koi": {
+    "optional": true
+  }
+}

--- a/packages/lib/speculation/src/controller.test.ts
+++ b/packages/lib/speculation/src/controller.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, test } from "bun:test";
+import type { KoiError, Result, WorkspaceId } from "@koi/core";
+import { workspaceId } from "@koi/core";
+import { createSpeculationController } from "./controller.js";
+import type {
+  SpeculationAcceptResult,
+  SpeculationController,
+  SpeculationForkAgent,
+  SpeculationOverlay,
+  SpeculationOverlayManager,
+  SpeculationPresentedResult,
+} from "./types.js";
+
+function error(code: KoiError["code"], message: string): KoiError {
+  return { code, message, retryable: false };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (err: unknown) => void;
+} {
+  let resolveFn: ((value: T) => void) | undefined;
+  let rejectFn: ((err: unknown) => void) | undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return {
+    promise,
+    resolve: (value: T): void => resolveFn?.(value),
+    reject: (err: unknown): void => rejectFn?.(err),
+  };
+}
+
+function makeOverlay(idText = "overlay-1"): SpeculationOverlay {
+  return { id: workspaceId(idText), path: `/tmp/${idText}` };
+}
+
+function makeOverlayManager(): SpeculationOverlayManager & {
+  readonly created: WorkspaceId[];
+  readonly accepted: WorkspaceId[];
+  readonly rejected: WorkspaceId[];
+} {
+  const created: WorkspaceId[] = [];
+  const accepted: WorkspaceId[] = [];
+  const rejected: WorkspaceId[] = [];
+  return {
+    created,
+    accepted,
+    rejected,
+    async create(): Promise<Result<SpeculationOverlay, KoiError>> {
+      const overlay = makeOverlay(`overlay-${created.length + 1}`);
+      created.push(overlay.id);
+      return { ok: true, value: overlay };
+    },
+    async accept(id: WorkspaceId): Promise<Result<SpeculationAcceptResult, KoiError>> {
+      accepted.push(id);
+      return { ok: true, value: { changedPaths: ["README.md"] } };
+    },
+    async reject(id: WorkspaceId): Promise<Result<void, KoiError>> {
+      rejected.push(id);
+      return { ok: true, value: undefined };
+    },
+  };
+}
+
+async function startOne(controller: SpeculationController): Promise<WorkspaceId> {
+  const started = await controller.start({ agentName: "coder", description: "do work" });
+  expect(started.kind).toBe("started");
+  if (started.kind !== "started") throw new Error("not started");
+  return started.id;
+}
+
+describe("createSpeculationController", () => {
+  test("forks against an overlay and presents the speculative result", async () => {
+    const overlays = makeOverlayManager();
+    const presented: SpeculationPresentedResult[] = [];
+    const fork: SpeculationForkAgent = async (request) => ({
+      ok: true,
+      output: `ran in ${request.overlay.id}`,
+    });
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: fork,
+      presentResult: (result) => {
+        presented.push(result);
+      },
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+
+    expect(presented).toEqual([{ id, overlay: makeOverlay("overlay-1"), output: `ran in ${id}` }]);
+    expect(controller.snapshot(id)?.status).toBe("presented");
+  });
+
+  test("accept merges the overlay after presentation", async () => {
+    const overlays = makeOverlayManager();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => ({ ok: true, output: "ready" }),
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+    const accepted = await controller.accept(id);
+
+    expect(accepted).toEqual({ kind: "accepted", id, changedPaths: ["README.md"] });
+    expect(overlays.accepted).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("reject discards the overlay", async () => {
+    const overlays = makeOverlayManager();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => ({ ok: true, output: "ready" }),
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+    const rejected = await controller.reject(id);
+
+    expect(rejected).toEqual({ kind: "rejected", id });
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("new user input cancels running speculation and rejects its overlay", async () => {
+    const overlays = makeOverlayManager();
+    const gate = deferred<{ readonly ok: true; readonly output: string }>();
+    const signals: AbortSignal[] = [];
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async (request) => {
+        signals.push(request.signal);
+        return gate.promise;
+      },
+    });
+
+    const id = await startOne(controller);
+    const cancelled = await controller.cancelAll("new_user_input");
+    gate.resolve({ ok: true, output: "late" });
+    await controller.waitForIdle();
+
+    expect(cancelled).toEqual([id]);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("resource limit falls back without creating a second overlay", async () => {
+    const overlays = makeOverlayManager();
+    const gate = deferred<{ readonly ok: true; readonly output: string }>();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => gate.promise,
+      maxConcurrent: 1,
+    });
+
+    const id = await startOne(controller);
+    const second = await controller.start({ agentName: "coder", description: "second" });
+    gate.resolve({ ok: true, output: "done" });
+    await controller.waitForIdle();
+
+    expect(second).toEqual({ kind: "fallback", reason: "resource_limit" });
+    expect(overlays.created).toEqual([id]);
+  });
+
+  test("timeout aborts running speculation and discards the overlay", async () => {
+    const overlays = makeOverlayManager();
+    const signals: AbortSignal[] = [];
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async (request) => {
+        signals.push(request.signal);
+        return new Promise(() => {});
+      },
+      timeoutMs: 1,
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("fork failures silently reject the overlay and fall back", async () => {
+    const overlays = makeOverlayManager();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => ({ ok: false, error: error("EXTERNAL", "model unavailable") }),
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("overlay creation failure falls back before forking", async () => {
+    let forked = false;
+    const controller = createSpeculationController({
+      overlayManager: {
+        async create(): Promise<Result<SpeculationOverlay, KoiError>> {
+          return { ok: false, error: error("EXTERNAL", "git unavailable") };
+        },
+        async accept(): Promise<Result<SpeculationAcceptResult, KoiError>> {
+          throw new Error("accept should not run");
+        },
+        async reject(): Promise<Result<void, KoiError>> {
+          throw new Error("reject should not run");
+        },
+      },
+      forkAgent: async () => {
+        forked = true;
+        return { ok: true, output: "unused" };
+      },
+    });
+
+    const started = await controller.start({ agentName: "coder", description: "do work" });
+
+    expect(started).toEqual({
+      kind: "fallback",
+      reason: "overlay_create_failed",
+      error: error("EXTERNAL", "git unavailable"),
+    });
+    expect(forked).toBe(false);
+  });
+
+  test("presentation failure discards the overlay", async () => {
+    const overlays = makeOverlayManager();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => ({ ok: true, output: "ready" }),
+      presentResult: () => {
+        throw new Error("ui gone");
+      },
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.snapshot(id)).toBeUndefined();
+  });
+
+  test("accept and reject failures return fallback responses", async () => {
+    const overlays = makeOverlayManager();
+    const acceptError = error("CONFLICT", "changed locally");
+    const rejectError = error("EXTERNAL", "cleanup failed");
+    const controller = createSpeculationController({
+      overlayManager: {
+        async create(): Promise<Result<SpeculationOverlay, KoiError>> {
+          return { ok: true, value: makeOverlay("overlay-accept-fail") };
+        },
+        async accept(): Promise<Result<SpeculationAcceptResult, KoiError>> {
+          return { ok: false, error: acceptError };
+        },
+        async reject(): Promise<Result<void, KoiError>> {
+          return { ok: false, error: rejectError };
+        },
+      },
+      forkAgent: async () => ({ ok: true, output: "ready" }),
+    });
+
+    const acceptId = await startOne(controller);
+    await controller.waitForIdle();
+    const accepted = await controller.accept(acceptId);
+    const missingReject = await controller.reject(acceptId);
+
+    expect(accepted).toEqual({
+      kind: "fallback",
+      id: acceptId,
+      reason: "accept_failed",
+      error: acceptError,
+    });
+    expect(missingReject).toEqual({ kind: "fallback", id: acceptId, reason: "cancelled" });
+    expect(overlays.created.length).toBe(0);
+
+    const rejectController = createSpeculationController({
+      overlayManager: {
+        async create(): Promise<Result<SpeculationOverlay, KoiError>> {
+          return { ok: true, value: makeOverlay("overlay-reject-fail") };
+        },
+        async accept(): Promise<Result<SpeculationAcceptResult, KoiError>> {
+          return { ok: true, value: { changedPaths: [] } };
+        },
+        async reject(): Promise<Result<void, KoiError>> {
+          return { ok: false, error: rejectError };
+        },
+      },
+      forkAgent: async () => ({ ok: true, output: "ready" }),
+    });
+    const rejectId = await startOne(rejectController);
+    await rejectController.waitForIdle();
+    const rejected = await rejectController.reject(rejectId);
+
+    expect(rejected).toEqual({
+      kind: "fallback",
+      id: rejectId,
+      reason: "reject_failed",
+      error: rejectError,
+    });
+  });
+
+  test("fork exceptions are treated as best-effort fallback", async () => {
+    const overlays = makeOverlayManager();
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const id = await startOne(controller);
+    await controller.waitForIdle();
+
+    expect(overlays.rejected).toEqual([id]);
+    expect(controller.list()).toEqual([]);
+  });
+});

--- a/packages/lib/speculation/src/controller.ts
+++ b/packages/lib/speculation/src/controller.ts
@@ -1,0 +1,216 @@
+import type { WorkspaceId } from "@koi/core";
+import type {
+  SpeculationAcceptResponse,
+  SpeculationController,
+  SpeculationControllerConfig,
+  SpeculationFallbackReason,
+  SpeculationOverlay,
+  SpeculationPresentedResult,
+  SpeculationRejectResponse,
+  SpeculationSnapshot,
+  SpeculationStartResult,
+  StartSpeculationRequest,
+} from "./types.js";
+
+interface ActiveSpeculation {
+  readonly id: WorkspaceId;
+  readonly overlay: SpeculationOverlay;
+  readonly abortController: AbortController;
+  readonly clearTimer: () => void;
+  readonly status: SpeculationSnapshot["status"];
+  readonly output?: string | undefined;
+  readonly fallbackReason?: SpeculationFallbackReason | undefined;
+}
+
+function makeTimeoutPromise(
+  timeoutMs: number | undefined,
+  controller: AbortController,
+): {
+  readonly promise: Promise<"timeout"> | undefined;
+  readonly clear: () => void;
+} {
+  if (timeoutMs === undefined || timeoutMs <= 0) {
+    return { promise: undefined, clear: () => {} };
+  }
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<"timeout">((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      controller.abort("timeout");
+      resolve("timeout");
+    }, timeoutMs);
+  });
+  return {
+    promise,
+    clear: (): void => clearTimeout(timeoutHandle),
+  };
+}
+
+export function createSpeculationController(
+  config: SpeculationControllerConfig,
+): SpeculationController {
+  const maxConcurrent = config.maxConcurrent ?? 1;
+  const active = new Map<WorkspaceId, ActiveSpeculation>();
+  const inFlight = new Map<WorkspaceId, Promise<void>>();
+
+  function updateEntry(
+    id: WorkspaceId,
+    updates: Partial<Pick<ActiveSpeculation, "fallbackReason" | "output" | "status">>,
+  ): ActiveSpeculation | undefined {
+    const current = active.get(id);
+    if (current === undefined) return undefined;
+    const next = { ...current, ...updates };
+    active.set(id, next);
+    return next;
+  }
+
+  async function cleanup(id: WorkspaceId, reason: SpeculationFallbackReason): Promise<void> {
+    const entry = updateEntry(id, {
+      status: reason === "cancelled" ? "cancelled" : "fallback",
+      fallbackReason: reason,
+    });
+    if (entry === undefined) return;
+    entry.abortController.abort(reason);
+    entry.clearTimer();
+    await config.overlayManager.reject(id);
+    active.delete(id);
+  }
+
+  async function runSpeculation(
+    entry: ActiveSpeculation,
+    request: StartSpeculationRequest,
+    timeoutPromise: Promise<"timeout"> | undefined,
+  ): Promise<void> {
+    try {
+      const forkPromise = config.forkAgent({
+        description: request.description,
+        agentName: request.agentName,
+        overlay: entry.overlay,
+        signal: entry.abortController.signal,
+        ...(request.spawnRequest !== undefined ? { spawnRequest: request.spawnRequest } : {}),
+      });
+      const result =
+        timeoutPromise === undefined
+          ? await forkPromise
+          : await Promise.race([forkPromise, timeoutPromise]);
+
+      if (result === "timeout") {
+        await cleanup(entry.id, "timeout");
+        return;
+      }
+      if (!result.ok) {
+        await cleanup(entry.id, "fork_failed");
+        return;
+      }
+      if (entry.abortController.signal.aborted) {
+        await cleanup(entry.id, "cancelled");
+        return;
+      }
+      updateEntry(entry.id, { output: result.output, status: "presented" });
+      const presented: SpeculationPresentedResult = {
+        id: entry.id,
+        overlay: entry.overlay,
+        output: result.output,
+      };
+      try {
+        await config.presentResult?.(presented);
+      } catch {
+        await cleanup(entry.id, "present_failed");
+      }
+    } catch {
+      await cleanup(entry.id, "fork_failed").catch(() => {});
+    } finally {
+      entry.clearTimer();
+    }
+  }
+
+  function snapshotEntry(entry: ActiveSpeculation): SpeculationSnapshot {
+    return {
+      id: entry.id,
+      overlay: entry.overlay,
+      status: entry.status,
+      ...(entry.output !== undefined ? { output: entry.output } : {}),
+      ...(entry.fallbackReason !== undefined ? { fallbackReason: entry.fallbackReason } : {}),
+    };
+  }
+
+  return {
+    async start(request: StartSpeculationRequest): Promise<SpeculationStartResult> {
+      if (active.size >= maxConcurrent) return { kind: "fallback", reason: "resource_limit" };
+      const overlay = await config.overlayManager.create();
+      if (!overlay.ok) {
+        return { kind: "fallback", reason: "overlay_create_failed", error: overlay.error };
+      }
+      const abortController = new AbortController();
+      const timeout = makeTimeoutPromise(config.timeoutMs, abortController);
+      const entry: ActiveSpeculation = {
+        id: overlay.value.id,
+        overlay: overlay.value,
+        abortController,
+        status: "running",
+        clearTimer: timeout.clear,
+      };
+      active.set(entry.id, entry);
+      const done = runSpeculation(entry, request, timeout.promise).finally(() => {
+        inFlight.delete(entry.id);
+      });
+      inFlight.set(entry.id, done);
+      return { kind: "started", id: entry.id, overlay: entry.overlay };
+    },
+
+    async accept(id: WorkspaceId): Promise<SpeculationAcceptResponse> {
+      const entry = active.get(id);
+      if (entry === undefined) {
+        return { kind: "fallback", id, reason: "cancelled" };
+      }
+      entry.abortController.abort("accepted");
+      entry.clearTimer();
+      await inFlight.get(id)?.catch(() => {});
+      const accepted = await config.overlayManager.accept(id);
+      active.delete(id);
+      if (!accepted.ok) {
+        return {
+          kind: "fallback",
+          id,
+          reason: "accept_failed",
+          error: accepted.error,
+        };
+      }
+      return { kind: "accepted", id, changedPaths: accepted.value.changedPaths };
+    },
+
+    async reject(id: WorkspaceId): Promise<SpeculationRejectResponse> {
+      const entry = active.get(id);
+      if (entry === undefined) {
+        return { kind: "fallback", id, reason: "cancelled" };
+      }
+      entry.abortController.abort("rejected");
+      entry.clearTimer();
+      await inFlight.get(id)?.catch(() => {});
+      const rejected = await config.overlayManager.reject(id);
+      active.delete(id);
+      if (!rejected.ok) {
+        return { kind: "fallback", id, reason: "reject_failed", error: rejected.error };
+      }
+      return { kind: "rejected", id };
+    },
+
+    async cancelAll(): Promise<readonly WorkspaceId[]> {
+      const ids = [...active.keys()];
+      await Promise.all(ids.map((id) => cleanup(id, "cancelled").catch(() => {})));
+      return ids;
+    },
+
+    snapshot(id: WorkspaceId): SpeculationSnapshot | undefined {
+      const entry = active.get(id);
+      return entry === undefined ? undefined : snapshotEntry(entry);
+    },
+
+    list(): readonly SpeculationSnapshot[] {
+      return [...active.values()].map(snapshotEntry);
+    },
+
+    async waitForIdle(): Promise<void> {
+      await Promise.all([...inFlight.values()].map((done) => done.catch(() => {})));
+    },
+  };
+}

--- a/packages/lib/speculation/src/controller.ts
+++ b/packages/lib/speculation/src/controller.ts
@@ -45,85 +45,96 @@ function makeTimeoutPromise(
   };
 }
 
-export function createSpeculationController(
-  config: SpeculationControllerConfig,
-): SpeculationController {
-  const maxConcurrent = config.maxConcurrent ?? 1;
-  const active = new Map<WorkspaceId, ActiveSpeculation>();
-  const inFlight = new Map<WorkspaceId, Promise<void>>();
+class SpeculationControllerState {
+  private readonly active = new Map<WorkspaceId, ActiveSpeculation>();
+  private readonly inFlight = new Map<WorkspaceId, Promise<void>>();
+  private readonly config: SpeculationControllerConfig;
+  private readonly maxConcurrent: number;
 
-  function updateEntry(
+  constructor(config: SpeculationControllerConfig) {
+    this.config = config;
+    this.maxConcurrent = config.maxConcurrent ?? 1;
+  }
+
+  controller(): SpeculationController {
+    return {
+      start: (request) => this.start(request),
+      accept: (id) => this.accept(id),
+      reject: (id) => this.reject(id),
+      cancelAll: () => this.cancelAll(),
+      snapshot: (id) => this.snapshot(id),
+      list: () => this.list(),
+      waitForIdle: () => this.waitForIdle(),
+    };
+  }
+
+  private updateEntry(
     id: WorkspaceId,
     updates: Partial<Pick<ActiveSpeculation, "fallbackReason" | "output" | "status">>,
   ): ActiveSpeculation | undefined {
-    const current = active.get(id);
+    const current = this.active.get(id);
     if (current === undefined) return undefined;
     const next = { ...current, ...updates };
-    active.set(id, next);
+    this.active.set(id, next);
     return next;
   }
 
-  async function cleanup(id: WorkspaceId, reason: SpeculationFallbackReason): Promise<void> {
-    const entry = updateEntry(id, {
+  private async cleanup(id: WorkspaceId, reason: SpeculationFallbackReason): Promise<void> {
+    const entry = this.updateEntry(id, {
       status: reason === "cancelled" ? "cancelled" : "fallback",
       fallbackReason: reason,
     });
     if (entry === undefined) return;
     entry.abortController.abort(reason);
     entry.clearTimer();
-    await config.overlayManager.reject(id);
-    active.delete(id);
+    await this.config.overlayManager.reject(id);
+    this.active.delete(id);
   }
 
-  async function runSpeculation(
+  private async runSpeculation(
     entry: ActiveSpeculation,
     request: StartSpeculationRequest,
     timeoutPromise: Promise<"timeout"> | undefined,
   ): Promise<void> {
     try {
-      const forkPromise = config.forkAgent({
-        description: request.description,
-        agentName: request.agentName,
-        overlay: entry.overlay,
-        signal: entry.abortController.signal,
-        ...(request.spawnRequest !== undefined ? { spawnRequest: request.spawnRequest } : {}),
-      });
-      const result =
-        timeoutPromise === undefined
-          ? await forkPromise
-          : await Promise.race([forkPromise, timeoutPromise]);
-
-      if (result === "timeout") {
-        await cleanup(entry.id, "timeout");
-        return;
-      }
-      if (!result.ok) {
-        await cleanup(entry.id, "fork_failed");
-        return;
-      }
-      if (entry.abortController.signal.aborted) {
-        await cleanup(entry.id, "cancelled");
-        return;
-      }
-      updateEntry(entry.id, { output: result.output, status: "presented" });
-      const presented: SpeculationPresentedResult = {
-        id: entry.id,
-        overlay: entry.overlay,
-        output: result.output,
-      };
-      try {
-        await config.presentResult?.(presented);
-      } catch {
-        await cleanup(entry.id, "present_failed");
-      }
+      const result = await this.runFork(entry, request, timeoutPromise);
+      if (result === "timeout") return await this.cleanup(entry.id, "timeout");
+      if (!result.ok) return await this.cleanup(entry.id, "fork_failed");
+      if (entry.abortController.signal.aborted) return await this.cleanup(entry.id, "cancelled");
+      await this.presentForkResult(entry, result.output);
     } catch {
-      await cleanup(entry.id, "fork_failed").catch(() => {});
+      await this.cleanup(entry.id, "fork_failed").catch(() => {});
     } finally {
       entry.clearTimer();
     }
   }
 
-  function snapshotEntry(entry: ActiveSpeculation): SpeculationSnapshot {
+  private runFork(
+    entry: ActiveSpeculation,
+    request: StartSpeculationRequest,
+    timeoutPromise: Promise<"timeout"> | undefined,
+  ) {
+    const forkPromise = this.config.forkAgent({
+      description: request.description,
+      agentName: request.agentName,
+      overlay: entry.overlay,
+      signal: entry.abortController.signal,
+      ...(request.spawnRequest !== undefined ? { spawnRequest: request.spawnRequest } : {}),
+    });
+    return timeoutPromise === undefined ? forkPromise : Promise.race([forkPromise, timeoutPromise]);
+  }
+
+  private async presentForkResult(entry: ActiveSpeculation, output: string): Promise<void> {
+    this.updateEntry(entry.id, { output, status: "presented" });
+    const presented: SpeculationPresentedResult = { id: entry.id, overlay: entry.overlay, output };
+    try {
+      await this.config.presentResult?.(presented);
+    } catch {
+      await this.cleanup(entry.id, "present_failed");
+    }
+  }
+
+  private snapshotEntry(entry: ActiveSpeculation): SpeculationSnapshot {
     return {
       id: entry.id,
       overlay: entry.overlay,
@@ -133,84 +144,80 @@ export function createSpeculationController(
     };
   }
 
-  return {
-    async start(request: StartSpeculationRequest): Promise<SpeculationStartResult> {
-      if (active.size >= maxConcurrent) return { kind: "fallback", reason: "resource_limit" };
-      const overlay = await config.overlayManager.create();
-      if (!overlay.ok) {
-        return { kind: "fallback", reason: "overlay_create_failed", error: overlay.error };
-      }
-      const abortController = new AbortController();
-      const timeout = makeTimeoutPromise(config.timeoutMs, abortController);
-      const entry: ActiveSpeculation = {
-        id: overlay.value.id,
-        overlay: overlay.value,
-        abortController,
-        status: "running",
-        clearTimer: timeout.clear,
-      };
-      active.set(entry.id, entry);
-      const done = runSpeculation(entry, request, timeout.promise).finally(() => {
-        inFlight.delete(entry.id);
-      });
-      inFlight.set(entry.id, done);
-      return { kind: "started", id: entry.id, overlay: entry.overlay };
-    },
+  private async start(request: StartSpeculationRequest): Promise<SpeculationStartResult> {
+    if (this.active.size >= this.maxConcurrent)
+      return { kind: "fallback", reason: "resource_limit" };
+    const overlay = await this.config.overlayManager.create();
+    if (!overlay.ok) {
+      return { kind: "fallback", reason: "overlay_create_failed", error: overlay.error };
+    }
+    const abortController = new AbortController();
+    const timeout = makeTimeoutPromise(this.config.timeoutMs, abortController);
+    const entry: ActiveSpeculation = {
+      id: overlay.value.id,
+      overlay: overlay.value,
+      abortController,
+      status: "running",
+      clearTimer: timeout.clear,
+    };
+    this.active.set(entry.id, entry);
+    const done = this.runSpeculation(entry, request, timeout.promise).finally(() => {
+      this.inFlight.delete(entry.id);
+    });
+    this.inFlight.set(entry.id, done);
+    return { kind: "started", id: entry.id, overlay: entry.overlay };
+  }
 
-    async accept(id: WorkspaceId): Promise<SpeculationAcceptResponse> {
-      const entry = active.get(id);
-      if (entry === undefined) {
-        return { kind: "fallback", id, reason: "cancelled" };
-      }
-      entry.abortController.abort("accepted");
-      entry.clearTimer();
-      await inFlight.get(id)?.catch(() => {});
-      const accepted = await config.overlayManager.accept(id);
-      active.delete(id);
-      if (!accepted.ok) {
-        return {
-          kind: "fallback",
-          id,
-          reason: "accept_failed",
-          error: accepted.error,
-        };
-      }
-      return { kind: "accepted", id, changedPaths: accepted.value.changedPaths };
-    },
+  private async accept(id: WorkspaceId): Promise<SpeculationAcceptResponse> {
+    const entry = this.active.get(id);
+    if (entry === undefined) return { kind: "fallback", id, reason: "cancelled" };
+    entry.abortController.abort("accepted");
+    entry.clearTimer();
+    await this.inFlight.get(id)?.catch(() => {});
+    const accepted = await this.config.overlayManager.accept(id);
+    this.active.delete(id);
+    if (!accepted.ok) {
+      return { kind: "fallback", id, reason: "accept_failed", error: accepted.error };
+    }
+    return { kind: "accepted", id, changedPaths: accepted.value.changedPaths };
+  }
 
-    async reject(id: WorkspaceId): Promise<SpeculationRejectResponse> {
-      const entry = active.get(id);
-      if (entry === undefined) {
-        return { kind: "fallback", id, reason: "cancelled" };
-      }
-      entry.abortController.abort("rejected");
-      entry.clearTimer();
-      await inFlight.get(id)?.catch(() => {});
-      const rejected = await config.overlayManager.reject(id);
-      active.delete(id);
-      if (!rejected.ok) {
-        return { kind: "fallback", id, reason: "reject_failed", error: rejected.error };
-      }
-      return { kind: "rejected", id };
-    },
+  private async reject(id: WorkspaceId): Promise<SpeculationRejectResponse> {
+    const entry = this.active.get(id);
+    if (entry === undefined) return { kind: "fallback", id, reason: "cancelled" };
+    entry.abortController.abort("rejected");
+    entry.clearTimer();
+    await this.inFlight.get(id)?.catch(() => {});
+    const rejected = await this.config.overlayManager.reject(id);
+    this.active.delete(id);
+    if (!rejected.ok) {
+      return { kind: "fallback", id, reason: "reject_failed", error: rejected.error };
+    }
+    return { kind: "rejected", id };
+  }
 
-    async cancelAll(): Promise<readonly WorkspaceId[]> {
-      const ids = [...active.keys()];
-      await Promise.all(ids.map((id) => cleanup(id, "cancelled").catch(() => {})));
-      return ids;
-    },
+  private async cancelAll(): Promise<readonly WorkspaceId[]> {
+    const ids = [...this.active.keys()];
+    await Promise.all(ids.map((id) => this.cleanup(id, "cancelled").catch(() => {})));
+    return ids;
+  }
 
-    snapshot(id: WorkspaceId): SpeculationSnapshot | undefined {
-      const entry = active.get(id);
-      return entry === undefined ? undefined : snapshotEntry(entry);
-    },
+  private snapshot(id: WorkspaceId): SpeculationSnapshot | undefined {
+    const entry = this.active.get(id);
+    return entry === undefined ? undefined : this.snapshotEntry(entry);
+  }
 
-    list(): readonly SpeculationSnapshot[] {
-      return [...active.values()].map(snapshotEntry);
-    },
+  private list(): readonly SpeculationSnapshot[] {
+    return [...this.active.values()].map((entry) => this.snapshotEntry(entry));
+  }
 
-    async waitForIdle(): Promise<void> {
-      await Promise.all([...inFlight.values()].map((done) => done.catch(() => {})));
-    },
-  };
+  private async waitForIdle(): Promise<void> {
+    await Promise.all([...this.inFlight.values()].map((done) => done.catch(() => {})));
+  }
+}
+
+export function createSpeculationController(
+  config: SpeculationControllerConfig,
+): SpeculationController {
+  return new SpeculationControllerState(config).controller();
 }

--- a/packages/lib/speculation/src/index.ts
+++ b/packages/lib/speculation/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @koi/speculation — speculative fork execution coordinator.
+ *
+ * Owns best-effort speculative pre-execution lifecycle only. Hosts inject
+ * fork execution, overlay storage, and presentation so this L2 package stays
+ * independent of engine, workspace, and UI packages.
+ */
+
+export { createSpeculationController } from "./controller.js";
+export type {
+  PresentSpeculationResult,
+  SpeculationAcceptResponse,
+  SpeculationAcceptResult,
+  SpeculationController,
+  SpeculationControllerConfig,
+  SpeculationFallbackReason,
+  SpeculationForkAgent,
+  SpeculationForkRequest,
+  SpeculationForkResult,
+  SpeculationOverlay,
+  SpeculationOverlayManager,
+  SpeculationPresentedResult,
+  SpeculationRejectResponse,
+  SpeculationSnapshot,
+  SpeculationStartResult,
+  SpeculationStatus,
+  StartSpeculationRequest,
+} from "./types.js";

--- a/packages/lib/speculation/src/types.ts
+++ b/packages/lib/speculation/src/types.ts
@@ -1,0 +1,127 @@
+import type { KoiError, Result, SpawnRequest, SpawnResult, WorkspaceId } from "@koi/core";
+
+export interface SpeculationOverlay {
+  readonly id: WorkspaceId;
+  readonly path: string;
+  readonly baseCommit?: string | undefined;
+  readonly metadata?: Readonly<Record<string, string>> | undefined;
+}
+
+export interface SpeculationAcceptResult {
+  readonly changedPaths: readonly string[];
+}
+
+export interface SpeculationOverlayManager {
+  readonly create: () => Promise<Result<SpeculationOverlay, KoiError>>;
+  readonly accept: (id: WorkspaceId) => Promise<Result<SpeculationAcceptResult, KoiError>>;
+  readonly reject: (id: WorkspaceId) => Promise<Result<void, KoiError>>;
+}
+
+export interface SpeculationForkRequest {
+  readonly description: string;
+  readonly agentName: string;
+  readonly overlay: SpeculationOverlay;
+  readonly signal: AbortSignal;
+  readonly spawnRequest?: Omit<SpawnRequest, "signal"> | undefined;
+}
+
+export type SpeculationForkResult = SpawnResult;
+
+export type SpeculationForkAgent = (
+  request: SpeculationForkRequest,
+) => Promise<SpeculationForkResult>;
+
+export interface SpeculationPresentedResult {
+  readonly id: WorkspaceId;
+  readonly overlay: SpeculationOverlay;
+  readonly output: string;
+}
+
+export type PresentSpeculationResult = (result: SpeculationPresentedResult) => void | Promise<void>;
+
+export type SpeculationFallbackReason =
+  | "overlay_create_failed"
+  | "fork_failed"
+  | "present_failed"
+  | "accept_failed"
+  | "reject_failed"
+  | "resource_limit"
+  | "cancelled"
+  | "timeout";
+
+export type SpeculationStartResult =
+  | {
+      readonly kind: "started";
+      readonly id: WorkspaceId;
+      readonly overlay: SpeculationOverlay;
+    }
+  | {
+      readonly kind: "fallback";
+      readonly reason: SpeculationFallbackReason;
+      readonly error?: KoiError | undefined;
+    };
+
+export type SpeculationStatus =
+  | "running"
+  | "presented"
+  | "accepted"
+  | "rejected"
+  | "cancelled"
+  | "fallback";
+
+export interface SpeculationSnapshot {
+  readonly id: WorkspaceId;
+  readonly overlay: SpeculationOverlay;
+  readonly status: SpeculationStatus;
+  readonly output?: string | undefined;
+  readonly fallbackReason?: SpeculationFallbackReason | undefined;
+}
+
+export type SpeculationAcceptResponse =
+  | {
+      readonly kind: "accepted";
+      readonly id: WorkspaceId;
+      readonly changedPaths: readonly string[];
+    }
+  | {
+      readonly kind: "fallback";
+      readonly id: WorkspaceId;
+      readonly reason: SpeculationFallbackReason;
+      readonly error?: KoiError | undefined;
+    };
+
+export type SpeculationRejectResponse =
+  | {
+      readonly kind: "rejected";
+      readonly id: WorkspaceId;
+    }
+  | {
+      readonly kind: "fallback";
+      readonly id: WorkspaceId;
+      readonly reason: SpeculationFallbackReason;
+      readonly error?: KoiError | undefined;
+    };
+
+export interface SpeculationControllerConfig {
+  readonly overlayManager: SpeculationOverlayManager;
+  readonly forkAgent: SpeculationForkAgent;
+  readonly presentResult?: PresentSpeculationResult | undefined;
+  readonly maxConcurrent?: number | undefined;
+  readonly timeoutMs?: number | undefined;
+}
+
+export interface StartSpeculationRequest {
+  readonly description: string;
+  readonly agentName: string;
+  readonly spawnRequest?: Omit<SpawnRequest, "signal"> | undefined;
+}
+
+export interface SpeculationController {
+  readonly start: (request: StartSpeculationRequest) => Promise<SpeculationStartResult>;
+  readonly accept: (id: WorkspaceId) => Promise<SpeculationAcceptResponse>;
+  readonly reject: (id: WorkspaceId) => Promise<SpeculationRejectResponse>;
+  readonly cancelAll: (reason?: "new_user_input" | "shutdown") => Promise<readonly WorkspaceId[]>;
+  readonly snapshot: (id: WorkspaceId) => SpeculationSnapshot | undefined;
+  readonly list: () => readonly SpeculationSnapshot[];
+  readonly waitForIdle: () => Promise<void>;
+}

--- a/packages/lib/speculation/tsconfig.json
+++ b/packages/lib/speculation/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../../kernel/core" }]
+}

--- a/packages/lib/speculation/tsup.config.ts
+++ b/packages/lib/speculation/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: {
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  clean: true,
+  treeshake: true,
+  target: "node22",
+});

--- a/packages/meta/runtime/package.json
+++ b/packages/meta/runtime/package.json
@@ -170,6 +170,7 @@
     "@koi/skills-runtime": "workspace:*",
     "@koi/snapshot-store-sqlite": "workspace:*",
     "@koi/spawn-tools": "workspace:*",
+    "@koi/speculation": "workspace:*",
     "@koi/task-spawn": "workspace:*",
     "@koi/task-tools": "workspace:*",
     "@koi/tasks": "workspace:*",

--- a/packages/meta/runtime/src/__tests__/golden-queries.test.ts
+++ b/packages/meta/runtime/src/__tests__/golden-queries.test.ts
@@ -1726,8 +1726,8 @@ describe("Golden: @koi/model-router", () => {
 // Golden: @koi/middleware-otel (#1628)
 // ---------------------------------------------------------------------------
 
-import type { Agent, AgentManifest, ProcessId, ProcessState } from "@koi/core";
-import { agentId } from "@koi/core";
+import type { Agent, AgentManifest, ProcessId, ProcessState, WorkspaceId } from "@koi/core";
+import { agentId, workspaceId } from "@koi/core";
 import {
   createDebugAttach,
   createEventRingBuffer,
@@ -3881,6 +3881,88 @@ describe("Golden: @koi/task-spawn", () => {
     })) as string;
     expect(out).toContain("unknown agent type 'deployer'");
     expect(out).toContain("researcher");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden: @koi/speculation (#1406)
+// ---------------------------------------------------------------------------
+
+import type {
+  SpeculationAcceptResult,
+  SpeculationOverlay,
+  SpeculationOverlayManager,
+  SpeculationPresentedResult,
+} from "@koi/speculation";
+import { createSpeculationController } from "@koi/speculation";
+
+function makeSpeculationOverlay(idText = "spec-overlay-1"): SpeculationOverlay {
+  return { id: workspaceId(idText), path: `/tmp/${idText}` };
+}
+
+function makeGoldenSpeculationOverlayManager(): SpeculationOverlayManager & {
+  readonly accepted: readonly WorkspaceId[];
+  readonly rejected: readonly WorkspaceId[];
+} {
+  const accepted: WorkspaceId[] = [];
+  const rejected: WorkspaceId[] = [];
+  return {
+    accepted,
+    rejected,
+    async create(): Promise<Result<SpeculationOverlay, KoiError>> {
+      return { ok: true, value: makeSpeculationOverlay() };
+    },
+    async accept(id: WorkspaceId): Promise<Result<SpeculationAcceptResult, KoiError>> {
+      accepted.push(id);
+      return { ok: true, value: { changedPaths: ["src/answer.ts"] } };
+    },
+    async reject(id: WorkspaceId): Promise<Result<void, KoiError>> {
+      rejected.push(id);
+      return { ok: true, value: undefined };
+    },
+  };
+}
+
+describe("Golden: @koi/speculation", () => {
+  test("runtime re-exports the speculation controller for host wiring", async () => {
+    const runtime = await import("../index.js");
+
+    expect(typeof runtime.createSpeculationController).toBe("function");
+  });
+
+  test("pre-exec fork result can be presented and accepted into the base workspace", async () => {
+    const overlays = makeGoldenSpeculationOverlayManager();
+    const presented: SpeculationPresentedResult[] = [];
+    const controller = createSpeculationController({
+      overlayManager: overlays,
+      forkAgent: async (request) => ({
+        ok: true,
+        output: `speculated ${request.description} in ${request.overlay.id}`,
+      }),
+      presentResult: (result) => {
+        presented.push(result);
+      },
+    });
+
+    const started = await controller.start({
+      agentName: "coder",
+      description: "draft the patch",
+    });
+    expect(started.kind).toBe("started");
+    if (started.kind !== "started") throw new Error("speculation did not start");
+
+    await controller.waitForIdle();
+    expect(controller.snapshot(started.id)?.status).toBe("presented");
+    expect(presented[0]?.output).toContain("draft the patch");
+
+    const accepted = await controller.accept(started.id);
+    expect(accepted).toEqual({
+      kind: "accepted",
+      id: started.id,
+      changedPaths: ["src/answer.ts"],
+    });
+    expect(overlays.accepted).toEqual([started.id]);
+    expect(overlays.rejected).toEqual([]);
   });
 });
 

--- a/packages/meta/runtime/src/__tests__/speculation-reexport.test.ts
+++ b/packages/meta/runtime/src/__tests__/speculation-reexport.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test";
+
+describe("runtime speculation exports", () => {
+  test("re-exports speculation controller for host wiring", async () => {
+    const runtime = (await import("../index.js")) as Record<string, unknown>;
+
+    expect(typeof runtime.createSpeculationController).toBe("function");
+  });
+});

--- a/packages/meta/runtime/src/index.ts
+++ b/packages/meta/runtime/src/index.ts
@@ -162,6 +162,27 @@ export type {
   WasmExecutor,
   WasmResult,
 } from "@koi/sandbox-wasm";
+// Speculative fork execution API — hosts inject fork, overlay, and UI adapters.
+export type {
+  PresentSpeculationResult,
+  SpeculationAcceptResponse,
+  SpeculationAcceptResult,
+  SpeculationController,
+  SpeculationControllerConfig,
+  SpeculationFallbackReason,
+  SpeculationForkAgent,
+  SpeculationForkRequest,
+  SpeculationForkResult,
+  SpeculationOverlay,
+  SpeculationOverlayManager,
+  SpeculationPresentedResult,
+  SpeculationRejectResponse,
+  SpeculationSnapshot,
+  SpeculationStartResult,
+  SpeculationStatus,
+  StartSpeculationRequest,
+} from "@koi/speculation";
+export { createSpeculationController } from "@koi/speculation";
 // Activity-based stream timeouts (#1638)
 export type {
   ActivityTerminationReason,

--- a/packages/meta/runtime/tsconfig.json
+++ b/packages/meta/runtime/tsconfig.json
@@ -164,6 +164,7 @@
     { "path": "../../lib/playbook-store-nexus" },
     { "path": "../../lib/playbook-store-sqlite" },
     { "path": "../../lib/skills-runtime" },
+    { "path": "../../lib/speculation" },
     { "path": "../../lib/model-router" },
     { "path": "../../security/middleware-audit" },
     { "path": "../../security/audit-sink-nexus" },

--- a/scripts/check-cli-wiring.ts
+++ b/scripts/check-cli-wiring.ts
@@ -136,6 +136,9 @@ const EXEMPT: ReadonlySet<string> = new Set([
   "@koi/scratchpad-local",
   // Skill distillation is an offline/autonomous pipeline, separate from the default Skill meta-tool.
   "@koi/skill-distiller",
+  // Speculation is a host-injected pre-execution coordinator; default TUI has
+  // no concrete overlay/fork/accept UI wiring yet.
+  "@koi/speculation",
   // The TUI exposes the engine Spawn tool plus task_* board tools; this alternate task tool is opt-in.
   "@koi/task-spawn",
   "@koi/toolsets",

--- a/scripts/layers.ts
+++ b/scripts/layers.ts
@@ -228,6 +228,7 @@ export const L2_PACKAGES: ReadonlySet<string> = new Set([
   "@koi/snapshot-store-nexus",
   "@koi/snapshot-store-sqlite",
   "@koi/spawn-tools",
+  "@koi/speculation",
   "@koi/swarm",
   "@koi/task-spawn",
   "@koi/task-tools",


### PR DESCRIPTION
## Summary

- Add L2 `@koi/speculation`, a host-injected speculation controller for best-effort pre-execution forks, overlay presentation, accept/reject decisions, cancellation, resource limits, timeouts, and fallback behavior.
- Re-export speculation APIs through `@koi/runtime` and add golden/runtime coverage.
- Register the package in layer/docs metadata and document the speculation contract.
- Mark default TUI CLI wiring as explicitly exempt for now because there is not yet concrete overlay/fork/accept UI wiring in the default TUI surface.

## Validation

- `bun run --cwd packages/lib/speculation lint`
- `bun run --cwd packages/lib/speculation typecheck`
- `bun test packages/lib/speculation/src/controller.test.ts`
- `bun run --cwd packages/lib/speculation build`
- `bun run --cwd packages/meta/runtime test src/__tests__/speculation-reexport.test.ts`
- `bun run --cwd packages/meta/runtime typecheck`
- `bun test packages/meta/runtime/src/__tests__/golden-queries.test.ts -t "@koi/speculation"`
- `bunx biome check packages/meta/runtime/src/index.ts scripts/check-cli-wiring.ts packages/meta/runtime/src/__tests__/golden-queries.test.ts packages/meta/runtime/src/__tests__/speculation-reexport.test.ts`
- `bun run check:golden-queries`
- `bun run check:tui-tools`
- `bun run check:tui-single-writer` (passes with existing soft warning in `packages/ui/tui/src/profiling/integration.ts:227`)
- `bun run --cwd packages/ui/tui test`
- `bun run --cwd packages/ui/tui typecheck`
- `bun run --cwd packages/ui/tui build`
- `bun run build --filter=@koi-agent/cli`
- `bun run check:layers`
- `bun run check:doc-gate`
- `bun run check:doc-sync`
- `bun run check:orphans`
- Pre-push hook: `build` and `typecheck` passed.

## Manual TUI E2E

Using the API key from the repo `.env`, ran source-mode `koi tui --no-manifest --no-governance` in tmux:

- `/model` rendered provider/model state.
- Prompt `Reply exactly: OK-1406` returned `OK-1406`.
- Interrupt corner case: long-running prompt + Ctrl-C showed `Turn interrupted before the model produced a reply` and returned idle.
- `/quit` exited cleanly with `TUI_EXIT:0` and resume hint.
- Parse conflict corner case: `koi tui --manifest koi.yaml --no-manifest` failed with the expected mutual exclusion error.

Non-fatal observed stderr during manual TUI run: `artifact store disabled — ArtifactStore already open by another process`.

## Notes

`bun run check:cli-wiring` still reports unrelated pre-existing missing runtime dependencies, but `@koi/speculation` is no longer in the missing list and is represented by the explicit TUI exemption.


## Issue

Closes #1406
