### PR TITLE
Add Nexus session backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1151,7 +1151,11 @@
       "dependencies": {
         "@koi/core": "workspace:*",
         "@koi/errors": "workspace:*",
+        "@koi/nexus-client": "workspace:*",
         "@koi/session-repair": "workspace:*",
+      },
+      "devDependencies": {
+        "@koi/fs-nexus": "workspace:*",
       },
     },
     "packages/lib/settings": {

--- a/docs/L2/session.md
+++ b/docs/L2/session.md
@@ -1,12 +1,13 @@
 # @koi/session
 
 **Layer**: L2 — Feature package  
-**Dependencies**: `@koi/core` (L0), `@koi/errors` (L0u), `@koi/session-repair` (L0u)
+**Dependencies**: `@koi/core` (L0), `@koi/errors` (L0u), `@koi/nexus-client` (L0u), `@koi/session-repair` (L0u)
 
 Provides two implementations of the L0 session contracts for crash recovery, plus a pure resume function for converting transcript history back to engine-ready messages:
 
 - **`SessionPersistence`** via SQLite/WAL — durable metadata store for session records and pending outbound frames
 - **`SessionTranscript`** via append-only JSONL — per-session conversation log for replay on restart
+- **Nexus session backend** — opt-in remote composition of `SessionPersistence`, `SessionTranscript`, checkpoint state, and session-scoped artifacts
 - **`resumeFromTranscript()`** — pure function: `TranscriptEntry[]` → `InboundMessage[]` for engine replay
 
 ## Why It Exists
@@ -29,6 +30,14 @@ src/
 │   ├── open-db.ts                    # Inline WAL helper (~25 lines, no @koi/sqlite-utils dep)
 │   ├── sqlite-store.ts               # createSqliteSessionPersistence — bun:sqlite backend
 │   └── memory-store.ts               # createInMemorySessionPersistence — Map-based, tests only
+├── nexus/
+│   ├── session-backend.ts            # createNexusSessionBackend — composed Nexus backend
+│   ├── transcript-store.ts           # SessionTranscript over Nexus JSONL files
+│   ├── persistence-store.ts          # SessionPersistence over Nexus JSON files
+│   ├── artifact-store.ts             # session-scoped artifact persistence
+│   ├── json-io.ts                    # Nexus read/write/list/delete helpers
+│   ├── paths.ts                      # namespace layout and path validation
+│   └── types.ts                      # Nexus backend and artifact contracts
 └── transcript/
     ├── jsonl-store.ts                # createJsonlTranscript — flat JSONL, per-session queue
     └── memory-store.ts               # createInMemoryTranscript — Map-based, tests only
@@ -73,6 +82,20 @@ const result = await transcript.compact(sessionId, "Summary of first 10 turns", 
 const { messages, issues } = (await resumeForSession(sessionId, transcript)).value;
 // messages: InboundMessage[] ready for the engine's context builder
 // issues: RepairIssue[] from repairSession() (orphan repairs, deduplication, merges)
+
+// Nexus-backed session state (opt-in; local stores remain the default)
+const nexus = createNexusSessionBackend({
+  transport,
+  basePath: "sessions",
+});
+await nexus.saveTurn(sessionId, transcriptEntry);
+await nexus.saveCheckpoint(sessionId, engineState);
+await nexus.artifacts.saveArtifact(sessionId, {
+  artifactId: "tool-output",
+  content: JSON.stringify(output),
+  contentType: "application/json",
+  createdAt: Date.now(),
+});
 ```
 
 ## Design Decisions
@@ -124,6 +147,45 @@ All ~12 SQLite queries are `db.prepare()`'d once at construction. Query plans ca
 
 ### Batch pending-frame query in `recover()`
 `recover()` loads all pending frames in one `SELECT * FROM pending_frames` query, then groups by `sessionId` in memory. Avoids N+1 pattern when recovering many sessions.
+
+### Nexus session backend composition
+`createNexusSessionBackend()` deliberately composes existing contracts instead
+of introducing a parallel L0 `SessionBackend` abstraction. Its
+`transcript` member implements `SessionTranscript`, its `persistence` member
+implements `SessionPersistence`, and the high-level helpers
+`saveTurn/loadHistory/saveCheckpoint/loadCheckpoint` are thin conveniences over
+those contracts. This keeps existing local SQLite/JSONL stores as the default
+and lets assembly/runtime code select Nexus explicitly when remote durability is
+required.
+
+### Nexus namespace layout
+All paths live under `basePath` (default `"sessions"`), with URL-encoded session
+IDs and artifact IDs so runtime IDs containing `/` or `:` cannot escape the
+namespace:
+
+```
+<basePath>/transcripts/<sessionId>.jsonl
+<basePath>/records/<sessionId>.json
+<basePath>/pending/<sessionId>/<frameId>.json
+<basePath>/content-replacements/<sessionId>/<messageId>.json
+<basePath>/artifacts/<sessionId>/<artifactId>.json
+```
+
+Transcript history remains append-first JSONL at the contract surface. Because
+the current Nexus file RPC exposes read/write rather than an atomic append verb,
+the v2 adapter serializes per-session transcript mutations in-process, reads
+the existing JSONL, appends new lines, and writes the file back. A future Nexus
+append RPC can replace that internal implementation without changing callers.
+
+### Nexus checkpoint and artifact state
+Checkpoint state is stored in the existing `SessionRecord.lastEngineState`
+field and updated through `SessionPersistence.updateLastEngineState()` with the
+same `expectedVersion` CAS behavior used by local stores. Session-scoped
+artifacts are intentionally separate from `@koi/artifacts`: this first slice
+needs durable per-session tool outputs, not the full versioned artifact
+lifecycle. The artifact store persists plain JSON records under the session
+artifact namespace and can later be backed by content-addressed storage without
+changing the session backend facade.
 
 ## Cancel-Resume (issue #1683)
 
@@ -179,6 +241,12 @@ interface SessionStoreConfig {
 interface JsonlTranscriptConfig {
   readonly baseDir: string;                 // Directory for .jsonl files
 }
+
+interface NexusSessionBackendConfig {
+  readonly transport: NexusTransport;
+  readonly basePath?: string;               // default: "sessions"
+  readonly lockScope?: string;              // default: basePath
+}
 ```
 
 ### Trajectory Visibility
@@ -192,12 +260,15 @@ Contract test factories live in `src/__tests__/contracts/`. Both implementations
 ```typescript
 runSessionPersistenceContractTests(() => createInMemorySessionPersistence());
 runSessionPersistenceContractTests(() => createSqliteSessionPersistence({ dbPath: ":memory:" }));
+runSessionPersistenceContractTests(() => createNexusSessionBackend({ transport }).persistence);
 
 runSessionTranscriptContractTests(() => createInMemoryTranscript());
 runSessionTranscriptContractTests(() => createJsonlTranscript({ baseDir: tmpDir }));
+runSessionTranscriptContractTests(() => createNexusSessionBackend({ transport }).transcript);
 ```
 
 Additional tests specific to each backend:
 - `sqlite-store.test.ts` — corruption injection, status lifecycle, content replacement round-trips, v1→v2 migration
 - `jsonl-store.test.ts` — concurrency (`Promise.all(10 appends)`), crash artifact detection, compaction boundary extension (cases A/B/C)
+- `nexus/session-backend.test.ts` — Nexus contract parity, high-level history/checkpoint helpers, session-scoped artifact isolation
 - `resume.test.ts` — empty/compaction-only/tool-pair/dangling/orphan cases, determinism, validation

--- a/docs/L3/cli.md
+++ b/docs/L3/cli.md
@@ -6,6 +6,16 @@ Command-line interface for running Koi agents locally. Provides interactive (`st
 
 ## Recent updates
 
+- **Nexus session backend foundation (#2203)**: `@koi/session` now exports
+  `createNexusSessionBackend()`, an opt-in Nexus-backed composition of
+  transcript, persistence, checkpoint, and session-scoped artifact storage.
+  CLI/TUI defaults are unchanged in this slice: transcript JSONL and optional
+  SQLite cancel-resume persistence remain the active local path, and the CLI
+  does not auto-switch sessions to Nexus merely because a Nexus endpoint is
+  resolved for filesystem, scheduler, delegation, or audit subsystems. Future
+  host wiring can inject the backend explicitly over the resolved
+  `NexusTransport` while preserving the same `SessionTranscript` and
+  `SessionPersistence` contracts documented in `docs/L2/session.md`.
 - **CI/benchmark runtime knobs**: the CLI runtime now reads two env vars, both
   no-ops when unset so interactive/`tui` behavior is unchanged. (1) Integrated
   `@koi/model-openai-compat` honors `KOI_MAX_TOKENS` as an output-token cap. (2)

--- a/docs/L3/runtime.md
+++ b/docs/L3/runtime.md
@@ -4,6 +4,19 @@ The canonical L3 integration layer. Wires every production-ready L2 package into
 
 ## Recent updates
 
+- 2026-05-18: `@koi/session` adds an opt-in Nexus session backend (#2203).
+  The runtime dependency set is unchanged: `@koi/runtime` already integrates
+  `@koi/session`, and local JSONL/SQLite session stores remain the default
+  runtime path. Hosts that need remote durability can now select
+  `createNexusSessionBackend()` explicitly to compose Nexus-backed
+  `SessionTranscript`, `SessionPersistence`, checkpoint helpers, and
+  session-scoped artifacts over a `NexusTransport`. The backend uses the same
+  L0 contracts as the local stores, URL-encodes session/artifact ids inside the
+  Nexus namespace, stores checkpoints in `SessionRecord.lastEngineState` with
+  the existing CAS semantics, and exposes thin `saveTurn`/`loadHistory` and
+  `saveCheckpoint`/`loadCheckpoint` helpers. Golden runtime behavior is
+  unchanged because this is a host-selected storage adapter with contract tests
+  in `@koi/session`; see `docs/L2/session.md` for the namespace layout.
 - 2026-05-18: `@koi/speculation` wired (#1406). Runtime now depends on and
   re-exports the host-injected speculation controller for best-effort
   pre-execution forks. The controller coordinates overlay creation, speculative

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 153 | 794 | 134 |
+| lib | 153 | 795 | 134 |
 | meta | 7 | 122 | 5 |
 | mm | 12 | 54 | 12 |
 | net | 12 | 100 | 12 |
@@ -170,7 +170,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/secure-storage` (packages/lib/secure-storage) - OS keychain token storage with file-based locking for concurrent access. Tests: 3. Docs: -.
 - `@koi/sensor-ide` (packages/lib/sensor-ide) - Low-overhead IDE activity sensor for typing, diagnostics, file switching, and flow signals. Tests: 1. Docs: docs/L2/sensor-ide.md.
 - `@koi/sensor-neuroskill` (packages/lib/sensor-neuroskill) - Real-time BCI/EXG signal sensor with preprocessing, cognitive-state estimates, and event streaming. Tests: 1. Docs: docs/L2/sensor-neuroskill.md.
-- `@koi/session` (packages/lib/session) - Session persistence (SQLite/WAL) and transcript (append-only JSONL) for crash recovery. Tests: 9. Docs: docs/L2/session.md.
+- `@koi/session` (packages/lib/session) - Session persistence (SQLite/WAL) and transcript (append-only JSONL) for crash recovery. Tests: 10. Docs: docs/L2/session.md.
 - `@koi/settings` (packages/lib/settings) - Hierarchical settings cascade: user → project → local → flag → policy. Tests: 4. Docs: docs/L2/settings.md.
 - `@koi/shutdown` (packages/lib/shutdown) - Handle graceful shutdown signals and map exit codes for CLI and deploy. Tests: 3. Docs: -.
 - `@koi/skill-distiller` (packages/lib/skill-distiller) - Distill reusable skill drafts from successful task traces with content-hash dedupe and provenance audit. Tests: 12. Docs: docs/L2/skill-distiller.md.

--- a/packages/lib/session/package.json
+++ b/packages/lib/session/package.json
@@ -20,6 +20,10 @@
   "dependencies": {
     "@koi/core": "workspace:*",
     "@koi/errors": "workspace:*",
+    "@koi/nexus-client": "workspace:*",
     "@koi/session-repair": "workspace:*"
+  },
+  "devDependencies": {
+    "@koi/fs-nexus": "workspace:*"
   }
 }

--- a/packages/lib/session/src/index.ts
+++ b/packages/lib/session/src/index.ts
@@ -1,5 +1,12 @@
 export type { SessionTranscriptMiddlewareConfig } from "./middleware/session-transcript.js";
 export { createSessionTranscriptMiddleware } from "./middleware/session-transcript.js";
+export { createNexusSessionBackend } from "./nexus/session-backend.js";
+export type {
+  NexusSessionBackend,
+  NexusSessionBackendConfig,
+  SessionArtifactRecord,
+  SessionArtifactStore,
+} from "./nexus/types.js";
 export type {
   PersistEngineStateOptions,
   SessionRecordTemplate,

--- a/packages/lib/session/src/nexus/__tests__/session-backend.test.ts
+++ b/packages/lib/session/src/nexus/__tests__/session-backend.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import type { EngineState, TranscriptEntry } from "@koi/core";
+import { sessionId, transcriptEntryId } from "@koi/core";
+import { createFakeNexusTransport } from "@koi/fs-nexus/testing";
+import { runSessionPersistenceContractTests } from "../../__tests__/contracts/session-persistence-contract.js";
+import {
+  makeTranscriptEntry,
+  runSessionTranscriptContractTests,
+} from "../../__tests__/contracts/transcript-contract.js";
+import { createNexusSessionBackend } from "../session-backend.js";
+
+function uniqueBasePath(label: string): string {
+  return `test-sessions/${label}-${crypto.randomUUID()}`;
+}
+
+describe("Nexus session backend", () => {
+  runSessionTranscriptContractTests(() => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("transcript"),
+    });
+    return backend.transcript;
+  });
+
+  runSessionPersistenceContractTests(() => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("persistence"),
+    });
+    return backend.persistence;
+  });
+
+  test("high-level history facade stores turns through the transcript contract", async () => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("facade-history"),
+    });
+    const sid = sessionId("facade-session");
+    const turn: TranscriptEntry = makeTranscriptEntry({
+      id: transcriptEntryId("turn-1"),
+      content: "hello nexus",
+    });
+
+    await backend.saveTurn(sid, turn);
+
+    const history = await backend.loadHistory(sid);
+    expect(history).toEqual([turn]);
+  });
+
+  test("high-level checkpoint facade round-trips engine state", async () => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("facade-checkpoint"),
+    });
+    const sid = sessionId("checkpoint-session");
+    const state: EngineState = { engineId: "engine-a", data: { step: 3 } };
+
+    await backend.saveCheckpoint(sid, state);
+
+    expect(await backend.loadCheckpoint(sid)).toEqual(state);
+    expect(await backend.loadCheckpoint(sessionId("missing"))).toBeUndefined();
+  });
+
+  test("high-level checkpoint facade propagates load errors", async () => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport({
+        failMethod: "read",
+        failCode: -32_001,
+        failMessage: "transport exploded",
+      }),
+      basePath: uniqueBasePath("facade-checkpoint-load-error"),
+    });
+    const sid = sessionId("checkpoint-error");
+    const state: EngineState = { engineId: "engine-a", data: { step: 3 } };
+
+    let caught: unknown;
+    try {
+      await backend.saveCheckpoint(sid, state);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught instanceof Error ? caught.message : "").toContain("transport exploded");
+  });
+
+  test("session artifacts are scoped by session", async () => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("artifacts"),
+    });
+    const firstSession = sessionId("artifact-session-a");
+    const secondSession = sessionId("artifact-session-b");
+
+    await backend.artifacts.saveArtifact(firstSession, {
+      artifactId: "summary",
+      content: "session A",
+      contentType: "text/plain",
+      metadata: { kind: "summary" },
+      createdAt: 1_000,
+    });
+    await backend.artifacts.saveArtifact(secondSession, {
+      artifactId: "summary",
+      content: "session B",
+      createdAt: 2_000,
+    });
+
+    const loaded = await backend.artifacts.loadArtifact(firstSession, "summary");
+    const listed = await backend.artifacts.listArtifacts(firstSession);
+
+    expect(loaded?.content).toBe("session A");
+    expect(loaded?.metadata).toEqual({ kind: "summary" });
+    expect(listed.map((artifact) => artifact.artifactId)).toEqual(["summary"]);
+  });
+
+  test("session artifact facade rejects with Error objects", async () => {
+    const backend = createNexusSessionBackend({
+      transport: createFakeNexusTransport(),
+      basePath: uniqueBasePath("artifacts-errors"),
+    });
+
+    let caught: unknown;
+    try {
+      await backend.artifacts.loadArtifact(sessionId(""), "summary");
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught instanceof Error ? caught.message : "").toContain("Session ID");
+  });
+});

--- a/packages/lib/session/src/nexus/artifact-store.ts
+++ b/packages/lib/session/src/nexus/artifact-store.ts
@@ -1,0 +1,95 @@
+import type { KoiError, SessionId } from "@koi/core";
+import { internal, validateNonEmpty } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+import { deletePath, listFilePaths, readJson, writeJson } from "./json-io.js";
+import { artifactPath } from "./paths.js";
+import type { SessionArtifactRecord, SessionArtifactStore } from "./types.js";
+
+function isSessionArtifactRecord(value: unknown): value is SessionArtifactRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.artifactId === "string" &&
+    typeof obj.content === "string" &&
+    typeof obj.createdAt === "number"
+  );
+}
+
+function throwKoiError(error: KoiError): never {
+  throw new Error(error.message, { cause: error });
+}
+
+export function createNexusSessionArtifactStore(
+  transport: NexusTransport,
+  basePath: string,
+): SessionArtifactStore {
+  async function saveArtifact(
+    sessionId: SessionId,
+    artifact: SessionArtifactRecord,
+  ): Promise<void> {
+    const sessionCheck = validateNonEmpty(sessionId, "Session ID");
+    if (!sessionCheck.ok) throwKoiError(sessionCheck.error);
+    const artifactCheck = validateNonEmpty(artifact.artifactId, "Artifact ID");
+    if (!artifactCheck.ok) throwKoiError(artifactCheck.error);
+    const result = await writeJson(
+      transport,
+      artifactPath(basePath, sessionId, artifact.artifactId),
+      artifact,
+    );
+    if (!result.ok) throwKoiError(result.error);
+  }
+
+  async function loadArtifact(
+    sessionId: SessionId,
+    artifactId: string,
+  ): Promise<SessionArtifactRecord | undefined> {
+    const sessionCheck = validateNonEmpty(sessionId, "Session ID");
+    if (!sessionCheck.ok) throwKoiError(sessionCheck.error);
+    const artifactCheck = validateNonEmpty(artifactId, "Artifact ID");
+    if (!artifactCheck.ok) throwKoiError(artifactCheck.error);
+    const loaded = await readJson<unknown>(
+      transport,
+      artifactPath(basePath, sessionId, artifactId),
+    );
+    if (!loaded.ok) throwKoiError(loaded.error);
+    if (loaded.value === undefined) return undefined;
+    const value = loaded.value;
+    if (!isSessionArtifactRecord(value)) {
+      throwKoiError(internal(`Invalid session artifact ${artifactId}`));
+    }
+    return value;
+  }
+
+  async function listArtifacts(sessionId: SessionId): Promise<readonly SessionArtifactRecord[]> {
+    const sessionCheck = validateNonEmpty(sessionId, "Session ID");
+    if (!sessionCheck.ok) throwKoiError(sessionCheck.error);
+    const paths = await listFilePaths(
+      transport,
+      `${basePath}/artifacts/${encodeURIComponent(sessionId)}`,
+    );
+    if (!paths.ok) throwKoiError(paths.error);
+    const artifacts: SessionArtifactRecord[] = [];
+    for (const path of paths.value) {
+      const loaded = await readJson<unknown>(transport, path);
+      if (!loaded.ok) throwKoiError(loaded.error);
+      if (isSessionArtifactRecord(loaded.value)) artifacts.push(loaded.value);
+    }
+    return artifacts.sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  async function removeArtifact(sessionId: SessionId, artifactId: string): Promise<void> {
+    const sessionCheck = validateNonEmpty(sessionId, "Session ID");
+    if (!sessionCheck.ok) throwKoiError(sessionCheck.error);
+    const artifactCheck = validateNonEmpty(artifactId, "Artifact ID");
+    if (!artifactCheck.ok) throwKoiError(artifactCheck.error);
+    const result = await deletePath(transport, artifactPath(basePath, sessionId, artifactId));
+    if (!result.ok) throwKoiError(result.error);
+  }
+
+  return {
+    saveArtifact,
+    loadArtifact,
+    listArtifacts,
+    removeArtifact,
+  };
+}

--- a/packages/lib/session/src/nexus/json-io.ts
+++ b/packages/lib/session/src/nexus/json-io.ts
@@ -1,0 +1,88 @@
+import type { KoiError, Result } from "@koi/core";
+import { internal } from "@koi/core";
+import { extractReadContent, type NexusTransport } from "@koi/nexus-client";
+
+interface NexusListEntry {
+  readonly is_directory?: boolean;
+  readonly path: string;
+}
+
+interface NexusListResponse {
+  readonly files: readonly NexusListEntry[];
+  readonly has_more?: boolean | undefined;
+}
+
+export async function readText(
+  transport: NexusTransport,
+  path: string,
+): Promise<Result<string | undefined, KoiError>> {
+  const result = await transport.call<unknown>("read", { path });
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") return { ok: true, value: undefined };
+    return result;
+  }
+  const extracted = extractReadContent(result.value);
+  if (!extracted.ok) return extracted;
+  return extracted;
+}
+
+export async function writeText(
+  transport: NexusTransport,
+  path: string,
+  content: string,
+): Promise<Result<void, KoiError>> {
+  const result = await transport.call<unknown>("write", { path, content });
+  if (!result.ok) return result;
+  return { ok: true, value: undefined };
+}
+
+export async function deletePath(
+  transport: NexusTransport,
+  path: string,
+): Promise<Result<void, KoiError>> {
+  const result = await transport.call<unknown>("delete", { path });
+  if (!result.ok && result.error.code !== "NOT_FOUND") return result;
+  return { ok: true, value: undefined };
+}
+
+export async function readJson<T>(
+  transport: NexusTransport,
+  path: string,
+): Promise<Result<T | undefined, KoiError>> {
+  const text = await readText(transport, path);
+  if (!text.ok) return text;
+  if (text.value === undefined) return { ok: true, value: undefined };
+  try {
+    return { ok: true, value: JSON.parse(text.value) as T };
+  } catch (error: unknown) {
+    return { ok: false, error: internal(`nexus session JSON parse failed at ${path}`, error) };
+  }
+}
+
+export async function writeJson(
+  transport: NexusTransport,
+  path: string,
+  value: unknown,
+): Promise<Result<void, KoiError>> {
+  return writeText(transport, path, JSON.stringify(value));
+}
+
+export async function listFilePaths(
+  transport: NexusTransport,
+  path: string,
+): Promise<Result<readonly string[], KoiError>> {
+  const result = await transport.call<NexusListResponse>("list", { path, recursive: true });
+  if (!result.ok) return result;
+  if (result.value.has_more === true) {
+    return {
+      ok: false,
+      error: internal(`nexus session list truncated at ${path}`),
+    };
+  }
+  return {
+    ok: true,
+    value: result.value.files
+      .filter((entry) => entry.is_directory !== true)
+      .map((entry) => entry.path),
+  };
+}

--- a/packages/lib/session/src/nexus/paths.ts
+++ b/packages/lib/session/src/nexus/paths.ts
@@ -1,0 +1,51 @@
+import type { KoiError, Result } from "@koi/core";
+import { RETRYABLE_DEFAULTS } from "@koi/core";
+
+export const DEFAULT_NEXUS_SESSION_BASE_PATH = "sessions";
+
+export function encodePathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function validateBasePath(basePath: string): Result<void, KoiError> {
+  if (basePath.length === 0) return invalid("basePath cannot be empty");
+  if (basePath.includes("..")) return invalid("basePath cannot contain '..'");
+  if (basePath.includes("\\")) return invalid("basePath cannot contain '\\'");
+  if (basePath.includes("\0")) return invalid("basePath cannot contain null bytes");
+  return { ok: true, value: undefined };
+}
+
+export function sessionRecordPath(basePath: string, sessionId: string): string {
+  return `${basePath}/records/${encodePathSegment(sessionId)}.json`;
+}
+
+export function transcriptPath(basePath: string, sessionId: string): string {
+  return `${basePath}/transcripts/${encodePathSegment(sessionId)}.jsonl`;
+}
+
+export function pendingFramePath(basePath: string, sessionId: string, frameId: string): string {
+  return `${basePath}/pending/${encodePathSegment(sessionId)}/${encodePathSegment(frameId)}.json`;
+}
+
+export function contentReplacementPath(
+  basePath: string,
+  sessionId: string,
+  messageId: string,
+): string {
+  return `${basePath}/content-replacements/${encodePathSegment(sessionId)}/${encodePathSegment(messageId)}.json`;
+}
+
+export function artifactPath(basePath: string, sessionId: string, artifactId: string): string {
+  return `${basePath}/artifacts/${encodePathSegment(sessionId)}/${encodePathSegment(artifactId)}.json`;
+}
+
+function invalid(message: string): Result<void, KoiError> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION",
+      message,
+      retryable: RETRYABLE_DEFAULTS.VALIDATION,
+    },
+  };
+}

--- a/packages/lib/session/src/nexus/persistence-store.ts
+++ b/packages/lib/session/src/nexus/persistence-store.ts
@@ -1,0 +1,352 @@
+import type {
+  ContentReplacement,
+  EngineState,
+  KoiError,
+  PendingFrame,
+  RecoveryPlan,
+  Result,
+  SessionFilter,
+  SessionPersistence,
+  SessionRecord,
+  SessionStatus,
+} from "@koi/core";
+import { conflict, notFound, validateNonEmpty } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+import { deletePath, listFilePaths, readJson, writeJson } from "./json-io.js";
+import { contentReplacementPath, pendingFramePath, sessionRecordPath } from "./paths.js";
+
+const locks = new Map<string, Promise<void>>();
+
+async function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = locks.get(key) ?? Promise.resolve();
+  let release = (): void => {};
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  locks.set(key, next);
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (locks.get(key) === next) locks.delete(key);
+  }
+}
+
+function isSessionRecord(value: unknown): value is SessionRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.sessionId === "string" &&
+    typeof obj.agentId === "string" &&
+    typeof obj.seq === "number" &&
+    typeof obj.remoteSeq === "number" &&
+    typeof obj.connectedAt === "number" &&
+    typeof obj.lastPersistedAt === "number" &&
+    (obj.status === "running" || obj.status === "idle" || obj.status === "done") &&
+    typeof obj.metadata === "object" &&
+    obj.metadata !== null
+  );
+}
+
+function isPendingFrame(value: unknown): value is PendingFrame {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.frameId === "string" &&
+    typeof obj.sessionId === "string" &&
+    typeof obj.agentId === "string" &&
+    typeof obj.frameType === "string" &&
+    typeof obj.orderIndex === "number" &&
+    typeof obj.createdAt === "number" &&
+    typeof obj.retryCount === "number"
+  );
+}
+
+function isContentReplacement(value: unknown): value is ContentReplacement {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.sessionId === "string" &&
+    typeof obj.messageId === "string" &&
+    typeof obj.filePath === "string" &&
+    typeof obj.byteCount === "number" &&
+    typeof obj.replacedAt === "number"
+  );
+}
+
+export function createNexusSessionPersistence(
+  transport: NexusTransport,
+  basePath: string,
+  lockScope: string,
+): SessionPersistence {
+  async function loadRecord(sessionId: string): Promise<Result<SessionRecord, KoiError>> {
+    const loaded = await readJson<unknown>(transport, sessionRecordPath(basePath, sessionId));
+    if (!loaded.ok) return loaded;
+    if (loaded.value === undefined) {
+      return { ok: false, error: notFound(sessionId, `Session not found: ${sessionId}`) };
+    }
+    if (!isSessionRecord(loaded.value)) {
+      return {
+        ok: false,
+        error: {
+          code: "INTERNAL",
+          message: `Invalid session record at ${sessionId}`,
+          retryable: false,
+        },
+      };
+    }
+    return { ok: true, value: loaded.value };
+  }
+
+  async function listPendingPaths(sessionId: string): Promise<Result<readonly string[], KoiError>> {
+    return listFilePaths(transport, `${basePath}/pending/${encodeURIComponent(sessionId)}`);
+  }
+
+  async function listReplacementPaths(
+    sessionId: string,
+  ): Promise<Result<readonly string[], KoiError>> {
+    return listFilePaths(
+      transport,
+      `${basePath}/content-replacements/${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  const saveSession: SessionPersistence["saveSession"] = async (
+    record: SessionRecord,
+  ): Promise<Result<void, KoiError>> => {
+    const sessionCheck = validateNonEmpty(record.sessionId, "Session ID");
+    if (!sessionCheck.ok) return sessionCheck;
+    const agentCheck = validateNonEmpty(record.agentId, "Agent ID");
+    if (!agentCheck.ok) return agentCheck;
+    return writeJson(transport, sessionRecordPath(basePath, record.sessionId), record);
+  };
+
+  const loadSession: SessionPersistence["loadSession"] = async (
+    sessionId: string,
+  ): Promise<Result<SessionRecord, KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    return loadRecord(sessionId);
+  };
+
+  const removeSession: SessionPersistence["removeSession"] = async (
+    sessionId: string,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    const loaded = await loadRecord(sessionId);
+    if (!loaded.ok) return loaded;
+    const recordDeleted = await deletePath(transport, sessionRecordPath(basePath, sessionId));
+    if (!recordDeleted.ok) return recordDeleted;
+
+    const pending = await listPendingPaths(sessionId);
+    if (!pending.ok) return pending;
+    for (const path of pending.value) {
+      const deleted = await deletePath(transport, path);
+      if (!deleted.ok) return deleted;
+    }
+
+    const replacements = await listReplacementPaths(sessionId);
+    if (!replacements.ok) return replacements;
+    for (const path of replacements.value) {
+      const deleted = await deletePath(transport, path);
+      if (!deleted.ok) return deleted;
+    }
+
+    return { ok: true, value: undefined };
+  };
+
+  const listSessions: SessionPersistence["listSessions"] = async (
+    filter?: SessionFilter,
+  ): Promise<Result<readonly SessionRecord[], KoiError>> => {
+    const paths = await listFilePaths(transport, `${basePath}/records`);
+    if (!paths.ok) return paths;
+    const records: SessionRecord[] = [];
+    for (const path of paths.value) {
+      const loaded = await readJson<unknown>(transport, path);
+      if (!loaded.ok) return loaded;
+      if (isSessionRecord(loaded.value)) {
+        if (filter?.agentId !== undefined && loaded.value.agentId !== filter.agentId) continue;
+        records.push(loaded.value);
+      }
+    }
+    return { ok: true, value: records };
+  };
+
+  const savePendingFrame: SessionPersistence["savePendingFrame"] = async (
+    frame: PendingFrame,
+  ): Promise<Result<void, KoiError>> => {
+    const frameCheck = validateNonEmpty(frame.frameId, "Frame ID");
+    if (!frameCheck.ok) return frameCheck;
+    const sessionCheck = validateNonEmpty(frame.sessionId, "Session ID");
+    if (!sessionCheck.ok) return sessionCheck;
+    return writeJson(transport, pendingFramePath(basePath, frame.sessionId, frame.frameId), frame);
+  };
+
+  const loadPendingFrames: SessionPersistence["loadPendingFrames"] = async (
+    sessionId: string,
+  ): Promise<Result<readonly PendingFrame[], KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    const paths = await listPendingPaths(sessionId);
+    if (!paths.ok) return paths;
+    const frames: PendingFrame[] = [];
+    for (const path of paths.value) {
+      const loaded = await readJson<unknown>(transport, path);
+      if (!loaded.ok) return loaded;
+      if (isPendingFrame(loaded.value)) frames.push(loaded.value);
+    }
+    return { ok: true, value: frames.sort((a, b) => a.orderIndex - b.orderIndex) };
+  };
+
+  const clearPendingFrames: SessionPersistence["clearPendingFrames"] = async (
+    sessionId: string,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    const paths = await listPendingPaths(sessionId);
+    if (!paths.ok) return paths;
+    for (const path of paths.value) {
+      const deleted = await deletePath(transport, path);
+      if (!deleted.ok) return deleted;
+    }
+    return { ok: true, value: undefined };
+  };
+
+  const removePendingFrame: SessionPersistence["removePendingFrame"] = async (
+    frameId: string,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(frameId, "Frame ID");
+    if (!check.ok) return check;
+    const paths = await listFilePaths(transport, `${basePath}/pending`);
+    if (!paths.ok) return paths;
+    const suffix = `/${encodeURIComponent(frameId)}.json`;
+    for (const path of paths.value.filter((candidate) => candidate.endsWith(suffix))) {
+      const deleted = await deletePath(transport, path);
+      if (!deleted.ok) return deleted;
+    }
+    return { ok: true, value: undefined };
+  };
+
+  const updateLastEngineState: NonNullable<SessionPersistence["updateLastEngineState"]> = async (
+    sessionId: string,
+    apply: (prev: EngineState | undefined) => EngineState | undefined,
+    nowMs: number,
+    expectedVersion?: number,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    return withLock(`${lockScope}:session:${sessionId}`, async () => {
+      const loaded = await loadRecord(sessionId);
+      if (!loaded.ok) return loaded;
+      if (expectedVersion !== undefined && loaded.value.lastPersistedAt !== expectedVersion) {
+        return {
+          ok: false,
+          error: conflict(
+            `Session ${sessionId} version mismatch — expected ${expectedVersion}, found ${loaded.value.lastPersistedAt}`,
+          ),
+        };
+      }
+      return writeJson(transport, sessionRecordPath(basePath, sessionId), {
+        ...loaded.value,
+        lastEngineState: apply(loaded.value.lastEngineState),
+        lastPersistedAt: nowMs,
+      });
+    });
+  };
+
+  const setSessionStatus: SessionPersistence["setSessionStatus"] = async (
+    sessionId: string,
+    status: SessionStatus,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    return withLock(`${lockScope}:session:${sessionId}`, async () => {
+      const loaded = await loadRecord(sessionId);
+      if (!loaded.ok) return loaded;
+      return writeJson(transport, sessionRecordPath(basePath, sessionId), {
+        ...loaded.value,
+        status,
+      });
+    });
+  };
+
+  const saveContentReplacement: SessionPersistence["saveContentReplacement"] = async (
+    record: ContentReplacement,
+  ): Promise<Result<void, KoiError>> => {
+    const sessionCheck = validateNonEmpty(record.sessionId, "Session ID");
+    if (!sessionCheck.ok) return sessionCheck;
+    const messageCheck = validateNonEmpty(record.messageId, "Message ID");
+    if (!messageCheck.ok) return messageCheck;
+    return writeJson(
+      transport,
+      contentReplacementPath(basePath, record.sessionId, record.messageId),
+      record,
+    );
+  };
+
+  const loadContentReplacements: SessionPersistence["loadContentReplacements"] = async (
+    sessionId: string,
+  ): Promise<Result<readonly ContentReplacement[], KoiError>> => {
+    const check = validateNonEmpty(sessionId, "Session ID");
+    if (!check.ok) return check;
+    const paths = await listReplacementPaths(sessionId);
+    if (!paths.ok) return paths;
+    const replacements: ContentReplacement[] = [];
+    for (const path of paths.value) {
+      const loaded = await readJson<unknown>(transport, path);
+      if (!loaded.ok) return loaded;
+      if (isContentReplacement(loaded.value)) replacements.push(loaded.value);
+    }
+    return { ok: true, value: replacements };
+  };
+
+  const recover: SessionPersistence["recover"] = async (): Promise<
+    Result<RecoveryPlan, KoiError>
+  > => {
+    const sessions = await listSessions();
+    if (!sessions.ok) return sessions;
+    const pendingPaths = await listFilePaths(transport, `${basePath}/pending`);
+    if (!pendingPaths.ok) return pendingPaths;
+    const pendingFrames = new Map<string, PendingFrame[]>();
+    for (const path of pendingPaths.value) {
+      const loaded = await readJson<unknown>(transport, path);
+      if (!loaded.ok) return loaded;
+      if (!isPendingFrame(loaded.value)) continue;
+      const existing = pendingFrames.get(loaded.value.sessionId) ?? [];
+      pendingFrames.set(loaded.value.sessionId, [...existing, loaded.value]);
+    }
+    for (const [sessionId, frames] of pendingFrames) {
+      pendingFrames.set(
+        sessionId,
+        frames.sort((a, b) => a.orderIndex - b.orderIndex),
+      );
+    }
+    return {
+      ok: true,
+      value: {
+        sessions: sessions.value,
+        pendingFrames,
+        skipped: [],
+      },
+    };
+  };
+
+  return {
+    saveSession,
+    loadSession,
+    removeSession,
+    listSessions,
+    savePendingFrame,
+    loadPendingFrames,
+    clearPendingFrames,
+    removePendingFrame,
+    updateLastEngineState,
+    setSessionStatus,
+    saveContentReplacement,
+    loadContentReplacements,
+    recover,
+    close: () => undefined,
+  };
+}

--- a/packages/lib/session/src/nexus/session-backend.ts
+++ b/packages/lib/session/src/nexus/session-backend.ts
@@ -1,0 +1,90 @@
+import type { EngineState, SessionId, TranscriptEntry } from "@koi/core";
+import { agentId } from "@koi/core";
+import { createNexusSessionArtifactStore } from "./artifact-store.js";
+import { DEFAULT_NEXUS_SESSION_BASE_PATH, validateBasePath } from "./paths.js";
+import { createNexusSessionPersistence } from "./persistence-store.js";
+import { createNexusTranscriptStore } from "./transcript-store.js";
+import type { NexusSessionBackend, NexusSessionBackendConfig } from "./types.js";
+
+export function createNexusSessionBackend(config: NexusSessionBackendConfig): NexusSessionBackend {
+  const basePath = config.basePath ?? DEFAULT_NEXUS_SESSION_BASE_PATH;
+  const validBasePath = validateBasePath(basePath);
+  if (!validBasePath.ok) {
+    throw new Error(validBasePath.error.message, { cause: validBasePath.error });
+  }
+  const lockScope = config.lockScope ?? basePath;
+  const transcript = createNexusTranscriptStore(config.transport, basePath, lockScope);
+  const persistence = createNexusSessionPersistence(config.transport, basePath, lockScope);
+  const artifacts = createNexusSessionArtifactStore(config.transport, basePath);
+
+  async function saveTurn(sessionId: SessionId, turn: TranscriptEntry): Promise<void> {
+    const result = await transcript.append(sessionId, [turn]);
+    if (!result.ok) throw new Error(result.error.message, { cause: result.error });
+  }
+
+  async function loadHistory(sessionId: SessionId): Promise<readonly TranscriptEntry[]> {
+    const result = await transcript.load(sessionId);
+    if (!result.ok) throw new Error(result.error.message, { cause: result.error });
+    return result.value.entries;
+  }
+
+  async function saveCheckpoint(sessionId: SessionId, state: EngineState): Promise<void> {
+    const loaded = await persistence.loadSession(sessionId);
+    if (loaded.ok) {
+      const updated = await persistence.updateLastEngineState?.(
+        sessionId,
+        () => state,
+        Date.now(),
+        loaded.value.lastPersistedAt,
+      );
+      if (updated === undefined) throw new Error("Nexus persistence missing checkpoint support");
+      if (!updated.ok) throw new Error(updated.error.message, { cause: updated.error });
+      return;
+    }
+    if (loaded.error.code !== "NOT_FOUND") {
+      throw new Error(loaded.error.message, { cause: loaded.error });
+    }
+    const now = Date.now();
+    const saved = await persistence.saveSession({
+      sessionId,
+      agentId: agentId("nexus-session-backend"),
+      manifestSnapshot: {
+        name: "nexus-session-backend",
+        version: "0.0.0",
+        description: "Synthetic session record for checkpoint-only persistence",
+        model: { name: "unknown" },
+      },
+      seq: 0,
+      remoteSeq: 0,
+      connectedAt: now,
+      lastPersistedAt: now,
+      lastEngineState: state,
+      status: "idle",
+      metadata: { createdBy: "createNexusSessionBackend.saveCheckpoint" },
+    });
+    if (!saved.ok) throw new Error(saved.error.message, { cause: saved.error });
+  }
+
+  async function loadCheckpoint(sessionId: SessionId): Promise<EngineState | undefined> {
+    const result = await persistence.loadSession(sessionId);
+    if (!result.ok) {
+      if (result.error.code === "NOT_FOUND") return undefined;
+      throw new Error(result.error.message, { cause: result.error });
+    }
+    return result.value.lastEngineState;
+  }
+
+  return {
+    transcript,
+    persistence,
+    artifacts,
+    saveTurn,
+    loadHistory,
+    saveCheckpoint,
+    loadCheckpoint,
+    close: async () => {
+      await transcript.close();
+      await persistence.close();
+    },
+  };
+}

--- a/packages/lib/session/src/nexus/session-backend.ts
+++ b/packages/lib/session/src/nexus/session-backend.ts
@@ -6,6 +6,8 @@ import { createNexusSessionPersistence } from "./persistence-store.js";
 import { createNexusTranscriptStore } from "./transcript-store.js";
 import type { NexusSessionBackend, NexusSessionBackendConfig } from "./types.js";
 
+type NexusSessionPersistence = NexusSessionBackend["persistence"];
+
 export function createNexusSessionBackend(config: NexusSessionBackendConfig): NexusSessionBackend {
   const basePath = config.basePath ?? DEFAULT_NEXUS_SESSION_BASE_PATH;
   const validBasePath = validateBasePath(basePath);
@@ -28,63 +30,82 @@ export function createNexusSessionBackend(config: NexusSessionBackendConfig): Ne
     return result.value.entries;
   }
 
-  async function saveCheckpoint(sessionId: SessionId, state: EngineState): Promise<void> {
-    const loaded = await persistence.loadSession(sessionId);
-    if (loaded.ok) {
-      const updated = await persistence.updateLastEngineState?.(
-        sessionId,
-        () => state,
-        Date.now(),
-        loaded.value.lastPersistedAt,
-      );
-      if (updated === undefined) throw new Error("Nexus persistence missing checkpoint support");
-      if (!updated.ok) throw new Error(updated.error.message, { cause: updated.error });
-      return;
-    }
-    if (loaded.error.code !== "NOT_FOUND") {
-      throw new Error(loaded.error.message, { cause: loaded.error });
-    }
-    const now = Date.now();
-    const saved = await persistence.saveSession({
-      sessionId,
-      agentId: agentId("nexus-session-backend"),
-      manifestSnapshot: {
-        name: "nexus-session-backend",
-        version: "0.0.0",
-        description: "Synthetic session record for checkpoint-only persistence",
-        model: { name: "unknown" },
-      },
-      seq: 0,
-      remoteSeq: 0,
-      connectedAt: now,
-      lastPersistedAt: now,
-      lastEngineState: state,
-      status: "idle",
-      metadata: { createdBy: "createNexusSessionBackend.saveCheckpoint" },
-    });
-    if (!saved.ok) throw new Error(saved.error.message, { cause: saved.error });
-  }
-
-  async function loadCheckpoint(sessionId: SessionId): Promise<EngineState | undefined> {
-    const result = await persistence.loadSession(sessionId);
-    if (!result.ok) {
-      if (result.error.code === "NOT_FOUND") return undefined;
-      throw new Error(result.error.message, { cause: result.error });
-    }
-    return result.value.lastEngineState;
-  }
-
   return {
     transcript,
     persistence,
     artifacts,
     saveTurn,
     loadHistory,
-    saveCheckpoint,
-    loadCheckpoint,
+    saveCheckpoint: (sessionId, state) => saveCheckpoint(persistence, sessionId, state),
+    loadCheckpoint: (sessionId) => loadCheckpoint(persistence, sessionId),
     close: async () => {
       await transcript.close();
       await persistence.close();
     },
   };
+}
+
+async function saveCheckpoint(
+  persistence: NexusSessionPersistence,
+  sessionId: SessionId,
+  state: EngineState,
+): Promise<void> {
+  const loaded = await persistence.loadSession(sessionId);
+  if (loaded.ok) {
+    await updateExistingCheckpoint(persistence, sessionId, state, loaded.value.lastPersistedAt);
+    return;
+  }
+  if (loaded.error.code !== "NOT_FOUND") {
+    throw new Error(loaded.error.message, { cause: loaded.error });
+  }
+  const saved = await persistence.saveSession(createCheckpointRecord(sessionId, state, Date.now()));
+  if (!saved.ok) throw new Error(saved.error.message, { cause: saved.error });
+}
+
+async function updateExistingCheckpoint(
+  persistence: NexusSessionPersistence,
+  sessionId: SessionId,
+  state: EngineState,
+  expectedVersion: number,
+): Promise<void> {
+  const updated = await persistence.updateLastEngineState?.(
+    sessionId,
+    () => state,
+    Date.now(),
+    expectedVersion,
+  );
+  if (updated === undefined) throw new Error("Nexus persistence missing checkpoint support");
+  if (!updated.ok) throw new Error(updated.error.message, { cause: updated.error });
+}
+
+function createCheckpointRecord(sessionId: SessionId, state: EngineState, now: number) {
+  return {
+    sessionId,
+    agentId: agentId("nexus-session-backend"),
+    manifestSnapshot: {
+      name: "nexus-session-backend",
+      version: "0.0.0",
+      description: "Synthetic session record for checkpoint-only persistence",
+      model: { name: "unknown" },
+    },
+    seq: 0,
+    remoteSeq: 0,
+    connectedAt: now,
+    lastPersistedAt: now,
+    lastEngineState: state,
+    status: "idle" as const,
+    metadata: { createdBy: "createNexusSessionBackend.saveCheckpoint" },
+  };
+}
+
+async function loadCheckpoint(
+  persistence: NexusSessionPersistence,
+  sessionId: SessionId,
+): Promise<EngineState | undefined> {
+  const result = await persistence.loadSession(sessionId);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") return undefined;
+    throw new Error(result.error.message, { cause: result.error });
+  }
+  return result.value.lastEngineState;
 }

--- a/packages/lib/session/src/nexus/transcript-store.ts
+++ b/packages/lib/session/src/nexus/transcript-store.ts
@@ -1,0 +1,244 @@
+import type {
+  CompactResult,
+  KoiError,
+  Result,
+  SessionId,
+  SessionTranscript,
+  SkippedTranscriptEntry,
+  TranscriptEntry,
+  TranscriptLoadResult,
+  TranscriptPage,
+  TranscriptPageOptions,
+  TruncateResult,
+} from "@koi/core";
+import { transcriptEntryId, validateNonEmpty } from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+import { deletePath, readText, writeText } from "./json-io.js";
+import { transcriptPath } from "./paths.js";
+
+const VALID_ROLES: ReadonlySet<string> = new Set([
+  "user",
+  "assistant",
+  "tool_call",
+  "tool_result",
+  "system",
+  "compaction",
+]);
+
+const queues = new Map<string, Promise<void>>();
+
+function isTranscriptEntry(value: unknown): value is TranscriptEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === "string" &&
+    typeof obj.role === "string" &&
+    VALID_ROLES.has(obj.role) &&
+    typeof obj.content === "string" &&
+    typeof obj.timestamp === "number"
+  );
+}
+
+function parseJsonlLines(text: string): TranscriptLoadResult {
+  const lines = text.split("\n");
+  const entries: TranscriptEntry[] = [];
+  const skipped: SkippedTranscriptEntry[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === "") continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isTranscriptEntry(parsed)) {
+        entries.push(parsed);
+      } else {
+        skipped.push({
+          lineNumber: i + 1,
+          raw: line,
+          error: "Parsed JSON does not match TranscriptEntry schema",
+          reason: "parse_error",
+        });
+      }
+    } catch (error: unknown) {
+      const isLastNonEmpty = lines.slice(i + 1).every((candidate) => candidate.trim() === "");
+      skipped.push({
+        lineNumber: i + 1,
+        raw: line,
+        error: error instanceof Error ? error.message : String(error),
+        reason: isLastNonEmpty ? "crash_artifact" : "parse_error",
+      });
+    }
+  }
+
+  return { entries, skipped };
+}
+
+function toJsonl(entries: readonly TranscriptEntry[]): string {
+  if (entries.length === 0) return "";
+  return `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+}
+
+async function serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const previous = queues.get(key) ?? Promise.resolve();
+  const result = previous.then(
+    () => fn(),
+    () => fn(),
+  );
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  queues.set(key, tail);
+  void tail.then(() => {
+    if (queues.get(key) === tail) queues.delete(key);
+  });
+  return result;
+}
+
+export function createNexusTranscriptStore(
+  transport: NexusTransport,
+  basePath: string,
+  lockScope: string,
+): SessionTranscript {
+  function pathFor(sessionId: string): string {
+    return transcriptPath(basePath, sessionId);
+  }
+
+  const append: SessionTranscript["append"] = async (
+    sid: SessionId,
+    entries: readonly TranscriptEntry[],
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+    if (entries.length === 0) return { ok: true, value: undefined };
+
+    return serialized(`${lockScope}:transcript:${sid}`, async () => {
+      const path = pathFor(sid);
+      const existing = await readText(transport, path);
+      if (!existing.ok) return existing;
+      return writeText(transport, path, `${existing.value ?? ""}${toJsonl(entries)}`);
+    });
+  };
+
+  const load: SessionTranscript["load"] = async (
+    sid: SessionId,
+  ): Promise<Result<TranscriptLoadResult, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+    const existing = await readText(transport, pathFor(sid));
+    if (!existing.ok) return existing;
+    return { ok: true, value: parseJsonlLines(existing.value ?? "") };
+  };
+
+  const loadPage: SessionTranscript["loadPage"] = async (
+    sid: SessionId,
+    options: TranscriptPageOptions,
+  ): Promise<Result<TranscriptPage, KoiError>> => {
+    const result = await load(sid);
+    if (!result.ok) return result;
+    const offset = options.offset ?? 0;
+    return {
+      ok: true,
+      value: {
+        entries: result.value.entries.slice(offset, offset + options.limit),
+        total: result.value.entries.length,
+        hasMore: offset + options.limit < result.value.entries.length,
+      },
+    };
+  };
+
+  const compact: SessionTranscript["compact"] = async (
+    sid: SessionId,
+    summary: string,
+    preserveLastN: number,
+  ): Promise<Result<CompactResult, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+    if (preserveLastN < 0) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION",
+          message: "preserveLastN must be non-negative",
+          retryable: false,
+        },
+      };
+    }
+    return serialized(`${lockScope}:transcript:${sid}`, async () => {
+      const loaded = await load(sid);
+      if (!loaded.ok) return loaded;
+      if (loaded.value.entries.length === 0) {
+        return { ok: true, value: { preserved: 0, extended: false } };
+      }
+      const naiveCutIndex = Math.max(0, loaded.value.entries.length - preserveLastN);
+      let cutIndex = naiveCutIndex;
+      while (cutIndex > 0 && loaded.value.entries[cutIndex]?.role === "tool_result") {
+        cutIndex--;
+      }
+      const preserved = loaded.value.entries.slice(cutIndex);
+      const compactionEntry: TranscriptEntry = {
+        id: transcriptEntryId(`compaction-${Date.now()}`),
+        role: "compaction",
+        content: summary,
+        timestamp: Date.now(),
+      };
+      const written = await writeText(
+        transport,
+        pathFor(sid),
+        toJsonl([compactionEntry, ...preserved]),
+      );
+      if (!written.ok) return written;
+      return {
+        ok: true,
+        value: { preserved: preserved.length, extended: cutIndex < naiveCutIndex },
+      };
+    });
+  };
+
+  const truncate: SessionTranscript["truncate"] = async (
+    sid: SessionId,
+    keepFirstN: number,
+  ): Promise<Result<TruncateResult, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+    if (keepFirstN < 0) {
+      return {
+        ok: false,
+        error: { code: "VALIDATION", message: "keepFirstN must be non-negative", retryable: false },
+      };
+    }
+    return serialized(`${lockScope}:transcript:${sid}`, async () => {
+      const loaded = await load(sid);
+      if (!loaded.ok) return loaded;
+      if (keepFirstN >= loaded.value.entries.length) {
+        return { ok: true, value: { kept: loaded.value.entries.length, dropped: 0 } };
+      }
+      const kept = loaded.value.entries.slice(0, keepFirstN);
+      const dropped = loaded.value.entries.length - kept.length;
+      const result =
+        kept.length === 0
+          ? await deletePath(transport, pathFor(sid))
+          : await writeText(transport, pathFor(sid), toJsonl(kept));
+      if (!result.ok) return result;
+      return { ok: true, value: { kept: kept.length, dropped } };
+    });
+  };
+
+  const remove: SessionTranscript["remove"] = async (
+    sid: SessionId,
+  ): Promise<Result<void, KoiError>> => {
+    const check = validateNonEmpty(sid, "Session ID");
+    if (!check.ok) return check;
+    return serialized(`${lockScope}:transcript:${sid}`, () => deletePath(transport, pathFor(sid)));
+  };
+
+  return {
+    append,
+    load,
+    loadPage,
+    compact,
+    truncate,
+    remove,
+    close: () => undefined,
+  };
+}

--- a/packages/lib/session/src/nexus/types.ts
+++ b/packages/lib/session/src/nexus/types.ts
@@ -1,0 +1,46 @@
+import type {
+  EngineState,
+  SessionId,
+  SessionPersistence,
+  SessionTranscript,
+  TranscriptEntry,
+} from "@koi/core";
+import type { NexusTransport } from "@koi/nexus-client";
+
+export interface NexusSessionBackendConfig {
+  /** Configured Nexus transport. */
+  readonly transport: NexusTransport;
+  /** Base namespace for all session state. Defaults to "sessions". */
+  readonly basePath?: string | undefined;
+  /** In-process lock scope for read-modify-write operations. Defaults to basePath. */
+  readonly lockScope?: string | undefined;
+}
+
+export interface SessionArtifactRecord {
+  readonly artifactId: string;
+  readonly content: string;
+  readonly contentType?: string | undefined;
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+  readonly createdAt: number;
+}
+
+export interface SessionArtifactStore {
+  readonly saveArtifact: (sessionId: SessionId, artifact: SessionArtifactRecord) => Promise<void>;
+  readonly loadArtifact: (
+    sessionId: SessionId,
+    artifactId: string,
+  ) => Promise<SessionArtifactRecord | undefined>;
+  readonly listArtifacts: (sessionId: SessionId) => Promise<readonly SessionArtifactRecord[]>;
+  readonly removeArtifact: (sessionId: SessionId, artifactId: string) => Promise<void>;
+}
+
+export interface NexusSessionBackend {
+  readonly transcript: SessionTranscript;
+  readonly persistence: SessionPersistence;
+  readonly artifacts: SessionArtifactStore;
+  readonly saveTurn: (sessionId: SessionId, turn: TranscriptEntry) => Promise<void>;
+  readonly loadHistory: (sessionId: SessionId) => Promise<readonly TranscriptEntry[]>;
+  readonly saveCheckpoint: (sessionId: SessionId, state: EngineState) => Promise<void>;
+  readonly loadCheckpoint: (sessionId: SessionId) => Promise<EngineState | undefined>;
+  readonly close: () => void | Promise<void>;
+}


### PR DESCRIPTION
## Summary
- add `createNexusSessionBackend` with Nexus-backed transcript, persistence, checkpoint helpers, and session-scoped artifacts
- export the Nexus backend API from `@koi/session` and add the Nexus package dependencies
- document the Nexus session layout and refresh generated package coverage metadata

## Testing
- `bun test src/nexus/__tests__/session-backend.test.ts`
- `bun run typecheck` (`packages/lib/session`)
- `bun run lint` (`packages/lib/session`)
- `bun run test` (`packages/lib/session`)
- `bun run build` (`packages/lib/session`)
- `bun run check:doc-sync`
- `bun run check:layers`
- `git diff --check`
- `bun run check:golden-queries`
- `bun run test:runtime-golden-replay`
- `bun run test` (`packages/ui/tui`)
- `bun run check:tui-tools`
- `bun run check:tui-single-writer` (no hard violations; existing soft warning at `packages/ui/tui/src/profiling/integration.ts:227`)
- pre-push hook: `build`, `typecheck`

## Manual TUI / E2E
- launched the TUI in a pseudo-TTY with dummy provider config and verified terminal restore on Ctrl-C
- verified `--max-turns 1` fails closed with the governance alert
- verified provider failure via unreachable OpenAI-compatible base URL surfaces `Turn failed (model_stream)` and returns idle
- verified a successful mocked OpenAI-compatible turn renders output and writes transcript JSONL
- exercised CLI/TUI edge gates for help, mutually exclusive flags, unsafe loop/resume, and Nexus session ids containing `:` and `/`
- confirmed Nexus checkpoint overwrite, artifact load/list, recovery behavior, invalid base path rejection, checkpoint read failure propagation, and artifact validation errors

Closes #2203
