### PR TITLE
[codex] Add shared context namespace

### DIFF
--- a/docs/L2/fs-scoped.md
+++ b/docs/L2/fs-scoped.md
@@ -1,0 +1,47 @@
+# @koi/fs-scoped
+
+`@koi/fs-scoped` contains L0u filesystem adapters that reduce a broader
+`FileSystemBackend` into a smaller authority surface.
+
+## Scoped Filesystems
+
+`createScopedFileSystem(backend, { root, mode })` wraps a backend with a root
+boundary and access mode:
+
+- `ro` allows `read`, `list`, and `search`, and blocks `write`, `edit`,
+  `delete`, and `rename`.
+- `rw` allows the full backend operation set, still constrained to the root.
+
+All path arguments are normalized at call time and rejected if they escape the
+compiled root.
+
+## Context Namespaces
+
+`createContextNamespace()` creates an in-memory shared namespace for mounting
+filesystem backends under stable namespace paths such as `/shared`.
+
+```ts
+import { createContextNamespace } from "@koi/fs-scoped";
+
+const namespace = createContextNamespace();
+namespace.mount({ path: "/shared", backend, mode: "rw" });
+
+const shared = namespace.resolve("/shared/note.md");
+shared?.write("/shared/note.md", "hello");
+```
+
+Namespace resolution uses longest-prefix matching, so `/shared/project/file.ts`
+resolves to a `/shared/project` mount before a broader `/shared` mount. The
+resolved backend accepts namespace paths and delegates to the mounted backend
+with the mount prefix stripped, so `/shared/note.md` reaches the backend as
+`/note.md`.
+
+Mount access modes reuse `createScopedFileSystem()` enforcement. Read-only
+mounts expose the same backend shape but return `PERMISSION` errors for writes,
+edits, deletes, and renames.
+
+Callers may subscribe with `watch(listener)`. The listener receives `mounted`,
+`resolved`, and `unmounted` events until the returned unsubscribe function is
+called. The namespace object is ordinary shared state, so a parent runtime can
+pass the same instance to child runtimes to expose a common `/shared` view
+without adding direct agent-to-agent communication.

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -108,7 +108,7 @@ Each line shows package name, package directory, package description, test-file 
 - `@koi/forge-verifier` (packages/lib/forge-verifier) - Sequential short-circuiting verification pipeline for forge artifacts with pluggable stages and caching.. Tests: 2. Docs: docs/L2/forge-verifier.md.
 - `@koi/fs-local` (packages/lib/fs-local) - Local filesystem FileSystemBackend using Bun.file/node:fs. Tests: 1. Docs: docs/L2/fs-local.md.
 - `@koi/fs-nexus` (packages/lib/fs-nexus) - Nexus-backed FileSystemBackend via JSON-RPC. Tests: 8. Docs: docs/L2/fs-nexus.md.
-- `@koi/fs-scoped` (packages/lib/fs-scoped) - Scoped filesystem wrapper — restricts a FileSystemBackend to a root with configurable ro/rw access. Tests: 1. Docs: -.
+- `@koi/fs-scoped` (packages/lib/fs-scoped) - Scoped filesystem wrapper — restricts a FileSystemBackend to a root with configurable ro/rw access. Tests: 2. Docs: docs/L2/fs-scoped.md.
 - `@koi/gateway-types` (packages/lib/gateway-types) - Shared gateway wire-protocol types (GatewayFrame, Session, RoutingContext). L0u — no logic, no deps beyond @koi/core.. Tests: 1. Docs: -.
 - `@koi/git-utils` (packages/lib/git-utils) - Wrap git CLI commands and resolve worktree paths via Bun.spawn. Tests: 4. Docs: -.
 - `@koi/handoff` (packages/lib/handoff) - Structured context relay between agents — typed envelopes + auto-injecting middleware. Tests: 9. Docs: docs/L2/handoff.md.

--- a/docs/package-coverage-map.md
+++ b/docs/package-coverage-map.md
@@ -7,7 +7,7 @@ Current snapshot:
 - 234 workspace packages
 - 11 package families
 - 234 packages with local test files
-- 209 packages with dedicated package docs
+- 210 packages with dedicated package docs
 
 ## Family Summary
 
@@ -16,7 +16,7 @@ Current snapshot:
 | drivers | 2 | 41 | 2 |
 | exec | 3 | 17 | 3 |
 | kernel | 4 | 126 | 0 |
-| lib | 153 | 795 | 134 |
+| lib | 153 | 796 | 135 |
 | meta | 7 | 122 | 5 |
 | mm | 12 | 55 | 12 |
 | net | 12 | 100 | 12 |

--- a/docs/superpowers/plans/2026-05-18-issue-2205-shared-context-namespace.md
+++ b/docs/superpowers/plans/2026-05-18-issue-2205-shared-context-namespace.md
@@ -1,0 +1,104 @@
+# Issue 2205 Shared Context Namespace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first shared context namespace contract and in-memory implementation for `/shared/` style multi-agent context.
+
+**Architecture:** Add L0 contract types in `@koi/core`, then implement `createContextNamespace()` in `@koi/fs-scoped` using the existing scoped filesystem wrapper for read-only/read-write access. Keep spawn composition indirect through shared world-service components rather than direct parent-child communication.
+
+**Tech Stack:** Bun, TypeScript 6 strict mode, `bun:test`, `@koi/core`, `@koi/fs-scoped`.
+
+---
+
+### Task 1: L0 Context Namespace Contract
+
+**Files:**
+- Create: `packages/kernel/core/src/context-namespace.ts`
+- Modify: `packages/kernel/core/src/index.ts`
+- Modify: `packages/kernel/core/package.json`
+- Modify: `packages/kernel/core/tsup.config.ts`
+- Modify: `packages/kernel/core/src/__tests__/exports.test.ts`
+
+- [ ] **Step 1: Write the failing export/type test**
+
+Add `ContextNamespace`, `ContextNamespaceAccessMode`, `ContextNamespaceChangeEvent`, and `ContextNamespaceMount` to the type import list in `packages/kernel/core/src/__tests__/exports.test.ts`, and add each to the `_TypeGuard` union.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/__tests__/exports.test.ts` from `packages/kernel/core`.
+
+Expected: FAIL because the new types are not exported from `../index.js`.
+
+- [ ] **Step 3: Add the L0 contract**
+
+Create `packages/kernel/core/src/context-namespace.ts` with readonly interfaces only, importing `FileSystemBackend` from `./filesystem-backend.js`.
+
+- [ ] **Step 4: Export the contract**
+
+Export the new types from `packages/kernel/core/src/index.ts`, add `./context-namespace` to `packages/kernel/core/package.json`, and add `src/context-namespace.ts` to `packages/kernel/core/tsup.config.ts`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bun test src/__tests__/exports.test.ts` from `packages/kernel/core`.
+
+Expected: PASS.
+
+### Task 2: In-Memory Namespace Implementation
+
+**Files:**
+- Create: `packages/lib/fs-scoped/src/context-namespace.ts`
+- Create: `packages/lib/fs-scoped/src/context-namespace.test.ts`
+- Modify: `packages/lib/fs-scoped/src/index.ts`
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Add tests for mount/list/unmount, longest-prefix resolution, read-only write rejection, read-write write success, watcher events, and stable `/shared/` visibility through one shared namespace instance.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/context-namespace.test.ts` from `packages/lib/fs-scoped`.
+
+Expected: FAIL because `createContextNamespace()` does not exist.
+
+- [ ] **Step 3: Implement minimal namespace manager**
+
+Implement path normalization, mount replacement, longest-prefix matching, scoped backend creation, and watcher notification in `packages/lib/fs-scoped/src/context-namespace.ts`.
+
+- [ ] **Step 4: Export implementation**
+
+Export `createContextNamespace()` from `packages/lib/fs-scoped/src/index.ts`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test src/context-namespace.test.ts` from `packages/lib/fs-scoped`.
+
+Expected: PASS.
+
+### Task 3: Docs, API Surface, And Verification
+
+**Files:**
+- Modify: `docs/L2/fs-scoped.md`
+- Modify generated snapshots under `packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap`
+
+- [ ] **Step 1: Document namespace behavior**
+
+Update `docs/L2/fs-scoped.md` with the shared context namespace contract, `/shared/` example, access modes, and change notification behavior.
+
+- [ ] **Step 2: Build core and update API surface snapshots**
+
+Run: `bun --cwd packages/kernel/core run build` from repo root, then `bun test src/__tests__/api-surface.test.ts` from `packages/kernel/core`.
+
+Expected: snapshots update for the new `./context-namespace` export.
+
+- [ ] **Step 3: Run focused verification**
+
+Run:
+
+```bash
+bun --cwd packages/kernel/core run build
+bun test src/__tests__/exports.test.ts src/__tests__/api-surface.test.ts
+bun test src/context-namespace.test.ts
+bun run check:layers
+```
+
+Expected: all commands pass.

--- a/docs/superpowers/specs/2026-05-18-issue-2205-shared-context-namespace-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-2205-shared-context-namespace-design.md
@@ -1,0 +1,57 @@
+# Issue 2205 Shared Context Namespace Design
+
+## Goal
+
+Add the first multi-agent shared context namespace surface for agents and sub-agents working in parallel. The initial slice defines the L0 contract, provides an in-memory namespace implementation, supports namespace-level read-only/read-write access, and emits change notifications without creating direct agent-to-agent communication.
+
+## Architecture
+
+`@koi/core` owns only the contract types. The runtime implementation lives in `@koi/fs-scoped`, reusing its existing `createScopedFileSystem()` wrapper for read-only/read-write enforcement over `FileSystemBackend`.
+
+The namespace is a world-service style component: parents and children can share the same `ContextNamespace` instance, but agents interact with the mounted filesystem backend through namespace resolution rather than by calling each other. This preserves the architecture rule that agents communicate through world services, not entity-to-entity links.
+
+## Contract
+
+The L0 contract adds:
+
+- `ContextNamespaceAccessMode = "ro" | "rw"`
+- `ContextNamespaceMount` with `path`, `backend`, `mode`, and optional `metadata`
+- `ContextNamespaceChangeEvent` for `mounted`, `unmounted`, and `resolved` observations
+- `ContextNamespace` with `mount`, `unmount`, `resolve`, `list`, and optional `watch`
+
+`resolve(path)` returns the mounted backend for the longest matching namespace prefix. The resolved backend is scoped to the mounted backend root and access mode. Paths under `/shared/` resolve to the stable shared context namespace when mounted there.
+
+## Implementation
+
+`@koi/fs-scoped` adds `createContextNamespace()` because it already owns filesystem scoping and is an L0u package. The implementation:
+
+- normalizes namespace paths to absolute POSIX-style paths
+- rejects non-absolute mount paths and root (`/`) mounts
+- replaces an existing mount when the same path is mounted again
+- resolves by longest prefix so `/shared/project` wins over `/shared`
+- wraps each mounted backend with `createScopedFileSystem(backend, { root, mode })`
+- emits watcher events for mount, unmount, and resolve
+
+The initial implementation uses in-memory mounts and synchronous watchers. A future Nexus-backed implementation can use the same L0 contract and forward events to `EventBackend` or Nexus record streams.
+
+## Spawn Composition
+
+The first implementation does not add direct spawn behavior. Spawn and handoff flows can pass the same `ContextNamespace` instance through existing provider/component composition. A later L1 wiring step can add a narrow `SpawnChildOptions` inheritance field if needed, but the contract and namespace behavior are useful and testable without coupling `spawnChildAgent()` to a concrete storage package.
+
+## Testing
+
+Tests cover:
+
+- L0 export inventory and API surface for the new contract
+- mount/list/unmount behavior
+- longest-prefix resolution
+- read-only vs read-write enforcement through the resolved backend
+- watcher events for namespace changes and resolution
+- stable `/shared/` visibility through a shared namespace instance
+
+## Out of Scope
+
+- Per-file grants
+- Nexus/ReBAC RPC integration
+- Direct engine spawn option wiring
+- Durable event replay for namespace changes

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/context-engine.d.ts",
       "import": "./dist/context-engine.js"
     },
+    "./context-namespace": {
+      "types": "./dist/context-namespace.d.ts",
+      "import": "./dist/context-namespace.js"
+    },
     "./delegation": {
       "types": "./dist/delegation.d.ts",
       "import": "./dist/delegation.js"

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -242,7 +242,7 @@
     "build": "bun ../../../scripts/run-tsup.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "bun test",
+    "test": "bun test src",
     "test:api": "bun test src/__tests__/api-surface.test.ts"
   }
 }

--- a/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
+++ b/packages/kernel/core/src/__tests__/__snapshots__/api-surface.test.ts.snap
@@ -17,6 +17,7 @@ export { ChannelAdapter, ChannelCapabilities, ChannelInheritMode, ChannelStatus,
 export { ConfigListener, ConfigSource, ConfigStore, ConfigUnsubscribe, FeatureFlags, ForgeConfigSection, KoiConfig, LimitsConfig, LogLevel, LoopDetectionConfigSection, ModelRouterConfigSection, ModelTargetConfigEntry, SpawnConfig, TelemetryConfig } from './config.js';
 export { CompactionResult, ContextCompactor, TokenEstimator } from './context.js';
 export { CONTEXT_ENGINE, ContextEngine, ContextEngineIdentity, ContextEngineSwapEvent, ContextOccupancy } from './chunk-HASH.js';
+export { ContextNamespace, ContextNamespaceAccessMode, ContextNamespaceChangeEvent, ContextNamespaceMount } from './chunk-HASH.js';
 export { AgentCostBreakdown, BudgetTracker, CostBreakdown, CostCalculator, CostEntry, CostTokenBreakdown, ModelCostBreakdown, ProviderCostBreakdown, ToolCostBreakdown, UsageInfo, formatCost, formatTokens } from './chunk-HASH.js';
 export { BackgroundSessionEvent, BackgroundSessionRecord, BackgroundSessionRegistry, BackgroundSessionStatus, BackgroundSessionUpdate, DEFAULT_HEARTBEAT_CONFIG, DEFAULT_WORKER_RESTART_POLICY, HeartbeatConfig, SUPERVISOR_HEALTH_STATUS, Supervisor, SupervisorConfig, SupervisorHealth, SupervisorHealthMetrics, SupervisorHealthStatus, WorkerBackend, WorkerBackendKind, WorkerEvent, WorkerHandle, WorkerHealth, WorkerId, WorkerRestartPolicy, WorkerSpawnRequest, validateBackgroundSessionRecord, validateSupervisorConfig, workerId } from './daemon.js';
 export { Breakpoint, BreakpointId, BreakpointOptions, BreakpointPredicate, ComponentMetadata, ComponentSnapshot, DEFAULT_DEBUG_BUFFER_SIZE, DEFAULT_INSPECT_LIMIT, DebugEvent, DebugObserver, DebugSession, DebugSessionId, DebugSnapshot, DebugState, InspectComponentOptions, StepOptions, breakpointId, debugSessionId } from './debug.js';
@@ -3847,6 +3848,62 @@ interface ContextEngineSwapEvent {
 declare const CONTEXT_ENGINE: SubsystemToken<ContextEngine>;
 
 export { CONTEXT_ENGINE, type ContextEngine, type ContextEngineIdentity, type ContextEngineSwapEvent, type ContextOccupancy };
+"
+`;
+
+exports[`@koi/core API surface ./context-namespace has stable type surface 1`] = `
+"import { FileSystemBackend } from './chunk-HASH.js';
+
+/**
+ * Shared context namespace contract.
+ *
+ * L0 types only: implementations live in L0u/L2 packages and may be
+ * in-memory, local filesystem-backed, or Nexus-backed.
+ */
+
+/** Namespace-level access grant for mounted context backends. */
+type ContextNamespaceAccessMode = "ro" | "rw";
+/** Mounted backend metadata for a shared context namespace path. */
+interface ContextNamespaceMount {
+    /** Stable absolute namespace path, e.g. "/shared". */
+    readonly path: string;
+    /** Backend mounted under the namespace path. */
+    readonly backend: FileSystemBackend;
+    /** Access mode applied to this namespace mount. */
+    readonly mode: ContextNamespaceAccessMode;
+    /** Optional implementation-specific metadata such as ReBAC grant IDs. */
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+/** Change event emitted by a context namespace implementation. */
+type ContextNamespaceChangeEvent = {
+    readonly kind: "mounted";
+    readonly path: string;
+    readonly mode: ContextNamespaceAccessMode;
+    readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+} | {
+    readonly kind: "unmounted";
+    readonly path: string;
+} | {
+    readonly kind: "resolved";
+    readonly path: string;
+    readonly mountPath: string;
+    readonly mode: ContextNamespaceAccessMode;
+};
+/**
+ * Mount table for shared agent context.
+ *
+ * Agents use this as a world service: a parent and child may receive the
+ * same namespace instance, but no direct agent-to-agent channel is implied.
+ */
+interface ContextNamespace {
+    readonly mount: (mount: ContextNamespaceMount) => void | Promise<void>;
+    readonly unmount: (path: string) => boolean | Promise<boolean>;
+    readonly resolve: (path: string) => FileSystemBackend | undefined | Promise<FileSystemBackend | undefined>;
+    readonly list: () => readonly ContextNamespaceMount[] | Promise<readonly ContextNamespaceMount[]>;
+    readonly watch?: (listener: (event: ContextNamespaceChangeEvent) => void) => () => void;
+}
+
+export type { ContextNamespace, ContextNamespaceAccessMode, ContextNamespaceChangeEvent, ContextNamespaceMount };
 "
 `;
 

--- a/packages/kernel/core/src/__tests__/exports.test.ts
+++ b/packages/kernel/core/src/__tests__/exports.test.ts
@@ -31,6 +31,10 @@ import type {
   ChildLifecycleEvent,
   ComponentProvider,
   ContentBlock,
+  ContextNamespace,
+  ContextNamespaceAccessMode,
+  ContextNamespaceChangeEvent,
+  ContextNamespaceMount,
   CredentialComponent,
   CustomBlock,
   EngineAdapter,
@@ -258,6 +262,10 @@ type _TypeGuard =
   | AssertDefined<AgentCondition>
   | AssertDefined<AgentStatus>
   | AssertDefined<AgentRegistry>
+  | AssertDefined<ContextNamespace>
+  | AssertDefined<ContextNamespaceAccessMode>
+  | AssertDefined<ContextNamespaceChangeEvent>
+  | AssertDefined<ContextNamespaceMount>
   | AssertDefined<TransitionReason>
   | AssertDefined<RegistryEntry>
   | AssertDefined<RegistryEvent>

--- a/packages/kernel/core/src/context-namespace.ts
+++ b/packages/kernel/core/src/context-namespace.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared context namespace contract.
+ *
+ * L0 types only: implementations live in L0u/L2 packages and may be
+ * in-memory, local filesystem-backed, or Nexus-backed.
+ */
+
+import type { FileSystemBackend } from "./filesystem-backend.js";
+
+/** Namespace-level access grant for mounted context backends. */
+export type ContextNamespaceAccessMode = "ro" | "rw";
+
+/** Mounted backend metadata for a shared context namespace path. */
+export interface ContextNamespaceMount {
+  /** Stable absolute namespace path, e.g. "/shared". */
+  readonly path: string;
+  /** Backend mounted under the namespace path. */
+  readonly backend: FileSystemBackend;
+  /** Access mode applied to this namespace mount. */
+  readonly mode: ContextNamespaceAccessMode;
+  /** Optional implementation-specific metadata such as ReBAC grant IDs. */
+  readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+}
+
+/** Change event emitted by a context namespace implementation. */
+export type ContextNamespaceChangeEvent =
+  | {
+      readonly kind: "mounted";
+      readonly path: string;
+      readonly mode: ContextNamespaceAccessMode;
+      readonly metadata?: Readonly<Record<string, unknown>> | undefined;
+    }
+  | {
+      readonly kind: "unmounted";
+      readonly path: string;
+    }
+  | {
+      readonly kind: "resolved";
+      readonly path: string;
+      readonly mountPath: string;
+      readonly mode: ContextNamespaceAccessMode;
+    };
+
+/**
+ * Mount table for shared agent context.
+ *
+ * Agents use this as a world service: a parent and child may receive the
+ * same namespace instance, but no direct agent-to-agent channel is implied.
+ */
+export interface ContextNamespace {
+  readonly mount: (mount: ContextNamespaceMount) => void | Promise<void>;
+  readonly unmount: (path: string) => boolean | Promise<boolean>;
+  readonly resolve: (
+    path: string,
+  ) => FileSystemBackend | undefined | Promise<FileSystemBackend | undefined>;
+  readonly list: () => readonly ContextNamespaceMount[] | Promise<readonly ContextNamespaceMount[]>;
+  readonly watch?: (listener: (event: ContextNamespaceChangeEvent) => void) => () => void;
+}

--- a/packages/kernel/core/src/index.ts
+++ b/packages/kernel/core/src/index.ts
@@ -292,6 +292,13 @@ export type {
   ContextOccupancy,
 } from "./context-engine.js";
 export { CONTEXT_ENGINE } from "./context-engine.js";
+// context namespace — shared mounted backends for multi-agent context
+export type {
+  ContextNamespace,
+  ContextNamespaceAccessMode,
+  ContextNamespaceChangeEvent,
+  ContextNamespaceMount,
+} from "./context-namespace.js";
 // correlation
 export type { CorrelationIds } from "./correlation.js";
 // cost tracker — per-session, per-tool, per-model cost transparency

--- a/packages/kernel/core/tsup.config.ts
+++ b/packages/kernel/core/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "src/common.ts",
     "src/context.ts",
     "src/context-engine.ts",
+    "src/context-namespace.ts",
     "src/delegation.ts",
     "src/daemon.ts",
     "src/ecs.ts",

--- a/packages/lib/channel-base/src/rate-limit.test.ts
+++ b/packages/lib/channel-base/src/rate-limit.test.ts
@@ -1140,15 +1140,19 @@ describe("createRateLimiter", () => {
         sendTimeoutMs: 20,
         onLateSuccess: () => lateOutcomes.push("late-success"),
       });
-      // Resolves at +60ms — well past the bounded final-attempt grace.
-      const slowSuccess: SendFn = () => new Promise<void>((resolve) => setTimeout(resolve, 60));
+      let resolveSlow!: () => void;
+      const slowSuccess: SendFn = () =>
+        new Promise<void>((resolve) => {
+          resolveSlow = resolve;
+        });
       expect(await captureRejection(limiter.enqueue(slowSuccess))).toMatchObject({
         code: "TIMEOUT",
         retryable: false,
         context: { phase: "delivery-unknown" },
       });
       // Late success eventually flows to the telemetry hook.
-      await new Promise<void>((res) => setTimeout(res, 80));
+      resolveSlow();
+      await new Promise<void>((res) => setTimeout(res, 10));
       expect(lateOutcomes).toEqual(["late-success"]);
     });
 

--- a/packages/lib/fs-scoped/src/context-namespace.test.ts
+++ b/packages/lib/fs-scoped/src/context-namespace.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import type { FileSystemBackend, KoiError, Result } from "@koi/core";
+import { createContextNamespace } from "./context-namespace.js";
+
+function createMockBackend(name = "mock"): FileSystemBackend & {
+  readonly calls: () => readonly string[];
+} {
+  const calls: string[] = [];
+  return {
+    name,
+    read: (path) => {
+      calls.push(`read:${path}`);
+      return { ok: true, value: { content: "", path, size: 0 } };
+    },
+    write: (path, content) => {
+      calls.push(`write:${path}:${content}`);
+      return { ok: true, value: { path, bytesWritten: content.length } };
+    },
+    edit: (path) => {
+      calls.push(`edit:${path}`);
+      return { ok: true, value: { path, hunksApplied: 1 } };
+    },
+    list: (path) => {
+      calls.push(`list:${path}`);
+      return { ok: true, value: { entries: [], truncated: false } };
+    },
+    search: (pattern) => {
+      calls.push(`search:${pattern}`);
+      return { ok: true, value: { matches: [], truncated: false } };
+    },
+    delete: (path) => {
+      calls.push(`delete:${path}`);
+      return { ok: true, value: { path } };
+    },
+    rename: (from, to) => {
+      calls.push(`rename:${from}:${to}`);
+      return { ok: true, value: { from, to } };
+    },
+    calls: () => calls,
+  };
+}
+
+function isErr(
+  result: Result<unknown, KoiError>,
+): result is { readonly ok: false; readonly error: KoiError } {
+  return !result.ok;
+}
+
+describe("createContextNamespace", () => {
+  test("mounts, lists, and unmounts namespace backends", () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+
+    ns.mount({ path: "/shared/", backend, mode: "rw", metadata: { grant: "team" } });
+
+    expect(ns.list()).toEqual([
+      { path: "/shared", backend, mode: "rw", metadata: { grant: "team" } },
+    ]);
+    expect(ns.unmount("/shared/")).toBe(true);
+    expect(ns.list()).toEqual([]);
+    expect(ns.unmount("/shared")).toBe(false);
+  });
+
+  test("resolves the longest matching namespace prefix", async () => {
+    const ns = createContextNamespace();
+    const shared = createMockBackend("shared");
+    const project = createMockBackend("project");
+    ns.mount({ path: "/shared", backend: shared, mode: "rw" });
+    ns.mount({ path: "/shared/project", backend: project, mode: "rw" });
+
+    const resolved = await ns.resolve("/shared/project/notes.md");
+
+    expect(resolved?.name).toBe("context-namespace(project:/shared/project)");
+    resolved?.read("/shared/project/notes.md");
+    expect(project.calls()).toContain("read:/notes.md");
+    expect(shared.calls()).toEqual([]);
+  });
+
+  test("resolved read-only backend blocks write operations", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "ro" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const result = resolved?.write("/shared/notes.md", "nope") as Result<unknown, KoiError>;
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe("PERMISSION");
+      expect(result.error.message).toContain("read-only");
+    }
+    expect(backend.calls()).toEqual([]);
+  });
+
+  test("resolved read-write backend permits writes under the mount", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "rw" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const result = resolved?.write("/shared/notes.md", "ok");
+
+    expect(result).toHaveProperty("ok", true);
+    expect(backend.calls()).toContain("write:/notes.md:ok");
+  });
+
+  test("watch emits mounted, resolved, and unmounted events", () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    const events: string[] = [];
+    const unsubscribe = ns.watch?.((event) => {
+      events.push(event.kind);
+    });
+
+    ns.mount({ path: "/shared", backend, mode: "rw" });
+    ns.resolve("/shared/a.txt");
+    ns.unmount("/shared");
+    unsubscribe?.();
+    ns.mount({ path: "/after-unsubscribe", backend, mode: "rw" });
+
+    expect(events).toEqual(["mounted", "resolved", "unmounted"]);
+  });
+
+  test("one shared namespace instance gives parent and child the same /shared visibility", async () => {
+    const parentNamespace = createContextNamespace();
+    const childNamespace = parentNamespace;
+    const backend = createMockBackend();
+
+    parentNamespace.mount({ path: "/shared", backend, mode: "rw" });
+
+    const childResolved = await childNamespace.resolve("/shared/child.txt");
+    childResolved?.write("/shared/child.txt", "hello");
+
+    expect(backend.calls()).toContain("write:/child.txt:hello");
+  });
+});

--- a/packages/lib/fs-scoped/src/context-namespace.test.ts
+++ b/packages/lib/fs-scoped/src/context-namespace.test.ts
@@ -22,11 +22,17 @@ function createMockBackend(name = "mock"): FileSystemBackend & {
     },
     list: (path) => {
       calls.push(`list:${path}`);
-      return { ok: true, value: { entries: [], truncated: false } };
+      return {
+        ok: true,
+        value: { entries: [{ path: "/notes.md", kind: "file" }], truncated: false },
+      };
     },
-    search: (pattern) => {
-      calls.push(`search:${pattern}`);
-      return { ok: true, value: { matches: [], truncated: false } };
+    search: (pattern, options) => {
+      calls.push(`search:${pattern}:${options?.glob ?? ""}`);
+      return {
+        ok: true,
+        value: { matches: [{ path: "/notes.md", line: 1, text: pattern }], truncated: false },
+      };
     },
     delete: (path) => {
       calls.push(`delete:${path}`);
@@ -59,6 +65,20 @@ describe("createContextNamespace", () => {
     expect(ns.unmount("/shared/")).toBe(true);
     expect(ns.list()).toEqual([]);
     expect(ns.unmount("/shared")).toBe(false);
+  });
+
+  test("rejects invalid access modes at runtime", () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+
+    expect(() =>
+      ns.mount({
+        path: "/shared",
+        backend,
+        mode: "write" as unknown as "rw",
+      }),
+    ).toThrow(/access mode/);
+    expect(ns.list()).toEqual([]);
   });
 
   test("resolves the longest matching namespace prefix", async () => {
@@ -102,6 +122,67 @@ describe("createContextNamespace", () => {
 
     expect(result).toHaveProperty("ok", true);
     expect(backend.calls()).toContain("write:/notes.md:ok");
+  });
+
+  test("resolved backend returns namespace paths in path-bearing results", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "rw" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const read = await resolved?.read("/shared/notes.md");
+    const write = await resolved?.write("/shared/notes.md", "ok");
+    const edit = await resolved?.edit("/shared/notes.md", []);
+    const list = await resolved?.list("/shared");
+    const del = await resolved?.delete?.("/shared/notes.md");
+    const rename = await resolved?.rename?.("/shared/old.md", "/shared/new.md");
+
+    expect(read).toHaveProperty("value.path", "/shared/notes.md");
+    expect(write).toHaveProperty("value.path", "/shared/notes.md");
+    expect(edit).toHaveProperty("value.path", "/shared/notes.md");
+    expect(list).toHaveProperty("value.entries.0.path", "/shared/notes.md");
+    expect(del).toHaveProperty("value.path", "/shared/notes.md");
+    expect(rename).toHaveProperty("value", { from: "/shared/old.md", to: "/shared/new.md" });
+  });
+
+  test("resolved search maps globs into the mount and returns namespace paths", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "ro" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const result = await resolved?.search("needle", { glob: "/shared/docs/*" });
+
+    expect(result).toHaveProperty("ok", true);
+    if (result === undefined || !result.ok) return;
+    expect(result.value.matches).toEqual([{ path: "/shared/notes.md", line: 1, text: "needle" }]);
+    expect(backend.calls()).toContain("search:needle:docs/*");
+  });
+
+  test("resolved search treats relative globs as mount-relative", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "ro" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const result = await resolved?.search("needle", { glob: "docs/*" });
+
+    expect(result).toHaveProperty("ok", true);
+    expect(backend.calls()).toContain("search:needle:docs/*");
+  });
+
+  test("resolved search rejects globs outside the mount", async () => {
+    const ns = createContextNamespace();
+    const backend = createMockBackend();
+    ns.mount({ path: "/shared", backend, mode: "ro" });
+
+    const resolved = await ns.resolve("/shared/notes.md");
+    const result = await resolved?.search("needle", { glob: "/private/*" });
+
+    expect(result).toHaveProperty("ok", false);
+    if (result === undefined || result.ok) return;
+    expect(result.error.code).toBe("PERMISSION");
+    expect(backend.calls()).toEqual([]);
   });
 
   test("watch emits mounted, resolved, and unmounted events", () => {

--- a/packages/lib/fs-scoped/src/context-namespace.ts
+++ b/packages/lib/fs-scoped/src/context-namespace.ts
@@ -1,0 +1,277 @@
+import type {
+  ContextNamespace,
+  ContextNamespaceChangeEvent,
+  ContextNamespaceMount,
+  FileSystemBackend,
+  KoiError,
+  Result,
+} from "@koi/core";
+import { permission } from "@koi/core";
+import { createScopedFileSystem } from "./scoped-filesystem.js";
+
+const VIRTUAL_SCOPE_ROOT = "/__koi_context_namespace__";
+
+function normalizeNamespacePath(path: string): string {
+  const withLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  const parts = withLeadingSlash.split("/").filter((part) => part.length > 0 && part !== ".");
+  if (parts.includes("..")) {
+    throw new Error(`Context namespace path cannot contain '..': ${path}`);
+  }
+  return parts.length === 0 ? "/" : `/${parts.join("/")}`;
+}
+
+function assertMountPath(path: string): string {
+  const normalized = normalizeNamespacePath(path);
+  if (normalized === "/") {
+    throw new Error("Context namespace cannot mount at root '/'");
+  }
+  return normalized;
+}
+
+function mountContainsPath(mountPath: string, path: string): boolean {
+  return path === mountPath || path.startsWith(`${mountPath}/`);
+}
+
+function emit(
+  listeners: ReadonlySet<(event: ContextNamespaceChangeEvent) => void>,
+  event: ContextNamespaceChangeEvent,
+): void {
+  for (const listener of listeners) {
+    listener(event);
+  }
+}
+
+function toMountRelativePath(mountPath: string, namespacePath: string): string | undefined {
+  const normalized = normalizeNamespacePath(namespacePath);
+  if (!mountContainsPath(mountPath, normalized)) {
+    return undefined;
+  }
+  const suffix = normalized.slice(mountPath.length);
+  return suffix.length === 0 ? "." : suffix.slice(1);
+}
+
+function toBackendPath(virtualPath: string): string | undefined {
+  if (virtualPath === VIRTUAL_SCOPE_ROOT) {
+    return "/";
+  }
+  const prefix = `${VIRTUAL_SCOPE_ROOT}/`;
+  if (!virtualPath.startsWith(prefix)) {
+    return undefined;
+  }
+  return `/${virtualPath.slice(prefix.length)}`;
+}
+
+function pathDenied(path: string, mountPath: string): Result<never, KoiError> {
+  return {
+    ok: false,
+    error: permission(
+      `Access to '${path}' was blocked: path is outside context mount '${mountPath}'.`,
+    ),
+  };
+}
+
+function createVirtualRootBackend(backend: FileSystemBackend): FileSystemBackend {
+  const del = backend.delete;
+  const ren = backend.rename;
+  const resolveFn = backend.resolvePath;
+  const dispose = backend.dispose;
+
+  return {
+    name: `context-namespace-virtual(${backend.name})`,
+
+    read(path, options) {
+      const backendPath = toBackendPath(path);
+      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
+      return backend.read(backendPath, options);
+    },
+
+    write(path, content, options) {
+      const backendPath = toBackendPath(path);
+      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
+      return backend.write(backendPath, content, options);
+    },
+
+    edit(path, edits, options) {
+      const backendPath = toBackendPath(path);
+      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
+      return backend.edit(backendPath, edits, options);
+    },
+
+    list(path, options) {
+      const backendPath = toBackendPath(path);
+      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
+      return backend.list(backendPath, options);
+    },
+
+    search(pattern, options) {
+      return backend.search(pattern, options);
+    },
+
+    ...(del !== undefined
+      ? {
+          delete(path: string) {
+            const backendPath = toBackendPath(path);
+            if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
+            return del(backendPath);
+          },
+        }
+      : {}),
+    ...(ren !== undefined
+      ? {
+          rename(from: string, to: string) {
+            const backendFrom = toBackendPath(from);
+            if (backendFrom === undefined) return pathDenied(from, VIRTUAL_SCOPE_ROOT);
+            const backendTo = toBackendPath(to);
+            if (backendTo === undefined) return pathDenied(to, VIRTUAL_SCOPE_ROOT);
+            return ren(backendFrom, backendTo);
+          },
+        }
+      : {}),
+    ...(resolveFn !== undefined
+      ? {
+          resolvePath(path: string): string | undefined {
+            const backendPath = toBackendPath(path);
+            return backendPath === undefined ? undefined : resolveFn(backendPath);
+          },
+        }
+      : {}),
+    ...(dispose !== undefined ? { dispose: () => dispose() } : {}),
+  };
+}
+
+function createResolvedMountBackend(mount: ContextNamespaceMount): FileSystemBackend {
+  const scoped = createScopedFileSystem(createVirtualRootBackend(mount.backend), {
+    root: VIRTUAL_SCOPE_ROOT,
+    mode: mount.mode,
+  });
+
+  const rewrite = (path: string): string | undefined => toMountRelativePath(mount.path, path);
+  const del = scoped.delete;
+  const ren = scoped.rename;
+  const resolveFn = scoped.resolvePath;
+  const dispose = scoped.dispose;
+
+  return {
+    name: `context-namespace(${mount.backend.name}:${mount.path})`,
+
+    read(path, options) {
+      const relative = rewrite(path);
+      if (relative === undefined) return pathDenied(path, mount.path);
+      return scoped.read(relative, options);
+    },
+
+    write(path, content, options) {
+      const relative = rewrite(path);
+      if (relative === undefined) return pathDenied(path, mount.path);
+      return scoped.write(relative, content, options);
+    },
+
+    edit(path, edits, options) {
+      const relative = rewrite(path);
+      if (relative === undefined) return pathDenied(path, mount.path);
+      return scoped.edit(relative, edits, options);
+    },
+
+    list(path, options) {
+      const relative = rewrite(path);
+      if (relative === undefined) return pathDenied(path, mount.path);
+      return scoped.list(relative, options);
+    },
+
+    search(pattern, options) {
+      return scoped.search(pattern, options);
+    },
+
+    ...(del !== undefined
+      ? {
+          delete(path: string) {
+            const relative = rewrite(path);
+            if (relative === undefined) return pathDenied(path, mount.path);
+            return del(relative);
+          },
+        }
+      : {}),
+    ...(ren !== undefined
+      ? {
+          rename(from: string, to: string) {
+            const relativeFrom = rewrite(from);
+            if (relativeFrom === undefined) return pathDenied(from, mount.path);
+            const relativeTo = rewrite(to);
+            if (relativeTo === undefined) return pathDenied(to, mount.path);
+            return ren(relativeFrom, relativeTo);
+          },
+        }
+      : {}),
+    ...(resolveFn !== undefined
+      ? {
+          resolvePath(path: string): string | undefined {
+            const relative = rewrite(path);
+            return relative === undefined ? undefined : resolveFn(relative);
+          },
+        }
+      : {}),
+    ...(dispose !== undefined ? { dispose: () => dispose() } : {}),
+  };
+}
+
+export function createContextNamespace(): ContextNamespace {
+  const mounts = new Map<string, ContextNamespaceMount>();
+  const resolved = new Map<string, FileSystemBackend>();
+  const listeners = new Set<(event: ContextNamespaceChangeEvent) => void>();
+
+  return {
+    mount(mount) {
+      const path = assertMountPath(mount.path);
+      const normalized: ContextNamespaceMount =
+        mount.metadata === undefined
+          ? { path, backend: mount.backend, mode: mount.mode }
+          : { path, backend: mount.backend, mode: mount.mode, metadata: mount.metadata };
+      mounts.set(path, normalized);
+      resolved.set(path, createResolvedMountBackend(normalized));
+      emit(
+        listeners,
+        normalized.metadata === undefined
+          ? { kind: "mounted", path, mode: normalized.mode }
+          : { kind: "mounted", path, mode: normalized.mode, metadata: normalized.metadata },
+      );
+    },
+
+    unmount(path) {
+      const normalized = normalizeNamespacePath(path);
+      const removed = mounts.delete(normalized);
+      resolved.delete(normalized);
+      if (removed) {
+        emit(listeners, { kind: "unmounted", path: normalized });
+      }
+      return removed;
+    },
+
+    resolve(path) {
+      const normalized = normalizeNamespacePath(path);
+      const match = [...mounts.values()]
+        .filter((mount) => mountContainsPath(mount.path, normalized))
+        .sort((left, right) => right.path.length - left.path.length)[0];
+      if (match === undefined) {
+        return undefined;
+      }
+      emit(listeners, {
+        kind: "resolved",
+        path: normalized,
+        mountPath: match.path,
+        mode: match.mode,
+      });
+      return resolved.get(match.path);
+    },
+
+    list() {
+      return [...mounts.values()];
+    },
+
+    watch(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/packages/lib/fs-scoped/src/context-namespace.ts
+++ b/packages/lib/fs-scoped/src/context-namespace.ts
@@ -70,73 +70,111 @@ function pathDenied(path: string, mountPath: string): Result<never, KoiError> {
   };
 }
 
-function createVirtualRootBackend(backend: FileSystemBackend): FileSystemBackend {
+type RewritePath = (path: string) => string | undefined;
+
+function rewriteOrDeny(
+  path: string,
+  rewrite: RewritePath,
+  mountPath: string,
+): Result<string, KoiError> {
+  const rewritten = rewrite(path);
+  return rewritten === undefined ? pathDenied(path, mountPath) : { ok: true, value: rewritten };
+}
+
+function createRoutedRequiredMethods(
+  backend: FileSystemBackend,
+  rewrite: RewritePath,
+  mountPath: string,
+): Pick<FileSystemBackend, "read" | "write" | "edit" | "list" | "search"> {
+  return {
+    read(path, options) {
+      const routed = rewriteOrDeny(path, rewrite, mountPath);
+      return routed.ok ? backend.read(routed.value, options) : routed;
+    },
+    write(path, content, options) {
+      const routed = rewriteOrDeny(path, rewrite, mountPath);
+      return routed.ok ? backend.write(routed.value, content, options) : routed;
+    },
+    edit(path, edits, options) {
+      const routed = rewriteOrDeny(path, rewrite, mountPath);
+      return routed.ok ? backend.edit(routed.value, edits, options) : routed;
+    },
+    list(path, options) {
+      const routed = rewriteOrDeny(path, rewrite, mountPath);
+      return routed.ok ? backend.list(routed.value, options) : routed;
+    },
+    search(pattern, options) {
+      return backend.search(pattern, options);
+    },
+  };
+}
+
+function createRoutedOptionalMethods(
+  backend: FileSystemBackend,
+  rewrite: RewritePath,
+  mountPath: string,
+): Partial<FileSystemBackend> {
   const del = backend.delete;
   const ren = backend.rename;
   const resolveFn = backend.resolvePath;
   const dispose = backend.dispose;
-
   return {
-    name: `context-namespace-virtual(${backend.name})`,
-
-    read(path, options) {
-      const backendPath = toBackendPath(path);
-      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
-      return backend.read(backendPath, options);
-    },
-
-    write(path, content, options) {
-      const backendPath = toBackendPath(path);
-      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
-      return backend.write(backendPath, content, options);
-    },
-
-    edit(path, edits, options) {
-      const backendPath = toBackendPath(path);
-      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
-      return backend.edit(backendPath, edits, options);
-    },
-
-    list(path, options) {
-      const backendPath = toBackendPath(path);
-      if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
-      return backend.list(backendPath, options);
-    },
-
-    search(pattern, options) {
-      return backend.search(pattern, options);
-    },
-
-    ...(del !== undefined
-      ? {
+    ...(del === undefined
+      ? {}
+      : {
           delete(path: string) {
-            const backendPath = toBackendPath(path);
-            if (backendPath === undefined) return pathDenied(path, VIRTUAL_SCOPE_ROOT);
-            return del(backendPath);
+            const next = rewriteOrDeny(path, rewrite, mountPath);
+            return next.ok ? del(next.value) : next;
           },
-        }
-      : {}),
-    ...(ren !== undefined
-      ? {
-          rename(from: string, to: string) {
-            const backendFrom = toBackendPath(from);
-            if (backendFrom === undefined) return pathDenied(from, VIRTUAL_SCOPE_ROOT);
-            const backendTo = toBackendPath(to);
-            if (backendTo === undefined) return pathDenied(to, VIRTUAL_SCOPE_ROOT);
-            return ren(backendFrom, backendTo);
+        }),
+    ...(ren === undefined
+      ? {}
+      : { rename: (from: string, to: string) => routeRename(ren, rewrite, mountPath, from, to) }),
+    ...(resolveFn === undefined
+      ? {}
+      : {
+          resolvePath(path: string) {
+            const next = rewrite(path);
+            return next === undefined ? undefined : resolveFn(next);
           },
-        }
-      : {}),
-    ...(resolveFn !== undefined
-      ? {
-          resolvePath(path: string): string | undefined {
-            const backendPath = toBackendPath(path);
-            return backendPath === undefined ? undefined : resolveFn(backendPath);
-          },
-        }
-      : {}),
-    ...(dispose !== undefined ? { dispose: () => dispose() } : {}),
+        }),
+    ...(dispose === undefined ? {} : { dispose: () => dispose() }),
   };
+}
+
+function routeRename(
+  rename: NonNullable<FileSystemBackend["rename"]>,
+  rewrite: RewritePath,
+  mountPath: string,
+  from: string,
+  to: string,
+) {
+  const nextFrom = rewriteOrDeny(from, rewrite, mountPath);
+  if (!nextFrom.ok) return nextFrom;
+  const nextTo = rewriteOrDeny(to, rewrite, mountPath);
+  return nextTo.ok ? rename(nextFrom.value, nextTo.value) : nextTo;
+}
+
+function createRoutedBackend(
+  name: string,
+  backend: FileSystemBackend,
+  rewrite: RewritePath,
+  mountPath: string,
+): FileSystemBackend {
+  return {
+    name,
+    ...createRoutedRequiredMethods(backend, rewrite, mountPath),
+    ...createRoutedOptionalMethods(backend, rewrite, mountPath),
+  };
+}
+
+function createVirtualRootBackend(backend: FileSystemBackend): FileSystemBackend {
+  return createRoutedBackend(
+    `context-namespace-virtual(${backend.name})`,
+    backend,
+    toBackendPath,
+    VIRTUAL_SCOPE_ROOT,
+  );
 }
 
 function createResolvedMountBackend(mount: ContextNamespaceMount): FileSystemBackend {
@@ -144,74 +182,35 @@ function createResolvedMountBackend(mount: ContextNamespaceMount): FileSystemBac
     root: VIRTUAL_SCOPE_ROOT,
     mode: mount.mode,
   });
+  return createRoutedBackend(
+    `context-namespace(${mount.backend.name}:${mount.path})`,
+    scoped,
+    (path) => toMountRelativePath(mount.path, path),
+    mount.path,
+  );
+}
 
-  const rewrite = (path: string): string | undefined => toMountRelativePath(mount.path, path);
-  const del = scoped.delete;
-  const ren = scoped.rename;
-  const resolveFn = scoped.resolvePath;
-  const dispose = scoped.dispose;
+function normalizeMount(mount: ContextNamespaceMount, path: string): ContextNamespaceMount {
+  if (mount.metadata === undefined) {
+    return { path, backend: mount.backend, mode: mount.mode };
+  }
+  return { path, backend: mount.backend, mode: mount.mode, metadata: mount.metadata };
+}
 
-  return {
-    name: `context-namespace(${mount.backend.name}:${mount.path})`,
+function toMountedEvent(mount: ContextNamespaceMount): ContextNamespaceChangeEvent {
+  if (mount.metadata === undefined) {
+    return { kind: "mounted", path: mount.path, mode: mount.mode };
+  }
+  return { kind: "mounted", path: mount.path, mode: mount.mode, metadata: mount.metadata };
+}
 
-    read(path, options) {
-      const relative = rewrite(path);
-      if (relative === undefined) return pathDenied(path, mount.path);
-      return scoped.read(relative, options);
-    },
-
-    write(path, content, options) {
-      const relative = rewrite(path);
-      if (relative === undefined) return pathDenied(path, mount.path);
-      return scoped.write(relative, content, options);
-    },
-
-    edit(path, edits, options) {
-      const relative = rewrite(path);
-      if (relative === undefined) return pathDenied(path, mount.path);
-      return scoped.edit(relative, edits, options);
-    },
-
-    list(path, options) {
-      const relative = rewrite(path);
-      if (relative === undefined) return pathDenied(path, mount.path);
-      return scoped.list(relative, options);
-    },
-
-    search(pattern, options) {
-      return scoped.search(pattern, options);
-    },
-
-    ...(del !== undefined
-      ? {
-          delete(path: string) {
-            const relative = rewrite(path);
-            if (relative === undefined) return pathDenied(path, mount.path);
-            return del(relative);
-          },
-        }
-      : {}),
-    ...(ren !== undefined
-      ? {
-          rename(from: string, to: string) {
-            const relativeFrom = rewrite(from);
-            if (relativeFrom === undefined) return pathDenied(from, mount.path);
-            const relativeTo = rewrite(to);
-            if (relativeTo === undefined) return pathDenied(to, mount.path);
-            return ren(relativeFrom, relativeTo);
-          },
-        }
-      : {}),
-    ...(resolveFn !== undefined
-      ? {
-          resolvePath(path: string): string | undefined {
-            const relative = rewrite(path);
-            return relative === undefined ? undefined : resolveFn(relative);
-          },
-        }
-      : {}),
-    ...(dispose !== undefined ? { dispose: () => dispose() } : {}),
-  };
+function findMount(
+  mounts: Iterable<ContextNamespaceMount>,
+  path: string,
+): ContextNamespaceMount | undefined {
+  return [...mounts]
+    .filter((mount) => mountContainsPath(mount.path, path))
+    .sort((left, right) => right.path.length - left.path.length)[0];
 }
 
 export function createContextNamespace(): ContextNamespace {
@@ -222,18 +221,10 @@ export function createContextNamespace(): ContextNamespace {
   return {
     mount(mount) {
       const path = assertMountPath(mount.path);
-      const normalized: ContextNamespaceMount =
-        mount.metadata === undefined
-          ? { path, backend: mount.backend, mode: mount.mode }
-          : { path, backend: mount.backend, mode: mount.mode, metadata: mount.metadata };
+      const normalized = normalizeMount(mount, path);
       mounts.set(path, normalized);
       resolved.set(path, createResolvedMountBackend(normalized));
-      emit(
-        listeners,
-        normalized.metadata === undefined
-          ? { kind: "mounted", path, mode: normalized.mode }
-          : { kind: "mounted", path, mode: normalized.mode, metadata: normalized.metadata },
-      );
+      emit(listeners, toMountedEvent(normalized));
     },
 
     unmount(path) {
@@ -248,12 +239,8 @@ export function createContextNamespace(): ContextNamespace {
 
     resolve(path) {
       const normalized = normalizeNamespacePath(path);
-      const match = [...mounts.values()]
-        .filter((mount) => mountContainsPath(mount.path, normalized))
-        .sort((left, right) => right.path.length - left.path.length)[0];
-      if (match === undefined) {
-        return undefined;
-      }
+      const match = findMount(mounts.values(), normalized);
+      if (match === undefined) return undefined;
       emit(listeners, {
         kind: "resolved",
         path: normalized,

--- a/packages/lib/fs-scoped/src/context-namespace.ts
+++ b/packages/lib/fs-scoped/src/context-namespace.ts
@@ -2,7 +2,15 @@ import type {
   ContextNamespace,
   ContextNamespaceChangeEvent,
   ContextNamespaceMount,
+  FileDeleteResult,
+  FileEditResult,
+  FileListResult,
+  FileReadResult,
+  FileRenameResult,
+  FileSearchOptions,
+  FileSearchResult,
   FileSystemBackend,
+  FileWriteResult,
   KoiError,
   Result,
 } from "@koi/core";
@@ -26,6 +34,11 @@ function assertMountPath(path: string): string {
     throw new Error("Context namespace cannot mount at root '/'");
   }
   return normalized;
+}
+
+function assertAccessMode(mode: ContextNamespaceMount["mode"]): ContextNamespaceMount["mode"] {
+  if (mode === "ro" || mode === "rw") return mode;
+  throw new Error(`Context namespace access mode must be 'ro' or 'rw', got ${String(mode)}.`);
 }
 
 function mountContainsPath(mountPath: string, path: string): boolean {
@@ -71,6 +84,10 @@ function pathDenied(path: string, mountPath: string): Result<never, KoiError> {
 }
 
 type RewritePath = (path: string) => string | undefined;
+type MapSearchPath = (path: string) => string;
+type RewriteSearchOptions = (
+  options: FileSearchOptions | undefined,
+) => Result<FileSearchOptions | undefined, KoiError>;
 
 function rewriteOrDeny(
   path: string,
@@ -81,30 +98,110 @@ function rewriteOrDeny(
   return rewritten === undefined ? pathDenied(path, mountPath) : { ok: true, value: rewritten };
 }
 
+function mapResultPath<T extends { readonly path: string }>(
+  raw: Result<T, KoiError> | Promise<Result<T, KoiError>>,
+  mapPath: MapSearchPath,
+): Result<T, KoiError> | Promise<Result<T, KoiError>> {
+  const finish = (result: Result<T, KoiError>): Result<T, KoiError> =>
+    result.ok ? { ok: true, value: { ...result.value, path: mapPath(result.value.path) } } : result;
+  return raw instanceof Promise ? raw.then(finish) : finish(raw);
+}
+
+function mapListResult(
+  raw: Result<FileListResult, KoiError> | Promise<Result<FileListResult, KoiError>>,
+  mapPath: MapSearchPath,
+): Result<FileListResult, KoiError> | Promise<Result<FileListResult, KoiError>> {
+  const finish = (result: Result<FileListResult, KoiError>): Result<FileListResult, KoiError> =>
+    result.ok
+      ? {
+          ok: true,
+          value: {
+            entries: result.value.entries.map((entry) => ({
+              ...entry,
+              path: mapPath(entry.path),
+            })),
+            truncated: result.value.truncated,
+          },
+        }
+      : result;
+  return raw instanceof Promise ? raw.then(finish) : finish(raw);
+}
+
+function mapSearchResults(
+  raw: Result<FileSearchResult, KoiError> | Promise<Result<FileSearchResult, KoiError>>,
+  mapPath: MapSearchPath,
+): Result<FileSearchResult, KoiError> | Promise<Result<FileSearchResult, KoiError>> {
+  const finish = (
+    result: Result<FileSearchResult, KoiError>,
+  ): Result<FileSearchResult, KoiError> =>
+    result.ok
+      ? {
+          ok: true,
+          value: {
+            matches: result.value.matches.map((match) => ({
+              ...match,
+              path: mapPath(match.path),
+            })),
+            truncated: result.value.truncated,
+          },
+        }
+      : result;
+  return raw instanceof Promise ? raw.then(finish) : finish(raw);
+}
+
+function mapRenameResult(
+  raw: Result<FileRenameResult, KoiError> | Promise<Result<FileRenameResult, KoiError>>,
+  mapPath: MapSearchPath,
+): Result<FileRenameResult, KoiError> | Promise<Result<FileRenameResult, KoiError>> {
+  const finish = (
+    result: Result<FileRenameResult, KoiError>,
+  ): Result<FileRenameResult, KoiError> =>
+    result.ok
+      ? {
+          ok: true,
+          value: { from: mapPath(result.value.from), to: mapPath(result.value.to) },
+        }
+      : result;
+  return raw instanceof Promise ? raw.then(finish) : finish(raw);
+}
+
 function createRoutedRequiredMethods(
   backend: FileSystemBackend,
   rewrite: RewritePath,
   mountPath: string,
+  mapSearchPath: MapSearchPath,
+  rewriteSearchOptions: RewriteSearchOptions,
 ): Pick<FileSystemBackend, "read" | "write" | "edit" | "list" | "search"> {
   return {
     read(path, options) {
       const routed = rewriteOrDeny(path, rewrite, mountPath);
-      return routed.ok ? backend.read(routed.value, options) : routed;
+      return routed.ok
+        ? mapResultPath<FileReadResult>(backend.read(routed.value, options), mapSearchPath)
+        : routed;
     },
     write(path, content, options) {
       const routed = rewriteOrDeny(path, rewrite, mountPath);
-      return routed.ok ? backend.write(routed.value, content, options) : routed;
+      return routed.ok
+        ? mapResultPath<FileWriteResult>(
+            backend.write(routed.value, content, options),
+            mapSearchPath,
+          )
+        : routed;
     },
     edit(path, edits, options) {
       const routed = rewriteOrDeny(path, rewrite, mountPath);
-      return routed.ok ? backend.edit(routed.value, edits, options) : routed;
+      return routed.ok
+        ? mapResultPath<FileEditResult>(backend.edit(routed.value, edits, options), mapSearchPath)
+        : routed;
     },
     list(path, options) {
       const routed = rewriteOrDeny(path, rewrite, mountPath);
-      return routed.ok ? backend.list(routed.value, options) : routed;
+      return routed.ok ? mapListResult(backend.list(routed.value, options), mapSearchPath) : routed;
     },
     search(pattern, options) {
-      return backend.search(pattern, options);
+      const nextOptions = rewriteSearchOptions(options);
+      if (!nextOptions.ok) return nextOptions;
+      return mapSearchResults(backend.search(pattern, nextOptions.value), mapSearchPath);
     },
   };
 }
@@ -113,6 +210,7 @@ function createRoutedOptionalMethods(
   backend: FileSystemBackend,
   rewrite: RewritePath,
   mountPath: string,
+  mapPath: MapSearchPath,
 ): Partial<FileSystemBackend> {
   const del = backend.delete;
   const ren = backend.rename;
@@ -124,12 +222,15 @@ function createRoutedOptionalMethods(
       : {
           delete(path: string) {
             const next = rewriteOrDeny(path, rewrite, mountPath);
-            return next.ok ? del(next.value) : next;
+            return next.ok ? mapResultPath<FileDeleteResult>(del(next.value), mapPath) : next;
           },
         }),
     ...(ren === undefined
       ? {}
-      : { rename: (from: string, to: string) => routeRename(ren, rewrite, mountPath, from, to) }),
+      : {
+          rename: (from: string, to: string) =>
+            routeRename(ren, rewrite, mountPath, mapPath, from, to),
+        }),
     ...(resolveFn === undefined
       ? {}
       : {
@@ -146,13 +247,14 @@ function routeRename(
   rename: NonNullable<FileSystemBackend["rename"]>,
   rewrite: RewritePath,
   mountPath: string,
+  mapPath: MapSearchPath,
   from: string,
   to: string,
 ) {
   const nextFrom = rewriteOrDeny(from, rewrite, mountPath);
   if (!nextFrom.ok) return nextFrom;
   const nextTo = rewriteOrDeny(to, rewrite, mountPath);
-  return nextTo.ok ? rename(nextFrom.value, nextTo.value) : nextTo;
+  return nextTo.ok ? mapRenameResult(rename(nextFrom.value, nextTo.value), mapPath) : nextTo;
 }
 
 function createRoutedBackend(
@@ -160,12 +262,25 @@ function createRoutedBackend(
   backend: FileSystemBackend,
   rewrite: RewritePath,
   mountPath: string,
+  mapSearchPath: MapSearchPath,
+  rewriteSearchOptions: RewriteSearchOptions = (options) => ({ ok: true, value: options }),
 ): FileSystemBackend {
   return {
     name,
-    ...createRoutedRequiredMethods(backend, rewrite, mountPath),
-    ...createRoutedOptionalMethods(backend, rewrite, mountPath),
+    ...createRoutedRequiredMethods(
+      backend,
+      rewrite,
+      mountPath,
+      mapSearchPath,
+      rewriteSearchOptions,
+    ),
+    ...createRoutedOptionalMethods(backend, rewrite, mountPath, mapSearchPath),
   };
+}
+
+function toVirtualPath(backendPath: string): string {
+  const normalized = normalizeNamespacePath(backendPath);
+  return normalized === "/" ? VIRTUAL_SCOPE_ROOT : `${VIRTUAL_SCOPE_ROOT}${normalized}`;
 }
 
 function createVirtualRootBackend(backend: FileSystemBackend): FileSystemBackend {
@@ -174,7 +289,24 @@ function createVirtualRootBackend(backend: FileSystemBackend): FileSystemBackend
     backend,
     toBackendPath,
     VIRTUAL_SCOPE_ROOT,
+    toVirtualPath,
   );
+}
+
+function toNamespaceSearchPath(mountPath: string, virtualPath: string): string {
+  const backendPath = toBackendPath(virtualPath) ?? normalizeNamespacePath(virtualPath);
+  return backendPath === "/" ? mountPath : `${mountPath}${backendPath}`;
+}
+
+function rewriteMountSearchOptions(
+  mountPath: string,
+  options: FileSearchOptions | undefined,
+): Result<FileSearchOptions | undefined, KoiError> {
+  if (options?.glob === undefined) return { ok: true, value: options };
+  if (!options.glob.startsWith("/")) return { ok: true, value: options };
+  const glob = toMountRelativePath(mountPath, options.glob);
+  if (glob === undefined) return pathDenied(options.glob, mountPath);
+  return { ok: true, value: { ...options, glob } };
 }
 
 function createResolvedMountBackend(mount: ContextNamespaceMount): FileSystemBackend {
@@ -187,21 +319,20 @@ function createResolvedMountBackend(mount: ContextNamespaceMount): FileSystemBac
     scoped,
     (path) => toMountRelativePath(mount.path, path),
     mount.path,
+    (path) => toNamespaceSearchPath(mount.path, path),
+    (options) => rewriteMountSearchOptions(mount.path, options),
   );
 }
 
 function normalizeMount(mount: ContextNamespaceMount, path: string): ContextNamespaceMount {
-  if (mount.metadata === undefined) {
-    return { path, backend: mount.backend, mode: mount.mode };
-  }
-  return { path, backend: mount.backend, mode: mount.mode, metadata: mount.metadata };
+  const mode = assertAccessMode(mount.mode);
+  const base = { path, backend: mount.backend, mode };
+  return mount.metadata === undefined ? base : { ...base, metadata: mount.metadata };
 }
 
 function toMountedEvent(mount: ContextNamespaceMount): ContextNamespaceChangeEvent {
-  if (mount.metadata === undefined) {
-    return { kind: "mounted", path: mount.path, mode: mount.mode };
-  }
-  return { kind: "mounted", path: mount.path, mode: mount.mode, metadata: mount.metadata };
+  const event = { kind: "mounted" as const, path: mount.path, mode: mount.mode };
+  return mount.metadata === undefined ? event : { ...event, metadata: mount.metadata };
 }
 
 function findMount(

--- a/packages/lib/fs-scoped/src/index.ts
+++ b/packages/lib/fs-scoped/src/index.ts
@@ -1,2 +1,3 @@
+export { createContextNamespace } from "./context-namespace.js";
 export type { CompiledFileSystemScope, FileSystemScope } from "./scoped-filesystem.js";
 export { compileFileSystemScope, createScopedFileSystem } from "./scoped-filesystem.js";

--- a/packages/lib/tool-exec/src/__tests__/execute-code-tool.test.ts
+++ b/packages/lib/tool-exec/src/__tests__/execute-code-tool.test.ts
@@ -103,6 +103,10 @@ describe("createExecuteCodeTool — timeout_ms validation", () => {
 describe("createExecuteCodeTool — abort signal propagation", () => {
   test("aborting execute_code cancels worker and in-flight inner tool", async () => {
     let innerSignal: AbortSignal | undefined;
+    let resolveInnerSignal!: (signal: AbortSignal) => void;
+    const innerSignalReady = new Promise<AbortSignal>((resolve) => {
+      resolveInnerSignal = resolve;
+    });
     const watch: Tool = {
       descriptor: {
         name: "watch",
@@ -114,8 +118,13 @@ describe("createExecuteCodeTool — abort signal propagation", () => {
       policy: { sandbox: false, capabilities: {} },
       execute: async (_args, ctx) =>
         new Promise((_resolve, reject) => {
-          innerSignal = ctx?.signal;
-          ctx?.signal?.addEventListener("abort", () => reject(new Error("inner-aborted")));
+          if (ctx?.signal === undefined) {
+            reject(new Error("missing signal"));
+            return;
+          }
+          innerSignal = ctx.signal;
+          resolveInnerSignal(ctx.signal);
+          ctx.signal.addEventListener("abort", () => reject(new Error("inner-aborted")));
         }),
     };
 
@@ -129,12 +138,15 @@ describe("createExecuteCodeTool — abort signal propagation", () => {
 
     const controller = new AbortController();
     const userReason = new Error("outer-cancel");
-    setTimeout(() => controller.abort(userReason), 50);
 
-    const scriptResult = (await tool.execute(
+    const scriptRun = tool.execute(
       { script: `await tools.watch({}); return "never";` } satisfies JsonObject,
       { signal: controller.signal },
-    )) as { readonly ok: boolean; readonly error?: string };
+    );
+    await innerSignalReady;
+    controller.abort(userReason);
+
+    const scriptResult = (await scriptRun) as { readonly ok: boolean; readonly error?: string };
 
     expect(scriptResult.ok).toBe(false);
     expect(scriptResult.error).toMatch(/aborted/i);


### PR DESCRIPTION
## Summary
- Adds the `@koi/core` context namespace contract and API subpath for shared mounted context backends.
- Implements `createContextNamespace()` in `@koi/fs-scoped` with normalized mounts, longest-prefix resolution, ro/rw enforcement, watcher events, and shared instance behavior.
- Documents the new fs-scoped namespace behavior and updates package coverage metadata.

## Validation
- `bun run lint` in `packages/kernel/core`
- `bun run lint` in `packages/lib/fs-scoped`
- `bun run typecheck` in `packages/kernel/core`
- `bun run typecheck` in `packages/lib/fs-scoped`
- `bun test src/__tests__/exports.test.ts src/__tests__/api-surface.test.ts` in `packages/kernel/core`
- `bun test src/context-namespace.test.ts` in `packages/lib/fs-scoped`
- `bun run check:layers`
- `bun run build` from repo root: 234/234 packages successful
- pre-push hook: scoped build/typecheck passed

Closes #2205